### PR TITLE
add option to transformer to preserve element ids

### DIFF
--- a/common/api/core-transformer.api.md
+++ b/common/api/core-transformer.api.md
@@ -87,7 +87,7 @@ export abstract class IModelExportHandler {
 }
 
 // @beta
-export class IModelImporter {
+export class IModelImporter implements Required<IModelImportOptions> {
     constructor(targetDb: IModelDb, options?: IModelImportOptions);
     autoExtendProjectExtents: boolean | {
         excludeOutliers: boolean;
@@ -113,6 +113,7 @@ export class IModelImporter {
     protected onUpdateElementAspect(aspectProps: ElementAspectProps): void;
     protected onUpdateModel(modelProps: ModelProps): void;
     protected onUpdateRelationship(relationshipProps: RelationshipProps): void;
+    preserveElementIdsForFiltering: boolean;
     progressInterval: number;
     simplifyElementGeometry: boolean;
     readonly targetDb: IModelDb;
@@ -123,6 +124,7 @@ export interface IModelImportOptions {
     autoExtendProjectExtents?: boolean | {
         excludeOutliers: boolean;
     };
+    preserveElementIdsForFiltering?: boolean;
 }
 
 // @beta
@@ -185,6 +187,7 @@ export interface IModelTransformOptions {
     isReverseSynchronization?: boolean;
     loadSourceGeometry?: boolean;
     noProvenance?: boolean;
+    preserveElementIdsForFiltering?: boolean;
     targetScopeElementId?: Id64String;
     wasSourceIModelCopiedToTarget?: boolean;
 }

--- a/common/api/summary/core-transformer.exports.csv
+++ b/common/api/summary/core-transformer.exports.csv
@@ -2,7 +2,7 @@ sep=;
 Release Tag;API Item
 beta;IModelExporter
 beta;class IModelExportHandler
-beta;IModelImporter
+beta;IModelImporter 
 beta;IModelImportOptions
 beta;IModelTransformer 
 beta;IModelTransformOptions

--- a/common/changes/@itwin/core-transformer/transformer-filter-maintain-ids_2021-12-03-14-03.json
+++ b/common/changes/@itwin/core-transformer/transformer-filter-maintain-ids_2021-12-03-14-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "add preserveElementIdsForFiltering option for transformations",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1536,19 +1536,6 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       }
     }
 
-    /** Insert a new element into the iModel, with an id of `elProps.id`
-     * @param elProps The properties of the new element.
-     * @returns The passed in element properties Id.
-     * @throws [[IModelError]] if unable to insert the element.
-     */
-    public insertElementForceUseId(elProps: ElementProps): Id64String {
-      try {
-        return elProps.id = this._iModel.nativeDb.insertElementForceUseId(elProps instanceof Element ? elProps.toJSON() : elProps);
-      } catch (err: any) {
-        throw new IModelError(err.errorNumber, `insertElement with class=${elProps.classFullName}: ${err.message}`);
-      }
-    }
-
     /** Update some properties of an existing element.
      * To support clearing a property value, every property name that is present in the `elProps` object will be updated even if the value is `undefined`.
      * To keep an individual element property unchanged, it should either be excluded from the `elProps` parameter or set to its current value.

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1545,7 +1545,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       try {
         return elProps.id = this._iModel.nativeDb.insertElementForceUseId(elProps instanceof Element ? elProps.toJSON() : elProps);
       } catch (err: any) {
-        throw new IModelError(err.errorNumber, `insertElement with class=${elProps.classFullName}: ${err.message}`,);
+        throw new IModelError(err.errorNumber, `insertElement with class=${elProps.classFullName}: ${err.message}`);
       }
     }
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1536,6 +1536,19 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       }
     }
 
+    /** Insert a new element into the iModel, with an id of `elProps.id`
+     * @param elProps The properties of the new element.
+     * @returns The passed in element properties Id.
+     * @throws [[IModelError]] if unable to insert the element.
+     */
+    public insertElementForceUseId(elProps: ElementProps & {id: Id64String}): Id64String {
+      try {
+        return elProps.id = this._iModel.nativeDb.insertElementForceUseId(elProps instanceof Element ? elProps.toJSON() : elProps);
+      } catch (err: any) {
+        throw new IModelError(err.errorNumber, `insertElement with class=${elProps.classFullName}: ${err.message}`,);
+      }
+    }
+
     /** Update some properties of an existing element.
      * To support clearing a property value, every property name that is present in the `elProps` object will be updated even if the value is `undefined`.
      * To keep an individual element property unchanged, it should either be excluded from the `elProps` parameter or set to its current value.

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1541,7 +1541,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @returns The passed in element properties Id.
      * @throws [[IModelError]] if unable to insert the element.
      */
-    public insertElementForceUseId(elProps: ElementProps & {id: Id64String}): Id64String {
+    public insertElementForceUseId(elProps: ElementProps): Id64String {
       try {
         return elProps.id = this._iModel.nativeDb.insertElementForceUseId(elProps instanceof Element ? elProps.toJSON() : elProps);
       } catch (err: any) {

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -25,9 +25,6 @@ export interface IModelImportOptions {
    * @see [IModelImporter Options]($docs/learning/transformer/index.md#IModelImporter)
    */
   autoExtendProjectExtents?: boolean | { excludeOutliers: boolean };
-
-  /** @see [IModelTransformerOptions.preserveIdsInPureFilterTransform]($transformer) */
-  preserveIdsInPureFilterTransform?: boolean;
 }
 
 /** Base class for importing data into an iModel.
@@ -45,8 +42,6 @@ export class IModelImporter implements Required<IModelImportOptions> {
    * @see [IModelImporter Options]($docs/learning/transformer/index.md#IModelImporter)
    */
   public autoExtendProjectExtents: boolean | { excludeOutliers: boolean };
-  /** @see [[IModelImportOptions.preserveIdsInPureFilterTransform]] */
-  public preserveIdsInPureFilterTransform: boolean;
   /** If `true`, simplify the element geometry for visualization purposes. For example, convert b-reps into meshes.
    * @note `false` is the default
    */
@@ -69,7 +64,6 @@ export class IModelImporter implements Required<IModelImportOptions> {
   public constructor(targetDb: IModelDb, options?: IModelImportOptions) {
     this.targetDb = targetDb;
     this.autoExtendProjectExtents = options?.autoExtendProjectExtents ?? true;
-    this.preserveIdsInPureFilterTransform = options?.preserveIdsInPureFilterTransform ?? false;
     // Add in the elements that are always present (even in an "empty" iModel) and therefore do not need to be updated
     this.doNotUpdateElementIds.add(IModel.rootSubjectId);
     this.doNotUpdateElementIds.add(IModel.dictionaryId);
@@ -432,6 +426,19 @@ export class IModelImporter implements Required<IModelImportOptions> {
       }
     }
   }
+}
+
+/** an [[IModelImporter]] that allows "filtering" an iModel, keeping ids of remaining elements in the
+ * target as matching with the source.
+ * Due to the inability to create an element with a specific id, we treat inserts as preventing
+ * deletion of elements, then delete all filtered (not-inserted) elements at the end of the transformation
+ * to keep just the unfiltered elements intact. All other updates apply normally.
+ *
+ * An instance of this subclass of [IModelTransformer]($transformer) is used when the options for the transformer have
+ * [IModelTransformOptions.preserveIdsInPureFilterTransform]($transformer) as `true`.
+ * @internal
+ */
+export class IModelFilterer extends IModelImporter {
 }
 
 /** Returns true if a change within an Entity is detected.

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -25,6 +25,9 @@ export interface IModelImportOptions {
    * @see [IModelImporter Options]($docs/learning/transformer/index.md#IModelImporter)
    */
   autoExtendProjectExtents?: boolean | { excludeOutliers: boolean };
+
+  /** @see [IModelTransformerOptions.preserveIdsInPureFilterTransform]($transformer) */
+  preserveIdsInPureFilterTransform?: boolean;
 }
 
 /** Base class for importing data into an iModel.
@@ -33,7 +36,7 @@ export interface IModelImportOptions {
  * @see [IModelTransformer]($transformer)
  * @beta
  */
-export class IModelImporter {
+export class IModelImporter implements Required<IModelImportOptions> {
   /** The read/write target iModel. */
   public readonly targetDb: IModelDb;
   /** If `true` (the default), compute the projectExtents of the target iModel after elements are imported.
@@ -42,6 +45,8 @@ export class IModelImporter {
    * @see [IModelImporter Options]($docs/learning/transformer/index.md#IModelImporter)
    */
   public autoExtendProjectExtents: boolean | { excludeOutliers: boolean };
+  /** @see [[IModelImportOptions.preserveIdsInPureFilterTransform]] */
+  public preserveIdsInPureFilterTransform: boolean;
   /** If `true`, simplify the element geometry for visualization purposes. For example, convert b-reps into meshes.
    * @note `false` is the default
    */
@@ -64,6 +69,7 @@ export class IModelImporter {
   public constructor(targetDb: IModelDb, options?: IModelImportOptions) {
     this.targetDb = targetDb;
     this.autoExtendProjectExtents = options?.autoExtendProjectExtents ?? true;
+    this.preserveIdsInPureFilterTransform = options?.preserveIdsInPureFilterTransform ?? false;
     // Add in the elements that are always present (even in an "empty" iModel) and therefore do not need to be updated
     this.doNotUpdateElementIds.add(IModel.rootSubjectId);
     this.doNotUpdateElementIds.add(IModel.dictionaryId);

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -439,6 +439,9 @@ export class IModelImporter implements Required<IModelImportOptions> {
  * @internal
  */
 export class IModelFilterer extends IModelImporter {
+  public override importElement(_elementProps: ElementProps): Id64String {
+    return Id64.invalid;
+  }
 }
 
 /** Returns true if a change within an Entity is detected.

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -26,7 +26,7 @@ export interface IModelImportOptions {
    */
   autoExtendProjectExtents?: boolean | { excludeOutliers: boolean };
   /** @see [IModelTransformOptions]($transformer) */
-  preserveIdsInFilterTransform?: boolean;
+  preserveElementIdsForFiltering?: boolean;
 }
 
 /** Base class for importing data into an iModel.
@@ -44,8 +44,8 @@ export class IModelImporter implements Required<IModelImportOptions> {
    * @see [IModelImporter Options]($docs/learning/transformer/index.md#IModelImporter)
    */
   public autoExtendProjectExtents: boolean | { excludeOutliers: boolean };
-  /** @see [IModelTransformOptions]($transformer) */
-  public preserveIdsInFilterTransform: boolean;
+  /** @see [IModelTransformOptions.preserveElementIdsForFiltering]($transformer) */
+  public preserveElementIdsForFiltering: boolean;
   /** If `true`, simplify the element geometry for visualization purposes. For example, convert b-reps into meshes.
    * @note `false` is the default
    */
@@ -68,7 +68,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
   public constructor(targetDb: IModelDb, options?: IModelImportOptions) {
     this.targetDb = targetDb;
     this.autoExtendProjectExtents = options?.autoExtendProjectExtents ?? true;
-    this.preserveIdsInFilterTransform  = options?.preserveIdsInFilterTransform ?? false;
+    this.preserveElementIdsForFiltering = options?.preserveElementIdsForFiltering ?? false;
     // Add in the elements that are always present (even in an "empty" iModel) and therefore do not need to be updated
     this.doNotUpdateElementIds.add(IModel.rootSubjectId);
     this.doNotUpdateElementIds.add(IModel.dictionaryId);
@@ -139,7 +139,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
       Logger.logInfo(loggerCategory, `Do not update target element ${elementProps.id}`);
       return elementProps.id;
     }
-    if (this.preserveIdsInFilterTransform) {
+    if (this.preserveElementIdsForFiltering) {
       // categories are the only element that onInserted will immediately insert a new element (their default subcategory)
       // since default subcategories always exist and always will be inserted after their categories, we treat them as an update
       // to prevent duplicate inserts
@@ -166,7 +166,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
     // XXXXXXXXXXX: need to update the default subcategory after inserting any [spatial?] category
     try {
       let elementId: Id64String;
-      if (this.preserveIdsInFilterTransform) {
+      if (this.preserveElementIdsForFiltering) {
         const hasId = (a: ElementProps): a is ElementProps & {id: Id64String} => typeof a.id === "string";
         if (!hasId(elementProps))
           throw new IModelError(IModelStatus.BadArg, "element tried to be inserted without an id during an id-preserving filter");

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -163,13 +163,9 @@ export class IModelImporter implements Required<IModelImportOptions> {
    * @note A subclass may override this method to customize insert behavior but should call `super.onInsertElement`.
    */
   protected onInsertElement(elementProps: ElementProps): Id64String {
-    // XXXXXXXXXXX: need to update the default subcategory after inserting any [spatial?] category
     try {
       let elementId: Id64String;
       if (this.preserveElementIdsForFiltering) {
-        const hasId = (a: ElementProps): a is ElementProps & {id: Id64String} => typeof a.id === "string";
-        if (!hasId(elementProps))
-          throw new IModelError(IModelStatus.BadArg, "element tried to be inserted without an id during an id-preserving filter");
         elementId = this.targetDb.elements.insertElementForceUseId(elementProps);
       } else {
         elementId = this.targetDb.elements.insertElement(elementProps);

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -164,12 +164,10 @@ export class IModelImporter implements Required<IModelImportOptions> {
    */
   protected onInsertElement(elementProps: ElementProps): Id64String {
     try {
-      let elementId: Id64String;
-      if (this.preserveElementIdsForFiltering) {
-        elementId = this.targetDb.elements.insertElementForceUseId(elementProps);
-      } else {
-        elementId = this.targetDb.elements.insertElement(elementProps);
-      }
+      const elementId = this.targetDb.nativeDb.insertElement(
+        elementProps,
+        { forceUseId: this.preserveElementIdsForFiltering },
+      );
       Logger.logInfo(loggerCategory, `Inserted ${this.formatElementForLogger(elementProps)}`);
       this.trackProgress();
       if (this.simplifyElementGeometry) {

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -169,7 +169,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
       if (this.preserveIdsInFilterTransform) {
         const hasId = (a: ElementProps): a is ElementProps & {id: Id64String} => typeof a.id === "string";
         if (!hasId(elementProps))
-          throw new IModelError(IModelStatus.BadArg, "element tried to be an inserted without an id during an id-preserving filter");
+          throw new IModelError(IModelStatus.BadArg, "element tried to be inserted without an id during an id-preserving filter");
         elementId = this.targetDb.elements.insertElementForceUseId(elementProps);
       } else {
         elementId = this.targetDb.elements.insertElement(elementProps);
@@ -451,11 +451,6 @@ export class IModelImporter implements Required<IModelImportOptions> {
       }
     }
   }
-
-  /** called after all other importing work.
-   * a subclass may perform arbitrary work after all other importing is done by overriding this method
-   */
-  public async onFinalizeImport(): Promise<void> {}
 }
 
 /** Returns true if a change within an Entity is detected.

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -168,6 +168,8 @@ export class IModelImporter implements Required<IModelImportOptions> {
         elementProps,
         { forceUseId: this.preserveElementIdsForFiltering },
       );
+      // set the id like [IModelDb.insertElement]($backend), does, the raw nativeDb method does not
+      elementProps.id = elementId;
       Logger.logInfo(loggerCategory, `Inserted ${this.formatElementForLogger(elementProps)}`);
       this.trackProgress();
       if (this.simplifyElementGeometry) {

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -787,11 +787,6 @@ export class IModelTransformer extends IModelExportHandler {
     this.sourceDb.nativeDb.exportSchema(schema.name, this._schemaExportDir);
   }
 
-  // pending PR https://github.com/typescript-eslint/typescript-eslint/pull/3601 fixes the rule @typescript-eslint/return-await
-  // to work in try/catch syntax in functions that contain a nested function
-  // until that merges and we upgrade our dependency, the callback cannot be defined inside the method it is used
-  private makeAbsolute = (s: string) => path.join(this._schemaExportDir, s);
-
   /** Cause all schemas to be exported from the source iModel and imported into the target iModel.
    * @note For performance reasons, it is recommended that [IModelDb.saveChanges]($backend) be called after `processSchemas` is complete.
    * It is more efficient to process *data* changes after the schema changes have been saved.
@@ -804,7 +799,7 @@ export class IModelTransformer extends IModelExportHandler {
       const exportedSchemaFiles = IModelJsFs.readdirSync(this._schemaExportDir);
       if (exportedSchemaFiles.length === 0)
         return;
-      const schemaFullPaths = exportedSchemaFiles.map(this.makeAbsolute);
+      const schemaFullPaths = exportedSchemaFiles.map((s) => path.join(this._schemaExportDir, s));
       return await this.targetDb.importSchemas(schemaFullPaths);
     } finally {
       IModelJsFs.removeSync(this._schemaExportDir);

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -780,8 +780,6 @@ export class IModelTransformer extends IModelExportHandler {
     return Semver.gt(`${schemaKey.version.read}.${schemaKey.version.write}.${schemaKey.version.minor}`, Schema.toSemverString(versionInTarget));
   }
 
-  private _hasNativelyExportedAllSchemas = false;
-
   /** Override of [IModelExportHandler.onExportSchema]($transformer) that serializes a schema to disk for [[processSchemas]] to import into
    * the target iModel when it is exported from the source iModel. */
   protected override async onExportSchema(schema: ECSchemaMetaData.Schema): Promise<void> {
@@ -796,7 +794,6 @@ export class IModelTransformer extends IModelExportHandler {
     try {
       IModelJsFs.mkdirSync(this._schemaExportDir);
       await this.exporter.exportSchemas();
-      this._hasNativelyExportedAllSchemas = false;
       const exportedSchemaFiles = IModelJsFs.readdirSync(this._schemaExportDir);
       if (exportedSchemaFiles.length === 0)
         return;

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -73,9 +73,18 @@ export interface IModelTransformOptions {
 
   /** Flag that indicates whether or not the transformation process should clone using binary geometry.
    * Only transformations that need to manipulate geometry should consider setting this flag as it impacts performance.
-   * @note The default is `true`.
+   * @default true
    */
   cloneUsingBinaryGeometry?: boolean;
+
+  /** Flag that indicates that the transform will be a "pure filter" and the transformer should enforce matching ids in the target
+   * and source.
+   * A "pure filter" transform takes an empty target and will not insert any elements into the target that aren't directly in the source.
+   * When this flag is active, the transformer will assert on attempts to add elements to the source that aren't in the target.
+   * This safety checking can be disabled with the [[IModelTransformerOptions.disablePureFilterSafetyChecks]] option.
+   * @default false
+   */
+  preserveIdsInPureFilterTransform?: boolean;
 }
 
 /** Base class used to transform a source iModel into a different target iModel.

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -871,7 +871,7 @@ export class IModelTransformer extends IModelExportHandler {
       await this.detectRelationshipDeletes();
     }
     this.importer.computeProjectExtents();
-    this.importer.onFinalizeImport();
+    await this.importer.onFinalizeImport();
   }
 
   /** Export changes from the source iModel and import the transformed entities into the target iModel.
@@ -889,7 +889,7 @@ export class IModelTransformer extends IModelExportHandler {
     await this.exporter.exportChanges(accessToken, startChangesetId);
     await this.processDeferredElements();
     this.importer.computeProjectExtents();
-    this.importer.onFinalizeImport();
+    await this.importer.onFinalizeImport();
   }
 }
 

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -176,6 +176,7 @@ export class IModelTransformer extends IModelExportHandler {
       }
       this.importer = target;
     }
+    this.importer.preserveIdsInFilterTransform = options?.preserveIdsInFilterTransform ?? false;
     this.targetDb = this.importer.targetDb;
     // initialize the IModelCloneContext
     this.context = new IModelCloneContext(this.sourceDb, this.targetDb);

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -867,7 +867,6 @@ export class IModelTransformer extends IModelExportHandler {
       await this.detectRelationshipDeletes();
     }
     this.importer.computeProjectExtents();
-    await this.importer.onFinalizeImport();
   }
 
   /** Export changes from the source iModel and import the transformed entities into the target iModel.
@@ -885,7 +884,6 @@ export class IModelTransformer extends IModelExportHandler {
     await this.exporter.exportChanges(accessToken, startChangesetId);
     await this.processDeferredElements();
     this.importer.computeProjectExtents();
-    await this.importer.onFinalizeImport();
   }
 }
 

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -864,7 +864,7 @@ export class IModelTransformer extends IModelExportHandler {
       await this.detectElementDeletes();
       await this.detectRelationshipDeletes();
     }
-    this.finishProcessing();
+    this.importer.computeProjectExtents();
   }
 
   /** Export changes from the source iModel and import the transformed entities into the target iModel.
@@ -881,15 +881,7 @@ export class IModelTransformer extends IModelExportHandler {
     this.initFromExternalSourceAspects();
     await this.exporter.exportChanges(accessToken, startChangesetId);
     await this.processDeferredElements();
-    this.finishProcessing();
-  }
-
-  /** final steps of processing, regardless of whether it's processing all of the iModel or just changes  */
-  private finishProcessing() {
     this.importer.computeProjectExtents();
-    if (this._preserveElementIdsForFiltering) {
-      this.targetDb.nativeDb.resetElementIdSequence(); // we used insertElementForceUseId so we must call this now
-    }
   }
 }
 

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1205,12 +1205,23 @@ describe("IModelTransformer", () => {
 
     const spatialCateg2 = sourceDb.elements.getElement<SpatialCategory>(spatialCateg2Id);
 
-    function filterCategoryPredicate(elem: Element): boolean {
+    /** filter the category and all related elements from the source for transformation */
+    function filterCategoryTransformationPredicate(elem: Element): boolean {
+      // if we don't filter out the elements, the transformer will see that the category is a predecessor
+      // and re-add it to the transformation.
       if (elem instanceof GeometricElement && elem.category === spatialCateg2Id)
         return false;
       if (elem.id === spatialCateg2Id)
         return false;
-      // we don't actually need this for filtering during the transform, but for filtering the sourceContent
+      return true;
+    }
+
+    /** filter the category and all related and child elements from the source for comparison, not transformation */
+    function filterCategoryContentsPredicate(elem: Element): boolean {
+      if (elem instanceof GeometricElement && elem.category === spatialCateg2Id)
+        return false;
+      if (elem.id === spatialCateg2Id)
+        return false;
       if (elem.id === spatialCateg2.myDefaultSubCategoryId())
         return false;
       return true;
@@ -1218,7 +1229,7 @@ describe("IModelTransformer", () => {
 
     class FilterCategoryTransformer extends IModelTransformer {
       public override shouldExportElement(elem: Element): boolean {
-        if (!filterCategoryPredicate(elem))
+        if (!filterCategoryTransformationPredicate(elem))
           return false;
         return super.shouldExportElement(elem);
       }
@@ -1244,7 +1255,7 @@ describe("IModelTransformer", () => {
       return result;
     }
 
-    const sourceContent = await getAllElementsInvariants(sourceDb, filterCategoryPredicate);
+    const sourceContent = await getAllElementsInvariants(sourceDb, filterCategoryContentsPredicate);
     const targetContent = await getAllElementsInvariants(targetDb);
     expect(targetContent).to.deep.equal(sourceContent);
 

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1179,7 +1179,7 @@ describe("IModelTransformer", () => {
     targetDb.close();
   });
 
-  it.only("filter preserves Ids", async () => {
+  it.only("preserveId option preserves element ids, not other entity ids", async () => {
     const sourceDbPath = IModelTestUtils.prepareOutputFile("IModelTransformer", "PreserveIdSource.bim");
     const sourceDb = SnapshotDb.createEmpty(sourceDbPath, { rootSubject: { name: "PreserveId" } });
 

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -15,7 +15,7 @@ import {
   GeometricElement,
   IModelCloneContext, IModelDb, IModelHost, IModelJsFs, IModelSchemaLoader, InformationRecordModel, InformationRecordPartition, LinkElement, Model,
   ModelSelector, OrthographicViewDefinition, PhysicalModel, PhysicalObject, PhysicalPartition, PhysicalType, Relationship, RepositoryLink, Schema,
-  SnapshotDb, SpatialCategory, StandaloneDb, Subject,
+  SnapshotDb, SpatialCategory, StandaloneDb, SubCategory, Subject,
 } from "@itwin/core-backend";
 import { ExtensiveTestScenario, IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test";
 import {
@@ -1258,6 +1258,20 @@ describe("IModelTransformer", () => {
     const sourceContent = await getAllElementsInvariants(sourceDb, filterCategoryContentsPredicate);
     const targetContent = await getAllElementsInvariants(targetDb);
     expect(targetContent).to.deep.equal(sourceContent);
+
+    // now try inserting both an element and a relationship into the target to check the two id sequences are fine
+    const spatialCateg3Id = SpatialCategory.insert(
+      targetDb,
+      IModelDb.dictionaryId,
+      "spatial-category3",
+      { color: ColorDef.black.toJSON() }
+    );
+    const _spatialCateg3Subcateg1Id = SubCategory.insert(
+      targetDb,
+      spatialCateg3Id,
+      "spatial-categ-subcateg-1",
+      { color: ColorDef.white.toJSON() }
+    );
 
     sourceDb.close();
     targetDb.close();

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1204,8 +1204,8 @@ describe("IModelTransformer", () => {
     const targetDb = SnapshotDb.createEmpty(targetDbPath, { rootSubject: { name: "PreserveId" } });
 
     function filterCategoryPredicate(elem: Element): boolean {
-      // if (elem instanceof GeometricElement && elem.category === spatialCateg2Id)
-      //   return false;
+      if (elem instanceof GeometricElement && elem.category === spatialCateg2Id)
+        return false;
       if (elem.id === spatialCateg2Id)
         return false;
       return true;
@@ -1219,7 +1219,7 @@ describe("IModelTransformer", () => {
       }
     }
 
-    const transformer = new FilterCategoryTransformer(sourceDb, targetDb, { /* preserveIdsInFilterTransform: true*/ });
+    const transformer = new FilterCategoryTransformer(sourceDb, targetDb, { preserveIdsInFilterTransform: true });
     await transformer.processAll();
     targetDb.saveChanges();
 
@@ -1238,14 +1238,6 @@ describe("IModelTransformer", () => {
       }
       return result;
     }
-
-    /*
-    the issue is that when we export the definition model, while filtering the category
-    so how does the default transformer filter out elements related to the filtered category?
-
-    regular transformer actually fails to filter it out since it is a predecessor, it just scoops up the spatial category later...
-    you need to filter them all out to actually lose it. I should have this behavior too
-    */
 
     const sourceContent = await getAllElementsInvariants(sourceDb, filterCategoryPredicate);
     const targetContent = await getAllElementsInvariants(targetDb);

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1206,7 +1206,7 @@ describe("IModelTransformer", () => {
     return result;
   }
 
-  it.only("preserveId option preserves element ids, not other entity ids", async () => {
+  it("preserveId option preserves element ids, not other entity ids", async () => {
     const sourceDbPath = IModelTestUtils.prepareOutputFile("IModelTransformer", "PreserveIdSource.bim");
     const sourceDb = SnapshotDb.createEmpty(sourceDbPath, { rootSubject: { name: "PreserveId" } });
 
@@ -1360,7 +1360,7 @@ describe("IModelTransformer", () => {
     targetDb.close();
   });
 
-  it.only("preserveId on test model", async () => {
+  it("preserveId on test model", async () => {
     const seedDb = SnapshotDb.openFile(IModelTestUtils.resolveAssetFile("CompatibilityTestSeed.bim"));
     const sourceDbPath = IModelTestUtils.prepareOutputFile("IModelTransformer", "PreserveIdOnTestModel-Source.bim");
     // transforming the seed to an empty will update it to the latest bis from the new target

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1203,10 +1203,15 @@ describe("IModelTransformer", () => {
     const targetDbPath = IModelTestUtils.prepareOutputFile("IModelTransformer", "PreserveIdTarget.bim");
     const targetDb = SnapshotDb.createEmpty(targetDbPath, { rootSubject: { name: "PreserveId" } });
 
+    const spatialCateg2 = sourceDb.elements.getElement<SpatialCategory>(spatialCateg2Id);
+
     function filterCategoryPredicate(elem: Element): boolean {
       if (elem instanceof GeometricElement && elem.category === spatialCateg2Id)
         return false;
       if (elem.id === spatialCateg2Id)
+        return false;
+      // we don't actually need this for filtering during the transform, but for filtering the sourceContent
+      if (elem.id === spatialCateg2.myDefaultSubCategoryId())
         return false;
       return true;
     }


### PR DESCRIPTION
- add option to transformer to preserve element ids during transformations, valid during a pure-filter transform where no elements are added during the transformation

[imodel02 PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/211450)