### PR TITLE
add configurable auth URL to full stack tests

### DIFF
--- a/common/changes/@itwin/ecschema-rpcinterface-tests/full-stack-oidcauthority_2021-12-02-16-27.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-tests/full-stack-oidcauthority_2021-12-02-16-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-tests"
+}

--- a/common/changes/@itwin/rpcinterface-full-stack-tests/full-stack-oidcauthority_2021-12-02-16-27.json
+++ b/common/changes/@itwin/rpcinterface-full-stack-tests/full-stack-oidcauthority_2021-12-02-16-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/rpcinterface-full-stack-tests"
+}

--- a/full-stack-tests/ecschema-rpc-interface/src/common/Settings.ts
+++ b/full-stack-tests/ecschema-rpc-interface/src/common/Settings.ts
@@ -38,7 +38,7 @@ export class Settings {
   public oidcClientId!: string;
   public oidcScopes!: string;
   public oidcRedirect!: string;
-  public imsUrl!: string;
+  public oidcAuthority?: string;
   public discovery!: string;
   public gprid?: string;
   public logLevel?: number;
@@ -91,6 +91,9 @@ export class Settings {
     if (undefined === process.env.OIDC_SCOPES)
       throw new Error("Missing the 'OIDC_SCOPES' setting");
     this.oidcScopes = process.env.OIDC_SCOPES;
+
+    if (process.env.OIDC_AUTHORITY)
+      this.oidcAuthority = process.env.OIDC_AUTHORITY;
 
     this.oidcRedirect = (undefined === process.env.OIDC_REDIRECT) ? "http://localhost:5000" : process.env.OIDC_REDIRECT;
 

--- a/full-stack-tests/ecschema-rpc-interface/src/frontend/setup/TestContext.ts
+++ b/full-stack-tests/ecschema-rpc-interface/src/frontend/setup/TestContext.ts
@@ -60,6 +60,7 @@ export class TestContext {
         clientId: this.settings.oidcClientId,
         redirectUri: this.settings.oidcRedirect,
         scope: this.settings.oidcScopes,
+        authority: this.settings.oidcAuthority,
       } as TestBrowserAuthorizationClientConfiguration);
     }
 

--- a/full-stack-tests/rpc-interface/src/common/Settings.ts
+++ b/full-stack-tests/rpc-interface/src/common/Settings.ts
@@ -58,7 +58,7 @@ export class Settings {
   public oidcClientId!: string;
   public oidcScopes!: string;
   public oidcRedirect!: string;
-  public imsUrl!: string;
+  public oidcAuthority?: string;
   public gprid?: string;
   public logLevel?: number;
   public users: TestUserCredentials[] = [];
@@ -119,6 +119,9 @@ export class Settings {
     if (undefined === process.env.OIDC_SCOPES)
       throw new Error("Missing the 'OIDC_SCOPES' setting");
     this.oidcScopes = process.env.OIDC_SCOPES;
+
+    if (process.env.OIDC_AUTHORITY)
+      this.oidcAuthority = process.env.OIDC_AUTHORITY;
 
     this.oidcRedirect = (undefined === process.env.OIDC_REDIRECT) ? "http://localhost:5000" : process.env.OIDC_REDIRECT;
 
@@ -195,6 +198,7 @@ export class Settings {
         clientId: process.env.CLIENT_WITH_ACCESS_ID,
         clientSecret: process.env.CLIENT_WITH_ACCESS_SECRET,
         scope: process.env.CLIENT_WITH_ACCESS_SCOPES,
+        authority: this.oidcAuthority,
       };
     }
   }

--- a/full-stack-tests/rpc-interface/src/frontend/setup/TestContext.ts
+++ b/full-stack-tests/rpc-interface/src/frontend/setup/TestContext.ts
@@ -69,6 +69,7 @@ export class TestContext {
         clientId: this.settings.oidcClientId,
         redirectUri: this.settings.oidcRedirect,
         scope: this.settings.oidcScopes,
+        authority: this.settings.oidcAuthority,
       } as TestBrowserAuthorizationClientConfiguration);
     }
 


### PR DESCRIPTION
RPC full stack tests would try to use non-existing dev-ims.bentley.com when testing in DEV (required by GPB)