### PR TITLE
Add IModelDb.workspace

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -367,6 +367,49 @@ export enum BackendLoggerCategory {
     Schemas = "core-backend.Schemas"
 }
 
+// @internal
+export class BaseSettings implements Settings {
+    // (undocumented)
+    addDictionary(dictionaryName: string, priority: SettingsPriority, settings: SettingDictionary): void;
+    // (undocumented)
+    addFile(fileName: LocalFileName, priority: SettingsPriority): void;
+    // (undocumented)
+    addJson(dictionaryName: string, priority: SettingsPriority, settingsJson: string): void;
+    // (undocumented)
+    close(): void;
+    // (undocumented)
+    dropDictionary(dictionaryName: DictionaryName, raiseEvent?: boolean): boolean;
+    // (undocumented)
+    getArray<T>(name: SettingName, defaultValue: Array<T>): Array<T>;
+    // (undocumented)
+    getArray<T>(name: SettingName): Array<T> | undefined;
+    // (undocumented)
+    getBoolean(name: SettingName, defaultValue: boolean): boolean;
+    // (undocumented)
+    getBoolean(name: SettingName): boolean | undefined;
+    // (undocumented)
+    getNumber(name: SettingName, defaultValue: number): number;
+    // (undocumented)
+    getNumber(name: SettingName): number | undefined;
+    // (undocumented)
+    getObject(name: SettingName, defaultValue: SettingObject): SettingObject;
+    // (undocumented)
+    getObject(name: SettingName): SettingObject | undefined;
+    // (undocumented)
+    getSetting<T extends SettingType>(name: SettingName, defaultValue?: T): T | undefined;
+    // (undocumented)
+    getString(name: SettingName, defaultValue: string): string;
+    // (undocumented)
+    getString(name: SettingName): string | undefined;
+    inspectSetting<T extends SettingType>(name: SettingName): SettingInspector<T>[];
+    // (undocumented)
+    readonly onSettingsChanged: BeEvent<() => void>;
+    // (undocumented)
+    resolveSetting<T extends SettingType>(name: SettingName, resolver: SettingResolver<T>, defaultValue?: T): T | undefined;
+    // (undocumented)
+    protected verifyPriority(_priority: SettingsPriority): void;
+}
+
 // @public
 export type BindParameter = number | string;
 
