### PR TITLE
Fix display-performance-test-app build script

### DIFF
--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -12,8 +12,8 @@
   },
   "private": true,
   "scripts": {
-    "build": "npm run -s build:backend & tsc",
-    "build:ci": "npm run -s build:backend & npm run -s build:frontend",
+    "build": "npm run -s build:backend & npm run -s build:frontend",
+    "build:ci": "npm run -s build",
     "build:backend": "tsc -p tsconfig.backend.json",
     "build:frontend": "cross-env DISABLE_NEW_JSX_TRANSFORM=true SKIP_PREFLIGHT_CHECK=true DISABLE_NEW_ASSET_COPY=true DISABLE_ESLINT=true TRANSPILE_DEPS=false USE_FAST_SASS=true react-scripts --max_old_space_size=8192 build",
     "clean": "rimraf lib build .rush/temp/package-deps*.json",


### PR DESCRIPTION
@DStradley has ImageTests scripts that run rush build and expect it to produce an executable build of display-performance-test-app.
Those scripts run on various branches including release/2.19.x, imodel02, and branches thereof. We also frequently need to run those scripts against arbitrary historical commits. That is now impossible because he had to change his scripts to use the build:ci command, which doesn't historically exist and the build script has been changed to only compile.
Running rush build needs to continue to do what it has always done and what its name implies: produce a usable build.
