### PR TITLE
Make version name required for now in FrontendHubAccess.getChangesetFromNamedVersion

### DIFF
--- a/clients/imodelhub/src/IModelHub.ts
+++ b/clients/imodelhub/src/IModelHub.ts
@@ -62,11 +62,11 @@ export class IModelHubFrontend implements FrontendHubAccess {
     return this.getLatestChangeset(arg);
   }
 
-  public async getChangesetFromNamedVersion(arg: IModelIdArg & { versionName?: string }): Promise<ChangesetIndexAndId> {
-    const versionQuery = arg.versionName ? new VersionQuery().select("ChangeSetId").byName(arg.versionName) : new VersionQuery().top(1);
+  public async getChangesetFromNamedVersion(arg: IModelIdArg & { versionName: string }): Promise<ChangesetIndexAndId> {
+    const versionQuery = new VersionQuery().select("ChangeSetId").byName(arg.versionName);
     const versions: Version[] = await this.hubClient.versions.get(arg.accessToken, arg.iModelId, versionQuery);
     if (!versions[0] || !versions[0].changeSetIndex || !versions[0].changeSetId)
-      throw new BentleyError(BentleyStatus.ERROR, `Named version ${arg.versionName ?? ""} not found`);
+      throw new BentleyError(BentleyStatus.ERROR, `Named version ${arg.versionName} not found`);
     return { index: versions[0].changeSetIndex, id: versions[0].changeSetId };
   }
 

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3282,7 +3282,7 @@ export class FrameStatsCollector {
 // @public (undocumented)
 export interface FrontendHubAccess {
     getChangesetFromNamedVersion(arg: IModelIdArg & {
-        versionName?: string;
+        versionName: string;
     }): Promise<ChangesetIndexAndId>;
     // (undocumented)
     getChangesetFromVersion(arg: IModelIdArg & {

--- a/common/api/imodelhub-client.api.md
+++ b/common/api/imodelhub-client.api.md
@@ -880,7 +880,7 @@ export enum IModelHubEventType {
 export class IModelHubFrontend implements FrontendHubAccess {
     // (undocumented)
     getChangesetFromNamedVersion(arg: IModelIdArg & {
-        versionName?: string;
+        versionName: string;
     }): Promise<ChangesetIndexAndId>;
     // (undocumented)
     getChangesetFromVersion(arg: IModelIdArg & {

--- a/common/changes/@bentley/imodelhub-client/frontend-hub-access_2021-12-13-13-52.json
+++ b/common/changes/@bentley/imodelhub-client/frontend-hub-access_2021-12-13-13-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelhub-client",
+      "comment": "React to HubAccess Api change",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelhub-client"
+}

--- a/common/changes/@itwin/core-frontend/frontend-hub-access_2021-12-13-13-52.json
+++ b/common/changes/@itwin/core-frontend/frontend-hub-access_2021-12-13-13-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Make versionName required for time being",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/FrontendHubAccess.ts
+++ b/core/frontend/src/FrontendHubAccess.ts
@@ -19,5 +19,8 @@ export interface IModelIdArg {
 export interface FrontendHubAccess {
   getLatestChangeset(arg: IModelIdArg): Promise<ChangesetIndexAndId>;
   getChangesetFromVersion(arg: IModelIdArg & { version: IModelVersion }): Promise<ChangesetIndexAndId>;
+  /**
+   * Fetches the changeset with the given named version.
+   */
   getChangesetFromNamedVersion(arg: IModelIdArg & { versionName: string }): Promise<ChangesetIndexAndId>;
 }

--- a/core/frontend/src/FrontendHubAccess.ts
+++ b/core/frontend/src/FrontendHubAccess.ts
@@ -19,9 +19,5 @@ export interface IModelIdArg {
 export interface FrontendHubAccess {
   getLatestChangeset(arg: IModelIdArg): Promise<ChangesetIndexAndId>;
   getChangesetFromVersion(arg: IModelIdArg & { version: IModelVersion }): Promise<ChangesetIndexAndId>;
-  /**
-   * Fetches the changeset with the given named version.
-   * @param versionName If omitted will default to the latest named version.
-   */
-  getChangesetFromNamedVersion(arg: IModelIdArg & { versionName?: string }): Promise<ChangesetIndexAndId>;
+  getChangesetFromNamedVersion(arg: IModelIdArg & { versionName: string }): Promise<ChangesetIndexAndId>;
 }

--- a/full-stack-tests/core/src/frontend/hub/ITwinPlatformEnv.ts
+++ b/full-stack-tests/core/src/frontend/hub/ITwinPlatformEnv.ts
@@ -64,11 +64,11 @@ export class IModelBankFrontend implements TestFrontendHubAccess {
     return this.getLatestChangeset(arg);
   }
 
-  public async getChangesetFromNamedVersion(arg: IModelIdArg & { versionName?: string }): Promise<ChangesetIndexAndId> {
-    const versionQuery = arg.versionName ? new VersionQuery().select("ChangeSetId").byName(arg.versionName) : new VersionQuery().top(1);
+  public async getChangesetFromNamedVersion(arg: IModelIdArg & { versionName: string }): Promise<ChangesetIndexAndId> {
+    const versionQuery = new VersionQuery().select("ChangeSetId").byName(arg.versionName);
     const versions = await this._hubClient.versions.get(arg.accessToken, arg.iModelId, versionQuery);
     if (!versions[0] || !versions[0].changeSetIndex || !versions[0].changeSetId)
-      throw new BentleyError(BentleyStatus.ERROR, `Named version ${arg.versionName ?? ""} not found`);
+      throw new BentleyError(BentleyStatus.ERROR, `Named version ${arg.versionName} not found`);
     return { index: versions[0].changeSetIndex, id: versions[0].changeSetId };
   }
 


### PR DESCRIPTION
IModelHub team needs some time to implement this change and would hold up 3.0 release. Temporarily make it required