### PR TITLE
[iOS] Update dta webpack to ignore the ElectronBackend setup

### DIFF
--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -263,3 +263,11 @@ display-test-app has access to all key-ins defined in the imodeljs-editor-fronte
 * `dta place line string` - start placing a line string. Each data point defines another point in the string; a reset (right mouse button) finishes. The element is placed into the first spatial model and spatial category in the viewport's model and category selectors.
 * `dta push` - push local changes to iModelHub. A description of the changes must be supplied. It should be enclosed in double quotes if it contains whitespace characters.
 * `dta pull` - pull and merge changes from iModelHub into the local briefcase. You must be signed in.
+
+## Running in iOS
+
+The steps to run the display test app in an iOS app:
+
+1. Run `npm run build:ios`
+2. Open `test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj`
+3. Start the XCode Project to an iPad

--- a/test-apps/display-test-app/ios/backend.config.js
+++ b/test-apps/display-test-app/ios/backend.config.js
@@ -46,6 +46,10 @@ function getConfig(env) {
         {
           test: /AzCopyFileHandler\.js/g,
           use: 'null-loader'
+        },
+        {
+          test: /ElectronBackend\.js/g,
+          use: 'null-loader'
         }
       ]
     },


### PR DESCRIPTION
The native dependency on key tar is tripping up webpack and it's not needed for the iOS app, only valid for Electron.