### PR TITLE
Do not try and send an access token when we are in an Electron frontend

### DIFF
--- a/core/common/src/rpc/core/RpcInvocation.ts
+++ b/core/common/src/rpc/core/RpcInvocation.ts
@@ -42,7 +42,7 @@ export interface SerializedRpcActivity {
   applicationId: string;
   applicationVersion: string;
   sessionId: string;
-  authorization: string;
+  authorization?: string;
   csrfToken?: { headerName: string, headerValue: string };
 }
 
@@ -146,7 +146,7 @@ export class RpcInvocation {
       applicationId: request.applicationId,
       applicationVersion: request.applicationVersion,
       sessionId: request.sessionId,
-      accessToken: request.authorization,
+      accessToken: request.authorization ?? "",
       rpcMethod: request.operation.operationName,
     };
 


### PR DESCRIPTION
Update the RPC handling from the frontend to not send an authorization token if we are in a native application where the backend are local to the frontend.

The web browser case will still execute the same as today, this will only effect the Electron/Desktop and Mobile case.