### PR TITLE
Chickneas/misc documentation

### DIFF
--- a/docs/learning/Provenence-in-iModels.md
+++ b/docs/learning/Provenence-in-iModels.md
@@ -1,0 +1,57 @@
+# Provenence in iModels
+
+## What is meant by "Provenence in iModels"
+
+Provenence in iModels concerns the ability to trace an element in an iModel back to it's native, external source. Several classes are available in the BisCore schema version (> version 01.00.13) for modeling the sources-of-data of an iModel, to provide provenance information for Elements in the iModel. A RepositoryLink is a URL and it roughly maps to an external source file such as MicroStation _.dgn file or an IFC_.ifc file. The [ExternalSource](#ExternalSource) is used for external source files which are divided into smaller models. Models within a MicroStation \*.dgn are the primary use case for ExternalSource.
+
+## Entity Classes
+
+### ExternalSource
+
+The ExternalSource maps roughly to a model in a Dgn file, but, is also intended for connectors of non-dgn sources such as IFC where a one-to-one relationship exists between a model and a repository. e.g. IFC has no notion of a model and therefore it is implied that the contents of the IFC file comprise one model. For external repositories such as a MicroStation Dgn file in which more than one model can be contained by the repository, the CodeScope is the RepositoryLink and the CodeValue is the DgnModel.Name. The CodeValue has a maximum length which is 350. For other repositories with a one-to-one relationship such as IFC, it should have the same CodeScope and CodeValue as the RepositoryLink. ExternalSource.UserLabel identifies the actual source in the terms that that the user understands.
+
+### ExternalSourceGroup
+
+ExternalSourceGroup is interesting because it is a special case of an [ExternalSource](#ExternalSource) and therefore it is valid to be used as the target of the ExternalSourceAspect.Source navigation property while at the same time it serves as a container for 1 to N ExternalSources. The ExternalSourceGroup is intended to be used when there is a potential for duplicate elements in external source files. One real-world use case is the appearance of walls with the same "unique" ids in two different ifc models. For example, merely for the purpose of referencing, locating or visualizing pipes and hvac elements along with walls they are associated with, wall elements were duplicated in both the pipe and duct files. To associate the resulting element in the iModel with BOTH pipes.ifc and hvac.ifc, the ExternalSourceGroup is used.
+
+### ExternalSourceAttachment
+
+An ExternalSourceAttachment allows connectors to represent complex reference file hierarchies or even acyclical dependency graphs that can be encountered in a Dgn file. The CodeScope should be set to the parent ExternalSource and the CodeValue should be set to the logical name of the attachment in the MicroStation case (or equivalent in the general case) and the attached ExternalSource Code. The UserLabel should be set to the logical name in the MicroStation case (or equivalent in the general case).
+
+### RepositoryLink
+
+A RepositoryLink UrlLink element that links to an external repository.
+
+## Relationship Classes
+
+### ExternalSourceOwnsAttachments
+
+ExternalSourceOwnsAttachments relationship from an ExternalSource to its [ExternalSourceAttachment](#ExternalSourceAttachment)
+
+### ExternalSourceAttachmentAttachesSource
+
+ExternalSourceAttachmentAttachesSource is a relationship between an [ExternalSourceAttachment](#ExternalSourceAttachment) and another ExternalSource. For the simplest case, one model (A) attaching another (B) requires ExternalSources A and B, a single ExternalSourceAttachment and two relationships: 1) ExternalSourceOwnsAttachments from A to the ExternalSourceAttachment and ExternalSourceAttachmentAttachesSource from the ExternalSourceAttachment to B.
+
+### ExternalSourceGroupGroupsSources
+
+ExternalSourceGroupGroupsSources is used to associate the [ExternalSourceGroup](#ExternalSourceGroup) with the 1 to N ExternalSources which it groups.
+
+### ElementIsFromSource
+
+ElementIsFromSource relates Element which owns the ExternalSourceAspect with the target [ExternalSource](#ExternalSource).
+
+### ElementOwnsExternalSourceAspects
+
+ElementOwnsExternalSourceAspects relates an [ExternalSourceAspect](#ExternalSourceAspect) with the Element that owns it.
+
+## Element Aspects
+
+### ExternalSourceAspect
+
+ExternalSourceAspect is a aspect which begins the association of an Element to it's [ExternalSource](#ExternalSource). The Scope is a navigation property of ExternalSourceAspect which is recommended to point to a [RepositoryLink](#RepositoryLink) when ids are unique per repository. Source is another navigation property of this aspect which points to the ExternalSource using the [ElementIsFromSource](#ElementIsFromSource) relationship.
+
+## Enums
+
+### ExternalSourceAttachmentRole
+
+ExternalSourceAttachmentRole is used by ExternalSource.Role to indicate role that an attached [ExternalSource](#ExternalSource) plays, e.g. to specify context or a part-of-a-whole. Context implies that the elements contained in the ExternalSource are for reference only (e.g. wall elements duplicated in pipe and hvac models example above) while part-of-a-whole implies that elements contained in the ExternalSource are additive (a complete car model composed by attaching wheel models, engine model, chasis model, transmission model, etc.).

--- a/docs/learning/WriteAConnector.md
+++ b/docs/learning/WriteAConnector.md
@@ -311,6 +311,8 @@ A Connector must also relate each physical model that it creates to the source d
     const key = scope + sourceItem.id.toLowerCase();
 ```
 
+Also refer to [Provenence in iModels](./Provenence-in-iModels) for more information about ExternalSource and related classes.
+
 ###### Case 2 : Id mapping
 
 Id mapping is a way of looking up the data in the iModel that corresponds to a given piece of source data. If the source data has stable, unique IDs, then Id mapping could be straightforward.

--- a/docs/learning/imodel-connectors.md
+++ b/docs/learning/imodel-connectors.md
@@ -22,17 +22,17 @@ Examples of iModel Connectors include:
 
 ## Connector execution
 
-Connectors are invoked by the *Bentley Orchestration Framework(OF)* product. The *Orchestration Framework* is installed on an *Automation server* machine. The *Automation Server* has access to a ProjectWise managed data source that contains the application native files. Any desired connector can be installed on the *Automation Server*. All this data is specified in the connected project web-UI under *connection*.
-The application source file and destination iModel are identified in *mapping*.
-A *connector-job* is the combination of *connection* and *mapping* and may be run on a pre-determined schedule.
+Connectors be invoked either on the cloud using the iTwin Synchronizer Portal or from the desktop using the iTwin Synchronzier Client. This Bentley Communities article, [Ways to sync your data to an iTwin](https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/47596/ways-to-sync-your-data-to-an-itwin) provides a detailed description of both of these options as well as the benefits and limitations of each.
+The application source file and destination iModel are identified in _mapping_.
+A _connector-job_ is the combination of _connection_ and _mapping_ and may be run on a pre-determined schedule.
 
 ## Key characteristics of iModel Connectors
 
-- Mappings of data are *from* the source *into* an iModel.
-- If necessary, connectors store enough information about source data to detect the differences in it between job-runs. In this manner connectors generate *ChangeSets* that are sent to iModelHub. This is the key difference between a Connector and a one-time converter.
+- Mappings of data are _from_ the source _into_ an iModel.
+- If necessary, connectors store enough information about source data to detect the differences in it between job-runs. In this manner connectors generate _ChangeSets_ that are sent to iModelHub. This is the key difference between a Connector and a one-time converter.
 - Connectors locally store a mapping of native source Ids to iModel global Ids. This creates a "back-link" from data in iModels to its source application.
 - Each job generates data in the iModel that is isolated from all other jobs' data. The resulting combined iModel is partitioned at the Subject level of the iModel; each connectors job has its own Subject.
-- Connector jobs *hold the locks* for all of their data, so it may not be modified by other iModel applications.
+- Connector jobs _hold the locks_ for all of their data, so it may not be modified by other iModel applications.
 
 ## Data Alignment
 
@@ -65,14 +65,14 @@ As discussed in [Element Fundamentals](../bis/intro/element-fundamentals.md), th
 
 iModel Connector data transformations should be written considering the Display Label logic; UserLabel is the appropriate property for a Connector to set to control the Display Label (CodeValue should never be set for anything other than coding purposes).
 
-*But what value should an iModel Connector set UserLabel to?* There are two goals to consider in the generation of UserLabels. Those goals, in priority order, are:
+_But what value should an iModel Connector set UserLabel to?_ There are two goals to consider in the generation of UserLabels. Those goals, in priority order, are:
 
 1. Consistency with source application label usage.
 2. Consistency with BIS domain default labeling strategy.
 
 If the source application data has a property that conceptually matches the BIS UserLabel property, that value should always be transformed to UserLabel.
 
-Each BIS domain author should provide a default Display Label strategy for each of its classes. This strategy should be determined by the optimal *user* experience and typically will represent the consensus of Product Management for applications and services that are associated with the domain. Information that is typically considered in the domain's Display Label logic is:
+Each BIS domain author should provide a default Display Label strategy for each of its classes. This strategy should be determined by the optimal _user_ experience and typically will represent the consensus of Product Management for applications and services that are associated with the domain. Information that is typically considered in the domain's Display Label logic is:
 
 - Class Name
 


### PR DESCRIPTION
Addressing two open documentation ADO items:
1) ADO #689880 Received a comment that discouraged against reference to BAS in "Connector execution" section of "iModel Connectors" markdown.
2) ADO #579150 Though we added quite a bit of documentation under "Provenance and External Repository" in the "Write A Connector" markdown, we had an open backlog item dating back to when we first added the ExternalSource and related classes to the BisCore schema.  This was timely b/c there is a concurrent PR for implementing the ExternalSource in the ConnectorFramework. I added a new markdown with class by class description to help in the implementation effort and to close the open backlog item.  