### PR TITLE
Improve tree-shaking in core-geometry.

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -4016,7 +4016,7 @@ export class Point3d extends XYZ {
     static fromJSON(json?: XYZProps): Point3d;
     interpolate(fraction: number, other: XYAndZ, result?: Point3d): Point3d;
     interpolatePerpendicularXY(fraction: number, pointB: Point3d, fractionXYPerp: number, result?: Point3d): Point3d;
-    interpolatePointAndTangent(fraction: number, other: Point3d, tangentScale: number, result?: Ray3d): Ray3d;
+    interpolatePointAndTangent(fraction: number, other: Point3d, tangentScale: number, result: Ray3d): Ray3d;
     interpolateXYZ(fractionX: number, fractionY: number, fractionZ: number, other: Point3d, result?: Point3d): Point3d;
     minus(vector: XYAndZ, result?: Point3d): Point3d;
     plus(vector: XYAndZ, result?: Point3d): Point3d;

--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -4016,7 +4016,6 @@ export class Point3d extends XYZ {
     static fromJSON(json?: XYZProps): Point3d;
     interpolate(fraction: number, other: XYAndZ, result?: Point3d): Point3d;
     interpolatePerpendicularXY(fraction: number, pointB: Point3d, fractionXYPerp: number, result?: Point3d): Point3d;
-    interpolatePointAndTangent(fraction: number, other: Point3d, tangentScale: number, result: Ray3d): Ray3d;
     interpolateXYZ(fractionX: number, fractionY: number, fractionZ: number, other: Point3d, result?: Point3d): Point3d;
     minus(vector: XYAndZ, result?: Point3d): Point3d;
     plus(vector: XYAndZ, result?: Point3d): Point3d;
@@ -4845,6 +4844,7 @@ export class Ray3d implements BeJSONFunctions {
     static fromJSON(json?: any): Ray3d;
     getDirectionRef(): Vector3d;
     getOriginRef(): Point3d;
+    static interpolatePointAndTangent(pt1: XYAndZ, fraction: number, pt2: XYAndZ, tangentScale: number, result?: Ray3d): Ray3d;
     intersectionWithPlane(plane: Plane3dByOriginAndUnitNormal, result?: Point3d): number | undefined;
     intersectionWithRange3d(range: Range3d, result?: Range1d): Range1d;
     isAlmostEqual(other: Ray3d): boolean;

--- a/common/changes/@itwin/core-geometry/treeshake-geom_2021-11-09-21-04.json
+++ b/common/changes/@itwin/core-geometry/treeshake-geom_2021-11-09-21-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-geometry",
-      "comment": "Out parameter in Point3d.interpolatePointAndTangent is no longer optional.",
+      "comment": "Moved Point3d.interpolatePointAndTangent to Ray3d.interpolatePointAndTangent.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-geometry/treeshake-geom_2021-11-09-21-04.json
+++ b/common/changes/@itwin/core-geometry/treeshake-geom_2021-11-09-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "Out parameter in Point3d.interpolatePointAndTangent is no longer optional.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/package.json
+++ b/core/geometry/package.json
@@ -7,6 +7,7 @@
   "typings": "lib/cjs/core-geometry",
   "imodeljsSharedLibrary": true,
   "license": "MIT",
+  "sideEffects": false,
   "scripts": {
     "build": "npm run -s build:cjs",
     "build:ci": "npm run -s build && npm run -s build:esm",

--- a/core/geometry/src/geometry3d/Point3dVector3d.ts
+++ b/core/geometry/src/geometry3d/Point3dVector3d.ts
@@ -9,7 +9,6 @@
 import { Geometry } from "../Geometry";
 import { Point4d } from "../geometry4d/Point4d";
 import { Angle } from "./Angle";
-import type { Ray3d } from "./Ray3d";
 import { HasZ, XAndY, XYAndZ, XYZProps } from "./XYZProps";
 
 /**
@@ -455,28 +454,6 @@ export class Point3d extends XYZ {
       return Point3d.create(this.x + fraction * (other.x - this.x), this.y + fraction * (other.y - this.y), this.z + fraction * (other.z - this.z), result);
     const t: number = fraction - 1.0;
     return Point3d.create(other.x + t * (other.x - this.x), other.y + t * (other.y - this.y), other.z + t * (other.z - this.z), result);
-  }
-  /**
-   * Return a ray whose ray.origin is interpolated, and ray.direction is the vector between points with a
-   * scale factor applied.
-   * @param fraction fractional position between points.
-   * @param other endpoint of interpolation
-   * @param tangentScale scale factor to apply to the startToEnd vector
-   * @param result  optional receiver.
-   */
-  public interpolatePointAndTangent(fraction: number, other: Point3d, tangentScale: number, result: Ray3d): Ray3d {
-    result = result;
-    const dx = other.x - this.x;
-    const dy = other.y - this.y;
-    const dz = other.z - this.z;
-    result.direction.set(tangentScale * dx, tangentScale * dy, tangentScale * dz);
-    if (fraction <= 0.5)
-      result.origin.set(this.x + fraction * dx, this.y + fraction * dy, this.z + fraction * dz);
-    else {
-      const t: number = fraction - 1.0;
-      result.origin.set(other.x + t * dx, other.y + t * dy, other.z + t * dz);
-    }
-    return result;
   }
   /** Return a point with independent x,y,z fractional interpolation. */
   public interpolateXYZ(fractionX: number, fractionY: number, fractionZ: number, other: Point3d, result?: Point3d): Point3d {

--- a/core/geometry/src/geometry3d/Point3dVector3d.ts
+++ b/core/geometry/src/geometry3d/Point3dVector3d.ts
@@ -9,7 +9,7 @@
 import { Geometry } from "../Geometry";
 import { Point4d } from "../geometry4d/Point4d";
 import { Angle } from "./Angle";
-import { Ray3d } from "./Ray3d";
+import type { Ray3d } from "./Ray3d";
 import { HasZ, XAndY, XYAndZ, XYZProps } from "./XYZProps";
 
 /**
@@ -464,8 +464,8 @@ export class Point3d extends XYZ {
    * @param tangentScale scale factor to apply to the startToEnd vector
    * @param result  optional receiver.
    */
-  public interpolatePointAndTangent(fraction: number, other: Point3d, tangentScale: number, result?: Ray3d): Ray3d {
-    result = result ? result : Ray3d.createZero();
+  public interpolatePointAndTangent(fraction: number, other: Point3d, tangentScale: number, result: Ray3d): Ray3d {
+    result = result;
     const dx = other.x - this.x;
     const dy = other.y - this.y;
     const dz = other.z - this.z;

--- a/core/geometry/src/geometry3d/Ray3d.ts
+++ b/core/geometry/src/geometry3d/Ray3d.ts
@@ -342,6 +342,7 @@ export class Ray3d implements BeJSONFunctions {
   /**
    * Return a ray whose ray.origin is interpolated, and ray.direction is the vector between points with a
    * scale factor applied.
+   * @param pt1 start point of interpolation
    * @param fraction fractional position between points.
    * @param pt2 endpoint of interpolation
    * @param tangentScale scale factor to apply to the startToEnd vector

--- a/core/geometry/src/geometry3d/Ray3d.ts
+++ b/core/geometry/src/geometry3d/Ray3d.ts
@@ -338,4 +338,27 @@ export class Ray3d implements BeJSONFunctions {
     pair.approachType = pairType;
     return pair;
   }
+
+  /**
+   * Return a ray whose ray.origin is interpolated, and ray.direction is the vector between points with a
+   * scale factor applied.
+   * @param fraction fractional position between points.
+   * @param pt2 endpoint of interpolation
+   * @param tangentScale scale factor to apply to the startToEnd vector
+   * @param result optional receiver.
+   */
+  public static interpolatePointAndTangent(pt1: XYAndZ, fraction: number, pt2: XYAndZ, tangentScale: number, result?: Ray3d): Ray3d {
+    result = result ?? Ray3d.createZero();
+    const dx = pt2.x - pt1.x;
+    const dy = pt2.y - pt1.y;
+    const dz = pt2.z - pt1.z;
+    result.direction.set(tangentScale * dx, tangentScale * dy, tangentScale * dz);
+    if (fraction <= 0.5)
+      result.origin.set(pt1.x + fraction * dx, pt1.y + fraction * dy, pt1.z + fraction * dz);
+    else {
+      const t: number = fraction - 1.0;
+      result.origin.set(pt2.x + t * dx, pt2.y + t * dy, pt2.z + t * dz);
+    }
+    return result;
+  }
 }

--- a/core/geometry/src/test/geometry3d/Point3d.test.ts
+++ b/core/geometry/src/test/geometry3d/Point3d.test.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
+import { Ray3d } from "../../core-geometry";
 import { Geometry } from "../../Geometry";
 import { Angle } from "../../geometry3d/Angle";
 import { Point3d, Vector3d, XYZ } from "../../geometry3d/Point3dVector3d";
@@ -127,7 +128,7 @@ describe("Point3d", () => {
           ck.testCoordinate(unitIJV.dotProduct(vectorIJV), vectorI.distance(vectorJ));
         }
         for (const f of [0.1, 0.5, 0.9, 1.1]) {
-          const ray = pointI.interpolatePointAndTangent(f, pointJ, 1.0);
+          const ray = pointI.interpolatePointAndTangent(f, pointJ, 1.0, Ray3d.createZero());
           const point = pointI.interpolate(f, pointJ);
           ck.testPoint3d(point, ray.origin);
           ck.testVector3d(vectorIJ, ray.direction);

--- a/core/geometry/src/test/geometry3d/Point3d.test.ts
+++ b/core/geometry/src/test/geometry3d/Point3d.test.ts
@@ -128,7 +128,7 @@ describe("Point3d", () => {
           ck.testCoordinate(unitIJV.dotProduct(vectorIJV), vectorI.distance(vectorJ));
         }
         for (const f of [0.1, 0.5, 0.9, 1.1]) {
-          const ray = pointI.interpolatePointAndTangent(f, pointJ, 1.0, Ray3d.createZero());
+          const ray = Ray3d.interpolatePointAndTangent(pointI, f, pointJ, 1.0);
           const point = pointI.interpolate(f, pointJ);
           ck.testPoint3d(point, ray.origin);
           ck.testVector3d(vectorIJ, ray.direction);


### PR DESCRIPTION
Now that we're delivering ES modules, bundlers like webpack are able to do [tree-shaking](https://webpack.js.org/guides/tree-shaking/) to remove unused code.  The @itwin/core-geometry package ought to be a perfect candidate for tree-shaking, because it is large (>1MB minified), free of [side-effects](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free), and often times a consumer of core-geometry really only actually needs a few primitive types.

However, after explicitly marking @itwin/core-geometry as free of side-effects, some experimentation revealed that just importing `Point2d`, `Point3d`, `Range2d` into an extension still pulled more than 200KB from core-geometry into the bundle: 
![pre-change](https://user-images.githubusercontent.com/33036725/141328434-ef26635a-2110-4953-86e5-cec4316dd91a.png)

After some investigation, it turns out that a lot of this can be eliminated simply by removing the hard dependency on `Ray3d` from `Point3d.interpolatePointAndTangent()`.  This is technically a breaking change, but IMO this is well worth the more than 3x reduction in size when using those three types:
![post-change](https://user-images.githubusercontent.com/33036725/141327701-d291c3da-b71f-41dc-b846-aeae563fefae.png)

Ultimately, I believe there are much bigger changes we should consider making to core-geometry in the future, but this felt like a good first step here.
 