### PR TITLE
Compute frustum depth from view attachments.

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-view-attachment-frustum_2021-02-16-13-14.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-view-attachment-frustum_2021-02-16-13-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Fix failure to compute frustum depth from view attachments causing them to be severely clipped.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}

--- a/core/frontend/src/SheetViewState.ts
+++ b/core/frontend/src/SheetViewState.ts
@@ -217,7 +217,9 @@ class ViewAttachments {
     for (const info of infos) {
       const drawAsRaster = info.jsonProperties?.displayOptions?.drawAsRaster || info.attachedView.isCameraEnabled();
       const ctor = drawAsRaster ? RasterAttachment : OrthographicAttachment;
-      this._attachments.push(new ctor(info.attachedView, info, sheetView));
+      const attachment = new ctor(info.attachedView, info, sheetView);
+      this._attachments.push(attachment);
+      this.maxDepth = Math.max(this.maxDepth, attachment.zDepth);
     }
   }
 


### PR DESCRIPTION
Regression causing most 'pseudo-3d' view attachments to be severely clipped.

Introduced in #491.