### PR TITLE
Make copy-config script agnostic to imodeljs repo directory name.

### DIFF
--- a/tools/internal/scripts/copyConfig.js
+++ b/tools/internal/scripts/copyConfig.js
@@ -24,8 +24,7 @@ exports.handler = async (argv) => {
   let envFile = process.env.IMJS_CONFIG_FILE ? process.env.IMJS_CONFIG_FILE : "";
 
   if (!envFile) {
-    const lastIndex = rootDir.lastIndexOf(path.sep + "imodeljs");
-    const pathDir = rootDir.substring(0, lastIndex + 1);
+    const pathDir = path.dirname(rootDir);
     const configDir = path.resolve(pathDir, "imodeljs-config");
     envFile = path.resolve(configDir, ".env");
   }


### PR DESCRIPTION
Since the move from imodeljs to itwinjs-core, developers who clone a new repo get (by default) a directory named "itwinjs-core".
copyConfig.js expects the repo to be in a directory named "imodeljs", with a sibling directory named "imodeljs-config", causing it to fail to locate the sibling directory and copy the config files.
Change it so it just looks in the parent directory of the repo root for the imodeljs-config directory.