### PR TITLE
Presentation: Get content instance keys

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3912,7 +3912,7 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
     // (undocumented)
     protected changeElementGroupingNodeState(key: ECClassGroupingNodeKey, on: boolean): Promise<void>;
     // (undocumented)
-    protected changeElementsState(modelId: Id64String | undefined, categoryId: Id64String | undefined, elementIds: Id64String[], on: boolean): void;
+    protected changeElementsState(modelId: Id64String | undefined, categoryId: Id64String | undefined, elementIds: AsyncGenerator<Id64String>, on: boolean): Promise<void>;
     // (undocumented)
     protected changeElementState(id: Id64String, modelId: Id64String | undefined, categoryId: Id64String | undefined, on: boolean): Promise<void>;
     // (undocumented)

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -274,6 +274,15 @@ export enum ContentFlags {
     ShowLabels = 4
 }
 
+// @alpha
+export interface ContentInstanceKeysRequestOptions<TIModel, TKeySet, TRulesetVariable = RulesetVariable> extends Paged<RequestOptionsWithRuleset<TIModel, TRulesetVariable>> {
+    displayType?: string;
+    keys: TKeySet;
+}
+
+// @alpha
+export type ContentInstanceKeysRpcRequestOptions = PresentationRpcRequestOptions<ContentInstanceKeysRequestOptions<never, KeySetJSON, RulesetVariableJSON>>;
+
 // @public
 export interface ContentInstancesOfSpecificClassesSpecification extends ContentSpecificationBase {
     classes: MultiSchemaClassesSpecification | MultiSchemaClassesSpecification[];
@@ -1878,6 +1887,11 @@ export class PresentationRpcInterface extends RpcInterface {
     computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string): PresentationRpcResponse<KeySetJSON>;
     // (undocumented)
     getContentDescriptor(_token: IModelRpcProps, _options: ContentDescriptorRpcRequestOptions): PresentationRpcResponse<DescriptorJSON | undefined>;
+    // @alpha (undocumented)
+    getContentInstanceKeys(_token: IModelRpcProps, _options: ContentInstanceKeysRpcRequestOptions): PresentationRpcResponse<{
+        total: number;
+        items: KeySetJSON;
+    }>;
     // (undocumented)
     getContentSetSize(_token: IModelRpcProps, _options: ContentRpcRequestOptions): PresentationRpcResponse<number>;
     // @beta (undocumented)
@@ -2410,6 +2424,11 @@ export class RpcRequestsHandler implements IDisposable {
     dispose(): void;
     // (undocumented)
     getContentDescriptor(options: ContentDescriptorRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON>): Promise<DescriptorJSON | undefined>;
+    // (undocumented)
+    getContentInstanceKeys(options: ContentInstanceKeysRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON>): Promise<{
+        total: number;
+        items: KeySetJSON;
+    }>;
     // (undocumented)
     getContentSetSize(options: ContentRequestOptions<IModelRpcProps, DescriptorOverrides, KeySetJSON, RulesetVariableJSON>): Promise<number>;
     // (undocumented)

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -7,6 +7,7 @@
 import { BeEvent } from '@itwin/core-bentley';
 import { Content } from '@itwin/presentation-common';
 import { ContentDescriptorRequestOptions } from '@itwin/presentation-common';
+import { ContentInstanceKeysRequestOptions } from '@itwin/presentation-common';
 import { ContentRequestOptions } from '@itwin/presentation-common';
 import { ContentSourcesRequestOptions } from '@itwin/presentation-common';
 import { ContentUpdateInfo } from '@itwin/presentation-common';
@@ -75,7 +76,7 @@ export class BrowserLocalFavoritePropertiesStorage implements IFavoritePropertie
 }
 
 // @internal (undocumented)
-export const buildPagedResponse: <TItem>(requestedPage: PageOptions | undefined, getter: (page: Required<PageOptions>, requestIndex: number) => Promise<PagedResponse<TItem>>) => Promise<PagedResponse<TItem>>;
+export const buildPagedArrayResponse: <TItem>(requestedPage: PageOptions | undefined, getter: (page: Required<PageOptions>, requestIndex: number) => Promise<PagedResponse<TItem>>) => Promise<PagedResponse<TItem>>;
 
 // @alpha (undocumented)
 export function consoleDiagnosticsHandler(scopeLogs: DiagnosticsScopeLogs[]): void;
@@ -295,6 +296,11 @@ export class PresentationManager implements IDisposable {
         size: number;
     } | undefined>;
     getContentDescriptor(requestOptions: ContentDescriptorRequestOptions<IModelConnection, KeySet, RulesetVariable>): Promise<Descriptor | undefined>;
+    // @alpha
+    getContentInstanceKeys(requestOptions: ContentInstanceKeysRequestOptions<IModelConnection, KeySet, RulesetVariable>): Promise<{
+        total: number;
+        items: () => AsyncGenerator<InstanceKey>;
+    }>;
     getContentSetSize(requestOptions: ContentRequestOptions<IModelConnection, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>): Promise<number>;
     // @beta
     getContentSources(requestOptions: ContentSourcesRequestOptions<IModelConnection>): Promise<SelectClassInfo[]>;

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -33,6 +33,8 @@ public;Content
 public;ContentDescriptorRequestOptions
 public;ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions
 public;ContentFlags
+alpha;ContentInstanceKeysRequestOptions
+alpha;ContentInstanceKeysRpcRequestOptions = PresentationRpcRequestOptions
 public;ContentInstancesOfSpecificClassesSpecification 
 public;ContentJSON
 public;ContentModifier 

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -1,7 +1,7 @@
 sep=;
 Release Tag;API Item
 internal;BrowserLocalFavoritePropertiesStorage 
-internal;buildPagedResponse: 
+internal;buildPagedArrayResponse: 
 alpha;consoleDiagnosticsHandler(scopeLogs: DiagnosticsScopeLogs[]): void
 alpha;createCombinedDiagnosticsHandler(handlers: DiagnosticsHandler[]): (scopeLogs: DiagnosticsScopeLogs[]) => void
 public;createFavoritePropertiesStorage(type: DefaultFavoritePropertiesStorageTypes): IFavoritePropertiesStorage

--- a/common/changes/@itwin/appui-react/presentation-get-content-instance-keys_2021-11-02-09-44.json
+++ b/common/changes/@itwin/appui-react/presentation-get-content-instance-keys_2021-11-02-09-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Improve performance of determining visibility state of element and element grouping nodes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/presentation-backend/presentation-get-content-instance-keys_2021-11-02-09-13.json
+++ b/common/changes/@itwin/presentation-backend/presentation-get-content-instance-keys_2021-11-02-09-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Add `getContentInstanceKeys` RPC to efficiently get content instance keys.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-get-content-instance-keys_2021-11-02-09-13.json
+++ b/common/changes/@itwin/presentation-common/presentation-get-content-instance-keys_2021-11-02-09-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Add `getContentInstanceKeys` RPC to efficiently get content instance keys.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/presentation-get-content-instance-keys_2021-11-02-09-13.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-get-content-instance-keys_2021-11-02-09-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Add `getContentInstanceKeys` RPC to efficiently get content instance keys.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/full-stack-tests/presentation/src/frontend/Content.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Content.test.ts
@@ -608,6 +608,59 @@ describe("Content", () => {
 
   });
 
+  describe("Content instance keys", () => {
+
+    it("retrieves content instance keys for given input", async () => {
+      const ruleset: Ruleset = {
+        id: "model elements",
+        rules: [{
+          ruleType: RuleTypes.Content,
+          specifications: [{
+            specType: ContentSpecificationTypes.ContentRelatedInstances,
+            relationshipPaths: [{
+              relationship: { schemaName: "BisCore", className: "ModelContainsElements" },
+              direction: RelationshipDirection.Forward,
+            }],
+          }],
+        }],
+      };
+      const modelKeys = new KeySet([{ className: "BisCore:DictionaryModel", id: "0x10" }]);
+      const result = await Presentation.presentation.getContentInstanceKeys({
+        imodel,
+        rulesetOrId: ruleset,
+        keys: modelKeys,
+      });
+      expect(result.total).to.eq(7);
+
+      const resultKeys = [];
+      for await (const key of result.items())
+        resultKeys.push(key);
+      expect(resultKeys).to.deep.eq([{
+        className: "BisCore:LineStyle",
+        id: "0x1d",
+      }, {
+        className: "BisCore:LineStyle",
+        id: "0x1e",
+      }, {
+        className: "BisCore:LineStyle",
+        id: "0x1f",
+      }, {
+        className: "BisCore:LineStyle",
+        id: "0x20",
+      }, {
+        className: "BisCore:LineStyle",
+        id: "0x21",
+      }, {
+        className: "BisCore:LineStyle",
+        id: "0x22",
+      }, {
+        className: "BisCore:LineStyle",
+        id: "0x23",
+      }]);
+    });
+
+  });
+
   describe("when request in the backend exceeds the backend timeout time", () => {
 
     let raceStub: sinon.SinonStub<[readonly unknown[]], Promise<unknown>>;

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -10,22 +10,23 @@ import { IModelDb } from "@itwin/core-backend";
 import { Id64String } from "@itwin/core-bentley";
 import { IModelNotFoundResponse, IModelRpcProps } from "@itwin/core-common";
 import {
-  Content, ContentDescriptorRequestOptions, ContentDescriptorRpcRequestOptions, ContentRequestOptions, ContentRpcRequestOptions,
-  ContentSourcesRequestOptions, ContentSourcesRpcRequestOptions, ContentSourcesRpcResult, Descriptor, DescriptorOverrides, DiagnosticsScopeLogs,
-  DisplayLabelRequestOptions, DisplayLabelRpcRequestOptions, DisplayLabelsRequestOptions, DisplayLabelsRpcRequestOptions,
-  DistinctValuesRequestOptions, DistinctValuesRpcRequestOptions, ElementProperties, FieldDescriptor, FieldDescriptorType,
-  FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions, HierarchyRequestOptions, HierarchyRpcRequestOptions, InstanceKey,
-  Item, KeySet, MultiElementPropertiesRequestOptions, MultiElementPropertiesRpcRequestOptions, Node, NodeKey, NodePathElement, Paged, PageOptions,
-  PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable, RulesetVariableJSON, SelectClassInfo,
-  SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions, SingleElementPropertiesRpcRequestOptions, VariableValueTypes,
+  Content, ContentDescriptorRequestOptions, ContentDescriptorRpcRequestOptions, ContentFlags, ContentInstanceKeysRpcRequestOptions,
+  ContentRequestOptions, ContentRpcRequestOptions, ContentSourcesRequestOptions, ContentSourcesRpcRequestOptions, ContentSourcesRpcResult, Descriptor,
+  DescriptorOverrides, DiagnosticsScopeLogs, DisplayLabelRequestOptions, DisplayLabelRpcRequestOptions, DisplayLabelsRequestOptions,
+  DisplayLabelsRpcRequestOptions, DistinctValuesRequestOptions, DistinctValuesRpcRequestOptions, ElementProperties, FieldDescriptor,
+  FieldDescriptorType, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions, HierarchyRequestOptions,
+  HierarchyRpcRequestOptions, InstanceKey, Item, KeySet, MultiElementPropertiesRequestOptions, MultiElementPropertiesRpcRequestOptions, Node, NodeKey,
+  NodePathElement, Paged, PageOptions, PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable, RulesetVariableJSON,
+  SelectClassInfo, SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions, SingleElementPropertiesRpcRequestOptions, VariableValueTypes,
 } from "@itwin/presentation-common";
 import {
   createRandomECInstanceKey, createRandomECInstancesNode, createRandomECInstancesNodeKey, createRandomId, createRandomLabelDefinitionJSON,
-  createRandomNodePathElement, createRandomSelectionScope, createTestContentDescriptor, createTestSelectClassInfo, ResolvablePromise,
+  createRandomNodePathElement, createRandomSelectionScope, createTestContentDescriptor, createTestECInstanceKey, createTestSelectClassInfo,
+  ResolvablePromise,
 } from "@itwin/presentation-common/lib/cjs/test";
 import { Presentation } from "../presentation-backend/Presentation";
 import { PresentationManager } from "../presentation-backend/PresentationManager";
-import { MAX_ALLOWED_PAGE_SIZE, PresentationRpcImpl } from "../presentation-backend/PresentationRpcImpl";
+import { MAX_ALLOWED_KEYS_PAGE_SIZE, MAX_ALLOWED_PAGE_SIZE, PresentationRpcImpl } from "../presentation-backend/PresentationRpcImpl";
 import { RulesetManager } from "../presentation-backend/RulesetManager";
 import { RulesetVariablesManager } from "../presentation-backend/RulesetVariablesManager";
 
@@ -1191,6 +1192,185 @@ describe("PresentationRpcImpl", () => {
         const actualResult = await impl.getElementProperties(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(expectedRpcResponse);
+      });
+
+    });
+
+    describe("getContentInstanceKeys", () => {
+
+      it("calls manager", async () => {
+        const keys = new KeySet();
+        const contentItemKeys = [createTestECInstanceKey({ id: "0x123" }), createTestECInstanceKey({ id: "0x456" })];
+        const contentItem = new Item(contentItemKeys, "", "", undefined, {}, {}, [], undefined);
+        const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
+        const rpcOptions: Paged<ContentInstanceKeysRpcRequestOptions> = {
+          ...defaultRpcParams,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          displayType: content.descriptor.displayType,
+          keys: keys.toJSON(),
+        };
+        const managerOptions: Paged<ContentRequestOptions<IModelDb, DescriptorOverrides, KeySet, RulesetVariable>> = {
+          imodel: testData.imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor: {
+            displayType: content.descriptor.displayType,
+            contentFlags: ContentFlags.KeysOnly,
+          },
+          keys,
+        };
+        presentationManagerMock.setup(async (x) => x.getContent(managerOptions))
+          .returns(async () => content)
+          .verifiable();
+        presentationManagerMock.setup(async (x) => x.getContentSetSize(managerOptions))
+          .returns(async () => 999)
+          .verifiable();
+        const actualResult = await impl.getContentInstanceKeys(testData.imodelToken, rpcOptions);
+        presentationManagerMock.verifyAll();
+        expect(actualResult.result).to.deep.eq({
+          total: 999,
+          items: new KeySet(contentItemKeys).toJSON(),
+        });
+      });
+
+      it("handles case when manager returns no content", async () => {
+        const keys = new KeySet();
+        const rpcOptions: Paged<ContentInstanceKeysRpcRequestOptions> = {
+          ...defaultRpcParams,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          keys: keys.toJSON(),
+        };
+        const managerOptions: Paged<ContentRequestOptions<IModelDb, DescriptorOverrides, KeySet, RulesetVariable>> = {
+          imodel: testData.imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor: {
+            displayType: undefined,
+            contentFlags: ContentFlags.KeysOnly,
+          },
+          keys,
+        };
+        presentationManagerMock.setup(async (x) => x.getContent(managerOptions))
+          .returns(async () => undefined)
+          .verifiable();
+        presentationManagerMock.setup(async (x) => x.getContentSetSize(managerOptions))
+          .returns(async () => 0)
+          .verifiable();
+        const actualResult = await impl.getContentInstanceKeys(testData.imodelToken, rpcOptions);
+        presentationManagerMock.verifyAll();
+        expect(actualResult.result).to.deep.eq({
+          total: 0,
+          items: new KeySet().toJSON(),
+        });
+      });
+
+      it("enforces maximum page size when requesting with larger size than allowed", async () => {
+        const keys = new KeySet();
+        const contentItemKeys = [createTestECInstanceKey()];
+        const contentItem = new Item(contentItemKeys, "", "", undefined, {}, {}, [], undefined);
+        const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
+        const rpcOptions: Paged<ContentInstanceKeysRpcRequestOptions> = {
+          ...defaultRpcParams,
+          rulesetOrId: testData.rulesetOrId,
+          paging: { start: 0, size: MAX_ALLOWED_KEYS_PAGE_SIZE + 1 },
+          displayType: content.descriptor.displayType,
+          keys: keys.toJSON(),
+        };
+        const managerOptions: Paged<ContentRequestOptions<IModelDb, DescriptorOverrides, KeySet, RulesetVariable>> = {
+          imodel: testData.imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: { start: 0, size: MAX_ALLOWED_KEYS_PAGE_SIZE },
+          descriptor: {
+            displayType: content.descriptor.displayType,
+            contentFlags: ContentFlags.KeysOnly,
+          },
+          keys,
+        };
+        presentationManagerMock.setup(async (x) => x.getContent(managerOptions))
+          .returns(async () => content)
+          .verifiable();
+        presentationManagerMock.setup(async (x) => x.getContentSetSize(managerOptions))
+          .returns(async () => 999)
+          .verifiable();
+        const actualResult = await impl.getContentInstanceKeys(testData.imodelToken, rpcOptions);
+        presentationManagerMock.verifyAll();
+        expect(actualResult.result).to.deep.eq({
+          total: 999,
+          items: new KeySet(contentItemKeys).toJSON(),
+        });
+      });
+
+      it("enforces maximum page size when requesting with undefined size", async () => {
+        const keys = new KeySet();
+        const contentItemKeys = [createTestECInstanceKey()];
+        const contentItem = new Item(contentItemKeys, "", "", undefined, {}, {}, [], undefined);
+        const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
+        const rpcOptions: Paged<ContentInstanceKeysRpcRequestOptions> = {
+          ...defaultRpcParams,
+          rulesetOrId: testData.rulesetOrId,
+          paging: { start: 123 },
+          displayType: content.descriptor.displayType,
+          keys: keys.toJSON(),
+        };
+        const managerOptions: Paged<ContentRequestOptions<IModelDb, DescriptorOverrides, KeySet, RulesetVariable>> = {
+          imodel: testData.imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: { start: 123, size: MAX_ALLOWED_KEYS_PAGE_SIZE },
+          descriptor: {
+            displayType: content.descriptor.displayType,
+            contentFlags: ContentFlags.KeysOnly,
+          },
+          keys,
+        };
+        presentationManagerMock.setup(async (x) => x.getContent(managerOptions))
+          .returns(async () => content)
+          .verifiable();
+        presentationManagerMock.setup(async (x) => x.getContentSetSize(managerOptions))
+          .returns(async () => 999)
+          .verifiable();
+        const actualResult = await impl.getContentInstanceKeys(testData.imodelToken, rpcOptions);
+        presentationManagerMock.verifyAll();
+        expect(actualResult.result).to.deep.eq({
+          total: 999,
+          items: new KeySet(contentItemKeys).toJSON(),
+        });
+      });
+
+      it("enforces maximum page size when requesting with undefined page options", async () => {
+        const keys = new KeySet();
+        const contentItemKeys = [createTestECInstanceKey()];
+        const contentItem = new Item(contentItemKeys, "", "", undefined, {}, {}, [], undefined);
+        const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
+        const rpcOptions: Paged<ContentInstanceKeysRpcRequestOptions> = {
+          ...defaultRpcParams,
+          rulesetOrId: testData.rulesetOrId,
+          displayType: content.descriptor.displayType,
+          keys: keys.toJSON(),
+        };
+        const managerOptions: Paged<ContentRequestOptions<IModelDb, DescriptorOverrides, KeySet, RulesetVariable>> = {
+          imodel: testData.imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: { size: MAX_ALLOWED_KEYS_PAGE_SIZE },
+          descriptor: {
+            displayType: content.descriptor.displayType,
+            contentFlags: ContentFlags.KeysOnly,
+          },
+          keys,
+        };
+        presentationManagerMock.setup(async (x) => x.getContent(managerOptions))
+          .returns(async () => content)
+          .verifiable();
+        presentationManagerMock.setup(async (x) => x.getContentSetSize(managerOptions))
+          .returns(async () => 999)
+          .verifiable();
+        const actualResult = await impl.getContentInstanceKeys(testData.imodelToken, rpcOptions);
+        presentationManagerMock.verifyAll();
+        expect(actualResult.result).to.deep.eq({
+          total: 999,
+          items: new KeySet(contentItemKeys).toJSON(),
+        });
       });
 
     });

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -160,6 +160,20 @@ export interface MultiElementPropertiesRequestOptions<TIModel> extends Paged<Req
 }
 
 /**
+ * Request type for content instance keys' requests.
+ * @alpha
+ */
+export interface ContentInstanceKeysRequestOptions<TIModel, TKeySet, TRulesetVariable = RulesetVariable> extends Paged<RequestOptionsWithRuleset<TIModel, TRulesetVariable>> {
+  /**
+   * Content display type.
+   * @see [[DefaultContentDisplayTypes]]
+   */
+  displayType?: string;
+  /** Input keys for getting the content. */
+  keys: TKeySet;
+}
+
+/**
  * Request type for label requests
  * @public
  */

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -21,9 +21,10 @@ import { NodePathElementJSON } from "./hierarchy/NodePathElement";
 import { KeySetJSON } from "./KeySet";
 import { LabelDefinitionJSON } from "./LabelDefinition";
 import {
-  ContentDescriptorRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
-  DistinctValuesRequestOptions, ElementPropertiesRequestOptions, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions,
-  HierarchyRequestOptions, MultiElementPropertiesRequestOptions, Paged, SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions,
+  ContentDescriptorRequestOptions, ContentInstanceKeysRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions,
+  DisplayLabelsRequestOptions, DistinctValuesRequestOptions, ElementPropertiesRequestOptions, FilterByInstancePathsHierarchyRequestOptions,
+  FilterByTextHierarchyRequestOptions, HierarchyRequestOptions, MultiElementPropertiesRequestOptions, Paged, SelectionScopeRequestOptions,
+  SingleElementPropertiesRequestOptions,
 } from "./PresentationManagerOptions";
 import { RulesetVariableJSON } from "./RulesetVariables";
 import { SelectionScope } from "./selection/SelectionScope";
@@ -132,6 +133,12 @@ export type MultiElementPropertiesRpcRequestOptions = PresentationRpcRequestOpti
 export type DistinctValuesRpcRequestOptions = PresentationRpcRequestOptions<DistinctValuesRequestOptions<never, DescriptorOverrides, KeySetJSON, RulesetVariableJSON>>;
 
 /**
+ * Data structure for content instance keys' request options.
+ * @alpha
+ */
+export type ContentInstanceKeysRpcRequestOptions = PresentationRpcRequestOptions<ContentInstanceKeysRequestOptions<never, KeySetJSON, RulesetVariableJSON>>;
+
+/**
  * Data structure for label request options.
  * @public
  */
@@ -188,6 +195,9 @@ export class PresentationRpcInterface extends RpcInterface {
   public async getElementProperties(_token: IModelRpcProps, _options: ElementPropertiesRpcRequestOptions): PresentationRpcResponse<ElementPropertiesRpcResult> { return this.forward(arguments); }
 
   public async getPagedDistinctValues(_token: IModelRpcProps, _options: DistinctValuesRpcRequestOptions): PresentationRpcResponse<PagedResponse<DisplayValueGroupJSON>> { return this.forward(arguments); }
+
+  /** @alpha */
+  public async getContentInstanceKeys(_token: IModelRpcProps, _options: ContentInstanceKeysRpcRequestOptions): PresentationRpcResponse<{ total: number, items: KeySetJSON }> { return this.forward(arguments); }
 
   public async getDisplayLabelDefinition(_token: IModelRpcProps, _options: DisplayLabelRpcRequestOptions): PresentationRpcResponse<LabelDefinitionJSON> { return this.forward(arguments); }
   public async getPagedDisplayLabelDefinitions(_token: IModelRpcProps, _options: DisplayLabelsRpcRequestOptions): PresentationRpcResponse<PagedResponse<LabelDefinitionJSON>> { return this.forward(arguments); }

--- a/presentation/common/src/presentation-common/RpcRequestsHandler.ts
+++ b/presentation/common/src/presentation-common/RpcRequestsHandler.ts
@@ -21,10 +21,10 @@ import { NodePathElementJSON } from "./hierarchy/NodePathElement";
 import { KeySetJSON } from "./KeySet";
 import { LabelDefinitionJSON } from "./LabelDefinition";
 import {
-  ContentDescriptorRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
-  DistinctValuesRequestOptions, ElementPropertiesRequestOptions, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions,
-  HierarchyRequestOptions, MultiElementPropertiesRequestOptions, Paged, RequestOptions, SelectionScopeRequestOptions,
-  SingleElementPropertiesRequestOptions,
+  ContentDescriptorRequestOptions, ContentInstanceKeysRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions,
+  DisplayLabelsRequestOptions, DistinctValuesRequestOptions, ElementPropertiesRequestOptions, FilterByInstancePathsHierarchyRequestOptions,
+  FilterByTextHierarchyRequestOptions, HierarchyRequestOptions, MultiElementPropertiesRequestOptions, Paged, RequestOptions,
+  SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions,
 } from "./PresentationManagerOptions";
 import {
   ContentSourcesRpcResult, ElementPropertiesRpcResult, PresentationRpcInterface, PresentationRpcRequestOptions, PresentationRpcResponse,
@@ -178,6 +178,11 @@ export class RpcRequestsHandler implements IDisposable {
   public async getElementProperties(options: ElementPropertiesRequestOptions<IModelRpcProps>): Promise<ElementPropertiesRpcResult> {
     return this.request<ElementPropertiesRpcResult, ElementPropertiesRequestOptions<IModelRpcProps>>(
       this.rpcClient.getElementProperties.bind(this.rpcClient), options);
+  }
+
+  public async getContentInstanceKeys(options: ContentInstanceKeysRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON>): Promise<{ total: number, items: KeySetJSON }> {
+    return this.request<{ total: number, items: KeySetJSON }, ContentInstanceKeysRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON>>(
+      this.rpcClient.getContentInstanceKeys.bind(this.rpcClient), options);
   }
 
   public async getDisplayLabelDefinition(options: DisplayLabelRequestOptions<IModelRpcProps, InstanceKeyJSON>): Promise<LabelDefinitionJSON> {

--- a/presentation/common/src/test/PresentationRpcInterface.test.ts
+++ b/presentation/common/src/test/PresentationRpcInterface.test.ts
@@ -14,8 +14,8 @@ import {
 } from "../presentation-common";
 import { FieldDescriptorType } from "../presentation-common/content/Fields";
 import {
-  FilterByInstancePathsHierarchyRpcRequestOptions, FilterByTextHierarchyRpcRequestOptions, MultiElementPropertiesRpcRequestOptions,
-  SingleElementPropertiesRpcRequestOptions,
+  ContentInstanceKeysRpcRequestOptions, FilterByInstancePathsHierarchyRpcRequestOptions, FilterByTextHierarchyRpcRequestOptions,
+  MultiElementPropertiesRpcRequestOptions, SingleElementPropertiesRpcRequestOptions,
 } from "../presentation-common/PresentationRpcInterface";
 import { createTestContentDescriptor } from "./_helpers/Content";
 import { createRandomECInstanceKey, createRandomECInstancesNodeKey, createRandomECInstancesNodeKeyJSON } from "./_helpers/random";
@@ -184,6 +184,16 @@ describe("PresentationRpcInterface", () => {
         elementClasses: ["TestSchema:TestClass"],
       };
       await rpcInterface.getElementProperties(token, options);
+      expect(spy).to.be.calledOnceWith(toArguments(token, options));
+    });
+
+    it("forwards getContentInstanceKeys call", async () => {
+      const options: ContentInstanceKeysRpcRequestOptions = {
+        rulesetOrId: "test ruleset",
+        displayType: "test display type",
+        keys: new KeySet().toJSON(),
+      };
+      await rpcInterface.getContentInstanceKeys(token, options);
       expect(spy).to.be.calledOnceWith(toArguments(token, options));
     });
 

--- a/presentation/common/src/test/RpcRequestsHandler.test.ts
+++ b/presentation/common/src/test/RpcRequestsHandler.test.ts
@@ -19,13 +19,13 @@ import { InstanceKeyJSON } from "../presentation-common/EC";
 import { ElementProperties } from "../presentation-common/ElementProperties";
 import { NodeKey, NodeKeyJSON } from "../presentation-common/hierarchy/Key";
 import {
-  ContentDescriptorRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
-  DistinctValuesRequestOptions, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions, HierarchyRequestOptions,
-  MultiElementPropertiesRequestOptions, SingleElementPropertiesRequestOptions,
+  ContentDescriptorRequestOptions, ContentInstanceKeysRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions,
+  DisplayLabelsRequestOptions, DistinctValuesRequestOptions, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions,
+  HierarchyRequestOptions, MultiElementPropertiesRequestOptions, SingleElementPropertiesRequestOptions,
 } from "../presentation-common/PresentationManagerOptions";
 import {
-  ContentDescriptorRpcRequestOptions, ContentRpcRequestOptions, ContentSourcesRpcRequestOptions, ContentSourcesRpcResult,
-  DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions, FilterByInstancePathsHierarchyRpcRequestOptions,
+  ContentDescriptorRpcRequestOptions, ContentInstanceKeysRpcRequestOptions, ContentRpcRequestOptions, ContentSourcesRpcRequestOptions,
+  ContentSourcesRpcResult, DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions, FilterByInstancePathsHierarchyRpcRequestOptions,
   FilterByTextHierarchyRpcRequestOptions, HierarchyRpcRequestOptions, MultiElementPropertiesRpcRequestOptions,
   SingleElementPropertiesRpcRequestOptions,
 } from "../presentation-common/PresentationRpcInterface";
@@ -507,6 +507,34 @@ describe("RpcRequestsHandler", () => {
       };
       rpcInterfaceMock.setup(async (x) => x.getElementProperties(token, rpcOptions)).returns(async () => successResponse(result)).verifiable();
       expect(await handler.getElementProperties(handlerOptions)).to.deep.eq(result);
+      rpcInterfaceMock.verifyAll();
+    });
+
+    it("forwards getContentInstanceKeys call", async () => {
+      const handlerOptions: ContentInstanceKeysRequestOptions<IModelRpcProps, KeySetJSON, RulesetVariableJSON> = {
+        imodel: token,
+        rulesetOrId: faker.random.word(),
+        displayType: "test display type",
+        keys: new KeySet().toJSON(),
+      };
+      const rpcOptions: ContentInstanceKeysRpcRequestOptions = {
+        clientId,
+        rulesetOrId: handlerOptions.rulesetOrId,
+        displayType: handlerOptions.displayType,
+        keys: handlerOptions.keys,
+      };
+      const result = {
+        total: 2,
+        items: new KeySet([{
+          className: "test class 1",
+          id: "0x1",
+        }, {
+          className: "test class 2",
+          id: "0x2",
+        }]).toJSON(),
+      };
+      rpcInterfaceMock.setup(async (x) => x.getContentInstanceKeys(token, rpcOptions)).returns(async () => successResponse(result)).verifiable();
+      expect(await handler.getContentInstanceKeys(handlerOptions)).to.eq(result);
       rpcInterfaceMock.verifyAll();
     });
 

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -6,27 +6,27 @@ import { expect } from "chai";
 import * as faker from "faker";
 import sinon from "sinon";
 import * as moq from "typemoq";
-import { BeDuration, BeEvent, CompressedId64Set, Logger, using } from "@itwin/core-bentley";
+import { BeDuration, BeEvent, CompressedId64Set, using } from "@itwin/core-bentley";
 import { IModelRpcProps, IpcListener, RemoveFunction } from "@itwin/core-common";
 import { IModelConnection, IpcApp } from "@itwin/core-frontend";
 import { ITwinLocalization } from "@itwin/core-i18n";
 import { UnitSystemKey } from "@itwin/core-quantity";
 import {
-  Content, ContentDescriptorRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, ContentSourcesRpcResult, Descriptor,
-  DescriptorOverrides, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DisplayValueGroup, DistinctValuesRequestOptions, ElementProperties,
-  FieldDescriptor, FieldDescriptorType, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions, HierarchyRequestOptions,
-  InstanceKey, Item, KeySet, LabelDefinition, MultiElementPropertiesRequestOptions, Node, NodeKey, NodePathElement, Paged, PresentationIpcEvents,
-  RegisteredRuleset, RpcRequestsHandler, Ruleset, RulesetVariable, SelectClassInfo, SingleElementPropertiesRequestOptions, UpdateInfo,
-  VariableValueTypes,
+  Content, ContentDescriptorRequestOptions, ContentInstanceKeysRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions,
+  ContentSourcesRpcResult, Descriptor, DescriptorOverrides, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DisplayValueGroup,
+  DistinctValuesRequestOptions, ElementProperties, FieldDescriptor, FieldDescriptorType, FilterByInstancePathsHierarchyRequestOptions,
+  FilterByTextHierarchyRequestOptions, HierarchyRequestOptions, InstanceKey, Item, KeySet, LabelDefinition, MultiElementPropertiesRequestOptions,
+  Node, NodeKey, NodePathElement, Paged, PresentationIpcEvents, RegisteredRuleset, RpcRequestsHandler, Ruleset, RulesetVariable, SelectClassInfo,
+  SingleElementPropertiesRequestOptions, UpdateInfo, VariableValueTypes,
 } from "@itwin/presentation-common";
 import {
   createRandomECInstanceKey, createRandomECInstancesNode, createRandomECInstancesNodeKey, createRandomLabelDefinition, createRandomNodePathElement,
-  createRandomRuleset, createRandomTransientId, createTestContentDescriptor,
+  createRandomRuleset, createRandomTransientId, createTestContentDescriptor, createTestECInstanceKey,
 } from "@itwin/presentation-common/lib/cjs/test";
 import { IpcRequestsHandler } from "../presentation-frontend/IpcRequestsHandler";
 import { Presentation } from "../presentation-frontend/Presentation";
 import {
-  buildPagedResponse, IModelContentChangeEventArgs, IModelHierarchyChangeEventArgs, PresentationManager,
+  buildPagedArrayResponse, IModelContentChangeEventArgs, IModelHierarchyChangeEventArgs, PresentationManager,
 } from "../presentation-frontend/PresentationManager";
 import { RulesetManagerImpl } from "../presentation-frontend/RulesetManager";
 import { RulesetVariablesManagerImpl } from "../presentation-frontend/RulesetVariablesManager";
@@ -1053,6 +1053,69 @@ describe("PresentationManager", () => {
 
   });
 
+  describe("getContentInstanceKeys", () => {
+
+    it("requests content instance keys", async () => {
+      const inputKeys = new KeySet();
+      const displayType = "test display type";
+      const instanceKeys = [createTestECInstanceKey({ id: "0x123" })];
+      const rpcHandlerResult = {
+        total: 1,
+        items: new KeySet(instanceKeys).toJSON(),
+      };
+      const managerOptions: ContentInstanceKeysRequestOptions<IModelConnection, KeySet, RulesetVariable> = {
+        imodel: testData.imodelMock.object,
+        rulesetOrId: testData.rulesetId,
+        displayType,
+        keys: inputKeys,
+      };
+      const rpcHandlerOptions = {
+        ...prepareOptions(managerOptions),
+        keys: inputKeys.toJSON(),
+        paging: { start: 0, size: 0 },
+      };
+      rpcRequestsHandlerMock
+        .setup(async (x) => x.getContentInstanceKeys(rpcHandlerOptions))
+        .returns(async () => rpcHandlerResult)
+        .verifiable();
+      const actualResult = await manager.getContentInstanceKeys(managerOptions);
+      rpcRequestsHandlerMock.verifyAll();
+      expect(actualResult.total).to.eq(1);
+      expect(await generatedValues(actualResult.items())).to.deep.eq(instanceKeys);
+    });
+
+    it("requests instance keys through multiple requests when getting partial responses", async () => {
+      const inputKeys = new KeySet();
+      const displayType = "test display type";
+      const instanceKeys1 = [createTestECInstanceKey({ id: "0x1" }), createTestECInstanceKey({ id: "0x2" })];
+      const instanceKeys2 = [createTestECInstanceKey({ id: "0x3" }), createTestECInstanceKey({ id: "0x4" })];
+      const managerOptions: ContentInstanceKeysRequestOptions<IModelConnection, KeySet, RulesetVariable> = {
+        imodel: testData.imodelMock.object,
+        rulesetOrId: testData.rulesetId,
+        displayType,
+        keys: inputKeys,
+        paging: undefined,
+      };
+      const rpcHandlerOptions = {
+        ...prepareOptions(managerOptions),
+        keys: inputKeys.toJSON(),
+      };
+      rpcRequestsHandlerMock
+        .setup(async (x) => x.getContentInstanceKeys({ ...rpcHandlerOptions, paging: { start: 0, size: 0 } }))
+        .returns(async () => ({ total: 4, items: new KeySet(instanceKeys1).toJSON() }))
+        .verifiable();
+      rpcRequestsHandlerMock
+        .setup(async (x) => x.getContentInstanceKeys({ ...rpcHandlerOptions, paging: { start: 2, size: 0 } }))
+        .returns(async () => ({ total: 4, items: new KeySet(instanceKeys2).toJSON() }))
+        .verifiable();
+      const actualResult = await manager.getContentInstanceKeys(managerOptions);
+      expect(actualResult.total).to.eq(4);
+      expect(await generatedValues(actualResult.items())).to.deep.eq([...instanceKeys1, ...instanceKeys2]);
+      rpcRequestsHandlerMock.verifyAll();
+    });
+
+  });
+
   describe("getDisplayLabelDefinition", () => {
 
     it("requests display label definition", async () => {
@@ -1276,23 +1339,23 @@ describe("PresentationManager", () => {
 
   });
 
-  describe("buildPagedResponse", () => {
+  describe("buildPagedArrayResponse", () => {
 
     it("calls getter once with 0,0 partial page options when given `undefined` page options", async () => {
       const getter = sinon.stub().resolves({ total: 0, items: [] });
-      await buildPagedResponse(undefined, getter);
+      await buildPagedArrayResponse(undefined, getter);
       expect(getter).to.be.calledOnceWith({ start: 0, size: 0 });
     });
 
     it("calls getter once with 0,0 partial page options when given empty page options", async () => {
       const getter = sinon.stub().resolves({ total: 0, items: [] });
-      await buildPagedResponse({}, getter);
+      await buildPagedArrayResponse({}, getter);
       expect(getter).to.be.calledOnceWith({ start: 0, size: 0 });
     });
 
     it("calls getter once with partial page options equal to given page options", async () => {
       const getter = sinon.stub().resolves({ total: 0, items: [] });
-      await buildPagedResponse({ start: 1, size: 2 }, getter);
+      await buildPagedArrayResponse({ start: 1, size: 2 }, getter);
       expect(getter).to.be.calledOnceWith({ start: 1, size: 2 });
     });
 
@@ -1301,7 +1364,7 @@ describe("PresentationManager", () => {
       getter.onFirstCall().resolves({ total: 5, items: [2] });
       getter.onSecondCall().resolves({ total: 5, items: [3] });
       getter.onThirdCall().resolves({ total: 5, items: [4] });
-      const result = await buildPagedResponse({ start: 1, size: 3 }, getter);
+      const result = await buildPagedArrayResponse({ start: 1, size: 3 }, getter);
       expect(getter).to.be.calledThrice;
       expect(getter.firstCall).to.be.calledWith({ start: 1, size: 3 });
       expect(getter.secondCall).to.be.calledWith({ start: 2, size: 2 });
@@ -1313,35 +1376,38 @@ describe("PresentationManager", () => {
       const getter = sinon.stub();
       getter.onFirstCall().resolves({ total: 5, items: [2, 3] });
       getter.onSecondCall().resolves({ total: 5, items: [4, 5] });
-      const result = await buildPagedResponse({ start: 1 }, getter);
+      const result = await buildPagedArrayResponse({ start: 1 }, getter);
       expect(getter).to.be.calledTwice;
       expect(getter.firstCall).to.be.calledWith({ start: 1, size: 0 });
       expect(getter.secondCall).to.be.calledWith({ start: 3, size: 0 });
       expect(result).to.deep.eq({ total: 5, items: [2, 3, 4, 5] });
     });
 
-    it("logs a warning when page start index is larger than total number of items", async () => {
-      const loggerSpy = sinon.spy(Logger, "logWarning");
+    it("returns zero response when page start index is larger than total number of items", async () => {
       const getter = sinon.stub();
       getter.resolves({ total: 5, items: [] });
-      const result = await buildPagedResponse({ start: 9 }, getter);
+      const result = await buildPagedArrayResponse({ start: 9 }, getter);
       expect(getter).to.be.calledOnce;
       expect(getter).to.be.calledWith({ start: 9, size: 0 });
       expect(result).to.deep.eq({ total: 0, items: [] });
-      expect(loggerSpy).to.be.calledOnce;
     });
 
-    it("logs an error when partial request returns no items", async () => {
-      const loggerSpy = sinon.spy(Logger, "logError");
+    it("returns zero response when partial request returns no items", async () => {
       const getter = sinon.stub();
       getter.resolves({ total: 5, items: [] });
-      const result = await buildPagedResponse({ start: 1 }, getter);
+      const result = await buildPagedArrayResponse({ start: 1 }, getter);
       expect(getter).to.be.calledOnce;
       expect(getter).to.be.calledWith({ start: 1, size: 0 });
       expect(result).to.deep.eq({ total: 0, items: [] });
-      expect(loggerSpy).to.be.calledOnce;
     });
 
   });
 
 });
+
+async function generatedValues<T>(gen: AsyncGenerator<T>) {
+  const arr = new Array<T>();
+  for await (const v of gen)
+    arr.push(v);
+  return arr;
+}

--- a/ui/appui-react/src/appui-react/imodel-components/VisibilityTreeEventHandler.ts
+++ b/ui/appui-react/src/appui-react/imodel-components/VisibilityTreeEventHandler.ts
@@ -10,14 +10,14 @@ import { EMPTY } from "rxjs/internal/observable/empty";
 import { from } from "rxjs/internal/observable/from";
 import { map } from "rxjs/internal/operators/map";
 import { mergeMap } from "rxjs/internal/operators/mergeMap";
-import { BeEvent, IDisposable } from "@itwin/core-bentley";
-import { NodeKey } from "@itwin/presentation-common";
-import { UnifiedSelectionTreeEventHandler, UnifiedSelectionTreeEventHandlerParams } from "@itwin/presentation-components";
 import {
   CheckBoxInfo, CheckboxStateChange, toRxjsObservable, TreeCheckboxStateChangeEventArgs, TreeModelNode, TreeNodeItem,
   TreeSelectionModificationEventArgs, TreeSelectionReplacementEventArgs,
 } from "@itwin/components-react";
+import { BeEvent, IDisposable } from "@itwin/core-bentley";
 import { CheckBoxState, isPromiseLike } from "@itwin/core-react";
+import { NodeKey } from "@itwin/presentation-common";
+import { UnifiedSelectionTreeEventHandler, UnifiedSelectionTreeEventHandlerParams } from "@itwin/presentation-components";
 
 /**
  * Data structure that describes instance visibility status.
@@ -169,14 +169,12 @@ export class VisibilityTreeEventHandler extends UnifiedSelectionTreeEventHandler
     if (affectedNodes.length === 0)
       return nodeStates;
 
-    for (const nodeId of affectedNodes) {
+    await Promise.all(affectedNodes.map(async (nodeId) => {
       const node = this.modelSource.getModel().getNode(nodeId);
-      // istanbul ignore if
-      if (!node)
-        continue;
-
-      nodeStates.set(nodeId, await this.getNodeCheckBoxInfo(node, visibilityStatus));
-    }
+      // istanbul ignore else
+      if (node)
+        nodeStates.set(nodeId, await this.getNodeCheckBoxInfo(node, visibilityStatus));
+    }));
     return nodeStates;
   }
 

--- a/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsVisibilityHandler.ts
+++ b/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsVisibilityHandler.ts
@@ -8,10 +8,10 @@
 
 import { TreeNodeItem } from "@itwin/components-react";
 import { BeEvent, Id64String } from "@itwin/core-bentley";
-import { QueryBinder } from "@itwin/core-common";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
 import { IModelConnection, PerModelCategoryVisibility, Viewport } from "@itwin/core-frontend";
-import { ContentFlags, ECClassGroupingNodeKey, GroupingNodeKey, Keys, KeySet, NodeKey } from "@itwin/presentation-common";
-import { ContentDataProvider, IFilteredPresentationTreeDataProvider, IPresentationTreeDataProvider } from "@itwin/presentation-components";
+import { ECClassGroupingNodeKey, GroupingNodeKey, Keys, KeySet, NodeKey } from "@itwin/presentation-common";
+import { IFilteredPresentationTreeDataProvider, IPresentationTreeDataProvider } from "@itwin/presentation-components";
 import { Presentation } from "@itwin/presentation-frontend";
 import { UiFramework } from "../../UiFramework";
 import { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
@@ -211,18 +211,32 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
     if (!modelId || !this._props.viewport.view.viewsModel(modelId))
       return { isDisabled: true, state: "hidden", tooltip: createTooltip("disabled", "element.modelNotDisplayed") };
 
-    const atLeastOneElementForceDisplayed = (this._props.viewport.alwaysDrawn !== undefined)
-      && elementIds.some((elementId) => this._props.viewport.alwaysDrawn!.has(elementId));
-    if (atLeastOneElementForceDisplayed)
-      return { state: "visible", tooltip: createTooltip("visible", "element.displayedThroughAlwaysDrawnList") };
+    if (this._props.viewport.alwaysDrawn !== undefined && this._props.viewport.alwaysDrawn.size > 0) {
+      let atLeastOneElementForceDisplayed = false;
+      for await (const elementId of elementIds.getElementIds()) {
+        if (this._props.viewport.alwaysDrawn.has(elementId)) {
+          atLeastOneElementForceDisplayed = true;
+          break;
+        }
+      }
+      if (atLeastOneElementForceDisplayed)
+        return { state: "visible", tooltip: createTooltip("visible", "element.displayedThroughAlwaysDrawnList") };
+    }
 
     if (this._props.viewport.alwaysDrawn !== undefined && this._props.viewport.alwaysDrawn.size !== 0 && this._props.viewport.isAlwaysDrawnExclusive)
       return { state: "hidden", tooltip: createTooltip("hidden", "element.hiddenDueToOtherElementsExclusivelyAlwaysDrawn") };
 
-    const allElementsForceHidden = (this._props.viewport.neverDrawn !== undefined)
-      && elementIds.every((elementId) => this._props.viewport.neverDrawn!.has(elementId));
-    if (allElementsForceHidden)
-      return { state: "hidden", tooltip: createTooltip("visible", "element.hiddenThroughNeverDrawnList") };
+    if (this._props.viewport.neverDrawn !== undefined && this._props.viewport.neverDrawn.size > 0) {
+      let allElementsForceHidden = true;
+      for await (const elementId of elementIds.getElementIds()) {
+        if (!this._props.viewport.neverDrawn.has(elementId)) {
+          allElementsForceHidden = false;
+          break;
+        }
+      }
+      if (allElementsForceHidden)
+        return { state: "hidden", tooltip: createTooltip("visible", "element.hiddenThroughNeverDrawnList") };
+    }
 
     if (categoryId && this.getCategoryDisplayStatus(categoryId, modelId).state === "visible")
       return { state: "visible", tooltip: createTooltip("visible", undefined) };
@@ -301,14 +315,20 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
 
   protected async changeElementGroupingNodeState(key: ECClassGroupingNodeKey, on: boolean) {
     const { modelId, categoryId, elementIds } = await this.getGroupedElementIds(key);
-    this.changeElementsState(modelId, categoryId, elementIds, on);
+    await this.changeElementsState(modelId, categoryId, elementIds.getElementIds(), on);
   }
 
   protected async changeElementState(id: Id64String, modelId: Id64String | undefined, categoryId: Id64String | undefined, on: boolean) {
-    this.changeElementsState(modelId, categoryId, [id, ...await this.getAssemblyElementIds(id)], on);
+    const childIdsContainer = this.getAssemblyElementIds(id);
+    async function* elementIds() {
+      yield id;
+      for await (const childId of childIdsContainer.getElementIds())
+        yield childId;
+    }
+    await this.changeElementsState(modelId, categoryId, elementIds(), on);
   }
 
-  protected changeElementsState(modelId: Id64String | undefined, categoryId: Id64String | undefined, elementIds: Id64String[], on: boolean) {
+  protected async changeElementsState(modelId: Id64String | undefined, categoryId: Id64String | undefined, elementIds: AsyncGenerator<Id64String>, on: boolean) {
     const isDisplayedByDefault = modelId && this.getModelDisplayStatus(modelId).state === "visible"
       && categoryId && this.getCategoryDisplayStatus(categoryId, modelId).state === "visible";
     const isHiddenDueToExclusiveAlwaysDrawnElements = this._props.viewport.isAlwaysDrawnExclusive && this._props.viewport.alwaysDrawn && 0 !== this._props.viewport.alwaysDrawn.size;
@@ -316,7 +336,7 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
     const currAlwaysDrawn = new Set(this._props.viewport.alwaysDrawn ?
       this._props.viewport.alwaysDrawn : /* istanbul ignore next */[],
     );
-    elementIds.forEach((elementId) => {
+    for await (const elementId of elementIds) {
       if (on) {
         currNeverDrawn.delete(elementId);
         if (!isDisplayedByDefault || isHiddenDueToExclusiveAlwaysDrawnElements)
@@ -326,7 +346,7 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
         if (isDisplayedByDefault && !isHiddenDueToExclusiveAlwaysDrawnElements)
           currNeverDrawn.add(elementId);
       }
-    });
+    }
     this._props.viewport.setNeverDrawn(currNeverDrawn);
     this._props.viewport.setAlwaysDrawn(currAlwaysDrawn, this._props.viewport.isAlwaysDrawnExclusive);
   }
@@ -374,7 +394,7 @@ export class ModelsVisibilityHandler implements IVisibilityHandler {
   }
 
   // istanbul ignore next
-  private async getAssemblyElementIds(assemblyId: Id64String) {
+  private getAssemblyElementIds(assemblyId: Id64String) {
     return this._elementIdsCache.getAssemblyElementIds(assemblyId);
   }
 
@@ -402,7 +422,7 @@ class SubjectModelIdsCache {
   private async initSubjectsHierarchy() {
     this._subjectsHierarchy = new Map();
     const ecsql = `SELECT ECInstanceId id, Parent.Id parentId FROM bis.Subject WHERE Parent IS NOT NULL`;
-    const result = this._imodel.query(ecsql);
+    const result = this._imodel.query(ecsql, undefined, QueryRowFormat.UseJsPropertyNames);
     for await (const row of result) {
       let list = this._subjectsHierarchy.get(row.parentId);
       if (!list) {
@@ -421,7 +441,7 @@ class SubjectModelIdsCache {
       INNER JOIN bis.GeometricModel3d m ON m.ModeledElement.Id = p.ECInstanceId
       INNER JOIN bis.Subject s ON (s.ECInstanceId = p.Parent.Id OR json_extract(s.JsonProperties, '$.Subject.Model.TargetPartition') = printf('0x%x', p.ECInstanceId))
       WHERE NOT m.IsPrivate`;
-    const result = this._imodel.query(ecsql);
+    const result = this._imodel.query(ecsql, undefined, QueryRowFormat.UseJsPropertyNames);
     for await (const row of result) {
       let list = this._subjectModels.get(row.subjectId);
       if (!list) {
@@ -458,40 +478,15 @@ class SubjectModelIdsCache {
   }
 }
 
-// istanbul ignore next
-class RulesetDrivenIdsProvider extends ContentDataProvider {
-  constructor(imodel: IModelConnection, rulesetId: string, displayType: string, inputKeys: Keys) {
-    super({ imodel, ruleset: rulesetId, displayType });
-    this.keys = new KeySet(inputKeys);
-  }
-  protected override async getDescriptorOverrides() {
-    return {
-      displayType: this.displayType,
-      contentFlags: ContentFlags.KeysOnly,
-    };
-  }
-  protected async getResultIds() {
-    const content = await this.getContent();
-    if (!content)
-      return [];
-
-    const result: string[] = [];
-    content.contentSet.forEach((item) => {
-      result.push(...item.primaryKeys.map((k) => k.id));
-    });
-    return result;
-  }
-}
-
 interface GroupedElementIds {
   modelId?: string;
   categoryId?: string;
-  elementIds: string[];
+  elementIds: CachingElementIdsContainer;
 }
 
 // istanbul ignore next
 class ElementIdsCache {
-  private _assemblyElementIdsCache = new Map<string, string[]>();
+  private _assemblyElementIdsCache = new Map<string, CachingElementIdsContainer>();
   private _groupedElementIdsCache = new Map<string, GroupedElementIds>();
 
   constructor(private _imodel: IModelConnection, private _rulesetId: string) {
@@ -502,54 +497,76 @@ class ElementIdsCache {
     this._groupedElementIdsCache.clear();
   }
 
-  public async getAssemblyElementIds(assemblyId: Id64String) {
+  public getAssemblyElementIds(assemblyId: Id64String) {
     const ids = this._assemblyElementIdsCache.get(assemblyId);
     if (ids)
       return ids;
 
-    const idsProvider = new AssemblyElementIdsProvider(this._imodel, this._rulesetId, assemblyId);
-    const newIds = await idsProvider.getElementIds();
-    this._assemblyElementIdsCache.set(assemblyId, newIds);
-    return newIds;
+    const container = createAssemblyElementIdsContainer(this._imodel, this._rulesetId, assemblyId);
+    this._assemblyElementIdsCache.set(assemblyId, container);
+    return container;
   }
 
-  public async getGroupedElementIds(groupingNodeKey: GroupingNodeKey) {
+  public async getGroupedElementIds(groupingNodeKey: GroupingNodeKey): Promise<GroupedElementIds> {
     const keyString = JSON.stringify(groupingNodeKey);
     const ids = this._groupedElementIdsCache.get(keyString);
     if (ids)
       return ids;
-    const idsProvider = new GroupedElementIdsProvider(this._imodel, this._rulesetId, groupingNodeKey);
-    const newIds = await idsProvider.getElementIds();
-    this._groupedElementIdsCache.set(keyString, newIds);
-    return newIds;
+    const info = await createGroupedElementsInfo(this._imodel, this._rulesetId, groupingNodeKey);
+    this._groupedElementIdsCache.set(keyString, info);
+    return info;
+  }
+}
+
+async function* createInstanceIdsGenerator(imodel: IModelConnection, rulesetId: string, displayType: string, inputKeys: Keys) {
+  const res = await Presentation.presentation.getContentInstanceKeys({
+    imodel,
+    rulesetOrId: rulesetId,
+    displayType,
+    keys: new KeySet(inputKeys),
+  });
+  for await (const key of res.items()) {
+    yield key.id;
   }
 }
 
 // istanbul ignore next
-class AssemblyElementIdsProvider extends RulesetDrivenIdsProvider {
-  constructor(imodel: IModelConnection, rulesetId: string, assemblyId: Id64String) {
-    super(imodel, rulesetId, "AssemblyElementsRequest", [{ className: "BisCore:Element", id: assemblyId }]);
+class CachingElementIdsContainer {
+  private _generator;
+  private _ids;
+  constructor(generator: AsyncGenerator<Id64String>) {
+    this._generator = generator;
+    this._ids = new Array<Id64String>();
   }
-  public async getElementIds() {
-    return this.getResultIds();
-  }
-}
-
-// istanbul ignore next
-class GroupedElementIdsProvider extends RulesetDrivenIdsProvider {
-  constructor(imodel: IModelConnection, rulesetId: string, groupingNodeKey: GroupingNodeKey) {
-    super(imodel, rulesetId, "AssemblyElementsRequest", [groupingNodeKey]);
-  }
-  public async getElementIds(): Promise<GroupedElementIds> {
-    const elementIds = await this.getResultIds();
-    let modelId, categoryId;
-    const query = `SELECT Model.Id AS modelId, Category.Id AS categoryId FROM bis.GeometricElement3d WHERE ECInstanceId = ? LIMIT 1`;
-    for await (const modelAndCategoryIds of this.imodel.query(query, QueryBinder.from([elementIds[0]]))) {
-      modelId = modelAndCategoryIds.modelId;
-      categoryId = modelAndCategoryIds.categoryId;
+  public async* getElementIds() {
+    for (const id of this._ids) {
+      yield id;
     }
-    return { modelId, categoryId, elementIds };
+    for await (const id of this._generator) {
+      this._ids.push(id);
+      yield id;
+    }
   }
+}
+
+function createAssemblyElementIdsContainer(imodel: IModelConnection, rulesetId: string, assemblyId: Id64String) {
+  return new CachingElementIdsContainer(createInstanceIdsGenerator(imodel, rulesetId, "AssemblyElementsRequest", [{ className: "BisCore:Element", id: assemblyId }]));
+}
+
+async function createGroupedElementsInfo(imodel: IModelConnection, rulesetId: string, groupingNodeKey: GroupingNodeKey) {
+  const groupedElementIdsContainer = new CachingElementIdsContainer(createInstanceIdsGenerator(imodel, rulesetId, "AssemblyElementsRequest", [groupingNodeKey]));
+  const elementId = await groupedElementIdsContainer.getElementIds().next();
+  if (elementId.done)
+    throw new Error("Invalid grouping node key");
+
+  let modelId, categoryId;
+  const query = `SELECT Model.Id AS modelId, Category.Id AS categoryId FROM bis.GeometricElement3d WHERE ECInstanceId = ? LIMIT 1`;
+  for await (const modelAndCategoryIds of imodel.query(query, QueryBinder.from([elementId.value]), QueryRowFormat.UseJsPropertyNames)) {
+    modelId = modelAndCategoryIds.modelId;
+    categoryId = modelAndCategoryIds.categoryId;
+    break;
+  }
+  return { modelId, categoryId, elementIds: groupedElementIdsContainer };
 }
 
 const createTooltip = (status: "visible" | "hidden" | "disabled", tooltipStringId: string | undefined): string => {


### PR DESCRIPTION
The RPC only sends instance keys instead of content records. In addition, the IDs are sent as a `KeySet`, which compresses them, and that substantially reduces the payload size. 