### PR TITLE
Backport fix gradient caching 2866

### DIFF
--- a/common/api/imodeljs-common.api.md
+++ b/common/api/imodeljs-common.api.md
@@ -8181,6 +8181,7 @@ export class ThematicGradientSettings {
     clone(changedProps?: ThematicGradientSettingsProps): ThematicGradientSettings;
     readonly colorMix: number;
     readonly colorScheme: ThematicGradientColorScheme;
+    static compare(lhs: ThematicGradientSettings, rhs: ThematicGradientSettings): number;
     // (undocumented)
     static get contentMax(): number;
     // (undocumented)

--- a/common/changes/@bentley/imodeljs-common/backport-fix-gradient-caching-2866_2021-12-09-14-38.json
+++ b/common/changes/@bentley/imodeljs-common/backport-fix-gradient-caching-2866_2021-12-09-14-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-common",
+      "comment": "Add compare method to ThematicGradientSettings. Fix Gradient.Symb.compareSymb method to also compare thematicSettings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-common",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/imodeljs-frontend/backport-fix-gradient-caching-2866_2021-12-09-14-38.json
+++ b/common/changes/@bentley/imodeljs-frontend/backport-fix-gradient-caching-2866_2021-12-09-14-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/core/common/src/Gradient.ts
+++ b/core/common/src/Gradient.ts
@@ -206,6 +206,16 @@ export namespace Gradient {
         if (!lhs.keys[i].color.equals(rhs.keys[i].color))
           return lhs.keys[i].color.tbgr - rhs.keys[i].color.tbgr;
       }
+      if (lhs.thematicSettings !== rhs.thematicSettings)
+        if (undefined === lhs.thematicSettings)
+          return -1;
+        else if (undefined === rhs.thematicSettings)
+          return 1;
+        else {
+          const thematicCompareResult = ThematicGradientSettings.compare(lhs.thematicSettings, rhs.thematicSettings);
+          if (0 !== thematicCompareResult)
+            return thematicCompareResult;
+        }
       return 0;
     }
 

--- a/core/common/src/ThematicDisplay.ts
+++ b/core/common/src/ThematicDisplay.ts
@@ -6,6 +6,7 @@
  * @module Symbology
  */
 
+import { compareNumbers } from "@bentley/bentleyjs-core";
 import { Point3d, Range1d, Range1dProps, Vector3d, XYZProps } from "@bentley/geometry-core";
 import { ColorDef, ColorDefProps } from "./ColorDef";
 import { Gradient } from "./Gradient";
@@ -117,6 +118,34 @@ export class ThematicGradientSettings {
     }
 
     return true;
