### PR TITLE
Planar mask inversion

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -5925,6 +5925,7 @@ export enum PlanarClipMaskPriority {
 
 // @public
 export interface PlanarClipMaskProps {
+    invert?: boolean;
     mode: PlanarClipMaskMode;
     modelIds?: CompressedId64Set;
     priority?: number;
@@ -5936,13 +5937,14 @@ export interface PlanarClipMaskProps {
 export class PlanarClipMaskSettings {
     clone(changedProps?: PlanarClipMaskProps): PlanarClipMaskSettings;
     get compressedModelIds(): CompressedId64Set | undefined;
-    static createByPriority(priority: number, transparency?: number): PlanarClipMaskSettings;
-    static createForElementsOrSubCategories(mode: PlanarClipMaskMode.IncludeElements | PlanarClipMaskMode.ExcludeElements | PlanarClipMaskMode.IncludeSubCategories, elementOrSubCategoryIds: Iterable<Id64String>, modelIds?: Iterable<Id64String>, transparency?: number): PlanarClipMaskSettings;
-    static createForModels(modelIds: Iterable<Id64String> | undefined, transparency?: number): PlanarClipMaskSettings;
+    static createByPriority(priority: number, transparency?: number, invert?: boolean): PlanarClipMaskSettings;
+    static createForElementsOrSubCategories(mode: PlanarClipMaskMode.IncludeElements | PlanarClipMaskMode.ExcludeElements | PlanarClipMaskMode.IncludeSubCategories, elementOrSubCategoryIds: Iterable<Id64String>, modelIds?: Iterable<Id64String>, transparency?: number, invert?: boolean): PlanarClipMaskSettings;
+    static createForModels(modelIds: Iterable<Id64String> | undefined, transparency?: number, invert?: boolean): PlanarClipMaskSettings;
     static defaults: PlanarClipMaskSettings;
     // (undocumented)
     equals(other: PlanarClipMaskSettings): boolean;
     static fromJSON(json?: PlanarClipMaskProps): PlanarClipMaskSettings;
+    readonly invert?: boolean;
     get isValid(): boolean;
     readonly mode: PlanarClipMaskMode;
     readonly modelIds?: OrderedId64Iterable;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -514,6 +514,12 @@ export interface BaseReaderOptions {
 }
 
 // @public
+export interface BasicPlanarClipMaskArgs {
+    invert?: boolean;
+    transparency?: number;
+}
+
+// @public
 export enum BatchType {
     PlanarClassifier = 2,
     Primary = 0,
@@ -2674,6 +2680,17 @@ export interface ElementLoadProps extends ElementLoadOptions {
     federationGuid?: GuidString;
     // (undocumented)
     id?: Id64String;
+}
+
+// @public
+export interface ElementPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
+    elementIds: Iterable<Id64String>;
+    exclude?: boolean;
+    modelIds?: Iterable<Id64String>;
+    // @internal (undocumented)
+    priority?: never;
+    // @internal (undocumented)
+    subCategoryIds?: never;
 }
 
 // @public
@@ -5375,6 +5392,19 @@ export interface ModelLoadProps {
 }
 
 // @public
+export interface ModelPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
+    // @internal (undocumented)
+    elementIds?: never;
+    // @internal (undocumented)
+    exclude?: never;
+    modelIds?: Iterable<Id64String>;
+    // @internal (undocumented)
+    priority?: never;
+    // @internal (undocumented)
+    subCategoryIds?: never;
+}
+
+// @public
 export interface ModelProps extends EntityProps {
     // (undocumented)
     isPrivate?: boolean;
@@ -5937,14 +5967,12 @@ export interface PlanarClipMaskProps {
 export class PlanarClipMaskSettings {
     clone(changedProps?: PlanarClipMaskProps): PlanarClipMaskSettings;
     get compressedModelIds(): CompressedId64Set | undefined;
-    static createByPriority(priority: number, transparency?: number, invert?: boolean): PlanarClipMaskSettings;
-    static createForElementsOrSubCategories(mode: PlanarClipMaskMode.IncludeElements | PlanarClipMaskMode.ExcludeElements | PlanarClipMaskMode.IncludeSubCategories, elementOrSubCategoryIds: Iterable<Id64String>, modelIds?: Iterable<Id64String>, transparency?: number, invert?: boolean): PlanarClipMaskSettings;
-    static createForModels(modelIds: Iterable<Id64String> | undefined, transparency?: number, invert?: boolean): PlanarClipMaskSettings;
+    static create(args: ModelPlanarClipMaskArgs | ElementPlanarClipMaskArgs | SubCategoryPlanarClipMaskArgs | PriorityPlanarClipMaskArgs): PlanarClipMaskSettings;
     static defaults: PlanarClipMaskSettings;
     // (undocumented)
     equals(other: PlanarClipMaskSettings): boolean;
     static fromJSON(json?: PlanarClipMaskProps): PlanarClipMaskSettings;
-    readonly invert?: boolean;
+    readonly invert: boolean;
     get isValid(): boolean;
     readonly mode: PlanarClipMaskMode;
     readonly modelIds?: OrderedId64Iterable;
@@ -6129,6 +6157,17 @@ export enum PrimitiveTypeCode {
     String = 2305,
     // (undocumented)
     Uninitialized = 0
+}
+
+// @public
+export interface PriorityPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
+    // @internal (undocumented)
+    elementIds?: never;
+    // @internal (undocumented)
+    exclude?: never;
+    // @internal (undocumented)
+    modelIds?: never;
+    priority: number;
 }
 
 // @beta
@@ -8242,6 +8281,18 @@ export class SubCategoryOverride {
     toJSON(): SubCategoryAppearance.Props;
     readonly transparency?: number;
     readonly weight?: number;
+}
+
+// @public
+export interface SubCategoryPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
+    // @internal (undocumented)
+    elementIds?: never;
+    // @internal (undocumented)
+    exclude?: never;
+    modelIds?: Iterable<Id64String>;
+    // @internal (undocumented)
+    priority?: never;
+    subCategoryIds: Iterable<Id64String>;
 }
 
 // @public

--- a/common/api/frontend-devtools.api.md
+++ b/common/api/frontend-devtools.api.md
@@ -1370,6 +1370,8 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
     // (undocumented)
     filterHit(hit: HitDetail, _out?: LocateResponse): Promise<LocateFilterStatus>;
     // (undocumented)
+    protected _invert: boolean;
+    // (undocumented)
     onCleanup(): Promise<void>;
     // (undocumented)
     onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled>;
@@ -1392,7 +1394,7 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
     // (undocumented)
     protected targetModelRequired(): boolean;
     // (undocumented)
-    protected _transparency?: number;
+    protected _transparency: number;
     // (undocumented)
     protected _useSelection: boolean;
 }
@@ -1702,7 +1704,7 @@ export class SetMapHigherPriorityMasking extends Tool {
     // (undocumented)
     parseAndRun(...args: string[]): Promise<boolean>;
     // (undocumented)
-    run(transparency?: number): Promise<boolean>;
+    run(transparency: number, invert: boolean): Promise<boolean>;
     // (undocumented)
     static toolId: string;
 }

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -39,6 +39,7 @@ beta;BaseLayerSettings
 beta;BaseMapLayerProps 
 beta;BaseMapLayerSettings 
 public;BaseReaderOptions
+public;BasicPlanarClipMaskArgs
 public;BatchType
 internal;class BentleyCloudRpcConfiguration 
 internal;BentleyCloudRpcManager 
@@ -200,6 +201,7 @@ public;ElementGraphicsRequestProps = PersistentGraphicsRequestProps | DynamicGra
 public;ElementIdsAndRangesProps
 public;ElementLoadOptions
 public;ElementLoadProps 
+public;ElementPlanarClipMaskArgs 
 public;ElementProps 
 public;EmphasizeElementsProps
 public;EmptyLocalization 
@@ -417,6 +419,7 @@ public;ModelGeometryChanges
 public;ModelGeometryChangesProps
 public;ModelIdAndGeometryGuid
 public;ModelLoadProps
+public;ModelPlanarClipMaskArgs 
 public;ModelProps 
 public;ModelQueryParams 
 public;ModelSelectorProps 
@@ -488,6 +491,7 @@ public;PositionalVectorTransform
 public;PositionalVectorTransformProps
 internal;PrimaryTileTreeId
 beta;PrimitiveTypeCode
+public;PriorityPlanarClipMaskArgs 
 beta;ProfileOptions
 public;Projection 
 public;ProjectionMethod = "None" | "TransverseMercator" | "SouthOrientedTransverseMercator" | "TransverseMercatorWisconsin" | "TransverseMercatorMinnesota" | "TransverseMercatorAffine" | "MercatorStandardParallel" | "Mercator" | "UniversalTransverseMercator" | "LambertConformalConicTwoParallels" | "LambertConformalConicBelgium" | "LambertConformalConicAffine" | "LambertConformalConicWisconsin" | "LambertConformalConicMinnesota" | "LambertConformalConicMichigan" | "LambertConformalConicOneParallel" | "AlbersEqualArea" | "NewZealandNationalGrid" | "ObliqueMercator1" | "ObliqueMercator2" | "TransverseMercatorOSTN97" | "TransverseMercatorOSTN02" | "TransverseMercatorOSTN15" | "Krovak" | "KrovakModified" | "ObliqueCylindricalSwiss" | "TransverseMercatorDenmarkSystem34" | "TransverseMercatorDenmarkSystem3499" | "TransverseMercatorDenmarkSystem3401" | "Cassini" | "Sinusoidal" | "VanDerGrinten" | "Bonne" | "Mollweide" | "EckertIV" | "EckertVI" | "GoodeHomolosine" | "Robinson" | "PlateCarree" | "MillerCylindrical" | "WinkelTripel" | "AzimuthalEqualArea" | "ObliqueStereographic" | "RectifiedSkewOrthomorphicCentered" | "RectifiedSkewOrthomorphicOrigin" | "ObliqueCylindricalHungary" | "Orthographic" | "AmericanPolyconic" | "LambertEquidistantAzimuthal" | "ObliqueMercatorMinnesota"
@@ -644,6 +648,7 @@ beta;StorageValue = string | number | boolean | undefined | Uint8Array
 public;SubCategoryAppearance
 public;SubCategoryAppearance
 public;SubCategoryOverride
+public;SubCategoryPlanarClipMaskArgs 
 public;SubCategoryProps 
 public;SubjectProps 
 beta;SubLayerId = string | number

--- a/common/changes/@itwin/core-common/planar-mask-inversion_2021-11-01-14-29.json
+++ b/common/changes/@itwin/core-common/planar-mask-inversion_2021-11-01-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Add support for inverting planar clip mask (inside vs outside)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/planar-mask-inversion_2021-11-01-14-29.json
+++ b/common/changes/@itwin/core-frontend/planar-mask-inversion_2021-11-01-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add support for inverting planar clip mask (inside vs outside)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/frontend-devtools/planar-mask-inversion_2021-11-01-14-29.json
+++ b/common/changes/@itwin/frontend-devtools/planar-mask-inversion_2021-11-01-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "Add support for inverting planar clip mask (inside vs outside)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/common/src/PlanarClipMask.ts
+++ b/core/common/src/PlanarClipMask.ts
@@ -59,6 +59,8 @@ export interface PlanarClipMaskProps {
   priority?: number;
   /** @see [[PlanarClipMaskSettings.transparency]]. */
   transparency?: number;
+  /** @see PlanarClipMaskSettings.invert */
+  invert?: boolean;
 }
 
 /** Describes how to mask the geometry of one [GeometricModel]($backend) for display. The mask is produced by projecting geometry from any number of other models -
@@ -88,6 +90,8 @@ export class PlanarClipMaskSettings {
    If no transparency is defined then the transparencies of the mask elements are used.
    */
   public readonly transparency?: number;
+  /** A value of true indicates that the mask should be inverted and only content within the mask should be displayed */
+  public readonly invert?: boolean;
   private readonly _modelIds?: CompressedId64Set;
   private readonly _subCategoryOrElementIds?: CompressedId64Set;
 
@@ -101,24 +105,26 @@ export class PlanarClipMaskSettings {
     if (!json || undefined === json.mode)
       return this.defaults;
 
-    return new PlanarClipMaskSettings(json.mode, json.transparency, json.modelIds, json.subCategoryOrElementIds, json.priority);
+    return new PlanarClipMaskSettings(json.mode, json.transparency, json.modelIds, json.subCategoryOrElementIds, json.priority, json.invert);
   }
 
   /** Create settings for [[PlanarClipMaskMode.Models]]. */
-  public static createForModels(modelIds: Iterable<Id64String> | undefined, transparency?: number): PlanarClipMaskSettings {
+  public static createForModels(modelIds: Iterable<Id64String> | undefined, transparency?: number, invert?: boolean): PlanarClipMaskSettings {
     return this.fromJSON({
       mode: PlanarClipMaskMode.Models,
       transparency,
       modelIds: modelIds ? CompressedId64Set.sortAndCompress(modelIds) : undefined,
+      invert,
     });
   }
 
   /** Create settings that filter by element or subcategory. */
   public static createForElementsOrSubCategories(mode: PlanarClipMaskMode.IncludeElements | PlanarClipMaskMode.ExcludeElements | PlanarClipMaskMode.IncludeSubCategories,
-    elementOrSubCategoryIds: Iterable<Id64String>, modelIds?: Iterable<Id64String>, transparency?: number): PlanarClipMaskSettings {
+    elementOrSubCategoryIds: Iterable<Id64String>, modelIds?: Iterable<Id64String>, transparency?: number, invert?: boolean): PlanarClipMaskSettings {
     return this.fromJSON({
       mode,
       transparency,
+      invert,
       modelIds: modelIds ? CompressedId64Set.sortAndCompress(modelIds) : undefined,
       subCategoryOrElementIds: CompressedId64Set.sortAndCompress(elementOrSubCategoryIds),
     });
@@ -127,8 +133,8 @@ export class PlanarClipMaskSettings {
   /** Create settings that mask by priority.
    * @see [[PlanarClipMaskPriority]] for default priority values based on model type.
    */
-  public static createByPriority(priority: number, transparency?: number) {
-    return new PlanarClipMaskSettings(PlanarClipMaskMode.Priority, transparency, undefined, undefined, priority);
+  public static createByPriority(priority: number, transparency?: number, invert?: boolean) {
+    return new PlanarClipMaskSettings(PlanarClipMaskMode.Priority, transparency, undefined, undefined, priority, invert);
   }
 
   /** Create JSON object representing this [[PlanarClipMaskSettings]] */
@@ -146,6 +152,9 @@ export class PlanarClipMaskSettings {
     if (undefined !== this.transparency)
       props.transparency = this.transparency;
 
+    if (undefined !== this.invert && this.invert)
+      props.invert = this.invert;
+
     return props;
   }
 
@@ -158,6 +167,7 @@ export class PlanarClipMaskSettings {
     return this.mode === other.mode &&
       this.priority === other.priority &&
       this.transparency === other.transparency &&
+      this.invert === other.invert &&
       this._modelIds === other._modelIds &&
       this._subCategoryOrElementIds === other._subCategoryOrElementIds;
   }
@@ -176,11 +186,12 @@ export class PlanarClipMaskSettings {
     });
   }
 
-  private constructor(mode: PlanarClipMaskMode, transparency?: number, modelIds?: CompressedId64Set, subCategoryOrElementIds?: CompressedId64Set, priority?: number) {
+  private constructor(mode: PlanarClipMaskMode, transparency?: number, modelIds?: CompressedId64Set, subCategoryOrElementIds?: CompressedId64Set, priority?: number, invert?: boolean) {
     this.mode = mode;
     this._modelIds = modelIds;
     this._subCategoryOrElementIds = subCategoryOrElementIds;
     this.priority = priority;
+    this.invert = invert;
     this.transparency = undefined !== transparency ? Math.max(0, Math.min(1, transparency)) : undefined;
 
     if (modelIds)

--- a/core/common/src/PlanarClipMask.ts
+++ b/core/common/src/PlanarClipMask.ts
@@ -90,7 +90,7 @@ export class PlanarClipMaskSettings {
    If no transparency is defined then the transparencies of the mask elements are used.
    */
   public readonly transparency?: number;
-  /** A value of true indicates that the mask should be inverted and only content within the mask should be displayed */
+  /** A value of true indicates that the mask should be inverted and only content within the mask should be displayed, in other words the area inside the mask is displayed rather than outside. */
   public readonly invert?: boolean;
   private readonly _modelIds?: CompressedId64Set;
   private readonly _subCategoryOrElementIds?: CompressedId64Set;

--- a/core/common/src/PlanarClipMask.ts
+++ b/core/common/src/PlanarClipMask.ts
@@ -78,7 +78,7 @@ export interface BasicPlanarClipMaskArgs {
  */
 export interface ModelPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
   /** @see [[PlanarClipMaskSettings.modelIds]]. */
-  modelIds?:Iterable<Id64String>;
+  modelIds?: Iterable<Id64String>;
   /** @internal */
   exclude?: never;
   /** @internal */
@@ -94,7 +94,7 @@ export interface ModelPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
  */
 export interface ElementPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
   /** @see [[PlanarClipMaskSettings.modelIds]]. */
-  modelIds?: Iterable<Id64String>
+  modelIds?: Iterable<Id64String>;
   /** The elements used by the mask. @see [[PlanarClipMaskSettings.subCategoryOrElementIds]]. */
   elementIds: Iterable<Id64String>;
   /** If true, creates a mask of [[PlanarClipMaskMode.ExcludeElements]]; otherwise, [[PlanarClipMaskMode.IncludeElements]]. */
@@ -110,7 +110,7 @@ export interface ElementPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
  */
 export interface SubCategoryPlanarClipMaskArgs extends BasicPlanarClipMaskArgs {
   /** @see [[PlanarClipMaskSettings.modelIds]]. */
-  modelIds?: Iterable<Id64String>
+  modelIds?: Iterable<Id64String>;
   /** The subcategories used by the mask. @see [[PlanarClipMaskSettings.subCategoryOrElementIds]]. */
   subCategoryIds: Iterable<Id64String>;
   /** @internal */

--- a/core/common/src/PlanarClipMask.ts
+++ b/core/common/src/PlanarClipMask.ts
@@ -163,7 +163,7 @@ export class PlanarClipMaskSettings {
    */
   public readonly transparency?: number;
   /** A value of true indicates that the mask should be inverted and only content within the mask should be displayed, in other words the area inside the mask is displayed rather than outside. */
-  public readonly invert?: boolean;
+  public readonly invert: boolean;
   private readonly _modelIds?: CompressedId64Set;
   private readonly _subCategoryOrElementIds?: CompressedId64Set;
 
@@ -180,35 +180,7 @@ export class PlanarClipMaskSettings {
     return new PlanarClipMaskSettings(json.mode, json.transparency, json.modelIds, json.subCategoryOrElementIds, json.priority, json.invert);
   }
 
-  /** Create settings for [[PlanarClipMaskMode.Models]]. */
-  public static createForModels(modelIds: Iterable<Id64String> | undefined, transparency?: number, invert?: boolean): PlanarClipMaskSettings {
-    return this.fromJSON({
-      mode: PlanarClipMaskMode.Models,
-      transparency,
-      modelIds: modelIds ? CompressedId64Set.sortAndCompress(modelIds) : undefined,
-      invert,
-    });
-  }
-
-  /** Create settings that filter by element or subcategory. */
-  public static createForElementsOrSubCategories(mode: PlanarClipMaskMode.IncludeElements | PlanarClipMaskMode.ExcludeElements | PlanarClipMaskMode.IncludeSubCategories,
-    elementOrSubCategoryIds: Iterable<Id64String>, modelIds?: Iterable<Id64String>, transparency?: number, invert?: boolean): PlanarClipMaskSettings {
-    return this.fromJSON({
-      mode,
-      transparency,
-      invert,
-      modelIds: modelIds ? CompressedId64Set.sortAndCompress(modelIds) : undefined,
-      subCategoryOrElementIds: CompressedId64Set.sortAndCompress(elementOrSubCategoryIds),
-    });
-  }
-
-  /** Create settings that mask by priority.
-   * @see [[PlanarClipMaskPriority]] for default priority values based on model type.
-   */
-  public static createByPriority(priority: number, transparency?: number, invert?: boolean) {
-    return new PlanarClipMaskSettings(PlanarClipMaskMode.Priority, transparency, undefined, undefined, priority, invert);
-  }
-
+  /** Create a new PlanarClipMaskSettings. */
   public static create(args: ModelPlanarClipMaskArgs | ElementPlanarClipMaskArgs | SubCategoryPlanarClipMaskArgs | PriorityPlanarClipMaskArgs): PlanarClipMaskSettings {
     const modelIds = args.modelIds ? CompressedId64Set.sortAndCompress(args.modelIds) : undefined;
     if (undefined !== args.priority)
@@ -236,8 +208,8 @@ export class PlanarClipMaskSettings {
     if (undefined !== this.transparency)
       props.transparency = this.transparency;
 
-    if (undefined !== this.invert && this.invert)
-      props.invert = this.invert;
+    if (this.invert)
+      props.invert = true;
 
     return props;
   }
@@ -275,7 +247,7 @@ export class PlanarClipMaskSettings {
     this._modelIds = modelIds;
     this._subCategoryOrElementIds = subCategoryOrElementIds;
     this.priority = priority;
-    this.invert = invert;
+    this.invert = true === invert;
     this.transparency = undefined !== transparency ? Math.max(0, Math.min(1, transparency)) : undefined;
 
     if (modelIds)

--- a/core/common/src/test/ContextRealityModel.test.ts
+++ b/core/common/src/test/ContextRealityModel.test.ts
@@ -86,7 +86,7 @@ describe("ContextRealityModel", () => {
     model = makeModel(props);
     model.appearanceOverrides = FeatureAppearance.fromJSON({ weight: 5 });
     model.classifiers!.add(new SpatialClassifier("0x123", "new"));
-    model.planarClipMaskSettings = PlanarClipMaskSettings.createByPriority(123);
+    model.planarClipMaskSettings = PlanarClipMaskSettings.create({ priority: 123 });
 
     expectProps(props, {
       tilesetUrl: "a",
@@ -165,7 +165,7 @@ describe("ContextRealityModel", () => {
     model.onPlanarClipMaskChanged.addListener((x, m) => { expect(m).to.equal(model); mask = x; });
     model.onAppearanceOverridesChanged.addListener((x, m) => { expect(m).to.equal(model); app = x; });
 
-    const newMask = model.planarClipMaskSettings = PlanarClipMaskSettings.createByPriority(1234);
+    const newMask = model.planarClipMaskSettings = PlanarClipMaskSettings.create({ priority: 1234 });
     expect(mask).to.equal(newMask);
     expect(model.planarClipMaskSettings).to.equal(newMask);
 
@@ -389,9 +389,9 @@ describe("ContextRealityModels", () => {
     }
 
     it("are dispatched when clip mask or appearance is changed", () => {
-      models.models[0].planarClipMaskSettings = PlanarClipMaskSettings.createByPriority(1);
+      models.models[0].planarClipMaskSettings = PlanarClipMaskSettings.create({ priority: 1 });
       models.models[1].appearanceOverrides = FeatureAppearance.fromJSON({ weight: 1 });
-      models.models[1].planarClipMaskSettings = PlanarClipMaskSettings.createByPriority(2);
+      models.models[1].planarClipMaskSettings = PlanarClipMaskSettings.create({ priority: 2 });
       models.models[0].appearanceOverrides = undefined;
 
       expectEvents([
@@ -406,9 +406,9 @@ describe("ContextRealityModels", () => {
       const m0 = models.models[0];
       const m1 = models.models[1];
 
-      m0.planarClipMaskSettings = PlanarClipMaskSettings.createByPriority(1);
+      m0.planarClipMaskSettings = PlanarClipMaskSettings.create({ priority: 1 });
       models.delete(m0);
-      m0.planarClipMaskSettings = PlanarClipMaskSettings.createByPriority(2);
+      m0.planarClipMaskSettings = PlanarClipMaskSettings.create({ priority: 2 });
 
       m1.appearanceOverrides = FeatureAppearance.fromJSON({ weight: 1 });
       models.clear();

--- a/core/common/src/test/DisplayStyle.test.ts
+++ b/core/common/src/test/DisplayStyle.test.ts
@@ -192,7 +192,7 @@ describe("DisplayStyleSettings", () => {
 
   describe("planarClipMasks", () => {
     function makeSettings(priority: number) {
-      return PlanarClipMaskSettings.createByPriority(priority);
+      return PlanarClipMaskSettings.create({ priority });
     }
 
     function makeProps(priority: number, modelId: Id64String) {

--- a/core/common/src/test/PlanarClipMaskSettings.test.ts
+++ b/core/common/src/test/PlanarClipMaskSettings.test.ts
@@ -19,32 +19,35 @@ describe("PlanarClipMaskSettings", () => {
   });
 
   it("clamps transparency", () => {
-    expect(PlanarClipMaskSettings.createByPriority(1, -0.1).transparency).to.equal(0);
-    expect(PlanarClipMaskSettings.createByPriority(1, 0).transparency).to.equal(0);
-    expect(PlanarClipMaskSettings.createByPriority(1, 0.1).transparency).to.equal(0.1);
-    expect(PlanarClipMaskSettings.createByPriority(1, 0.9).transparency).to.equal(0.9);
-    expect(PlanarClipMaskSettings.createByPriority(1, 1).transparency).to.equal(1);
-    expect(PlanarClipMaskSettings.createByPriority(1, 1.1).transparency).to.equal(1);
+    expect(PlanarClipMaskSettings.create({ priority: 1, transparency: -0.1 }).transparency).to.equal(0);
+    expect(PlanarClipMaskSettings.create({ priority: 1, transparency: 0 }).transparency).to.equal(0);
+    expect(PlanarClipMaskSettings.create({ priority: 1, transparency: 0.1 }).transparency).to.equal(0.1);
+    expect(PlanarClipMaskSettings.create({ priority: 1, transparency: 0.9 }).transparency).to.equal(0.9);
+    expect(PlanarClipMaskSettings.create({ priority: 1, transparency: 1 }).transparency).to.equal(1);
+    expect(PlanarClipMaskSettings.create({ priority: 1, transparency: 1.1 }).transparency).to.equal(1);
   });
 
   it("creates for models", () => {
-    expectProps(PlanarClipMaskSettings.createForModels(undefined), { mode: PlanarClipMaskMode.Models });
-    expectProps(PlanarClipMaskSettings.createForModels(["0x3", "0x1"]), { mode: PlanarClipMaskMode.Models, modelIds: "+1+2" });
-    expectProps(PlanarClipMaskSettings.createForModels("0xabc", 0.5), { mode: PlanarClipMaskMode.Models, modelIds: "+ABC", transparency: 0.5 });
+    expectProps(PlanarClipMaskSettings.create({ }), { mode: PlanarClipMaskMode.Models });
+    expectProps(PlanarClipMaskSettings.create({ modelIds: undefined }), { mode: PlanarClipMaskMode.Models });
+    expectProps(PlanarClipMaskSettings.create({ modelIds: ["0x3", "0x1"] }), { mode: PlanarClipMaskMode.Models, modelIds: "+1+2" });
+    expectProps(PlanarClipMaskSettings.create({ modelIds: "0xabc", transparency: 0.5 }), { mode: PlanarClipMaskMode.Models, modelIds: "+ABC", transparency: 0.5 });
   });
 
   it("creates for elements or subcategories", () => {
-    expectProps(PlanarClipMaskSettings.createForElementsOrSubCategories(PlanarClipMaskMode.IncludeElements, "0x5"),
+    expectProps(PlanarClipMaskSettings.create({ elementIds: "0x5" }),
       { mode: PlanarClipMaskMode.IncludeElements, subCategoryOrElementIds: "+5"});
-    expectProps(PlanarClipMaskSettings.createForElementsOrSubCategories(PlanarClipMaskMode.ExcludeElements, ["0x1", "0x5"], "0x2"),
+
+    expectProps(PlanarClipMaskSettings.create({ elementIds: ["0x1", "0x5"], modelIds: "0x2", exclude: true }),
       { mode: PlanarClipMaskMode.ExcludeElements, subCategoryOrElementIds: "+1+4", modelIds: "+2" });
-    expectProps(PlanarClipMaskSettings.createForElementsOrSubCategories(PlanarClipMaskMode.IncludeSubCategories, "0x2", undefined, 0.5),
+
+    expectProps(PlanarClipMaskSettings.create({ subCategoryIds: "0x2", transparency: 0.5 }),
       { mode: PlanarClipMaskMode.IncludeSubCategories, subCategoryOrElementIds: "+2", transparency: 0.5 });
   });
 
   it("creates by priority", () => {
-    expectProps(PlanarClipMaskSettings.createByPriority(1234), { mode: PlanarClipMaskMode.Priority, priority: 1234 });
-    expectProps(PlanarClipMaskSettings.createByPriority(-321, 0.75), { mode: PlanarClipMaskMode.Priority, priority: -321, transparency: 0.75 });
+    expectProps(PlanarClipMaskSettings.create({ priority: 1234 }), { mode: PlanarClipMaskMode.Priority, priority: 1234 });
+    expectProps(PlanarClipMaskSettings.create({ priority: -321, transparency: 0.75 }), { mode: PlanarClipMaskMode.Priority, priority: -321, transparency: 0.75 });
   });
 
   it("clones", () => {

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -196,19 +196,19 @@ These keyins control the planar masking of the background map.
 
 * `fdt set map mask by priority`  Set the background map to be masked based on priority.  Masking by priority will mask by higher priority models.  By default background map have lowest priorty (-2048) Unless their priority is overridden reality models are higher priority and BIM models are always higher priority, therefore if priority masking is selected then the background map will be masked by all reality and BIM models. A value for transparency may optionally be included.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask elements` Set the background map to be masked by one or more elements.  If elements are already selected they are used for the mask, otherwise the mask elements may be selected individually.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask exclude elements` Set the background map to be masked by all elements except the selected (or individually picked) excluded elements.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask models` Set the background map to be masked by the selected models.  The selected models can come from either the current selection set or can be picked individually.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask subcategory` Set the background map to be masked by one or more picked subcategories.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt unmask map`  Removes the current background map masks.
 
 #### Reality model planar masks
@@ -218,19 +218,19 @@ These keysins control the planar masking of reality models.
 * `fdt set reality model mask by priority` Set the reality model to masked based on priority.  Masking by priority will cause the masked model to be masked by all higher priority models.  By default global reality models (such as the OpenStreetMap building layer) have a priority of -1024 and standard reality models have a priority of zero.  BIM models have a priority of 1024.  Therefore with default priorities reality models are always masked by BIM model and global reality models are masked by standard reality models.  By specifying a priority bias for the when creating the masks for a reality model the masking of reality models by other reality models can be controlled.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
   * `priority`: (optional) - A bias to be applied to the default reality model priority.  As lower priority models are masked by higher priority ones, specifying a priority of -1 would cause the reality model to be masked by other reality models.
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask models`
   * `transparency`: (optional)- A value for the mask transparency override.  A value of 0 (the default) will completely mask the reality model, higher values will produce less masking and more more map display [0..1]  If no transparency is included then the transparency value from the mask elements is used.
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask elements` Set the reality model to be masked by one or more elements.  If elements are already selected they are used for the mask, otherwise the mask elements may be selected individually.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask exclude elements` Set a reality model to be masked by all elements except the selected (or individually picked) excluded elements.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask subcategory` Set a reality mdel to be masked by one or more picked subcategories.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed
+  * `invert`: (optional) - If `on` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed
 * `fdt unmask reality model` Removes the masks from the selected reality model.
 
 ### Other key-ins

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -188,7 +188,7 @@ Reality models can be attached to a display style to provide context when that d
 ### Planar Mask keyins
 
 This package supplies several keyins to control planar masking for background maps and reality models. These masks provide a two and a half dimensional method for masking the regions where the background map, reality models and BIM geometry overlap.
-Planar masks include an optional transparency override.  If a transparency values is specified, a value of 0 will completely mask the reality model  - the masked portion will be omitted completely, higher values will produce less masking and a semit translucent display of the masked geometry. If no transparency is included then the transparency value from the mask elements is used.
+Planar masks include an optional transparency override.  If a transparency values is specified, a value of 0 will completely mask the reality model  - the masked portion will be omitted completely, higher values will produce less masking and a semit translucent display of the masked geometry. If no transparency is included then the transparency value from the mask elements is used.  An additional argument boolean argument will invert the mask and mask the area outside the mask geometry rather than inside.
 
 #### Background map planar masks
 
@@ -196,15 +196,19 @@ These keyins control the planar masking of the background map.
 
 * `fdt set map mask by priority`  Set the background map to be masked based on priority.  Masking by priority will mask by higher priority models.  By default background map have lowest priorty (-2048) Unless their priority is overridden reality models are higher priority and BIM models are always higher priority, therefore if priority masking is selected then the background map will be masked by all reality and BIM models. A value for transparency may optionally be included.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
-  * `priority`: (optional) - A bias to be applied to the default reality model priority.  As lower priority models are masked by higher priority ones, specifying a priority of -1 would cause the reality model to be masked by other reality models.
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask elements` Set the background map to be masked by one or more elements.  If elements are already selected they are used for the mask, otherwise the mask elements may be selected individually.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask exclude elements` Set the background map to be masked by all elements except the selected (or individually picked) excluded elements.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask models` Set the background map to be masked by the selected models.  The selected models can come from either the current selection set or can be picked individually.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set map mask subcategory` Set the background map to be masked by one or more picked subcategories.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt unmask map`  Removes the current background map masks.
 
 #### Reality model planar masks
@@ -214,14 +218,19 @@ These keysins control the planar masking of reality models.
 * `fdt set reality model mask by priority` Set the reality model to masked based on priority.  Masking by priority will cause the masked model to be masked by all higher priority models.  By default global reality models (such as the OpenStreetMap building layer) have a priority of -1024 and standard reality models have a priority of zero.  BIM models have a priority of 1024.  Therefore with default priorities reality models are always masked by BIM model and global reality models are masked by standard reality models.  By specifying a priority bias for the when creating the masks for a reality model the masking of reality models by other reality models can be controlled.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
   * `priority`: (optional) - A bias to be applied to the default reality model priority.  As lower priority models are masked by higher priority ones, specifying a priority of -1 would cause the reality model to be masked by other reality models.
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask models`
   * `transparency`: (optional)- A value for the mask transparency override.  A value of 0 (the default) will completely mask the reality model, higher values will produce less masking and more more map display [0..1]  If no transparency is included then the transparency value from the mask elements is used.
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask elements` Set the reality model to be masked by one or more elements.  If elements are already selected they are used for the mask, otherwise the mask elements may be selected individually.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask exclude elements` Set a reality model to be masked by all elements except the selected (or individually picked) excluded elements.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed.
 * `fdt set reality model mask subcategory` Set a reality mdel to be masked by one or more picked subcategories.
   * `transparency`: (optional) - A value for the mask transparency override. [0...1]
+  * `invert`: (optional) - If `1 ` or `true` then the mask sense is inverted and the area outside the mask geometry will be masked and the area inside the mask is displayed
 * `fdt unmask reality model` Removes the masks from the selected reality model.
 
 ### Other key-ins

--- a/core/frontend-devtools/src/tools/PlanarMaskTools.ts
+++ b/core/frontend-devtools/src/tools/PlanarMaskTools.ts
@@ -174,16 +174,26 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
   }
 
   protected createSubCategoryMask() {
-    return PlanarClipMaskSettings.createForElementsOrSubCategories(PlanarClipMaskMode.IncludeSubCategories, this._acceptedSubCategoryIds, this._acceptedModelIds, this._transparency, this._invert);
+    return PlanarClipMaskSettings.create({
+      subCategoryIds: this._acceptedSubCategoryIds,
+      modelIds: this._acceptedModelIds,
+      transparency: this._transparency,
+      invert: this._invert,
+    });
   }
 
   protected createElementMask(option: "include" | "exclude") {
-    const mode = "include" === option ? PlanarClipMaskMode.IncludeElements : PlanarClipMaskMode.ExcludeElements;
-    return PlanarClipMaskSettings.createForElementsOrSubCategories(mode, this._acceptedElementIds, this._acceptedModelIds, this._transparency, this._invert);
+    return PlanarClipMaskSettings.create({
+      elementIds: this._acceptedElementIds,
+      exclude: "exclude" === option,
+      modelIds: this._acceptedModelIds,
+      transparency: this._transparency,
+      invert: this._invert,
+    });
   }
 
   protected createModelMask() {
-    return PlanarClipMaskSettings.createForModels(this._acceptedModelIds, this._transparency, this._invert);
+    return PlanarClipMaskSettings.create({ modelIds: this._acceptedModelIds, transparency: this._transparency, invert: this._invert });
   }
 
   protected setRealityModelMask(vp: ScreenViewport, mask: PlanarClipMaskSettings): void {
@@ -357,7 +367,7 @@ export class SetHigherPriorityRealityModelMasking extends PlanarMaskBaseTool {
   protected createToolInstance(): PlanarMaskBaseTool { return new SetHigherPriorityRealityModelMasking(); }
   protected applyMask(vp: ScreenViewport): void {
     const basePriority = this._targetMaskModel === vp.displayStyle.getOSMBuildingRealityModel() ? PlanarClipMaskPriority.GlobalRealityModel : PlanarClipMaskPriority.RealityModel;
-    this.setRealityModelMask(vp, PlanarClipMaskSettings.createByPriority(basePriority + this._priority, this._transparency, this._invert)!);
+    this.setRealityModelMask(vp, PlanarClipMaskSettings.create({ priority: basePriority + this._priority, transparency: this._transparency, invert: this._invert }));
   }
 
   public override async parseAndRun(...args: string[]): Promise<boolean> {
@@ -388,7 +398,7 @@ export class UnmaskRealityModelTool extends PlanarMaskBaseTool {
   }
   protected createToolInstance(): PlanarMaskBaseTool { return new UnmaskRealityModelTool(); }
   protected applyMask(vp: ScreenViewport): void {
-    const settings = PlanarClipMaskSettings.createForElementsOrSubCategories(PlanarClipMaskMode.IncludeSubCategories, this._acceptedSubCategoryIds, this._acceptedModelIds);
+    const settings = PlanarClipMaskSettings.create({ subCategoryIds: this._acceptedSubCategoryIds, modelIds: this._acceptedModelIds });
     this.setRealityModelMask(vp, settings);
   }
   public override async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {

--- a/core/frontend-devtools/src/tools/PlanarMaskTools.ts
+++ b/core/frontend-devtools/src/tools/PlanarMaskTools.ts
@@ -12,6 +12,7 @@ import { PlanarClipMaskMode, PlanarClipMaskPriority, PlanarClipMaskSettings } fr
 import {
   BeButtonEvent, ContextRealityModelState, EventHandled, HitDetail, IModelApp, LocateFilterStatus, LocateResponse, PrimitiveTool, ScreenViewport, Tool,
 } from "@itwin/core-frontend";
+import { parseBoolean } from "./parseBoolean";
 
 /** Set Map Masking by selected models.
  * @beta
@@ -19,7 +20,7 @@ import {
 export class SetMapHigherPriorityMasking extends Tool {
   public static override toolId = "SetMapHigherPriorityMask";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
 
   public override async run(transparency?: number): Promise<boolean> {
     const vp = IModelApp.viewManager.selectedView;
@@ -65,6 +66,7 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
   protected readonly _acceptedElementIds = new Set<Id64String>();
   protected _transparency?: number;
   protected _useSelection: boolean = false;
+  protected _invert?: boolean;
   protected _targetMaskModel?: Id64String | ContextRealityModelState;
 
   public override requireWriteableTarget(): boolean { return false; }
@@ -103,6 +105,9 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
   public override async parseAndRun(...args: string[]): Promise<boolean> {
     const transparency = parseFloat(args[0]);
     this._transparency = (transparency !== undefined && transparency < 1.0) ? transparency : undefined;
+    if (args.length > 1)
+      this._invert = parseBoolean(args[1]);
+
     return this.run();
   }
 
@@ -166,16 +171,16 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
   }
 
   protected createSubCategoryMask() {
-    return PlanarClipMaskSettings.createForElementsOrSubCategories(PlanarClipMaskMode.IncludeSubCategories, this._acceptedSubCategoryIds, this._acceptedModelIds, this._transparency);
+    return PlanarClipMaskSettings.createForElementsOrSubCategories(PlanarClipMaskMode.IncludeSubCategories, this._acceptedSubCategoryIds, this._acceptedModelIds, this._transparency, this._invert);
   }
 
   protected createElementMask(option: "include" | "exclude") {
     const mode = "include" === option ? PlanarClipMaskMode.IncludeElements : PlanarClipMaskMode.ExcludeElements;
-    return PlanarClipMaskSettings.createForElementsOrSubCategories(mode, this._acceptedElementIds, this._acceptedModelIds, this._transparency);
+    return PlanarClipMaskSettings.createForElementsOrSubCategories(mode, this._acceptedElementIds, this._acceptedModelIds, this._transparency, this._invert);
   }
 
   protected createModelMask() {
-    return PlanarClipMaskSettings.createForModels(this._acceptedModelIds, this._transparency);
+    return PlanarClipMaskSettings.createForModels(this._acceptedModelIds, this._transparency, this._invert);
   }
 
   protected setRealityModelMask(vp: ScreenViewport, mask: PlanarClipMaskSettings): void {
@@ -191,7 +196,7 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
 export class MaskBackgroundMapByElementTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskBackgroundMapByElement";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   protected override targetModelRequired() { return false; }
   protected showPrompt(): void {
     IModelApp.notifications.outputPromptByKey(`FrontendDevTools:tools.MaskBackgroundMapByElement.Prompts.${this._useSelection ? "AcceptSelection" : "IdentifyMaskElement"}`);
@@ -207,7 +212,7 @@ export class MaskBackgroundMapByElementTool extends PlanarMaskBaseTool {
 export class MaskBackgroundMapByExcludedElementTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskBackgroundMapByExcludedElement";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   protected override targetModelRequired() { return false; }
   protected showPrompt(): void {
     IModelApp.notifications.outputPromptByKey(`FrontendDevTools:tools.MaskBackgroundMapByExcludedElement.Prompts.${this._useSelection ? "AcceptSelection" : "IdentifyMaskElement"}`);
@@ -224,7 +229,7 @@ export class MaskBackgroundMapByExcludedElementTool extends PlanarMaskBaseTool {
 export class MaskBackgroundMapBySubCategoryTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskBackgroundMapBySubCategory";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   protected override targetModelRequired() { return false; }
   protected override allowSelection(): boolean { return false; }   // Need picking to get subcategory.
   protected showPrompt(): void {
@@ -242,7 +247,7 @@ export class MaskBackgroundMapBySubCategoryTool extends PlanarMaskBaseTool {
 export class MaskBackgroundMapByModelTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskBackgroundMapByModel";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   protected override targetModelRequired() { return false; }
   protected showPrompt(): void {
     IModelApp.notifications.outputPromptByKey(`FrontendDevTools:tools.MaskBackgroundMapByModel.Prompts.${this._useSelection ? "AcceptSelection" : "IdentifyMaskModel"}`);
@@ -259,7 +264,7 @@ export class MaskBackgroundMapByModelTool extends PlanarMaskBaseTool {
 export class MaskRealityModelByElementTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskRealityModelByElement";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   protected override targetModelRequired() { return true; }
 
   protected showPrompt(): void {
@@ -278,7 +283,7 @@ export class MaskRealityModelByElementTool extends PlanarMaskBaseTool {
 export class MaskRealityModelByExcludedElementTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskRealityModelByExcludedElement";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   protected override targetModelRequired() { return true; }
 
   protected showPrompt(): void {
@@ -298,7 +303,7 @@ export class MaskRealityModelByExcludedElementTool extends PlanarMaskBaseTool {
 export class MaskRealityModelByModelTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskRealityModelByModel";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
 
   protected override targetModelRequired() { return true; }
 
@@ -318,7 +323,7 @@ export class MaskRealityModelByModelTool extends PlanarMaskBaseTool {
 export class MaskRealityModelBySubCategoryTool extends PlanarMaskBaseTool {
   public static override toolId = "MaskRealityModelBySubCategory";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   protected override targetModelRequired() { return true; }
   protected override allowSelection(): boolean { return false; }   // Need picking to get subcategory.
 
@@ -338,7 +343,7 @@ export class MaskRealityModelBySubCategoryTool extends PlanarMaskBaseTool {
 export class SetHigherPriorityRealityModelMasking extends PlanarMaskBaseTool {
   public static override toolId = "SetHigherPriorityRealityModelMasking";
   public static override get minArgs() { return 0; }
-  public static override get maxArgs() { return 2; }
+  public static override get maxArgs() { return 3; }
   protected override targetModelRequired() { return true; }
   protected override elementRequired() { return false; }
   private _priority = 0;
@@ -349,13 +354,21 @@ export class SetHigherPriorityRealityModelMasking extends PlanarMaskBaseTool {
   protected createToolInstance(): PlanarMaskBaseTool { return new SetHigherPriorityRealityModelMasking(); }
   protected applyMask(vp: ScreenViewport): void {
     const basePriority = this._targetMaskModel === vp.displayStyle.getOSMBuildingRealityModel() ? PlanarClipMaskPriority.GlobalRealityModel : PlanarClipMaskPriority.RealityModel;
-    this.setRealityModelMask(vp, PlanarClipMaskSettings.createByPriority(basePriority + this._priority, this._transparency)!);
+    this.setRealityModelMask(vp, PlanarClipMaskSettings.createByPriority(basePriority + this._priority, this._transparency, this._invert)!);
   }
 
   public override async parseAndRun(...args: string[]): Promise<boolean> {
     await super.parseAndRun(...args);
     const priority = parseInt(args[0], 10);
     this._priority = (priority === undefined || isNaN(priority)) ? 0 : priority;
+    if (args.length > 1) {
+      const value = parseInt(args[1], 10);
+      if (!isNaN(value) && value >= 0 && value <= 1)
+        this._transparency = value;
+    }
+    if (args.length > 2)
+      this._invert = parseBoolean(args[2]);
+
     return this.run();
   }
 }

--- a/core/frontend/src/render/webgl/PlanarClassifier.ts
+++ b/core/frontend/src/render/webgl/PlanarClassifier.ts
@@ -361,6 +361,8 @@ export class PlanarClassifier extends RenderPlanarClassifier implements RenderMe
     params[1] = this.outsideDisplay;
     params[2] = this._contentMode;
     params[3] = (this._planarClipMask?.settings.transparency === undefined) ? -1 : this._planarClipMask.settings.transparency;
+    if (this._planarClipMask?.settings.invert)
+      params[2] = - params[2];
   }
 
   public get hiliteTexture(): Texture | undefined { return undefined !== this._classifierBuffers ? this._classifierBuffers.textures.hilite : undefined; }

--- a/core/frontend/src/render/webgl/PlanarClassifier.ts
+++ b/core/frontend/src/render/webgl/PlanarClassifier.ts
@@ -360,9 +360,11 @@ export class PlanarClassifier extends RenderPlanarClassifier implements RenderMe
     params[0] = this.insideDisplay;
     params[1] = this.outsideDisplay;
     params[2] = this._contentMode;
-    params[3] = (this._planarClipMask?.settings.transparency === undefined) ? -1 : this._planarClipMask.settings.transparency;
-    if (this._planarClipMask?.settings.invert)
+    if (this._planarClipMask?.settings.invert)   // If the mask sense is inverted, negate the contentMode to indicate this to the shader.
       params[2] = - params[2];
+
+    params[3] = (this._planarClipMask?.settings.transparency === undefined) ? -1 : this._planarClipMask.settings.transparency;
+
   }
 
   public get hiliteTexture(): Texture | undefined { return undefined !== this._classifierBuffers ? this._classifierBuffers.textures.hilite : undefined; }

--- a/core/frontend/src/render/webgl/glsl/PlanarClassification.ts
+++ b/core/frontend/src/render/webgl/glsl/PlanarClassification.ts
@@ -51,6 +51,11 @@ if (u_pClassColorParams.x > kClassifierDisplay_Element) { // texture/terrain dra
   return vec4(rgb, baseColor.a);
 }
 float imageCount = u_pClassColorParams.z;
+bool doInvert = false;
+if (imageCount < 0.0) {
+  imageCount = - imageCount;
+  doInvert = true;
+}
 
 vec4 colorTexel = vec4(0);
 vec4 maskTexel = vec4(0);
@@ -77,7 +82,10 @@ if (!isOutside) {
   }
 }
 if (doMask) {
-  if (!isOutside && (maskTexel.r + maskTexel.g + maskTexel.b + maskTexel.a > 0.0)) {
+  bool masked = !isOutside && (maskTexel.r + maskTexel.g + maskTexel.b + maskTexel.a) > 0.0;
+  if (doInvert)
+    masked = !masked;
+  if (masked) {
     float   maskTransparency = u_pClassColorParams.w < 0.0 ? (1.0 - maskTexel.a) : u_pClassColorParams.w;
     if (maskTransparency <= 0.0) {
       discard;

--- a/core/frontend/src/render/webgl/glsl/PlanarClassification.ts
+++ b/core/frontend/src/render/webgl/glsl/PlanarClassification.ts
@@ -51,6 +51,7 @@ if (u_pClassColorParams.x > kClassifierDisplay_Element) { // texture/terrain dra
   return vec4(rgb, baseColor.a);
 }
 float imageCount = u_pClassColorParams.z;
+// If imageCount is less than zero - the mask sense is inverted - inside rather than outside.  (masks only)
 bool doInvert = false;
 if (imageCount < 0.0) {
   imageCount = - imageCount;


### PR DESCRIPTION
Add support for inverting planar clip masks to mask outside rather than inside.   This is useful for confining either reality model or background maps to the interior of a mask.
Addresses #2585.