### PR TITLE
UI: Fix PropertyGrid unit test producing a warning

### DIFF
--- a/common/changes/@itwin/components-react/components-react-property-grid-test_2021-11-17-16-16.json
+++ b/common/changes/@itwin/components-react/components-react-property-grid-test_2021-11-17-16-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}


### PR DESCRIPTION
This PR fixes a test that used to produce `Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.` log message during a test run.

The test sets up a property grid in the following configuration:
- Root1 category
    - Child category
- Root2 category

It then used to attempt to click on Child header to expand its category *after* collapsing Root1 category, which is obviously an issue. 

This fix changes the order in which clicks are issued so that all three categories toggle their expansion state properly. It also gets rid of `flushAsyncOperations` and rewrites expectations to follow best testing practices.

