### PR TITLE
Fix regression in ImageTests animated test cases

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -4343,7 +4343,7 @@ export interface ImageryTileContent extends TileContent {
 export class ImdlReader extends GltfReader {
     // (undocumented)
     protected colorDefFromMaterialJson(json: any): ColorDef | undefined;
-    static create(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, is3d: boolean, system: RenderSystem, type?: BatchType, loadEdges?: boolean, isCanceled?: ShouldAbortReadGltf, sizeMultiplier?: number, options?: BatchOptions | false): ImdlReader | undefined;
+    static create(args: ImdlReaderCreateArgs): ImdlReader | undefined;
     // (undocumented)
     protected createDisplayParams(json: any): DisplayParams | undefined;
     // (undocumented)
@@ -4354,6 +4354,32 @@ export class ImdlReader extends GltfReader {
     // (undocumented)
     protected readFeatureTable(startPos: number): PackedFeatureTable | undefined;
     }
+
+// @internal
+export interface ImdlReaderCreateArgs {
+    // (undocumented)
+    containsTransformNodes?: boolean;
+    // (undocumented)
+    iModel: IModelConnection;
+    // (undocumented)
+    is3d: boolean;
+    // (undocumented)
+    isCanceled?: ShouldAbortReadGltf;
+    // (undocumented)
+    loadEdges?: boolean;
+    // (undocumented)
+    modelId: Id64String;
+    // (undocumented)
+    options?: BatchOptions | false;
+    // (undocumented)
+    sizeMultiplier?: number;
+    // (undocumented)
+    stream: ByteStream;
+    // (undocumented)
+    system: RenderSystem;
+    // (undocumented)
+    type?: BatchType;
+}
 
 // @internal (undocumented)
 export interface ImdlReaderResult extends IModelTileContent {
@@ -4731,6 +4757,8 @@ export class IModelTileTree extends TileTree {
     constructor(params: IModelTileTreeParams, treeId: IModelTileTreeId);
     // (undocumented)
     get batchType(): BatchType;
+    // (undocumented)
+    get containsTransformNodes(): boolean;
     // (undocumented)
     readonly contentIdProvider: ContentIdProvider;
     // (undocumented)

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -262,6 +262,7 @@ internal;ImageryMapTile
 internal;ImageryMapTileTree 
 internal;ImageryTileContent 
 internal;ImdlReader 
+internal;ImdlReaderCreateArgs
 internal;ImdlReaderResult 
 public;IModelApp
 public;IModelAppOptions

--- a/common/changes/@itwin/core-frontend/fix-animated-root-node_2021-11-25-11-02.json
+++ b/common/changes/@itwin/core-frontend/fix-animated-root-node_2021-11-25-11-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/DynamicIModelTile.ts
+++ b/core/frontend/src/tile/DynamicIModelTile.ts
@@ -384,7 +384,13 @@ class GraphicsTile extends Tile {
 
     const tree = this.tree;
     assert(tree instanceof IModelTileTree);
-    const reader = ImdlReader.create(stream, tree.iModel, tree.modelId, tree.is3d, system, tree.batchType, tree.hasEdges, isCanceled, undefined, { tileId: this.contentId });
+    const { iModel, modelId, is3d, containsTransformNodes } = tree;
+    const reader = ImdlReader.create({
+      stream, iModel, modelId, is3d, system, isCanceled, containsTransformNodes,
+      type: tree.batchType,
+      loadEdges: tree.hasEdges,
+      options: { tileId: this.contentId },
+    });
 
     let content: TileContent = { isLeaf: true };
     if (reader) {

--- a/core/frontend/src/tile/IModelTile.ts
+++ b/core/frontend/src/tile/IModelTile.ts
@@ -113,8 +113,15 @@ export class IModelTile extends Tile {
       return content;
 
     const tree = this.iModelTree;
-    const mult = this.hasSizeMultiplier ? this.sizeMultiplier : undefined;
-    const reader = ImdlReader.create(streamBuffer, tree.iModel, tree.modelId, tree.is3d, system, tree.batchType, tree.hasEdges, isCanceled, mult, { tileId: this.contentId });
+    const sizeMultiplier = this.hasSizeMultiplier ? this.sizeMultiplier : undefined;
+    const { iModel, modelId, is3d, containsTransformNodes } = tree;
+    const reader = ImdlReader.create({
+      stream: streamBuffer,
+      type: tree.batchType,
+      loadEdges: tree.hasEdges,
+      iModel, modelId, is3d, system, isCanceled, sizeMultiplier, containsTransformNodes,
+    });
+
     if (undefined !== reader) {
       try {
         content = await reader.read();

--- a/core/frontend/src/tile/IModelTileTree.ts
+++ b/core/frontend/src/tile/IModelTileTree.ts
@@ -429,4 +429,8 @@ export class IModelTileTree extends TileTree {
   public getTransformNodeRange(nodeId: number): Range3d | undefined {
     return this._transformNodeRanges?.get(nodeId);
   }
+
+  public get containsTransformNodes(): boolean {
+    return undefined !== this._transformNodeRanges;
+  }
 }

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -189,7 +189,7 @@ interface ImdlAreaPatternSymbol {
   readonly primitives: AnyImdlPrimitive[];
 }
 
-/** Arguments supplied to [[ImdlReader.create]].
+/** Arguments supplied to [[ImdlReader.create]]
  * @internal
  */
 export interface ImdlReaderCreateArgs {

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -189,6 +189,9 @@ interface ImdlAreaPatternSymbol {
   readonly primitives: AnyImdlPrimitive[];
 }
 
+/** Arguments supplied to [[ImdlReader.create]].
+ * @internal
+ */
 export interface ImdlReaderCreateArgs {
   stream: ByteStream;
   iModel: IModelConnection;
@@ -198,7 +201,7 @@ export interface ImdlReaderCreateArgs {
   type?: BatchType; // default Primary
   loadEdges?: boolean; // default true
   isCanceled?: ShouldAbortReadGltf;
-  sizeMultiplier?: number
+  sizeMultiplier?: number;
   options?: BatchOptions | false;
   containsTransformNodes?: boolean; // default false
 }

--- a/full-stack-tests/core/src/frontend/standalone/tile/Disposable.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/tile/Disposable.test.ts
@@ -208,7 +208,14 @@ describe("Disposal of WebGL Resources", () => {
     // Get a render graphic from tile reader
     const model = new FakeGMState(new FakeModelProps(new FakeREProps()), imodel0);
     const stream = new ByteStream(TILE_DATA_1_1.triangles.bytes.buffer);
-    const reader = ImdlReader.create(stream, model.iModel, model.id, model.is3d, system);
+    const reader = ImdlReader.create({
+      stream,
+      iModel: model.iModel,
+      modelId: model.id,
+      is3d: model.is3d,
+      system,
+    });
+
     expect(reader).not.to.be.undefined;
     const readerRes = await reader!.read();
     const tileGraphic = readerRes.graphic!;

--- a/full-stack-tests/core/src/frontend/standalone/tile/TileIO.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/tile/TileIO.test.ts
@@ -98,7 +98,14 @@ function processHeader(data: TileTestData, test: TileTestCase, numElements: numb
 function createReader(imodel: IModelConnection, data: TileTestData, test: TileTestCase): ImdlReader | undefined {
   const model = new FakeGMState(new FakeModelProps(new FakeREProps()), imodel);
   const stream = new ByteStream(test.bytes.buffer);
-  const reader = ImdlReader.create(stream, imodel, model.id, model.is3d, IModelApp.renderSystem);
+  const reader = ImdlReader.create({
+    stream,
+    iModel: imodel,
+    modelId: model.id,
+    is3d: model.is3d,
+    system: IModelApp.renderSystem,
+  });
+
   expect(undefined === reader).to.equal(!!data.unreadable);
   return reader;
 }
@@ -441,7 +448,17 @@ describe("TileIO (mock render)", () => {
     if (IModelApp.initialized) {
       const model = new FakeGMState(new FakeModelProps(new FakeREProps()), imodel);
       const stream = new ByteStream(currentTestCase.rectangle.bytes.buffer);
-      const reader = ImdlReader.create(stream, model.iModel, model.id, model.is3d, IModelApp.renderSystem, BatchType.Primary, true, (_) => true);
+      const reader = ImdlReader.create({
+        stream,
+        iModel: model.iModel,
+        modelId: model.id,
+        is3d: model.is3d,
+        system: IModelApp.renderSystem,
+        type: BatchType.Primary,
+        loadEdges: true,
+        isCanceled: (_) => true,
+      });
+
       expect(reader).not.to.be.undefined;
 
       const result = await reader!.read();
@@ -799,7 +816,14 @@ describe.skip("TileAdmin", () => {
         expect(response).instanceof(Uint8Array);
 
         const stream = new ByteStream(response.buffer);
-        const reader = ImdlReader.create(stream, imodel, "0x1c", true, IModelApp.renderSystem)!;
+        const reader = ImdlReader.create({
+          stream,
+          iModel: imodel,
+          modelId: "0x1c",
+          is3d: true,
+          system: IModelApp.renderSystem,
+        });
+
         expect(reader).not.to.be.undefined;
 
         const meshes = (reader as any)._meshes;

--- a/test-apps/display-test-app/src/frontend/TileContentTool.ts
+++ b/test-apps/display-test-app/src/frontend/TileContentTool.ts
@@ -22,7 +22,15 @@ export class GenerateTileContentTool extends Tool {
       const { tree, contentId } = args;
       const bytes = await IModelApp.tileAdmin.generateTileContent({ contentId, iModelTree: tree });
       const stream = new ByteStream(bytes.buffer);
-      const reader = ImdlReader.create(stream, tree.iModel, tree.modelId, tree.is3d, IModelApp.renderSystem, tree.batchType, tree.hasEdges, undefined, undefined, { tileId: contentId });
+      const { iModel, modelId, is3d, containsTransformNodes } = tree;
+      const reader = ImdlReader.create({
+        stream, iModel, modelId, is3d, containsTransformNodes,
+        system: IModelApp.renderSystem,
+        type: tree.batchType,
+        loadEdges: tree.hasEdges,
+        options: { tileId: contentId },
+      });
+
       assert(undefined !== reader);
       await reader.read();
       return true;


### PR DESCRIPTION
Previously we were always creating a branch for the root node, which is unnecessary and wasteful for non-animated tile trees.
This was detected by a TileIO test. The test was fixed by [this commit](9d7b8d9e595f6bcedb455e46bb674d18fab89397).
But that is also wrong: a tile containing one node in a tile tree containing transform nodes still needs to put that one node into a branch. This produced some image differences in the proj.ibim.animated.bim ImageTests data set.

Fix: Create a branch for the root node in the tile if and only if the tile tree contains transform nodes.
Forward to ImdlReader the flag indicating whether or not transform nodes are present.
Incidentally clean up the garbage pile of optional/default arguments to `ImdlReader.create`.