### PR TITLE
Adjust VirtualizedPropertyGrid category header height

### DIFF
--- a/common/changes/@itwin/components-react/components-react-virtualized-property-grid_2021-11-08-15-38.json
+++ b/common/changes/@itwin/components-react/components-react-virtualized-property-grid_2021-11-08-15-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -209,7 +209,7 @@ export class VirtualizedPropertyGrid extends React.Component<VirtualizedProperty
    * @returns current height of node.
    */
   private calculateNodeHeight(node: FlatGridItem) {
-    const categoryHeaderHeight = 34;
+    const categoryHeaderHeight = 35;
     const categoryHeaderPadding = 4;
     const categoryPropertyHeight = 27;
     const bottomBorderPadding = 5;

--- a/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
@@ -524,11 +524,11 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         const category = await findByText("test_category");
         expect(baseElement.querySelector(".iui-expanded")).to.not.exist;
         const node = baseElement.querySelector(".virtualized-grid-node") as HTMLElement;
-        expect(node.style.height).to.be.equal("38px");
+        expect(node.style.height).to.be.equal("39px");
 
         fireEvent.click(category);
         expect(baseElement.querySelector(".iui-expanded")).to.exist;
-        expect(node.style.height).to.be.equal("543px");
+        expect(node.style.height).to.be.equal("544px");
       });
 
       it("updates node height on collapse", async () => {
@@ -541,10 +541,10 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
 
         const category = await findByText("test_category");
         const node = baseElement.querySelector(".virtualized-grid-node") as HTMLElement;
-        expect(node.style.height).to.be.equal("543px");
+        expect(node.style.height).to.be.equal("544px");
 
         fireEvent.click(category);
-        expect(node.style.height).to.be.equal("38px");
+        expect(node.style.height).to.be.equal("39px");
       });
     });
   });


### PR DESCRIPTION
Reacting to #2618. Small expandable block header in iTwinUI-react is 1px taller than the override we used.