### PR TITLE
Support open reality data point cloud (opc) from any http server

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -7463,6 +7463,8 @@ export namespace RealityDataSource {
     export function createKeyFromUrl(tilesetUrl: string, inputProvider?: RealityDataProvider, inputFormat?: RealityDataFormat): RealityDataSourceKey;
     // (undocumented)
     export function createOrbitGtBlobPropsFromKey(rdSourceKey: RealityDataSourceKey): OrbitGtBlobProps | undefined;
+    // (undocumented)
+    export function formatfromUrl(tilesetUrl: string): RealityDataFormat;
     // @internal
     export function fromKey(rdSourceKey: RealityDataSourceKey, iTwinId: GuidString | undefined): Promise<RealityDataSource | undefined>;
     export function keyToString(rdSourceKey: RealityDataSourceKey): string;

--- a/common/changes/@itwin/core-frontend/OPCFromLocalHTTPServer_2021-11-01-13-15.json
+++ b/common/changes/@itwin/core-frontend/OPCFromLocalHTTPServer_2021-11-01-13-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Support to open OPC file from local hosted server (http-server)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/OPCFromLocalHTTPServer_2021-11-01-13-15.json
+++ b/common/changes/@itwin/core-frontend/OPCFromLocalHTTPServer_2021-11-01-13-15.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Support to open OPC file from local hosted server (http-server)",
+      "comment": "Support to open OPC file from any server",
       "type": "none"
     }
   ],

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -59,8 +59,14 @@ export namespace RealityDataSource {
   export function keyToString(rdSourceKey: RealityDataSourceKey): string {
     return `${rdSourceKey.provider}:${rdSourceKey.format}:${rdSourceKey.id}:${rdSourceKey.iTwinId}`;
   }
+  export function formatfromUrl(tilesetUrl: string): RealityDataFormat {
+    let format = RealityDataFormat.ThreeDTile;
+    if (tilesetUrl.includes(".opc"))
+      format = RealityDataFormat.OPC;
+    return format;
+  }
   export function createKeyFromUrl(tilesetUrl: string, inputProvider?: RealityDataProvider, inputFormat?: RealityDataFormat): RealityDataSourceKey {
-    let format = inputFormat ? inputFormat : RealityDataFormat.ThreeDTile;
+    let format = inputFormat ? inputFormat : formatfromUrl(tilesetUrl);
     if (CesiumIonAssetProvider.isProviderUrl(tilesetUrl)) {
       const provider = inputProvider ? inputProvider : RealityDataProvider.CesiumIonAsset;
       const cesiumIonAssetKey: RealityDataSourceKey = { provider, format, id: tilesetUrl };

--- a/core/frontend/src/test/RealityDataSouce.test.ts
+++ b/core/frontend/src/test/RealityDataSouce.test.ts
@@ -72,6 +72,15 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.id).to.be.equal(tilesetUrl);
     expect(rdSourceKey.iTwinId).to.be.undefined;
   });
+  it("should handle creation from url to an OPC local file", () => {
+    // we detect format based on extension-> .opc -> OPC format, otherwise 3dTile
+    const tilesetUrl = "c:\\customserver\\myFile.opc";
+    const rdSourceKey = RealityDataSource.createKeyFromUrl(tilesetUrl);
+    expect(rdSourceKey.provider).to.equal(RealityDataProvider.TilesetUrl);
+    expect(rdSourceKey.format).to.equal(RealityDataFormat.OPC);
+    expect(rdSourceKey.id).to.be.equal(tilesetUrl);
+    expect(rdSourceKey.iTwinId).to.be.undefined;
+  });
   it("should handle invalid url and fallback to simply returns it in id as tileset url", () => {
     const tilesetUrl = "Anything that is not a valid url";
     const rdSourceKey = RealityDataSource.createKeyFromUrl(tilesetUrl);

--- a/core/frontend/src/tile/OrbitGtTileTree.ts
+++ b/core/frontend/src/tile/OrbitGtTileTree.ts
@@ -373,6 +373,7 @@ export namespace OrbitGtTileTree {
   export async function createOrbitGtTileTree(rdSourceKey: RealityDataSourceKey, iModel: IModelConnection, modelId: Id64String): Promise<TileTree | undefined> {
     const rdSource = await RealityDataSource.fromKey(rdSourceKey, iModel.iTwinId);
     const isContextShare = rdSourceKey.provider === RealityDataProvider.ContextShare;
+    const isTilestUrl = rdSourceKey.provider === RealityDataProvider.TilesetUrl;
 
     let blobStringUrl: string;
     if (isContextShare) {
@@ -385,6 +386,8 @@ export namespace OrbitGtTileTree {
       const token = await IModelApp.getAccessToken();
       const blobUrl = await realityData.getBlobUrl(token, docRootName);
       blobStringUrl = blobUrl.toString();
+    } else if (isTilestUrl) {
+      blobStringUrl = rdSourceKey.id;
     } else {
       const orbitGtBlobProps = RealityDataSource.createOrbitGtBlobPropsFromKey(rdSourceKey);
       if (orbitGtBlobProps === undefined)


### PR DESCRIPTION
Currently, the code extract the reality data type from context share or assume that we always have a 3dTile when hosted locally (e.g. from http.server)

This change extracts reality data format from the extension found in the tileset url when not from context share.