### PR TITLE
Restore compile scripts for test apps.

### DIFF
--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -17,6 +17,7 @@
     "build:backend": "tsc -p tsconfig.backend.json",
     "build:frontend": "cross-env DISABLE_NEW_JSX_TRANSFORM=true SKIP_PREFLIGHT_CHECK=true DISABLE_NEW_ASSET_COPY=true DISABLE_ESLINT=true TRANSPILE_DEPS=false USE_FAST_SASS=true react-scripts --max_old_space_size=8192 build",
     "clean": "rimraf lib build .rush/temp/package-deps*.json",
+    "compile": "npm run -s build:backend & tsc",
     "docs": "",
     "lint": "eslint -f visualstudio --config package.json --no-eslintrc \"./src/**/*.ts\" 1>&2",
     "mobile": "tsc 1>&2 && webpack --config mobile.backend.webpack.config.js 1>&2 && webpack --config mobile.frontend.webpack.config.js 1>&2 && cpx \"public/**/*\" ./lib/mobile/public && cpx \"assets/**/*\" ./lib/mobile/assets ",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -18,6 +18,7 @@
     "build:backend-webpack": "backend-webpack-tools build -s ./lib/backend/DtaElectronMain.js -o ./lib/build/",
     "build:frontend": "cross-env DISABLE_NEW_JSX_TRANSFORM=true SKIP_PREFLIGHT_CHECK=true DISABLE_NEW_ASSET_COPY=true DISABLE_ESLINT=true TRANSPILE_DEPS=false USE_FAST_SASS=true DISABLE_TERSER=true NODE_OPTIONS=--max_old_space_size=4096 react-scripts build",
     "clean": "rimraf build lib .rush/temp/package-deps*.json",
+    "compile": "npm run -s build:backend & tsc",
     "copy:assets": "cpx \"./node_modules/@bentley/icons-generic-webfont/dist/**/*\" ./build",
     "docs": "",
     "lint": "eslint -f visualstudio --config package.json --no-eslintrc \"./src/**/*.ts\" 1>&2",


### PR DESCRIPTION
These were removed in #2448. They are useful when iterating on code changes.

`build` is slow and outputs 10 lines for each error and is not easily parsed by tools or humans:
```
d:/js/s/imodeljs/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
TypeScript error in d:/js/s/imodeljs/test-apps/display-performance-test-app/src/frontend/TestRunner.ts(526,38):
Property 'collecStatistics' does not exist on type 'RenderSystem'. Did you mean 'collectStatistics'?  TS2551
  524 |       tileGpuBytes: calcGpuBytes((stats) => viewport.collectStatistics(stats)),
  525 |       totalGpuBytes: calcGpuBytes((stats) => {
> 526 |         viewport.target.renderSystem.collecStatistics(stats);
      |                                      ^
  527 |         viewport.target.collectStatistics(stats);
  528 |         viewport.iModel.tiles.forEachTreeOwner((owner) => owner.tileTree?.collectStatistics(stats));
  529 |       }),

```

`compile` is quick and outputs one line per error that can be easily parsed by tools allowing quick navigation to the location of each error:
```
src/frontend/TestRunner.ts(526,38): error TS2551: Property 'collecStatistics' does not exist on type 'RenderSystem'. Did you mean 'collectStatistics'?
```