### PR TITLE
Test persistence of skybox image URLs

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2068,9 +2068,8 @@ export class DisplayStyle3dSettings extends DisplayStyleSettings {
     // @internal
     applyOverrides(overrides: DisplayStyle3dSettingsProps): void;
     clearSunTime(): void;
-    // @internal (undocumented)
-    get environment(): EnvironmentProps;
-    set environment(environment: EnvironmentProps);
+    get environment(): Environment;
+    set environment(environment: Environment);
     getPlanProjectionSettings(modelId: Id64String): PlanProjectionSettings | undefined;
     get hiddenLineSettings(): HiddenLine.Settings;
     set hiddenLineSettings(hline: HiddenLine.Settings);
@@ -2087,6 +2086,8 @@ export class DisplayStyle3dSettings extends DisplayStyleSettings {
     get sunTime(): number | undefined;
     get thematic(): ThematicDisplay;
     set thematic(thematic: ThematicDisplay);
+    toggleGroundPlane(display?: boolean): void;
+    toggleSkyBox(display?: boolean): void;
     // @internal (undocumented)
     toJSON(): DisplayStyle3dSettingsProps;
     // @internal (undocumented)
@@ -2193,7 +2194,7 @@ export class DisplayStyleSettings {
     readonly onBackgroundColorChanged: BeEvent<(newColor: ColorDef) => void>;
     readonly onBackgroundMapChanged: BeEvent<(newMap: BackgroundMapSettings) => void>;
     readonly onClipStyleChanged: BeEvent<(newStyle: ClipStyle) => void>;
-    readonly onEnvironmentChanged: BeEvent<(newProps: Readonly<EnvironmentProps>) => void>;
+    readonly onEnvironmentChanged: BeEvent<(newEnv: Readonly<Environment>) => void>;
     readonly onExcludedElementsChanged: BeEvent<() => void>;
     readonly onHiddenLineSettingsChanged: BeEvent<(newSettings: HiddenLine.Settings) => void>;
     readonly onLightsChanged: BeEvent<(newLights: LightSettings) => void>;
@@ -2817,10 +2818,29 @@ export interface EntityQueryParams {
 }
 
 // @public
+export class Environment {
+    protected constructor(props?: Partial<EnvironmentProperties>);
+    clone(changedProps?: Partial<EnvironmentProperties>): Environment;
+    static create(props?: Partial<EnvironmentProperties>): Environment;
+    static readonly defaults: Environment;
+    readonly displayGround: boolean;
+    readonly displaySky: boolean;
+    static fromJSON(props?: EnvironmentProps): Environment;
+    readonly ground: GroundPlane;
+    readonly sky: SkyBox;
+    toJSON(): EnvironmentProps;
+    withDisplay(display: {
+        sky?: boolean;
+        ground?: boolean;
+    }): Environment;
+}
+
+// @public
+export type EnvironmentProperties = NonFunctionPropertiesOf<Environment>;
+
+// @public
 export interface EnvironmentProps {
-    // (undocumented)
     ground?: GroundPlaneProps;
-    // (undocumented)
     sky?: SkyBoxProps;
 }
 
@@ -4016,16 +4036,19 @@ export enum GridOrientationType {
 
 // @public
 export class GroundPlane {
-    constructor(ground?: GroundPlaneProps);
-    aboveColor: ColorDef;
-    belowColor: ColorDef;
-    display: boolean;
-    elevation: number;
-    // @internal
-    getGroundPlaneGradient(aboveGround: boolean): Gradient.Symb;
-    // (undocumented)
-    toJSON(): GroundPlaneProps;
+    protected constructor(props: Partial<GroundPlaneProperties>);
+    readonly aboveColor: ColorDef;
+    readonly belowColor: ColorDef;
+    clone(changedProps?: Partial<GroundPlaneProperties>): GroundPlane;
+    static create(props?: Partial<GroundPlaneProperties>): GroundPlane;
+    static readonly defaults: GroundPlane;
+    readonly elevation: number;
+    static fromJSON(props?: GroundPlaneProps): GroundPlane;
+    toJSON(display?: boolean): GroundPlaneProps;
 }
+
+// @public
+export type GroundPlaneProperties = NonFunctionPropertiesOf<GroundPlane>;
 
 // @public
 export interface GroundPlaneProps {
@@ -7983,18 +8006,29 @@ export class SilhouetteEdgeArgs extends EdgeArgs {
 }
 
 // @public
-export interface SkyBoxImageProps {
-    texture?: Id64String;
-    textures?: SkyCubeProps;
-    type?: SkyBoxImageType;
+export class SkyBox {
+    protected constructor(gradient: SkyGradient);
+    static createGradient(gradient?: SkyGradient): SkyBox;
+    static readonly defaults: SkyBox;
+    static fromJSON(props?: SkyBoxProps): SkyBox;
+    readonly gradient: SkyGradient;
+    // @internal (undocumented)
+    get textureIds(): Iterable<Id64String>;
+    toJSON(display?: boolean): SkyBoxProps;
 }
+
+// @public
+export type SkyBoxImageProps = SkySphereImageProps | SkyCubeImageProps | {
+    type?: SkyBoxImageType;
+    texture?: never;
+    textures?: never;
+};
 
 // @public
 export enum SkyBoxImageType {
     Cube = 3,
     // @internal
     Cylindrical = 2,
-    // (undocumented)
     None = 0,
     Spherical = 1
 }
@@ -8013,13 +8047,86 @@ export interface SkyBoxProps {
 }
 
 // @public
+export class SkyCube extends SkyBox {
+    constructor(images: SkyCubeProps, gradient?: SkyGradient);
+    readonly images: SkyCubeProps;
+    // @internal (undocumented)
+    get textureIds(): Iterable<Id64String>;
+    // @internal
+    toJSON(display?: boolean): SkyBoxProps;
+}
+
+// @public
+export interface SkyCubeImageProps {
+    // @internal (undocumented)
+    texture?: never;
+    // (undocumented)
+    textures: SkyCubeProps;
+    // (undocumented)
+    type: SkyBoxImageType.Cube;
+}
+
+// @public
 export interface SkyCubeProps {
-    back?: Id64String;
-    bottom?: Id64String;
-    front?: Id64String;
-    left?: Id64String;
-    right?: Id64String;
-    top?: Id64String;
+    // (undocumented)
+    back: TextureImageSpec;
+    // (undocumented)
+    bottom: TextureImageSpec;
+    // (undocumented)
+    front: TextureImageSpec;
+    // (undocumented)
+    left: TextureImageSpec;
+    // (undocumented)
+    right: TextureImageSpec;
+    // (undocumented)
+    top: TextureImageSpec;
+}
+
+// @public
+export class SkyGradient {
+    clone(changedProps: SkyGradientProperties): SkyGradient;
+    static create(props?: Partial<SkyGradientProperties>): SkyGradient;
+    static readonly defaults: SkyGradient;
+    equals(other: SkyGradient): boolean;
+    static fromJSON(props?: SkyBoxProps): SkyGradient;
+    // (undocumented)
+    readonly groundColor: ColorDef;
+    // (undocumented)
+    readonly groundExponent: number;
+    // (undocumented)
+    readonly nadirColor: ColorDef;
+    // (undocumented)
+    readonly skyColor: ColorDef;
+    // (undocumented)
+    readonly skyExponent: number;
+    toJSON(): SkyBoxProps;
+    // (undocumented)
+    readonly twoColor: boolean;
+    // (undocumented)
+    readonly zenithColor: ColorDef;
+}
+
+// @public
+export type SkyGradientProperties = NonFunctionPropertiesOf<SkyGradient>;
+
+// @public
+export class SkySphere extends SkyBox {
+    constructor(image: TextureImageSpec, gradient?: SkyGradient);
+    readonly image: TextureImageSpec;
+    // @internal (undocumented)
+    get textureIds(): Iterable<Id64String>;
+    // @internal
+    toJSON(display?: boolean): SkyBoxProps;
+}
+
+// @public
+export interface SkySphereImageProps {
+    // (undocumented)
+    texture: TextureImageSpec;
+    // @internal (undocumented)
+    textures?: never;
+    // (undocumented)
+    type: SkyBoxImageType.Spherical;
 }
 
 // @internal
@@ -8458,6 +8565,9 @@ export interface TextureData {
     height: number;
     width: number;
 }
+
+// @public
+export type TextureImageSpec = Id64String | string;
 
 // @public
 export interface TextureLoadProps {

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -86,7 +86,7 @@ import { EllipsoidPatch } from '@itwin/core-geometry';
 import { EmphasizeElementsProps } from '@itwin/core-common';
 import { EntityProps } from '@itwin/core-common';
 import { EntityQueryParams } from '@itwin/core-common';
-import { EnvironmentProps } from '@itwin/core-common';
+import { Environment } from '@itwin/core-common';
 import { Feature } from '@itwin/core-common';
 import { FeatureAppearance } from '@itwin/core-common';
 import { FeatureAppearanceProvider } from '@itwin/core-common';
@@ -120,7 +120,6 @@ import { GltfDataType } from '@itwin/core-common';
 import { Gradient } from '@itwin/core-common';
 import { GraphicParams } from '@itwin/core-common';
 import { GridOrientationType } from '@itwin/core-common';
-import { GroundPlane } from '@itwin/core-common';
 import { GuidString } from '@itwin/core-bentley';
 import { HiddenLine } from '@itwin/core-common';
 import { Hilite } from '@itwin/core-common';
@@ -254,8 +253,7 @@ import { SessionProps } from '@itwin/core-common';
 import { SettingsAdmin } from '@bentley/product-settings-client';
 import { SheetProps } from '@itwin/core-common';
 import { SilhouetteEdgeArgs } from '@itwin/core-common';
-import { SkyBoxProps } from '@itwin/core-common';
-import { SkyCubeProps } from '@itwin/core-common';
+import { SkyGradient } from '@itwin/core-common';
 import { SmoothTransformBetweenFrusta } from '@itwin/core-geometry';
 import { SnapRequestProps } from '@itwin/core-common';
 import { SnapResponseProps } from '@itwin/core-common';
@@ -1227,6 +1225,12 @@ export function areaToEyeHeight(view3d: ViewState3d, area: GlobalLocationArea, o
 
 // @internal
 export function areaToEyeHeightFromGcs(view3d: ViewState3d, area: GlobalLocationArea, offset?: number): Promise<number>;
+
+// @internal
+export interface AttachToViewportArgs {
+    // (undocumented)
+    invalidateDecorations: () => void;
+}
 
 // @public
 export class AuxCoordSystem2dState extends AuxCoordSystemState implements AuxCoordSystem2dProps {
@@ -2363,13 +2367,12 @@ export class DisplayStyle3dState extends DisplayStyleState {
     constructor(props: DisplayStyleProps, iModel: IModelConnection, source?: DisplayStyle3dState);
     // @internal (undocumented)
     static get className(): string;
+    // (undocumented)
     get environment(): Environment;
     set environment(env: Environment);
     // (undocumented)
     get lights(): LightSettings;
     set lights(lights: LightSettings);
-    // @internal
-    loadSkyBoxParams(system: RenderSystem, vp?: Viewport): SkyBox.CreateParams | undefined;
     // @internal (undocumented)
     overrideTerrainDisplay(): TerrainDisplayOverrides | undefined;
     // @internal (undocumented)
@@ -2548,7 +2551,7 @@ export class DrawingViewState extends ViewState2d {
     // @internal
     get attachmentInfo(): Object;
     // @internal (undocumented)
-    attachToViewport(): void;
+    attachToViewport(args: AttachToViewportArgs): void;
     // @internal (undocumented)
     changeViewedModel(modelId: Id64String): Promise<void>;
     // @internal (undocumented)
@@ -2954,15 +2957,27 @@ export class EntityState implements EntityProps {
     toJSON(): EntityProps;
 }
 
-// @public
-export class Environment {
-    constructor(json?: EnvironmentProps);
+// @internal (undocumented)
+export class EnvironmentDecorations {
+    constructor(view: ViewState3d, onLoaded: () => void, onDispose: () => void);
     // (undocumented)
-    readonly ground: GroundPlane;
+    decorate(context: DecorateContext): void;
     // (undocumented)
-    readonly sky: SkyBox;
+    dispose(): void;
     // (undocumented)
-    toJSON(): EnvironmentProps;
+    protected _environment: Environment;
+    // (undocumented)
+    protected _ground?: GroundPlaneDecorations;
+    // (undocumented)
+    protected readonly _onDispose: () => void;
+    // (undocumented)
+    protected readonly _onLoaded: () => void;
+    // (undocumented)
+    setEnvironment(env: Environment): void;
+    // (undocumented)
+    protected _sky: SkyBoxDecorations;
+    // (undocumented)
+    protected readonly _view: ViewState3d;
 }
 
 // @public
@@ -3960,6 +3975,14 @@ export enum GraphicType {
     ViewOverlay = 4,
     WorldDecoration = 2,
     WorldOverlay = 3
+}
+
+// @internal (undocumented)
+export interface GroundPlaneDecorations {
+    // (undocumented)
+    readonly aboveParams: GraphicParams;
+    // (undocumented)
+    readonly belowParams: GraphicParams;
 }
 
 // @alpha (undocumented)
@@ -8201,6 +8224,39 @@ export class RenderScheduleState extends RenderSchedule.ScriptReference {
     getTransformNodeIds(modelId: Id64String): ReadonlyArray<number> | undefined;
 }
 
+// @internal (undocumented)
+export type RenderSkyBoxParams = RenderSkyGradientParams | RenderSkySphereParams | RenderSkyCubeParams;
+
+// @internal (undocumented)
+export interface RenderSkyCubeParams {
+    // (undocumented)
+    texture: RenderTexture;
+    // (undocumented)
+    type: "cube";
+}
+
+// @internal (undocumented)
+export interface RenderSkyGradientParams {
+    // (undocumented)
+    gradient: SkyGradient;
+    // (undocumented)
+    type: "gradient";
+    // (undocumented)
+    zOffset: number;
+}
+
+// @internal (undocumented)
+export interface RenderSkySphereParams {
+    // (undocumented)
+    rotation: number;
+    // (undocumented)
+    texture: RenderTexture;
+    // (undocumented)
+    type: "sphere";
+    // (undocumented)
+    zOffset: number;
+}
+
 // @public
 export abstract class RenderSystem implements IDisposable {
     // @internal
@@ -8257,7 +8313,8 @@ export abstract class RenderSystem implements IDisposable {
     // @internal
     abstract createRenderGraphic(_geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic | undefined;
     createScreenSpaceEffectBuilder(_params: ScreenSpaceEffectBuilderParams): ScreenSpaceEffectBuilder | undefined;
-    createSkyBox(_params: SkyBox.CreateParams): RenderGraphic | undefined;
+    // @internal
+    createSkyBox(_params: RenderSkyBoxParams): RenderGraphic | undefined;
     // @internal (undocumented)
     abstract createTarget(canvas: HTMLCanvasElement): RenderTarget;
     // (undocumented)
@@ -9070,7 +9127,7 @@ export class SheetViewState extends ViewState2d {
     // @internal
     get attachments(): Object[] | undefined;
     // @internal (undocumented)
-    attachToViewport(): void;
+    attachToViewport(args: AttachToViewportArgs): void;
     // @internal (undocumented)
     changeViewedModel(modelId: Id64String): Promise<void>;
     // @internal (undocumented)
@@ -9118,88 +9175,12 @@ export class SheetViewState extends ViewState2d {
 // @internal
 export type ShouldAbortReadGltf = (reader: GltfReader) => boolean;
 
-// @public
-export abstract class SkyBox implements SkyBoxProps {
-    protected constructor(sky?: SkyBoxProps);
-    static createFromJSON(json?: SkyBoxProps): SkyBox;
-    display: boolean;
-    // @internal (undocumented)
-    abstract loadParams(_system: RenderSystem, _iModel: IModelConnection): SkyBoxParams;
+// @internal (undocumented)
+export interface SkyBoxDecorations {
     // (undocumented)
-    toJSON(): SkyBoxProps;
-}
-
-// @public
-export namespace SkyBox {
-    export class CreateParams {
-        // (undocumented)
-        static createForCube(cube: RenderTexture): CreateParams;
-        // (undocumented)
-        static createForGradient(gradient: SkyGradient, zOffset: number): CreateParams;
-        // (undocumented)
-        static createForSphere(sphere: SphereParams, zOffset: number): CreateParams;
-        // (undocumented)
-        readonly cube?: RenderTexture;
-        // (undocumented)
-        readonly gradient?: SkyGradient;
-        // (undocumented)
-        readonly sphere?: SphereParams;
-        // (undocumented)
-        readonly zOffset: number;
-    }
-    export class SphereParams {
-        constructor(texture: RenderTexture, rotation: number);
-        // (undocumented)
-        readonly rotation: number;
-        // (undocumented)
-        readonly texture: RenderTexture;
-    }
-}
-
-// @internal
-export type SkyBoxParams = Promise<SkyBox.CreateParams | undefined> | SkyBox.CreateParams | undefined;
-
-// @public
-export class SkyCube extends SkyBox implements SkyCubeProps {
-    readonly back: Id64String;
-    readonly bottom: Id64String;
-    static create(front: Id64String, back: Id64String, top: Id64String, bottom: Id64String, right: Id64String, left: Id64String, display?: boolean): SkyCube | undefined;
-    // @internal
-    static fromJSON(skyboxJson: SkyBoxProps): SkyCube | undefined;
-    readonly front: Id64String;
-    readonly left: Id64String;
-    // @internal (undocumented)
-    loadParams(system: RenderSystem, iModel: IModelConnection): SkyBoxParams;
-    readonly right: Id64String;
+    params?: RenderSkyBoxParams | undefined;
     // (undocumented)
-    toJSON(): SkyBoxProps;
-    readonly top: Id64String;
-}
-
-// @public
-export class SkyGradient extends SkyBox {
-    constructor(sky?: SkyBoxProps);
-    readonly groundColor: ColorDef;
-    readonly groundExponent: number;
-    // @internal (undocumented)
-    loadParams(_system: RenderSystem, iModel: IModelConnection): SkyBoxParams;
-    readonly nadirColor: ColorDef;
-    readonly skyColor: ColorDef;
-    readonly skyExponent: number;
-    // (undocumented)
-    toJSON(): SkyBoxProps;
-    readonly twoColor: boolean;
-    readonly zenithColor: ColorDef;
-}
-
-// @public
-export class SkySphere extends SkyBox {
-    static fromJSON(json: SkyBoxProps): SkySphere | undefined;
-    // @internal (undocumented)
-    loadParams(system: RenderSystem, iModel: IModelConnection): SkyBoxParams;
-    textureId: Id64String;
-    // (undocumented)
-    toJSON(): SkyBoxProps;
+    promise?: Promise<RenderSkyBoxParams | undefined>;
 }
 
 // @public
@@ -9332,7 +9313,7 @@ export class SpatialViewState extends ViewState3d {
     // (undocumented)
     addViewedModel(id: Id64String): void;
     // @internal (undocumented)
-    attachToViewport(): void;
+    attachToViewport(args: AttachToViewportArgs): void;
     // @internal (undocumented)
     static get className(): string;
     // (undocumented)
@@ -12706,7 +12687,7 @@ export abstract class ViewState extends ElementState {
     abstract applyPose(props: ViewPose): this;
     get areAllTileTreesLoaded(): boolean;
     // @internal
-    attachToViewport(): void;
+    attachToViewport(_args: AttachToViewportArgs): void;
     get auxiliaryCoordinateSystem(): AuxCoordSystemState;
     get backgroundColor(): ColorDef;
     // (undocumented)
@@ -12922,6 +12903,8 @@ export abstract class ViewState3d extends ViewState {
     allow3dManipulations(): boolean;
     // @internal (undocumented)
     applyPose(val: ViewPose3d): this;
+    // @internal (undocumented)
+    attachToViewport(args: AttachToViewportArgs): void;
     calcLensAngle(): Angle;
     // (undocumented)
     protected static calculateMaxDepth(delta: Vector3d, zVec: Vector3d): number;
@@ -12941,13 +12924,11 @@ export abstract class ViewState3d extends ViewState {
     createAuxCoordSystem(acsName: string): AuxCoordSystemState;
     // (undocumented)
     decorate(context: DecorateContext): void;
+    // (undocumented)
+    detachFromViewport(): void;
     get details(): ViewDetails3d;
     get displayStyle(): DisplayStyle3dState;
     set displayStyle(style: DisplayStyle3dState);
-    // @internal (undocumented)
-    protected drawGroundPlane(context: DecorateContext): void;
-    // @internal (undocumented)
-    protected drawSkyBox(context: DecorateContext): void;
     // @internal (undocumented)
     protected enableCamera(): void;
     readonly extents: Vector3d;

--- a/common/api/frontend-devtools.api.md
+++ b/common/api/frontend-devtools.api.md
@@ -1899,6 +1899,38 @@ export class ShowTileVolumesTool extends Tool {
     static toolId: string;
 }
 
+// @beta
+export class SkyCubeTool extends DisplayStyleTool {
+    // (undocumented)
+    execute(vp: Viewport): boolean;
+    // (undocumented)
+    static get maxArgs(): number;
+    // (undocumented)
+    static get minArgs(): number;
+    // (undocumented)
+    parse(args: string[]): boolean;
+    // (undocumented)
+    get require3d(): boolean;
+    // (undocumented)
+    static toolId: string;
+}
+
+// @beta
+export class SkySphereTool extends DisplayStyleTool {
+    // (undocumented)
+    execute(vp: Viewport): boolean;
+    // (undocumented)
+    static get maxArgs(): number;
+    // (undocumented)
+    static get minArgs(): number;
+    // (undocumented)
+    parse(args: string[]): boolean;
+    // (undocumented)
+    get require3d(): boolean;
+    // (undocumented)
+    static toolId: string;
+}
+
 // @alpha (undocumented)
 export interface Slider {
     // (undocumented)

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -153,6 +153,7 @@ internal;DbResponseKind
 internal;DbResponseStatus
 beta;DbRuntimeStats
 internal;DecorationGeometryProps
+beta;DefaultSupportedTypes
 internal;defaultTileOptions: TileOptions
 public;DefinitionElementProps 
 public;DeletedElementGeometryChange
@@ -211,6 +212,8 @@ beta;EntityMetaData
 beta;EntityMetaDataProps
 public;EntityProps
 public;EntityQueryParams
+public;Environment
+public;EnvironmentProperties = NonFunctionPropertiesOf
 public;EnvironmentProps
 public;ExtantElementGeometryChange
 public;ExternalSourceAspectProps 
@@ -307,6 +310,7 @@ public;GridFileTransform
 public;GridFileTransformProps
 public;GridOrientationType
 public;GroundPlane
+public;GroundPlaneProperties = NonFunctionPropertiesOf
 public;GroundPlaneProps
 public;Helmert2DWithZOffset 
 public;Helmert2DWithZOffsetProps
@@ -522,6 +526,8 @@ beta;QueryValueType = any
 public;Rank
 internal;ReadableFormData 
 internal;readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription
+beta;RealityData
+beta;RealityDataAccess
 alpha;RealityDataFormat
 alpha;RealityDataProvider
 alpha;RealityDataSourceKey
@@ -621,10 +627,17 @@ beta;SheetBorderTemplateProps
 public;SheetProps 
 beta;SheetTemplateProps 
 internal;SilhouetteEdgeArgs 
-public;SkyBoxImageProps
+public;SkyBox
+public;SkyBoxImageProps = SkySphereImageProps | SkyCubeImageProps |
 public;SkyBoxImageType
 public;SkyBoxProps
+public;SkyCube 
+public;SkyCubeImageProps
 public;SkyCubeProps
+public;SkyGradient
+public;SkyGradientProperties = NonFunctionPropertiesOf
+public;SkySphere 
+public;SkySphereImageProps
 internal;SnapRequestProps
 internal;SnapResponseProps
 internal;class SnapshotIModelRpcInterface 
@@ -663,6 +676,7 @@ public;TextString
 public;TextStringPrimitive
 public;TextStringProps
 public;TextureData
+public;TextureImageSpec = Id64String | string
 public;TextureLoadProps
 public;TextureMapping
 public;TextureMapping

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -43,6 +43,7 @@ internal;ArcGisTokenManager
 internal;ArcGisUtilities
 internal;areaToEyeHeight(view3d: ViewState3d, area: GlobalLocationArea, offset?: number): number
 internal;areaToEyeHeightFromGcs(view3d: ViewState3d, area: GlobalLocationArea, offset?: number): Promise
+internal;AttachToViewportArgs
 public;AuxCoordSystem2dState 
 public;AuxCoordSystem3dState 
 public;AuxCoordSystemSpatialState 
@@ -146,7 +147,7 @@ internal;EllipsoidTerrainProvider
 public;EmphasizeElements 
 beta;EngineeringLengthDescription 
 public;EntityState 
-public;Environment
+internal;EnvironmentDecorations
 public;EventController
 public;EventHandled
 public;ExtentLimits
@@ -233,6 +234,7 @@ public;GraphicShape
 public;GraphicShape2d 
 public;GraphicSolidPrimitive
 public;GraphicType
+internal;GroundPlaneDecorations
 alpha;GroupMark
 internal;Hilites
 public;HiliteSet
@@ -454,6 +456,10 @@ internal;RenderPlan
 internal;class RenderPlanarClassifier 
 internal;class RenderRealityMeshGeometry 
 internal;RenderScheduleState 
+internal;RenderSkyBoxParams = RenderSkyGradientParams | RenderSkySphereParams | RenderSkyCubeParams
+internal;RenderSkyCubeParams
+internal;RenderSkyGradientParams
+internal;RenderSkySphereParams
 public;class RenderSystem 
 public;RenderSystem
 beta;RenderSystemDebugControl
@@ -495,12 +501,7 @@ public;SetupWalkCameraTool
 public;SheetModelState 
 public;SheetViewState 
 internal;ShouldAbortReadGltf = (reader: GltfReader) => boolean
-public;class SkyBox 
-public;SkyBox
-internal;SkyBoxParams = Promise
-public;SkyCube 
-public;SkyGradient 
-public;SkySphere 
+internal;SkyBoxDecorations
 public;SnapDetail 
 public;SnapHeat
 public;SnapMode

--- a/common/api/summary/frontend-devtools.exports.csv
+++ b/common/api/summary/frontend-devtools.exports.csv
@@ -167,6 +167,8 @@ beta;SetRealityModelTransparencyTool
 beta;SharpenEffect 
 beta;SharpnessEffect 
 beta;ShowTileVolumesTool 
+beta;SkyCubeTool 
+beta;SkySphereTool 
 alpha;Slider
 alpha;SliderHandler = (slider: HTMLInputElement) => void
 alpha;SliderProps

--- a/common/changes/@itwin/core-backend/fix-skybox-apis-and-loading_2021-11-07-19-35.json
+++ b/common/changes/@itwin/core-backend/fix-skybox-apis-and-loading_2021-11-07-19-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/fix-skybox-apis-and-loading_2021-11-07-19-35.json
+++ b/common/changes/@itwin/core-common/fix-skybox-apis-and-loading_2021-11-07-19-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Clean up SkyBox and GroundPlane APIs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/fix-skybox-apis-and-loading_2021-11-07-19-35.json
+++ b/common/changes/@itwin/core-frontend/fix-skybox-apis-and-loading_2021-11-07-19-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Clean up SkyBox and GroundPlane APIs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-transformer/fix-skybox-apis-and-loading_2021-11-07-19-35.json
+++ b/common/changes/@itwin/core-transformer/fix-skybox-apis-and-loading_2021-11-07-19-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/common/changes/@itwin/frontend-devtools/fix-skybox-apis-and-loading_2021-11-07-19-35.json
+++ b/common/changes/@itwin/frontend-devtools/fix-skybox-apis-and-loading_2021-11-07-19-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/common/changes/@itwin/frontend-devtools/fix-skybox-apis-and-loading_2021-11-08-12-57.json
+++ b/common/changes/@itwin/frontend-devtools/fix-skybox-apis-and-loading_2021-11-08-12-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "Added keyins for setting images to be used for sky sphere or sky cube.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/backend/src/DisplayStyle.ts
+++ b/core/backend/src/DisplayStyle.ts
@@ -217,47 +217,33 @@ export class DisplayStyle3d extends DisplayStyle implements DisplayStyle3dProps 
   /** @alpha */
   protected override collectPredecessorIds(predecessorIds: Id64Set): void {
     super.collectPredecessorIds(predecessorIds);
-    const skyBoxImageProps: SkyBoxImageProps | undefined = this.settings.environment?.sky?.image;
-    if (skyBoxImageProps?.texture) {
-      predecessorIds.add(Id64.fromJSON(skyBoxImageProps.texture));
-    }
-    if (skyBoxImageProps?.textures) {
-      if (skyBoxImageProps.textures.back) { predecessorIds.add(Id64.fromJSON(skyBoxImageProps.textures.back)); }
-      if (skyBoxImageProps.textures.bottom) { predecessorIds.add(Id64.fromJSON(skyBoxImageProps.textures.bottom)); }
-      if (skyBoxImageProps.textures.front) { predecessorIds.add(Id64.fromJSON(skyBoxImageProps.textures.front)); }
-      if (skyBoxImageProps.textures.left) { predecessorIds.add(Id64.fromJSON(skyBoxImageProps.textures.left)); }
-      if (skyBoxImageProps.textures.right) { predecessorIds.add(Id64.fromJSON(skyBoxImageProps.textures.right)); }
-      if (skyBoxImageProps.textures.top) { predecessorIds.add(Id64.fromJSON(skyBoxImageProps.textures.top)); }
-    }
-    if (this.settings.planProjectionSettings) {
-      for (const planProjectionSetting of this.settings.planProjectionSettings) {
+    for (const textureId of this.settings.environment.sky.textureIds)
+      predecessorIds.add(textureId);
+
+    if (this.settings.planProjectionSettings)
+      for (const planProjectionSetting of this.settings.planProjectionSettings)
         predecessorIds.add(planProjectionSetting[0]);
-      }
-    }
   }
+
   /** @alpha */
   protected static override onCloned(context: IModelCloneContext, sourceElementProps: DisplayStyle3dProps, targetElementProps: DisplayStyle3dProps): void {
     super.onCloned(context, sourceElementProps, targetElementProps);
     if (context.isBetweenIModels) {
+      const convertTexture = (id: string) => Id64.isValidId64(id) ? context.findTargetElementId(id) : id;
+
       const skyBoxImageProps: SkyBoxImageProps | undefined = targetElementProps?.jsonProperties?.styles?.environment?.sky?.image;
-      if (skyBoxImageProps?.texture) {
-        const textureId: Id64String = context.findTargetElementId(Id64.fromJSON(skyBoxImageProps.texture));
-        skyBoxImageProps.texture = Id64.isValidId64(textureId) ? textureId : undefined;
-      }
+      if (skyBoxImageProps?.texture && Id64.isValidId64(skyBoxImageProps.texture))
+        skyBoxImageProps.texture = convertTexture(skyBoxImageProps.texture);
+
       if (skyBoxImageProps?.textures) {
-        const backTextureId: Id64String = context.findTargetElementId(Id64.fromJSON(skyBoxImageProps.textures.back));
-        skyBoxImageProps.textures.back = Id64.isValidId64(backTextureId) ? backTextureId : undefined;
-        const bottomTextureId: Id64String = context.findTargetElementId(Id64.fromJSON(skyBoxImageProps.textures.bottom));
-        skyBoxImageProps.textures.bottom = Id64.isValidId64(bottomTextureId) ? bottomTextureId : undefined;
-        const frontTextureId: Id64String = context.findTargetElementId(Id64.fromJSON(skyBoxImageProps.textures.front));
-        skyBoxImageProps.textures.front = Id64.isValidId64(frontTextureId) ? frontTextureId : undefined;
-        const leftTextureId: Id64String = context.findTargetElementId(Id64.fromJSON(skyBoxImageProps.textures.left));
-        skyBoxImageProps.textures.left = Id64.isValidId64(leftTextureId) ? leftTextureId : undefined;
-        const rightTextureId: Id64String = context.findTargetElementId(Id64.fromJSON(skyBoxImageProps.textures.right));
-        skyBoxImageProps.textures.right = Id64.isValidId64(rightTextureId) ? rightTextureId : undefined;
-        const topTextureId: Id64String = context.findTargetElementId(Id64.fromJSON(skyBoxImageProps.textures.top));
-        skyBoxImageProps.textures.top = Id64.isValidId64(topTextureId) ? topTextureId : undefined;
+        skyBoxImageProps.textures.front = convertTexture(skyBoxImageProps.textures.front);
+        skyBoxImageProps.textures.back = convertTexture(skyBoxImageProps.textures.back);
+        skyBoxImageProps.textures.left = convertTexture(skyBoxImageProps.textures.left);
+        skyBoxImageProps.textures.right = convertTexture(skyBoxImageProps.textures.right);
+        skyBoxImageProps.textures.top = convertTexture(skyBoxImageProps.textures.top);
+        skyBoxImageProps.textures.bottom = convertTexture(skyBoxImageProps.textures.bottom);
       }
+
       if (targetElementProps?.jsonProperties?.styles?.planProjections) {
         const remappedPlanProjections: { [modelId: string]: PlanProjectionSettingsProps } = {};
         for (const entry of Object.entries(targetElementProps.jsonProperties.styles.planProjections)) {

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import { AccessToken, BeEvent, DbResult, Guid, GuidString, Id64, Id64String, IModelStatus, OpenMode } from "@itwin/core-bentley";
 import {
   AuxCoordSystem2dProps, Base64EncodedString, ChangesetIdWithIndex, Code, CodeProps, CodeScopeSpec, CodeSpec, ColorDef, ElementAspectProps,
-  ElementProps, ExternalSourceProps, FontType, GeometricElement2dProps, GeometryParams, GeometryPartProps, GeometryStreamBuilder, GeometryStreamProps,
+  ElementProps, Environment, ExternalSourceProps, FontType, GeometricElement2dProps, GeometryParams, GeometryPartProps, GeometryStreamBuilder, GeometryStreamProps,
   ImageSourceFormat, IModel, IModelError, IModelReadRpcInterface, IModelVersion, IModelVersionProps, LocalFileName, PhysicalElementProps,
   PlanProjectionSettings, RelatedElement, RepositoryLinkProps, RequestNewBriefcaseProps, RpcConfiguration, RpcManager, RpcPendingResponse,
   SkyBoxImageType, SubCategoryAppearance, SubCategoryOverride, SyncMode,
@@ -984,14 +984,14 @@ export class ExtensiveTestScenario {
     displayStyle3d.settings.overrideSubCategory(subCategoryId, subCategoryOverride);
     displayStyle3d.settings.addExcludedElements(physicalObjectId1);
     displayStyle3d.settings.setPlanProjectionSettings(spatialLocationModelId, new PlanProjectionSettings({ elevation: 10.0 }));
-    displayStyle3d.settings.environment = {
+    displayStyle3d.settings.environment = Environment.fromJSON({
       sky: {
         image: {
           type: SkyBoxImageType.Spherical,
           texture: textureId,
         },
       },
-    };
+    });
     const displayStyle3dId = displayStyle3d.insert();
     assert.isTrue(Id64.isValidId64(displayStyle3dId));
     // Insert ViewDefinitions

--- a/core/backend/src/test/standalone/DisplayStyle.test.ts
+++ b/core/backend/src/test/standalone/DisplayStyle.test.ts
@@ -60,6 +60,9 @@ describe("DisplayStyle", () => {
     roundTrip({ image: { type: SkyBoxImageType.None } });
 
     roundTrip({ image: { type: SkyBoxImageType.Spherical, texture: "0x123" } });
+    roundTrip({ image: { type: SkyBoxImageType.Spherical, texture: "images/sky.jpg" } });
+
     roundTrip({ image: { type: SkyBoxImageType.Cube, textures: { front: "0x1", back: "0x2", left: "0x3", right: "0x4", top: "0x5", bottom: "0x6" } } });
+    roundTrip({ image: { type: SkyBoxImageType.Cube, textures: { front: "front.jpg", back: "back.png", left: "left.jpeg", right: "right.jpg", top: "top.png", bottom: "bottom.png" } } });
   });
 });

--- a/core/backend/src/test/standalone/DisplayStyle.test.ts
+++ b/core/backend/src/test/standalone/DisplayStyle.test.ts
@@ -5,7 +5,7 @@
 
 import { expect } from "chai";
 import { Guid } from "@itwin/core-bentley";
-import { IModel, SkyBoxImageType, SkyBoxProps, SkyCubeProps } from "@itwin/core-common";
+import { IModel, SkyBoxImageType, SkyBoxProps } from "@itwin/core-common";
 import { DisplayStyle3d, StandaloneDb } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
@@ -35,10 +35,11 @@ describe("DisplayStyle", () => {
       expect(id).not.to.equal("0");
 
       const style = db.elements.getElement<DisplayStyle3d>(id);
-      expect(style.settings.environment.sky).not.to.be.undefined;
+      const sky2 = style.jsonProperties.styles.environment.sky!;
+      expect(sky2).not.to.be.undefined;
       for (const key of Object.keys(sky)) {
         const propName = key as keyof SkyBoxProps;
-        expect(style.settings.environment.sky![propName]).to.deep.equal(sky[propName]);
+        expect(sky2[propName]).to.deep.equal(sky[propName]);
       }
     }
 
@@ -58,15 +59,7 @@ describe("DisplayStyle", () => {
 
     roundTrip({ image: { type: SkyBoxImageType.None } });
 
-    function roundTripImage(type: SkyBoxImageType, texIdOrCube: string | SkyCubeProps): void {
-      if (typeof texIdOrCube === "string")
-        roundTrip({ image: { type, texture: texIdOrCube } });
-      else
-        roundTrip({ image: { type, textures: texIdOrCube } });
-    }
-
-    roundTripImage(SkyBoxImageType.Spherical, "0x123");
-    roundTripImage(SkyBoxImageType.Cylindrical, "0x123");
-    roundTripImage(SkyBoxImageType.Cube, { front: "0x1", back: "0x2", left: "0x3", right: "0x4", top: "0x5", bottom: "0x6" });
+    roundTrip({ image: { type: SkyBoxImageType.Spherical, texture: "0x123" } });
+    roundTrip({ image: { type: SkyBoxImageType.Cube, textures: { front: "0x1", back: "0x2", left: "0x3", right: "0x4", top: "0x5", bottom: "0x6" } } });
   });
 });

--- a/core/common/src/Environment.ts
+++ b/core/common/src/Environment.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module DisplayStyles
+ */
+
+import { NonFunctionPropertiesOf } from "@itwin/core-bentley";
+import { GroundPlane, GroundPlaneProps } from "./GroundPlane";
+import { SkyBox, SkyBoxProps } from "./SkyBox";
+
+/** JSON representation of an [[Environment]].
+ * @see [[DisplayStyle3dSettingsProps.environment]].
+ * @public
+ */
+export interface EnvironmentProps {
+  /** @see [[Environment.ground]] and [[Environment.displayGround]]. */
+  ground?: GroundPlaneProps;
+  /** @see [[Environment.sky]] and [[Environment.displaySky]]. */
+  sky?: SkyBoxProps;
+}
+
+/** A type containing all of the properties of [[Environment]] with none of the methods and with the `readonly` modifiers removed.
+ * @see [[Environment.create]] and [[Environment.clone]].
+ * @public
+ */
+export type EnvironmentProperties = NonFunctionPropertiesOf<Environment>;
+
+/** As part of a [[DisplayStyle3dSettings]], controls the display of a [[SkyBox]] and [[GroundPlane]] to simulate the
+ * outdoor environment.
+ * @see [[DisplayStyle3dSettings.environment]].
+ * @public
+ */
+export class Environment {
+  /** If true, the sky box will be displayed.
+   * Default: false.
+   * @see [[withDisplay]] or [[DisplayStyle3dSettings.toggleSkyBox]] to change this.
+   */
+  public readonly displaySky: boolean;
+  /** If true, the ground plane will be displayed.
+   * Default: false.
+   * @see [[withDisplay]] or [[DisplayStyle3dSettings.toggleGroundPlane]] to change this.
+   */
+  public readonly displayGround: boolean;
+  /** Describes how the sky box should be drawn. */
+  public readonly sky: SkyBox;
+  /** Describes how the ground plane should be drawn. */
+  public readonly ground: GroundPlane;
+
+  protected constructor(props?: Partial<EnvironmentProperties>) {
+    this.displaySky = props?.displaySky ?? false;
+    this.displayGround = props?.displayGround ?? false;
+    this.sky = props?.sky ?? SkyBox.defaults;
+    this.ground = props?.ground ?? GroundPlane.defaults;
+  }
+
+  /** Default settings with neither ground plane nor sky box displayed. */
+  public static readonly defaults = new Environment();
+
+  /** Create a new Environment. Any properties not specified by `props` will be initialized to their default values. */
+  public static create(props?: Partial<EnvironmentProperties>): Environment {
+    return props ? new this(props) : this.defaults;
+  }
+
+  /** Create a copy of this environment, changing the `displayGround` and/or `displaySky` flags. */
+  public withDisplay(display: { sky?: boolean, ground?: boolean }): Environment {
+    const displaySky = display.sky ?? this.displaySky;
+    const displayGround = display.ground ?? this.displayGround;
+    if (displaySky === this.displaySky && displayGround === this.displayGround)
+      return this;
+
+    return Environment.create({
+      ...this,
+      displaySky: displaySky ?? this.displaySky,
+      displayGround: displayGround ?? this.displayGround,
+    });
+  }
+
+  /** Convert to JSON representation. */
+  public toJSON(): EnvironmentProps {
+    return {
+      sky: this.sky.toJSON(this.displaySky),
+      ground: this.ground.toJSON(this.displayGround),
+    };
+  }
+
+  /** Create from JSON representation. */
+  public static fromJSON(props?: EnvironmentProps): Environment {
+    if (!props)
+      return this.defaults;
+
+    return new this({
+      displaySky: props?.sky?.display,
+      displayGround: props?.ground?.display,
+      sky: props?.sky ? SkyBox.fromJSON(props.sky) : undefined,
+      ground: props?.ground ? GroundPlane.fromJSON(props.ground) : undefined,
+    });
+  }
+
+  /** Create a copy of this environment, identical except for any properties specified by `changedProps`.
+   * Any properties of `changedProps` explicitly set to `undefined` will be reset to their default values.
+   */
+  public clone(changedProps?: Partial<EnvironmentProperties>): Environment {
+    if (!changedProps)
+      return this;
+
+    return Environment.create({ ...this, ...changedProps });
+  }
+}

--- a/core/common/src/RenderTexture.ts
+++ b/core/common/src/RenderTexture.ts
@@ -6,7 +6,15 @@
  * @module Rendering
  */
 
-import { IDisposable } from "@itwin/core-bentley";
+import { Id64String, IDisposable } from "@itwin/core-bentley";
+
+/** Identifies an image to be used to produce a [[RenderTexture]] for a given purpose - for example,
+ * as part of a [[SkyBox]]. If the string is a valid `Id64String`, it refers to a persistent [Texture]($backend) element stored in an iModel.
+ * Otherwise, it is interpreted as a Url resolving to an HTMLImageElement.
+ * @see [[SkySphereImageProps.texture]] and [[SkyCubeImageProps]].
+ * @public
+ */
+export type TextureImageSpec = Id64String | string;
 
 /** Represents a texture image applied to a surface during rendering.
  * A RenderTexture is typically - but not always - associated with a [[RenderMaterial]].

--- a/core/common/src/SkyBox.ts
+++ b/core/common/src/SkyBox.ts
@@ -6,53 +6,72 @@
  * @module DisplayStyles
  */
 
-import { Id64String } from "@itwin/core-bentley";
-import { ColorDefProps } from "./ColorDef";
+import { Id64, Id64String, NonFunctionPropertiesOf } from "@itwin/core-bentley";
+import { ColorDef, ColorDefProps } from "./ColorDef";
+import { TextureImageSpec } from "./RenderTexture";
 
-/** Enumerates the supported types of [SkyBox]($frontend) images.
+/** Supported types of [[SkyBox]] images.
+ * @see [[SkyBoxImageProps]].
  * @public
  */
 export enum SkyBoxImageType {
+  /** No image, indicating a [[SkyGradient]] should be displayed. */
   None = 0,
-  /** A single image mapped to the surface of a sphere. @see [SkySphere]($frontend) */
+  /** A single image mapped to the surface of a sphere.
+   * @see [[SkySphere]].
+   */
   Spherical = 1,
   /** @internal not yet supported */
   Cylindrical = 2,
-  /** 6 images mapped to the faces of a cube. @see [SkyCube]($frontend) */
+  /** Six images mapped to the faces of a cube.
+   * @see [[SkyCube]].
+   */
   Cube = 3,
 }
 
-/** JSON representation of a set of images used by a [SkyCube]($frontend). Each property specifies the element ID of a texture associated with one face of the cube.
+/** JSON representation of the six images used by a [[SkyCube]].
+ * Each property specifies the image for a face of the cube as either an image URL, or the Id of a [Texture]($backend) element.
+ * Each image must be square and have the same dimensions as all the other images.
  * @public
  */
 export interface SkyCubeProps {
-  /** Id of a persistent texture element stored in the iModel to use for the front side of the skybox cube. */
-  front?: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the back side of the skybox cube. */
-  back?: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the top of the skybox cube. */
-  top?: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the bottom of the skybox cube. */
-  bottom?: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the right side of the skybox cube. */
-  right?: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the left side of the skybox cube. */
-  left?: Id64String;
+  front: TextureImageSpec;
+  back: TextureImageSpec;
+  top: TextureImageSpec;
+  bottom: TextureImageSpec;
+  right: TextureImageSpec;
+  left: TextureImageSpec;
 }
 
-/** JSON representation of an image or images used by a [SkySphere]($frontend) or [SkyCube]($frontend).
+/** JSON representation of the image used for a [[SkySphere]].
+ * @see [[SkyBoxProps.image]].
  * @public
  */
-export interface SkyBoxImageProps {
-  /** The type of skybox image. */
-  type?: SkyBoxImageType;
-  /** For [[SkyBoxImageType.Spherical]], the Id of a persistent texture element stored in the iModel to be drawn as the "sky". */
-  texture?: Id64String;
-  /** For [[SkyBoxImageType.Cube]], the Ids of persistent texture elements stored in the iModel drawn on each face of the cube. */
-  textures?: SkyCubeProps;
+export interface SkySphereImageProps {
+  type: SkyBoxImageType.Spherical;
+  texture: TextureImageSpec;
+  /** @internal */
+  textures?: never;
 }
 
-/** JSON representation of a [SkyBox]($frontend) that can be drawn as the background of a [ViewState3d]($frontend).
+/** JSON representation of the images used for a [[SkyCube]].
+ * @see [[SkyBoxProps.image]].
+ * @public
+ */
+export interface SkyCubeImageProps {
+  type: SkyBoxImageType.Cube;
+  textures: SkyCubeProps;
+  /** @internal */
+  texture?: never;
+}
+
+/** JSON representation of the image(s) to be mapped to the surfaces of a [[SkyBox]].
+ * @see [[SkyBoxProps.image]].
+ * @public
+ */
+export type SkyBoxImageProps = SkySphereImageProps | SkyCubeImageProps | { type?: SkyBoxImageType, texture?: never, textures?: never };
+
+/** JSON representation of a [[SkyBox]] that can be drawn as the background of a [ViewState3d]($frontend).
  * An object of this type can describe one of several types of sky box:
  *  - A cube with a texture image mapped to each face; or
  *  - A sphere with a single texture image mapped to its surface; or
@@ -77,15 +96,15 @@ export interface SkyBoxProps {
    * Default: false.
    */
   display?: boolean;
-  /** For a [SkyGradient]($frontend), if true, a 2-color gradient skybox is used instead of a 4-color.
+  /** For a [[SkyGradient]], if true, a 2-color gradient skybox is used instead of a 4-color.
    * Default: false.
    */
   twoColor?: boolean;
-  /** The color of the sky at the horizon. Unused unless this is a four-color [SkyGradient]($frontend).
+  /** The color of the sky at the horizon. Unused unless this is a four-color [[SkyGradient]].
    * Default: (143, 205, 255).
    */
   skyColor?: ColorDefProps;
-  /** The color of the ground at the horizon. Unused unless this is a four-color [SkyGradient]($frontend).
+  /** The color of the ground at the horizon. Unused unless this is a four-color [[SkyGradient]].
    * Default: (120, 143, 125).
    */
   groundColor?: ColorDefProps;
@@ -97,11 +116,11 @@ export interface SkyBoxProps {
    * Default: (40, 15, 0).
    */
   nadirColor?: ColorDefProps;
-  /** For a 4-color [SkyGradient]($frontend), controls speed of change from sky color to zenith color; otherwise unused.
+  /** For a 4-color [[SkyGradient]], controls speed of change from sky color to zenith color; otherwise unused.
    * Default: 4.0.
    */
   skyExponent?: number;
-  /** For a 4-color [SkyGradient]($frontend), controls speed of change from ground color to nadir color; otherwise unused.
+  /** For a 4-color [[SkyGradient]], controls speed of change from ground color to nadir color; otherwise unused.
    * Default: 4.0.
    */
   groundExponent?: number;
@@ -109,4 +128,234 @@ export interface SkyBoxProps {
    * Default: undefined.
    */
   image?: SkyBoxImageProps;
+}
+
+const defaultGroundColor = ColorDef.from(143, 205, 125);
+const defaultZenithColor = ColorDef.from(54, 117, 255);
+const defaultNadirColor = ColorDef.from(40, 125, 0);
+const defaultSkyColor = ColorDef.from(142, 205, 255);
+const defaultExponent = 4.0;
+
+function colorDefFromJson(props?: ColorDefProps): ColorDef | undefined {
+  return undefined !== props ? ColorDef.fromJSON(props) : undefined;
+}
+
+/** A type containing all of the properties and none of the methods of [[SkyGradient]] with `readonly` modifiers removed.
+ * @see [[SkyGradient.create]] and [[SkyGradient.clone]].
+ * @public
+ */
+export type SkyGradientProperties = NonFunctionPropertiesOf<SkyGradient>;
+
+/** Describes how to map a two- or four-color [[Gradient]] to the interior of a sphere to produce a [[SkyBox]].
+ * @see [[SkyBox.gradient]].
+ * @public
+ */
+export class SkyGradient {
+  public readonly twoColor: boolean;
+  public readonly skyColor: ColorDef;
+  public readonly groundColor: ColorDef;
+  public readonly zenithColor: ColorDef;
+  public readonly nadirColor: ColorDef;
+  public readonly skyExponent: number;
+  public readonly groundExponent: number;
+
+  private constructor(args: Partial<SkyGradientProperties>) {
+    this.twoColor = args.twoColor ?? false;
+    this.skyColor = args.skyColor ?? defaultSkyColor;
+    this.groundColor = args.groundColor ?? defaultGroundColor;
+    this.nadirColor = args.nadirColor ?? defaultNadirColor;
+    this.zenithColor = args.zenithColor ?? defaultZenithColor;
+    this.skyExponent = args.skyExponent ?? defaultExponent;
+    this.groundExponent = args.groundExponent ?? defaultExponent;
+  }
+
+  /** Default settings for a four-color gradient. */
+  public static readonly defaults = new SkyGradient({});
+
+  /** Create a new gradient. Any properties not specified by `props` are initialized to their default values. */
+  public static create(props?: Partial<SkyGradientProperties>): SkyGradient {
+    return props ? new this(props) : this.defaults;
+  }
+
+  /** Create from JSON representation. */
+  public static fromJSON(props?: SkyBoxProps): SkyGradient {
+    if (!props)
+      return this.defaults;
+
+    return new this({
+      twoColor: props.twoColor,
+      skyExponent: props.skyExponent,
+      groundExponent: props.groundExponent,
+      skyColor: colorDefFromJson(props.skyColor),
+      groundColor: colorDefFromJson(props.groundColor),
+      nadirColor: colorDefFromJson(props.nadirColor),
+      zenithColor: colorDefFromJson(props.zenithColor),
+    });
+  }
+
+  /** Create ea copy of this gradient, identical except for any properties explicitly specified by `changedProps`.
+   * Any properties of `changedProps` explicitly set to `undefined` will be reset to their default values.
+   */
+  public clone(changedProps: SkyGradientProperties): SkyGradient {
+    return new SkyGradient({ ...this, ...changedProps });
+  }
+
+  /** Convert to JSON representation. */
+  public toJSON(): SkyBoxProps {
+    const props: SkyBoxProps = {
+      skyColor: this.skyColor.toJSON(),
+      groundColor: this.groundColor.toJSON(),
+      nadirColor: this.nadirColor.toJSON(),
+      zenithColor: this.zenithColor.toJSON(),
+    };
+
+    if (this.groundExponent !== defaultExponent)
+      props.groundExponent = this.groundExponent;
+
+    if (this.skyExponent !== defaultExponent)
+      props.skyExponent = this.skyExponent;
+
+    if (this.twoColor)
+      props.twoColor = this.twoColor;
+
+    return props;
+  }
+
+  /** Returns true if this gradient is equivalent to the supplied gradient. */
+  public equals(other: SkyGradient): boolean {
+    if (this === other)
+      return true;
+
+    return this.twoColor === other.twoColor && this.skyColor.equals(other.skyColor) && this.groundColor.equals(other.groundColor) &&
+      this.zenithColor.equals(other.zenithColor) && this.nadirColor.equals(other.nadirColor);
+  }
+}
+
+/** Describes how to draw a representation of a sky, as part of an [[Environment]].
+ * @see [[SkyBoxProps]].
+ * @public
+ */
+export class SkyBox {
+  /** The gradient settings, used if no cube or sphere images are supplied, or if the images cannot be loaded. */
+  public readonly gradient: SkyGradient;
+
+  protected constructor(gradient: SkyGradient) {
+    this.gradient = gradient;
+  }
+
+  /** Default settings for a four-color gradient. */
+  public static readonly defaults = new SkyBox(SkyGradient.defaults);
+
+  /** Create a skybox that displays the specified gradient, or the default gradient if none is supplied. */
+  public static createGradient(gradient?: SkyGradient): SkyBox {
+    return gradient ? new this(gradient) : this.defaults;
+  }
+
+  /** Create from JSON representation. */
+  public static fromJSON(props?: SkyBoxProps): SkyBox {
+    const gradient = SkyGradient.fromJSON(props);
+
+    if (props?.image) {
+      switch (props.image.type) {
+        case SkyBoxImageType.Spherical:
+          if (undefined !== props.image.texture)
+            return new SkySphere(props.image.texture, gradient);
+
+          break;
+        case SkyBoxImageType.Cube: {
+          const tx = props.image.textures;
+          if (tx && undefined !== tx.top && undefined !== tx.bottom && undefined !== tx.right && undefined !== tx.left && undefined !== tx.front && undefined !== tx.back)
+            return new SkyCube(tx, gradient);
+
+          break;
+        }
+      }
+    }
+
+    return this.createGradient(gradient);
+  }
+
+  /** Convert to JSON representation.
+   * @param display If defined, the value to use for [[SkyBoxProps.display]]; otherwise, that property will be left undefined.
+   */
+  public toJSON(display?: boolean): SkyBoxProps {
+    const props = this.gradient.toJSON();
+    if (undefined !== display)
+      props.display = display;
+
+    return props;
+  }
+
+  /** @internal */
+  public get textureIds(): Iterable<Id64String> {
+    return [];
+  }
+}
+
+/** Describes how to draw a representation of a sky by mapping a single image to the interior of a sphere.
+ * @public
+ */
+export class SkySphere extends SkyBox {
+  /** The image to map to the interior of the sphere. */
+  public readonly image: TextureImageSpec;
+
+  /** Create a new sky sphere using the specified image.
+   * @param image The image to map to the interior of the sphere.
+   * @param gradient Optionally overrides the default gradient settings used if the image cannot be obtained.
+   */
+  public constructor(image: TextureImageSpec, gradient?: SkyGradient) {
+    super(gradient ?? SkyGradient.defaults);
+    this.image = image;
+  }
+
+  /** @internal override */
+  public override toJSON(display?: boolean): SkyBoxProps {
+    const props = super.toJSON(display);
+    props.image = {
+      type: SkyBoxImageType.Spherical,
+      texture: this.image,
+    };
+
+    return props;
+  }
+
+  /** @internal */
+  public override get textureIds(): Iterable<Id64String> {
+    return Id64.isValidId64(this.image) ? [this.image] : [];
+  }
+}
+
+/** Describes how to draw a representation of a sky by mapping images to the interior faces of a cube.
+ * The images are required to be *square*, and each image must have the same dimensions as the other images.
+ * @public
+ */
+export class SkyCube extends SkyBox {
+  /** The images to map to each face of the cube. */
+  public readonly images: SkyCubeProps;
+
+  /** Create a new sky cube using the specified images.
+   * @param images The images to map to each face of the cube.
+   * @param Optionally overrides  the default gradient settings used if the images cannot be obtained.
+   */
+  public constructor(images: SkyCubeProps, gradient?: SkyGradient) {
+    super(gradient ?? SkyGradient.defaults);
+    this.images = { ...images };
+  }
+
+  /** @internal override */
+  public override toJSON(display?: boolean): SkyBoxProps {
+    const props = super.toJSON(display);
+    props.image = {
+      type: SkyBoxImageType.Cube,
+      textures: { ...this.images },
+    };
+
+    return props;
+  }
+
+  /** @internal */
+  public override get textureIds(): Iterable<Id64String> {
+    const imgs = this.images;
+    return [imgs.front, imgs.back, imgs.top, imgs.bottom, imgs.left, imgs.right].filter((x) => Id64.isValidId64(x));
+  }
 }

--- a/core/common/src/core-common.ts
+++ b/core/common/src/core-common.ts
@@ -28,6 +28,7 @@ export * from "./ECSqlTypes";
 export * from "./ElementProps";
 export * from "./EmphasizeElementsProps";
 export * from "./EntityProps";
+export * from "./Environment";
 export * from "./FeatureGates";
 export * from "./FeatureIndex";
 export * from "./FeatureSymbology";

--- a/core/common/src/test/DisplayStyle.test.ts
+++ b/core/common/src/test/DisplayStyle.test.ts
@@ -18,6 +18,8 @@ import { ThematicDisplayMode } from "../ThematicDisplay";
 import { RenderMode, ViewFlags } from "../ViewFlags";
 import { PlanarClipMaskMode, PlanarClipMaskSettings } from "../PlanarClipMask";
 import { WhiteOnWhiteReversalProps, WhiteOnWhiteReversalSettings } from "../WhiteOnWhiteReversalSettings";
+import { SkyGradient } from "../SkyBox";
+import { GroundPlane } from "../GroundPlane";
 
 describe("DisplayStyleSettings", () => {
   describe("whiteOnWhiteReversal", () => {
@@ -310,11 +312,13 @@ describe("DisplayStyleSettings overrides", () => {
     whiteOnWhiteReversal: { ignoreBackgroundColor: false },
     environment: {
       sky: {
+        ...SkyGradient.defaults.toJSON(),
         display: true,
         twoColor: true,
         skyExponent: 22,
       },
       ground: {
+        ...GroundPlane.defaults.toJSON(),
         display: false,
       },
     },
@@ -616,8 +620,8 @@ describe("DisplayStyleSettings overrides", () => {
     test({
       viewflags,
       environment: {
-        sky: { display: false },
-        ground: { display: true, elevation: 17, aboveColor: ColorByName.snow },
+        sky: { ...SkyGradient.defaults.toJSON(), display: false },
+        ground: { ...GroundPlane.defaults.toJSON(), display: true, elevation: 17, aboveColor: ColorByName.snow },
       },
     });
 

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -261,6 +261,14 @@ These keysins control the planar masking of reality models.
   * "copy=0|1" where `1` indicates the output should be copied to the system clipboard.
 * `fdt select elements` - given a list of element Ids separated by whitespace, replace the contents of the selection set with those Ids.
 * `fdt toggle skybox` - If the active viewport is displaying a spatial view, toggles display of the skybox.
+* `fdt sky sphere` - set the image used for the skybox as a Url or texture Id.
+* `fdt sky cube` - set the images used for the skybox, mapping each to one or more faces of the box. Each image is specified as a Url or texture Id. The images are mapped in the following orders based on how many are supplied:
+  * 1: all faces use the same image
+  * 2: top/bottom, sides
+  * 3: top/bottom, left/right, front/back
+  * 4: top, bottom, left/right, front/back
+  * 5: top/bottom, left, right, front, back
+  * 6: top, bottom, left, right, front, back
 * `fdt emphasize selection` - Emphasizes all elements in the selection set, and de-emphasizes all other elements by making them semi-transparent and grey. If the selection set is empty, clear the effects of any previous use of this key-in. Accepts one of the following arguments:
   * "none": Don't override color, don't apply silhouette.
   * "color": Override color to white.

--- a/core/frontend-devtools/public/locales/en/FrontendDevTools.json
+++ b/core/frontend-devtools/public/locales/en/FrontendDevTools.json
@@ -444,6 +444,12 @@
     },
     "WoWIgnoreBackground": {
       "keyin": "fdt wow ignore background"
+    },
+    "SetSkySphere": {
+      "keyin": "fdt sky sphere"
+    },
+    "SetSkyCube": {
+      "keyin": "fdt sky cube"
     }
   }
 }

--- a/core/frontend-devtools/src/FrontEndDevTools.ts
+++ b/core/frontend-devtools/src/FrontEndDevTools.ts
@@ -21,7 +21,7 @@ import { AnimationIntervalTool } from "./tools/AnimationIntervalTool";
 import { ChangeUnitsTool } from "./tools/ChangeUnitsTool";
 import { ClipColorTool, TestClipStyleTool, ToggleSectionCutTool } from "./tools/ClipTools";
 import {
-  ApplyRenderingStyleTool, ChangeViewFlagsTool, OverrideSubCategoryTool, SaveRenderingStyleTool, ToggleSkyboxTool, WoWIgnoreBackgroundTool,
+  ApplyRenderingStyleTool, ChangeViewFlagsTool, OverrideSubCategoryTool, SaveRenderingStyleTool, SkyCubeTool, SkySphereTool, ToggleSkyboxTool, WoWIgnoreBackgroundTool,
 } from "./tools/DisplayStyleTools";
 import {
   ClearEmphasizedElementsTool, ClearIsolatedElementsTool, EmphasizeSelectedElementsTool, EmphasizeVisibleElementsTool, IsolateSelectedElementsTool,
@@ -148,6 +148,8 @@ export class FrontendDevTools {
       SharpenEffect,
       SharpnessEffect,
       ShowTileVolumesTool,
+      SkyCubeTool,
+      SkySphereTool,
       SnowEffect,
       SourceAspectIdFromElementIdTool,
       TestClipStyleTool,

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -5,14 +5,14 @@
 /** @packageDocumentation
  * @module Views
  */
-import { assert, BeEvent, Id64, Id64String, JsonUtils } from "@itwin/core-bentley";
+import { assert, BeEvent, Id64, Id64String } from "@itwin/core-bentley";
 import { Angle, Range1d, Vector3d } from "@itwin/core-geometry";
 import {
   BackgroundMapProps, BackgroundMapProvider, BackgroundMapProviderProps, BackgroundMapSettings,
   BaseLayerSettings, BaseMapLayerSettings, ColorDef, ContextRealityModelProps, DisplayStyle3dSettings, DisplayStyle3dSettingsProps,
-  DisplayStyleProps, DisplayStyleSettings, EnvironmentProps, FeatureAppearance, GlobeMode, GroundPlane, LightSettings, MapLayerProps,
-  MapLayerSettings, MapSubLayerProps, RenderSchedule, RenderTexture, RenderTimelineProps, SkyBoxImageType, SkyBoxProps,
-  SkyCubeProps, SolarShadowSettings, SubCategoryOverride, SubLayerId, TerrainHeightOriginMode, ThematicDisplay, ThematicDisplayMode, ThematicGradientMode, ViewFlags,
+  DisplayStyleProps, DisplayStyleSettings, Environment, FeatureAppearance, GlobeMode, LightSettings, MapLayerProps,
+  MapLayerSettings, MapSubLayerProps, RenderSchedule, RenderTimelineProps,
+  SolarShadowSettings, SubCategoryOverride, SubLayerId, TerrainHeightOriginMode, ThematicDisplay, ThematicDisplayMode, ThematicGradientMode, ViewFlags,
 } from "@itwin/core-common";
 import { ApproximateTerrainHeights } from "./ApproximateTerrainHeights";
 import { BackgroundMapGeometry } from "./BackgroundMapGeometry";
@@ -22,11 +22,10 @@ import { IModelApp } from "./IModelApp";
 import { IModelConnection } from "./IModelConnection";
 import { PlanarClipMaskState } from "./PlanarClipMaskState";
 import { AnimationBranchStates } from "./render/GraphicBranch";
-import { RenderSystem } from "./render/RenderSystem";
 import { RenderScheduleState } from "./RenderScheduleState";
 import { getCesiumOSMBuildingsUrl, MapCartoRectangle, TileTreeReference } from "./tile/internal";
 import { viewGlobalLocation, ViewGlobalLocationConstants } from "./ViewGlobalLocation";
-import { ScreenViewport, Viewport } from "./Viewport";
+import { ScreenViewport } from "./Viewport";
 
 /** @internal */
 export class TerrainDisplayOverrides {
@@ -749,402 +748,32 @@ export class DisplayStyle2dState extends DisplayStyleState {
   }
 }
 
-/** ###TODO: Generalize this into something like a PromiseOrValue<T> type which can contain
- * either a Promise<T> or a resolved T.
- * This is used to avoid flickering when loading skybox - don't want to load asynchronously unless we have to.
- * @internal
- */
-export type SkyBoxParams = Promise<SkyBox.CreateParams | undefined> | SkyBox.CreateParams | undefined;
-
-/** The SkyBox is part of an [[Environment]] drawn in the background of spatial views to provide context.
- * Several types of skybox are supported:
- *  - A cube with a texture image mapped to each face;
- *  - A sphere with a single texture image mapped to its surface;
- *  - A sphere with a [[Gradient]] mapped to its surface.
- * @public
- */
-export abstract class SkyBox implements SkyBoxProps {
-  /** Whether or not the skybox should be displayed. */
-  public display: boolean = false;
-
-  protected constructor(sky?: SkyBoxProps) {
-    this.display = undefined !== sky && JsonUtils.asBool(sky.display, false);
-  }
-
-  public toJSON(): SkyBoxProps {
-    return { display: this.display };
-  }
-
-  /** Instantiate a [[SkyBox]] from its JSON representation. */
-  public static createFromJSON(json?: SkyBoxProps): SkyBox {
-    let imageType = SkyBoxImageType.None;
-    if (undefined !== json && undefined !== json.image && undefined !== json.image.type)
-      imageType = json.image.type;
-
-    let skybox: SkyBox | undefined;
-    switch (imageType) {
-      case SkyBoxImageType.Spherical:
-        skybox = SkySphere.fromJSON(json!);
-        break;
-      case SkyBoxImageType.Cube:
-        skybox = SkyCube.fromJSON(json!);
-        break;
-      case SkyBoxImageType.Cylindrical: // ###TODO...
-        break;
-    }
-
-    return undefined !== skybox ? skybox : new SkyGradient(json);
-  }
-
-  /** @internal */
-  public abstract loadParams(_system: RenderSystem, _iModel: IModelConnection): SkyBoxParams;
-}
-
-/** The SkyBox is part of an [[Environment]] drawn in the background of spatial views to provide context.
- * Several types of skybox are supported:
- *  - A cube with a texture image mapped to each face;
- *  - A sphere with a single texture image mapped to its surface;
- *  - A sphere with a [[Gradient]] mapped to its surface.
- * @public
- */
-export namespace SkyBox { // eslint-disable-line no-redeclare
-  /** Parameters defining a spherical [[SkyBox]].
-   * @public
-   */
-  export class SphereParams {
-    public constructor(public readonly texture: RenderTexture, public readonly rotation: number) { }
-  }
-
-  /** Parameters used by the [[RenderSystem]] to instantiate a [[SkyBox]].
-   * @public
-   */
-  export class CreateParams {
-    public readonly gradient?: SkyGradient;
-    public readonly sphere?: SphereParams;
-    public readonly cube?: RenderTexture;
-    public readonly zOffset: number;
-
-    private constructor(zOffset: number, gradient?: SkyGradient, sphere?: SphereParams, cube?: RenderTexture) {
-      this.gradient = gradient;
-      this.sphere = sphere;
-      this.cube = cube;
-      this.zOffset = zOffset;
-    }
-
-    public static createForGradient(gradient: SkyGradient, zOffset: number) { return new CreateParams(zOffset, gradient); }
-    public static createForSphere(sphere: SphereParams, zOffset: number) { return new CreateParams(zOffset, undefined, sphere); }
-    public static createForCube(cube: RenderTexture) { return new CreateParams(0.0, undefined, undefined, cube); }
-  }
-}
-
-/** A [[SkyBox]] drawn as a sphere with a gradient mapped to its interior surface.
- * @see [[SkyBox.createFromJSON]]
- * @see [SkyBoxProps]($common) for descriptions of the color and exponent properties.
- * @public
- */
-export class SkyGradient extends SkyBox {
-  /** If true, a 2-color gradient is used (nadir and zenith colors only); if false a 4-color gradient is used. Defaults to false. */
-  public readonly twoColor: boolean = false;
-  /** @see [SkyBoxProps.skyColor]($common). */
-  public readonly skyColor: ColorDef;
-  /** @see [SkyBoxProps.groundColor]($common). */
-  public readonly groundColor: ColorDef;
-  /** @see [SkyBoxProps.zenithColor]($common). */
-  public readonly zenithColor: ColorDef;
-  /** @see [SkyBoxProps.nadirColor]($common). */
-  public readonly nadirColor: ColorDef;
-  /** @see [SkyBoxProps.skyExponent]($common). */
-  public readonly skyExponent: number = 4.0;
-  /** @see [SkyBoxProps.groundExponent]($common). */
-  public readonly groundExponent: number = 4.0;
-
-  /** Construct a SkyGradient from its JSON representation. */
-  public constructor(sky?: SkyBoxProps) {
-    super(sky);
-
-    sky = sky ? sky : {};
-    this.twoColor = JsonUtils.asBool(sky.twoColor, false);
-    this.groundExponent = JsonUtils.asDouble(sky.groundExponent, 4.0);
-    this.skyExponent = JsonUtils.asDouble(sky.skyExponent, 4.0);
-    this.groundColor = (undefined !== sky.groundColor) ? ColorDef.fromJSON(sky.groundColor) : ColorDef.from(120, 143, 125);
-    this.zenithColor = (undefined !== sky.zenithColor) ? ColorDef.fromJSON(sky.zenithColor) : ColorDef.from(54, 117, 255);
-    this.nadirColor = (undefined !== sky.nadirColor) ? ColorDef.fromJSON(sky.nadirColor) : ColorDef.from(40, 15, 0);
-    this.skyColor = (undefined !== sky.skyColor) ? ColorDef.fromJSON(sky.skyColor) : ColorDef.from(143, 205, 255);
-  }
-
-  public override toJSON(): SkyBoxProps {
-    const val = super.toJSON();
-
-    val.twoColor = this.twoColor ? true : undefined;
-    val.groundExponent = this.groundExponent !== 4.0 ? this.groundExponent : undefined;
-    val.skyExponent = this.skyExponent !== 4.0 ? this.skyExponent : undefined;
-
-    val.groundColor = this.groundColor.toJSON();
-    val.zenithColor = this.zenithColor.toJSON();
-    val.nadirColor = this.nadirColor.toJSON();
-    val.skyColor = this.skyColor.toJSON();
-
-    return val;
-  }
-
-  /** @internal */
-  public loadParams(_system: RenderSystem, iModel: IModelConnection): SkyBoxParams {
-    return SkyBox.CreateParams.createForGradient(this, iModel.globalOrigin.z);
-  }
-}
-
-/** A [[SkyBox]] drawn as a sphere with an image mapped to its interior surface.
- * @see [[SkyBox.createFromJSON]]
- * @public
- */
-export class SkySphere extends SkyBox {
-  /** The Id of a persistent texture element stored in the iModel which supplies the skybox image. */
-  public textureId: Id64String;
-
-  private constructor(textureId: Id64String, display?: boolean) {
-    super({ display });
-    this.textureId = textureId;
-  }
-
-  /** Create a [[SkySphere]] from its JSON representation.
-   * @param json: The JSON representation
-   * @returns A SkySphere, or undefined if the JSON lacks a valid texture Id.
-   */
-  public static fromJSON(json: SkyBoxProps): SkySphere | undefined {
-    const textureId = Id64.fromJSON(undefined !== json.image ? json.image.texture : undefined);
-    return undefined !== textureId && Id64.isValid(textureId) ? new SkySphere(textureId, json.display) : undefined;
-  }
-
-  public override toJSON(): SkyBoxProps {
-    const val = super.toJSON();
-    val.image = {
-      type: SkyBoxImageType.Spherical,
-      texture: this.textureId,
-    };
-    return val;
-  }
-
-  /** @internal */
-  public loadParams(system: RenderSystem, iModel: IModelConnection): SkyBoxParams {
-    const rotation = 0.0; // ###TODO: from where do we obtain rotation?
-    const createParams = (tex?: RenderTexture) => undefined !== tex ? SkyBox.CreateParams.createForSphere(new SkyBox.SphereParams(tex, rotation), iModel.globalOrigin.z) : undefined;
-    const texture = system.findTexture(this.textureId, iModel);
-    if (undefined !== texture)
-      return createParams(texture);
-    else
-      return system.loadTexture(this.textureId, iModel).then((tex) => createParams(tex));
-  }
-}
-
-/** A [[SkyBox]] drawn as a cube with an image mapped to each of its interior faces.
- * Each member specifies the Id of a persistent texture element stored in the iModel
- * from which the image mapped to the corresponding face is obtained.
- * @see [[SkyBox.createFromJSON]].
- * @public
- */
-export class SkyCube extends SkyBox implements SkyCubeProps {
-  /** Id of a persistent texture element stored in the iModel to use for the front side of the skybox cube. */
-  public readonly front: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the back side of the skybox cube. */
-  public readonly back: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the top of the skybox cube. */
-  public readonly top: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the bottom of the skybox cube. */
-  public readonly bottom: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the front right of the skybox cube. */
-  public readonly right: Id64String;
-  /** Id of a persistent texture element stored in the iModel to use for the left side of the skybox cube. */
-  public readonly left: Id64String;
-
-  private constructor(front: Id64String, back: Id64String, top: Id64String, bottom: Id64String, right: Id64String, left: Id64String, display?: boolean) {
-    super({ display });
-    this.front = front;
-    this.back = back;
-    this.top = top;
-    this.bottom = bottom;
-    this.right = right;
-    this.left = left;
-  }
-
-  /** Use [[SkyCube.create]].
-   * @internal
-   */
-  public static fromJSON(skyboxJson: SkyBoxProps): SkyCube | undefined {
-    const image = skyboxJson.image;
-    const json = (undefined !== image && image.type === SkyBoxImageType.Cube ? image.textures : undefined) as SkyCubeProps;
-    if (undefined === json)
-      return undefined;
-
-    return this.create(Id64.fromJSON(json.front), Id64.fromJSON(json.back), Id64.fromJSON(json.top), Id64.fromJSON(json.bottom), Id64.fromJSON(json.right), Id64.fromJSON(json.left), skyboxJson.display);
-  }
-
-  public override toJSON(): SkyBoxProps {
-    const val = super.toJSON();
-    val.image = {
-      type: SkyBoxImageType.Cube,
-      textures: {
-        front: this.front,
-        back: this.back,
-        top: this.top,
-        bottom: this.bottom,
-        right: this.right,
-        left: this.left,
-      },
-    };
-    return val;
-  }
-
-  /** Create and return a SkyCube. (Calls the SkyCube constructor after validating the Ids passed in for the images.)
-   * @param front The Id of the image to use for the front side of the sky cube.
-   * @param back The Id of the image to use for the back side of the sky cube.
-   * @param top The Id of the image to use for the top side of the sky cube.
-   * @param bottom The Id of the image to use for the bottom side of the sky cube.
-   * @param right The Id of the image to use for the right side of the sky cube.
-   * @param left The Id of the image to use for the left side of the sky cube.
-   * @returns A SkyCube, or undefined if any of the supplied texture Ids are invalid.
-   * @note All Ids must refer to a persistent texture element stored in the iModel.
-   */
-  public static create(front: Id64String, back: Id64String, top: Id64String, bottom: Id64String, right: Id64String, left: Id64String, display?: boolean): SkyCube | undefined {
-    if (!Id64.isValid(front) || !Id64.isValid(back) || !Id64.isValid(top) || !Id64.isValid(bottom) || !Id64.isValid(right) || !Id64.isValid(left))
-      return undefined;
-    else
-      return new SkyCube(front, back, top, bottom, right, left, display);
-  }
-
-  /** @internal */
-  public loadParams(system: RenderSystem, iModel: IModelConnection): SkyBoxParams {
-    // ###TODO: We never cache the actual texture *images* used here to create a single cubemap texture...
-    const textureIds = new Set<string>([this.front, this.back, this.top, this.bottom, this.right, this.left]);
-    const promises = [];
-    for (const textureId of textureIds)
-      promises.push(system.loadTextureImage(textureId, iModel));
-
-    return Promise.all(promises).then((images) => {
-      // ###TODO there's gotta be a simpler way to map the unique images back to their texture Ids...
-      const idToImage = new Map<string, HTMLImageElement>();
-      let index = 0;
-      for (const textureId of textureIds) {
-        const image = images[index++];
-        if (undefined === image || undefined === image.image)
-          return undefined;
-        else
-          idToImage.set(textureId, image.image);
-      }
-
-      // eslint-disable-next-line deprecation/deprecation
-      const params = new RenderTexture.Params(undefined, RenderTexture.Type.SkyBox);
-      const textureImages = [
-        idToImage.get(this.front)!, idToImage.get(this.back)!, idToImage.get(this.top)!,
-        idToImage.get(this.bottom)!, idToImage.get(this.right)!, idToImage.get(this.left)!,
-      ];
-
-      const texture = system.createTextureFromCubeImages(textureImages[0], textureImages[1], textureImages[2], textureImages[3], textureImages[4], textureImages[5], iModel, params);
-      return undefined !== texture ? SkyBox.CreateParams.createForCube(texture) : undefined;
-    }).catch((_err) => {
-      return undefined;
-    });
-  }
-}
-
-/** Describes the [[SkyBox]] and [[GroundPlane]] associated with a [[DisplayStyle3dState]].
- * @public
- */
-export class Environment {
-  public readonly sky: SkyBox;
-  public readonly ground: GroundPlane;
-
-  /** Construct from JSON representation. */
-  public constructor(json?: EnvironmentProps) {
-    this.sky = SkyBox.createFromJSON(undefined !== json ? json.sky : undefined);
-    this.ground = new GroundPlane(undefined !== json ? json.ground : undefined);
-  }
-
-  public toJSON(): EnvironmentProps {
-    return {
-      sky: this.sky.toJSON(),
-      ground: this.ground.toJSON(),
-    };
-  }
-}
-
-function isSameSkyBox(a: SkyBoxProps | undefined, b: SkyBoxProps | undefined): boolean {
-  if (undefined === a || undefined === b)
-    return undefined === a && undefined === b;
-  return JSON.stringify(a) === JSON.stringify(b);
-}
-
 /** A [[DisplayStyleState]] that can be applied to spatial views.
  * @public
  */
 export class DisplayStyle3dState extends DisplayStyleState {
   /** @internal */
   public static override get className() { return "DisplayStyle3d"; }
-  private _skyBoxParams?: SkyBox.CreateParams;
-  private _skyBoxParamsLoaded?: boolean;
-  private _environment?: Environment;
   private _settings: DisplayStyle3dSettings;
 
   public get settings(): DisplayStyle3dSettings { return this._settings; }
 
   public constructor(props: DisplayStyleProps, iModel: IModelConnection, source?: DisplayStyle3dState) {
     super(props, iModel, source);
-    if (source && source.iModel === this.iModel) {
-      this._skyBoxParams = source._skyBoxParams;
-      this._skyBoxParamsLoaded = source._skyBoxParamsLoaded;
-    }
-
     this._settings = new DisplayStyle3dSettings(this.jsonProperties, { createContextRealityModel: (modelProps) => this.createRealityModel(modelProps) });
     this.registerSettingsEventListeners();
   }
 
-  /** The [[SkyBox]] and [[GroundPlane]] settings for this style. */
   public get environment(): Environment {
-    if (undefined === this._environment)
-      this._environment = new Environment(this.settings.environment);
-
-    return this._environment;
+    return this.settings.environment;
   }
   public set environment(env: Environment) {
-    this.changeEnvironment(env);
-    this.settings.environment = env.toJSON();
-  }
-  private changeEnvironment(env: Environment): void {
-    const prevEnv = this.settings.environment;
-    this._environment = undefined;
-
-    // Regenerate the skybox if the sky settings have changed
-    if (undefined !== this._skyBoxParamsLoaded && !isSameSkyBox(env.sky, prevEnv.sky)) {
-      // NB: We only reset _skyBoxParamsLoaded - keep the previous skybox (if any) to continue drawing until the new one (if any) is ready
-      this._skyBoxParamsLoaded = undefined;
-    }
+    this.settings.environment = env;
   }
 
   public get lights(): LightSettings { return this.settings.lights; }
   public set lights(lights: LightSettings) { this.settings.lights = lights; }
 
-  private onLoadSkyBoxParams(params?: SkyBox.CreateParams, vp?: Viewport): void {
-    this._skyBoxParams = params;
-    this._skyBoxParamsLoaded = true;
-    if (undefined !== vp)
-      vp.invalidateDecorations();
-  }
-
-  /** Attempts to create textures for the sky of the environment, and load it into the sky. Returns true on success, and false otherwise.
-   * @internal
-   */
-  public loadSkyBoxParams(system: RenderSystem, vp?: Viewport): SkyBox.CreateParams | undefined {
-    if (undefined === this._skyBoxParamsLoaded) {
-      const params = this.environment.sky.loadParams(system, this.iModel);
-      if (undefined === params || params instanceof SkyBox.CreateParams) {
-        this.onLoadSkyBoxParams(params, vp);
-      } else {
-        this._skyBoxParamsLoaded = false; // indicates we're currently loading them.
-        params.then((result?: SkyBox.CreateParams) => this.onLoadSkyBoxParams(result, vp)).catch((_err) => this.onLoadSkyBoxParams(undefined));
-      }
-    }
-
-    return this._skyBoxParams;
-  }
   /** The direction of the solar light. */
   public get sunDirection(): Readonly<Vector3d> {
     return this.settings.lights.solar.direction;
@@ -1170,10 +799,6 @@ export class DisplayStyle3dState extends DisplayStyleState {
   /** @internal */
   protected override registerSettingsEventListeners(): void {
     super.registerSettingsEventListeners();
-
-    this.settings.onEnvironmentChanged.addListener((env) => {
-      this.changeEnvironment(new Environment(env));
-    });
 
     this.settings.onOverridesApplied.addListener((overrides: DisplayStyle3dSettingsProps) => {
       if (overrides.thematic && this.settings.thematic.displayMode === ThematicDisplayMode.Height && undefined === overrides.thematic.range) {

--- a/core/frontend/src/DrawingViewState.ts
+++ b/core/frontend/src/DrawingViewState.ts
@@ -26,7 +26,7 @@ import { DisclosedTileTreeSet, TileGraphicType } from "./tile/internal";
 import { SceneContext } from "./ViewContext";
 import { OffScreenViewport } from "./Viewport";
 import { ViewRect } from "./ViewRect";
-import { ExtentLimits, ViewState2d, ViewState3d } from "./ViewState";
+import { AttachToViewportArgs, ExtentLimits, ViewState2d, ViewState3d } from "./ViewState";
 
 /** Strictly for testing.
  * @internal
@@ -319,8 +319,8 @@ export class DrawingViewState extends ViewState2d {
   }
 
   /** @internal */
-  public override attachToViewport(): void {
-    super.attachToViewport();
+  public override attachToViewport(args: AttachToViewportArgs): void {
+    super.attachToViewport(args);
     assert(undefined === this._attachment);
     this._attachment = this._attachmentInfo.createAttachment();
   }

--- a/core/frontend/src/EnvironmentDecorations.ts
+++ b/core/frontend/src/EnvironmentDecorations.ts
@@ -1,0 +1,259 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Views
+ */
+
+import { assert, Id64} from "@itwin/core-bentley";
+import { Point2d, Point3d, PolyfaceBuilder, StrokeOptions } from "@itwin/core-geometry";
+import {
+  ColorDef, Environment, Gradient, GraphicParams, RenderMaterial, RenderTexture, SkyCube, SkySphere, TextureImageSpec, TextureMapping,
+} from "@itwin/core-common";
+import { IModelApp } from "./IModelApp";
+import { ViewState3d } from "./ViewState";
+import { DecorateContext } from "./ViewContext";
+import { tryImageElementFromUrl } from "./ImageUtil";
+import { GraphicType } from "./render/GraphicBuilder";
+import { RenderSkyBoxParams } from "./render/RenderSystem";
+
+/** @internal */
+export interface GroundPlaneDecorations {
+  readonly aboveParams: GraphicParams;
+  readonly belowParams: GraphicParams;
+}
+
+/** @internal */
+export interface SkyBoxDecorations {
+  params?: RenderSkyBoxParams | undefined;
+  promise?: Promise<RenderSkyBoxParams | undefined>;
+}
+
+/** @internal */
+export class EnvironmentDecorations {
+  protected readonly _view: ViewState3d;
+  protected readonly _onLoaded: () => void;
+  protected readonly _onDispose: () => void;
+  protected _environment: Environment;
+  protected _ground?: GroundPlaneDecorations;
+  protected _sky: SkyBoxDecorations;
+
+  public constructor(view: ViewState3d, onLoaded: () => void, onDispose: () => void) {
+    this._environment = view.displayStyle.environment;
+    this._view = view;
+    this._onLoaded = onLoaded;
+    this._onDispose = onDispose;
+
+    this._sky = { };
+    this.loadSky();
+    if (this._environment.displayGround)
+      this.loadGround();
+  }
+
+  public dispose(): void {
+    this._ground = undefined;
+
+    this._sky.promise = this._sky.params = undefined;
+
+    this._onDispose();
+  }
+
+  public setEnvironment(env: Environment): void {
+    const prev = this._environment;
+    if (prev === env)
+      return;
+
+    this._environment = env;
+
+    // Update ground plane
+    if (!env.displayGround || env.ground !== prev.ground)
+      this._ground = undefined;
+
+    if (env.displayGround && !this._ground)
+      this.loadGround();
+
+    // Update sky box
+    if (env.sky !== prev.sky)
+      this.loadSky();
+  }
+
+  public decorate(context: DecorateContext): void {
+    const env = this._environment;
+    if (env.displaySky && this._sky.params) {
+      const sky = IModelApp.renderSystem.createSkyBox(this._sky.params);
+      if (sky)
+        context.setSkyBox(sky);
+    }
+
+    if (!env.displayGround || !this._ground)
+      return;
+
+    const extents = this._view.getGroundExtents(context.viewport);
+    if (extents.isNull)
+      return;
+
+    const points: Point3d[] = [extents.low.clone(), extents.low.clone(), extents.high.clone(), extents.high.clone()];
+    points[1].x = extents.high.x;
+    points[3].x = extents.low.x;
+
+    const aboveGround = this._view.isEyePointAbove(extents.low.z);
+    const params = aboveGround ? this._ground.aboveParams : this._ground.belowParams;
+    const builder = context.createGraphicBuilder(GraphicType.WorldDecoration);
+    builder.activateGraphicParams(params);
+
+    const strokeOptions = new StrokeOptions();
+    strokeOptions.needParams = true;
+    const polyfaceBuilder = PolyfaceBuilder.create(strokeOptions);
+    polyfaceBuilder.toggleReversedFacetFlag();
+    const uvParams: Point2d[] = [Point2d.create(0, 0), Point2d.create(1, 0), Point2d.create(1, 1), Point2d.create(0, 1)];
+    polyfaceBuilder.addQuadFacet(points, uvParams);
+    const polyface = polyfaceBuilder.claimPolyface(false);
+
+    builder.addPolyface(polyface, true);
+    context.addDecorationFromBuilder(builder);
+  }
+
+  private loadGround(): void {
+    assert(undefined === this._ground);
+    const aboveParams = this.createGroundParams(true);
+    const belowParams = this.createGroundParams(false);
+    if (aboveParams && belowParams)
+      this._ground = { aboveParams, belowParams };
+  }
+
+  private createGroundParams(above: boolean): GraphicParams | undefined {
+    // Create a gradient texture.
+    const ground = this._environment.ground;
+    const values = [0, 0.25, 0.5 ];
+    const color = above ? ground.aboveColor : ground.belowColor;
+    const alpha = above ? 0x80 : 0x85;
+    const groundColors = [color.withTransparency(0xff), color, color];
+    groundColors[1] = groundColors[2] = color.withTransparency(alpha);
+
+    const gradient = new Gradient.Symb();
+    gradient.mode = Gradient.Mode.Spherical;
+    gradient.keys = [{ color: groundColors[0], value: values[0] }, { color: groundColors[1], value: values[1] }, { color: groundColors[2], value: values[2] }];
+    const texture = IModelApp.renderSystem.getGradientTexture(gradient, this._view.iModel);
+    if (!texture)
+      return undefined;
+
+    // Create a material using the gradient texture
+    const matParams = new RenderMaterial.Params();
+    matParams.diffuseColor = ColorDef.white;
+    matParams.shadows = false;
+    matParams.ambient = 1;
+    matParams.diffuse = 0;
+
+    const mapParams = new TextureMapping.Params();
+    const transform = new TextureMapping.Trans2x3(0, 1, 0, 1, 0, 0);
+    mapParams.textureMatrix = transform;
+    matParams.textureMapping = new TextureMapping(texture, mapParams);
+    const material = IModelApp.renderSystem.createMaterial(matParams, this._view.iModel);
+    if (!material)
+      return undefined;
+
+    // Create GraphicParams using the material.
+    const params = new GraphicParams();
+    params.lineColor = gradient.keys[0].color;
+    params.fillColor = ColorDef.white;  // Fill should be set to opaque white for gradient texture...
+    params.material = material;
+
+    return params;
+  }
+
+  private loadSky(): void {
+    const promise = this.loadSkyParams();
+    this._sky.promise = promise;
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    promise.then((params) => {
+      if (promise === this._sky.promise)
+        this.setSky(params ?? this.createSkyGradientParams());
+    });
+
+    promise.catch(() => {
+      if (this._sky.promise === promise)
+        this.setSky(this.createSkyGradientParams());
+    });
+  }
+
+  private setSky(params: RenderSkyBoxParams): void {
+    this._sky.promise = undefined;
+    this._sky.params = params;
+    this._onLoaded();
+  }
+
+  private async loadSkyParams(): Promise<RenderSkyBoxParams | undefined> {
+    const sky = this._environment.sky;
+    if (sky instanceof SkyCube) {
+      const key = this.createCubeImageKey(sky);
+      const existingTexture = IModelApp.renderSystem.findTexture(key, this._view.iModel);
+      if (existingTexture)
+        return { type: "cube", texture: existingTexture };
+
+      // Some faces may use the same image. Only request each image once.
+      const specs = new Set<string>([sky.images.front, sky.images.back, sky.images.left, sky.images.right, sky.images.top, sky.images.bottom]);
+      const promises = [];
+      for (const spec of specs)
+        promises.push(this.imageFromSpec(spec));
+
+      return Promise.all(promises).then((images) => {
+        const idToImage = new Map<TextureImageSpec, HTMLImageElement>();
+        let index = 0;
+        for (const spec of specs) {
+          const image = images[index++];
+          if (!image)
+            return undefined;
+          else
+            idToImage.set(spec, image);
+        }
+
+        // eslint-disable-next-line deprecation/deprecation
+        const params = new RenderTexture.Params(key, RenderTexture.Type.SkyBox);
+        const txImgs = [
+          idToImage.get(sky.images.front)!, idToImage.get(sky.images.back)!, idToImage.get(sky.images.top)!,
+          idToImage.get(sky.images.bottom)!, idToImage.get(sky.images.right)!, idToImage.get(sky.images.left)!,
+        ];
+
+        const texture = IModelApp.renderSystem.createTextureFromCubeImages(txImgs[0], txImgs[1], txImgs[2], txImgs[3], txImgs[4], txImgs[5], this._view.iModel, params);
+        return texture ? { type: "cube", texture } : undefined;
+      });
+    } else if (sky instanceof SkySphere) {
+      const rotation = 0; // ###TODO where is this supposed to come from?
+      let texture = IModelApp.renderSystem.findTexture(sky.image, this._view.iModel);
+      if (!texture) {
+        const image = await this.imageFromSpec(sky.image);
+        if (image) {
+          texture = IModelApp.renderSystem.createTexture({
+            image: { source: image },
+            ownership: { iModel: this._view.iModel, key: sky.image },
+          });
+        }
+      }
+
+      if (!texture)
+        return undefined;
+
+      return { type: "sphere", texture, rotation, zOffset: this._view.iModel.globalOrigin.z };
+    } else {
+      return this.createSkyGradientParams();
+    }
+  }
+
+  private createCubeImageKey(sky: SkyCube): string {
+    const i = sky.images;
+    return `skycube:${i.front}:${i.back}:${i.left}:${i.right}:${i.top}:${i.bottom}`;
+  }
+
+  private createSkyGradientParams(): RenderSkyBoxParams {
+    return { type: "gradient", gradient: this._environment.sky.gradient, zOffset: this._view.iModel.globalOrigin.z };
+  }
+
+  private async imageFromSpec(spec: TextureImageSpec): Promise<HTMLImageElement | undefined> {
+    if (Id64.isValidId64(spec))
+      return (await IModelApp.renderSystem.loadTextureImage(spec, this._view.iModel))?.image;
+
+    return tryImageElementFromUrl(spec);
+  }
+}

--- a/core/frontend/src/SheetViewState.ts
+++ b/core/frontend/src/SheetViewState.ts
@@ -29,7 +29,7 @@ import { ViewRect } from "./ViewRect";
 import { IModelApp } from "./IModelApp";
 import { CoordSystem } from "./CoordSystem";
 import { OffScreenViewport, Viewport } from "./Viewport";
-import { ViewState, ViewState2d } from "./ViewState";
+import { AttachToViewportArgs, ViewState, ViewState2d } from "./ViewState";
 import { DrawingViewState } from "./DrawingViewState";
 import { createDefaultViewFlagOverrides, DisclosedTileTreeSet, TileGraphicType } from "./tile/internal";
 import { imageBufferToPngDataUrl, openImageDataUrlInNewWindow } from "./ImageUtil";
@@ -437,8 +437,8 @@ export class SheetViewState extends ViewState2d {
   }
 
   /** @internal */
-  public override attachToViewport(): void {
-    super.attachToViewport();
+  public override attachToViewport(args: AttachToViewportArgs): void {
+    super.attachToViewport(args);
     assert(undefined === this._attachments);
     this._attachments = this._attachmentsInfo.createAttachments(this);
   }

--- a/core/frontend/src/SpatialViewState.ts
+++ b/core/frontend/src/SpatialViewState.ts
@@ -16,7 +16,7 @@ import { DisplayStyle3dState } from "./DisplayStyleState";
 import { GeometricModel3dState, GeometricModelState } from "./ModelState";
 import { SceneContext } from "./ViewContext";
 import { IModelConnection } from "./IModelConnection";
-import { ViewState3d } from "./ViewState";
+import { AttachToViewportArgs, ViewState3d } from "./ViewState";
 import { SpatialTileTreeReferences, TileTreeReference } from "./tile/internal";
 
 /** Defines a view of one or more SpatialModels.
@@ -181,8 +181,8 @@ export class SpatialViewState extends ViewState3d {
   }
 
   /** @internal */
-  public override attachToViewport(): void {
-    super.attachToViewport();
+  public override attachToViewport(args: AttachToViewportArgs): void {
+    super.attachToViewport(args);
     this.registerModelSelectorListeners();
   }
 

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -14,7 +14,7 @@ Either takes in a list of modelIds, or displays all 3D models by default.
 
 import { Id64Array, Id64String } from "@itwin/core-bentley";
 import {
-  Camera, CategorySelectorProps, Code, DisplayStyle3dProps, IModel, IModelReadRpcInterface, ModelSelectorProps, QueryRowFormat,
+  Camera, CategorySelectorProps, Code, DisplayStyle3dProps, Environment, IModel, IModelReadRpcInterface, ModelSelectorProps, QueryRowFormat,
   RenderMode, ViewDefinition3dProps, ViewQueryParams, ViewStateProps,
 } from "@itwin/core-common";
 import { Range3d } from "@itwin/core-geometry";
@@ -22,7 +22,6 @@ import { StandardViewId } from "./StandardView";
 import { IModelConnection } from "./IModelConnection";
 import { ViewState } from "./ViewState";
 import { SpatialViewState } from "./SpatialViewState";
-import { Environment } from "./DisplayStyleState";
 
 /** Options for creating a [[ViewState3d]] via [[ViewCreator3d]].
  *  @public
@@ -176,7 +175,7 @@ export class ViewCreator3d {
             options !== undefined &&
               options.skyboxOn !== undefined &&
               options.skyboxOn
-              ? new Environment({ sky: { display: true } }).toJSON()
+              ? Environment.defaults.withDisplay({ sky: true }).toJSON()
               : undefined,
         },
       },

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -965,7 +965,7 @@ export abstract class Viewport implements IDisposable {
   private attachToView(): void {
     this.registerDisplayStyleListeners(this.view.displayStyle);
     this.registerViewListeners();
-    this.view.attachToViewport();
+    this.view.attachToViewport(this);
     this._mapTiledGraphicsProvider = new MapTiledGraphicsProvider(this);
   }
 
@@ -2955,7 +2955,7 @@ export class ScreenViewport extends Viewport {
       return npcPt.z < 1.0;
     };
 
-    if (this.view.getDisplayStyle3d().environment.ground.display) {
+    if (this.view.getDisplayStyle3d().environment.displayGround) {
       const groundPlane = Plane3dByOriginAndUnitNormal.create(Point3d.create(0, 0, this.view.getGroundElevation()), Vector3d.unitZ());
       if (undefined !== groundPlane && boresiteIntersect(groundPlane))
         return { plane: Plane3dByOriginAndUnitNormal.create(projectedPt, groundPlane.getNormalRef())!, source: DepthPointSource.GroundPlane };

--- a/core/frontend/src/core-frontend.ts
+++ b/core/frontend/src/core-frontend.ts
@@ -20,6 +20,7 @@ export * from "./DrawingViewState";
 export * from "./ElementLocateManager";
 export * from "./EmphasizeElements";
 export * from "./EntityState";
+export * from "./EnvironmentDecorations";
 export * from "./FeatureOverrideProvider";
 export * from "./FlashSettings";
 export * from "./FrontendLoggerCategory";

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -8,9 +8,11 @@
 
 import { base64StringToUint8Array, Id64String, IDisposable } from "@itwin/core-bentley";
 import { ClipVector, Matrix3d, Point2d, Point3d, Range2d, Range3d, Transform, Vector2d, XAndY } from "@itwin/core-geometry";
-import { ColorDef, ElementAlignedBox3d, FeatureIndexType, Frustum, Gradient, ImageBuffer, ImageBufferFormat, ImageSource, ImageSourceFormat, isValidImageSourceFormat, PackedFeatureTable, QParams3d, QPoint3dList, RenderMaterial, RenderTexture, TextureProps } from "@itwin/core-common";
+import {
+  ColorDef, ElementAlignedBox3d, FeatureIndexType, Frustum, Gradient, ImageBuffer, ImageBufferFormat, ImageSource, ImageSourceFormat,
+  isValidImageSourceFormat, PackedFeatureTable, QParams3d, QPoint3dList, RenderMaterial, RenderTexture, SkyGradient, TextureProps,
+} from "@itwin/core-common";
 import { WebGLExtensionName } from "@itwin/webgl-compatibility";
-import { SkyBox } from "../DisplayStyleState";
 import { imageElementFromImageSource } from "../ImageUtil";
 import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";
@@ -203,6 +205,30 @@ export type RenderGeometry = IDisposable & RenderMemory.Consumer;
  * @internal
  */
 export type RenderAreaPattern = IDisposable & RenderMemory.Consumer;
+
+/** @internal */
+export interface RenderSkyGradientParams {
+  type: "gradient";
+  gradient: SkyGradient;
+  zOffset: number;
+}
+
+/** @internal */
+export interface RenderSkySphereParams {
+  type: "sphere";
+  texture: RenderTexture;
+  rotation: number;
+  zOffset: number;
+}
+
+/** @internal */
+export interface RenderSkyCubeParams {
+  type: "cube";
+  texture: RenderTexture;
+}
+
+/** @internal */
+export type RenderSkyBoxParams = RenderSkyGradientParams | RenderSkySphereParams | RenderSkyCubeParams;
 
 /** A RenderSystem provides access to resources used by the internal WebGL-based rendering system.
  * An application rarely interacts directly with the RenderSystem; instead it interacts with types like [[Viewport]] which
@@ -436,8 +462,10 @@ export abstract class RenderSystem implements IDisposable {
     return this.createBranch(branch, transform);
   }
 
-  /** Create a Graphic for a [[SkyBox]] which encompasses the entire scene, rotating with the camera. */
-  public createSkyBox(_params: SkyBox.CreateParams): RenderGraphic | undefined { return undefined; }
+  /** Create a Graphic for a [[SkyBox]] which encompasses the entire scene, rotating with the camera.
+   * @internal
+   */
+  public createSkyBox(_params: RenderSkyBoxParams): RenderGraphic | undefined { return undefined; }
 
   /** Create a RenderGraphic consisting of a list of Graphics to be drawn together. */
   public abstract createGraphicList(primitives: RenderGraphic[]): RenderGraphic;

--- a/core/frontend/src/render/webgl/CachedGeometry.ts
+++ b/core/frontend/src/render/webgl/CachedGeometry.ts
@@ -9,7 +9,7 @@
 import { assert, dispose } from "@itwin/core-bentley";
 import { Angle, Point2d, Point3d, Range3d, Vector2d, Vector3d } from "@itwin/core-geometry";
 import { Npc, QParams2d, QParams3d, QPoint2dList, QPoint3dList, RenderMode, RenderTexture } from "@itwin/core-common";
-import { SkyBox } from "../../DisplayStyleState";
+import { RenderSkyGradientParams, RenderSkySphereParams } from "../RenderSystem";
 import { FlashMode } from "../../FlashSettings";
 import { TesselatedPolyline } from "../primitives/VertexTable";
 import { RenderMemory } from "../RenderMemory";
@@ -640,7 +640,7 @@ export class SkySphereViewportQuadGeometry extends ViewportQuadGeometry {
     }
   }
 
-  protected constructor(params: IndexedGeometryParams, skybox: SkyBox.CreateParams, techniqueId: TechniqueId) {
+  protected constructor(params: IndexedGeometryParams, skybox: RenderSkySphereParams | RenderSkyGradientParams, techniqueId: TechniqueId) {
     super(params, techniqueId);
 
     this.worldPos = new Float32Array(4 * 3);
@@ -652,11 +652,9 @@ export class SkySphereViewportQuadGeometry extends ViewportQuadGeometry {
     this.nadirColor = new Float32Array(3);
     this.zOffset = skybox.zOffset;
 
-    const sphere = skybox.sphere;
-    this.rotation = undefined !== sphere ? sphere.rotation : 0.0;
-
-    if (undefined !== sphere) {
-      this.skyTexture = sphere.texture;
+    this.rotation = "sphere" === skybox.type ? skybox.rotation : 0;
+    if (skybox.type === "sphere") {
+      this.skyTexture = skybox.texture;
       this.typeAndExponents[0] = 0.0;
       this.typeAndExponents[1] = 1.0;
       this.typeAndExponents[2] = 1.0;
@@ -673,7 +671,7 @@ export class SkySphereViewportQuadGeometry extends ViewportQuadGeometry {
       this.groundColor[1] = 0.0;
       this.groundColor[2] = 0.0;
     } else {
-      const gradient = skybox.gradient!;
+      const gradient = skybox.gradient;
 
       this.zenithColor[0] = gradient.zenithColor.colors.r / 255.0;
       this.zenithColor[1] = gradient.zenithColor.colors.g / 255.0;
@@ -706,12 +704,12 @@ export class SkySphereViewportQuadGeometry extends ViewportQuadGeometry {
     }
   }
 
-  public static createGeometry(skybox: SkyBox.CreateParams) {
+  public static createGeometry(skybox: RenderSkySphereParams | RenderSkyGradientParams) {
     const params = ViewportQuad.getInstance().createParams();
     if (undefined === params)
       return undefined;
 
-    const technique = undefined !== skybox.sphere ? TechniqueId.SkySphereTexture : TechniqueId.SkySphereGradient;
+    const technique = "sphere" === skybox.type ? TechniqueId.SkySphereTexture : TechniqueId.SkySphereGradient;
     return new SkySphereViewportQuadGeometry(params, skybox, technique);
   }
 

--- a/core/frontend/src/render/webgl/System.ts
+++ b/core/frontend/src/render/webgl/System.ts
@@ -12,7 +12,6 @@ import {
   ColorDef, ElementAlignedBox3d, Frustum, Gradient, ImageBuffer, ImageBufferFormat, ImageSourceFormat, IModelError, PackedFeatureTable, RenderMaterial, RenderTexture,
 } from "@itwin/core-common";
 import { Capabilities, DepthType, WebGLContext } from "@itwin/webgl-compatibility";
-import { SkyBox } from "../../DisplayStyleState";
 import { imageElementFromImageSource } from "../../ImageUtil";
 import { IModelApp } from "../../IModelApp";
 import { IModelConnection } from "../../IModelConnection";
@@ -31,7 +30,8 @@ import { RenderGraphic, RenderGraphicOwner } from "../RenderGraphic";
 import { RenderMemory } from "../RenderMemory";
 import { CreateTextureArgs, CreateTextureFromSourceArgs, TextureCacheKey, TextureTransparency } from "../RenderTexture";
 import {
-  DebugShaderFile, GLTimerResultCallback, PlanarGridProps, RenderAreaPattern, RenderDiagnostics, RenderGeometry, RenderSystem, RenderSystemDebugControl, TerrainTexture,
+  DebugShaderFile, GLTimerResultCallback, PlanarGridProps, RenderAreaPattern, RenderDiagnostics, RenderGeometry, RenderSkyBoxParams,
+  RenderSystem, RenderSystemDebugControl, TerrainTexture,
 } from "../RenderSystem";
 import { RenderTarget } from "../RenderTarget";
 import { ScreenSpaceEffectBuilder, ScreenSpaceEffectBuilderParams } from "../ScreenSpaceEffectBuilder";
@@ -575,11 +575,10 @@ export class System extends RenderSystem implements RenderSystemDebugControl, Re
     return new LayerContainer(graphic as Graphic, drawAsOverlay, transparency, elevation);
   }
 
-  public override createSkyBox(params: SkyBox.CreateParams): RenderGraphic | undefined {
-    if (undefined !== params.cube)
-      return SkyCubePrimitive.create(SkyBoxQuadsGeometry.create(params.cube));
+  public override createSkyBox(params: RenderSkyBoxParams): RenderGraphic | undefined {
+    if ("cube" === params.type)
+      return SkyCubePrimitive.create(SkyBoxQuadsGeometry.create(params.texture));
 
-    assert(undefined !== params.sphere || undefined !== params.gradient);
     return SkySpherePrimitive.create(SkySphereViewportQuadGeometry.createGeometry(params));
   }
 

--- a/core/frontend/src/test/render/EnvironmentDecorations.test.ts
+++ b/core/frontend/src/test/render/EnvironmentDecorations.test.ts
@@ -1,0 +1,300 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { BeDuration } from "@itwin/core-bentley";
+import { ColorDef, Environment, EnvironmentProps, ImageSource, ImageSourceFormat, RenderTexture, SkyBox, SkyBoxImageType } from "@itwin/core-common";
+import { EnvironmentDecorations } from "../../EnvironmentDecorations";
+import { imageElementFromImageSource } from "../../ImageUtil";
+import { SpatialViewState } from "../../SpatialViewState";
+import { IModelConnection } from "../../IModelConnection";
+import { IModelApp } from "../../IModelApp";
+import { createBlankConnection } from "../createBlankConnection";
+
+describe("EnvironmentDecorations", () => {
+  let iModel: IModelConnection;
+
+  function createView(env?: EnvironmentProps): SpatialViewState {
+    const view = SpatialViewState.createBlank(iModel, {x: 0, y: 0, z: 0}, {x: 1, y: 1, z: 1});
+    if (env)
+      view.displayStyle.environment = Environment.fromJSON(env);
+
+    return view;
+  }
+
+  class Decorations extends EnvironmentDecorations {
+    public get sky() { return this._sky; }
+    public get ground() { return this._ground; }
+    public get environment() { return this._environment; }
+
+    public constructor(view?: SpatialViewState, onLoad?: () => void, onDispose?: () => void) {
+      super(view ?? createView(), onLoad ?? (() => undefined), onDispose ?? (() => undefined));
+    }
+
+    public static async create(view?: SpatialViewState, onLoad?: () => void, onDispose?: () => void): Promise<Decorations> {
+      const dec = new Decorations(view, onLoad, onDispose);
+      await dec.load();
+      return dec;
+    }
+
+    public async load(): Promise<void> {
+      if (!this.sky.promise)
+        return;
+
+      await this.sky.promise;
+      return BeDuration.wait(1);
+    }
+  }
+
+  before(async () => {
+    await IModelApp.startup();
+
+    const pngData = new Uint8Array([
+      137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 3, 0, 0, 0, 3, 8, 2, 0, 0, 0, 217, 74, 34, 232, 0, 0, 0, 1, 115, 82, 71, 66, 0, 174, 206,
+      28, 233, 0, 0, 0, 4, 103, 65, 77, 65, 0, 0, 177, 143, 11, 252, 97, 5, 0, 0, 0, 9, 112, 72, 89, 115, 0, 0, 14, 195, 0, 0, 14, 195, 1, 199, 111, 168, 100, 0, 0, 0,
+      24, 73, 68, 65, 84, 24, 87, 99, 248, 15, 4, 12, 12, 64, 4, 198, 64, 46, 132, 5, 162, 254, 51, 0, 0, 195, 90, 10, 246, 127, 175, 154, 145, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ]);
+
+    const textureImage = {
+      image: await imageElementFromImageSource(new ImageSource(pngData, ImageSourceFormat.Png)),
+      format: ImageSourceFormat.Png,
+    };
+
+    const createTexture = () => { return {} as unknown as RenderTexture; };
+    IModelApp.renderSystem.createTextureFromCubeImages = createTexture;
+    IModelApp.renderSystem.createTexture = createTexture;
+    IModelApp.renderSystem.loadTextureImage = async () => Promise.resolve(textureImage);
+
+    iModel = createBlankConnection();
+  });
+
+  after(async () => {
+    await iModel.close();
+    await IModelApp.shutdown();
+  });
+
+  it("initializes from environment", async () => {
+    const dec = await Decorations.create(createView({
+      ground: {
+        display: true,
+        elevation: 20,
+        aboveColor: ColorDef.blue.toJSON(),
+        belowColor: ColorDef.red.toJSON(),
+      },
+      sky: {
+        display: true,
+        nadirColor: ColorDef.blue.toJSON(),
+        zenithColor: ColorDef.red.toJSON(),
+        skyColor: ColorDef.white.toJSON(),
+        groundColor: ColorDef.black.toJSON(),
+        skyExponent: 42,
+        groundExponent: 24,
+      },
+    }));
+
+    expect(dec.ground).not.to.be.undefined;
+    expect(dec.ground!.aboveParams.lineColor.equals(ColorDef.blue.withTransparency(0xff))).to.be.true;
+    expect(dec.ground!.belowParams.lineColor.equals(ColorDef.red.withTransparency(0xff))).to.be.true;
+
+    let params = dec.sky.params!;
+    expect(params).not.to.be.undefined;
+    expect(params.type).to.equal("gradient");
+    if ("gradient" === params.type) {
+      const sky = params.gradient;
+      expect(sky).not.to.be.undefined;
+      expect(sky.twoColor).to.be.false;
+      expect(sky.nadirColor.equals(ColorDef.blue)).to.be.true;
+      expect(sky.zenithColor.equals(ColorDef.red)).to.be.true;
+      expect(sky.skyColor.equals(ColorDef.white)).to.be.true;
+      expect(sky.groundColor.equals(ColorDef.black)).to.be.true;
+      expect(sky.skyExponent).to.equal(42);
+      expect(sky.groundExponent).to.equal(24);
+    }
+
+    dec.setEnvironment(Environment.fromJSON({
+      ground: {
+        display: true,
+        aboveColor: ColorDef.white.toJSON(),
+        belowColor: ColorDef.black.toJSON(),
+      },
+      sky: {
+        display: false,
+        nadirColor: ColorDef.white.toJSON(),
+        zenithColor: ColorDef.black.toJSON(),
+        skyColor: ColorDef.red.toJSON(),
+        groundColor: ColorDef.green.toJSON(),
+        skyExponent: 123,
+        groundExponent: 456,
+      },
+    }));
+
+    await dec.load();
+    expect(dec.ground!.aboveParams.lineColor.equals(ColorDef.white.withTransparency(0xff))).to.be.true;
+    expect(dec.ground!.belowParams.lineColor.equals(ColorDef.black.withTransparency(0xff))).to.be.true;
+
+    params = dec.sky.params!;
+    expect(params).not.to.be.undefined;
+    expect(params.type).to.equal("gradient");
+    if ("gradient" === params.type) {
+      const sky = params.gradient;
+      expect(sky.nadirColor.equals(ColorDef.white)).to.be.true;
+      expect(sky.zenithColor.equals(ColorDef.black)).to.be.true;
+      expect(sky.skyColor.equals(ColorDef.red)).to.be.true;
+      expect(sky.groundColor.equals(ColorDef.green)).to.be.true;
+      expect(sky.skyExponent).to.equal(123);
+      expect(sky.groundExponent).to.equal(456);
+    }
+  });
+
+  it("disposes", async () => {
+    let disposed = false;
+    const dec = new Decorations(createView({ ground: { display: true } }), undefined, () => disposed = true);
+    expect(disposed).to.be.false;
+    expect(dec.ground).not.to.be.undefined;
+    expect(dec.sky.promise).not.to.be.undefined;
+    expect(dec.sky.params).to.be.undefined;
+
+    await dec.load();
+    expect(disposed).to.be.false;
+    expect(dec.ground).not.to.be.undefined;
+    expect(dec.sky.promise).to.be.undefined;
+    expect(dec.sky.params).not.to.be.undefined;
+
+    dec.dispose();
+    expect(disposed).to.be.true;
+    expect(dec.ground).to.be.undefined;
+    expect(dec.sky.promise).to.be.undefined;
+    expect(dec.sky.params).to.be.undefined;
+  });
+
+  it("only allocates ground while displayed", async () => {
+    const dec = await Decorations.create();
+    expect(dec.ground).to.be.undefined;
+
+    dec.setEnvironment(Environment.fromJSON({ ground: { display: true } }));
+    expect(dec.ground).not.to.be.undefined;
+
+    dec.setEnvironment(Environment.fromJSON());
+    expect(dec.ground).to.be.undefined;
+  });
+
+  it("only recreates ground if settings change", async () => {
+    const dec = new Decorations(createView({ ground: { display: true } }));
+    const prevGround = dec.ground;
+    expect(prevGround).not.to.be.undefined;
+
+    dec.setEnvironment(dec.environment.clone({ displaySky: true }));
+    expect(dec.ground).to.equal(prevGround);
+
+    dec.setEnvironment(dec.environment.clone({ ground: dec.environment.ground.clone({ elevation: 100 }) }));
+    expect(dec.ground).not.to.equal(prevGround);
+    expect(dec.ground).not.to.be.undefined;
+
+    await dec.load();
+  });
+
+  it("always loads sky", async () => {
+    const dec = new Decorations(createView({ sky: { display: false } }));
+    expect(dec.sky.params).to.be.undefined;
+    expect(dec.sky.promise).not.to.be.undefined;
+
+    await dec.load();
+    expect(dec.sky.params).not.to.be.undefined;
+    expect(dec.sky.promise).to.be.undefined;
+  });
+
+  it("notifies when asynchronous loading completes", async () => {
+    let loaded = false;
+    const dec = new Decorations(undefined, () => loaded = true);
+    expect(loaded).to.be.false;
+    await dec.load();
+    expect(loaded).to.be.true;
+
+    loaded = false;
+    dec.setEnvironment(dec.environment.clone({ sky: SkyBox.fromJSON({ twoColor: true }) }));
+    expect(loaded).to.be.false;
+    await dec.load();
+    expect(loaded).to.be.true;
+  });
+
+  it("preserves previous skybox until new skybox loads", async () => {
+    const dec = await Decorations.create();
+    const params = dec.sky.params;
+    expect(params).not.to.be.undefined;
+
+    dec.setEnvironment(dec.environment.clone({ sky: SkyBox.fromJSON({ twoColor: true }) }));
+    expect(dec.sky.params).to.equal(params);
+    expect(dec.sky.promise).not.to.be.undefined;
+
+    await dec.load();
+    expect(dec.sky.params).not.to.equal(params);
+    expect(dec.sky.promise).to.be.undefined;
+  });
+
+  it("produces sky sphere", async () => {
+    const dec = await Decorations.create(createView({
+      sky: {
+        image: {
+          type: SkyBoxImageType.Spherical,
+          texture: "0x123",
+        },
+      },
+    }));
+
+    expect(dec.sky.params!.type).to.equal("sphere");
+  });
+
+  it("produces sky cube", async () => {
+    const dec = await Decorations.create(createView({
+      sky: {
+        image: {
+          type: SkyBoxImageType.Cube,
+          textures: {
+            front: "0x1", back: "0x2",
+            left: "0x3", right: "0x4",
+            top: "0x5", bottom: "0x6",
+          },
+        },
+      },
+    }));
+
+    expect(dec.sky.params!.type).to.equal("cube");
+  });
+
+  it("falls back to sky gradient on error", async () => {
+    let dec = await Decorations.create(createView({
+      sky: {
+        display: true,
+        image: {
+          type: SkyBoxImageType.Spherical,
+          texture: "NotATexture",
+        },
+      },
+    }));
+
+    expect(dec.sky.params).not.to.be.undefined;
+    expect(dec.sky.params!.type).to.equal("gradient");
+
+    dec = await Decorations.create(createView({
+      sky: {
+        display: true,
+        image: {
+          type: SkyBoxImageType.Cube,
+          textures: {
+            front: "front",
+            back: "back",
+            top: "top",
+            bottom: "bottom",
+            left: "left",
+            right: "right",
+          },
+        },
+      },
+    }));
+
+    expect(dec.sky.params).not.to.be.undefined;
+    expect(dec.sky.params!.type).to.equal("gradient");
+  });
+});

--- a/core/frontend/src/tools/EditManipulator.ts
+++ b/core/frontend/src/tools/EditManipulator.ts
@@ -280,8 +280,9 @@ export namespace EditManipulator {
      * @return color adjusted for view background color or original color if view background color isn't being used.
      */
     public static adjustForBackgroundColor(color: ColorDef, vp: Viewport): ColorDef {
-      if (vp.view.is3d() && vp.view.getDisplayStyle3d().environment.sky.display)
+      if (vp.view.is3d() && vp.view.getDisplayStyle3d().environment.displaySky)
         return color;
+
       return color.adjustedForContrast(vp.view.backgroundColor);
     }
 

--- a/core/transformer/src/test/IModelTransformerUtils.ts
+++ b/core/transformer/src/test/IModelTransformerUtils.ts
@@ -387,8 +387,8 @@ export class TransformerExtensiveTestScenario {
     assert.equal(displayStyle3d.settings.subCategoryOverrides.size, 1);
     assert.exists(displayStyle3d.settings.getSubCategoryOverride(subCategoryId), "Expect subCategoryOverrides to have been remapped");
     assert.isTrue(new Set<string>(displayStyle3d.settings.excludedElementIds).has(physicalObjectId1), "Expect excludedElements to be remapped");
-    assert.equal(displayStyle3d.settings.environment.sky?.image?.type, SkyBoxImageType.Spherical);
-    assert.equal(displayStyle3d.settings.environment.sky?.image?.texture, textureId);
+    assert.equal(displayStyle3d.settings.environment.sky.toJSON()?.image?.type, SkyBoxImageType.Spherical);
+    assert.equal(displayStyle3d.settings.environment.sky.toJSON()?.image?.texture, textureId);
     assert.equal(displayStyle3d.settings.getPlanProjectionSettings(spatialLocationModelId)?.elevation, 10.0);
     // ViewDefinition
     const viewId = targetDb.elements.queryElementIdByCode(OrthographicViewDefinition.createCode(targetDb, definitionModelId, "Orthographic View"))!;

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -20,6 +20,7 @@ The following dependencies of iTwin.js have been updated;
 ## Package name changes
 
 A number of packages have been renamed to use the @itwin scope rather than the @bentley scope, and we have modified a few package names to move towards a more consistent naming pattern. The full list of changed packages are listed in the table below.
+
 | Current                                | New                                  |
 |----------------------------------------|--------------------------------------|
 | @bentley/imodeljs-backend              | @itwin/core-backend                  |
@@ -123,6 +124,22 @@ The following code applies a display style similar to those illustrated above to
 Now, `TwoWayViewportSync` is extensible, allowing subclasses to specify which aspects of the viewports should be synchronized by overriding [TwoWayViewportSync.connectViewports]($frontend) and [TwoWayViewportSync.syncViewports]($frontend). To establish a connection between two viewports using your subclass `MyViewportSync`, use `MyViewportSync.connect(viewport1, viewport2)`.
 
 A new subclass [TwoWayViewportFrustumSync]($frontend) is supplied that synchronizes **only** the frusta of the viewports. The viewports will view the same volume of space, but may display different contents or apply different display styles. To establish this connection, use `TwoWayViewportFrustumSync.connect(viewport1, viewport2)`.
+
+## Environment decorations
+
+A [DisplayStyle3dSettings]($common) can specify a [SkyBox]($common) and [GroundPlane]($common) to be drawn as environmental decorations. Previously, [DisplayStyle3dSettings.environment]($common) was a mutable JSON [EnvironmentProps]($common), while [DisplayStyle3dState.environment]($frontend) was a mutable [Environment]($common) object, formerly defined in the core-frontend package. This made the API quite awkward and led to bugs in synchronizing the [Viewport]($frontend)'s decorations with changes to the environment settings.
+
+Now, [DisplayStyle3dSettings.environment]($common) is an immutable [Environment]($common) object consisting of a [GroundPlane]($common), [SkyBox]($common), and flags controlling the display of each. These changes require adjustment to existing code that toggles the display of either. For example:
+
+```ts
+// Replace this:
+style.environment.sky.display = true;
+style.environment.ground.display = false;
+// With this:
+style.environment = style.environment.withDisplay({ sky: true, ground: false });
+```
+
+Additionally, until now the images used by a [SkySphere]($common) or [SkyBox]($common) were required to be hosted by persistent [Texture]($backend) elements stored in the iModel. Now, they can also be specified as a URL resolving to an HTMLImageElement, allowing custom skyboxes to be created without modifying the iModel.
 
 ## BentleyError constructor no longer logs
 

--- a/docs/learning/frontend/Views.md
+++ b/docs/learning/frontend/Views.md
@@ -134,7 +134,7 @@ This includes the:
 - [SubCategoryAppearance]($common) visibility and overrides
 - Background color
 - [RenderMode]($common)
-- [Environment]($frontend)
+- [Environment]($common)
 - Other view-specific parameters
 
 They are loaded in memory in the frontend with the [DisplayStyleState]($frontend) class.

--- a/example-code/app/src/frontend/BlankConnection.ts
+++ b/example-code/app/src/frontend/BlankConnection.ts
@@ -41,10 +41,7 @@ export class BlankConnectionExample {
     style.backgroundColor = ColorDef.white;
 
     // turn on the ground and skybox in the environment
-    const env = style.environment;
-    env.ground.display = true;
-    env.sky.display = true;
-    style.environment = env; // call to accessor to get the json properties to reflect the changes
+    style.environment = style.environment.withDisplay({ sky: true, ground: true });
 
     return blankView;
   }

--- a/full-stack-tests/core/src/frontend/standalone/AttachView.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/AttachView.test.ts
@@ -87,7 +87,7 @@ describe("ViewState attached to Viewport", async () => {
     const view = await loadView();
     vp = ScreenViewport.create(div, view);
     expect(view.isAttachedToViewport).to.be.true;
-    expect(() => view.attachToViewport()).to.throw("Attempting to attach a ViewState that is already attached to a Viewport");
+    expect(() => view.attachToViewport(vp)).to.throw("Attempting to attach a ViewState that is already attached to a Viewport");
   });
 
   it("should only emit events while attached to a Viewport", async () => {

--- a/full-stack-tests/core/src/frontend/standalone/DisplayStyleState.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/DisplayStyleState.test.ts
@@ -6,8 +6,8 @@ import { expect } from "chai";
 import { CompressedId64Set } from "@itwin/core-bentley";
 import { Vector3d } from "@itwin/core-geometry";
 import {
-  BackgroundMapType, ColorByName, DisplayStyle3dProps, DisplayStyle3dSettingsProps, PlanarClipMaskMode, PlanarClipMaskSettings,
-  SpatialClassifierInsideDisplay, SpatialClassifierOutsideDisplay, ThematicDisplayMode,
+  BackgroundMapType, ColorByName, DisplayStyle3dProps, DisplayStyle3dSettingsProps, GroundPlane, PlanarClipMaskMode, PlanarClipMaskSettings,
+  SkyGradient, SpatialClassifierInsideDisplay, SpatialClassifierOutsideDisplay, ThematicDisplayMode,
 } from "@itwin/core-common";
 import { ContextRealityModelState, DisplayStyle3dState, IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
 import { TestUtility } from "../TestUtility";
@@ -161,7 +161,12 @@ describe("DisplayStyle", () => {
     });
 
     test({ planProjections: { "0x8": { elevation: 2, transparency: 0.25, overlay: true, enforceDisplayPriority: true } } });
-    test({ environment: { sky: { display: false, twoColor: true }, ground: { display: true } } });
+    test({
+      environment: {
+        sky: { ...SkyGradient.defaults.toJSON(), display: false, twoColor: true },
+        ground: { ...GroundPlane.defaults.toJSON(), display: true },
+      },
+    });
 
     test({
       contextRealityModels: [{
@@ -236,7 +241,12 @@ describe("DisplayStyle", () => {
     });
 
     test({ planProjections: { "0x9": { elevation: 3, transparency: 0.75, overlay: true, enforceDisplayPriority: true } } });
-    test({ environment: { sky: { display: true, twoColor: true }, ground: { display: false } } });
+    test({
+      environment: {
+        sky: { ...SkyGradient.defaults.toJSON(), display: true, twoColor: true },
+        ground: { ...GroundPlane.defaults.toJSON(), display: false },
+      },
+    });
 
     test({
       contextRealityModels: [{

--- a/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
@@ -263,7 +263,7 @@ describe("Viewport changed events", async () => {
       expectChange(() => settings.thematic = ThematicDisplay.fromJSON(thematicProps));
 
       expectChange(() => settings.ambientOcclusionSettings = AmbientOcclusion.Settings.fromJSON({ bias: 42, maxDistance: 24 }));
-      expectChange(() => settings.environment = { ground: { display: true, elevation: 42 } });
+      expectChange(() => settings.environment = settings.environment.withDisplay({ ground: !settings.environment.displayGround }));
 
       expectChange(() => settings.setPlanProjectionSettings("0xabcdef", undefined));
       expectChange(() => settings.setPlanProjectionSettings("0xfedcba", PlanProjectionSettings.fromJSON({ elevation: 42 })));

--- a/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
+++ b/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
@@ -6,7 +6,7 @@
 import { assert } from "@itwin/core-bentley";
 import { Angle, AuxChannel, AuxChannelData, AuxChannelDataType, IModelJson, Point3d, Polyface, PolyfaceAuxData, PolyfaceBuilder, StrokeOptions, Transform } from "@itwin/core-geometry";
 import {
-  AnalysisStyle, AnalysisStyleProps, ColorByName, ColorDef, RenderMode, ThematicGradientColorScheme, ThematicGradientMode, ThematicGradientSettingsProps,
+  AnalysisStyle, AnalysisStyleProps, ColorByName, ColorDef, RenderMode, SkyBox, ThematicGradientColorScheme, ThematicGradientMode, ThematicGradientSettingsProps,
 } from "@itwin/core-common";
 import {
   DecorateContext, GraphicType, IModelApp, RenderGraphicOwner, StandardViewId, Viewport,
@@ -284,12 +284,9 @@ export async function openAnalysisStyleExample(viewer: Viewer): Promise<void> {
 
   viewer.viewport.viewFlags = viewer.viewport.viewFlags.withRenderMode(RenderMode.SolidFill);
 
-  viewer.viewport.view.getDisplayStyle3d().settings.environment = {
-    sky: {
-      display: true,
-      twoColor: true,
-      nadirColor: 0xdfefff,
-      zenithColor: 0xffefdf,
-    },
-  };
+  const settings = viewer.viewport.view.getDisplayStyle3d().settings;
+  settings.environment = settings.environment.clone({
+    displaySky: true,
+    sky: SkyBox.fromJSON({ twoColor: true, nadirColor: 0xdfefff, zenithColor: 0xffefdf }),
+  });
 }

--- a/test-apps/display-test-app/src/frontend/DecorationGeometryExample.ts
+++ b/test-apps/display-test-app/src/frontend/DecorationGeometryExample.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { assert } from "@itwin/core-bentley";
 import { Box, Cone, Point3d, Range3d, Sphere, Transform } from "@itwin/core-geometry";
-import { ColorDef, RenderMode } from "@itwin/core-common";
+import { ColorDef, RenderMode, SkyBox } from "@itwin/core-common";
 import { DecorateContext, GraphicBranch, GraphicBuilder, GraphicType, IModelApp, IModelConnection, StandardViewId, Viewport } from "@itwin/core-frontend";
 import { Viewer } from "./Viewer";
 
@@ -90,12 +90,9 @@ export function openDecorationGeometryExample(viewer: Viewer): void {
     backgroundMap: true,
   });
 
-  viewer.viewport.view.getDisplayStyle3d().settings.environment = {
-    sky: {
-      display: true,
-      twoColor: true,
-      nadirColor: 0xdfefff,
-      zenithColor: 0xffefdf,
-    },
-  };
+  const settings = viewer.viewport.view.getDisplayStyle3d().settings;
+  settings.environment = settings.environment.clone({
+    displaySky: true,
+    sky: SkyBox.fromJSON({ twoColor: true, nadirColor: 0xdfefff, zenithColor: 0xffefdf }),
+  });
 }

--- a/test-apps/display-test-app/src/frontend/ViewPicker.ts
+++ b/test-apps/display-test-app/src/frontend/ViewPicker.ts
@@ -130,9 +130,7 @@ export class ViewList extends SortedArray<ViewSpec> {
     style.backgroundColor = ColorDef.white;
 
     // turn on the skybox in the environment
-    const env = style.environment;
-    env.sky.display = true;
-    style.environment = env; // call to accessor to get the json properties to reflect the changes
+    style.environment = style.environment.withDisplay({ sky: true });
 
     return blankView;
   }


### PR DESCRIPTION
#2661 introduced support for URLs in addition to texture Ids when specifying skybox images.
[Native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/205794) updates persistence layer and API.
This PR cherry-picks #2661 and adds some tests to verify the persistence layer.