### PR TITLE
Consistent deprecation messages.

### DIFF
--- a/common/changes/@itwin/appui-react/deprecation-message_2021-11-29-14-56.json
+++ b/common/changes/@itwin/appui-react/deprecation-message_2021-11-29-14-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/core-react/deprecation-message_2021-11-29-14-56.json
+++ b/common/changes/@itwin/core-react/deprecation-message_2021-11-29-14-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/appui-react/src/appui-react/backstage/BackstageItemProps.tsx
+++ b/ui/appui-react/src/appui-react/backstage/BackstageItemProps.tsx
@@ -12,7 +12,7 @@ import { BackstageItemUtilities } from "./BackstageItemUtilities";
 
 /** Base properties for a [[Backstage]] item.
  * @public
- * @deprecated - use [BackstageItem]($appui-abstract) in bentley/appui-abstract instead
+ * @deprecated Use [BackstageItem]($appui-abstract) instead
  */
 export interface BackstageItemProps extends IconProps {
   /** if set, component will be enabled - defaults to true */
@@ -39,7 +39,7 @@ export interface BackstageItemProps extends IconProps {
 
 /** Properties that define the state of a Backstage items.
  * @public
- * @deprecated - use [BackstageItem]($appui-abstract) in bentley/appui-abstract instead
+ * @deprecated Use [BackstageItem]($appui-abstract) instead
  */
 export interface BackstageItemState {
   isEnabled: boolean;
@@ -52,7 +52,7 @@ export interface BackstageItemState {
 
 /** Helper method to set backstage item state from props.
  * @public
- * @deprecated - use [BackstageItem]($appui-abstract) in bentley/appui-abstract instead
+ * @deprecated Use [BackstageItem]($appui-abstract) instead
  */
 // istanbul ignore next
 export const getBackstageItemStateFromProps = (props: BackstageItemProps): BackstageItemState => { // eslint-disable-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/backstage/BackstageItemUtilities.ts
+++ b/ui/appui-react/src/appui-react/backstage/BackstageItemUtilities.ts
@@ -12,7 +12,7 @@ import { BackstageItemProps, BackstageItemState } from "./BackstageItemProps";
 
 /** Used to specify the item type added to the backstage menu.
  * @beta
- * @deprecated Use [BackstageItemType]($appui-abstract) in bentley/appui-abstract instead
+ * @deprecated Use [BackstageItemType]($appui-abstract) instead
  */
 export enum BackstageItemType {
   /** Item that executes an action function */
@@ -23,7 +23,7 @@ export enum BackstageItemType {
 
 /** Describes the data needed to insert an action button into the backstage menu.
  * @beta
- * @deprecated Use [BackstageActionItem]($appui-abstract) in bentley/appui-abstract instead
+ * @deprecated Use [BackstageActionItem]($appui-abstract) instead
  */
 export interface BackstageActionItem extends UIA_BackstageActionItem {
   readonly type: BackstageItemType.ActionItem; // eslint-disable-line deprecation/deprecation
@@ -31,7 +31,7 @@ export interface BackstageActionItem extends UIA_BackstageActionItem {
 
 /** Describes the data needed to insert an action button into the backstage menu.
  * @beta
- * @deprecated Use [BackstageStageLauncher]($appui-abstract) in bentley/appui-abstract instead
+ * @deprecated Use [BackstageStageLauncher]($appui-abstract) instead
  */
 export interface BackstageStageLauncher extends UIA_BackstageStageLauncher {
   readonly type: BackstageItemType.StageLauncher; // eslint-disable-line deprecation/deprecation
@@ -43,7 +43,7 @@ export interface BackstageStageLauncher extends UIA_BackstageStageLauncher {
 export class BackstageItemUtilities {
   /** Creates a stage launcher backstage item
    * @beta
-   * @deprecated Use BackstageItemUtilities.createStageLauncher in bentley/appui-abstract instead
+   * @deprecated Use [BackstageItemUtilities.createStageLauncher]($appui-abstract) instead
    */
   public static createStageLauncher = (frontstageId: string, groupPriority: number, itemPriority: number, label: string, subtitle?: string, iconSpec?: string, overrides?: Partial<BackstageStageLauncher>): BackstageStageLauncher => ({ // eslint-disable-line deprecation/deprecation
     groupPriority,
@@ -59,7 +59,7 @@ export class BackstageItemUtilities {
 
   /** Creates an action backstage item
    * @beta
-   * @deprecated Use BackstageItemUtilities.createActionItem in bentley/appui-abstract instead
+   * @deprecated Use [BackstageItemUtilities.createActionItem]($appui-abstract) instead
    */
   public static createActionItem = (itemId: string, groupPriority: number, itemPriority: number, execute: () => void, label: string, subtitle?: string, iconSpec?: string, overrides?: Partial<BackstageActionItem>): BackstageActionItem => ({ // eslint-disable-line deprecation/deprecation
     execute,

--- a/ui/appui-react/src/appui-react/shared/CustomItemProps.ts
+++ b/ui/appui-react/src/appui-react/shared/CustomItemProps.ts
@@ -13,7 +13,7 @@ import { ItemProps } from "./ItemProps";
  */
 export interface CustomItemProps extends ItemProps {
   customId?: string;
-  // @deprecated - use popupPanelNode
+  // @deprecated Use popupPanelNode
   reactElement?: React.ReactNode;
   popupPanelNode?: React.ReactNode;
 }

--- a/ui/appui-react/src/appui-react/shared/ItemDefBase.ts
+++ b/ui/appui-react/src/appui-react/shared/ItemDefBase.ts
@@ -45,9 +45,9 @@ export abstract class ItemDefBase {
 
   public badgeType?: BadgeType;
 
-  /** @deprecated - use condition instead */
+  /** @deprecated Use condition instead */
   public stateFunc?: (state: Readonly<BaseItemState>) => BaseItemState;
-  /** @deprecated - use condition instead */
+  /** @deprecated Use condition instead */
   public stateSyncIds: string[] = [];
 
   public iconSpec?: IconSpec;

--- a/ui/appui-react/src/appui-react/shared/ItemProps.ts
+++ b/ui/appui-react/src/appui-react/shared/ItemProps.ts
@@ -52,11 +52,11 @@ export interface ItemProps extends IconProps {
   tooltipKey?: string;
 
   /** Function called to get the new items state
-   * @deprecated - use ConditionalStringValue or ConditionalBooleanValue instead
+   * @deprecated Use ConditionalStringValue or ConditionalBooleanValue instead
    */
   stateFunc?: (state: Readonly<BaseItemState>) => BaseItemState;
   /** Synchronize Ids to listen for
-   * @deprecated - use ConditionalStringValue or ConditionalBooleanValue instead
+   * @deprecated Use ConditionalStringValue or ConditionalBooleanValue instead
    */
   stateSyncIds?: string[];
 }

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarItemsManager.ts
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarItemsManager.ts
@@ -10,6 +10,6 @@ import { StatusBarItemsManager as UIA_StatusBarItemsManager } from "@itwin/appui
 
 /** StatusBar Items Manager class.
  * @beta
- * @deprecated Use [StatusBarItemsManager]($appui-abstract) in bentley/appui-abstract instead
+ * @deprecated Use [StatusBarItemsManager]($appui-abstract) instead
  */
 export class StatusBarItemsManager extends UIA_StatusBarItemsManager { }

--- a/ui/core-react/src/core-react/dialog/DialogButtonDef.ts
+++ b/ui/core-react/src/core-react/dialog/DialogButtonDef.ts
@@ -8,7 +8,7 @@
 
 /** Enum for button types. Determines button label, and default button style.
   * @public
-  * @deprecated Use DialogButtonType in bentley/appui-abstract instead
+  * @deprecated Use [DialogButtonType]($appui-abstract) instead
   */
 export enum DialogButtonType {
   None = "",
@@ -24,7 +24,7 @@ export enum DialogButtonType {
 
 /** Enum for button style.
   * @public
-  * @deprecated Use DialogButtonStyle in bentley/appui-abstract instead
+  * @deprecated Use [DialogButtonStyle]($appui-abstract) instead
   */
 export enum DialogButtonStyle {
   None = "",
@@ -35,7 +35,7 @@ export enum DialogButtonStyle {
 
 /** Interface for a dialog button in a button cluster
   * @public
-  * @deprecated Use DialogButtonDef in bentley/appui-abstract instead
+  * @deprecated Use [DialogButtonDef]($appui-abstract) instead
   */
 export interface DialogButtonDef {
   /** type of button */

--- a/ui/core-react/src/core-react/messagebox/MessageSeverity.ts
+++ b/ui/core-react/src/core-react/messagebox/MessageSeverity.ts
@@ -8,7 +8,7 @@
 
 /** Message Severity enum.
   * @public
-  * @deprecated Use [MessageSeverity]($appui-abstract) in bentley/appui-abstract instead
+  * @deprecated Use [MessageSeverity]($appui-abstract) instead
   */
 export enum MessageSeverity {
   None = 0,


### PR DESCRIPTION
Make deprecation messages consistent in UI packages (mainly to fix references to renamed bentley/appui-abstract).