### PR TITLE
Fix timepoint invalidation

### DIFF
--- a/common/changes/@itwin/core-frontend/timepoint-invalidation_2021-10-20-15-12.json
+++ b/common/changes/@itwin/core-frontend/timepoint-invalidation_2021-10-20-15-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2228,7 +2228,6 @@ export abstract class Viewport implements IDisposable {
 
     if (!this._timePointValid) {
       isRedrawNeeded = true;
-      this._timePointValid = true;
       const scheduleScript = view.displayStyle.scheduleState;
       if (scheduleScript) {
         target.animationBranches = scheduleScript.getAnimationBranches(this.timePoint ?? scheduleScript.duration.low);
@@ -2238,6 +2237,8 @@ export abstract class Viewport implements IDisposable {
         if (scheduleScript.script.containsTransform && !this._freezeScene)
           this.invalidateScene();
       }
+
+      this._timePointValid = true;
     }
 
     if (overridesNeeded) {


### PR DESCRIPTION
If timepoint is invalid, we set it as valid, then we invalidate the scene, which invalidates the timepoint again.
Instead set it valid after invalidating scene. Otherwise we are constantly recreating the scene.