+  }
+
+  /** Compares two sets of thematic gradient settings.
+   * @param lhs First set of thematic gradient settings to compare
+   * @param rhs Second set of thematic gradient settings to compare
+   * @returns 0 if lhs is equivalent to rhs, a negative number if lhs compares less than rhs, or a positive number if lhs compares greater than rhs.
+   */
+  public static compare(lhs: ThematicGradientSettings, rhs: ThematicGradientSettings): number {
+    let diff = 0;
+    if ((diff = compareNumbers(lhs.mode, rhs.mode)) !== 0)
+      return diff;
+    if ((diff = compareNumbers(lhs.stepCount, rhs.stepCount)) !== 0)
+      return diff;
+    if ((diff = compareNumbers(lhs.marginColor.tbgr, rhs.marginColor.tbgr)) !== 0)
+      return diff;
+    if ((diff = compareNumbers(lhs.colorScheme, rhs.colorScheme)) !== 0)
+      return diff;
+    if ((diff = compareNumbers(lhs.colorMix, rhs.colorMix)) !== 0)
+      return diff;
+    if ((diff = compareNumbers(lhs.customKeys.length, rhs.customKeys.length)) !== 0)
+      return diff;
+
+    for (let i = 0; i < lhs.customKeys.length; i++) {
+      if ((diff = compareNumbers(lhs.customKeys[i].color.tbgr, rhs.customKeys[i].color.tbgr)) !== 0)
+        return diff;
+    }
+
+    return diff;
   }
 
   private constructor(json?: ThematicGradientSettingsProps) {

--- a/core/common/src/test/ThematicGradientSettings.test.ts
+++ b/core/common/src/test/ThematicGradientSettings.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { ColorDef } from "../ColorDef";
+import { ThematicGradientColorScheme, ThematicGradientMode, ThematicGradientSettings, ThematicGradientSettingsProps } from "../ThematicDisplay";
+
+describe("ThematicGradientSettings", () => {
+  it("compares", () => {
+    const propsA: ThematicGradientSettingsProps = {
+      mode: ThematicGradientMode.Stepped,
+      stepCount: 5,
+      marginColor: ColorDef.blue.toJSON(),
+      colorScheme: ThematicGradientColorScheme.Topographic,
+      customKeys: [
+        {value: 0.0, color: ColorDef.green.toJSON()},
+        {value: 0.5, color: ColorDef.red.toJSON()},
+        {value: 1.0, color: ColorDef.white.toJSON()},
+      ],
+      colorMix: 0.5,
+    };
+    const settingsA = ThematicGradientSettings.fromJSON(propsA);
+
+    // Make sure A equals B when B is fully copied from A.
+    let propsB = settingsA.toJSON();
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.equal(0);
+
+    // Make sure A > B when B lowers the stepCount.
+    propsB = settingsA.toJSON();
+    propsB.stepCount = 4;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.greaterThan(0);
+
+    // Make sure A < B when B raises the stepCount.
+    propsB = settingsA.toJSON();
+    propsB.stepCount = 6;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.lessThan(0);
+
+    // Make sure A > B when B lowers the mode.
+    propsB = settingsA.toJSON();
+    propsB.mode = ThematicGradientMode.Smooth;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.greaterThan(0);
+
+    // // Make sure A < B when B raises the mode.
+    propsB = settingsA.toJSON();
+    propsB.mode = ThematicGradientMode.SteppedWithDelimiter;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.lessThan(0);
+
+    // // Make sure A > B when B lowers the colorScheme.
+    propsB = settingsA.toJSON();
+    propsB.colorScheme = ThematicGradientColorScheme.Monochrome;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.greaterThan(0);
+
+    // // Make sure A < B when B raises the colorScheme.
+    propsB = settingsA.toJSON();
+    propsB.colorScheme = ThematicGradientColorScheme.SeaMountain;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.lessThan(0);
+
+    // // Make sure A > B when B lowers the colorMix.
+    propsB = settingsA.toJSON();
+    propsB.colorMix = 0.4;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.greaterThan(0);
+
+    // Make sure A < B when B raises the colorMix.
+    propsB = settingsA.toJSON();
+    propsB.colorMix = 0.6;
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.lessThan(0);
+
+    // Make sure A !== B when B changes the marginColor.
+    propsB = settingsA.toJSON();
+    propsB.marginColor = ColorDef.red.toJSON();
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.not.equal(0);
+
+    // Make sure A !== B when B changes the customKeys.
+    propsB = settingsA.toJSON();
+    propsB.customKeys = [
+      {value: 0.0, color: ColorDef.black.toJSON()},
+      {value: 0.5, color: ColorDef.white.toJSON()},
+      {value: 1.0, color: ColorDef.green.toJSON()},
+    ],
+    expect(ThematicGradientSettings.compare(settingsA, ThematicGradientSettings.fromJSON(propsB))).to.not.equal(0);
+  });
+});

--- a/core/frontend/src/test/render/webgl/System.test.ts
+++ b/core/frontend/src/test/render/webgl/System.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { ImageSource, ImageSourceFormat, RenderTexture } from "@bentley/imodeljs-common";
+import { Gradient, ImageSource, ImageSourceFormat, RenderTexture } from "@bentley/imodeljs-common";
 import { Capabilities, WebGLContext } from "@bentley/webgl-compatibility";
 import { IModelApp } from "../../../IModelApp";
 import { IModelConnection } from "../../../IModelConnection";
@@ -198,6 +198,41 @@ describe("RenderSystem", () => {
 
     after(async () => {
       await IModelApp.shutdown();
+    });
+
+    function requestThematicGradient(stepCount: number) {
+      const symb = Gradient.Symb.fromJSON({
+        mode: Gradient.Mode.Thematic,
+        thematicSettings: {stepCount},
+        keys: [{ value: 0.6804815398789292, color: 610 }, { value: 0.731472008309797, color: 229 }],
+      });
+      return IModelApp.renderSystem.getGradientTexture(symb, imodel);
+    }
+
+    it("should properly request a thematic gradient texture", async () => {
+      const g1 = requestThematicGradient(5);
+      expect(g1).to.not.be.undefined;
+      g1!.dispose();
+    });
+
+    it("should properly cache and reuse thematic gradient textures", async () => {
+      const g1 = requestThematicGradient(5);
+      expect(g1).to.not.be.undefined;
+      const g2 = requestThematicGradient(5);
+      expect(g2).to.not.be.undefined;
+      expect(g2 === g1).to.be.true;
+      g1!.dispose();
+      g2!.dispose();
+    });
+
+    it("should properly create separate thematic gradient textures if thematic settings differ", async () => {
+      const g1 = requestThematicGradient(5);
+      expect(g1).to.not.be.undefined;
+      const g2 = requestThematicGradient(6);
+      expect(g2).to.not.be.undefined;
+      expect(g2 === g1).to.be.false;
+      g1!.dispose();
+      g2!.dispose();
     });
 
     async function requestTexture(key: string | undefined, source?: ImageSource): Promise<RenderTexture | undefined> {


### PR DESCRIPTION
This is a manual backport of 2.19.x-relevant portions of #2866.

This resolves issues brought up in this discussion thread: https://github.com/iTwin/itwinjs-core/discussions/2818