### PR TITLE
Remove transform CSS property when animation ends.

### DIFF
--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -1465,7 +1465,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentDidUpdate(previousProps: PopupProps): void;
+    componentDidUpdate(previousProps: PopupProps, prevState: PopupState): void;
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)

--- a/common/changes/@itwin/core-react/select-in-popup_2021-12-20-13-55.json
+++ b/common/changes/@itwin/core-react/select-in-popup_2021-12-20-13-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Fix Select menu position when redered in a Popup.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/core-react/src/core-react/popup/Popup.scss
+++ b/ui/core-react/src/core-react/popup/Popup.scss
@@ -29,6 +29,10 @@
  &.core-popup-hidden {
   display: none;
  }
+
+ &.core-animation-ended {
+   animation-name: none;
+ }
 }
 
 .core-popup.arrow::after, .core-popup.arrow::before {

--- a/ui/core-react/src/test/popup/Popup.test.tsx
+++ b/ui/core-react/src/test/popup/Popup.test.tsx
@@ -322,6 +322,21 @@ describe("<Popup />", () => {
     expect(component.queryByTestId("NestedPopup-Button")).to.be.null;
   });
 
+  it("should remove animation", () => {
+    const wrapper = mount<PopupProps>(<Popup isOpen />);
+    const popup = wrapper.find(".core-popup");
+    wrapper.state("animationEnded").should.false;
+
+    const element = document.createElement("div");
+    popup.simulate("animationEnd", { target: element });
+    wrapper.state("animationEnded").should.false;
+
+    popup.simulate("animationEnd");
+    wrapper.state("animationEnded").should.true;
+
+    wrapper.unmount();
+  });
+
   describe("renders", () => {
     it("should render with few props", () => {
       const wrapper = mount(


### PR DESCRIPTION
Remove `transform` CSS property from a `Popup` after animation ends (by removing `animation-name`).
This fixes an issue where `Select` dropdown/menu is not visible when rendered in a `Popup` (by default `Select` uses fixed positioning, which doesn't work correctly when parent element has a CSS `transform` property applied).