### PR TITLE
Fix FeatureOverrideProvider docs.

### DIFF
--- a/common/changes/@bentley/imodeljs-frontend/fix-feature-override-provider-docs_2021-08-26-09-58.json
+++ b/common/changes/@bentley/imodeljs-frontend/fix-feature-override-provider-docs_2021-08-26-09-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend"
+}

--- a/core/frontend/src/FeatureOverrideProvider.ts
+++ b/core/frontend/src/FeatureOverrideProvider.ts
@@ -9,16 +9,15 @@
 import { Viewport } from "./Viewport";
 import { FeatureSymbology } from "./render/FeatureSymbology";
 
-/** An object that customizes the appearance of Features within a [[Viewport]].
- * Only one FeatureOverrideProvider may be associated with a viewport at a time. Setting a new FeatureOverrideProvider replaces any existing provider.
+/** An object that customizes the appearance of [Feature]($common)s within a [[Viewport]] using [[FeatureSymbology.Overrides]].
+ * When the viewport needs to recreate the symbology overrides, it invokes the provider's [[addFeatureOverrides]] method.
+ * If necessary - for example, because of changes to some state from which the provider derives the overrides - the provider
+ * can request that the viewport recreate the overrides by calling [[Viewport.setFeatureOverrideProviderChanged]].
  *
- * If the provider's internal state changes such that the Viewport should recompute the symbology overrides, the provider should notify the viewport by
- * calling [[Viewport.setFeatureOverrideProviderChanged]].
- * @see [[Viewport.addFeatureOverrideProvider]]
- * @see [[Viewport.dropFeatureOverrideProvider]]
+ * @see [[Viewport.addFeatureOverrideProvider]] to register a provider with a viewport.
  * @public
  */
 export interface FeatureOverrideProvider {
-  /** Add to the supplied `overrides` any symbology overrides to be applied to the specified `viewport`. */
+  /** Add to the supplied overrides any symbology overrides to be applied to the specified viewport. */
   addFeatureOverrides(overrides: FeatureSymbology.Overrides, viewport: Viewport): void;
 }


### PR DESCRIPTION
They claimed only a single FeatureOverrideProvider could be registered with a Viewport at a given time, which hasn't been true for quite a while.