### PR TITLE
Typedoc version bump

### DIFF
--- a/clients/imodelhub/package.json
+++ b/clients/imodelhub/package.json
@@ -18,7 +18,7 @@
     "build:esm": "tsc 1>&2 --module ES2020 --outDir lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=imodelhub-client",
-    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/imodelhub-client/file.json --tsIndexFile=imodelhub-client.ts --onlyJson",
+    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/imodelhub-client/file.json --excludes=@types --tsIndexFile=imodelhub-client.ts --onlyJson",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "mocha",
     "cover": ""

--- a/clients/imodelhub/src/imodelhub/EventsBase.ts
+++ b/clients/imodelhub/src/imodelhub/EventsBase.ts
@@ -13,7 +13,7 @@ import { IModelBaseHandler } from "./BaseHandler";
 
 /**
  * Base class for event shared access signatures.
- * @public
+ * @internal
  */
 export abstract class BaseEventSAS extends WsgInstance {
   /** Base address for event requests. */

--- a/clients/itwin/package.json
+++ b/clients/itwin/package.json
@@ -14,7 +14,7 @@
     "build:esm": "tsc 1>&2 --module ES2020 --outDir lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "extract-api": "betools extract-api --entry=itwin-client",
-    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/itwin-client/file.json --tsIndexFile=itwin-client.ts --onlyJson",
+    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/clients/itwin-client/file.json --tsIndexFile=itwin-client.ts --onlyJson",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "mocha",
     "cover": "nyc npm -s test"

--- a/common/changes/@bentley/imodelhub-client/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@bentley/imodelhub-client/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client"
+}

--- a/common/changes/@bentley/itwin-client/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@bentley/itwin-client/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-client",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/itwin-client"
+}

