### PR TITLE
Update oidc-signin-tool to handle the new consent page

### DIFF
--- a/common/changes/@bentley/oidc-signin-tool/fix-oidc-signin_2021-10-11-17-03.json
+++ b/common/changes/@bentley/oidc-signin-tool/fix-oidc-signin_2021-10-11-17-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/oidc-signin-tool",
+      "comment": "Handle the new consent page for requesting scopes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/oidc-signin-tool",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/tools/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
+++ b/tools/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
@@ -403,6 +403,16 @@ export class TestBrowserAuthorizationClient implements FrontendAuthorizationClie
         }),
         page.$eval(".allow", (button: any) => button.click()),
       ]);
+    } else if (await page.title() === "Permissions") { // Another new consent page...
+      await page.waitForSelector("div.iui-input-bar button");
+
+      await Promise.all([
+        page.waitForNavigation({
+          timeout: 60000,
+          waitUntil: "networkidle2",
+        }),
+        page.$eval("div.iui-input-bar button span", (button: any) => button.click()),
+      ]);
     }
   }
 

--- a/tools/oidc-signin-tool/src/test/basic.test.ts
+++ b/tools/oidc-signin-tool/src/test/basic.test.ts
@@ -35,6 +35,16 @@ describe("Sign in (#integration)", () => {
     assert.exists(token);
   });
 
+  // test will not work without using a desktop client. setup correctly on master, will enable there.
+  it.skip("success with valid user and offline_access scope", async () => {
+    const validUser = TestUsers.regular;
+    const token = await getTestAccessToken({
+      ...oidcConfig,
+      scope: `${oidcConfig.scope} offline_access`,
+    }, validUser);
+    assert.exists(token);
+  });
+
   it("failure with invalid url", async () => {
     const oidcInvalidConfig = { ...oidcConfig, redirectUri: "invalid.com" };
     const validUser = TestUsers.regular;


### PR DESCRIPTION
There is a new Consent page being rolled out, currently only for when requesting the `offline_access` scope but will be rolled out more shortly.