### PR TITLE
Remove optimization that keep RealityDataSource from key in a list.

### DIFF
--- a/common/changes/@itwin/core-frontend/marc.bedard8-Remove_unnecessary_realityDataSourceList_2021-12-14-13-20.json
+++ b/common/changes/@itwin/core-frontend/marc.bedard8-Remove_unnecessary_realityDataSourceList_2021-12-14-13-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Remove optimization that keep RealityDataSource from key in a list.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -177,7 +177,6 @@ class RealityDataSourceImpl implements RealityDataSource {
     return (tilesetUrl !== undefined) ? rdSource: undefined;
   }
   /** Return an instance of a RealityDataSource from a source key.
-   * There will aways be only one reality data connection for a corresponding reality data source key.
    */
   public static async fromKey(rdSourceKey: RealityDataSourceKey, iTwinId: GuidString | undefined): Promise<RealityDataSource | undefined> {
     return RealityDataSourceImpl.createFromKey(rdSourceKey,  iTwinId);

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -138,7 +138,6 @@ export namespace RealityDataSource {
 * @beta
 */
 class RealityDataSourceImpl implements RealityDataSource {
-  private static _realityDataSources = new Map<string, RealityDataSource>();
   public readonly key: RealityDataSourceKey;
   /** The URL that supplies the 3d tiles for displaying the reality model. */
   private _tilesetUrl: string | undefined;
@@ -181,16 +180,7 @@ class RealityDataSourceImpl implements RealityDataSource {
    * There will aways be only one reality data connection for a corresponding reality data source key.
    */
   public static async fromKey(rdSourceKey: RealityDataSourceKey, iTwinId: GuidString | undefined): Promise<RealityDataSource | undefined> {
-    // search to see if it was already created
-    const rdSourceKeyString = RealityDataSourceKey.convertToString(rdSourceKey);
-    let rdSource = RealityDataSourceImpl._realityDataSources.get(rdSourceKeyString);
-    if (rdSource)
-      return rdSource;
-    // If not already in our list, create and add it to our list before returing it.
-    rdSource = await RealityDataSourceImpl.createFromKey(rdSourceKey,  iTwinId);
-    if (rdSource)
-      RealityDataSourceImpl._realityDataSources.set(rdSourceKeyString,rdSource);
-    return rdSource;
+    return RealityDataSourceImpl.createFromKey(rdSourceKey,  iTwinId);
   }
   public get isContextShare(): boolean {
     return (this.key.provider === RealityDataProvider.ContextShare);


### PR DESCRIPTION
We are keeping RealityDataSource created from key and a list so that every time the source is required it doesn't need to call the context share server.
This was causing several problem with state that change but list is not updated (see https://github.com/iTwin/itwinjs-core/pull/2882#issuecomment-992944899)
This optimization is not required any more since underlying code has been optimize to only use one RealityDataSource instead of calling create several time.