### PR TITLE
Add node-fetch to the optional dep list

### DIFF
--- a/common/changes/@itwin/core-webpack-tools/fix-webpack-plugin_2021-10-21-23-08.json
+++ b/common/changes/@itwin/core-webpack-tools/fix-webpack-plugin_2021-10-21-23-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-webpack-tools",
+      "comment": "Add node-fetch to the BackendDefaultPlugin list of ignored optional dependencies",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-webpack-tools"
+}

--- a/tools/webpack-core/src/plugins/BackendDefaultsPlugin.ts
+++ b/tools/webpack-core/src/plugins/BackendDefaultsPlugin.ts
@@ -53,6 +53,7 @@ export class BackendDefaultsPlugin {
         "got",
         "keyv",
         "ws",
+        "node-fetch",
       ]),
       new RequireMagicCommentsPlugin([
         {


### PR DESCRIPTION
The updated version of `@azure/storage-blob` added a dependency on node-fetch and we need webpacking to skip the encoding import as it's optional.