### PR TITLE
Fix WebGL view not updating when dropping second viewport

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-canvas-animation-not-updating-when-dropping-viewport_2021-11-02-17-56.json
+++ b/common/changes/@itwin/core-frontend/fix-canvas-animation-not-updating-when-dropping-viewport_2021-11-02-17-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix WebGL view not updating when dropping second viewport.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -3255,15 +3255,15 @@ export class ScreenViewport extends Viewport {
 
       this.addChildDiv(this.vpDiv, webglCanvas, 5);
 
-      /** The following workaround resolves an issue specific to iOS Safari. We really want this webgl canvas' zIndex to be
-       * lower than this.canvas, but if we do that on iOS Safari, Safari may decide to not display the canvas contents once
-       * it is re-added to the parent div after dropping other viewports. It will only display it once resizing the view.
-       * The offending element here is the 2d canvas sitting on top of the webgl canvas. We need to clear its contents
-       * immediately on iOS. Even though the 2d canvas gets cleared in OnScreenTarget.drawOverlayDecorations() in this case,
-       * it looks like iOS needs an immediate clear.
+      /** We really want this WebGL canvas' zIndex to be lower than this.canvas, but if we do that, browsers can decide to
+       * not update the WebGL canvas contents once it is re-added to the parent div after dropping other viewports.
+       * The offending element is the 2d canvas sitting on top of the WebGL canvas. We need to clear the 2d canvas' contents
+       * in order to ensure browsers allow the underlying WebGL canvas to update. If a decorator is present, the 2d canvas
+       * is cleared during the frame render process by virtue of updating the decorator. For the non-decorator case, and for
+       * iOS, we must make sure we still clear the 2d canvas, done here. iOS appears to need this clear even when decorators
+       * clear the canvas later in the frame render process.
        */
-      if (ProcessDetector.isIOSBrowser)
-        _clear2dCanvas(this.canvas);
+      _clear2dCanvas(this.canvas);
     }
 
     this.target.updateViewRect();

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -8,7 +8,6 @@
 
 import {
   asInstanceOf, assert, BeDuration, BeEvent, BeTimePoint, Constructor, dispose, Id64, Id64Arg, Id64Set, Id64String, IDisposable, isInstanceOf,
-  ProcessDetector,
   StopWatch,
 } from "@itwin/core-bentley";
 import {


### PR DESCRIPTION
When dropping a second viewport and re-enabling direct-to-screen WebGL rendering, we really want the WebGL canvas' zIndex to be lower than the 2d canvas, but if we do that, browsers can decide to not update the WebGL canvas contents once it is re-added to the parent div after dropping other viewports. The offending element is the 2d canvas sitting on top of the WebGL canvas. We need to clear the 2d canvas' contents in order to ensure browsers allow the underlying WebGL canvas to update. If a decorator is present, the 2d canvas is cleared during the frame render process by virtue of updating the decorator. For the non-decorator case, and for iOS, we must make sure we still clear the 2d canvas, done here. iOS appears to need this clear even when decorators clear the canvas later in the frame render process.

https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/724983