### PR TITLE
Recalculate table filter distinct values on row updates

### DIFF
--- a/ui/components/src/ui-components/table/component/Table.tsx
+++ b/ui/components/src/ui-components/table/component/Table.tsx
@@ -909,12 +909,10 @@ export class Table extends React.Component<TableProps, TableState> {
         this.props.onRowsLoaded(index, index + loadResult.rows.length - 1);
 
       const showFilter = this._isShowFilterRow();
-      if (showFilter !== this._filterRowShown) {
-        // istanbul ignore else
-        if (showFilter)
-          await this.loadDistinctValues();
-        this.toggleFilterRow(showFilter);
-      }
+      // istanbul ignore else
+      if (showFilter)
+        await this.loadDistinctValues();
+      this.toggleFilterRow(showFilter);
     });
   });
 


### PR DESCRIPTION
@DanEastBentley, I'm working with a TableDataProvider implementation which sources its data from a source external to the provider. This data is not available when the table is created, so when I define a filterable column for the table, there are no rows yet, so the distinct values are always empty.

When the rows are eventually generated, the filterRow is already visible, so distinct values are not recalculated.
Doesn't it make sense to re-generate the distinct values for filterable columns whenever the rows are updated to reflect the possible options, and not only when the filterRow is first created?