### PR TITLE
ViewCreator3d default lighting update

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -11734,6 +11734,7 @@ export interface ViewCreator3dOptions {
     skyboxOn?: boolean;
     standardViewId?: StandardViewId;
     useSeedView?: boolean;
+    useV2Stylings?: boolean;
     vpAspect?: number;
 }
 

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -153,6 +153,7 @@ internal;DbResponseKind
 internal;DbResponseStatus
 beta;DbRuntimeStats
 internal;DecorationGeometryProps
+beta;DefaultSupportedTypes
 internal;defaultTileOptions: TileOptions
 public;DefinitionElementProps 
 public;DeletedElementGeometryChange
@@ -522,6 +523,8 @@ beta;QueryValueType = any
 public;Rank
 internal;ReadableFormData 
 internal;readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription
+beta;RealityData
+beta;RealityDataAccess
 alpha;RealityDataFormat
 alpha;RealityDataProvider
 alpha;RealityDataSourceKey

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -38,6 +38,8 @@ export interface ViewCreator3dOptions {
   useSeedView?: boolean;
   /** Aspect ratio of [[Viewport]]. Required to fit contents of the model(s) in the initial state of the view. */
   vpAspect?: number;
+  /** Use the old, dimmer stylings when generating view. */
+  useV2Stylings?: boolean;
 }
 
 /**
@@ -140,6 +142,7 @@ export class ViewCreator3d {
 
     const cameraData = new Camera();
     const cameraOn = options?.cameraOn ? options.cameraOn : false;
+    const useLighting = options?.useV2Stylings ? options.useV2Stylings : true;
     const viewDefinitionProps: ViewDefinition3dProps = {
       categorySelectorId: "",
       displayStyleId: "",
@@ -172,6 +175,13 @@ export class ViewCreator3d {
             visEdges: false,
             backgroundMap: this._imodel.isGeoLocated,
           },
+          lights: useLighting ? {
+            solar: { intensity: 0 },
+            portrait: { intensity: 0 },
+            ambient: { intensity: 0.55 },
+            fresnel: { intensity: 0.8, invert: true },
+            specularIntensity: 0,
+          } : undefined,
           environment:
             options !== undefined &&
               options.skyboxOn !== undefined &&


### PR DESCRIPTION
This change updates the default view created by the ViewCreator3d with brighter lighting.  A flag was also added to the ViewCreatorOptions that would allow users to op-out of the display styling changes.