### PR TITLE
Wiremesh addenda

### DIFF
--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -623,14 +623,19 @@ export abstract class GltfReader {
     if (!mesh.points || !mesh.indices)
       return false;
 
-    const numIndices = mesh.indices.length;
-    assert(0 === numIndices % 3);
-    const points = new Uint16Array(3 * numIndices);
-    const normals = mesh.normals ? new Uint16Array(numIndices) : undefined;
-    const uvs = mesh.uvs ? new Uint16Array(2 * numIndices) : undefined;
+    const numPoints = mesh.indices.length;
+    assert(0 === numPoints % 3);
 
-    for (let i = 0; i < mesh.indices.length; i++) {
-      const index = mesh.indices[i];
+    const indices = mesh.indices;
+    if (indices instanceof Uint16Array && numPoints > 0xffff)
+      mesh.indices = new Uint32Array(numPoints);
+
+    const points = new Uint16Array(3 * numPoints);
+    const normals = mesh.normals ? new Uint16Array(numPoints) : undefined;
+    const uvs = mesh.uvs ? new Uint16Array(2 * numPoints) : undefined;
+
+    for (let i = 0; i < numPoints; i++) {
+      const index = indices[i];
       mesh.indices[i] = i;
 
       points[i * 3 + 0] = mesh.points[index * 3 + 0];

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -110,6 +110,20 @@ The following code applies a display style similar to those illustrated above to
   });
 ```
 
+## Wiremesh display
+
+The graphics displayed by an iTwin.js [Viewport]($frontend) consist primarily of triangulated meshes. It can sometimes be useful to visualize the triangulation of these meshes. A new view flag - [ViewFlags.wiremesh]($common) - now enables wiremesh display. When wiremesh display is enabled, the edges of each triangle are overlaid on top of the mesh as anti-aliased black lines approximately 1 pixel wide.
+
+To enable wiremesh display for a viewport:
+
+```ts
+  viewport.viewFlags = viewport.viewFlags.with("wiremesh", true);
+```
+
+![Wiremesh applied to a plant model](./assets/wiremesh-plant.jpg)
+
+![Wiremesh applied to a reality model](./assets/wiremesh-reality.jpg)
+
 ## Viewport synchronization
 
 [TwoWayViewportSync]($frontend) establishes a connection between two [Viewport]($frontend)s such that any change to one viewport is reflected in the other. This includes not only [Frustum]($common) changes, but changes to the display style, category and model selectors, and so on. Synchronizing **everything** is not always desirable; and if the viewports are viewing two different [IModelConnection]($frontend)s it is not even meaningful, as category and model Ids from one iModel will not make sense in the context of the other iModel.
@@ -1453,7 +1467,7 @@ Several changes to the APIs for executing ECSql statements have been made to imp
 - The `query` and `restartQuery` methods used to take multiple arguments indicating a limit on the number of rows to return, a priority, a quota, and so on. These have been combined into a single [QueryOptions]($common) parameter.
 
 - Previously there was no way to control the format of each row returned by the `query` and `restartQuery` methods, and the default format was verbose and inefficient. Now, these methods accept a [QueryRowFormat]($common) as part of their [QueryOptions]($common) parameter describing the desired format. The default format returns each row as an array instead of an object.
-- 
+
 - The `query`, `restartQuery`, and `queryRowCount` methods used to accept the statement bindings as type `any[] | object`. The bindings are now specified instead as the more type-safe type [QueryBinder]($common).
 
 ### Binding parameters using QueryBinder


### PR DESCRIPTION
Overlooked in #2787:
- If deduplication of vertices increases the number of points from below 64k to above 64k, we must allocate 32-bit indices.
- NextVersion.md