### PR TITLE
Add display-test-app keyin to sign out.

### DIFF
--- a/test-apps/display-test-app/public/locales/en/SVTTools.json
+++ b/test-apps/display-test-app/public/locales/en/SVTTools.json
@@ -73,6 +73,9 @@
     "SignIn": {
       "keyin": "dta signin"
     },
+    "SignOut": {
+      "keyin": "dta signout"
+    },
     "PushChanges": {
       "keyin": "dta push"
     },

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -36,7 +36,7 @@ import { Notifications } from "./Notifications";
 import { OutputShadersTool } from "./OutputShadersTool";
 import { PathDecorationTestTool } from "./PathDecorationTest";
 import { ToggleShadowMapTilesTool } from "./ShadowMapDecoration";
-import { signIn } from "./signIn";
+import { signIn, signOut } from "./signIn";
 import {
   CloneViewportTool, CloseIModelTool, CloseWindowTool, CreateWindowTool, DockWindowTool, FocusWindowTool, MaximizeWindowTool, OpenIModelTool,
   ReopenIModelTool, ResizeWindowTool, RestoreWindowTool, Surface,
@@ -81,6 +81,14 @@ class SignInTool extends Tool {
   public static override toolId = "SignIn";
   public override async run(): Promise<boolean> {
     await signIn();
+    return true;
+  }
+}
+
+class SignOutTool extends Tool {
+  public static override toolId = "SignOut";
+  public override async run(): Promise<boolean> {
+    await signOut();
     return true;
   }
 }
@@ -278,6 +286,7 @@ export class DisplayTestApp {
       SaveImageTool,
       ShutDownTool,
       SignInTool,
+      SignOutTool,
       SVTSelectionTool,
       SyncViewportsTool,
       ToggleAspectRatioSkewDecoratorTool,

--- a/test-apps/display-test-app/src/frontend/signIn.ts
+++ b/test-apps/display-test-app/src/frontend/signIn.ts
@@ -43,3 +43,9 @@ export async function signIn(): Promise<boolean> {
     browserAuth.signIn().catch((err) => reject(err));
   });
 }
+
+export async function signOut(): Promise<void> {
+  const auth = IModelApp.authorizationClient;
+  if (auth instanceof NativeAppAuthorization || auth instanceof BrowserAuthorizationClient)
+    return auth.signOut();
+}


### PR DESCRIPTION
If you're signed in, the access token appears to be passed along with every request for reality data, regardless of **where** that request is directed. (Exception for Cesium ION which is special-cased). That seems wrong, and if the request is made to localhost it fails with "blocked by CORS policy: Request header field authorization is not allowed by Access-Control-Allow-Headers in preflight response." This should be fixed. @MarcBedard8?

Electron caches the access token **somewhere** for reuse across sessions, so I added `dta signout` keyin to sign out.
