### PR TITLE
Update core-mobile API exports and release tags

### DIFF
--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -9,6 +9,8 @@ import { AsyncMethodsOf } from '@itwin/core-bentley';
 import { AuthorizationClient } from '@itwin/core-common';
 import { BeEvent } from '@itwin/core-bentley';
 import { CancelRequest } from '@bentley/itwin-client';
+import { FileHandler } from '@bentley/itwin-client';
+import * as https from 'https';
 import { IModelAppOptions } from '@itwin/core-frontend';
 import { NativeAppOpts } from '@itwin/core-frontend';
 import { NativeHostOpts } from '@itwin/core-backend';
@@ -42,6 +44,21 @@ export class AndroidHost extends MobileHost {
 
 // @beta (undocumented)
 export type AndroidHostOpts = MobileHostOpts;
+
+// @beta (undocumented)
+export enum BatteryState {
+    // (undocumented)
+    Charging = 2,
+    // (undocumented)
+    Full = 3,
+    // (undocumented)
+    Unknown = 0,
+    // (undocumented)
+    Unplugged = 1
+}
+
+// @beta (undocumented)
+export type DeviceEvents = "memoryWarning" | "orientationChanged" | "enterForeground" | "enterBackground" | "willTerminate";
 
 // @beta (undocumented)
 export interface DownloadTask {
@@ -108,6 +125,50 @@ export class MobileApp {
     static startup(opts?: NativeAppOpts): Promise<void>;
 }
 
+// @beta
+export interface MobileAppAuthorizationConfiguration {
+    readonly clientId: string;
+    readonly expiryBuffer?: number;
+    issuerUrl?: string;
+    readonly redirectUri?: string;
+    readonly scope: string;
+}
+
+// @beta
+export interface MobileAppFunctions {
+    // (undocumented)
+    reconnect: (connection: number) => Promise<void>;
+}
+
+// @beta
+export class MobileAuthorizationBackend implements AuthorizationClient {
+    constructor(config?: MobileAppAuthorizationConfiguration);
+    // (undocumented)
+    protected _accessToken?: AccessToken;
+    // (undocumented)
+    protected _baseUrl: string;
+    // (undocumented)
+    config?: MobileAppAuthorizationConfiguration;
+    // (undocumented)
+    static defaultRedirectUri: string;
+    // (undocumented)
+    expireSafety: number;
+    // (undocumented)
+    getAccessToken(): Promise<AccessToken>;
+    initialize(config?: MobileAppAuthorizationConfiguration): Promise<void>;
+    // (undocumented)
+    issuerUrl?: string;
+    // (undocumented)
+    get redirectUri(): string;
+    refreshToken(): Promise<AccessToken>;
+    // (undocumented)
+    setAccessToken(token?: AccessToken): void;
+    signIn(): Promise<void>;
+    signOut(): Promise<void>;
+    // (undocumented)
+    protected _url?: string;
+}
+
 // @beta (undocumented)
 export type MobileCancelCallback = () => boolean;
 
@@ -148,10 +209,24 @@ export abstract class MobileDevice {
     abstract resumeDownloadInForeground(requestId: number): boolean;
 }
 
+// @internal
+export class MobileFileHandler implements FileHandler {
+    constructor();
+    // (undocumented)
+    agent?: https.Agent;
+    basename(filePath: string): string;
+    downloadFile(_accessToken: AccessToken, downloadUrl: string, downloadToPathname: string, fileSize?: number, progressCallback?: ProgressCallback, cancelRequest?: CancelRequest): Promise<void>;
+    exists(filePath: string): boolean;
+    getFileSize(filePath: string): number;
+    isDirectory(filePath: string): boolean;
+    static isUrlExpired(downloadUrl: string, futureSeconds?: number): boolean;
+    join(...paths: string[]): string;
+    unlink(filePath: string): void;
+    uploadFile(accessToken: AccessToken, uploadUrlString: string, uploadFromPathname: string, progressCallback?: ProgressCallback): Promise<void>;
+}
+
 // @beta (undocumented)
 export class MobileHost {
-    // @internal (undocumented)
-    static get authorization(): MobileAuthorizationBackend;
     // (undocumented)
     static get device(): MobileDevice;
     // @internal (undocumented)
@@ -180,12 +255,28 @@ export interface MobileHostOpts extends NativeHostOpts {
         device?: MobileDevice;
         rpcInterfaces?: RpcInterfaceDefinition[];
         authConfig?: MobileAppAuthorizationConfiguration;
-        noInitializeAuthClient?: boolean;
     };
 }
 
 // @beta (undocumented)
+export interface MobileNotifications {
+    // (undocumented)
+    notifyEnterBackground: () => void;
+    // (undocumented)
+    notifyEnterForeground: () => void;
+    // (undocumented)
+    notifyMemoryWarning: () => void;
+    // (undocumented)
+    notifyOrientationChanged: () => void;
+    // (undocumented)
+    notifyWillTerminate: () => void;
+}
+
+// @beta (undocumented)
 export type MobileProgressCallback = (bytesWritten: number, totalBytesWritten: number, totalBytesExpectedToWrite: number) => void;
+
+// @beta (undocumented)
+export type MobileRpcChunks = Array<string | Uint8Array>;
 
 // @beta
 export abstract class MobileRpcConfiguration extends RpcConfiguration {
@@ -200,12 +291,75 @@ export abstract class MobileRpcConfiguration extends RpcConfiguration {
     };
 }
 
+// @beta (undocumented)
+export interface MobileRpcGateway {
+    // (undocumented)
+    connectionId: number;
+    // (undocumented)
+    handler: (payload: ArrayBuffer | string, connectionId: number) => void;
+    // (undocumented)
+    port: number;
+    // (undocumented)
+    sendBinary: (message: Uint8Array, connectionId: number) => void;
+    // (undocumented)
+    sendString: (message: string, connectionId: number) => void;
+}
+
 // @beta
 export class MobileRpcManager {
     static initializeClient(interfaces: RpcInterfaceDefinition[]): MobileRpcConfiguration;
     static initializeImpl(interfaces: RpcInterfaceDefinition[]): MobileRpcConfiguration;
     // @internal (undocumented)
     static ready(): Promise<void>;
+}
+
+// @beta
+export class MobileRpcProtocol extends RpcProtocol {
+    constructor(configuration: MobileRpcConfiguration, endPoint: RpcEndpoint);
+    // (undocumented)
+    static encodeRequest(request: MobileRpcRequest): Promise<MobileRpcChunks>;
+    // (undocumented)
+    static encodeResponse(fulfillment: RpcRequestFulfillment): MobileRpcChunks;
+    // (undocumented)
+    static obtainInterop(): MobileRpcGateway;
+    // (undocumented)
+    requests: Map<string, MobileRpcRequest>;
+    // (undocumented)
+    readonly requestType: typeof MobileRpcRequest;
+    // (undocumented)
+    sendToBackend(message: MobileRpcChunks): void;
+    // (undocumented)
+    sendToFrontend(message: MobileRpcChunks, connection?: number): void;
+    // (undocumented)
+    socket: WebSocket;
+    }
+
+// @beta (undocumented)
+export class MobileRpcRequest extends RpcRequest {
+    protected load(): Promise<RpcSerializedValue>;
+    // @internal (undocumented)
+    notifyResponse(fulfillment: RpcRequestFulfillment): void;
+    readonly protocol: MobileRpcProtocol;
+    protected send(): Promise<number>;
+    protected setHeader(_name: string, _value: string): void;
+}
+
+// @beta (undocumented)
+export enum Orientation {
+    // (undocumented)
+    FaceDown = 32,
+    // (undocumented)
+    FaceUp = 16,
+    // (undocumented)
+    LandscapeLeft = 4,
+    // (undocumented)
+    LandscapeRight = 8,
+    // (undocumented)
+    Portrait = 1,
+    // (undocumented)
+    PortraitUpsideDown = 2,
+    // (undocumented)
+    Unknown = 0
 }
 
 // @beta

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -377,6 +377,7 @@ internal;class IpcWebSocket
 internal;IpcWebSocketBackend 
 internal;IpcWebSocketFrontend 
 internal;IpcWebSocketMessage
+internal;IpcWebSocketMessage
 internal;IpcWebSocketMessageType
 internal;class IpcWebSocketTransport
 internal;isKnownTileFormat(format: number): boolean

--- a/core/mobile/src/MobileBackend.ts
+++ b/core/mobile/src/MobileBackend.ts
@@ -7,8 +7,10 @@
 
 export * from "./backend/AndroidHost";
 export * from "./backend/iOSHost";
-export * from "./backend/MobileHost";
 export * from "./backend/MobileAuthorizationBackend";
-export * from "./common/MobileRpcManager";
 export * from "./backend/MobileFileHandler";
-
+export * from "./backend/MobileHost";
+export * from "./common/MobileAppProps";
+export * from "./common/MobileRpcManager";
+export * from "./common/MobileRpcProtocol";
+export * from "./common/MobileRpcRequest";

--- a/core/mobile/src/MobileFrontend.ts
+++ b/core/mobile/src/MobileFrontend.ts
@@ -3,7 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+export * from "./common/MobileAppProps";
+export * from "./common/MobileRpcManager";
+export * from "./common/MobileRpcProtocol";
+export * from "./common/MobileRpcRequest";
 export * from "./frontend/AndroidApp";
 export * from "./frontend/IOSApp";
 export * from "./frontend/MobileApp";
-export * from "./common/MobileRpcManager";

--- a/core/mobile/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile/src/backend/MobileAuthorizationBackend.ts
@@ -42,8 +42,9 @@ export interface MobileAppAuthorizationConfiguration {
 }
 
 /** Utility to provide OIDC/OAuth tokens from native ios app to frontend
-   * @internal
-   */
+ * @beta
+ * Maybe not needed? Ask Mobile-sdk team
+ */
 export class MobileAuthorizationBackend implements AuthorizationClient {
   protected _accessToken?: AccessToken;
   public config?: MobileAppAuthorizationConfiguration;
@@ -57,8 +58,6 @@ export class MobileAuthorizationBackend implements AuthorizationClient {
   public constructor(config?: MobileAppAuthorizationConfiguration) {
     this.config = config;
   }
-
-  // public getClientRequestContext() { return ClientRequestContext.fromJSON(IModelHost.session); }
 
   /** Used to initialize the client - must be awaited before any other methods are called */
   public async initialize(config?: MobileAppAuthorizationConfiguration): Promise<void> {
@@ -137,6 +136,7 @@ export class MobileAuthorizationBackend implements AuthorizationClient {
       });
     });
   }
+
   /**
    * Gets the URL of the service. Uses the default URL provided by client implementations.
    * If defined, the value of `IMJS_URL_PREFIX` will be used as a prefix to all urls provided

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -4,16 +4,17 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BeEvent, BriefcaseStatus } from "@itwin/core-bentley";
-import { IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
+import { IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
 import {
-  IModelReadRpcInterface, IModelTileRpcInterface, InternetConnectivityStatus, RpcInterfaceDefinition,
+  IModelReadRpcInterface, IModelTileRpcInterface, RpcInterfaceDefinition,
   SnapshotIModelRpcInterface,
 } from "@itwin/core-common";
 import { CancelRequest, DownloadFailed, ProgressCallback, UserCancelledError } from "@bentley/itwin-client";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
-import { BatteryState, DeviceEvents, mobileAppChannel, MobileAppFunctions, Orientation } from "../common/MobileAppProps";
+import { mobileAppChannel } from "../common/MobileAppChannel";
+import { BatteryState, DeviceEvents,  MobileAppFunctions, Orientation } from "../common/MobileAppProps";
 import { MobileRpcManager } from "../common/MobileRpcManager";
-import { MobileAppAuthorizationConfiguration, MobileAuthorizationBackend } from "./MobileAuthorizationBackend";
+import { MobileAppAuthorizationConfiguration } from "./MobileAuthorizationBackend";
 import { setupMobileRpc } from "./MobileRpcServer";
 
 /** @beta */
@@ -84,10 +85,8 @@ export interface MobileHostOpts extends NativeHostOpts {
     device?: MobileDevice;
     /** list of RPC interface definitions to register */
     rpcInterfaces?: RpcInterfaceDefinition[];
-    /** if present, [[NativeHost.authorizationClient]] will be set to an instance of MobileAppAuthorizationConfiguration and will be initialized. */
+    /** if present, [[IModelHost.authorizationClient]] will be set to an instance of [[MobileAuthorizationBackend]]. */
     authConfig?: MobileAppAuthorizationConfiguration;
-    /** if true, do not attempt to initialize AuthorizationClient on startup */
-    noInitializeAuthClient?: boolean;
   };
 }
 
