### PR TITLE
Make display-test-app for iOS use "public.data" as the documentType

### DIFF
--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app/ViewController.swift
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app/ViewController.swift
@@ -73,7 +73,7 @@ class ViewController: UIViewController, WKUIDelegate, WKNavigationDelegate, UIDo
         pickSnapshot();
     }
     func pickSnapshot(){
-        let picker = UIDocumentPickerViewController(documentTypes: ["com.bentley.app.bim"], in: .open);
+        let picker = UIDocumentPickerViewController(documentTypes: ["public.data"], in: .open);
         picker.modalPresentationStyle = .fullScreen;
         picker.allowsMultipleSelection = false;
         picker.directoryURL = getDocumentsDirectory();


### PR DESCRIPTION
Make display-test-app for iOS use "public.data" as the documentType for UIDocumentPickerViewController. Otherwise, it will try to filter to .bim, which can malfunction and result in constantly grayed-out files in the file open dialog.