### PR TITLE
Update renderer string for buggy Intel chips

### DIFF
--- a/common/changes/@itwin/webgl-compatibility/update-intel-renderer-string_2021-11-09-20-13.json
+++ b/common/changes/@itwin/webgl-compatibility/update-intel-renderer-string_2021-11-09-20-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "Update workaround for buggy Intel integrated GPUs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -65,6 +65,14 @@ export enum DepthType {
 
 const maxTexSizeAllowed = 4096; // many devices and browsers have issues with source textures larger than this
 
+// Regexes to match Intel UHD/HD 620/630 integrated GPUS that suffer from GraphicsDriverBugs.fragDepthDoesNotDisableEarlyZ.
+const buggyIntelMatchers = [
+  // Original unmasked renderer string when workaround we implemented.
+  /ANGLE \(Intel\(R\) (U)?HD Graphics 6(2|3)0 Direct3D11/,
+  // New unmasked renderer string circa October 2021.
+  /ANGLE \(Intel, Intel\(R\) (U)?HD Graphics 6(2|3)0 Direct3D11/,
+];
+
 /** Describes the rendering capabilities of the host system.
  * @internal
  */
@@ -292,7 +300,7 @@ export class Capabilities {
     const unmaskedVendor = debugInfo !== null ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) : undefined;
 
     this._driverBugs = {};
-    if (undefined !== unmaskedRenderer && /ANGLE \(Intel\(R\) (U)?HD Graphics 6(2|3)0 Direct3D11/.test(unmaskedRenderer))
+    if (unmaskedRenderer && buggyIntelMatchers.some((x) => x.test(unmaskedRenderer)))
       this._driverBugs.fragDepthDoesNotDisableEarlyZ = true;
 
     return {

--- a/core/webgl-compatibility/src/test/Compatibility.test.ts
+++ b/core/webgl-compatibility/src/test/Compatibility.test.ts
@@ -188,6 +188,10 @@ describe("Render Compatibility", () => {
       [ "Intel(R) UHD Graphics 610", false ],
 
       [ "ANGLE (NVIDIA GeForce GTX 970 Direct3D11 vs_5_0 ps_5_0)", false ],
+
+      // Around October 2021 slightly different unmasked renderer strings began showing up, containing "Intel, Intel(R)" instead of just "Intel(R)".
+      [ "ANGLE (Intel, Intel(R) HD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)", true ],
+      [ "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11", true ],
     ];
 
     for (const renderer of renderers) {


### PR DESCRIPTION
Long ago we implemented a workaround for a bug in particular integrated GPUs that caused transparenct geometry to display behind other geometry.
We detect these GPUs using a regex match against the unmasked renderer string provided by WebGL.
It appears Intel has slightly changed that string, so our regex has ceased working and the bug has recurred.
Previously (for example):
`ANGLE (Intel(R) HD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)`
Now:
`ANGLE (Intel, Intel(R) HD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)`