@@ -2147,13 +2190,6 @@ export abstract class IModelDb extends IModel {
     close(): void;
     get codeSpecs(): CodeSpecs;
     computeProjectExtents(options?: ComputeProjectExtentsOptions): ComputedProjectExtents;
-    // (undocumented)
-    protected _concurrentQueryStats: {
-        resetTimerHandle: any;
-        logTimerHandle: any;
-        lastActivityTime: number;
-        dispose: () => void;
-    };
     constructEntity<T extends Entity>(props: EntityProps): T;
     containsClass(classFullName: string): boolean;
     // @alpha
@@ -2268,6 +2304,10 @@ export abstract class IModelDb extends IModel {
     withPreparedStatement<T>(ecsql: string, callback: (stmt: ECSqlStatement) => T, logErrors?: boolean): T;
     withSqliteStatement<T>(sql: string, callback: (stmt: SqliteStatement) => T, logErrors?: boolean): T;
     withStatement<T>(ecsql: string, callback: (stmt: ECSqlStatement) => T, logErrors?: boolean): T;
+    // @beta
+    get workspace(): Workspace;
+    // @internal (undocumented)
+    protected _workspace: Workspace;
 }
 
 // @public (undocumented)
@@ -2360,6 +2400,8 @@ export class IModelHost {
     static set applicationId(id: string);
     static get applicationVersion(): string;
     static set applicationVersion(version: string);
+    // @beta
+    static get appWorkspace(): Workspace;
     // (undocumented)
     static authorizationClient?: AuthorizationClient;
     // (undocumented)
@@ -2412,8 +2454,6 @@ export class IModelHost {
     static tileUploader: CloudStorageTileUploader;
     // @internal
     static get usingExternalTileCache(): boolean;
-    // @beta
-    static get workspace(): Workspace;
     }
 
 // @public
@@ -2630,49 +2670,9 @@ export interface ITwinIdArg {
     readonly iTwinId: GuidString;
 }
 
-// @internal
-export class ITwinSettings implements Settings {
-    constructor();
-    // (undocumented)
-    addDictionary(dictionaryName: string, priority: SettingsPriority, settings: SettingDictionary): void;
-    // (undocumented)
-    addFile(fileName: LocalFileName, priority: SettingsPriority): void;
-    // (undocumented)
-    addJson(dictionaryName: string, priority: SettingsPriority, settingsJson: string): void;
-    // (undocumented)
-    dropDictionary(dictionaryName: DictionaryName, raiseEvent?: boolean): boolean;
-    // (undocumented)
-    getArray<T>(name: SettingName, defaultValue: Array<T>): Array<T>;
-    // (undocumented)
-    getArray<T>(name: SettingName): Array<T> | undefined;
-    // (undocumented)
-    getBoolean(name: SettingName, defaultValue: boolean): boolean;
-    // (undocumented)
-    getBoolean(name: SettingName): boolean | undefined;
-    // (undocumented)
-    getNumber(name: SettingName, defaultValue: number): number;
-    // (undocumented)
-    getNumber(name: SettingName): number | undefined;
-    // (undocumented)
-    getObject(name: SettingName, defaultValue: SettingObject): SettingObject;
-    // (undocumented)
-    getObject(name: SettingName): SettingObject | undefined;
-    // (undocumented)
-    getSetting<T extends SettingType>(name: SettingName, defaultValue?: T): T | undefined;
-    // (undocumented)
-    getString(name: SettingName, defaultValue: string): string;
-    // (undocumented)
-    getString(name: SettingName): string | undefined;
-    inspectSetting<T extends SettingType>(name: SettingName): SettingInspector<T>[];
-    // (undocumented)
-    readonly onSettingsChanged: BeEvent<() => void>;
-    // (undocumented)
-    resolveSetting<T extends SettingType>(name: SettingName, resolver: SettingResolver<T>, defaultValue?: T): T | undefined;
-    }
-
 // @internal (undocumented)
 export class ITwinWorkspace implements Workspace {
-    constructor(opts?: WorkspaceOpts);
+    constructor(settings: Settings, opts?: WorkspaceOpts);
     // (undocumented)
     close(): void;
     // (undocumented)
@@ -2682,7 +2682,7 @@ export class ITwinWorkspace implements Workspace {
     // (undocumented)
     readonly filesDir: LocalDirName;
     // (undocumented)
-    getContainer(props: WorkspaceContainerProps, opts?: WorkspaceContainerOpts): Promise<WorkspaceContainer>;
+    getContainer(props: WorkspaceContainerProps): Promise<WorkspaceContainer>;
     // (undocumented)
     loadSettingsDictionary(settingRsc: WorkspaceResourceProps, priority: SettingsPriority): Promise<void>;
     // (undocumented)
@@ -3586,6 +3586,8 @@ export interface Settings {
     addDictionary(dictionaryName: DictionaryName, priority: SettingsPriority, settings: SettingDictionary): void;
     addFile(fileName: LocalFileName, priority: SettingsPriority): void;
     addJson(dictionaryName: DictionaryName, priority: SettingsPriority, settingsJson: string): void;
+    // @internal (undocumented)
+    close(): void;
     dropDictionary(dictionaryName: DictionaryName): void;
     getArray<T>(settingName: SettingName, defaultValue: Array<T>): Array<T>;
     // (undocumented)
@@ -4364,7 +4366,7 @@ export interface Workspace {
     readonly containerDir: LocalDirName;
     dropContainer(container: WorkspaceContainer): void;
     readonly filesDir: LocalDirName;
-    getContainer(props: WorkspaceContainerProps, opts?: WorkspaceContainerOpts): Promise<WorkspaceContainer>;
+    getContainer(props: WorkspaceContainerProps): Promise<WorkspaceContainer>;
     loadSettingsDictionary(settingRsc: WorkspaceResourceProps, priority: SettingsPriority): Promise<void>;
     resolveContainerId(props: WorkspaceContainerProps): WorkspaceContainerId;
     readonly settings: Settings;
@@ -4389,18 +4391,13 @@ export type WorkspaceContainerId = string;
 export type WorkspaceContainerName = string;
 
 // @beta
-export interface WorkspaceContainerOpts {
-    forIModel?: IModelDb;
-}
-
-// @beta
 export type WorkspaceContainerProps = WorkspaceContainerName | {
     id: WorkspaceContainerId;
 };
 
 // @beta
 export class WorkspaceFile implements WorkspaceContainer {
-    constructor(containerId: WorkspaceContainerId, workspace: Workspace, opts?: WorkspaceContainerOpts);
+    constructor(containerId: WorkspaceContainerId, workspace: Workspace);
     // (undocumented)
     attach(_token: AccessToken): Promise<void>;
     // (undocumented)
@@ -4419,8 +4416,6 @@ export class WorkspaceFile implements WorkspaceContainer {
     getFile(rscName: WorkspaceResourceName, targetFileName?: LocalFileName): LocalFileName | undefined;
     // (undocumented)
     getString(rscName: WorkspaceResourceName): string | undefined;
-    // (undocumented)
-    readonly iModelOwner?: IModelDb;
     // (undocumented)
     get isOpen(): boolean;
     // (undocumented)

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4379,7 +4379,6 @@ export interface WorkspaceContainer {
     getBlob(rscName: WorkspaceResourceName): Uint8Array | undefined;
     getFile(rscName: WorkspaceResourceName, targetFileName?: LocalFileName): LocalFileName | undefined;
     getString(rscName: WorkspaceResourceName): string | undefined;
-    readonly iModelOwner?: IModelDb;
     readonly onContainerClosed: BeEvent<() => void>;
     readonly workspace: Workspace;
 }

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -10,6 +10,7 @@ public;AuxCoordSystemSpatial
 beta;AzureBlobStorage 
 beta;BackendHubAccess
 public;BackendLoggerCategory
+internal;BaseSettings 
 public;BindParameter = number | string
 public;BisCoreSchema 
 public;BriefcaseDb 
@@ -201,7 +202,6 @@ public;class IpcHandler
 public;IpcHost
 public;IpcHostOpts
 public;ITwinIdArg
-internal;ITwinSettings 
 internal;ITwinWorkspace 
 public;KnownLocations
 internal;LightLocation 
@@ -354,7 +354,6 @@ beta;Workspace
 beta;WorkspaceContainer
 beta;WorkspaceContainerId = string
 beta;WorkspaceContainerName = string
-beta;WorkspaceContainerOpts
 beta;WorkspaceContainerProps = WorkspaceContainerName |
 beta;WorkspaceFile 
 beta;WorkspaceOpts

--- a/common/changes/@itwin/core-backend/cloud-workspace-containers_2021-11-02-16-33.json
+++ b/common/changes/@itwin/core-backend/cloud-workspace-containers_2021-11-02-16-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "added IModelDb.workspace",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/ECDb.ts
+++ b/core/backend/src/ECDb.ts
@@ -31,10 +31,8 @@ export enum ECDbOpenMode {
  */
 export class ECDb implements IDisposable {
   private _nativeDb?: IModelJsNative.ECDb;
-  private _concurrentQueryInitialized: boolean = false;
   private readonly _statementCache = new StatementCache<ECSqlStatement>();
   private _sqliteStatementCache = new StatementCache<SqliteStatement>();
-  private _concurrentQueryStats = { resetTimerHandle: (null as any), logTimerHandle: (null as any), lastActivityTime: Date.now(), dispose: () => { } };
 
   /** only for tests
    * @internal
@@ -92,7 +90,6 @@ export class ECDb implements IDisposable {
     this._statementCache.clear();
     this._sqliteStatementCache.clear();
     this.nativeDb.closeDb();
-    this._concurrentQueryStats.dispose();
   }
 
   /** @internal use to test statement caching */

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -212,6 +212,7 @@ export abstract class IModelDb extends IModel {
   private _codeSpecs?: CodeSpecs;
   private _classMetaDataRegistry?: MetaDataRegistry;
   protected _fontMap?: FontMap;
+  /** @internal */
   protected _workspace: Workspace;
   private readonly _snaps = new Map<string, IModelJsNative.SnapRequest>();
   private static _shutdownListener: VoidFunction | undefined; // so we only register listener once

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -46,6 +46,8 @@ import { ServerBasedLocks } from "./ServerBasedLocks";
 import { SqliteStatement, StatementCache } from "./SqliteStatement";
 import { TxnManager } from "./TxnManager";
 import { DrawingViewDefinition, SheetViewDefinition, ViewDefinition } from "./ViewDefinition";
+import { BaseSettings, SettingName, SettingResolver, SettingsPriority, SettingType } from "./workspace/Settings";
+import { ITwinWorkspace, Workspace } from "./workspace/Workspace";
 
 const loggerCategory: string = BackendLoggerCategory.IModelDb;
 
@@ -173,6 +175,22 @@ const withBriefcaseDb = async (briefcase: OpenBriefcaseArgs, fn: (_db: Briefcase
   }
 };
 
+/**
+ * Settings for an individual iModel. May only include settings priority for iModel, iTwin and organization.
+ * @note if there is more than one iModel for an iTwin or organization, they will *each* hold a copy of the settings for those priorities.
+ */
+class IModelSettings extends BaseSettings {
+  protected override verifyPriority(priority: SettingsPriority) {
+    if (priority <= SettingsPriority.application)
+      throw new Error("Use IModelHost.appSettings");
+  }
+
+  // attempt to resolve a setting from this iModel's settings, otherwise use appWorkspace's settings, otherwise defaultValue.
+  public override resolveSetting<T extends SettingType>(name: SettingName, resolver: SettingResolver<T>, defaultValue?: T): T | undefined {
+    return super.resolveSetting(name, resolver) ?? IModelHost.appWorkspace.settings.resolveSetting(name, resolver, defaultValue);
+  }
+}
+
 /** An iModel database file. The database file can either be a briefcase or a snapshot.
  * @see [Accessing iModels]($docs/learning/backend/AccessingIModels.md)
  * @see [About IModelDb]($docs/learning/backend/IModelDb.md)
@@ -194,17 +212,23 @@ export abstract class IModelDb extends IModel {
   private _codeSpecs?: CodeSpecs;
   private _classMetaDataRegistry?: MetaDataRegistry;
   protected _fontMap?: FontMap;
-  protected _concurrentQueryStats = { resetTimerHandle: (null as any), logTimerHandle: (null as any), lastActivityTime: Date.now(), dispose: () => { } };
+  protected _workspace: Workspace;
   private readonly _snaps = new Map<string, IModelJsNative.SnapRequest>();
   private static _shutdownListener: VoidFunction | undefined; // so we only register listener once
 
   /** @internal */
   protected _locks?: LockControl = new NoLocks();
   /**
-   * Get the lock control for this iModel.
+   * Get the [[LockControl]] for this iModel.
    * @beta
    */
-  public get locks() { return this._locks!; }
+  public get locks(): LockControl { return this._locks!; }
+
+  /**
+   * Get the [[Workspace]] for this iModel.
+   * @beta
+   */
+  public get workspace(): Workspace { return this._workspace; }
 
   /** Acquire the exclusive schema lock on this iModel.
    * > Note: To acquire the schema lock, all other briefcases must first release *all* their locks. No other briefcases
@@ -251,6 +275,7 @@ export abstract class IModelDb extends IModel {
     this.nativeDb.setIModelDb(this);
     this.initializeIModelDb();
     IModelDb._openDbs.set(this._fileKey, this);
+    this._workspace = new ITwinWorkspace(new IModelSettings(), IModelHost.appWorkspace);
 
     if (undefined === IModelDb._shutdownListener) { // the first time we create an IModelDb, add a listener to close any orphan files at shutdown.
       IModelDb._shutdownListener = IModelHost.onBeforeShutdown.addListener(() => {
@@ -271,6 +296,7 @@ export abstract class IModelDb extends IModel {
 
     this.beforeClose();
     IModelDb._openDbs.delete(this._fileKey);
+    this._workspace.close();
     this.locks.close();
     this._locks = undefined;
     this.nativeDb.closeIModel();
@@ -290,7 +316,6 @@ export abstract class IModelDb extends IModel {
   protected beforeClose() {
     this.onBeforeClose.raiseEvent();
     this.clearCaches();
-    this._concurrentQueryStats.dispose();
   }
 
   /** @internal */

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -235,7 +235,7 @@ export class IModelHost {
   public static get cacheDir(): LocalDirName { return this._cacheDir; }
 
   /** The application [[Workspace]] for this `IModelHost`
-   * @note this `Workspace` only holds [[WorkspaceContainers]] and [[Settings]] scoped to the currently loaded application(s).
+   * @note this `Workspace` only holds [[WorkspaceContainer]]s and [[Settings]] scoped to the currently loaded application(s).
    * All organization, iTwin, and iModel based containers or settings must be accessed through [[IModelDb.workspace]] and
    * attempting to add them to this Workspace will fail.
    * @beta

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -158,12 +158,12 @@ export class IModelHostConfiguration {
 
 /**
  * Settings for the application workspace.
- * @note this includes the default dictionary
+ * @note this includes the default dictionary from the SettingsSpecRegistry
  */
 class ApplicationSettings extends BaseSettings {
   private _remove?: VoidFunction;
   protected override verifyPriority(priority: SettingsPriority) {
-    if (priority > SettingsPriority.application)
+    if (priority >= SettingsPriority.iModel) // iModel settings may not appear in ApplicationSettings
       throw new Error("Use IModelSettings");
   }
   private updateDefaults() {

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -29,6 +29,8 @@ import { SnapshotIModelRpcImpl } from "./rpc-impl/SnapshotIModelRpcImpl";
 import { WipRpcImpl } from "./rpc-impl/WipRpcImpl";
 import { initializeRpcBackend } from "./RpcBackend";
 import { ITwinWorkspace, Workspace, WorkspaceOpts } from "./workspace/Workspace";
+import { BaseSettings, SettingDictionary, SettingsPriority } from "./workspace/Settings";
+import { SettingsSpecRegistry } from "./workspace/SettingsSpecRegistry";
 
 const loggerCategory = BackendLoggerCategory.IModelHost;
 
@@ -154,6 +156,36 @@ export class IModelHostConfiguration {
 
 }
 
+/**
+ * Settings for the application workspace.
+ * @note this includes the default dictionary
+ */
+class ApplicationSettings extends BaseSettings {
+  private _remove?: VoidFunction;
+  protected override verifyPriority(priority: SettingsPriority) {
+    if (priority > SettingsPriority.application)
+      throw new Error("Use IModelSettings");
+  }
+  private updateDefaults() {
+    const defaults: SettingDictionary = {};
+    for (const [specName, val] of SettingsSpecRegistry.allSpecs)
+      defaults[specName] = val.default!;
+    this.addDictionary("_default_", 0, defaults);
+  }
+
+  public constructor() {
+    super();
+    this._remove = SettingsSpecRegistry.onSpecsChanged.addListener(() => this.updateDefaults());
+    this.updateDefaults();
+  }
+  public override close() {
+    if (this._remove) {
+      this._remove();
+      this._remove = undefined;
+    }
+  }
+}
+
 /** IModelHost initializes ($backend) and captures its configuration. A backend must call [[IModelHost.startup]] before using any backend classes.
  * See [the learning article]($docs/learning/backend/IModelHost.md)
  * @public
@@ -167,7 +199,7 @@ export class IModelHost {
 
   public static backendVersion = "";
   private static _cacheDir = "";
-  private static _workspace: Workspace;
+  private static _appWorkspace?: Workspace;
 
   private static _platform?: typeof IModelJsNative;
   /** @internal */
@@ -202,10 +234,13 @@ export class IModelHost {
   /** Root directory holding files that iTwin.js caches */
   public static get cacheDir(): LocalDirName { return this._cacheDir; }
 
-  /** The Workspace for this `IModelHost`
+  /** The application [[Workspace]] for this `IModelHost`
+   * @note this `Workspace` only holds [[WorkspaceContainers]] and [[Settings]] scoped to the currently loaded application(s).
+   * All organization, iTwin, and iModel based containers or settings must be accessed through [[IModelDb.workspace]] and
+   * attempting to add them to this Workspace will fail.
    * @beta
    */
-  public static get workspace(): Workspace { return this._workspace; }
+  public static get appWorkspace(): Workspace { return this._appWorkspace!; }
 
   /** The optional [[FileNameResolver]] that resolves keys and partial file names for snapshot iModels. */
   public static snapshotFileNameResolver?: FileNameResolver;
@@ -334,7 +369,7 @@ export class IModelHost {
     }
 
     this.setupHostDirs(configuration);
-    this._workspace = new ITwinWorkspace(configuration.workspace);
+    this._appWorkspace = new ITwinWorkspace(new ApplicationSettings(), configuration.workspace);
 
     BriefcaseManager.initialize(this._briefcaseCacheDir);
 
@@ -407,6 +442,8 @@ export class IModelHost {
     IModelHost._isValid = false;
     IModelHost.onBeforeShutdown.raiseEvent();
     IModelHost.configuration = undefined;
+    IModelHost.appWorkspace.close();
+    IModelHost._appWorkspace = undefined;
     process.removeListener("beforeExit", IModelHost.shutdown);
   }
 

--- a/core/backend/src/test/IModelHost.test.ts
+++ b/core/backend/src/test/IModelHost.test.ts
@@ -52,6 +52,13 @@ describe("IModelHost", () => {
     IModelHost.onBeforeShutdown.addOnce(eventHandler);
     const filename = IModelTestUtils.resolveAssetFile("GetSetAutoHandledStructProperties.bim");
 
+    const workspaceClose = sinon.spy((IModelHost.appWorkspace as any), "close");
+    const saveSettings = IModelHost.appWorkspace.settings as any;
+    const settingClose = sinon.spy(saveSettings, "close");
+    expect(workspaceClose.callCount).eq(0);
+    expect(settingClose.callCount).eq(0);
+    expect(saveSettings._remove).to.not.be.undefined;
+
     // shutdown should close any opened iModels. Make sure that happens
     const imodel1 = SnapshotDb.openFile(filename, { key: "imodel1" });
     const imodel2 = SnapshotDb.openFile(filename, { key: "imodel2" });
@@ -68,6 +75,9 @@ describe("IModelHost", () => {
     assert.isFalse(imodel1.isOpen, "shutdown should close iModel1");
     assert.isFalse(imodel2.isOpen, "shutdown should close iModel2");
     assert.isFalse(imodel3.isOpen, "shutdown should close iModel3");
+    expect(workspaceClose.callCount).eq(1);
+    expect(settingClose.callCount).eq(1);
+    expect(saveSettings._remove).to.be.undefined;
   });
 
   it("should auto-shutdown on process beforeExit event", async () => {

--- a/core/backend/src/test/standalone/Settings.test.ts
+++ b/core/backend/src/test/standalone/Settings.test.ts
@@ -4,12 +4,25 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { IModelTestUtils } from "../IModelTestUtils";
-import { ITwinSettings, SettingsPriority } from "../../workspace/Settings";
-import { SettingsGroupSpec, SettingSpec, SettingsSpecRegistry } from "../../workspace/SettingsSpecRegistry";
 import { Mutable } from "@itwin/core-bentley";
+import { SnapshotDb } from "../../IModelDb";
+import { IModelHost } from "../../IModelHost";
+import { SettingsPriority } from "../../workspace/Settings";
+import { SettingsGroupSpec, SettingSpec, SettingsSpecRegistry } from "../../workspace/SettingsSpecRegistry";
+import { IModelTestUtils } from "../IModelTestUtils";
 
 describe("Settings", () => {
+  let iModel: SnapshotDb;
+
+  before(() => {
+    const seedFileName = IModelTestUtils.resolveAssetFile("CompatibilityTestSeed.bim");
+    const testFileName = IModelTestUtils.prepareOutputFile("SettingsTest", "SettingsTest.bim");
+    iModel = IModelTestUtils.createSnapshotFromSeed(testFileName, seedFileName);
+  });
+
+  after(() => {
+    iModel.close();
+  });
 
   const app1: SettingsGroupSpec = {
     groupName: "app1",
@@ -43,6 +56,16 @@ describe("Settings", () => {
         default: 22,
       },
     },
+  };
+
+  const app1Settings = {
+    "app1/sub1": "app1 value",
+    "app1/sub2": {
+      arr: ["app1", "app2"],
+    },
+    "app1/setting2": 1002,
+    "app1/setting3": "app setting 3 val",
+    "app1/setting5": "app setting 5 val",
   };
 
   const imodel1Settings = {
@@ -81,14 +104,21 @@ describe("Settings", () => {
   };
 
   it("settings priorities", () => {
-    const settings = new ITwinSettings();
+
+    const settings = iModel.workspace.settings;
     SettingsSpecRegistry.addGroup(app1);
+    IModelHost.appWorkspace.settings.addDictionary("app1", SettingsPriority.application, app1Settings);
     settings.addDictionary("iModel1.setting.json", SettingsPriority.iModel, imodel1Settings);
     settings.addDictionary("iModel2.setting.json", SettingsPriority.iModel, imodel2Settings);
     settings.addDictionary("iTwin.setting.json", SettingsPriority.iTwin, iTwinSettings);
 
+    expect(() => IModelHost.appWorkspace.settings.addDictionary("iModel", SettingsPriority.iModel, imodel1Settings)).to.throw("Use IModelSettings");
+    expect(() => IModelHost.appWorkspace.settings.addDictionary("iModel", SettingsPriority.organization, imodel1Settings)).to.throw("Use IModelSettings");
+    expect(() => IModelHost.appWorkspace.settings.addDictionary("itwin", SettingsPriority.iTwin, iTwinSettings)).to.throw("Use IModelSettings");
+
     expect(settings.getString("app1/sub1")).equals(imodel2Settings["app1/sub1"]);
     expect(settings.getString("app2/setting6")).equals(iTwinSettings["app2/setting6"]);
+    expect(settings.getString("app1/setting5")).equals(app1Settings["app1/setting5"]); // comes from app settings
     expect(settings.getSetting<any>("app1/sub2").arr).deep.equals(imodel2Settings["app1/sub2"].arr);
 
     const app3obj = settings.getSetting<any>("app3/obj");
@@ -121,22 +151,29 @@ describe("Settings", () => {
     expect(settings.getString("app1/strVal")).equals(app1.properties["app1/strVal"].default);
 
     const inspect = settings.inspectSetting("app1/sub1");
-    expect(inspect.length).equals(4);
-    expect(inspect[3].dictionary).equals("_default_");
-    expect(inspect[3].value).equals("val1");
-    expect(inspect[3].priority).equals(0);
+    expect(inspect.length).equals(5);
+    expect(inspect[0]).to.deep.equal({ value: "imodel2 value", dictionary: "iModel2.setting.json", priority: 500 });
+    expect(inspect[1]).to.deep.equal({ value: "imodel1 value", dictionary: "iModel1.setting.json", priority: 500 });
+    expect(inspect[2]).to.deep.equal({ value: "val3", dictionary: "iTwin.setting.json", priority: 400 });
+    expect(inspect[3]).to.deep.equal({ value: "app1 value", dictionary: "app1", priority: 200 });
+    expect(inspect[4]).to.deep.equal({ value: "val1", dictionary: "_default_", priority: 0 });
 
     settings.dropDictionary("iTwin.setting.json");
     expect(settings.getString("app2/setting6")).is.undefined;
   });
 
   it("read settings file", () => {
-    const settings = new ITwinSettings();
-    settings.addFile(IModelTestUtils.resolveAssetFile("test.setting.json5"), SettingsPriority.application);
-    expect(settings.getString("workbench/colorTheme")).equals("Visual Studio Light");
-    const token = settings.getSetting<any>("editor/tokenColorCustomizations")!;
+    const appSettings = IModelHost.appWorkspace.settings;
+    const iModelSettings = iModel.workspace.settings;
+    const settingFileName = IModelTestUtils.resolveAssetFile("test.setting.json5");
+    appSettings.addFile(settingFileName, SettingsPriority.application);
+    expect(() => iModelSettings.addFile(settingFileName, SettingsPriority.application)).to.throw("Use IModelHost.appSettings");
+    expect(appSettings.getString("workbench/colorTheme")).equals("Visual Studio Light");
+    expect(iModelSettings.getString("workbench/colorTheme")).equals("Visual Studio Light");
+    const token = appSettings.getSetting<any>("editor/tokenColorCustomizations")!;
     expect(token["Visual Studio Light"].textMateRules[0].settings.foreground).equals("#d16c6c");
     expect(token["Default High Contrast"].comments).equals("#FF0000");
-    expect(settings.getArray<string>("cSpell/enableFiletypes")!.length).equals(17);
+    expect(appSettings.getArray<string>("cSpell/enableFiletypes")!.length).equals(17);
+    appSettings.dropDictionary(settingFileName);
   });
 });

--- a/core/backend/src/test/standalone/Settings.test.ts
+++ b/core/backend/src/test/standalone/Settings.test.ts
@@ -103,14 +103,21 @@ describe("Settings", () => {
     },
   };
 
-  it("settings priorities", () => {
+  it.only("settings priorities", () => {
 
     const settings = iModel.workspace.settings;
     SettingsSpecRegistry.addGroup(app1);
     IModelHost.appWorkspace.settings.addDictionary("app1", SettingsPriority.application, app1Settings);
+
+    let settingsChanged = 0;
+    settings.onSettingsChanged.addListener(() => settingsChanged++);
+
     settings.addDictionary("iModel1.setting.json", SettingsPriority.iModel, imodel1Settings);
+    expect(settingsChanged).eq(1);
     settings.addDictionary("iModel2.setting.json", SettingsPriority.iModel, imodel2Settings);
+    expect(settingsChanged).eq(2);
     settings.addDictionary("iTwin.setting.json", SettingsPriority.iTwin, iTwinSettings);
+    expect(settingsChanged).eq(3);
 
     expect(() => IModelHost.appWorkspace.settings.addDictionary("iModel", SettingsPriority.iModel, imodel1Settings)).to.throw("Use IModelSettings");
 
@@ -141,6 +148,7 @@ describe("Settings", () => {
     iTwinSettings["app2/setting6"] = "new value for 6";
     settings.addDictionary("iTwin.setting.json", SettingsPriority.iTwin, iTwinSettings);
     expect(settings.getString("app2/setting6")).equals(iTwinSettings["app2/setting6"]);
+    expect(settingsChanged).eq(4);
 
     (app1.properties["app1/strVal"] as Mutable<SettingSpec>).default = "new default";
     SettingsSpecRegistry.addGroup(app1);
@@ -157,6 +165,7 @@ describe("Settings", () => {
     expect(inspect[4]).to.deep.equal({ value: "val1", dictionary: "_default_", priority: 0 });
 
     settings.dropDictionary("iTwin.setting.json");
+    expect(settingsChanged).eq(5);
     expect(settings.getString("app2/setting6")).is.undefined;
   });
 

--- a/core/backend/src/test/standalone/Settings.test.ts
+++ b/core/backend/src/test/standalone/Settings.test.ts
@@ -103,7 +103,7 @@ describe("Settings", () => {
     },
   };
 
-  it.only("settings priorities", () => {
+  it("settings priorities", () => {
 
     const settings = iModel.workspace.settings;
     SettingsSpecRegistry.addGroup(app1);

--- a/core/backend/src/test/standalone/Settings.test.ts
+++ b/core/backend/src/test/standalone/Settings.test.ts
@@ -113,8 +113,6 @@ describe("Settings", () => {
     settings.addDictionary("iTwin.setting.json", SettingsPriority.iTwin, iTwinSettings);
 
     expect(() => IModelHost.appWorkspace.settings.addDictionary("iModel", SettingsPriority.iModel, imodel1Settings)).to.throw("Use IModelSettings");
-    expect(() => IModelHost.appWorkspace.settings.addDictionary("iModel", SettingsPriority.organization, imodel1Settings)).to.throw("Use IModelSettings");
-    expect(() => IModelHost.appWorkspace.settings.addDictionary("itwin", SettingsPriority.iTwin, iTwinSettings)).to.throw("Use IModelSettings");
 
     expect(settings.getString("app1/sub1")).equals(imodel2Settings["app1/sub1"]);
     expect(settings.getString("app2/setting6")).equals(iTwinSettings["app2/setting6"]);

--- a/core/backend/src/test/standalone/Workspace.test.ts
+++ b/core/backend/src/test/standalone/Workspace.test.ts
@@ -13,11 +13,11 @@ import { IModelJsFs } from "../../IModelJsFs";
 import { EditableWorkspaceFile, ITwinWorkspace, WorkspaceContainerId, WorkspaceFile } from "../../workspace/Workspace";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
-import { SettingDictionary, SettingsPriority } from "../../workspace/Settings";
+import { BaseSettings, SettingDictionary, SettingsPriority } from "../../workspace/Settings";
 
 describe("WorkspaceFile", () => {
 
-  const workspace = new ITwinWorkspace({ containerDir: join(KnownTestLocations.outputDir, "TestWorkspaces") });
+  const workspace = new ITwinWorkspace(new BaseSettings(), { containerDir: join(KnownTestLocations.outputDir, "TestWorkspaces") });
 
   function makeContainer(id: WorkspaceContainerId) {
     const wsFile = new EditableWorkspaceFile(id, workspace);
@@ -152,5 +152,9 @@ describe("WorkspaceFile", () => {
 
     settings.dropDictionary("imodel-02");
     expect(workspace.resolveContainerId(fontContainerName)).equals("fonts-01");
+  });
+
+  it("appWorkspace", () => {
+
   });
 });

--- a/core/backend/src/test/standalone/Workspace.test.ts
+++ b/core/backend/src/test/standalone/Workspace.test.ts
@@ -153,8 +153,4 @@ describe("WorkspaceFile", () => {
     settings.dropDictionary("imodel-02");
     expect(workspace.resolveContainerId(fontContainerName)).equals("fonts-01");
   });
-
-  it("appWorkspace", () => {
-
-  });
 });

--- a/core/backend/src/workspace/Settings.ts
+++ b/core/backend/src/workspace/Settings.ts
@@ -221,13 +221,16 @@ export class BaseSettings implements Settings {
     this.verifyPriority(priority);
     this.dropDictionary(dictionaryName, false); // make sure we don't have the same dictionary twice
     const file = new SettingsDictionary(dictionaryName, priority, settings);
-    for (let i = 0; i < this._dictionaries.length; ++i) {
-      if (this._dictionaries[i].priority <= file.priority) {
-        this._dictionaries.splice(i, 0, file);
-        return;
+    const doAdd = () => {
+      for (let i = 0; i < this._dictionaries.length; ++i) {
+        if (this._dictionaries[i].priority <= file.priority) {
+          this._dictionaries.splice(i, 0, file);
+          return;
+        }
       }
-    }
-    this._dictionaries.push(file);
+      this._dictionaries.push(file);
+    };
+    doAdd();
     this.onSettingsChanged.raiseEvent();
   }
 

--- a/core/backend/src/workspace/Settings.ts
+++ b/core/backend/src/workspace/Settings.ts
@@ -9,7 +9,6 @@
 import * as fs from "fs-extra";
 import { parse } from "json5";
 import { BeEvent, JSONSchemaType } from "@itwin/core-bentley";
-import { SettingsSpecRegistry } from "./SettingsSpecRegistry";
 import { LocalFileName } from "@itwin/core-common";
 
 /** The type of a Setting, according to its schema
@@ -82,6 +81,9 @@ export enum SettingsPriority {
  * @beta
  */
 export interface Settings {
+  /** @internal */
+  close(): void;
+
   /** Event raised whenever a SettingsDictionary is added or removed. */
   readonly onSettingsChanged: BeEvent<() => void>;
 
@@ -201,22 +203,11 @@ class SettingsDictionary {
  * Internal implementation of Settings interface.
  * @internal
  */
-export class ITwinSettings implements Settings {
+export class BaseSettings implements Settings {
   private _dictionaries: SettingsDictionary[] = [];
+  protected verifyPriority(_priority: SettingsPriority) { }
+  public close() { }
   public readonly onSettingsChanged = new BeEvent<() => void>();
-
-  private updateDefaults() {
-    const defaults: SettingDictionary = {};
-    for (const [specName, val] of SettingsSpecRegistry.allSpecs)
-      defaults[specName] = val.default!;
-    this.addDictionary("_default_", 0, defaults);
-  }
-
-  public constructor() {
-    SettingsSpecRegistry.onSpecsChanged.addListener(() => this.updateDefaults());
-    this._dictionaries = [];
-    this.updateDefaults();
-  }
 
   public addFile(fileName: LocalFileName, priority: SettingsPriority) {
     this.addJson(fileName, priority, fs.readFileSync(fileName, "utf-8"));
@@ -227,6 +218,7 @@ export class ITwinSettings implements Settings {
   }
 
   public addDictionary(dictionaryName: string, priority: SettingsPriority, settings: SettingDictionary) {
+    this.verifyPriority(priority);
     this.dropDictionary(dictionaryName, false); // make sure we don't have the same dictionary twice
     const file = new SettingsDictionary(dictionaryName, priority, settings);
     for (let i = 0; i < this._dictionaries.length; ++i) {

--- a/core/backend/src/workspace/Workspace.ts
+++ b/core/backend/src/workspace/Workspace.ts
@@ -93,8 +93,6 @@ export interface WorkspaceContainer {
   readonly containerId: WorkspaceContainerId;
   /** The Workspace that opened this WorkspaceContainer */
   readonly workspace: Workspace;
-  /** If present, IModelDb that owns this [[WorkspaceContainer]]. The lifetime of this container is paired with the iModelDb. */
-  readonly iModelOwner?: IModelDb;
   /** the directory for extracting file resources. */
   readonly containerFilesDir: LocalDirName;
   /** event raised when the container is closed. */

--- a/core/backend/src/workspace/Workspace.ts
+++ b/core/backend/src/workspace/Workspace.ts
@@ -16,7 +16,7 @@ import { IModelJsFs } from "../IModelJsFs";
 import { SQLiteDb } from "../SQLiteDb";
 import { SqliteStatement } from "../SqliteStatement";
 import { ITwinSettings, Settings, SettingsPriority } from "./Settings";
-import { NativeLibrary } from "@bentley/imodeljs-native";
+import { BlobDaemon, BlobDaemonCommand, BlobDaemonCommandArg, NativeLibrary } from "@bentley/imodeljs-native";
 
 /** The names of Settings used by Workspace
  * @beta
@@ -48,7 +48,7 @@ export type WorkspaceContainerName = string;
  *  - be blank or start or end with a space
  *  - be longer than 255 characters
  *  - contain any characters with Unicode values less than 0x20
- *  - contain characters reserved for filename, device, wildcard, or url syntax (e.g. "\.<>:"/\\"`'|?*")
+ *  - contain characters reserved for filename, device, wildcard, or url syntax (e.g. "#\.<>:"/\\"`'|?*")
  * @beta
  */
 export type WorkspaceContainerId = string;
@@ -263,6 +263,10 @@ export class WorkspaceFile implements WorkspaceContainer {
   public readonly iModelOwner?: IModelDb;
   public readonly onContainerClosed = new BeEvent<() => void>();
 
+  private async runCommand(command: BlobDaemonCommand, dbProps: BlobDaemonCommandArg) {
+    await BlobDaemon.command(command, dbProps);
+  }
+
   public get containerFilesDir() { return join(this.workspace.filesDir, this.containerId); }
   public get isOpen() { return this.db.isOpen; }
 
@@ -284,7 +288,7 @@ export class WorkspaceFile implements WorkspaceContainer {
   }
 
   private static validateContainerId(id: WorkspaceContainerId) {
-    if (id === "" || id.length > 255 || /[\.<>:"/\\"`'|?*\u0000-\u001F]/g.test(id) || /^(con|prn|aux|nul|com\d|lpt\d)$/i.test(id))
+    if (id === "" || id.length > 255 || /[#\.<>:"/\\"`'|?*\u0000-\u001F]/g.test(id) || /^(con|prn|aux|nul|com\d|lpt\d)$/i.test(id))
       throw new Error(`invalid containerId: [${id}]`);
     this.noLeadingOrTrailingSpaces(id, "containerId");
   }

--- a/core/backend/src/workspace/Workspace.ts
+++ b/core/backend/src/workspace/Workspace.ts
@@ -12,7 +12,6 @@ import { dirname, extname, join } from "path";
 import { NativeLibrary } from "@bentley/imodeljs-native";
 import { AccessToken, BeEvent, DbResult, OpenMode } from "@itwin/core-bentley";
 import { IModelError, LocalDirName, LocalFileName } from "@itwin/core-common";
-import { IModelDb } from "../IModelDb";
 import { IModelJsFs } from "../IModelJsFs";
 import { SQLiteDb } from "../SQLiteDb";
 import { SqliteStatement } from "../SqliteStatement";

--- a/docs/learning/backend/Workspace.md
+++ b/docs/learning/backend/Workspace.md
@@ -4,7 +4,7 @@ When an iTwin.js backend starts, [IModelHost.startup]($backend) creates an insta
 
 `IModelHost.appWorkspace` customizes the session according to the choices of the host application(s), including the default values for its settings.
 
-Whenever an application opens an iModel using the [IModelDb]($backend) class, it creates an instance of a [Workspace]($backend) in [IModelDb.workspace] to customize the session according to the choices made by administrators for the organization, the iTwin and the iModel.
+Whenever an application opens an iModel using the [IModelDb]($backend) class, it creates an instance of a [Workspace]($backend) in [IModelDb.workspace]($backend) to customize the session according to the choices made by administrators for the organization, the iTwin and the iModel.
 
 When combined, the `IModelHost.appWorkspace` and the `IModelDb.workspace` customize the session according to the:
 

--- a/docs/learning/backend/Workspace.md
+++ b/docs/learning/backend/Workspace.md
@@ -1,17 +1,21 @@
 # Workspaces in iTwin.js
 
-When an iTwin.js backend starts, [IModelHost.startup]($backend) creates an instance of a [Workspace]($backend), in [IModelHost.workspace]($backend).
+When an iTwin.js backend starts, [IModelHost.startup]($backend) creates an instance of a [Workspace]($backend), in [IModelHost.appWorkspace]($backend).
 
-`IModelHost.workspace` customizes the session according to the choices of the:
- 1. host application(s)
+`IModelHost.appWorkspace` customizes the session according to the choices of the host application(s), including the default values for its settings.
+
+Whenever an application opens an iModel using the [IModelDb]($backend) class, it creates an instance of a [Workspace]($backend) in [IModelDb.workspace] to customize the session according to the choices made by administrators for the organization, the iTwin and the iModel.
+
+When combined, the `IModelHost.appWorkspace` and the `IModelDb.workspace` customize the session according to the:
+
+ 1. application's defaults
  2. organization of the user
  3. current iTwin
  4. current iModel
- 5. current "activity" being performed
 
 In the list above, later entries tend to change more frequently and, in the case of conflicting choices, later entries override earlier ones.
 
-`IModelHost.workspace` expresses the current state of the session in two forms:
+[Workspace]($backend)s expresses the current state of the session in two forms:
   1. [Settings](#settings)
   2. [WorkspaceContainers](#workspacecontainers)
 

--- a/example-code/snippets/src/backend/ExampleCode.test.ts
+++ b/example-code/snippets/src/backend/ExampleCode.test.ts
@@ -130,7 +130,7 @@ describe("Example Code", () => {
     // __PUBLISH_EXTRACT_END__
 
     // __PUBLISH_EXTRACT_START__ Settings.addDictionary
-    let workspace = IModelHost.workspace;
+    let workspace = IModelHost.appWorkspace;
     let settings = workspace.settings;
     settings.addDictionary("initial values", SettingsPriority.defaults, defaultsDict);
     let defaultTool = settings.getString("core/default-tool"); // returns "select"
@@ -150,7 +150,7 @@ describe("Example Code", () => {
       "app5/markerName": "arrows",
       "app5/markerIcon": "arrows.ico",
     };
-    workspace = IModelHost.workspace;
+    workspace = iModel.workspace;
     settings = workspace.settings;
     settings.addDictionary("for iTwin 555", SettingsPriority.iTwin, iTwin555);
     defaultTool = settings.getString("core/default-tool"); // returns "measure"
@@ -158,7 +158,7 @@ describe("Example Code", () => {
     expect(defaultTool).eq(iTwin555["core/default-tool"]);
 
     // __PUBLISH_EXTRACT_START__ Settings.dropITwinDictionary
-    workspace = IModelHost.workspace;
+    workspace = iModel.workspace;
     settings = workspace.settings;
     settings.dropDictionary("for iTwin 555");
     defaultTool = settings.getString("core/default-tool"); // returns "select" again
@@ -181,7 +181,7 @@ describe("Example Code", () => {
       ],
     };
 
-    workspace = IModelHost.workspace;
+    workspace = iModel.workspace;
     settings = workspace.settings;
     const fontContainerName = "default-fonts";
     settings.addDictionary("iTwin", SettingsPriority.iTwin, iTwinDict);


### PR DESCRIPTION
The `workspace` member on `IModelHost` is now called `appWorkspace` and it cannot hold iModel settings. There is now a new member `IModelDb.workspace` that may hold information at the organization, iTwin, and iModel priorities. Calling `IModelDb.workspace.settings.getValue` will resolve settings from all priorities (including application). 

This makes it possible to have more than one `IModelDb` at a time, each with their own independent workspaces.