### PR TITLE
Keyin to generate tile content

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -10108,11 +10108,27 @@ export class TileAdmin {
     // @internal
     freeMemory(): void;
     // @internal (undocumented)
-    generateTileContent(tile: IModelTile): Promise<Uint8Array>;
+    generateTileContent(tile: {
+        iModelTree: IModelTileTree;
+        contentId: string;
+        request?: {
+            isCanceled: boolean;
+        };
+    }): Promise<Uint8Array>;
     getMaximumMajorTileFormatVersion(formatVersion?: number): number;
     getNumRequestsForViewport(vp: Viewport): number;
     // @internal
     getRequestsForViewport(vp: Viewport): Set<Tile> | undefined;
+    // @internal (undocumented)
+    getTileRequestProps(tile: {
+        iModelTree: IModelTileTree;
+        contentId: string;
+    }): {
+        tokenProps: import("@itwin/core-common").IModelRpcProps;
+        treeId: string;
+        contentId: string;
+        guid: string;
+    };
     // @internal
     getTilesForViewport(vp: Viewport): SelectedAndReadyTiles | undefined;
     // @internal
@@ -10157,7 +10173,10 @@ export class TileAdmin {
     // @internal
     registerViewport(vp: Viewport): void;
     // @internal (undocumented)
-    requestCachedTileContent(tile: IModelTile): Promise<Uint8Array | undefined>;
+    requestCachedTileContent(tile: {
+        iModelTree: IModelTileTree;
+        contentId: string;
+    }): Promise<Uint8Array | undefined>;
     requestElementGraphics(iModel: IModelConnection, requestProps: ElementGraphicsRequestProps): Promise<Uint8Array | undefined>;
     // @internal
     requestTiles(vp: Viewport, tiles: Set<Tile>): void;
@@ -10535,7 +10554,16 @@ export class TileRequestChannelStatistics {
 }
 
 // @public
-export class Tiles {
+export class Tiles implements Iterable<{
+    supplier: TileTreeSupplier;
+    id: any;
+    owner: TileTreeOwner;
+}> {
+    [Symbol.iterator](): Iterator<{
+        supplier: TileTreeSupplier;
+        id: any;
+        owner: TileTreeOwner;
+    }>;
     // @internal
     constructor(iModel: IModelConnection);
     // @internal (undocumented)

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -564,7 +564,6 @@ public;TileRequest
 public;TileRequestChannel
 public;TileRequestChannels
 public;TileRequestChannelStatistics
-public;Tiles
 public;class TileTree
 public;TileTreeDiscloser
 public;TileTreeLoadStatus

--- a/common/changes/@itwin/core-frontend/pmc-tile-content-keyin_2021-11-19-17-27.json
+++ b/common/changes/@itwin/core-frontend/pmc-tile-content-keyin_2021-11-19-17-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Tiles.ts
+++ b/core/frontend/src/Tiles.ts
@@ -73,7 +73,7 @@ class TreeOwner implements TileTreeOwner {
  * @see [[IModelConnection.tiles]].
  * @public
  */
-export class Tiles {
+export class Tiles implements Iterable<{ supplier: TileTreeSupplier, id: any, owner: TileTreeOwner }> {
   private _iModel: IModelConnection;
   private readonly _treesBySupplier = new Map<TileTreeSupplier, Dictionary<any, TreeOwner>>();
   private _disposed = false;
@@ -192,6 +192,14 @@ export class Tiles {
   public forEachTreeOwner(func: (owner: TileTreeOwner) => void): void {
     for (const dict of this._treesBySupplier.values())
       dict.forEach((_key, value) => func(value));
+  }
+
+  /** Iterate over all of the TileTreeOwners. */
+  public * [Symbol.iterator](): Iterator<{ supplier: TileTreeSupplier, id: any, owner: TileTreeOwner }> {
+    for (const [supplier, dict] of this._treesBySupplier) {
+      for (const entry of dict)
+        yield { supplier, id: entry.key, owner: entry.value };
+    }
   }
 
   /** Obtain the TileTreeOwners supplied by the specified supplier. */

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -19,7 +19,7 @@ import { IModelConnection } from "../IModelConnection";
 import { Viewport } from "../Viewport";
 import { ReadonlyViewportSet, UniqueViewportSets } from "../ViewportSet";
 import {
-  DisclosedTileTreeSet, IModelTile, IModelTileTree, LRUTileList, Tile, TileLoadStatus, TileRequest, TileRequestChannels, TileTree, TileTreeOwner, TileUsageMarker,
+  DisclosedTileTreeSet, IModelTileTree, LRUTileList, Tile, TileLoadStatus, TileRequest, TileRequestChannels, TileTree, TileTreeOwner, TileUsageMarker,
 } from "./internal";
 
 /** Details about any tiles not handled by [[TileAdmin]]. At this time, that means OrbitGT point cloud tiles.

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -19,7 +19,7 @@ import { IModelConnection } from "../IModelConnection";
 import { Viewport } from "../Viewport";
 import { ReadonlyViewportSet, UniqueViewportSets } from "../ViewportSet";
 import {
-  DisclosedTileTreeSet, IModelTile, LRUTileList, Tile, TileLoadStatus, TileRequest, TileRequestChannels, TileTree, TileTreeOwner, TileUsageMarker,
+  DisclosedTileTreeSet, IModelTile, IModelTileTree, LRUTileList, Tile, TileLoadStatus, TileRequest, TileRequestChannels, TileTree, TileTreeOwner, TileUsageMarker,
 } from "./internal";
 
 /** Details about any tiles not handled by [[TileAdmin]]. At this time, that means OrbitGT point cloud tiles.
@@ -583,12 +583,12 @@ export class TileAdmin {
   }
 
   /** @internal */
-  public async requestCachedTileContent(tile: IModelTile): Promise<Uint8Array | undefined> {
+  public async requestCachedTileContent(tile: { iModelTree: IModelTileTree, contentId: string }): Promise<Uint8Array | undefined> {
     return CloudStorageTileCache.getCache().retrieve(this.getTileRequestProps(tile));
   }
 
   /** @internal */
-  public async generateTileContent(tile: IModelTile): Promise<Uint8Array> {
+  public async generateTileContent(tile: { iModelTree: IModelTileTree, contentId: string, request?: { isCanceled: boolean } }): Promise<Uint8Array> {
     this.initializeRpc();
     const props = this.getTileRequestProps(tile);
     const retrieveMethod = await IModelTileRpcInterface.getClient().generateTileContent(props.tokenProps, props.treeId, props.contentId, props.guid);
@@ -609,7 +609,7 @@ export class TileAdmin {
   }
 
   /** @internal */
-  private getTileRequestProps(tile: IModelTile) {
+  public getTileRequestProps(tile: { iModelTree: IModelTileTree, contentId: string }) {
     const tree = tile.iModelTree;
     const tokenProps = tree.iModel.getRpcProps();
     let guid = tree.geometryGuid || tokenProps.changeset?.id || "first";

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -240,6 +240,7 @@ display-test-app has access to all key-ins defined in the imodeljs-frontend and 
 * `dta model transform` - Apply a display transform to all models currently displayed in the selected viewport. Origin is specified like `x=1 y=2 z=3`; pitch and roll as `p=45 r=90` in degrees. Any argument can be omitted. Omitting all arguments clears the display transform. Snapping intentionally does not take the display transform into account.
 * `dta viewport sync *viewportId1* *viewportId2*` - Synchronize the contents of two viewports, specifying them by integer Id displayed in their title bars. Omit the Ids to disconnect two previously synchronized viewports.
 * `dta frustum sync *viewportId1* *viewportId2*` - Like `dta viewport sync but synchronizes only the frusta of the viewports.
+* `dta gen tile *modelId=<modelId>* *contentId=<contentId>*` - Trigger a request to obtain tile content for the specified tile. This is chiefly useful for breaking in the debugger during that process to diagnose issues.
 
 ## Editing
 

--- a/test-apps/display-test-app/public/locales/en/SVTTools.json
+++ b/test-apps/display-test-app/public/locales/en/SVTTools.json
@@ -138,6 +138,9 @@
     },
     "SyncFrusta": {
       "keyin": "dta frustum sync"
+    },
+    "GenerateTileContent": {
+      "keyin": "dta gen tile"
     }
   }
 }

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -24,6 +24,7 @@ import { DtaRpcInterface } from "../common/DtaRpcInterface";
 import { ToggleAspectRatioSkewDecoratorTool } from "./AspectRatioSkewDecorator";
 import { ApplyModelDisplayScaleTool } from "./DisplayScale";
 import { ApplyModelTransformTool } from "./DisplayTransform";
+import { GenerateTileContentTool } from "./TileContentTool";
 import { DrawingAidTestTool } from "./DrawingAidTestTool";
 import { EditingScopeTool, PlaceLineStringTool } from "./EditingTools";
 import { FenceClassifySelectedTool } from "./Fence";
@@ -266,6 +267,7 @@ export class DisplayTestApp {
       FenceClassifySelectedTool,
       FocusWindowTool,
       FrameStatsTool,
+      GenerateTileContentTool,
       IncidentMarkerDemoTool,
       PathDecorationTestTool,
       MarkupSelectTestTool,

--- a/test-apps/display-test-app/src/frontend/TileContentTool.ts
+++ b/test-apps/display-test-app/src/frontend/TileContentTool.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { assert, ByteStream } from "@itwin/core-bentley";
+import {
+  ImdlReader, IModelApp, IModelTileTree, Tool,
+} from "@itwin/core-frontend";
+import { parseArgs } from "@itwin/frontend-devtools";
+
+export class GenerateTileContentTool extends Tool {
+  public static override toolId = "GenerateTileContent";
+  public static override get minArgs() { return 2; }
+  public static override get maxArgs() { return 2; }
+
+  public override async run(args?: { tree: IModelTileTree, contentId: string }) {
+    if (!args)
+      return false;
+
+    try {
+      const { tree, contentId } = args;
+      const bytes = await IModelApp.tileAdmin.generateTileContent({ contentId, iModelTree: tree });
+      const stream = new ByteStream(bytes.buffer);
+      const reader = ImdlReader.create(stream, tree.iModel, tree.modelId, tree.is3d, IModelApp.renderSystem, tree.batchType, tree.hasEdges, undefined, undefined, { tileId: contentId });
+      assert(undefined !== reader);
+      await reader.read();
+      return true;
+    } catch (err) {
+      if (err instanceof Error)
+        alert(err.toString());
+
+      return false;
+    }
+  }
+
+  public override async parseAndRun(...input: string[]) {
+    const iModel = IModelApp.viewManager.selectedView?.iModel;
+    if (!iModel)
+      return false;
+
+    const args = parseArgs(input);
+    const contentId = args.get("c");
+    const modelId = args.get("m");
+    if (!contentId || !modelId)
+      return false;
+
+    for (const owner of iModel.tiles) {
+      const tree = owner.owner.tileTree;
+      if (tree instanceof IModelTileTree && tree.modelId === modelId)
+        return this.run({ tree, contentId });
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
I frequently need to debug the generation and/or deserialization of a specific tile.
Every time, I think about how much more efficient that process would be if I could simply key in `dta gen tile -modelId=0x123 -contentId=-whatever` to trigger generation of exactly that tile.
Well, now I finally can.

Incidentally makes `IModelConnection.tiles` iterable.