### PR TITLE
Updates to remove setting UiStateStorage

### DIFF
--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -33,7 +33,6 @@ import {
 } from "@itwin/core-frontend";
 import { MarkupApp } from "@itwin/core-markup";
 import { AndroidApp, IOSApp } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
-import { LocalStateStorage, UiStateStorage } from "@itwin/core-react";
 import { EditTools } from "@itwin/editor-frontend";
 import { FrontendDevTools } from "@itwin/frontend-devtools";
 import { HyperModeling } from "@itwin/hypermodeling-frontend";
@@ -162,17 +161,12 @@ export class SampleAppIModelApp {
   public static iModelParams: SampleIModelParams | undefined;
   public static testAppConfiguration: TestAppConfiguration | undefined;
   private static _appStateManager: StateManager | undefined;
-  private static _localStateStorage = new LocalStateStorage();
 
   // Favorite Properties Support
   private static _selectionSetListener = new ElementSelectionListener(true);
 
   public static get store(): Store<RootState> {
     return StateManager.store as Store<RootState>;
-  }
-
-  public static get uiStateStorage(): UiStateStorage {
-    return SampleAppIModelApp._localStateStorage;
   }
 
   public static async startup(opts: NativeAppOpts): Promise<void> {
@@ -326,9 +320,6 @@ export class SampleAppIModelApp {
 
     // initialize any settings providers that may need to have defaults set by iModelApp
     UiFramework.registerUserSettingsProvider(new AppUiSettings(defaults));
-
-    // go ahead and initialize settings before login or in case login is by-passed
-    await UiFramework.setUiStateStorage(SampleAppIModelApp.uiStateStorage);
 
     UiFramework.useDefaultPopoutUrl = true;
 

--- a/test-apps/ui-test-app/src/frontend/tools/AppUi2StageItemsProvider.tsx
+++ b/test-apps/ui-test-app/src/frontend/tools/AppUi2StageItemsProvider.tsx
@@ -12,6 +12,7 @@ import {
 import { BackstageManager, ToolbarHelper } from "@itwin/appui-react";
 import { FloatingLayoutInfo, LayoutControls, LayoutInfo } from "../appui/widgets/LayoutWidget";
 import { AppTools } from "./ToolSpecifications";
+import { FrontstageUi2 } from "../appui/frontstages/FrontstageUi2";
 
 export class AppUi2StageItemsProvider implements UiItemsProvider {
   public static providerId = "sampleApp:ui2-stage-widget-provider";
@@ -248,7 +249,7 @@ export class AppUi2StageItemsProvider implements UiItemsProvider {
   }
 
   public provideWidgets(stageId: string, _stageUsage: string, location: StagePanelLocation, section?: StagePanelSection | undefined): ReadonlyArray<AbstractWidgetProps> {
-    const allowedStages = ["Ui2"];
+    const allowedStages = [FrontstageUi2.stageId];
     if (allowedStages.includes(stageId)) {
       switch (location) {
         case StagePanelLocation.Left:
@@ -266,7 +267,7 @@ export class AppUi2StageItemsProvider implements UiItemsProvider {
   }
 
   public provideToolbarButtonItems(stageId: string, _stageUsage: string, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation): CommonToolbarItem[] {
-    const allowedStages = ["Ui2"];
+    const allowedStages = [FrontstageUi2.stageId];
     if (allowedStages.includes(stageId)) {
       if (toolbarUsage === ToolbarUsage.ContentManipulation && toolbarOrientation === ToolbarOrientation.Horizontal) {
         const items: CommonToolbarItem[] = [];


### PR DESCRIPTION
Updates to remove setting UiStateStorage - it is not needed as it UiFramework defaults to using local storage.
Also fix AppUi2StageItemsProvider to properly check stageId.