### PR TITLE
PrimitiveTool.iModel returns an IModelConnection.

### DIFF
--- a/common/api/imodeljs-editor-backend.api.md
+++ b/common/api/imodeljs-editor-backend.api.md
@@ -20,7 +20,7 @@ export class BasicManipulationCommand extends EditCommand implements BasicManipu
     // (undocumented)
     deleteElements(ids: CompressedId64Set): Promise<IModelStatus>;
     // (undocumented)
-    rotatePlacement(_ids: CompressedId64Set, _matrix: Matrix3dProps, _aboutCenter: boolean): Promise<IModelStatus>;
+    rotatePlacement(ids: CompressedId64Set, matrixProps: Matrix3dProps, aboutCenter: boolean): Promise<IModelStatus>;
     // (undocumented)
     protected _str: string;
     // (undocumented)

--- a/common/api/imodeljs-editor-frontend.api.md
+++ b/common/api/imodeljs-editor-frontend.api.md
@@ -10,6 +10,7 @@ import { DialogItem } from '@bentley/ui-abstract';
 import { DialogPropertySyncItem } from '@bentley/ui-abstract';
 import { DynamicsContext } from '@bentley/imodeljs-frontend';
 import { ElementSetTool } from '@bentley/imodeljs-frontend';
+import { Frustum } from '@bentley/imodeljs-common';
 import { Point3d } from '@bentley/geometry-core';
 import { PropertyDescription } from '@bentley/ui-abstract';
 import { Tool } from '@bentley/imodeljs-frontend';
@@ -134,6 +135,10 @@ export class RotateElementsTool extends TransformElementsTool {
     // (undocumented)
     static toolId: string;
     // (undocumented)
+    protected transformAgenda(transform: Transform): Promise<void>;
+    // (undocumented)
+    protected transformAgendaDynamics(transform: Transform, context: DynamicsContext): void;
+    // (undocumented)
     protected get wantAdditionalInput(): boolean;
     // (undocumented)
     protected wantProcessAgenda(ev: BeButtonEvent): boolean;
@@ -166,6 +171,10 @@ export abstract class TransformElementsTool extends ElementSetTool {
     // (undocumented)
     protected createAgendaGraphics(changed: boolean): Promise<void>;
     // (undocumented)
+    protected _elementAlignedBoxes?: Frustum[];
+    // (undocumented)
+    protected _elementOrigins?: Point3d[];
+    // (undocumented)
     protected initAgendaDynamics(): Promise<boolean>;
     // (undocumented)
     protected onAgendaModified(): Promise<void>;
@@ -177,6 +186,8 @@ export abstract class TransformElementsTool extends ElementSetTool {
     processAgenda(ev: BeButtonEvent): Promise<void>;
     // (undocumented)
     protected startCommand(): Promise<string>;
+    // (undocumented)
+    protected _startedCmd?: string;
     // (undocumented)
     protected transformAgenda(transform: Transform): Promise<void>;
     // (undocumented)

--- a/common/changes/@bentley/imodeljs-editor-backend/rotate-about_2021-03-10-16-33.json
+++ b/common/changes/@bentley/imodeljs-editor-backend/rotate-about_2021-03-10-16-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-editor-backend",
+      "comment": "Implement rotate about center/origin options.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-editor-backend",
+  "email": "65233531+bbastings@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-editor-frontend/rotate-about_2021-03-10-16-33.json
+++ b/common/changes/@bentley/imodeljs-editor-frontend/rotate-about_2021-03-10-16-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-editor-frontend",
+      "comment": "Implement rotate about center/origin options.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-editor-frontend",
+  "email": "65233531+bbastings@users.noreply.github.com"
+}


### PR DESCRIPTION
@kabentley  changed it to EditableConnection for `saveChanges`. I later changed it to BriefcaseConnection when I removed EditableConnection. It can be used for read-only tools, so it should remain an IModelConnection.