### PR TITLE
Fixes to iModelJSLogoCard

### DIFF
--- a/common/changes/@itwin/core-frontend/ui-about-box-styling_2021-11-18-14-10.json
+++ b/common/changes/@itwin/core-frontend/ui-about-box-styling_2021-11-18-14-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Protect logoCard styling from app's CSS and make sure the logoCard opens in the correct window for pop-out viewports.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -645,13 +645,13 @@ export class IModelApp {
     const noticeCell = IModelApp.makeHTMLElement("td", { parent: card, className: "logo-card-message" });
     if (undefined !== opts.heading) {
       if (typeof opts.heading === "string")
-        IModelApp.makeHTMLElement("h2", { parent: noticeCell, innerHTML: opts.heading });
+        IModelApp.makeHTMLElement("h2", { parent: noticeCell, innerHTML: opts.heading,  className:"logo-card-header" });
       else
         noticeCell.appendChild(opts.heading);
     }
     if (undefined !== opts.notice) {
       if (typeof opts.notice === "string")
-        IModelApp.makeHTMLElement("p", { parent: noticeCell, innerHTML: opts.notice });
+        IModelApp.makeHTMLElement("p", { parent: noticeCell, innerHTML: opts.notice, className: "logo-cards" });
       else
         noticeCell.appendChild(opts.notice);
     }

--- a/core/frontend/src/IModeljs-css.ts
+++ b/core/frontend/src/IModeljs-css.ts
@@ -28,6 +28,8 @@ let iModelJsCss: string | undefined = `
   --safe-area-bottom: env(safe-area-inset-bottom);
   --safe-area-right: constant(safe-area-inset-right);
   --safe-area-right: env(safe-area-inset-right);
+  --logo-foreground-body:#000000;
+  --logo-background-1:#ffffff;
 }
 
 .logo-card-logo {
@@ -39,10 +41,10 @@ let iModelJsCss: string | undefined = `
 
 .logo-card-logo img {
   margin-top:4px;
-  border: solid 3px var(--background-1)
+  border: solid 3px var(--logo-background-1)
 }
 
-.logo-card-message p {
+.logo-card-message {
   font-size:13px;
   line-height:1.25;
   margin-block-start:.5em;
@@ -51,7 +53,7 @@ let iModelJsCss: string | undefined = `
   opacity:.7
 }
 
-.logo-cards h2 {
+.logo-card-header {
   margin:auto;
   font-size:18px;
   font-weight:bold;
@@ -79,8 +81,8 @@ let iModelJsCss: string | undefined = `
 .imodeljs-modal {
   border-radius:3px;
   box-shadow: 0px 1px 3px 0 rgba(0,0,0,0.1);
-  color:var(--foreground-body);
-  background-color:var(--background-1);
+  color:var(--logo-foreground-body);
+  background-color:var(--logo-background-1);
   font-family:"Segoe UI","Open Sans",sans-serif;
   font-weight:normal;
   font-stretch:normal;

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2792,7 +2792,7 @@ export class ScreenViewport extends Viewport {
     logo.alt = "";
 
     const showLogos = (ev: Event) => {
-      const aboutBox = IModelApp.makeModalDiv({ autoClose: true, width: 460, closeBox: true }).modal;
+      const aboutBox = IModelApp.makeModalDiv({ autoClose: true, width: 460, closeBox: true, rootDiv: this.vpDiv.ownerDocument.body }).modal;
       aboutBox.className += " imodeljs-about"; // only added so the CSS knows this is the about dialog
       const logos = IModelApp.makeHTMLElement("table", { parent: aboutBox, className: "logo-cards" });
       if (undefined !== IModelApp.applicationLogoCard)


### PR DESCRIPTION
Modify iModelJSLogoCard to
1. Use local CSS variables and classes to avoid having the styling changed by apps
2. Pass in the ownerDocument.body of the Viewport so that the card opens properly in a popped-out Viewport.