### PR TITLE
Fix map layer collation to meshes

### DIFF
--- a/common/changes/@itwin/core-frontend/Fix-map-layer-collation-to-meshes_2021-12-10-14-43.json
+++ b/common/changes/@itwin/core-frontend/Fix-map-layer-collation-to-meshes_2021-12-10-14-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Correct loop for collating imagery tiles to map mesh primitives",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/RealityMesh.ts
+++ b/core/frontend/src/render/webgl/RealityMesh.ts
@@ -206,10 +206,10 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
               if (!textureRange.isNull)
                 layerTextures.push(new TerrainTexture(secondaryTexture.texture, secondaryTexture.featureId, secondaryTexture.scale, secondaryTexture.translate, secondaryTexture.targetRectangle, secondaryTexture.layerIndex, secondaryTexture.transparency, textureRange));
             }
-            layerTextures.length = Math.min(layerTextures.length, texturesPerMesh);
-            meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain));
           }
         }
+        layerTextures.length = Math.min(layerTextures.length, texturesPerMesh);
+        meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain));
       }
     }
 


### PR DESCRIPTION
Mesh primitives were generated incorrectly when collating the imagery textures.  The spurious primitives caused the tool tips to stop working.