### PR TITLE
Add macro capability to display-test-app

### DIFF
--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -125,7 +125,7 @@ You can use these environment variables to alter the default behavior of various
 * IMJS_STANDALONE_SIGNIN
   * If defined (value does not matter), the user will be required to sign in at startup. This enables access to content stored on the reality data service. As a side effect, you may observe a harmless "failed to fetch" dialog on startup, which can be safely dismissed.
 * IMJS_STARTUP_MACRO
-  * If defined, run macro from specified path. If file extension not specified, .txt is assumed.
+  * If defined, run macro from specified path. If the file path contains no periods, a .txt extension will be appended.
 * IMJS_NO_MAXIMIZE_WINDOW
   * If defined, don't maximize the electron window on startup
 * IMJS_NO_DEV_TOOLS

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -124,7 +124,7 @@ You can use these environment variables to alter the default behavior of various
   * The name of a view to open by default within an iModel.
 * IMJS_STANDALONE_SIGNIN
   * If defined (value does not matter), the user will be required to sign in at startup. This enables access to content stored on the reality data service. As a side effect, you may observe a harmless "failed to fetch" dialog on startup, which can be safely dismissed.
-* IMJS_NO_STARTUP_MACRO
+* IMJS_STARTUP_MACRO
   * If defined, run macro from specified path. If file extension not specified, .txt is assumed.
 * IMJS_NO_MAXIMIZE_WINDOW
   * If defined, don't maximize the electron window on startup
@@ -214,6 +214,7 @@ display-test-app has access to all key-ins defined in the imodeljs-frontend and 
 * `dta signin` - sign in to use Bentley services like iModelHub and reality data.
 * `dta macro` - runs the macro file specified in the argument.  If file extension not specified, .txt is assumed.  Each line in the file is executed as a keyin command and run sequentially.
 * `dta output shaders` - output debug information for compiled shaders. Requires IMJS_DEBUG_SHADERS to have been set. Accepts 0-2 arguments:
