### PR TITLE
View independent transparency override

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2914,32 +2914,32 @@ export class Feature {
 }
 
 // @public
-export class FeatureAppearance implements FeatureAppearanceProps {
+export class FeatureAppearance {
     protected constructor(props: FeatureAppearanceProps);
     get anyOverridden(): boolean;
     clone(changedProps: FeatureAppearanceProps): FeatureAppearance;
     cloneProps(changedProps: FeatureAppearanceProps): FeatureAppearanceProps;
     static readonly defaults: FeatureAppearance;
     // (undocumented)
-    readonly emphasized?: true | undefined;
+    readonly emphasized?: true;
     // (undocumented)
     equals(other: FeatureAppearance): boolean;
     extendAppearance(base: FeatureAppearance): FeatureAppearance;
     // (undocumented)
     static fromJSON(props?: FeatureAppearanceProps): FeatureAppearance;
     static fromRgb(color: ColorDef): FeatureAppearance;
-    static fromRgba(color: ColorDef): FeatureAppearance;
+    static fromRgba(color: ColorDef, viewDependentTransparency?: boolean): FeatureAppearance;
     static fromSubCategoryOverride(ovr: SubCategoryOverride): FeatureAppearance;
-    static fromTransparency(transparencyValue: number): FeatureAppearance;
+    static fromTransparency(transparencyValue: number, viewDependent?: boolean): FeatureAppearance;
     // (undocumented)
-    readonly ignoresMaterial?: true | undefined;
+    readonly ignoresMaterial?: true;
     // (undocumented)
     get isFullyTransparent(): boolean;
     // (undocumented)
     readonly linePixels?: LinePixels;
     get matchesDefaults(): boolean;
     // (undocumented)
-    readonly nonLocatable?: true | undefined;
+    readonly nonLocatable?: true;
     // (undocumented)
     get overridesLinePixels(): boolean;
     // (undocumented)
@@ -2959,17 +2959,20 @@ export class FeatureAppearance implements FeatureAppearanceProps {
     // (undocumented)
     readonly transparency?: number;
     // (undocumented)
+    readonly viewDependentTransparency?: true;
+    // (undocumented)
     readonly weight?: number;
 }
 
 // @public
 export interface FeatureAppearanceProps {
-    emphasized?: true | undefined;
-    ignoresMaterial?: true | undefined;
+    emphasized?: true;
+    ignoresMaterial?: true;
     linePixels?: LinePixels;
-    nonLocatable?: true | undefined;
+    nonLocatable?: true;
     rgb?: RgbColorProps;
     transparency?: number;
+    viewDependentTransparency?: true;
     weight?: number;
 }
 

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2920,7 +2920,6 @@ export class FeatureAppearance {
     clone(changedProps: FeatureAppearanceProps): FeatureAppearance;
     cloneProps(changedProps: FeatureAppearanceProps): FeatureAppearanceProps;
     static readonly defaults: FeatureAppearance;
-    // (undocumented)
     readonly emphasized?: true;
     // (undocumented)
     equals(other: FeatureAppearance): boolean;
@@ -2931,14 +2930,11 @@ export class FeatureAppearance {
     static fromRgba(color: ColorDef, viewDependentTransparency?: boolean): FeatureAppearance;
     static fromSubCategoryOverride(ovr: SubCategoryOverride): FeatureAppearance;
     static fromTransparency(transparencyValue: number, viewDependent?: boolean): FeatureAppearance;
-    // (undocumented)
     readonly ignoresMaterial?: true;
     // (undocumented)
     get isFullyTransparent(): boolean;
-    // (undocumented)
     readonly linePixels?: LinePixels;
     get matchesDefaults(): boolean;
-    // (undocumented)
     readonly nonLocatable?: true;
     // (undocumented)
     get overridesLinePixels(): boolean;
@@ -2952,15 +2948,11 @@ export class FeatureAppearance {
     get overridesTransparency(): boolean;
     // (undocumented)
     get overridesWeight(): boolean;
-    // (undocumented)
     readonly rgb?: RgbColor;
     // (undocumented)
     toJSON(): FeatureAppearanceProps;
-    // (undocumented)
     readonly transparency?: number;
-    // (undocumented)
     readonly viewDependentTransparency?: true;
-    // (undocumented)
     readonly weight?: number;
 }
 

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -221,7 +221,7 @@ beta;ExternalSourceAttachmentProps
 beta;ExternalSourceAttachmentRole
 beta;ExternalSourceProps 
 public;Feature
-public;FeatureAppearance 
+public;FeatureAppearance
 public;FeatureAppearanceProps
 public;FeatureAppearanceProvider
 public;FeatureAppearanceProvider

--- a/common/changes/@itwin/core-common/view-independent-transparency-override_2021-11-12-15-20.json
+++ b/common/changes/@itwin/core-common/view-independent-transparency-override_2021-11-12-15-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-common",
-      "comment": "FeatureAppearance transparency by default ignores render mode and transparency view flag.",
+      "comment": "FeatureAppearance transparency override by default ignores render mode and transparency view flag.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-common/view-independent-transparency-override_2021-11-12-15-20.json
+++ b/common/changes/@itwin/core-common/view-independent-transparency-override_2021-11-12-15-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "FeatureAppearance transparency by default ignores render mode and transparency view flag.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/view-independent-transparency-override_2021-11-12-15-20.json
+++ b/common/changes/@itwin/core-frontend/view-independent-transparency-override_2021-11-12-15-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "FeatureAppearance transparency by default ignores render mode and transparency view flag.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/common/src/FeatureSymbology.ts
+++ b/core/common/src/FeatureSymbology.ts
@@ -109,7 +109,7 @@ export class FeatureAppearance {
     const transparency = ovr.transparency;
     const weight = ovr.weight;
     const ignoresMaterial = undefined !== ovr.material && Id64.isValid(ovr.material) ? true : undefined;
-    return this.fromJSON({ rgb, transparency, weight, ignoresMaterial, viewDependentTransparency: undefined !== transparency ? true : undefined });
+    return this.fromJSON({ rgb, transparency, weight, ignoresMaterial, viewDependentTransparency: true });
   }
 
   /** Returns true if this appearance does not override any aspects of symbology. */

--- a/core/common/src/FeatureSymbology.ts
+++ b/core/common/src/FeatureSymbology.ts
@@ -109,7 +109,7 @@ export class FeatureAppearance {
     const transparency = ovr.transparency;
     const weight = ovr.weight;
     const ignoresMaterial = undefined !== ovr.material && Id64.isValid(ovr.material) ? true : undefined;
-    return this.fromJSON({ rgb, transparency, weight, ignoresMaterial, viewDependentTransparency: true });
+    return this.fromJSON({ rgb, transparency, weight, ignoresMaterial, viewDependentTransparency: undefined !== transparency ? true : undefined });
   }
 
   /** Returns true if this appearance does not override any aspects of symbology. */

--- a/core/common/src/FeatureSymbology.ts
+++ b/core/common/src/FeatureSymbology.ts
@@ -26,28 +26,25 @@ function copyIdSetToUint32Set(dst: Id64.Uint32Set, src: Iterable<string>): void 
 
 // cspell:ignore subcat subcats
 
-/** Properties used to initialize a [[FeatureAppearance]].
+/** JSON representation of a [[FeatureAppearance]].
  * @public
  */
 export interface FeatureAppearanceProps {
-  /** The color of the Feature */
+  /** @see [[FeatureAppearance.rgb]]. */
   rgb?: RgbColorProps;
-  /** The line weight in pixels as an integer in [1, 31] */
+  /** @see [[FeatureAppearance.weight]]. */
   weight?: number;
-  /** The transparency in the range [0.0, 1.0] where 0 indicates fully opaque and 1 indicates fully transparent. */
+  /** @see [[FeatureAppearance.transparency]]. */
   transparency?: number;
-  /** If true, then [[transparency]] only applies if [[ViewFlags.transparency]] is enabled and the current [[RenderMode]] supports transparency.
-   * Default: false, meaning the transparency is applied regardless of view flags or render mode.
-   * This property has no effect if [[transparency]] is `undefined`.
-   */
+  /** @see [[FeatureAppearance.viewDependentTransparency]]. */
   viewDependentTransparency?: true;
-  /** The pixel pattern used to draw lines. */
+  /** @see [[FeatureAppearance.linePixels]]. */
   linePixels?: LinePixels;
-  /** If true, ignore the [[RenderMaterial]] associated with surfaces. */
+  /** @see [[FeatureAppearance.ignoresMaterial]]. */
   ignoresMaterial?: true;
-  /** If true, the associated [[Feature]] will not be drawn when using [Viewport.readPixels]($frontend). */
+  /** @see [[FeatureAppearance.nonLocatable]]. */
   nonLocatable?: true;
-  /** If true, the associated [[Feature]] will be emphasized. Emphasized features are rendered using the [[Hilite.Settings]] defined by [Viewport.emphasisSettings]($frontend). */
+  /** @see [[FeatureAppearance.emphasized]]. */
   emphasized?: true;
 }
 
@@ -57,13 +54,26 @@ export interface FeatureAppearanceProps {
  * @public
  */
 export class FeatureAppearance {
+  /** Overrides the feature's color. */
   public readonly rgb?: RgbColor;
+  /** The width of lines and edges in pixels as an integer in [1, 31]. */
   public readonly weight?: number;
+  /** The transparency in the range [0, 1] where 0 indicates fully opaque and 1 indicates fully transparent.
+   * @see [[viewDependentTransparency]] for details on how this override interacts with the [DisplayStyle]($backend).
+   */
   public readonly transparency?: number;
+  /** The pixel pattern applied to lines and edges. */
   public readonly linePixels?: LinePixels;
+  /** If true, don't apply the [[RenderMaterial]] to the feature's surfaces. */
   public readonly ignoresMaterial?: true;
+  /** If true, the feature will not be drawn when using [Viewport.readPixels]($frontend), meaning [Tool]($frontend)s will not be able to interact with it. */
   public readonly nonLocatable?: true;
+  /** If true, the feature will be rendered using the [[Hilite.Settings]] defined by [Viewport.emphasisSettings]($frontend) to make it stand out. */
   public readonly emphasized?: true;
+  /** If true, then [[transparency]] will only be applied if [[ViewFlags.transparency]] is enabled and the current [[RenderMode]] supports transparency.
+   * Default: false, meaning the transparency will be applied regardless of view flags or render mode.
+   * This property has no effect if [[transparency]] is `undefined`.
+   */
   public readonly viewDependentTransparency?: true;
 
   /** An appearance that overrides nothing. */

--- a/core/common/src/test/FeatureSymbology.test.ts
+++ b/core/common/src/test/FeatureSymbology.test.ts
@@ -87,6 +87,18 @@ describe("FeatureAppearance", () => {
     test({ transp: 0.5 }, { transparency: 0.5 });
     test({ transp: 1.0 }, { transparency: 1.0 });
   });
+
+  describe("view-dependent transparency", () => {
+    it("is ignored unless transparency is overridden", () => {
+      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ transp: undefined })).viewDependentTransparency).to.be.undefined;
+      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ color: ColorDef.blue.toJSON() })).viewDependentTransparency).to.be.undefined;
+    });
+
+    it("is set by default only for subcategory overrides", () => {
+      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ transp: 0.5 })).viewDependentTransparency).to.be.true;
+      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ transp: 0 })).viewDependentTransparency).to.be.true;
+    });
+  });
 });
 
 describe("FeatureOverrides", () => {

--- a/core/common/src/test/FeatureSymbology.test.ts
+++ b/core/common/src/test/FeatureSymbology.test.ts
@@ -88,15 +88,41 @@ describe("FeatureAppearance", () => {
     test({ transp: 1.0 }, { transparency: 1.0 });
   });
 
-  describe("view-dependent transparency", () => {
-    it("is ignored unless transparency is overridden", () => {
-      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ transp: undefined })).viewDependentTransparency).to.be.undefined;
-      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ color: ColorDef.blue.toJSON() })).viewDependentTransparency).to.be.undefined;
+  it("view-dependent transparency", () => {
+    it("to and from JSON", () => {
+      function test(appProps: FeatureAppearanceProps, expectViewDependent: boolean): void {
+        const expected = expectViewDependent ? true : undefined;
+        const app = FeatureAppearance.fromJSON(appProps);
+        expect(app.viewDependentTransparency).to.equal(expected);
+        expect(app.toJSON().viewDependentTransparency).to.equal(expected);
+      }
+
+      test({ }, false);
+      test({ transparency: undefined }, false);
+      test({ transparency: 1 }, false);
+      test({ transparency: 0 }, false );
+
+      test({ transparency: 1, viewDependentTransparency: true }, true);
+      test({ transparency: 0, viewDependentTransparency: true }, true);
+
+      test({ viewDependentTransparency: true }, false);
+      test({ transparency: undefined, viewDependentTransparency: true }, false);
     });
 
-    it("is set by default only for subcategory overrides", () => {
-      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ transp: 0.5 })).viewDependentTransparency).to.be.true;
-      expect(FeatureAppearance.fromSubCategoryOverride(SubCategoryOverride.fromJSON({ transp: 0 })).viewDependentTransparency).to.be.true;
+    it("from subcategory override", () => {
+      function test(ovrProps: SubCategoryAppearance.Props, expectViewDependent: boolean): void {
+        const expected = expectViewDependent ? true : undefined;
+        const ovr = SubCategoryOverride.fromJSON(ovrProps);
+        const app = FeatureAppearance.fromSubCategoryOverride(ovr);
+        expect(app.viewDependentTransparency).to.equal(expected);
+        expect(app.toJSON().viewDependentTransparency).to.equal(expected);
+      }
+
+      test({ transp: 0.5 }, true);
+      test({ transp: 0 }, true);
+      test({ transp: undefined }, false);
+      test({ }, false);
+      test({ color: ColorDef.blue.toJSON() }, false);
     });
   });
 });