--- a/common/changes/@itwin/appui-layout-react/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/appui-layout-react/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/appui-react/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/appui-react/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/build-tools/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/build-tools/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/common/changes/@itwin/components-react/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/components-react/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-backend/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/core-backend/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-frontend/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/core-frontend/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-geometry/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/core-geometry/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/common/changes/@itwin/core-react/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/core-react/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/presentation-testing/typedoc-version-bump_2021-11-09-15-05.json
+++ b/common/changes/@itwin/presentation-testing/typedoc-version-bump_2021-11-09-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-testing",
+      "comment": "Support for TypeDoc v0.22.7. Fix various broken docs links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-testing"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -887,6 +887,10 @@
       "allowedCategories": [ "tools" ]
     },
     {
+      "name": "typedoc-plugin-merge-modules",
+      "allowedCategories": [ "tools" ]
+    },
+    {
       "name": "typemoq",
       "allowedCategories": [ "backend", "common", "extensions", "frontend", "internal", "tools" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3541,9 +3541,8 @@ importers:
       recursive-readdir: ^2.2.2
       rimraf: ^3.0.2
       tree-kill: ^1.2.0
-      typedoc: ^0.16.8
-      typedoc-plugin-external-module-name: 3.0.0
-      typedoc-plugin-internal-external: 2.1.1
+      typedoc: ^0.22.7
+      typedoc-plugin-merge-modules: ^3.0.2
       typescript: ~4.4.0
       wtfnode: ^0.9.1
       yargs: ^16.0.0
@@ -3559,9 +3558,8 @@ importers:
       recursive-readdir: 2.2.2
       rimraf: 3.0.2
       tree-kill: 1.2.2
-      typedoc: 0.16.11
-      typedoc-plugin-external-module-name: 3.0.0_typedoc@0.16.11
-      typedoc-plugin-internal-external: 2.1.1_typedoc@0.16.11
+      typedoc: 0.22.8_typescript@4.4.4
+      typedoc-plugin-merge-modules: 3.0.2_typedoc@0.22.8
       typescript: 4.4.4
       wtfnode: 0.9.1
       yargs: 16.2.0
@@ -6736,9 +6734,6 @@ packages:
       '@itwin/core-bentley': 3.0.0-extension.1
       '@itwin/core-common': 3.0.0-extension.1_f2c3418fbeb77077b236020c30c9aae4
       oidc-client: 1.11.5
-    transitivePeerDependencies:
-      - '@bentley/itwin-client'
-      - '@itwin/core-geometry'
     dev: false
 
   /@itwin/certa/3.0.0-extension.1:
@@ -6930,9 +6925,6 @@ packages:
       '@itwin/core-bentley': 3.0.0-extension.1
       '@itwin/core-common': 3.0.0-extension.1_f2c3418fbeb77077b236020c30c9aae4
       openid-client: 4.9.1
-    transitivePeerDependencies:
-      - '@bentley/itwin-client'
-      - '@itwin/core-geometry'
     dev: false
 
   /@jest/console/26.6.2:
@@ -7934,10 +7926,6 @@ packages:
   /@types/mime/1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
     dev: true
-
-  /@types/minimatch/3.0.3:
-    resolution: {integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==}
-    dev: false
 
   /@types/minimatch/3.0.5:
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
@@ -9618,12 +9606,6 @@ packages:
     resolution: {integrity: sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==}
     hasBin: true
     dev: true
-
-  /backbone/1.4.0:
-    resolution: {integrity: sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==}
-    dependencies:
-      underscore: 1.13.1
-    dev: false
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -13350,19 +13332,6 @@ packages:
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  /handlebars/4.7.7:
-    resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.5
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.14.3
-    dev: false
-
   /harmony-reflect/1.6.2:
     resolution: {integrity: sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==}
     dev: true
@@ -13472,12 +13441,6 @@ packages:
 
   /highlight-words-core/1.2.2:
     resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
-    dev: false
-
-  /highlight.js/9.18.5:
-    resolution: {integrity: sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==}
-    deprecated: Support has ended for 9.x series. Upgrade to @latest
-    requiresBuild: true
     dev: false
 
   /hmac-drbg/1.0.1:
@@ -13964,6 +13927,7 @@ packages:
   /interpret/1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
+    dev: true
 
   /invariant/2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -15040,10 +15004,6 @@ packages:
     dependencies:
       '@panva/asn1.js': 1.0.0
 
-  /jquery/3.6.0:
-    resolution: {integrity: sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==}
-    dev: false
-
   /js-base64/2.6.4:
     resolution: {integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==}
     dev: true
@@ -15272,6 +15232,10 @@ packages:
 
   /jsonc-parser/2.0.3:
     resolution: {integrity: sha512-WJi9y9ABL01C8CxTKxRRQkkSpY/x2bo4Gy0WuiZGrInxQqgxQpvkBCLNcDYcHOSdhx4ODgbFcgAvfL49C+PHgQ==}
+
+  /jsonc-parser/3.0.0:
+    resolution: {integrity: sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==}
+    dev: false
 
   /jsonfile/3.0.1:
     resolution: {integrity: sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=}
@@ -15802,9 +15766,9 @@ packages:
     dependencies:
       object-visit: 1.0.1
 
-  /marked/0.8.2:
-    resolution: {integrity: sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==}
-    engines: {node: '>= 8.16.2'}
+  /marked/3.0.8:
+    resolution: {integrity: sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==}
+    engines: {node: '>= 12'}
     hasBin: true
     dev: false
 
@@ -16830,6 +16794,12 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
     dev: true
+
+  /onigasm/2.2.5:
+    resolution: {integrity: sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==}
+    dependencies:
+      lru-cache: 5.1.1
+    dev: false
 
   /ono/4.0.11:
     resolution: {integrity: sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==}
@@ -18903,13 +18873,6 @@ packages:
     resolution: {integrity: sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=}
     dev: false
 
-  /rechoir/0.6.2:
-    resolution: {integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      resolve: 1.19.0
-    dev: false
-
   /recursive-readdir/2.2.2:
     resolution: {integrity: sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==}
     engines: {node: '>=0.10.0'}
@@ -19693,20 +19656,18 @@ packages:
   /shell-quote/1.7.3:
     resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
 
-  /shelljs/0.8.4:
-    resolution: {integrity: sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dependencies:
-      glob: 7.2.0
-      interpret: 1.4.0
-      rechoir: 0.6.2
-    dev: false
-
   /shellwords/0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
     dev: true
     optional: true
+
+  /shiki/0.9.12:
+    resolution: {integrity: sha512-VXcROdldv0/Qu0w2XvzU4IrvTeBNs/Kj/FCmtcEXGz7Tic/veQzliJj6tEiAgoKianhQstpYmbPDStHU5Opqcw==}
+    dependencies:
+      jsonc-parser: 3.0.0
+      onigasm: 2.2.5
+      vscode-textmate: 5.2.0
+    dev: false
 
   /shortid/2.2.16:
     resolution: {integrity: sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==}
@@ -21008,49 +20969,26 @@ packages:
   /typedarray/0.0.6:
     resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
 
-  /typedoc-default-themes/0.7.2:
-    resolution: {integrity: sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==}
-    engines: {node: '>= 8'}
-    dependencies:
-      backbone: 1.4.0
-      jquery: 3.6.0
-      lunr: 2.3.9
-      underscore: 1.13.1
-    dev: false
-
-  /typedoc-plugin-external-module-name/3.0.0_typedoc@0.16.11:
-    resolution: {integrity: sha512-mTPO5Z+HIrM3b24A5/auFg+7ps7Y1jAGuccnOBhHcfUH3ZedInYdJuFcdisjDCW0i8BmRzCShB/KEpiG64oIWw==}
+  /typedoc-plugin-merge-modules/3.0.2_typedoc@0.22.8:
+    resolution: {integrity: sha512-RlMFUVcNAXi7jMIa5/EtCbMeBLnTzF0DcH150s8L5OlF2QdHrnUdNGnqgndfdFu4bUkCOQVl3bjOog9vjjlK3Q==}
     peerDependencies:
-      typedoc: '>=0.7.0 <0.15.0'
+      typedoc: 0.21.x || 0.22.x
     dependencies:
-      lodash: 4.17.21
-      semver: 7.3.5
-      typedoc: 0.16.11
+      typedoc: 0.22.8_typescript@4.4.4
     dev: false
 
-  /typedoc-plugin-internal-external/2.1.1_typedoc@0.16.11:
-    resolution: {integrity: sha512-T7f/zb4HDReKo8yhSyNUf6flhaWkIJx9/Od9BkNzXOBBaKs+TgWH5sLxQ5aeGa5IDDWohrtrFvHWm3D/RQq2Nw==}
-    peerDependencies:
-      typedoc: '>=0.7.2 <1.0.0'
-    dependencies:
-      typedoc: 0.16.11
-    dev: false
-
-  /typedoc/0.16.11:
-    resolution: {integrity: sha512-YEa5i0/n0yYmLJISJ5+po6seYfJQJ5lQYcHCPF9ffTF92DB/TAZO/QrazX5skPHNPtmlIht5FdTXCM2kC7jQFQ==}
-    engines: {node: '>= 8.0.0'}
+  /typedoc/0.22.8_typescript@4.4.4:
+    resolution: {integrity: sha512-92S+YzyhospdXN5rnkYUTgirdTYqNWY7NP9vco+IqQQoiSXzVSUsawVro+tMyEEsWUS7EMaJ2YOjB9uE0CBi6A==}
+    engines: {node: '>= 12.10.0'}
     hasBin: true
+    peerDependencies:
+      typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x
     dependencies:
-      '@types/minimatch': 3.0.3
-      fs-extra: 8.1.0
-      handlebars: 4.7.7
-      highlight.js: 9.18.5
-      lodash: 4.17.21
-      marked: 0.8.2
+      glob: 7.2.0
+      lunr: 2.3.9
+      marked: 3.0.8
       minimatch: 3.0.4
-      progress: 2.0.3
-      shelljs: 0.8.4
-      typedoc-default-themes: 0.7.2
+      shiki: 0.9.12
       typescript: 4.4.4
     dev: false
 
@@ -21089,13 +21027,6 @@ packages:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
     dev: false
 
-  /uglify-js/3.14.3:
-    resolution: {integrity: sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    dev: false
-    optional: true
-
   /uglify-js/3.4.10:
     resolution: {integrity: sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==}
     engines: {node: '>=0.8.0'}
@@ -21133,10 +21064,6 @@ packages:
   /underscore/1.12.1:
     resolution: {integrity: sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==}
     dev: true
-
-  /underscore/1.13.1:
-    resolution: {integrity: sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==}
-    dev: false
 
   /unicode-canonical-property-names-ecmascript/2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -21422,6 +21349,10 @@ packages:
 
   /vm-browserify/1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
+
+  /vscode-textmate/5.2.0:
+    resolution: {integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==}
+    dev: false
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
@@ -21830,10 +21761,6 @@ packages:
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
-
-  /wordwrap/1.0.0:
-    resolution: {integrity: sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=}
-    dev: false
 
   /workbox-background-sync/5.1.4:
     resolution: {integrity: sha512-AH6x5pYq4vwQvfRDWH+vfOePfPIYQ00nCEB7dJRU1e0n9+9HMRyvI63FlDvtFT2AvXVRsXvUt7DNMEToyJLpSA==}

--- a/core/backend/src/ECDb.ts
+++ b/core/backend/src/ECDb.ts
@@ -2,11 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { IModelJsNative } from "@bentley/imodeljs-native";
 /** @packageDocumentation
  * @module ECDb
  */
 import { assert, DbResult, IDisposable, Logger, OpenMode } from "@itwin/core-bentley";
+import { IModelJsNative } from "@bentley/imodeljs-native";
 import { DbQueryRequest, ECSqlReader, IModelError, QueryBinder, QueryOptions, QueryOptionsBuilder, QueryRowFormat } from "@itwin/core-common";
 import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { ConcurrentQuery } from "./ConcurrentQuery";

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -14,7 +14,7 @@
     "build:esm": "tsc 1>&2 --module ES2020 --outDir lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "copy:public": "cpx \"./src/public/**/*\" ./lib/public",
-    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/core-frontend/file.json --tsIndexFile=./core-frontend.ts --onlyJson --excludes=webgl/**/*,**/primitives --excludeGlob=**/*-css.ts",
+    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/core-frontend/file.json --tsIndexFile=./core-frontend.ts --onlyJson --excludes=webgl/**/*,**/primitives,**/map/*.d.ts,**/tile/*.d.ts,**/*-css.ts",
     "extract-api": "betools extract-api --entry=core-frontend",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./src/public/locales/en --out ./public/locales/en-PSEUDO",

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -676,7 +676,7 @@ export class IModelApp {
   }
 
   /** Localize an error status from iModel.js
-   * @param status one of the status values from [[BentleyStatus]], [[IModelStatus]] or [[DbResult]]
+   * @param status one of the status values from [BentleyStatus]($core-bentley), [IModelStatus]($core-bentley) or [DbResult]($core-bentley)
    * @returns a localized error message
    * @beta
    */

--- a/core/frontend/src/render/primitives/mesh/TerrainMeshPrimitive.ts
+++ b/core/frontend/src/render/primitives/mesh/TerrainMeshPrimitive.ts
@@ -34,7 +34,7 @@ const scratchQPoint2d = new QPoint2d(), scratchQPoint2d1 = new QPoint2d();
 
 /**  These are currently retained on terrain leaf tiles for upsampling.
  * It may be worthwhile to pack the data into buffers...
- * @internal.
+ * @internal
  */
 export class TerrainMeshPrimitive extends RealityMeshPrimitive {
   private _currPointCount = 0;

--- a/core/frontend/src/tile/map/WmsCapabilities.ts
+++ b/core/frontend/src/tile/map/WmsCapabilities.ts
@@ -2,14 +2,14 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Views
+ */
+
 import { MapSubLayerProps } from "@itwin/core-common";
 import { request, RequestBasicCredentials, RequestOptions } from "@bentley/itwin-client";
 import WMS from "wms-capabilities";
 import { MapCartoRectangle, WmsUtilities } from "../internal";
-
-/** @packageDocumentation
- * @module Views
- */
 
 /**
  * fetch XML from HTTP request

--- a/core/frontend/src/tile/map/WmtsCapabilities.ts
+++ b/core/frontend/src/tile/map/WmtsCapabilities.ts
@@ -2,14 +2,14 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Views
+ */
+
 import { Point2d, Range2d } from "@itwin/core-geometry";
 import { request, RequestBasicCredentials, RequestOptions } from "@bentley/itwin-client";
 import { xml2json } from "xml-js";
 import { MapCartoRectangle, WmsUtilities } from "../internal"; // WmsUtilities needed for getBaseUrl
-
-/** @packageDocumentation
- * @module Views
- */
 
 /**
  * fetch XML from HTTP request

--- a/core/geometry/src/curve/spiral/NormalizedTransition.ts
+++ b/core/geometry/src/curve/spiral/NormalizedTransition.ts
@@ -107,7 +107,7 @@ export class NormalizedBlossTransition extends NormalizedTransition {
     return u * u * u * (1 - 0.5 * u);
   }
 }
-/**
+
 /**
  * Transition functions for biquadratic transition
  * * Curvature is a pair of joining quadratics.

--- a/presentation/testing/package.json
+++ b/presentation/testing/package.json
@@ -30,7 +30,7 @@
     "cover": "nyc npm -s test",
     "docs": "npm run -s docs:reference && npm run -s docs:changelog",
     "docs:changelog": "cpx ./CHANGELOG.md ../../generated-docs/presentation/presentation-testing",
-    "docs:reference": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/presentation/presentation-testing/json/file.json --tsIndexFile=presentation-testing.ts --onlyJson",
+    "docs:reference": "",
     "extract": "betools extract --fileExt=ts --extractFrom=./src/test --recursive --out=../../generated-docs/extract",
     "extract-api": "betools extract-api --entry=presentation-testing",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",

--- a/tools/build/bin/betools.js
+++ b/tools/build/bin/betools.js
@@ -107,7 +107,7 @@ function docsCommand(options) {
   const baseUrlOpt = options.baseUrl ? ["--baseUrl", options.baseUrl] : [];
   const includesOpt = options.includes ? ["--includes", options.includes] : [];
   const excludesOpt = options.excludes ? ["--excludes", options.excludes] : [];
-  const excludesGlobOpt = options.excludes ? ["--excludeGlob", options.excludeGlob] : [];
+  const excludesGlobOpt = options.excludeGlob ? ["--excludeGlob", options.excludeGlob] : [];
   const indexFileOpt = options.tsIndexFile ? ["--tsIndexFile", options.tsIndexFile] : [];
   const onlyJsonOpt = options.onlyJson ? ["--onlyJson"] : [];
   exec(["node", path.resolve(__dirname, "../scripts/docs.js"),

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -40,9 +40,8 @@
     "recursive-readdir": "^2.2.2",
     "rimraf": "^3.0.2",
     "tree-kill": "^1.2.0",
-    "typedoc": "^0.16.8",
-    "typedoc-plugin-external-module-name": "3.0.0",
-    "typedoc-plugin-internal-external": "2.1.1",
+    "typedoc": "^0.22.7",
+    "typedoc-plugin-merge-modules": "^3.0.2",
     "typescript": "~4.4.0",
     "wtfnode": "^0.9.1",
     "yargs": "^16.0.0"

--- a/tools/build/scripts/docs.js
+++ b/tools/build/scripts/docs.js
@@ -26,7 +26,6 @@ const out = (argv.out === undefined) ? paths.appDocs : argv.out;
 const json = (argv.json === undefined) ? paths.appJsonDocs : argv.json;
 
 const baseUrlOptions = (argv.baseUrl === undefined) ? [] : ["--baseUrl", argv.baseUrl];
-console.log("Input: " + argv)
 const includeOptions = (argv.includes === undefined) ? [] : ["--includes", argv.includes];
 
 let excludeList = "**/node_modules/**/*,**/*test*/**/*";
@@ -34,6 +33,10 @@ if (argv.excludes !== undefined)
   excludeList += ",**/" + argv.excludes + "/**/*";
 if (argv.excludeGlob !== undefined)
   excludeList += "," + argv.excludeGlob;
+
+excludeList = excludeList.replace(/,/g, ',--exclude,')
+const excludeArray = excludeList.split(",");
+excludeArray.unshift("--exclude");
 
 let outputOptions = [
   "--json", json
@@ -46,11 +49,14 @@ const readmeOption = (argv.readme === undefined) ? "none" : argv.readme;
 
 const options = [
   "--excludePrivate",
-  "--experimentalDecorators",
-  "--excludeExternals",
-  "--excludeNotExported",
-  "--ignoreCompilerErrors",
   "--hideGenerator",
+  "--logLevel",
+  "Error"
+];
+
+const pluginOptions = [
+  "--plugin", "typedoc-plugin-merge-modules",
+  "--mergeModulesMergeMode", "module",
 ];
 
 if (argv.name) options.push("--name", argv.name);
@@ -58,16 +64,12 @@ if (argv.name) options.push("--name", argv.name);
 if (argv.theme) options.push("--theme", argv.theme);
 
 const args = [
-  path.resolve(process.cwd(), source),
+  "--entryPointStrategy", "expand", path.resolve(process.cwd(), source),
   ...options,
-  "--exclude", [excludeList],
+  ...excludeArray,
   ...outputOptions,
-  "--mode", "modules",
   "--readme", readmeOption,
-  "--module", "commonjs",
-  "--plugin", "typedoc-plugin-external-module-name,typedoc-plugin-internal-external",
-  "--external-aliases", "alpha,internal",
-  "--internal-aliases", "UNUSED",
+  ...pluginOptions,
   ...baseUrlOptions,
   ...includeOptions
 ];

--- a/tools/build/scripts/utils/validateTags.js
+++ b/tools/build/scripts/utils/validateTags.js
@@ -17,6 +17,7 @@ const validTags = [
   "example",
   "pattern",
   "returns",
+  "internal",
 
   // Following flags are added to support API-extractor (https://api-extractor.com/pages/tsdoc/syntax/#release-tags)
   "alpha",

--- a/ui/appui-layout-react/package.json
+++ b/ui/appui-layout-react/package.json
@@ -21,7 +21,7 @@
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "nyc npm -s test",
     "docs": "npm run -s docs:typedoc",
-    "docs:typedoc": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/appui-layout-react/file.json --tsIndexFile=./appui-layout-react.ts --onlyJson",
+    "docs:typedoc": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/appui-layout-react/file.json --excludeGlob=**/declarations.d.ts --tsIndexFile=./appui-layout-react.ts --onlyJson",
     "extract-api": "betools extract-api --entry=appui-layout-react",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "test": "mocha --config ../.mocharc.json \"./lib/cjs/test/**/*.test.js\"",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -25,7 +25,7 @@
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./public/locales/en-PSEUDO",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "nyc npm -s test",
-    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/appui-react/file.json --tsIndexFile=./appui-react.ts --onlyJson",
+    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/appui-react/file.json --excludeGlob=**/declarations.d.ts --tsIndexFile=./appui-react.ts --onlyJson",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "extract-api": "betools extract-api --entry=appui-react",
     "test": "mocha --config ../.mocharc.json \"./lib/cjs/test/**/*.test.js\"",

--- a/ui/components-react/src/components-react/datepicker/TimeField.tsx
+++ b/ui/components-react/src/components-react/datepicker/TimeField.tsx
@@ -48,7 +48,7 @@ function isSameTime(a: TimeSpec, b: TimeSpec) {
   return a.hours === b.hours && a.minutes === b.minutes && a.seconds === b.seconds;
 }
 
-/** Field used to set the Hour:Minutes:Seconds in the [[DataPicker]] Popup panel. The user may key-in the value or use up/down keys to
+/** Field used to set the Hour:Minutes:Seconds in the [[DatePicker]] Popup panel. The user may key-in the value or use up/down keys to
  * change the time.
  * @internal
  */

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -22,7 +22,7 @@
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./public/locales/en-PSEUDO",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "nyc npm -s test",
-    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/core-react/file.json --tsIndexFile=./core-react.ts --onlyJson",
+    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/ui/core-react/file.json --tsIndexFile=./core-react.ts --onlyJson --excludeGlob=**/declarations.d.ts",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "extract-api": "betools extract-api --entry=core-react",
     "test": "mocha --config ../.mocharc.json \"./lib/cjs/test/**/*.test.js\"",


### PR DESCRIPTION
- Bump TypeDoc version to latest
  - Update TypeDoc options accordingly
  - Namely `--entryPointStrategy` and corresponding `--exclude`s
- Fix various broken links that materialized as a result
- TODO: Use BeMetalsmith v4.2.0 in build pipelines