### PR TITLE
Build: clone repo with depth level 1

### DIFF
--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -30,7 +30,7 @@ jobs:
   steps:
     - checkout: self
       clean: true
-      depth: 1
+      fetchDepth: 1
     - task: NodeTool@0
       displayName: "Use Node ${{ parameters.nodeVersion }}"
       inputs:

--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -30,6 +30,7 @@ jobs:
   steps:
     - checkout: self
       clean: true
+      depth: 1
     - task: NodeTool@0
       displayName: "Use Node ${{ parameters.nodeVersion }}"
       inputs:

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -4,7 +4,8 @@ parameters:
 
 steps:
   - checkout: self
-    clean: all
+    clean: true
+    fetchDepth: 1
 
   - template: setup-integration-users.yaml
 

--- a/common/config/azure-pipelines/templates/setup-integration-users.yaml
+++ b/common/config/azure-pipelines/templates/setup-integration-users.yaml
@@ -10,15 +10,9 @@ steps:
 
     echo "##vso[task.setvariable variable=imjs_test_regular_user_password;]$test_reg_password"
     echo "##vso[task.setvariable variable=USER_WITH_ACCESS_PASSWORD;]$test_reg_password"
-    echo "##vso[task.setvariable variable=imjs_test_super_user_password;]$test_super_password"
-    echo "##vso[task.setvariable variable=imjs_test_super_manager_user_password;]$test_super_manager_password"
     echo "##vso[task.setvariable variable=imjs_test_manager_user_password;]$test_manager_password"
     echo "##vso[task.setvariable variable=CLIENT_WITH_ACCESS_SECRET;]$agent_client_secret"
     echo "##vso[task.setvariable variable=imjs_agent_test_client_secret;]$agent_client_secret"
-    echo "##vso[task.setvariable variable=imjs_agent_v1_test_client_secret;]$agent_v1_client_secret"
-    echo "##vso[task.setvariable variable=imjs_agent_v1_test_service_user_password;]$agent_v1_service_user_password"
-    echo "##vso[task.setvariable variable=imjs_delegation_test_client_secret;]$delegation_test_client_secret"
-    echo "##vso[task.setvariable variable=imjs_qa_seq_api_key;]$qa_seq_api_key"
     echo "##vso[task.setvariable variable=imjs_test_imodelhub_user_password;]$test_hub_password"
     echo "##vso[task.setvariable variable=test_bing_maps_key;]$bing_key"
     echo "##vso[task.setvariable variable=test_mapbox_key;]$mapbox_key"
@@ -26,13 +20,7 @@ steps:
   env:
     test_reg_password: $(imjs_regular_user_password)
     test_manager_password: $(imjs_manager_user_password)
-    test_super_password: $(imjs_super_user_password)
-    test_super_manager_password: $(imjs_super_manager_user_password)
     test_hub_password: $(imjs_imodelhub_user_password)
-    agent_v1_client_secret: $(imjs_agent_v1_client_secret)
-    agent_v1_service_user_password: $(imjs_agent_v1_service_user_password)
     agent_client_secret: $(imjs_agent_client_secret)
-    delegation_test_client_secret: $(imjs_delegation_client_secret)
-    qa_seq_api_key: $(imjs_qa_seq_key)
     bing_key: $(bing_maps_key)
     mapbox_key: $(mapbox_key)

--- a/common/config/azure-pipelines/templates/setup-integration-users.yaml
+++ b/common/config/azure-pipelines/templates/setup-integration-users.yaml
@@ -10,6 +10,7 @@ steps:
 
     echo "##vso[task.setvariable variable=imjs_test_regular_user_password;]$test_reg_password"
     echo "##vso[task.setvariable variable=USER_WITH_ACCESS_PASSWORD;]$test_reg_password"
+    echo "##vso[task.setvariable variable=imjs_test_super_user_password;]$test_super_password"
     echo "##vso[task.setvariable variable=imjs_test_manager_user_password;]$test_manager_password"
     echo "##vso[task.setvariable variable=CLIENT_WITH_ACCESS_SECRET;]$agent_client_secret"
     echo "##vso[task.setvariable variable=imjs_agent_test_client_secret;]$agent_client_secret"
@@ -20,6 +21,7 @@ steps:
   env:
     test_reg_password: $(imjs_regular_user_password)
     test_manager_password: $(imjs_manager_user_password)
+    test_super_password: $(imjs_super_user_password)
     test_hub_password: $(imjs_imodelhub_user_password)
     agent_client_secret: $(imjs_agent_client_secret)
     bing_key: $(bing_maps_key)


### PR DESCRIPTION
Our git checkout time on every build is around 25-30 seconds for a full checkout. With doing a clone of only depth 1 it goes down to ~15 seconds.

With ~200 PR triggers a week * 5 builds a PR * 10 second savings = ~167 minutes of build time spent git cloning we save a week.

Also, minor clean up on the variables used in the integration tests.