### PR TITLE
Fix exception when pulling changesets.

### DIFF
--- a/clients/imodelhub/src/IModelHubBackend.ts
+++ b/clients/imodelhub/src/IModelHubBackend.ts
@@ -217,6 +217,14 @@ export class IModelHubBackend implements BackendHubAccess {
   }
 
   public async queryChangeset(arg: ChangesetArg): Promise<ChangesetProps> {
+    const changeset = await this.tryQueryChangeset(arg);
+    if (!changeset)
+      throw new IModelError(IModelStatus.NotFound, `Changeset not found`);
+
+    return changeset;
+  }
+
+  private async tryQueryChangeset(arg: ChangesetArg): Promise<ChangesetProps | undefined> {
     const hasIndex = (undefined !== arg.changeset.index);
     if ((hasIndex && arg.changeset.index <= 0) || arg.changeset.id === "")
       return changeSet0;
@@ -230,9 +238,17 @@ export class IModelHubBackend implements BackendHubAccess {
     const accessToken = await this.getAccessToken(arg);
     const changeSets = await this.iModelClient.changeSets.get(accessToken, arg.iModelId, query);
     if (undefined === changeSets)
-      throw new IModelError(IModelStatus.NotFound, `Changeset not found`);
+      return undefined;
 
-    return this.toChangeSetProps(changeSets[0]);
+    return changeSets.length > 0 ? this.toChangeSetProps(changeSets[0]) : undefined;
+  }
+
+  private async getParentChangesetId(arg: IModelIdArg, index: ChangesetIndex): Promise<ChangesetId | undefined> {
+    if (index === 0)
+      return "";
+
+    const changeset = await this.tryQueryChangeset({ ...arg, changeset: { index } });
+    return changeset?.parentId;
   }
 
   private async getQueryFromRange(arg: ChangesetRangeArg): Promise<ChangeSetQuery | undefined> {
@@ -241,11 +257,13 @@ export class IModelHubBackend implements BackendHubAccess {
       return query; // returns all changesets
 
     const range = arg.range;
-    const after = range.first === 0 ? "" : (await this.queryChangeset({ ...arg, changeset: { index: range.first } })).parentId;
+    const after = await this.getParentChangesetId(arg, range.first);
+    if (undefined === after)
+      return undefined;
 
-    if (!range.end)
-      query.fromId(after); //
-    else {
+    if (range.end === undefined) {
+      query.fromId(after);
+    } else {
       const last = (await this.queryChangeset({ ...arg, changeset: { index: range.end } })).id;
       if (range.end === 0 || after === last)
         return undefined;

--- a/common/changes/@bentley/imodelhub-client/fix-pull-exception_2021-10-20-17-07.json
+++ b/common/changes/@bentley/imodelhub-client/fix-pull-exception_2021-10-20-17-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client",
+      "comment": "Fix an exception when attempting to pull changes into a briefcase that already has all the changes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client"
+}


### PR DESCRIPTION
Originally implemented in #2476 but IModelHubBackend.ts has moved to a different package.
Our integration test project includes an iModel with no changesets (NoVersionsTest) but I couldn't find an appropriate place to put a test the downloads a briefcase and attempts to pull changes.