### PR TITLE
Presentation: fix ruleset variables storing in IPC apps

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-ruleset_variables_in_electron_2021-12-06-14-39.json
+++ b/common/changes/@itwin/presentation-backend/presentation-ruleset_variables_in_electron_2021-12-06-14-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fix ruleset variables storing in IPC apps",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
+++ b/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
@@ -9,8 +9,8 @@
 import { Logger } from "@itwin/core-bentley";
 import { IModelDb, IpcHandler } from "@itwin/core-backend";
 import {
-  NodeKeyJSON, PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariableJSON, SetRulesetVariableParams, UnsetRulesetVariableParams,
-  UpdateHierarchyStateParams,
+  NodeKeyJSON, PRESENTATION_IPC_CHANNEL_NAME, PresentationIpcInterface, RulesetVariable, RulesetVariableJSON, SetRulesetVariableParams,
+  UnsetRulesetVariableParams, UpdateHierarchyStateParams,
 } from "@itwin/presentation-common";
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { Presentation } from "./Presentation";
@@ -21,7 +21,8 @@ export class PresentationIpcHandler extends IpcHandler implements PresentationIp
 
   public async setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void> {
     const { clientId, rulesetId, variable } = params;
-    Presentation.getManager(clientId).vars(rulesetId).setValue(variable.id, variable.type, variable.value);
+    const parsedVariable = RulesetVariable.fromJSON(variable);
+    Presentation.getManager(clientId).vars(rulesetId).setValue(parsedVariable.id, parsedVariable.type, parsedVariable.value);
   }
 
   public async unsetRulesetVariable(params: UnsetRulesetVariableParams): Promise<void> {

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -446,6 +446,15 @@ export class PresentationManager {
 
   private getRulesetIdObject(rulesetOrId: Ruleset | string): { uniqueId: string, parts: { id: string, hash?: string } } {
     if (typeof rulesetOrId === "object") {
+      if (IpcHost.isValid) {
+        // in case of native apps we don't want to enforce ruleset id uniqueness as ruleset variables
+        // are stored on a backend and creating new id will lose those variables
+        return {
+          uniqueId: rulesetOrId.id,
+          parts: { id: rulesetOrId.id },
+        };
+      }
+
       const hashedId = hash.MD5(rulesetOrId);
       return {
         uniqueId: `${rulesetOrId.id}-${hashedId}`,

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -592,6 +592,14 @@ describe("PresentationManager", () => {
       expect(manager.getRulesetId(ruleset)).to.contain(ruleset.id);
     });
 
+    it("returns correct id when input is a ruleset and in one-backend-one-frontend mode", async () => {
+      sinon.stub(IpcHost, "isValid").get(() => true);
+      sinon.stub(IpcHost, "handle");
+      manager = new PresentationManager({ addon: moq.Mock.ofType<NativePlatformDefinition>().object });
+      const ruleset = await createRandomRuleset();
+      expect(manager.getRulesetId(ruleset)).to.eq(ruleset.id);
+    });
+
   });
 
   describe("handling options", () => {


### PR DESCRIPTION
* Do not create unique ids for rulesets in IPC apps as it causes to lose variables for those rulesets.
* Parse variable json before setting it's value on a backend.