### PR TITLE
Fix for IModel._ecefTrans not being updated when setting IModel._ecefLocation.

### DIFF
--- a/common/changes/@itwin/core-common/set-ecef-location_2021-12-08-13-09.json
+++ b/common/changes/@itwin/core-common/set-ecef-location_2021-12-08-13-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix for IModel._ecefTrans not being updated when setting IModel._ecefLocation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/editor-backend/set-ecef-location_2021-12-08-13-09.json
+++ b/common/changes/@itwin/editor-backend/set-ecef-location_2021-12-08-13-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-backend",
+      "comment": "Fix for IModel._ecefTrans not being updated when setting IModel._ecefLocation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-backend"
+}

--- a/common/changes/@itwin/editor-common/set-ecef-location_2021-12-08-13-09.json
+++ b/common/changes/@itwin/editor-common/set-ecef-location_2021-12-08-13-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-common",
+      "comment": "Fix for IModel._ecefTrans not being updated when setting IModel._ecefLocation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-common"
+}

--- a/core/common/src/IModel.ts
+++ b/core/common/src/IModel.ts
@@ -201,6 +201,7 @@ export interface FilePropertyProps {
 }
 
 /** The position and orientation of an iModel on the earth in [ECEF](https://en.wikipedia.org/wiki/ECEF) (Earth Centered Earth Fixed) coordinates
+ * @note This is an immutable type - all of its properties are frozen.
  * @see [GeoLocation of iModels]($docs/learning/GeoLocation.md)
  * @public
  */

--- a/editor/backend/src/EditBuiltInCommand.ts
+++ b/editor/backend/src/EditBuiltInCommand.ts
@@ -220,6 +220,8 @@ export class BasicManipulationCommand extends EditCommand implements BasicManipu
     if (newExtents.isNull)
       throw new IModelError(DbResult.BE_SQLITE_ERROR, "Invalid project extents");
 
+    await this.iModel.acquireSchemaLock();
+
     this.iModel.updateProjectExtents(newExtents);
 
     // Set source from calculated to user so connectors preserve the change.
@@ -238,6 +240,8 @@ export class BasicManipulationCommand extends EditCommand implements BasicManipu
   }
 
   public async updateEcefLocation(ecefLocation: EcefLocationProps): Promise<void> {
+    await this.iModel.acquireSchemaLock();
+
     // Clear GCS that caller already determined was invalid...
     this.iModel.deleteFileProperty({ name: "DgnGCS", namespace: "dgn_Db" });
 

--- a/editor/common/src/EditorBuiltInIpc.ts
+++ b/editor/common/src/EditorBuiltInIpc.ts
@@ -93,14 +93,14 @@ export interface BasicManipulationCommandIpc extends EditCommandIpc {
 
   /** Update the project extents for the iModel.
    * @param extents New project extents.
-   * @throws [[IModelError]] if unable to update the extents property.
+   * @throws [[IModelError]] if unable to aquire schema lock or update the extents property.
    */
   updateProjectExtents(extents: Range3dProps): Promise<void>;
 
   /** Update the position of the iModel on the earth.
    * @param ecefLocation New ecef location properties.
-   * @throws [[IModelError]] if unable to update the ecef location property.
-   * @note Clears the geographic coordinate reference system of the iModel, should only be called if invalid.
+   * @throws [[IModelError]] if unable to aquire schema lock or update the ecef location property.
+   * @note Clears the geographic coordinate reference system of the iModel, do not call when a valid GCS exists.
    */
   updateEcefLocation(ecefLocation: EcefLocationProps): Promise<void>;
 }


### PR DESCRIPTION
Require schema lock to save changes to project extents and ecef location file properties.