### PR TITLE
stop overriding tile admin props

### DIFF
--- a/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
+++ b/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
@@ -24,10 +24,15 @@ class MarkerHandler extends SectionMarkerHandler {
 export class DisplayPerfTestApp {
   public static async startup(iModelApp?: IModelAppOptions): Promise<void> {
     iModelApp = iModelApp ?? {};
-    iModelApp.tileAdmin = {
-      minimumSpatialTolerance: 0,
-      cesiumIonKey: process.env.IMJS_CESIUM_ION_KEY,
-    };
+    if (iModelApp.tileAdmin === undefined) {
+      iModelApp.tileAdmin = {
+        minimumSpatialTolerance: 0,
+        cesiumIonKey: process.env.IMJS_CESIUM_ION_KEY,
+      };
+    } else {
+      iModelApp.tileAdmin.minimumSpatialTolerance = 0;
+      iModelApp.tileAdmin.cesiumIonKey = process.env.IMJS_CESIUM_ION_KEY;
+    }
 
     /* eslint-disable @typescript-eslint/naming-convention */
     iModelApp.mapLayerOptions = {


### PR DESCRIPTION
display-performance-test-app lets you specify tile admin properties in the config file, but these were being totally overridden by recent changes so that they were ignored.