### PR TITLE
Adds support for EPSG:4326 CRS in WMS imagery provider

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5279,6 +5279,15 @@ export abstract class MapLayerImageryProvider {
     // (undocumented)
     getEPSG3857Y(latitude: number): number;
     // (undocumented)
+    getEPSG4326Extent(row: number, column: number, zoomLevel: number): {
+        longitudeLeft: number;
+        longitudeRight: number;
+        latitudeTop: number;
+        latitudeBottom: number;
+    };
+    // (undocumented)
+    getEPSG4326ExtentString(row: number, column: number, zoomLevel: number, latLongAxisOrdering: boolean): string;
+    // (undocumented)
     protected getImageFromTileResponse(tileResponse: Response, zoomLevel: number): ImageSource | undefined;
     // (undocumented)
     getLogo(_viewport: ScreenViewport): HTMLTableRowElement | undefined;
@@ -13217,6 +13226,8 @@ export class WmsCapabilities {
     // (undocumented)
     getSubLayers(visible?: boolean): undefined | MapSubLayerProps[];
     // (undocumented)
+    getSubLayersCrs(subLayerNames: string[]): Map<string, string[]> | undefined;
+    // (undocumented)
     get json(): any;
     // (undocumented)
     readonly layer?: WmsCapability.Layer;
@@ -13237,6 +13248,8 @@ export namespace WmsCapability {
         readonly cartoRange?: MapCartoRectangle;
         // (undocumented)
         getSubLayers(visible?: boolean): MapSubLayerProps[];
+        // (undocumented)
+        getSubLayersCrs(layerNameFilter: string[]): Map<string, string[]>;
         // (undocumented)
         readonly queryable: boolean;
         // (undocumented)
@@ -13270,7 +13283,11 @@ export namespace WmsCapability {
         // (undocumented)
         readonly children?: SubLayer[];
         // (undocumented)
+        readonly crs: string[];
+        // (undocumented)
         readonly name: string;
+        // (undocumented)
+        readonly ownCrs: string[];
         // (undocumented)
         readonly parent?: SubLayer | undefined;
         // (undocumented)
@@ -13281,10 +13298,23 @@ export namespace WmsCapability {
 }
 
 // @internal (undocumented)
+export interface WmsCrsSupport {
+    // (undocumented)
+    support3857: boolean;
+    // (undocumented)
+    support4326: boolean;
+}
+
+// @internal (undocumented)
 export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
     constructor(settings: MapLayerSettings);
     // (undocumented)
     constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
+    // (undocumented)
+    getCrsSupport(): {
+        support3857: boolean;
+        support4326: boolean;
+    };
     // (undocumented)
     getToolTip(strings: string[], quadId: QuadId, carto: Cartographic, tree: ImageryMapTileTree): Promise<void>;
     // (undocumented)

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -13311,10 +13311,7 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
     // (undocumented)
     constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
     // (undocumented)
-    getCrsSupport(): {
-        support3857: boolean;
-        support4326: boolean;
-    };
+    getCrsSupport(): WmsCrsSupport;
     // (undocumented)
     getToolTip(strings: string[], quadId: QuadId, carto: Cartographic, tree: ImageryMapTileTree): Promise<void>;
     // (undocumented)

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -665,6 +665,7 @@ internal;WheelEventProcessor
 public;WindowAreaTool 
 internal;WmsCapabilities
 internal;WmsCapability
+internal;WmsCrsSupport
 internal;WmsMapLayerImageryProvider 
 internal;WmsUtilities
 internal;WmtsCapabilities

--- a/common/changes/@itwin/core-frontend/geo-wms_4326_support_2021-11-04-17-55.json
+++ b/common/changes/@itwin/core-frontend/geo-wms_4326_support_2021-11-04-17-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Added support for EPSG:4326 in WMS imagery provider.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/public/assets/wms_capabilities/continents.xml
+++ b/core/frontend/src/test/public/assets/wms_capabilities/continents.xml
@@ -1,0 +1,151 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
+
+<!-- MapServer version 7.0.7 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=FASTCGI SUPPORTS=GEOS SUPPORTS=DPAPI_ENCRYPTION SUPPORTS=DPAPI_ENCRYPTION_CERT INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE -->
+
+<Service>
+  <Name>WMS</Name>
+<!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
+  <Title>WFS_server</Title>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/>
+  <ContactInformation>
+  </ContactInformation>
+  <MaxWidth>4096</MaxWidth>
+  <MaxHeight>4096</MaxHeight>
+</Service>
+
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/png; mode=8bit</Format>
+      <Format>application/x-pdf</Format>
+      <Format>image/svg+xml</Format>
+      <Format>image/tiff</Format>
+      <Format>application/vnd.google-earth.kml+xml</Format>
+      <Format>application/vnd.google-earth.kmz</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+    <GetFeatureInfo>
+      <Format>text/html</Format>
+      <Format>application/vnd.ogc.gml</Format>
+      <Format>text/plain</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+    <sld:DescribeLayer>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </sld:DescribeLayer>
+    <sld:GetLegendGraphic>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/png; mode=8bit</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </sld:GetLegendGraphic>
+    <ms:GetStyles>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </ms:GetStyles>
+  </Request>
+  <Exception>
+    <Format>XML</Format>
+    <Format>INIMAGE</Format>
+    <Format>BLANK</Format>
+  </Exception>
+  <sld:UserDefinedSymbolization SupportSLD="1" UserLayer="0" UserStyle="1" RemoteWFS="0" InlineFeature="0" RemoteWCS="0"/>
+  <Layer>
+    <Name>WFS_server</Name>
+<!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
+    <Title>WFS_server</Title>
+    <Abstract>WFS_server</Abstract>
+    <CRS>EPSG:4326</CRS>
+    <EX_GeographicBoundingBox>
+        <westBoundLongitude>-180</westBoundLongitude>
+        <eastBoundLongitude>180</eastBoundLongitude>
+        <southBoundLatitude>-90</southBoundLatitude>
+        <northBoundLatitude>90</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox CRS="EPSG:4326"
+                minx="-90" miny="-180" maxx="90" maxy="180" />
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>continents</Name>
+<!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
+        <Title>continents</Title>
+        <CRS>EPSG:4326</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180</westBoundLongitude>
+            <eastBoundLongitude>180</eastBoundLongitude>
+            <southBoundLatitude>-90</southBoundLatitude>
+            <northBoundLatitude>83.6274</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:4326"
+                    minx="-90" miny="-180" maxx="83.6274" maxy="180" />
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="136" height="20">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=continents&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>continents2</Name>
+<!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
+        <Title>continents2</Title>
+        <CRS>EPSG:3857</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>-180</westBoundLongitude>
+            <eastBoundLongitude>180</eastBoundLongitude>
+            <southBoundLatitude>-90</southBoundLatitude>
+            <northBoundLatitude>83.6274</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3857"
+                    minx="-2.00375e+07" miny="-6.209e+07" maxx="2.00375e+07" maxy="1.84222e+07" />
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="136" height="20">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="https://naou37251.bentley.com/MapRenderingEngine/mapserv.exe?map=continents/continents.map&amp;version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=continents2&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+  </Layer>
+</Capability>
+</WMS_Capabilities>

--- a/core/frontend/src/test/tile/map/MapLayerImageryProvider.test.ts
+++ b/core/frontend/src/test/tile/map/MapLayerImageryProvider.test.ts
@@ -88,6 +88,10 @@ describe("WmsMapLayerImageryProvider", () => {
     if (!settings)
       chai.assert.fail("Could not create settings");
 
+    sandbox.stub(WmsMapLayerImageryProvider.prototype, "constructUrl").callsFake(async function (_row: number, _column: number, _zoomLevel: number) {
+      return "https://fake/url";
+    });
+
     // Test with empty body
     const makeTileRequestStub = sandbox.stub(MapLayerImageryProvider.prototype, "makeTileRequest").callsFake(async function (_url: string) {
       const header: any = { "content-type": "image/png" };
@@ -203,6 +207,10 @@ describe("MapLayerImageryProvider with IModelApp", () => {
       chai.assert.fail("Could not create settings");
     const provider = new WmsMapLayerImageryProvider(settings);
     const outputMessageSpy = sinon.spy(IModelApp.notifications, "outputMessage");
+
+    sandbox.stub(WmsMapLayerImageryProvider.prototype, "constructUrl").callsFake(async function (_row: number, _column: number, _zoomLevel: number) {
+      return "https://fake/url";
+    });
 
     // Make the tile fetch fails with error 401
     let makeTileRequestStub = sandbox.stub(MapLayerImageryProvider.prototype, "makeTileRequest").callsFake(async function (_url: string) {

--- a/core/frontend/src/tile/map/ImageryProviders/WmsMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/WmsMapLayerImageryProvider.ts
@@ -7,7 +7,7 @@
  */
 import { IModelStatus } from "@itwin/core-bentley";
 import { Point2d } from "@itwin/core-geometry";
-import { Cartographic, MapLayerSettings, ServerError } from "@itwin/core-common";
+import { Cartographic, MapLayerSettings, MapSubLayerSettings, ServerError } from "@itwin/core-common";
 
 import {
   ImageryMapTileTree, MapCartoRectangle, MapLayerImageryProvider, MapLayerImageryProviderStatus, QuadId, WmsCapabilities,
@@ -20,6 +20,12 @@ let doToolTips = true;
 const scratchPoint2d = Point2d.createZero();
 
 /** @internal */
+export interface WmsCrsSupport {
+  support3857: boolean;
+  support4326: boolean;
+}
+
+/** @internal */
 export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
   private _capabilities?: WmsCapabilities;
   private _allLayersRange?: MapCartoRectangle;
@@ -27,6 +33,8 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
   private _baseUrl: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   private _isVersion1_1 = false;
+  private _crsSupport: WmsCrsSupport|undefined;
+
   constructor(settings: MapLayerSettings) {
     super(settings, false);
     this._baseUrl = WmsUtilities.getBaseUrl(this._settings.url);
@@ -60,6 +68,8 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
 
         if (!this.cartoRange)
           this.cartoRange = this._allLayersRange;
+
+        this._crsSupport = this.getCrsSupport();
       }
     } catch (error: any) {
       // Don't throw error if unauthorized status:
@@ -74,13 +84,18 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
   }
 
   private getVisibleLayerString() {
-    const layerNames = this.getVisibleLayers();
+    const layerNames = this.getVisibleLayers().map((layer)=>layer.name);
     return layerNames.join("%2C");
   }
-  private getVisibleLayers(): string[] {
-    const layerNames = new Array<string>();
-    this._settings.subLayers.forEach((subLayer) => { if (this._settings.isSubLayerVisible(subLayer) && subLayer.isNamed) layerNames.push(subLayer.name); });
-    return layerNames;
+
+  private getVisibleLayers(): MapSubLayerSettings[] {
+    return this._settings.subLayers.filter((subLayer) =>  this._settings.isSubLayerVisible(subLayer) && subLayer.isNamed);
+  }
+
+  private getVisibleLayersSrs() {
+    const visibleLayers = this.getVisibleLayers();
+    const visibleLayerNames = visibleLayers.map((layer) => layer.name);
+    return this._capabilities?.getSubLayersCrs(visibleLayerNames);
   }
 
   private getQueryableLayers(): string[] {
@@ -100,17 +115,59 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
 
   private getVisibleQueryableLayersString(): string {
     const layers = new Array<string>();
-    const queryables = this.getQueryableLayers();
-    const visibles = this.getVisibleLayers();
-    queryables.forEach((layer: string) => { if (visibles.includes(layer)) layers.push(layer); });
+    const queryable = this.getQueryableLayers();
+    const visibleLayerNames = this.getVisibleLayers().map((layer) => layer.name);
+    queryable.forEach((layer: string) => { if (visibleLayerNames.includes(layer)) layers.push(layer); });
     return layers.join("%2C");
+  }
+
+  public getCrsSupport(): {support3857: boolean,  support4326: boolean} {
+    const layersCrs = this.getVisibleLayersSrs();
+
+    let support3857: boolean|undefined;
+    let support4326: boolean|undefined;
+    if (layersCrs) {
+      for (const [_layerName, crs] of layersCrs) {
+        if (crs.find((layerCrs) => {return layerCrs.includes("3857");}) === undefined ) {
+          support3857 = false;
+        } else if (support3857 === undefined) {
+          support3857 = true;
+        }
+
+        if (crs.find((layerCrs) => {return layerCrs.includes("4326");}) === undefined ) {
+          support4326 = false;
+        } else if (support4326 === undefined) {
+          support4326 = true;
+        }
+      }
+    }
+
+    return {support3857: support3857 ?? false, support4326: support4326 ?? false};
   }
 
   // construct the Url from the desired Tile
   public async constructUrl(row: number, column: number, zoomLevel: number): Promise<string> {
-    const bboxString = this.getEPSG3857ExtentString(row, column, zoomLevel);
+
+    let bboxString ="";
+    let crsString ="";
+
+    // We support 2 SRS: EPSG:3857 and EPSG:4326, we prefer EPSG:3857.
+    if (this._crsSupport?.support3857) {
+      bboxString = this.getEPSG3857ExtentString(row, column, zoomLevel);
+      crsString= "EPSG%3A3857";
+    } else if (this._crsSupport?.support4326) {
+      // The WMS 1.3.0 specification mandates using the axis ordering as defined in the EPSG database.
+      // For instance, for EPSG:4326 the axis ordering is latitude/longitude, or north/east.
+      bboxString = this.getEPSG4326ExtentString(row, column, zoomLevel, true); // lat/long ordering
+      crsString= "EPSG%3A4326";
+    }
+
     const layerString = this.getVisibleLayerString();
-    return `${this._baseUrl}?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=${this.transparentBackgroundString}&LAYERS=${layerString}&WIDTH=${this.tileSize}&HEIGHT=${this.tileSize}&CRS=EPSG%3A3857&STYLES=&BBOX=${bboxString}`;
+
+    if (bboxString.length === 0 || crsString.length === 0 ||layerString.length === 0)
+      return "";
+
+    return `${this._baseUrl}?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=${this.transparentBackgroundString}&LAYERS=${layerString}&WIDTH=${this.tileSize}&HEIGHT=${this.tileSize}&CRS=${crsString}&STYLES=&BBOX=${bboxString}`;
   }
 
   public override async getToolTip(strings: string[], quadId: QuadId, carto: Cartographic, tree: ImageryMapTileTree): Promise<void> {

--- a/core/frontend/src/tile/map/ImageryProviders/WmsMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/WmsMapLayerImageryProvider.ts
@@ -121,7 +121,7 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
     return layers.join("%2C");
   }
 
-  public getCrsSupport(): {support3857: boolean,  support4326: boolean} {
+  public getCrsSupport(): WmsCrsSupport {
     const layersCrs = this.getVisibleLayersSrs();
 
     let support3857: boolean|undefined;


### PR DESCRIPTION
Based on the WMS GetCapabilities response, and the currently visible layers, the provider will automatically switch between EPSG:4326 or EPSG:3857, EPSG:3857 being our favorite CRS if both options are available.
Previously only EPSG:3857 was supported.  