### PR TITLE
Fix convert RealityDataSourceKey to string

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -6778,8 +6778,8 @@ export interface RealityDataSourceKey {
 
 // @beta
 export namespace RealityDataSourceKey {
+    export function convertToString(rdSourceKey: RealityDataSourceKey): string;
     export function isEqual(key1: RealityDataSourceKey, key2: RealityDataSourceKey): boolean;
-    export function toString(rdSourceKey: RealityDataSourceKey): string;
 }
 
 // @beta

--- a/common/changes/@itwin/core-common/marc.bedard8-FixRealityDataSourceKey.toString_2021-12-09-14-53.json
+++ b/common/changes/@itwin/core-common/marc.bedard8-FixRealityDataSourceKey.toString_2021-12-09-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix problem with RealityDataSourceKey string convertion",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/marc.bedard8-FixRealityDataSourceKey.toString_2021-12-09-14-53.json
+++ b/common/changes/@itwin/core-frontend/marc.bedard8-FixRealityDataSourceKey.toString_2021-12-09-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix problem with RealityDataSourceKey string convertion",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/common/src/ContextRealityModel.ts
+++ b/core/common/src/ContextRealityModel.ts
@@ -109,7 +109,7 @@ export interface RealityDataSourceKey {
  * @beta */
 export namespace RealityDataSourceKey {
   /** Utility function to convert a RealityDataSourceKey into its string representation */
-  export function toString(rdSourceKey: RealityDataSourceKey): string {
+  export function convertToString(rdSourceKey: RealityDataSourceKey): string {
     return `${rdSourceKey.provider}:${rdSourceKey.format}:${rdSourceKey.id}:${rdSourceKey?.iTwinId}`;
   }
   /** Utility function to compare two RealityDataSourceKey, we consider it equal even if itwinId is different */

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -182,7 +182,7 @@ class RealityDataSourceImpl implements RealityDataSource {
    */
   public static async fromKey(rdSourceKey: RealityDataSourceKey, iTwinId: GuidString | undefined): Promise<RealityDataSource | undefined> {
     // search to see if it was already created
-    const rdSourceKeyString = rdSourceKey.toString();
+    const rdSourceKeyString = RealityDataSourceKey.convertToString(rdSourceKey);
     let rdSource = RealityDataSourceImpl._realityDataSources.get(rdSourceKeyString);
     if (rdSource)
       return rdSource;

--- a/core/frontend/src/test/RealityDataSouce.test.ts
+++ b/core/frontend/src/test/RealityDataSouce.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { OrbitGtBlobProps, RealityDataFormat, RealityDataProvider } from "@itwin/core-common";
+import { OrbitGtBlobProps, RealityDataFormat, RealityDataProvider, RealityDataSourceKey } from "@itwin/core-common";
 import { expect } from "chai";
 import { RealityDataSource } from "../RealityDataSource";
 
@@ -15,6 +15,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal(tilesetUrl);
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("TilesetUrl:ThreeDTile::undefined");
   });
   it("should handle creation from CesiumIonAsset url", () => {
     const tilesetUrl = "$CesiumIonAsset=";
@@ -24,6 +26,8 @@ describe("RealityDataSource", () => {
     // dummy id for CesiumIonAsset, we want to hide the url and key
     expect(rdSourceKey.id).to.be.equal("OSMBuildings");
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("CesiumIonAsset:ThreeDTile:OSMBuildings:undefined");
   });
   it("should handle creation from Context Share url", () => {
     const tilesetUrl = "https://connect-realitydataservices.bentley.com/v2.9/Repositories/S3MXECPlugin--5b4ebd22-d94b-456b-8bd8-d59563de9acd/S3MX/RealityData/994fc408-401f-4ee1-91f0-3d7bfba50136";
@@ -32,6 +36,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal("994fc408-401f-4ee1-91f0-3d7bfba50136");
     expect(rdSourceKey.iTwinId).to.equal("5b4ebd22-d94b-456b-8bd8-d59563de9acd");
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:ThreeDTile:994fc408-401f-4ee1-91f0-3d7bfba50136:5b4ebd22-d94b-456b-8bd8-d59563de9acd");
   });
   it("should handle creation from Context Share url with server context", () => {
     const tilesetUrl = "https://connect-realitydataservices.bentley.com/v2.9/Repositories/S3MXECPlugin--server/S3MX/RealityData/994fc408-401f-4ee1-91f0-3d7bfba50136";
@@ -40,6 +46,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal("994fc408-401f-4ee1-91f0-3d7bfba50136");
     expect(rdSourceKey.iTwinId).to.equal("server");
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:ThreeDTile:994fc408-401f-4ee1-91f0-3d7bfba50136:server");
   });
   it("should handle creation from Context Share url with empty guid context", () => {
     const tilesetUrl = "https://connect-realitydataservices.bentley.com/v2.9/Repositories/S3MXECPlugin--00000000-0000-0000-0000-000000000000/S3MX/RealityData/994fc408-401f-4ee1-91f0-3d7bfba50136";
@@ -48,6 +56,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal("994fc408-401f-4ee1-91f0-3d7bfba50136");
     expect(rdSourceKey.iTwinId).to.equal("00000000-0000-0000-0000-000000000000");
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:ThreeDTile:994fc408-401f-4ee1-91f0-3d7bfba50136:00000000-0000-0000-0000-000000000000");
   });
   it("should handle creation from Context Share url using apim in QA (qa-api.bentley.com)", () => {
     const tilesetUrl = "https://qa-api.bentley.com/realitydata/c9fddf2c-e519-468b-b6fa-6d0e39f198a7?projectId=a57f6b1c-747d-4253-b0ce-9900c4dd7c1c";
@@ -56,6 +66,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal("c9fddf2c-e519-468b-b6fa-6d0e39f198a7");
     expect(rdSourceKey.iTwinId).to.equal("a57f6b1c-747d-4253-b0ce-9900c4dd7c1c");
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:ThreeDTile:c9fddf2c-e519-468b-b6fa-6d0e39f198a7:a57f6b1c-747d-4253-b0ce-9900c4dd7c1c");
   });
   it("should handle creation from Context Share url using apim in PROD (api.bentley.com)", () => {
     const tilesetUrl = "https://api.bentley.com/realitydata/c9fddf2c-e519-468b-b6fa-6d0e39f198a7?projectId=a57f6b1c-747d-4253-b0ce-9900c4dd7c1c";
@@ -64,6 +76,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal("c9fddf2c-e519-468b-b6fa-6d0e39f198a7");
     expect(rdSourceKey.iTwinId).to.equal("a57f6b1c-747d-4253-b0ce-9900c4dd7c1c");
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:ThreeDTile:c9fddf2c-e519-468b-b6fa-6d0e39f198a7:a57f6b1c-747d-4253-b0ce-9900c4dd7c1c");
   });
   it("should handle creation from url to an .opc file on an azure blob", () => {
     const tilesetUrl = "https://realityblobqaeussa01.blob.core.windows.net/fe8d32a5-f6ab-4157-b3ec-a9b53db923e3/Tuxford.opc?sv=2020-08-04&se=2021-08-26T05%3A11%3A31Z&sr=c&sp=rl&sig=J9wGT1f3nyKePPj%2FI%2BJdx086GylEfM0P4ZXBQL%2FaRD4%3D";
@@ -72,6 +86,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.OPC);
     expect(rdSourceKey.id).to.be.equal("fe8d32a5-f6ab-4157-b3ec-a9b53db923e3");
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:OPC:fe8d32a5-f6ab-4157-b3ec-a9b53db923e3:undefined");
   });
   it("should handle creation from url to any http server", () => {
     const tilesetUrl = "https://customserver/myFile.json";
@@ -80,6 +96,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal(tilesetUrl);
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("TilesetUrl:ThreeDTile:https://customserver/myFile.json:undefined");
   });
   it("should handle creation from url to any local file", () => {
     const tilesetUrl = "c:\\customserver\\myFile.json";
@@ -88,6 +106,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal(tilesetUrl);
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("TilesetUrl:ThreeDTile:c:\\customserver\\myFile.json:undefined");
   });
   it("should handle creation from url to an OPC local file", () => {
     // we detect format based on extension-> .opc -> OPC format, otherwise 3dTile
@@ -97,6 +117,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.OPC);
     expect(rdSourceKey.id).to.be.equal(tilesetUrl);
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("TilesetUrl:OPC:c:\\customserver\\myFile.opc:undefined");
   });
   it("should handle invalid url and fallback to simply returns it in id as tileset url", () => {
     const tilesetUrl = "Anything that is not a valid url";
@@ -105,6 +127,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal(tilesetUrl);
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("TilesetUrl:ThreeDTile:Anything that is not a valid url:undefined");
   });
   it("should handle creation from Context Share url with provider override", () => {
     const tilesetUrl = "https://connect-realitydataservices.bentley.com/v2.9/Repositories/S3MXECPlugin--5b4ebd22-d94b-456b-8bd8-d59563de9acd/S3MX/RealityData/994fc408-401f-4ee1-91f0-3d7bfba50136";
@@ -114,6 +138,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.ThreeDTile);
     expect(rdSourceKey.id).to.be.equal("994fc408-401f-4ee1-91f0-3d7bfba50136");
     expect(rdSourceKey.iTwinId).to.equal("5b4ebd22-d94b-456b-8bd8-d59563de9acd");
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("TilesetUrl:ThreeDTile:994fc408-401f-4ee1-91f0-3d7bfba50136:5b4ebd22-d94b-456b-8bd8-d59563de9acd");
   });
   it("should handle creation from Context Share url with format override", () => {
     const tilesetUrl = "https://connect-realitydataservices.bentley.com/v2.9/Repositories/S3MXECPlugin--5b4ebd22-d94b-456b-8bd8-d59563de9acd/S3MX/RealityData/994fc408-401f-4ee1-91f0-3d7bfba50136";
@@ -123,6 +149,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(forceFormat);
     expect(rdSourceKey.id).to.be.equal("994fc408-401f-4ee1-91f0-3d7bfba50136");
     expect(rdSourceKey.iTwinId).to.equal("5b4ebd22-d94b-456b-8bd8-d59563de9acd");
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:OPC:994fc408-401f-4ee1-91f0-3d7bfba50136:5b4ebd22-d94b-456b-8bd8-d59563de9acd");
   });
 
   it("should handle creation from a blob url to an .opc file on an azure blob", () => {
@@ -132,6 +160,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.OPC);
     expect(rdSourceKey.id).to.be.equal("fe8d32a5-f6ab-4157-b3ec-a9b53db923e3");
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:OPC:fe8d32a5-f6ab-4157-b3ec-a9b53db923e3:undefined");
   });
   it("should handle creation from blob url with provider override", () => {
     const blobUrl = "https://realityblobqaeussa01.blob.core.windows.net/fe8d32a5-f6ab-4157-b3ec-a9b53db923e3/Tuxford.opc?sv=2020-08-04&se=2021-08-26T05%3A11%3A31Z&sr=c&sp=rl&sig=J9wGT1f3nyKePPj%2FI%2BJdx086GylEfM0P4ZXBQL%2FaRD4%3D";
@@ -141,6 +171,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.OPC);
     expect(rdSourceKey.id).to.be.equal("fe8d32a5-f6ab-4157-b3ec-a9b53db923e3");
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("TilesetUrl:OPC:fe8d32a5-f6ab-4157-b3ec-a9b53db923e3:undefined");
   });
   it("should handle creation from blob url with format override", () => {
     const blobUrl = "https://realityblobqaeussa01.blob.core.windows.net/fe8d32a5-f6ab-4157-b3ec-a9b53db923e3/Tuxford.opc?sv=2020-08-04&se=2021-08-26T05%3A11%3A31Z&sr=c&sp=rl&sig=J9wGT1f3nyKePPj%2FI%2BJdx086GylEfM0P4ZXBQL%2FaRD4%3D";
@@ -150,6 +182,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(forceFormat);
     expect(rdSourceKey.id).to.be.equal("fe8d32a5-f6ab-4157-b3ec-a9b53db923e3");
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:ThreeDTile:fe8d32a5-f6ab-4157-b3ec-a9b53db923e3:undefined");
   });
   it("should handle creation from orbitGtBlobProps", () => {
     const orbitGtBlob: OrbitGtBlobProps = {
@@ -163,6 +197,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.format).to.equal(RealityDataFormat.OPC);
     expect(rdSourceKey.id).to.be.equal("ocpalphaeudata001:a5932aa8-2fde-470d-b5ab-637412ec4e49:/datasources/0b2ad731-ec01-4b8b-8f0f-c99a593f1ff3/Seinajoki_Trees_utm.opc:?sig=EaHCCCSX6bWw%2FOHgad%2Fn3VCgUs2gPbDn%2BE2p5osMYIg%3D&se=2022-01-11T12%3A01%3A20Z&sv=2019-02-02&sp=r&sr=b");
     expect(rdSourceKey.iTwinId).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("OrbitGtBlob:OPC:ocpalphaeudata001:a5932aa8-2fde-470d-b5ab-637412ec4e49:/datasources/0b2ad731-ec01-4b8b-8f0f-c99a593f1ff3/Seinajoki_Trees_utm.opc:?sig=EaHCCCSX6bWw%2FOHgad%2Fn3VCgUs2gPbDn%2BE2p5osMYIg%3D&se=2022-01-11T12%3A01%3A20Z&sv=2019-02-02&sp=r&sr=b:undefined");
     const orbitGtBlobFromKey = RealityDataSource.createOrbitGtBlobPropsFromKey(rdSourceKey);
     expect(orbitGtBlobFromKey).to.not.be.undefined;
     if (orbitGtBlobFromKey !== undefined) {
@@ -186,6 +222,8 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.iTwinId).to.be.undefined;
     const orbitGtBlobFromKey = RealityDataSource.createOrbitGtBlobPropsFromKey(rdSourceKey);
     expect(orbitGtBlobFromKey).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:OPC:fe8d32a5-f6ab-4157-b3ec-a9b53db923e3:undefined");
   });
   it("should handle creation from orbitGtBlobProps when rdsUrl is defined", () => {
     const orbitGtBlob: OrbitGtBlobProps = {
@@ -202,5 +240,7 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.iTwinId).to.be.equal("5b4ebd22-d94b-456b-8bd8-d59563de9acd");
     const orbitGtBlobFromKey = RealityDataSource.createOrbitGtBlobPropsFromKey(rdSourceKey);
     expect(orbitGtBlobFromKey).to.be.undefined;
+    const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
+    expect(rdSourceKeyStr).to.be.equal("ContextShare:OPC:994fc408-401f-4ee1-91f0-3d7bfba50136:5b4ebd22-d94b-456b-8bd8-d59563de9acd");
   });
 });


### PR DESCRIPTION
RealityDataSourceKey namespace defines a method call toString(key: RealityDataSourceKey), this was call by mistake without any parameter.

This results to a call to default toString(). Prevent this confusion by renaming toString to convertToString(key: RealityDataSourceKey) and change call accordingly.