### PR TITLE
iModelHub full stack tests fix

### DIFF
--- a/common/changes/@itwin/imodelhub-client-tests/imodelhub-tests-fix_2021-12-07-13-07.json
+++ b/common/changes/@itwin/imodelhub-client-tests/imodelhub-tests-fix_2021-12-07-13-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodelhub-client-tests",
+      "comment": "Adjusting Checkpoint test setup logic: skip tests if only the Baseline Checkpoint exists.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodelhub-client-tests"
+}

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Checkpoint.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Checkpoint.test.ts
@@ -58,9 +58,8 @@ describe("iModelHub CheckpointHandler", () => {
 
     if (!TestConfig.enableMocks) {
       const checkpoints = await iModelClient.checkpoints.get(accessToken, imodelId);
-      if (checkpoints.length === 0)
+      if (checkpoints.length === 0 || (checkpoints.length === 1 && !checkpoints[0].mergedChangeSetId))
         this.skip();
-      return;
     }
 
     if (!fs.existsSync(workDir)) {

--- a/full-stack-tests/imodelhub-client/src/imodelhub/Checkpoint.test.ts
+++ b/full-stack-tests/imodelhub-client/src/imodelhub/Checkpoint.test.ts
@@ -60,6 +60,7 @@ describe("iModelHub CheckpointHandler", () => {
       const checkpoints = await iModelClient.checkpoints.get(accessToken, imodelId);
       if (checkpoints.length === 0 || (checkpoints.length === 1 && !checkpoints[0].mergedChangeSetId))
         this.skip();
+      return;
     }
 
     if (!fs.existsSync(workDir)) {


### PR DESCRIPTION
In this PR:
- Fixed the test setup logic to skip the Checkpoint test suite not only when no Checkpoints exist but also when the only Checkpoint that exists is a Baseline. This accommodates the new behavior in iModelHub service.