### PR TITLE
Fixing default config file for firefox on mac

### DIFF
--- a/test-apps/display-performance-test-app/src/backend/DefaultConfig.json
+++ b/test-apps/display-performance-test-app/src/backend/DefaultConfig.json
@@ -591,24 +591,24 @@
       "iModelName": "LinesTest.bim",
       "tests": [
         {
-          "viewName": "351"
+          "viewName": "200"
         },
         {
-          "viewName": "351",
+          "viewName": "200",
           "viewFlags": {
             "weights": false,
             "styles": true
           }
         },
         {
-          "viewName": "351",
+          "viewName": "200",
           "viewFlags": {
             "weights": true,
             "styles": false
           }
         },
         {
-          "viewName": "351",
+          "viewName": "200",
           "viewFlags": {
             "weights": false,
             "styles": false


### PR DESCRIPTION
Changing line tests to use 200 views instead of 351, to stop crashing on firefox on mac.