### PR TITLE
Presentation: Remove ModelsTreeProps.enablePreloading flag 

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3887,8 +3887,6 @@ export interface ModelsTreeProps {
     enableElementsClassGrouping?: ClassGroupingOption;
     // @alpha
     enableHierarchyAutoUpdate?: boolean;
-    // @deprecated
-    enablePreloading?: boolean;
     // @alpha
     filteredElementIds?: Id64Array;
     // @alpha

--- a/common/changes/@itwin/appui-react/presentation-remove_preloading_flag_2021-11-17-17-07.json
+++ b/common/changes/@itwin/appui-react/presentation-remove_preloading_flag_2021-11-17-17-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Removed 'ModelsTreeProps.enablePreloading' flag",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -987,6 +987,7 @@ SAML support has officially been dropped as a supported workflow. All related AP
 | `VisibilityWidget`                         | `TreeWidgetControl` in @bentley/tree-widget-react                                                                             |
 | `ContentLayoutProps`                       | `ContentLayoutProps` in @itwin/appui-abstract                                                                                 |
 | All drag & drop related APIs               | Third party components. E.g. see this [example](https://www.itwinjs.org/sample-showcase/?group=UI+Trees&sample=drag-and-drop) |
+| `ModelsTreeProps.enablePreloading`         | *eliminated*                                                                                                                  |
 
 ### @itwin/core-bentley
 

--- a/test-apps/ui-test-app/src/frontend/appui/widgets/VisibilityWidget.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/widgets/VisibilityWidget.tsx
@@ -22,7 +22,7 @@ import filterIconSvg from "../icons/filter.svg?sprite";
 export class VisibilityWidgetControl extends WidgetControl {
   constructor(info: ConfigurableCreateInfo, options: any) {
     super(info, options);
-    this.reactNode = <VisibilityTreeComponent imodel={options.iModelConnection} activeView={IModelApp.viewManager.selectedView} enablePreloading={options.enablePreloading}
+    this.reactNode = <VisibilityTreeComponent imodel={options.iModelConnection} activeView={IModelApp.viewManager.selectedView}
       config={options.config} />;
   }
 }
@@ -30,7 +30,6 @@ export class VisibilityWidgetControl extends WidgetControl {
 interface VisibilityTreeComponentProps {
   imodel: IModelConnection;
   activeView?: Viewport;
-  enablePreloading?: boolean;
   config?: {
     modelsTree: {
       selectionMode?: SelectionMode;
@@ -43,7 +42,7 @@ interface VisibilityTreeComponentProps {
 }
 
 function VisibilityTreeComponent(props: VisibilityTreeComponentProps) {
-  const { imodel, activeView, enablePreloading } = props;
+  const { imodel, activeView } = props;
   const modelsTreeProps = props.config?.modelsTree;
   const categoriesTreeProps = props.config?.categoriesTree;
   const selectLabel = IModelApp.localization.getLocalizedString("UiFramework:visibilityWidget.options");
@@ -55,16 +54,16 @@ function VisibilityTreeComponent(props: VisibilityTreeComponentProps) {
           id: "models-tree",
           label: IModelApp.localization.getLocalizedString("UiFramework:visibilityWidget.modeltree"),
           render: React.useCallback(
-            () => <ModelsTreeComponent iModel={imodel} activeView={activeView} enablePreloading={enablePreloading} {...modelsTreeProps} filteredElementIds={filteredElementIds} />,
-            [imodel, activeView, enablePreloading, modelsTreeProps, filteredElementIds],
+            () => <ModelsTreeComponent iModel={imodel} activeView={activeView} {...modelsTreeProps} filteredElementIds={filteredElementIds} />,
+            [imodel, activeView, modelsTreeProps, filteredElementIds],
           ),
         },
         {
           id: "categories-tree",
           label: IModelApp.localization.getLocalizedString("UiFramework:visibilityWidget.categories"),
           render: React.useCallback(
-            () => <CategoriesTreeComponent iModel={imodel} activeView={activeView} enablePreloading={enablePreloading} {...categoriesTreeProps} />,
-            [imodel, activeView, enablePreloading, categoriesTreeProps],
+            () => <CategoriesTreeComponent iModel={imodel} activeView={activeView} {...categoriesTreeProps} />,
+            [imodel, activeView, categoriesTreeProps],
           ),
         }]}
       </SelectableContent>
@@ -76,7 +75,6 @@ interface ModelsTreeComponentProps {
   iModel: IModelConnection;
   selectionMode?: SelectionMode;
   selectionPredicate?: ModelsTreeSelectionPredicate;
-  enablePreloading?: boolean;
   activeView?: Viewport;
   filteredElementIds?: Id64Array;
 }
@@ -127,7 +125,6 @@ interface CategoriesTreeComponentProps {
   iModel: IModelConnection;
   allViewports?: boolean;
   activeView?: Viewport;
-  enablePreloading?: boolean;
 }
 
 function CategoriesTreeComponent(props: CategoriesTreeComponentProps) {

--- a/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsTree.tsx
+++ b/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsTree.tsx
@@ -54,11 +54,6 @@ export interface ModelsTreeProps {
    */
   selectionPredicate?: ModelsTreeSelectionPredicate;
   /**
-   * Start loading hierarchy as soon as the component is created
-   * @deprecated Going to be removed due to too high pressure on the backend
-   */
-  enablePreloading?: boolean;
-  /**
    * Active view used to determine and control visibility
    */
   activeView?: Viewport;


### PR DESCRIPTION
Removed deprecated ModelsTreeProps.enablePreloading flag.