### PR TITLE
Fix styling of number editor to properly fit into toolsettings

### DIFF
--- a/common/changes/@itwin/appui-layout-react/fixTypeEditorCssStyle_2021-11-10-13-23.json
+++ b/common/changes/@itwin/appui-layout-react/fixTypeEditorCssStyle_2021-11-10-13-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Update Floating Widget to allow overflow so popups like from Select component will properly display.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/components-react/fixTypeEditorCssStyle_2021-11-10-13-23.json
+++ b/common/changes/@itwin/components-react/fixTypeEditorCssStyle_2021-11-10-13-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Update CustomNumberEditor to use size='small' itwinUi style.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
@@ -10,6 +10,7 @@
   position: absolute;
   border: 1px solid $buic-background-5;
   border-radius: 3px;
+  overflow:visible;
   @include uicore-z-index(dragged-widget);
   @include nz-widget-opacity;
 

--- a/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
+++ b/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
@@ -16,7 +16,9 @@ import {
   CustomFormattedNumberParams, IconEditorParams, InputEditorSizeParams, MessageSeverity, PrimitiveValue, PropertyEditorParams, PropertyEditorParamTypes,
   PropertyRecord, PropertyValue, PropertyValueFormat, SpecialKey, StandardEditorNames, StandardTypeNames, UiAdmin,
 } from "@itwin/appui-abstract";
-import { Icon, IconInput, Input, InputProps } from "@itwin/core-react";
+import { Icon, IconInput } from "@itwin/core-react";
+import { Input, InputProps } from "@itwin/itwinui-react";
+
 import { UiComponents } from "../UiComponents";
 import { PropertyEditorProps, TypeEditor } from "./EditorContainer";
 import { PropertyEditorBase, PropertyEditorManager } from "./PropertyEditorManager";
@@ -289,11 +291,11 @@ export class CustomNumberEditor extends React.PureComponent<PropertyEditorProps,
     } else {
       // NEEDSWORK: still using core-react Input component because of `nativeKeyHandler` prop
       reactNode = (
-        // eslint-disable-next-line deprecation/deprecation
         <Input
           {...inputProps}
           ref={this._inputElement}
           data-testid="components-customnumber-editor"
+          size="small"
         />
       );
     }

--- a/ui/components-react/src/components-react/editors/EnumEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumEditor.tsx
@@ -165,15 +165,12 @@ export class EnumEditor extends React.PureComponent<PropertyEditorProps, EnumEdi
 
     // The iTwinUI-react Select onBlur still does not work properly, so it cannot be used yet. NEEDSWORK
     // onBlur={this.props.onBlur}
-
-    /* The following popoverProps are required for the popup to properly show in floating widgets because this makes it work similar to a portal */
     return (
       <div ref={this._divElement}>
         <Select
           className={className}
           style={this.props.style ? this.props.style : minWidthStyle}
           value={selectValue}
-          popoverProps={{ appendTo: () => this.state.parentDiv ? this.state.parentDiv.ownerDocument.body : /* istanbul ignore next */ document.body }}
           onChange={this._updateSelectValue}
           data-testid="components-select-editor"
           options={this.state.options}


### PR DESCRIPTION
- Since type editors are now using iTwinUi components those components must use size="small" prop to be properly sized for AppUI.
- Removed the prop on `<Select>` component that was forcing popup to be child of document as that was messing up z-index in many situations.
- Updated to allow overflow on FloatingWidgets so popups, like from `<Select>` would be properly shown.