@@ -102,9 +101,6 @@ export class MobileHost {
   public static readonly onEnterForeground = new BeEvent();
   public static readonly onEnterBackground = new BeEvent();
   public static readonly onWillTerminate = new BeEvent();
-
-  /** @internal */
-  public static get authorization() { return IModelHost.authorizationClient as MobileAuthorizationBackend; }
 
   /**  @internal */
   public static reconnect(connection: number) {
@@ -171,12 +167,5 @@ export class MobileHost {
     ];
 
     MobileRpcManager.initializeImpl(rpcInterfaces);
-
-    const authorizationBackend = new MobileAuthorizationBackend(opt?.mobileHost?.authConfig);
-    const connectivityStatus = NativeHost.checkInternetConnectivity();
-    if (opt?.mobileHost?.authConfig && true !== opt?.mobileHost?.noInitializeAuthClient && connectivityStatus === InternetConnectivityStatus.Online) {
-      await authorizationBackend.initialize(opt?.mobileHost?.authConfig);
-    }
-    IModelHost.authorizationClient = authorizationBackend;
   }
 }

--- a/core/mobile/src/backend/MobileRpcServer.ts
+++ b/core/mobile/src/backend/MobileRpcServer.ts
@@ -17,6 +17,7 @@ interface MobileAddon {
 
 let addon: MobileAddon | undefined;
 
+/** @beta */
 export class MobileRpcServer {
   private static _nextId = -1;
 
@@ -34,7 +35,7 @@ export class MobileRpcServer {
   private _connectionId: number;
   private _pingTimer: NodeJS.Timeout;
   public constructor() {
-    /* _pingTime is a fix for ios/mobile case where when app move into foreground from
+    /* _pingTime is a fix for ios/mobile case where when the app moves into foreground from
      * background backend restart ws.Server and then notify frontend to reconnect. But ws.Server
      * listening event is not fired as node yield to kevent and wait for some io event to happen.
      * This causes a delay in reconnection which may be as long a 40 secs. To solve the issue we

--- a/core/mobile/src/common/MobileAppChannel.ts
+++ b/core/mobile/src/common/MobileAppChannel.ts
@@ -3,9 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-// THIS FILE EXISTS ONLY FOR DOCUMENTATION GENERATION.
-// It imports both frontend and backend code, which is not legal anywhere.
-// Do not import it in real code!
-
-export * from "./MobileBackend";
-export * from "./MobileFrontend";
+/** @internal */
+export const mobileAppChannel = "mobileApp";
+/** @internal */
+export const mobileAppNotify = "mobileApp-notify";

--- a/core/mobile/src/common/MobileAppProps.ts
+++ b/core/mobile/src/common/MobileAppProps.ts
@@ -3,11 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-/** @internal */
-export const mobileAppChannel = "mobileApp";
-/** @internal */
-export const mobileAppNotify = "mobileApp-notify";
-
+/** @beta */
 export enum Orientation {
   Unknown = 0,
   Portrait = 0x1,
@@ -18,6 +14,7 @@ export enum Orientation {
   FaceDown = 0x20,
 }
 
+/** @beta */
 export enum BatteryState {
   Unknown = 0,
   Unplugged = 1,
@@ -25,6 +22,7 @@ export enum BatteryState {
   Full = 3,
 }
 
+/** @beta */
 export interface MobileNotifications {
   notifyMemoryWarning: () => void;
   notifyOrientationChanged: () => void;
@@ -33,11 +31,12 @@ export interface MobileNotifications {
   notifyWillTerminate: () => void;
 }
 
+/** @beta */
 export type DeviceEvents = "memoryWarning" | "orientationChanged" | "enterForeground" | "enterBackground" | "willTerminate";
 
 /**
 * The methods that may be invoked via Ipc from the frontend of a Mobile App that are implemented on its backend.
-* @internal
+* @beta
 */
 export interface MobileAppFunctions {
   reconnect: (connection: number) => Promise<void>;

--- a/core/mobile/src/frontend/MobileApp.ts
+++ b/core/mobile/src/frontend/MobileApp.ts
@@ -6,7 +6,8 @@
 import { AsyncMethodsOf, BeEvent, Logger, PromiseReturnType } from "@itwin/core-bentley";
 import { IModelReadRpcInterface, IModelTileRpcInterface, IpcWebSocketFrontend } from "@itwin/core-common";
 import { IpcApp, NativeApp, NativeAppOpts, NotificationHandler } from "@itwin/core-frontend";
-import { mobileAppChannel, MobileAppFunctions, mobileAppNotify, MobileNotifications } from "../common/MobileAppProps";
+import { mobileAppChannel, mobileAppNotify } from "../common/MobileAppChannel";
+import { MobileAppFunctions, MobileNotifications } from "../common/MobileAppProps";
 import { MobileRpcManager } from "../common/MobileRpcManager";
 
 /** receive notifications from backend */
@@ -40,7 +41,7 @@ export class MobileApp {
   private static _isValid = false;
   public static get isValid() { return this._isValid; }
   /**
-   * This is called by either ElectronApp.startup or MobileApp.startup - it should not be called directly
+   * This is called by either AndroidApp.startup or IOSApp.startup - it should not be called directly
    * @internal
    */
   public static async startup(opts?: NativeAppOpts) {

--- a/test-apps/display-test-app/src/backend/MobileMain.ts
+++ b/test-apps/display-test-app/src/backend/MobileMain.ts
@@ -3,17 +3,23 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { MobileHostOpts } from "@itwin/core-mobile/lib/cjs/MobileBackend";
+import { IModelHostConfiguration } from "@itwin/core-backend";
+import { MobileAuthorizationBackend, MobileHostOpts } from "@itwin/core-mobile/lib/cjs/MobileBackend";
 import { getRpcInterfaces, initializeDtaBackend } from "./Backend";
 
 const dtaMobileMain = (async () => {
+  const authBackend = new MobileAuthorizationBackend({
+    clientId: process.env.IMJS_OIDC_MOBILE_TEST_CLIENT_ID ?? "",
+    redirectUri: process.env.IMJS_OIDC_MOBILE_TEST_REDIRECT_URI ?? "",
+    scope: process.env.IMJS_OIDC_MOBILE_TEST_SCOPES ?? "",
+  });
+
+  const config = new IModelHostConfiguration();
+  config.authorizationClient = authBackend;
+
   const opts: MobileHostOpts = {
+    iModelHost: config,
     mobileHost: {
-      authConfig: {
-        clientId: "imodeljs-electron-test",
-        redirectUri: "imodeljs://app/signin-callback",
-        scope: "openid email profile organization itwinjs",
-      },
       rpcInterfaces: getRpcInterfaces(),
     },
   };


### PR DESCRIPTION
The current setup of the barrel files for core-mobile were missing a handful of exports that appear to be needed for apps to work properly

In addition, updated the way authorization is handled to be more closely aligned with the rest of the *Host classes. As of 3.0, none of them will automatically handled the sign-in workflow for you and instead allow the application to be in control of performing it. 