+  * `c`: compile all shaders – compiles all shaders before output, otherwise only shaders that have been compiled by the time it is run will output.
   * `d=output\directory\` - directory into which to put the output files.
   * filter string: a combination of the following characters to filter the output (e.g., `gu` outputs all used glsl shaders, both fragment and vertex):
     * `f` or `v`: output only fragment or vertex shaders, respectively.

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -124,6 +124,8 @@ You can use these environment variables to alter the default behavior of various
   * The name of a view to open by default within an iModel.
 * IMJS_STANDALONE_SIGNIN
   * If defined (value does not matter), the user will be required to sign in at startup. This enables access to content stored on the reality data service. As a side effect, you may observe a harmless "failed to fetch" dialog on startup, which can be safely dismissed.
+* IMJS_NO_STARTUP_MACRO
+  * If defined, run macro from specified path. If file extension not specified, .txt is assumed.
 * IMJS_NO_MAXIMIZE_WINDOW
   * If defined, don't maximize the electron window on startup
 * IMJS_NO_DEV_TOOLS
@@ -210,6 +212,7 @@ display-test-app has access to all key-ins defined in the imodeljs-frontend and 
 * `dta path decoration` - toggle drawing a small path decoration in the selected viewport for testing purposes.
 * `dta markup` - toggle markup on the selected viewport.
 * `dta signin` - sign in to use Bentley services like iModelHub and reality data.
+* `dta macro` - runs the macro file specified in the argument.  If file extension not specified, .txt is assumed.  Each line in the file is executed as a keyin command and run sequentially.
 * `dta output shaders` - output debug information for compiled shaders. Requires IMJS_DEBUG_SHADERS to have been set. Accepts 0-2 arguments:
   * `d=output\directory\` - directory into which to put the output files.
   * filter string: a combination of the following characters to filter the output (e.g., `gu` outputs all used glsl shaders, both fragment and vertex):
@@ -218,6 +221,7 @@ display-test-app has access to all key-ins defined in the imodeljs-frontend and 
     * `u` or `n`: output only used or not-used shaders, respectively.
 * `dta drawing aid points` - start tool for testing AccuSnap.
 * `dta refresh tiles` *modelId* - reload tile trees for the specified model, or all models if no modelId is specified.
+* `dta exit` - Shuts down the backend server and exits the app.
 * `dta shutdown` - Closes all open viewports and iModels, invokes IModelApp.shutdown(), and finally breaks in the debugger (if debugger is open). Useful for diagnosing memory leaks.
 * `dta shadow tiles` - Display in all but the selected viewport the tiles that are selected for generating the shadow map for the selected viewport. Updates each time the shadow map is regenerated. Argument: "toggle", "on", or "off"; defaults to "toggle" if not supplied.
 * `dta detach views` - If the selected viewport is displaying a sheet view, remove all view attachments from it.

--- a/test-apps/display-test-app/public/locales/en/SVTTools.json
+++ b/test-apps/display-test-app/public/locales/en/SVTTools.json
@@ -70,6 +70,9 @@
     "ShutDown": {
       "keyin": "dta shutdown"
     },
+    "Exit": {
+      "keyin": "dta exit"
+    },
     "SignIn": {
       "keyin": "dta signin"
     },
@@ -141,6 +144,9 @@
     },
     "GenerateTileContent": {
       "keyin": "dta gen tile"
+    },
+    "Macro": {
+      "keyin": "dta macro"
     }
   }
 }

--- a/test-apps/display-test-app/src/backend/Backend.ts
+++ b/test-apps/display-test-app/src/backend/Backend.ts
@@ -9,7 +9,7 @@ import { ElectronMainAuthorization } from "@itwin/electron-authorization/lib/cjs
 import { ElectronHost, ElectronHostOptions } from "@itwin/core-electron/lib/cjs/ElectronBackend";
 import { IModelBankClient } from "@bentley/imodelhub-client";
 import { IModelHubBackend, UrlFileHandler } from "@bentley/imodelhub-client/lib/cjs/imodelhub-node";
-import { IModelHostConfiguration, LocalhostIpcHost } from "@itwin/core-backend";
+import { IModelHost, IModelHostConfiguration, LocalhostIpcHost } from "@itwin/core-backend";
 import {
   IModelReadRpcInterface, IModelTileRpcInterface, RpcInterfaceDefinition, RpcManager,
   SnapshotIModelRpcInterface,
@@ -20,6 +20,7 @@ import { DtaRpcInterface } from "../common/DtaRpcInterface";
 import { FakeTileCacheService } from "./FakeTileCacheService";
 import { EditCommandAdmin } from "@itwin/editor-backend";
 import * as editorBuiltInCommands from "@itwin/editor-backend";
+import { app } from "electron";
 
 /** Loads the provided `.env` file into process.env */
 function loadEnv(envFile: string) {
@@ -63,6 +64,20 @@ class DisplayTestAppRpc extends DtaRpcInterface {
     return this.writeExternalFile(esvFileName, namedViews);
   }
 
+  public override async readExternalFile(txtFileName: string): Promise<string> {
+    if (ProcessDetector.isMobileAppBackend && process.env.DOCS) {
+      const docPath = process.env.DOCS;
+      txtFileName = path.join(docPath, txtFileName);
+    }
+
+    const dataFileName = this.createTxtFilename(txtFileName);
+    if (!fs.existsSync(dataFileName))
+      return "";
+
+    const contents = fs.readFileSync(dataFileName).toString();
+    return contents ?? "";
+  }
+
   public override async writeExternalFile(fileName: string, content: string): Promise<void> {
     const filePath = this.getFilePath(fileName);
     if (!fs.existsSync(filePath))
@@ -101,6 +116,23 @@ class DisplayTestAppRpc extends DtaRpcInterface {
     if (-1 !== dotIndex)
       return `${fileName.substring(0, dotIndex)}_ESV.json`;
     return `${fileName}.sv`;
+  }
+
+  private createTxtFilename(fileName: string): string {
+    const dotIndex = fileName.lastIndexOf(".");
+    if (-1 === dotIndex)
+      return `${fileName}.txt`;
+    return fileName;
+  }
+
+  public override async terminate() {
+    await IModelHost.shutdown();
+
+    // Electron only
+    if (app !== undefined) app.exit();
+
+    // Browser only
+    if (DtaRpcInterface.backendServer) DtaRpcInterface.backendServer.close();
   }
 }
 

--- a/test-apps/display-test-app/src/backend/WebMain.ts
+++ b/test-apps/display-test-app/src/backend/WebMain.ts
@@ -11,6 +11,7 @@ import { Logger } from "@itwin/core-bentley";
 import { BentleyCloudRpcConfiguration, BentleyCloudRpcManager } from "@itwin/core-common";
 import { getRpcInterfaces, initializeDtaBackend } from "./Backend";
 import { LocalhostIpcHost } from "@itwin/core-backend";
+import { DtaRpcInterface } from "../common/DtaRpcInterface";
 
 /* eslint-disable no-console */
 
@@ -75,9 +76,9 @@ const dtaWebMain = (async () => {
   const announce = () => console.log(`***** display-test-app listening on ${serverConfig.baseUrl}:${app.get("port")}`);
 
   if (serverOptions === undefined) {
-    app.listen(app.get("port"), announce);
+    DtaRpcInterface.backendServer = app.listen(app.get("port"), announce);
   } else {
-    https.createServer(serverOptions, app).listen(app.get("port"), announce);
+    DtaRpcInterface.backendServer = https.createServer(serverOptions, app).listen(app.get("port"), announce);
   }
 });
 

--- a/test-apps/display-test-app/src/common/DtaConfiguration.ts
+++ b/test-apps/display-test-app/src/common/DtaConfiguration.ts
@@ -14,6 +14,7 @@ export interface DtaConfiguration {
   filename?: string;
   standalonePath?: string;    // Used when run in the browser - a common base path for all standalone imodels
   signInForStandalone?: boolean; // If true, and standalone is true, then sign in. Required when opening local files containing reality models.
+  startupMacro?: string;    // Used when running a macro at startup, specifies file path
   enableDiagnostics?: boolean; // If true, all RenderDiagnostics will be enabled (assertions, debug output, GL state checks).
   disabledExtensions?: string[]; // An array of names of WebGL extensions to be disabled
   disableInstancing?: boolean; // default false
@@ -74,6 +75,7 @@ export const getConfig = (): DtaConfiguration => {
   configuration.iModelName = process.env.IMJS_STANDALONE_FILENAME;
   configuration.standalonePath = process.env.IMJS_STANDALONE_FILEPATH; // optional (browser-use only)
   configuration.viewName = process.env.IMJS_STANDALONE_VIEWNAME; // optional
+  configuration.startupMacro = process.env.IMJS_STARTUP_MACRO;
 
   if (undefined !== process.env.IMJS_DISABLE_DIAGNOSTICS)
     configuration.enableDiagnostics = false;

--- a/test-apps/display-test-app/src/common/DtaRpcInterface.ts
+++ b/test-apps/display-test-app/src/common/DtaRpcInterface.ts
@@ -18,7 +18,7 @@ export class DtaRpcInterface extends RpcInterface {
   public static types = () => [];
 
   /** The backend server, when running on a browser */
-  public static backendServer: http.Server | https.Server;
+  public static backendServer: http.Server | https.Server | undefined;
 
   public static getClient(): DtaRpcInterface { return RpcManager.getClientForInterface(DtaRpcInterface); }
   public async readExternalSavedViews(_filename: string): Promise<string> { return this.forward(arguments); }

--- a/test-apps/display-test-app/src/common/DtaRpcInterface.ts
+++ b/test-apps/display-test-app/src/common/DtaRpcInterface.ts
@@ -3,6 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { RpcInterface, RpcManager } from "@itwin/core-common";
+import * as http from "http";
+import * as https from "https";
 
 /** Display Test App RPC interface. */
 export class DtaRpcInterface extends RpcInterface {
@@ -15,8 +17,13 @@ export class DtaRpcInterface extends RpcInterface {
   /** The types that can be marshaled by the interface. */
   public static types = () => [];
 
+  /** The backend server, when running on a browser */
+  public static backendServer: http.Server | https.Server;
+
   public static getClient(): DtaRpcInterface { return RpcManager.getClientForInterface(DtaRpcInterface); }
   public async readExternalSavedViews(_filename: string): Promise<string> { return this.forward(arguments); }
   public async writeExternalSavedViews(_filename: string, _namedViews: string): Promise<void> { return this.forward(arguments); }
+  public async readExternalFile(_filename: string): Promise<string> { return this.forward(arguments); }
   public async writeExternalFile(_filename: string, _content: string): Promise<void> { return this.forward(arguments); }
+  public async terminate(): Promise<void> { return this.forward(arguments); }
 }

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -47,6 +47,7 @@ import { TimePointComparisonTool } from "./TimePointComparison";
 import { UiManager } from "./UiManager";
 import { MarkupTool, ModelClipTool, SaveImageTool, ZoomToSelectedElementsTool } from "./Viewer";
 import { ElectronRendererAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronRenderer";
+import { MacroTool } from "./MacroTools";
 
 class DisplayTestAppAccuSnap extends AccuSnap {
   private readonly _activeSnaps: SnapMode[] = [SnapMode.NearestKeypoint];
@@ -190,6 +191,15 @@ class ShutDownTool extends Tool {
   }
 }
 
+class ExitTool extends Tool {
+  public static override toolId = "Exit";
+
+  public override async run(_args: any[]): Promise<boolean> {
+    await DtaRpcInterface.getClient().terminate();
+    return true;
+  }
+}
+
 export class DisplayTestApp {
   private static _surface?: Surface;
   public static get surface() { return this._surface!; }
@@ -268,12 +278,14 @@ export class DisplayTestApp {
       DockWindowTool,
       DrawingAidTestTool,
       EditingScopeTool,
+      ExitTool,
       FenceClassifySelectedTool,
       FocusWindowTool,
       FrameStatsTool,
       GenerateTileContentTool,
       IncidentMarkerDemoTool,
       PathDecorationTestTool,
+      MacroTool,
       MarkupSelectTestTool,
       MarkupTool,
       MaximizeWindowTool,

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -195,6 +195,7 @@ class ExitTool extends Tool {
   public static override toolId = "Exit";
 
   public override async run(_args: any[]): Promise<boolean> {
+    DisplayTestApp.surface.closeAllViewers();
     await DtaRpcInterface.getClient().terminate();
     return true;
   }

--- a/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
+++ b/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
@@ -144,6 +144,8 @@ const dtaFrontendMain = async () => {
 
     await uiReady; // Now wait for the HTML UI to finish loading.
     await initView(iModel);
+    if (configuration.startupMacro)
+      await IModelApp.tools.parseAndRun(`dta macro ${configuration.startupMacro}`);
   } catch (reason) {
     alert(reason);
     return;

--- a/test-apps/display-test-app/src/frontend/MacroTools.ts
+++ b/test-apps/display-test-app/src/frontend/MacroTools.ts
@@ -12,7 +12,9 @@ export class MacroTool extends Tool {
 
   public override async run(macroFile: string): Promise<boolean> {
     const macroString = await DtaRpcInterface.getClient().readExternalFile(macroFile);
-    const commands = macroString.split ("\r\n");
+    const re = /\r/g;
+    const macroStr2 = macroString.replace (re, "");
+    const commands = macroStr2.split ("\n");
     commands.forEach((item, index) => {
       if(item === "") commands.splice(index,1);
     });
@@ -27,14 +29,14 @@ export class MacroTool extends Tool {
               message = `Cannot find a key-in that matches: ${cmd}`;
               break;
             case ParseAndRunResult.BadArgumentCount:
-              message = "Incorrect number of arguments";
+              message = `Incorrect number of arguments for: ${cmd}`;
               break;
             case ParseAndRunResult.FailedToRun:
-              message = "Key-in failed to run";
+              message = `Key-in failed to run: ${cmd}`;
               break;
           }
         } catch (ex) {
-          message = `Key-in produced exception: ${ex}`;
+          message = `Key-in ${cmd} produced exception: ${ex}`;
         }
         if (undefined !== message)
           await IModelApp.notifications.openMessageBox(MessageBoxType.MediumAlert, message, MessageBoxIconType.Warning);

--- a/test-apps/display-test-app/src/frontend/MacroTools.ts
+++ b/test-apps/display-test-app/src/frontend/MacroTools.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { IModelApp, MessageBoxIconType, MessageBoxType, NotifyMessageDetails, OutputMessagePriority, ParseAndRunResult, Tool } from "@itwin/core-frontend";
+import { DtaRpcInterface } from "../common/DtaRpcInterface";
+
+export class MacroTool extends Tool {
+  public static override toolId = "Macro";
+  public static override get minArgs() { return 1; }
+  public static override get maxArgs() { return 1; }
+
+  public override async run(macroFile: string): Promise<boolean> {
+    const macroString = await DtaRpcInterface.getClient().readExternalFile(macroFile);
+    const commands = macroString.split ("\r\n");
+    commands.forEach((item, index) => {
+      if(item === "") commands.splice(index,1);
+    });
+    if (commands.length === 0)
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, "File not found or no content"));
+    else {
+      for (const cmd of commands) {
+        let message: string | undefined;
+        try {
+          switch (await IModelApp.tools.parseAndRun(cmd)) {
+            case ParseAndRunResult.ToolNotFound:
+              message = `Cannot find a key-in that matches: ${cmd}`;
+              break;
+            case ParseAndRunResult.BadArgumentCount:
+              message = "Incorrect number of arguments";
+              break;
+            case ParseAndRunResult.FailedToRun:
+              message = "Key-in failed to run";
+              break;
+          }
+        } catch (ex) {
+          message = `Key-in produced exception: ${ex}`;
+        }
+        if (undefined !== message)
+          await IModelApp.notifications.openMessageBox(MessageBoxType.MediumAlert, message, MessageBoxIconType.Warning);
+      }
+    }
+    return true;
+  }
+
+  public override async parseAndRun(...args: string[]): Promise<boolean> {
+    const macroFile=args[0];
+    return this.run(macroFile);
+  }
+}


### PR DESCRIPTION
Add a keyin macro capabililty to display-test-app, including a way to run a macro file at startup by setting an enviroment variable IMJS_STARTUP_MACRO=pathToMacroFile.

Besides being generally useful, this allows the overnight runs of ImageTests to have a reliable way to capture the shader usage.

https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/764411