### PR TITLE
Import and apply ScalableMesh clips from backend.

### DIFF
--- a/core/frontend/src/ModelState.ts
+++ b/core/frontend/src/ModelState.ts
@@ -178,6 +178,7 @@ export abstract class GeometricModelState extends ModelState implements Geometri
         modelId: this.id,
         tilesetToDbTransform: this.jsonProperties.tilesetToDbTransform,
         classifiers: undefined !== spatialModel ? spatialModel.classifiers : undefined,
+        scalablemeshProps: undefined !== spatialModel ? spatialModel.scalablemeshProps : undefined,
       });
     }
 
@@ -268,6 +269,7 @@ export class SheetModelState extends GeometricModel2dState {
 export class SpatialModelState extends GeometricModel3dState {
   /** If this is a reality model, provides access to a list of available spatial classifiers that can be applied to it. */
   public readonly classifiers?: SpatialClassifiers;
+  public readonly scalablemeshProps?: any;
 
   /** @internal */
   public static override get className() { return "SpatialModel"; }
@@ -276,9 +278,12 @@ export class SpatialModelState extends GeometricModel3dState {
 
   public constructor(props: ModelProps, iModel: IModelConnection, state?: SpatialModelState) {
     super(props, iModel, state);
-    if (this.isRealityModel)
+    if (this.isRealityModel) {
       this.classifiers = new SpatialClassifiers(this.jsonProperties);
+      this.scalablemeshProps = this.jsonProperties["scalablemesh"];
+    }
   }
+
   /** Return true if this is a reality model (represented by a 3d tile set). */
   public get isRealityModel(): boolean {
     return undefined !== this.jsonProperties.tilesetUrl;

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  assert, compareNumbers, compareStringsOrUndefined, CompressedId64Set, Id64String,
+  assert, ByteStream, compareNumbers, compareStringsOrUndefined, CompressedId64Set, Id64String, Logger,
 } from "@itwin/core-bentley";
 import {
   Cartographic, DefaultSupportedTypes, GeoCoordStatus, PlanarClipMaskPriority, PlanarClipMaskSettings,
@@ -15,7 +15,7 @@ import {
   RealityDataSourceKey,
   SpatialClassifiers, ViewFlagOverrides,
 } from "@itwin/core-common";
-import { Angle, Constant, Ellipsoid, Matrix3d, Point3d, Range3d, Ray3d, Transform, TransformProps, Vector3d, XYZ } from "@itwin/core-geometry";
+import { Angle, ClipPlane, ClipPrimitive, ClipShape, ClipUtilities, ClipVector, Constant, ConvexClipPlaneSet, Ellipsoid, LineString3d, Matrix3d, Plane3dByOriginAndUnitNormal, Point3d, Range3d, Ray3d, Transform, TransformProps, UnionOfConvexClipPlaneSets, Vector3d, XYZ } from "@itwin/core-geometry";
 import { calculateEcefToDbTransformAtLocation } from "../BackgroundMapGeometry";
 import { DisplayStyleState } from "../DisplayStyleState";
 import { HitDetail } from "../HitDetail";
@@ -27,12 +27,12 @@ import { RenderMemory } from "../render/RenderMemory";
 import { SceneContext } from "../ViewContext";
 import { ScreenViewport } from "../Viewport";
 import { ViewState } from "../ViewState";
+import { FrontendLoggerCategory } from "../FrontendLoggerCategory";
 import {
   BatchedTileIdMap, CesiumIonAssetProvider, createClassifierTileTreeReference, createDefaultViewFlagOverrides, DisclosedTileTreeSet, getCesiumOSMBuildingsUrl, getGcsConverterAvailable, RealityTile, RealityTileLoader, RealityTileParams,
   RealityTileTree, RealityTileTreeParams, SpatialClassifierTileTreeReference, Tile, TileDrawArgs, TileLoadPriority, TileRequest, TileTree,
   TileTreeOwner, TileTreeReference, TileTreeSupplier,
 } from "./internal";
-
 function getUrl(content: any) {
   return content ? (content.url ? content.url : content.uri) : undefined;
 }
@@ -510,6 +510,7 @@ export namespace RealityModelTileTree {
     name?: string;
     classifiers?: SpatialClassifiers;
     planarClipMask?: PlanarClipMaskSettings;
+    scalablemeshProps?: any;
   }
   export interface ReferenceProps extends ReferenceBaseProps {
     url?: string;
@@ -525,6 +526,7 @@ export namespace RealityModelTileTree {
     private _isGlobal?: boolean;
     protected _planarClipMask?: PlanarClipMaskState;
     protected _classifier?: SpatialClassifierTileTreeReference;
+    protected _clips?: ClipVector;
     protected _mapDrapeTree?: TileTreeReference;
     public get modelId() { return this._modelId; }
     public get classifiers(): SpatialClassifiers | undefined { return undefined !== this._classifier ? this._classifier.classifiers : undefined; }
@@ -560,6 +562,113 @@ export namespace RealityModelTileTree {
 
       if (undefined !== props.classifiers)
         this._classifier = createClassifierTileTreeReference(props.classifiers, this, props.iModel, props.source);
+
+      if (undefined !== props.scalablemeshProps) {
+        this._clips = ClipVector.fromJSON(props.scalablemeshProps.clip);
+      }
+
+      if (undefined !== props.modelId) {
+        const clipEcsql = `SELECT SmModelClips FROM ScalableMesh.ScalableMeshModel WHERE ECInstanceId=${props.modelId}`;
+
+        // Query clips stored in the iModel for this reality data.
+        this._iModel.query(clipEcsql).next().then((row) => this.parseAndAddClips(row, "LineString")).catch(() => {
+          const errMsg = `Error querying or parsing line string clips for Model Id=${props.modelId}`;
+          Logger.logError(FrontendLoggerCategory.RealityData, errMsg);
+        });
+
+        const clipVectorEcsql = `SELECT SmModelClipVectors FROM ScalableMesh.ScalableMeshModel WHERE ECInstanceId=${props.modelId}`;
+
+        // Query clips stored in the iModel for this reality data.
+        this._iModel.query(clipVectorEcsql).next().then((row) => this.parseAndAddClips(row, "Vector")).catch(() => {
+          const errMsg = `Error querying or parsing vector clips for Model Id=${props.modelId}`;
+          Logger.logError(FrontendLoggerCategory.RealityData, errMsg);
+        });
+      }
+    }
+
+    private parseAndAddClips(dbRow: IteratorResult<any,any> | undefined, clipType: String): void {
+      if (undefined === dbRow) {
+        // Skip models with no clips
+        return;
+      }
+
+      for (const value of dbRow.value) {
+        if (value !== undefined) {
+          const stream = new ByteStream(value.buffer);
+          while (stream.curPos !== stream.length) {
+            /* const clipId =*/ stream.nextId64;
+            if (clipType === "LineString") {
+              this._clips?.appendClone(this.createClipPrimitiveFromLineString(stream));
+            } else if (clipType === "Vector") {
+              /* const type =*/ stream.nextInt32;
+              /* const isActive =*/ stream.nextUint8;
+              /* const geomType =*/ stream.nextUint32;
+              const nbPrimitives = stream.nextUint32;
+              for (let i = 0; i < nbPrimitives; i++) {
+                this._clips?.appendClone(this.createClipPrimitiveFromVector(stream));
+              }
+            } else {
+              throw new Error("Unknown clip type");
+            }
+          }
+        }
+      }
+    }
+
+    private createClipPrimitiveFromLineString(stream: ByteStream): ClipPrimitive {
+      const nbClipShapePoints = stream.nextInt32;
+      /* const upper =*/ stream.nextInt32;
+      const points: Point3d[] = [];
+      for (let i = 0; i < nbClipShapePoints; i++) {
+        points.push(new Point3d(stream.nextFloat64, stream.nextFloat64, stream.nextFloat64));
+      }
+      const type = stream.nextInt32;
+      const isActive = stream.nextUint8;
+      /* const geomType =*/ stream.nextUint32;
+
+      const lineString = LineString3d.create(points);
+      const clipTransform = lineString.fractionToFrenetFrame(0.0);
+      clipTransform.multiplyInversePoint3dArrayInPlace(points);
+      const shape = ClipShape.createShape(points, undefined, undefined, clipTransform, type === 0, isActive === 0);
+      return ClipPrimitive.createCapture(shape?.fetchClipPlanesRef());
+    }
+
+    private createClipPrimitiveFromVector(stream: ByteStream): ClipPrimitive {
+      const nbConvexPlaneSets = stream.nextUint32;
+      let unionOfConvexClipPlaneSet = UnionOfConvexClipPlaneSets.createEmpty();
+      for (let j = 0; j < nbConvexPlaneSets; j++) {
+        const nbPlanes = stream.nextUint32;
+        const convexPlanes = ConvexClipPlaneSet.createEmpty();
+        for (let k = 0; k < nbPlanes; k++) {
+          const origin = new Point3d(stream.nextFloat64, stream.nextFloat64, stream.nextFloat64);
+          const normal = new Vector3d(stream.nextFloat64, stream.nextFloat64, stream.nextFloat64);
+          const newPlane = Plane3dByOriginAndUnitNormal.create(origin, normal);
+          if (newPlane !== undefined)
+            convexPlanes.addPlaneToConvexSet(ClipPlane.createPlane(newPlane, undefined, undefined, undefined));
+        }
+        unionOfConvexClipPlaneSet.addConvexSet(convexPlanes);
+      }
+      const isMask = stream.nextUint8 === 1 ? true : false;
+      const isInvisible = stream.nextUint8 === 1 ? true : false;
+      if (isMask === true) {
+        const origConvexCPS = unionOfConvexClipPlaneSet.clone();
+        unionOfConvexClipPlaneSet = UnionOfConvexClipPlaneSets.createEmpty();
+        for (const convexSet of origConvexCPS.convexSets) {
+          const complimentarySet = ClipUtilities.createComplementaryClips(convexSet);
+          for (const complimentaryConvexSet of complimentarySet.convexSets) {
+            unionOfConvexClipPlaneSet.addConvexSet(complimentaryConvexSet);
+          }
+        }
+      }
+
+      unionOfConvexClipPlaneSet.setInvisible(isInvisible);
+      const hasZClip = stream.nextUint8 === 1 ? true : false;
+      if (hasZClip) {
+        const zLow = stream.nextFloat64;
+        const zHigh = stream.nextFloat64;
+        unionOfConvexClipPlaneSet.addOutsideZClipSets(isMask, zLow, zHigh);
+      }
+      return ClipPrimitive.createCapture(unionOfConvexClipPlaneSet);
     }
 
     public get planarClassifierTreeRef() { return this._classifier && this._classifier.activeClassifier && this._classifier.isPlanar ? this._classifier : undefined; }
@@ -731,6 +840,9 @@ class RealityTreeReference extends RealityModelTileTree.Reference {
       if (undefined !== elevationBias)
         drawArgs.location.origin.z -= elevationBias;
     }
+
+    if (undefined !== drawArgs && undefined !== this._clips)
+      drawArgs.clipVolume = IModelApp.renderSystem.createClipVolume(this._clips);
 
     return drawArgs;
   }


### PR DESCRIPTION
Existing or newly created iModels stored in the Hub can contain clipping information that applies to Reality Meshes. The changes contained in this pull request will access this information if it exists and then apply the clipping accordingly. This allows WYSIWYG from DGN to iTwin.