### PR TITLE
Render 2d map when terrain data is not available

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5735,7 +5735,7 @@ export abstract class MapTileProjection {
 
 // @internal (undocumented)
 export class MapTileTree extends RealityTileTree {
-    constructor(params: RealityTileTreeParams, ecefToDb: Transform, bimElevationBias: number, geodeticOffset: number, sourceTilingScheme: MapTilingScheme, id: MapTreeId);
+    constructor(params: RealityTileTreeParams, ecefToDb: Transform, bimElevationBias: number, geodeticOffset: number, sourceTilingScheme: MapTilingScheme, id: MapTreeId, applyTerrain: boolean);
     // (undocumented)
     addImageryLayer(tree: ImageryMapTileTree, settings: MapLayerSettings): void;
     // (undocumented)

--- a/common/changes/@itwin/core-frontend/apply-terrain-fallback_2021-12-10-12-40.json
+++ b/common/changes/@itwin/core-frontend/apply-terrain-fallback_2021-12-10-12-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Render 2d map when terrain data is not available.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/public/locales/en/iModelJs.json
+++ b/core/frontend/src/public/locales/en/iModelJs.json
@@ -39,7 +39,8 @@
     "MapBoxCopyright": "© Mapbox, © OpenStreetMap contributors",
     "CesiumWorldTerrainAttribution": "Cesium World Terrain: Data available from the U.S. Geological Survey, © CGIAR-CSI, Produced using Copernicus data and information funded by the European Union - EU-DEM layers, Data available from Land Information New Zealand, Data available from data.gov.uk, Data courtesy Geoscience Australia",
     "OpenStreetMapContributors": "contributors",
-    "TerrainFallback": "Cannot obtain terrain data"
+    "CannotObtainTerrain": "Terrain is unavailable",
+    "MissingCesiumToken": "The application must be configured with a valid Cesium ION access key to obtain 3d terrain data."
   },
   "ExtensionErrors": {
     "Success": "Extension '{{extensionName}}' loaded",

--- a/core/frontend/src/public/locales/en/iModelJs.json
+++ b/core/frontend/src/public/locales/en/iModelJs.json
@@ -38,7 +38,8 @@
   "BackgroundMap": {
     "MapBoxCopyright": "© Mapbox, © OpenStreetMap contributors",
     "CesiumWorldTerrainAttribution": "Cesium World Terrain: Data available from the U.S. Geological Survey, © CGIAR-CSI, Produced using Copernicus data and information funded by the European Union - EU-DEM layers, Data available from Land Information New Zealand, Data available from data.gov.uk, Data courtesy Geoscience Australia",
-    "OpenStreetMapContributors": "contributors"
+    "OpenStreetMapContributors": "contributors",
+    "TerrainFallback": "Cannot obtain terrain data"
   },
   "ExtensionErrors": {
     "Success": "Extension '{{extensionName}}' loaded",

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -6,7 +6,6 @@
  * @module Tiles
  */
 
-import { MessageSeverity } from "@itwin/appui-abstract";
 import { assert, compareBooleans, compareNumbers, compareStrings, compareStringsOrUndefined, CompressedId64Set, Id64String } from "@itwin/core-bentley";
 import {
   Angle, AngleSweep, Constant, Ellipsoid, EllipsoidPatch, Point3d, Range1d, Range3d, Ray3d, Transform, Vector3d, XYZProps,
@@ -407,8 +406,6 @@ function createViewFlagOverrides(wantLighting: boolean, wantThematic: false | un
   return createDefaultViewFlagOverrides({ clipVolume: false, lighting: wantLighting, thematic: wantThematic });
 }
 
-let terrainFallbackNotification = true;
-
 class MapTreeSupplier implements TileTreeSupplier {
   public readonly isEcefDependent = true;
 
@@ -494,11 +491,8 @@ class MapTreeSupplier implements TileTreeSupplier {
       terrainProvider = await getCesiumTerrainProvider(iModel, modelId, id.wantSkirts, id.wantNormals, id.terrainExaggeration);
 
       if (!terrainProvider) {
-        if (terrainFallbackNotification)
-          IModelApp.notifications.displayMessage(MessageSeverity.Information, IModelApp.localization.getLocalizedString(`BackgroundMap.TerrainFallback`));
         applyTerrain = false;
         geodeticOffset = 0;
-        terrainFallbackNotification = false;
       }
     }
 
@@ -510,10 +504,6 @@ class MapTreeSupplier implements TileTreeSupplier {
     const loader = new MapTileLoader(iModel, modelId, bimElevationBias, terrainProvider);
     const ecefToDb = iModel.getMapEcefToDb(bimElevationBias);
 
-    if (undefined === loader) {
-      assert(false, "Invalid Terrain Provider");
-      return undefined;
-    }
     if (id.maskModelIds)
       await iModel.models.load(CompressedId64Set.decompressSet(id.maskModelIds));
 

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -6,6 +6,7 @@
  * @module Tiles
  */
 
+import { MessageSeverity } from "@itwin/appui-abstract";
 import { assert, compareBooleans, compareNumbers, compareStrings, compareStringsOrUndefined, CompressedId64Set, Id64String } from "@itwin/core-bentley";
 import {
   Angle, AngleSweep, Constant, Ellipsoid, EllipsoidPatch, Point3d, Range1d, Range3d, Ray3d, Transform, Vector3d, XYZProps,
@@ -74,14 +75,15 @@ export class MapTileTree extends RealityTileTree {
   public baseTransparent: boolean;
   public mapTransparent: boolean;
 
-  constructor(params: RealityTileTreeParams, public ecefToDb: Transform, public bimElevationBias: number, public geodeticOffset: number, public sourceTilingScheme: MapTilingScheme, id: MapTreeId) {
+  constructor(params: RealityTileTreeParams, public ecefToDb: Transform, public bimElevationBias: number, public geodeticOffset: number,
+    public sourceTilingScheme: MapTilingScheme, id: MapTreeId, applyTerrain: boolean) {
     super(params);
     this._mercatorTilingScheme = new WebMercatorTilingScheme();
-    this._mercatorFractionToDb = this._mercatorTilingScheme.computeMercatorFractionToDb(ecefToDb, bimElevationBias, params.iModel, id.applyTerrain);
+    this._mercatorFractionToDb = this._mercatorTilingScheme.computeMercatorFractionToDb(ecefToDb, bimElevationBias, params.iModel, applyTerrain);
     const quadId = new QuadId(sourceTilingScheme.rootLevel, 0, 0);
     this.globeOrigin = this.ecefToDb.getOrigin().clone();
     this.earthEllipsoid = Ellipsoid.createCenterMatrixRadii(this.globeOrigin, this.ecefToDb.matrix, Constant.earthRadiusWGS84.equator, Constant.earthRadiusWGS84.equator, Constant.earthRadiusWGS84.polar);
-    const globalHeightRange = id.applyTerrain ? ApproximateTerrainHeights.instance.globalHeightRange : Range1d.createXX(0, 0);
+    const globalHeightRange = applyTerrain ? ApproximateTerrainHeights.instance.globalHeightRange : Range1d.createXX(0, 0);
     const globalRectangle = MapCartoRectangle.create();
 
     this.globeMode = id.globeMode;
@@ -91,7 +93,7 @@ export class MapTileTree extends RealityTileTree {
     this.baseColor = id.baseColor;
     this.baseTransparent = id.baseTransparent;
     this.mapTransparent = id.mapTransparent;
-    if (id.applyTerrain) {
+    if (applyTerrain) {
       this.minEarthEllipsoid = Ellipsoid.createCenterMatrixRadii(this.globeOrigin, this.ecefToDb.matrix, Constant.earthRadiusWGS84.equator + globalHeightRange.low, Constant.earthRadiusWGS84.equator + globalHeightRange.low, Constant.earthRadiusWGS84.polar + globalHeightRange.low);
       this.maxEarthEllipsoid = Ellipsoid.createCenterMatrixRadii(this.globeOrigin, this.ecefToDb.matrix, Constant.earthRadiusWGS84.equator + globalHeightRange.high, Constant.earthRadiusWGS84.equator + globalHeightRange.high, Constant.earthRadiusWGS84.polar + globalHeightRange.high);
     } else {
@@ -405,6 +407,8 @@ function createViewFlagOverrides(wantLighting: boolean, wantThematic: false | un
   return createDefaultViewFlagOverrides({ clipVolume: false, lighting: wantLighting, thematic: wantThematic });
 }
 
+let terrainFallbackNotification = true;
+
 class MapTreeSupplier implements TileTreeSupplier {
   public readonly isEcefDependent = true;
 
@@ -475,7 +479,8 @@ class MapTreeSupplier implements TileTreeSupplier {
   }
 
   public async createTileTree(id: MapTreeId, iModel: IModelConnection): Promise<TileTree | undefined> {
-    let bimElevationBias, terrainProvider, geodeticOffset = 0;
+    let bimElevationBias = 0, terrainProvider, geodeticOffset = 0;
+    let applyTerrain = id.applyTerrain;
     const modelId = iModel.transientIds.next;
     const gcsConverterAvailable = await getGcsConverterAvailable(iModel);
 
@@ -487,12 +492,21 @@ class MapTreeSupplier implements TileTreeSupplier {
       bimElevationBias = - await this.computeHeightBias(id.terrainHeightOrigin, id.terrainHeightOriginMode, id.terrainExaggeration, iModel, elevationProvider);
       geodeticOffset = await elevationProvider.getGeodeticToSeaLevelOffset(iModel.projectExtents.center, iModel);
       terrainProvider = await getCesiumTerrainProvider(iModel, modelId, id.wantSkirts, id.wantNormals, id.terrainExaggeration);
-    } else {
+
+      if (!terrainProvider) {
+        if (terrainFallbackNotification)
+          IModelApp.notifications.displayMessage(MessageSeverity.Information, IModelApp.localization.getLocalizedString(`BackgroundMap.TerrainFallback`));
+        applyTerrain = false;
+        geodeticOffset = 0;
+        terrainFallbackNotification = false;
+      }
+    }
+
+    if (!terrainProvider) {
       terrainProvider = new EllipsoidTerrainProvider(iModel, modelId, id.wantSkirts);
       bimElevationBias = id.mapGroundBias;
     }
-    if (undefined === terrainProvider)
-      return undefined;
+
     const loader = new MapTileLoader(iModel, modelId, bimElevationBias, terrainProvider);
     const ecefToDb = iModel.getMapEcefToDb(bimElevationBias);
 
@@ -504,7 +518,7 @@ class MapTreeSupplier implements TileTreeSupplier {
       await iModel.models.load(CompressedId64Set.decompressSet(id.maskModelIds));
 
     const treeProps = new MapTileTreeProps(modelId, loader, iModel, gcsConverterAvailable);
-    return new MapTileTree(treeProps, ecefToDb, bimElevationBias, geodeticOffset, terrainProvider.tilingScheme, id);
+    return new MapTileTree(treeProps, ecefToDb, bimElevationBias, geodeticOffset, terrainProvider.tilingScheme, id, applyTerrain);
   }
 }
 


### PR DESCRIPTION
This PR enables rendering of 2d map when terrain data is not available.
The user is notified about that via the notifications system.