--- a/core/frontend/src/render/webgl/FeatureOverrides.ts
+++ b/core/frontend/src/render/webgl/FeatureOverrides.ts
@@ -74,6 +74,7 @@ export class FeatureOverrides implements WebGLDisposable {
   private _anyOverridden = true;
   private _allHidden = true;
   private _anyTranslucent = true;
+  private _anyViewIndependentTranslucent = true;
   private _anyOpaque = true;
   private _anyHilited = true;
   private _lutParams = new Float32Array(2);
@@ -83,6 +84,7 @@ export class FeatureOverrides implements WebGLDisposable {
   public get anyOverridden() { return this._anyOverridden; }
   public get allHidden() { return this._allHidden; }
   public get anyTranslucent() { return this._anyTranslucent; }
+  public get anyViewIndependentTranslucent() { return this._anyViewIndependentTranslucent; }
   public get anyOpaque() { return this._anyOpaque; }
   public get anyHilited() { return this._anyHilited; }
 
@@ -148,7 +150,7 @@ export class FeatureOverrides implements WebGLDisposable {
     const modelIdParts = Id64.getUint32Pair(map.modelId);
     const isModelHilited = allowHilite && hilites.models.has(modelIdParts.lower, modelIdParts.upper);
 
-    this._anyOpaque = this._anyTranslucent = this._anyHilited = false;
+    this._anyOpaque = this._anyTranslucent = this._anyViewIndependentTranslucent = this._anyHilited = false;
 
     let nHidden = 0;
     let nOverridden = 0;
@@ -213,10 +215,15 @@ export class FeatureOverrides implements WebGLDisposable {
           alpha = 0xff;
 
         data.setByteAtIndex(dataIndex + 7, alpha);
-        if (0xff === alpha)
+        if (0xff === alpha) {
           this._anyOpaque = true;
-        else
+        } else {
           this._anyTranslucent = true;
+          if (!app.viewDependentTransparency) {
+            flags |= OvrFlags.ViewIndependentTransparency;
+            this._anyViewIndependentTranslucent = true;
+          }
+        }
       }
 
       if (app.overridesWeight && app.weight) {

--- a/core/frontend/src/render/webgl/RenderCommands.ts
+++ b/core/frontend/src/render/webgl/RenderCommands.ts
@@ -641,7 +641,7 @@ export class RenderCommands implements Iterable<DrawCommands> {
     this._batchState.push(batch, true);
 
     this.pushAndPop(new PushBatchCommand(batch), PopBatchCommand.instance, () => {
-      if (this.currentViewFlags.transparency) {
+      if (this.currentViewFlags.transparency || overrides.anyViewIndependentTranslucent) {
         this._opaqueOverrides = overrides.anyOpaque;
         this._translucentOverrides = overrides.anyTranslucent;
 

--- a/core/frontend/src/render/webgl/RenderFlags.ts
+++ b/core/frontend/src/render/webgl/RenderFlags.ts
@@ -191,6 +191,7 @@ export const enum OvrFlags {
   Weight = 1 << 7,
   Hilited = 1 << 8,
   Emphasized = 1 << 9, // rendered with "emphasis" hilite settings (silhouette etc).
+  ViewIndependentTransparency = 1 << 10,
 
   Rgba = Rgb | Alpha,
 }

--- a/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
+++ b/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
@@ -52,6 +52,7 @@ export function addOvrFlagConstants(builder: ShaderBuilder): void {
   // NB: We treat the 16-bit flags as 2 bytes - so subtract 8 from each of these bit indices.
   builder.addBitFlagConstant("kOvrBit_Hilited", 0);
   builder.addBitFlagConstant("kOvrBit_Emphasized", 1);
+  builder.addBitFlagConstant("kOvrBit_ViewIndependentTransparency", 2);
 }
 
 const computeLUTFeatureIndex = `g_featureAndMaterialIndex.xyz`;
@@ -156,14 +157,19 @@ const checkVertexDiscard = `
   if (feature_alpha > 0.0)
     hasAlpha = feature_alpha <= s_maxAlpha;
 
+  int discardFlags = u_transparencyDiscardFlags;
+  bool discardViewIndependentDuringOpaque = discardFlags >= 4;
+  if (discardViewIndependentDuringOpaque)
+    discardFlags = discardFlags - 4;
+
   bool isOpaquePass = (kRenderPass_OpaqueLinear <= u_renderPass && kRenderPass_OpaqueGeneral >= u_renderPass);
-  bool discardTranslucentDuringOpaquePass = 1 == u_transparencyDiscardFlags || 3 == u_transparencyDiscardFlags;
-  if (isOpaquePass && !discardTranslucentDuringOpaquePass)
+  bool discardTranslucentDuringOpaquePass = 1 == discardFlags || 3 == discardFlags;
+  if (isOpaquePass && !discardTranslucentDuringOpaquePass && !discardViewIndependentDuringOpaque)
     return false;
 
   bool isTranslucentPass = kRenderPass_Translucent == u_renderPass;
-  bool discardOpaqueDuringTranslucentPass = 2 == u_transparencyDiscardFlags || 3 == u_transparencyDiscardFlags;
-  if (isTranslucentPass &&!discardOpaqueDuringTranslucentPass)
+  bool discardOpaqueDuringTranslucentPass = 2 == discardFlags || 3 == discardFlags;
+  if (isTranslucentPass && !discardOpaqueDuringTranslucentPass)
     return false;
 
   return (isOpaquePass && hasAlpha) || (isTranslucentPass && !hasAlpha);
@@ -174,13 +180,19 @@ function addTransparencyDiscardFlags(vert: VertexShaderBuilder) {
   // is used when applying transparency threshold. However, we need to ensure we don't DISCARD transparent stuff during
   // opaque pass if transparency is off (see checkVertexDiscard). Especially important for transparency threshold and readPixels().
   // Also, if we override raster text to be opaque we must still draw it in the translucent pass.
+  // Finally, if the transparency override is view-independent (i.e., ignores view flags and render mode) we want to discard it during opaque pass
+  // unless we're reading pixels.
+  // So we have a bit field:
   // 1: discard translucent during opaque.
   // 2: discard opaque during translucent.
-  // 3: both
+  // 4: discard view-independent translucent during opaque.
   vert.addUniform("u_transparencyDiscardFlags", VariableType.Int, (prog) => {
     prog.addGraphicUniform("u_transparencyDiscardFlags", (uniform, params) => {
       // During readPixels() we force transparency off. Make sure to ignore a Branch that turns it back on.
-      let flags = params.target.currentViewFlags.transparency && !params.target.isReadPixelsInProgress ? 1 : 0;
+      let flags = 0;
+      if (!params.target.isReadPixelsInProgress)
+        flags = params.target.currentViewFlags.transparency ? 1 : 4;
+
       if (!params.geometry.alwaysRenderTranslucent)
         flags += 2;
 
@@ -634,9 +646,11 @@ const computeFeatureOverrides = `
     if (rgbOverridden)
       feature_rgb = rgba.rgb;
 
-    if (alphaOverridden)
+    if (alphaOverridden) {
       feature_alpha = rgba.a;
+      feature_viewIndependentTransparency = nthFeatureBitSet(flags, kOvrBit_ViewIndependentTransparency);
     }
+  }
 
   linear_feature_overrides = vec4(nthFeatureBitSet(flags, kOvrBit_Weight),
                                   value.w * 256.0,
@@ -741,6 +755,8 @@ export function addFeatureSymbology(builder: ProgramBuilder, feat: FeatureMode, 
 
   const vert = builder.vert;
   vert.addGlobal("feature_invisible", VariableType.Boolean, "false");
+  vert.addGlobal("feature_viewIndependentTransparency", VariableType.Boolean, "false");
+
   addEmphasisFlags(vert);
   vert.addGlobal("use_material", VariableType.Boolean, "true");
   vert.set(VertexShaderComponent.ComputeFeatureOverrides, computeFeatureOverrides);

--- a/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
+++ b/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
@@ -822,5 +822,7 @@ export function addUniformFeatureSymbology(builder: ProgramBuilder, addFeatureCo
     });
   });
 
+  builder.vert.addGlobal("feature_viewIndependentTransparency", VariableType.Boolean, "false");
+
   addApplyFlash(builder.frag);
 }

--- a/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
+++ b/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
@@ -163,8 +163,8 @@ const checkVertexDiscard = `
     discardFlags = discardFlags - 4;
 
   bool isOpaquePass = (kRenderPass_OpaqueLinear <= u_renderPass && kRenderPass_OpaqueGeneral >= u_renderPass);
-  bool discardTranslucentDuringOpaquePass = 1 == discardFlags || 3 == discardFlags;
-  if (isOpaquePass && !discardTranslucentDuringOpaquePass && !discardViewIndependentDuringOpaque)
+  bool discardTranslucentDuringOpaquePass = 1 == discardFlags || 3 == discardFlags || (feature_viewIndependentTransparency && discardViewIndependentDuringOpaque);
+  if (isOpaquePass && !discardTranslucentDuringOpaquePass)
     return false;
 
   bool isTranslucentPass = kRenderPass_Translucent == u_renderPass;
@@ -648,7 +648,7 @@ const computeFeatureOverrides = `
 
     if (alphaOverridden) {
       feature_alpha = rgba.a;
-      feature_viewIndependentTransparency = nthFeatureBitSet(flags, kOvrBit_ViewIndependentTransparency);
+      feature_viewIndependentTransparency = nthFeatureBitSet(emphFlags, kOvrBit_ViewIndependentTransparency);
     }
   }
 

--- a/core/frontend/src/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/render/webgl/glsl/Surface.ts
@@ -363,7 +363,7 @@ const computeAnimatedNormal = `
 ${computeNormal}`;
 
 const applyBackgroundColor = `
-  return u_surfaceFlags[kSurfaceBitIndex_BackgroundFill] ? vec4(u_bgColor.rgb, 1.0) : baseColor;
+  return u_surfaceFlags[kSurfaceBitIndex_BackgroundFill] ? vec4(u_bgColor.rgb, baseColor.a) : baseColor;
 `;
 
 const computeTexCoord = `

--- a/full-stack-tests/core/src/frontend/standalone/Transparency.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/Transparency.test.ts
@@ -17,6 +17,7 @@ interface GraphicOptions {
   priority?: number;
   pickableId?: string;
   material?: RenderMaterial;
+  generateEdges?: boolean;
 }
 
 class TransparencyDecorator {
@@ -45,8 +46,8 @@ class TransparencyDecorator {
       overrides.overrideElement(id, app);
   }
 
-  public overrideTransparency(id: string, transparency: number): void {
-    this._symbologyOverrides.set(id, FeatureAppearance.fromTransparency(transparency));
+  public overrideTransparency(id: string, transparency: number, viewDependent?: boolean): void {
+    this._symbologyOverrides.set(id, FeatureAppearance.fromTransparency(transparency, viewDependent));
   }
 
   public ignoreMaterial(id: string): void {
@@ -74,7 +75,7 @@ class TransparencyDecorator {
       viewport: vp,
       pickable: opts.pickableId ? { id: opts.pickableId } : undefined,
       wantNormals: false,
-      generateEdges: false,
+      generateEdges: true === opts.generateEdges,
     });
 
     builder.activateGraphicParams(gfParams);
@@ -141,18 +142,28 @@ describe("Transparency", async () => {
   }
 
   function expectColor(vp: TestViewport, color: ColorDef): void {
-    const colors = vp.readUniqueColors();
-    expect(colors.length).to.equal(1);
-    const actual = colors.array[0];
-    const expected = color.colors;
+    expectColors(vp, [color]);
+  }
 
-    expectComponent(actual.r, expected.r);
-    expectComponent(actual.g, expected.g);
-    expectComponent(actual.b, expected.b);
+  function expectColors(vp: TestViewport, expectedColors: ColorDef[]): void {
+    const actualColors = vp.readUniqueColors();
+    expect(actualColors.length).to.equal(expectedColors.length);
+    for (let i = 0; i < actualColors.length; i++) {
+      const actual = actualColors.array[i];
+      const expected = expectedColors[i].colors;
+
+      expectComponent(actual.r, expected.r);
+      expectComponent(actual.g, expected.g);
+      expectComponent(actual.b, expected.b);
+    }
   }
 
   function expectTransparency(vp: TestViewport, color: ColorDef): void {
-    expectColor(vp, multiplyAlpha(color));
+    expectTransparencies(vp, [color]);
+  }
+
+  function expectTransparencies(vp: TestViewport, colors: ColorDef[]): void {
+    expectColors(vp, colors.map((x) => multiplyAlpha(x)));
   }
 
   it("should blend with background color", async () => {
@@ -426,5 +437,36 @@ describe("Transparency", async () => {
     await testCase(ColorDef.green, 1, createMaterial(1, createBlueTexture()), ColorDef.black);
 
     await testCase(ColorDef.green, 0.75, createMaterial(0.9, createBlueTexture(0x7f)), ColorDef.blue.withTransparency(0xdf));
+  });
+
+  it("symbology override applies regardless of render mode and view flags unless explicitly specified", async () => {
+    const pickableId = imodel.transientIds.next;
+    for (let iTransp = 0; iTransp < 2; iTransp++) {
+      for (let iViewDep = 0; iViewDep < 2; iViewDep++) {
+        const viewDep = iViewDep > 0;
+        const transp = iTransp > 0;
+        for (const renderMode of [RenderMode.SmoothShade, RenderMode.SolidFill, RenderMode.HiddenLine]) {
+          await test(
+            (vp) => {
+              vp.viewFlags = vp.viewFlags.with("transparency", transp).withRenderMode(renderMode);
+              if (vp.displayStyle.settings.is3d())
+                vp.displayStyle.settings.hiddenLineSettings = vp.displayStyle.settings.hiddenLineSettings.override({ transThreshold: 1});
+
+              decorator.add(vp, { color: ColorDef.green, pickableId, generateEdges: true });
+              decorator.overrideTransparency(pickableId, 0.5, viewDep);
+            },
+            (vp) => {
+              // NB: the edges are drawing outside the viewport, so we're only testing surface color+transparency.
+              const expectTransparent = !viewDep || (transp && RenderMode.HiddenLine !== renderMode && RenderMode.SolidFill !== renderMode);
+              let color = RenderMode.HiddenLine === renderMode ? ColorDef.black : ColorDef.green;
+              if (expectTransparent)
+                color = color.withTransparency(0x7f);
+
+              expectTransparency(vp, color);
+            }
+          );
+        }
+      }
+    }
   });
 });

--- a/test-apps/display-test-app/src/frontend/FeatureOverrides.ts
+++ b/test-apps/display-test-app/src/frontend/FeatureOverrides.ts
@@ -137,6 +137,13 @@ export class Settings implements IDisposable {
       handler: (cb) => this.updateAppearance("emphasized", cb.checked ? true : undefined),
     });
 
+    createCheckBox({
+      parent: this._element,
+      name: "View-dependent transparency",
+      id: "ovr_viewDep",
+      handler: (cb) => this.updateAppearance("viewDependentTransparency", cb.checked ? true : undefined),
+    });
+
     const buttonDiv = document.createElement("div");
     buttonDiv.style.textAlign = "center";
     createButton({
@@ -175,7 +182,7 @@ export class Settings implements IDisposable {
 
   // private reset() { this._appearance = FeatureSymbology.Appearance.defaults; }
 
-  private updateAppearance(field: "rgb" | "transparency" | "linePixels" | "weight" | "ignoresMaterial" | "nonLocatable" | "emphasized", value: any): void {
+  private updateAppearance(field: "rgb" | "transparency" | "linePixels" | "weight" | "ignoresMaterial" | "nonLocatable" | "emphasized" | "viewDependentTransparency", value: any): void {
     const props = this._appearance.toJSON();
     props[field] = value;
     this._appearance = FeatureAppearance.fromJSON(props);


### PR DESCRIPTION
Today, if you override a feature's transparency it will only draw with transparency if the transparency ViewFlag is enabled and the render mode is wireframe or smooth.
That makes EmphasizeElements utterly useless, as the de-emphasized stuff doesn't actually get de-emphasized.
Also, Brien wants to draw elements or faces thereof as transparent during push-pull modeling operations, regardless of whether the view enables transparency.

We could have simply changed this behavior but SubCategoryOverrides from a display style are also applied using the same transparency override.
It would be silly to create a display style that overrides subcategory transparency but doesn't enable transparency, but very easy to accidentally create such a style by modifying an existing one.

So, this PR introduces FeatureAppearance.viewDependentTransparency. If true, then the transparency override obeys the display style's settings; otherwise, it always applies transparency.
FeatureAppearance.fromSubCategoryOverride always sets this flag; all other APIs require caller to explicitly request it.

TODO:
- ~Add tests that draw with various overrides and display styles.~ Done.
- ~Make it work in HiddenLine mode?~ Done.