### PR TITLE
Filter out duplicates from UiItemsProviders

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -6256,7 +6256,7 @@ export class ToolInformation {
 // @public
 export class ToolItemDef extends ActionButtonItemDef {
     constructor(toolItemProps: ToolItemProps, onItemExecuted?: OnItemExecutedFunc);
-    static getItemDefForTool(tool: typeof Tool, iconSpec?: string, args?: any[]): ToolItemDef;
+    static getItemDefForTool(tool: typeof Tool, iconSpec?: string, ...args: any[]): ToolItemDef;
     // (undocumented)
     get id(): string;
     // (undocumented)

--- a/common/changes/@itwin/appui-react/ui-filterOutDuplicatesFromItemsProviders_2021-11-18-14-31.json
+++ b/common/changes/@itwin/appui-react/ui-filterOutDuplicatesFromItemsProviders_2021-11-18-14-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Ensure duplicate items provided via UiItemProviders are filtered out and only one item per Id is used. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/backstage/BackstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/backstage/BackstageComposer.tsx
@@ -51,10 +51,23 @@ function useBackstageItemSyncEffect(itemsManager: BackstageItemsManager, syncIds
 /** local function to combine items from Stage and from Extensions */
 function combineItems(stageItems: ReadonlyArray<BackstageItem>, addonItems: ReadonlyArray<BackstageItem>) {
   const items: BackstageItem[] = [];
-  if (stageItems.length)
-    items.push(...stageItems);
-  if (addonItems.length)
-    items.push(...addonItems);
+  if (stageItems.length) {
+    // Walk through each and ensure no duplicate ids are added.
+    stageItems.forEach((srcItem) => {
+      if (-1 === items.findIndex((item) => item.id === srcItem.id)) {
+        items.push(srcItem);
+      }
+    });
+  }
+  if (addonItems.length) {
+    // Walk through each and ensure no duplicate ids are added.
+    addonItems.forEach((srcItem) => {
+      if (-1 === items.findIndex((item) => item.id === srcItem.id)) {
+        items.push(srcItem);
+      }
+    });
+  }
+
   return items;
 }
 

--- a/ui/appui-react/src/appui-react/shared/ToolItemDef.ts
+++ b/ui/appui-react/src/appui-react/shared/ToolItemDef.ts
@@ -32,13 +32,13 @@ export class ToolItemDef extends ActionButtonItemDef {
   }
 
   /** Create a ToolItemDef that will run a registered tool. */
-  public static getItemDefForTool(tool: typeof Tool, iconSpec?: string, args?: any[]): ToolItemDef {
+  public static getItemDefForTool(tool: typeof Tool, iconSpec?: string, ...args: any[]): ToolItemDef {
     return new ToolItemDef({
       toolId: tool.toolId,
       iconSpec: iconSpec ? iconSpec : (tool.iconSpec && tool.iconSpec.length > 0) ? tool.iconSpec : undefined,
       label: () => tool.flyover,
       description: () => tool.description,
-      execute: async () => IModelApp.tools.run(tool.toolId, args),
+      execute: async () => IModelApp.tools.run(tool.toolId, ...args),
     });
   }
 }

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
@@ -144,10 +144,22 @@ function generateActionStatusBarItem(item: AbstractStatusBarActionItem, isInFoot
 /** local function to combine items from Stage and from Extensions */
 function combineItems(stageItems: ReadonlyArray<CommonStatusBarItem>, addonItems: ReadonlyArray<CommonStatusBarItem>) {
   const items: CommonStatusBarItem[] = [];
-  if (stageItems.length)
-    items.push(...stageItems);
-  if (addonItems.length)
-    items.push(...addonItems);
+  if (stageItems.length) {
+    // Walk through each and ensure no duplicate ids are added.
+    stageItems.forEach((srcItem) => {
+      if (-1 === items.findIndex((item) => item.id === srcItem.id)) {
+        items.push(srcItem);
+      }
+    });
+  }
+  if (addonItems.length) {
+    // Walk through each and ensure no duplicate ids are added.
+    addonItems.forEach((srcItem) => {
+      if (-1 === items.findIndex((item) => item.id === srcItem.id)) {
+        items.push(srcItem);
+      }
+    });
+  }
   return items;
 }
 
@@ -236,7 +248,7 @@ export function StatusBarComposer(props: StatusBarComposerProps) {
   useStatusBarItemSyncEffect(defaultItemsManager, syncIdsOfInterest);
 
   const statusBarContext = React.useContext(StatusBarContext);
-  const [addonItemsManager] = React.useState(new StatusBarItemsManager());
+  const [addonItemsManager] = React.useState(() => new StatusBarItemsManager());
   const addonItems = useUiItemsProviderStatusBarItems(addonItemsManager);
   const addonSyncIdsOfInterest = React.useMemo(() => StatusBarItemsManager.getSyncIdsOfInterest(addonItems), [addonItems]);
   useStatusBarItemSyncEffect(addonItemsManager, addonSyncIdsOfInterest);

--- a/ui/appui-react/src/test/backstage/BackstageComposer.test.tsx
+++ b/ui/appui-react/src/test/backstage/BackstageComposer.test.tsx
@@ -26,14 +26,16 @@ class TestUiItemsProvider implements UiItemsProvider {
   public readonly id = "BackstageComposer-TestUiProvider";
   public static sampleStatusVisible = true;
 
+  constructor(public testWithDuplicate=false) {}
+
   public provideBackstageItems(): BackstageItem[] {
     const isHiddenItem = new ConditionalBooleanValue(() => !TestUiItemsProvider.sampleStatusVisible, [uiSyncEventId]);
-
-    return [
-      BackstageItemUtilities.createActionItem("UiItemsProviderTest:backstage1", 500, 50, () => { }, "Dynamic Action", undefined, "icon-addon"),
-      BackstageItemUtilities.createActionItem("UiItemsProviderTest:backstage2", 600, 50, () => { }, "Dynamic Action", undefined, "icon-addon2", { isHidden: isHiddenItem }),
-      BackstageItemUtilities.createActionItem("UiItemsProviderTest:backstage3", 600, 30, () => { }, "Dynamic Action", undefined, "icon-addon3"),
-    ];
+    const items: BackstageItem[] = [];
+    items.push(BackstageItemUtilities.createActionItem("UiItemsProviderTest:backstage1", 500, 50, () => { }, "Dynamic Action", undefined, "icon-addon"));
+    items.push(  BackstageItemUtilities.createActionItem("UiItemsProviderTest:backstage2", 600, 50, () => { }, "Dynamic Action", undefined, "icon-addon2", { isHidden: isHiddenItem }));
+    items.push(  BackstageItemUtilities.createActionItem("UiItemsProviderTest:backstage3", 600, 30, () => { }, "Dynamic Action", undefined, "icon-addon3"));
+    this.testWithDuplicate && items.push(BackstageItemUtilities.createActionItem("UiItemsProviderTest:backstage3", 600, 30, () => { }, "Dynamic Action", undefined, "icon-addon3"));
+    return items;
   }
 }
 
@@ -126,6 +128,41 @@ describe("BackstageComposer", () => {
     await TestUtils.flushAsyncOperations();
     wrapper.update();
 
+    addonItem = wrapper.find("i.icon-addon");
+    expect(addonItem.exists()).to.be.false;
+  });
+
+  it("should filter out duplicate items", async () => {
+    const items: BackstageItem[] = [
+      getActionItem({ groupPriority: 200 }),
+      getStageLauncherItem(),
+      getStageLauncherItem(),
+    ];
+
+    const uiProvider = new TestUiItemsProvider(true);
+    const wrapper = mount(<BackstageComposer items={items} />);
+    expect(wrapper.find("li[data-item-type='backstage-item']")).to.have.lengthOf(2);
+
+    let addonItem = wrapper.find("i.icon-addon");
+    expect(addonItem.exists()).to.be.false;
+
+    act(() => UiItemsManager.register(uiProvider));
+    await TestUtils.flushAsyncOperations();
+    wrapper.update();
+    addonItem = wrapper.find("i.icon-addon");
+    expect(addonItem.exists()).to.be.true;
+    let addonItem2 = wrapper.find("i.icon-addon2");
+    expect(addonItem.exists()).to.be.true;
+    expect(wrapper.find("li[data-item-type='backstage-item']")).to.have.lengthOf(4);
+
+    act(() => triggerSyncRefresh());
+    await TestUtils.flushAsyncOperations();
+    wrapper.update();
+    addonItem2 = wrapper.find("i.icon-addon2");
+    expect(addonItem2.exists()).to.be.false;
+    act(() => UiItemsManager.unregister(uiProvider.id));
+    await TestUtils.flushAsyncOperations();
+    wrapper.update();
     addonItem = wrapper.find("i.icon-addon");
     expect(addonItem.exists()).to.be.false;
   });


### PR DESCRIPTION
- Ensure duplicates items are ignored when gathering backstage, toolbar, status bar, and widget items from registered UiItemProviders.
- Fixed bug in ToolItemDef.getItemDefForTool where arguments meant for passing to tool's run method where not properly handled.