### PR TITLE
Fix some oversights in GltfReader

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3631,13 +3631,11 @@ export class GltfMeshData {
 
 // @internal
 export abstract class GltfReader {
-    protected constructor(props: GltfReaderProps, iModel: IModelConnection, is3d: boolean, system: RenderSystem, type?: BatchType, isCanceled?: ShouldAbortReadGltf, deduplicateVertices?: boolean);
+    protected constructor(args: GltfReaderArgs);
     // (undocumented)
     protected get _accessors(): GltfDictionary<GltfAccessor>;
     // (undocumented)
     protected readonly _binaryData: Uint8Array;
-    // (undocumented)
-    protected readonly _buffer: ByteStream;
     // (undocumented)
     protected get _bufferViews(): GltfDictionary<GltfBufferViewProps>;
     // (undocumented)
@@ -3708,15 +3706,27 @@ export abstract class GltfReader {
     // (undocumented)
     protected readonly _type: BatchType;
     // (undocumented)
+    protected readonly _vertexTableRequired: boolean;
+    // (undocumented)
     protected readonly _yAxisUp: boolean;
+}
+
+// @internal
+export interface GltfReaderArgs {
+    deduplicateVertices?: boolean;
+    iModel: IModelConnection;
+    is2d?: boolean;
+    props: GltfReaderProps;
+    shouldAbort?: ShouldAbortReadGltf;
+    system?: RenderSystem;
+    type?: BatchType;
+    vertexTableRequired?: boolean;
 }
 
 // @internal
 export class GltfReaderProps {
     // (undocumented)
     readonly binaryData: Uint8Array;
-    // (undocumented)
-    readonly buffer: ByteStream;
     static create(buffer: ByteStream, yAxisUp?: boolean): GltfReaderProps | undefined;
     // (undocumented)
     readonly glTF: Gltf;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -210,6 +210,7 @@ internal;GltfDataBuffer = Uint8Array | Uint16Array | Uint32Array | Float32Array
 internal;GltfDataType
 internal;GltfMeshData
 internal;class GltfReader
+internal;GltfReaderArgs
 internal;GltfReaderProps
 internal;GltfReaderResult 
 internal;GLTimerResult

--- a/common/changes/@itwin/core-frontend/gltf-fixes_2021-12-21-13-46.json
+++ b/common/changes/@itwin/core-frontend/gltf-fixes_2021-12-21-13-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix some oversights in implementation of glTF.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/B3dmReader.ts
+++ b/core/frontend/src/tile/B3dmReader.ts
@@ -59,8 +59,11 @@ export class B3dmReader extends GltfReader {
 
   private constructor(props: GltfReaderProps, iModel: IModelConnection, modelId: Id64String, is3d: boolean, system: RenderSystem,
     private _range: ElementAlignedBox3d, private _isLeaf: boolean, private _batchTableLength: number, private _transformToRoot?: Transform, private _batchTableJson?: any
-    , isCanceled?: ShouldAbortReadGltf, private _idMap?: BatchedTileIdMap, private _pseudoRtcBias?: Vector3d, deduplicateVertices=false) {
-    super(props, iModel, is3d, system, BatchType.Primary, isCanceled, deduplicateVertices);
+    , shouldAbort?: ShouldAbortReadGltf, private _idMap?: BatchedTileIdMap, private _pseudoRtcBias?: Vector3d, deduplicateVertices=false) {
+    super({
+      props, iModel, system, shouldAbort, deduplicateVertices,
+      is2d: !is3d,
+    });
     this._modelId = modelId;
   }
 

--- a/core/frontend/src/tile/B3dmReader.ts
+++ b/core/frontend/src/tile/B3dmReader.ts
@@ -8,7 +8,7 @@
 
 import { ByteStream, Id64String, JsonUtils } from "@itwin/core-bentley";
 import { Point3d, Transform, Vector3d } from "@itwin/core-geometry";
-import { B3dmHeader, BatchType, ColorDef, ElementAlignedBox3d, Feature, FeatureTable, TileReadStatus } from "@itwin/core-common";
+import { B3dmHeader, ColorDef, ElementAlignedBox3d, Feature, FeatureTable, TileReadStatus } from "@itwin/core-common";
 import { IModelConnection } from "../IModelConnection";
 import { Mesh } from "../render/primitives/mesh/MeshPrimitives";
 import { RenderSystem } from "../render/RenderSystem";

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1501,7 +1501,7 @@ export abstract class GltfReader {
     try {
       const binaryImageJson = (imageJson.extensions && imageJson.extensions.KHR_binary_glTF) ? JsonUtils.asObject(imageJson.extensions.KHR_binary_glTF) : imageJson;
       const bufferView = this._bufferViews[binaryImageJson.bufferView];
-      if (!bufferView?.byteOffset || !bufferView?.byteLength)
+      if (!bufferView || undefined === bufferView.byteLength || bufferView.byteLength <= 0)
         return undefined;
 
       const mimeType = JsonUtils.asString(binaryImageJson.mimeType);
@@ -1514,7 +1514,7 @@ export abstract class GltfReader {
         (undefined !== samplerJson.wrapS || undefined !== samplerJson.wrapT))
         textureType = RenderTexture.Type.TileSection;
 
-      const offset = bufferView.byteOffset;
+      const offset = bufferView.byteOffset ?? 0;
 
       /* -----------------------------------
           const jpegArray = this._binaryData.slice(offset, offset + bufferView.byteLength);

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -542,7 +542,6 @@ export interface GltfReaderResult extends TileContent {
  */
 export class GltfReaderProps {
   private constructor(
-    public readonly buffer: ByteStream,
     public readonly binaryData: Uint8Array,
     public readonly glTF: Gltf,
     public readonly yAxisUp: boolean) { }
@@ -585,7 +584,7 @@ export class GltfReaderProps {
         techniques: JsonUtils.asObject(json.techniques),
       };
 
-      return glTF.meshes ? new GltfReaderProps(buffer, binaryData, glTF, yAxisUp) : undefined;
+      return glTF.meshes ? new GltfReaderProps(binaryData, glTF, yAxisUp) : undefined;
     } catch (e) {
       return undefined;
     }
@@ -714,7 +713,6 @@ export interface GltfReaderArgs {
  * @internal
  */
 export abstract class GltfReader {
-  protected readonly _buffer: ByteStream;
   protected readonly _binaryData: Uint8Array;
   protected readonly _glTF: Gltf;
   protected readonly _iModel: IModelConnection;
@@ -984,7 +982,6 @@ export abstract class GltfReader {
   public readBufferDataFloat(json: any, accessorName: string): GltfBufferData | undefined { return this.readBufferData(json, accessorName, GltfDataType.Float); }
 
   protected constructor(args: GltfReaderArgs) {
-    this._buffer = args.props.buffer;
     this._binaryData = args.props.binaryData;
     this._glTF = args.props.glTF;
     this._yAxisUp = args.props.yAxisUp;

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -697,16 +697,32 @@ class TransformStack {
   }
 }
 
-/** @internal */
+/** Arguments to [[GltfReader]] constructor.
+ * @internal
+ */
 export interface GltfReaderArgs {
-  props: GltfReaderProps,
-  iModel: IModelConnection,
-  is2d?: boolean,
-  system?: RenderSystem,
-  type?: BatchType, // default Primary
-  shouldAbort?: ShouldAbortReadGltf,
-  deduplicateVertices?: boolean,
-  vertexTableRequired?: boolean,
+  /** Properties of the glTF source. */
+  props: GltfReaderProps;
+  /** The iModel with which the graphics are to be associated. */
+  iModel: IModelConnection;
+  /** If true, create 2d graphics. */
+  is2d?: boolean;
+  /** The render system that will produce the graphics. Defaults to [[IModelApp.renderSystem]]. */
+  system?: RenderSystem;
+  /** The type of batch to create. Defaults to [BatchType.Primary]($common).
+   * @see [[RenderSystem.createBatch]].
+   */
+  type?: BatchType;
+  /** An optional function that, if supplied, is invoked periodically to determine if the process of producing graphics from the glTF should terminate early. */
+  shouldAbort?: ShouldAbortReadGltf;
+  /** If true, each vertex in the graphics should belong to exactly one triangle. This is less efficient than sharing vertices between adjoining triangles, but
+   * sometimes required - for example, for [ViewFlags.wiremesh]($common).
+   */
+  deduplicateVertices?: boolean;
+  /** If true, the graphics produced will always use a [[VertexTable]]; otherwise, where possible a [[RealityMeshPrimitive]] will be used instead.
+   * Reality meshes are simpler but do not support some features like lighting.
+   */
+  vertexTableRequired?: boolean;
 }
 
 /** Deserializes [glTF](https://www.khronos.org/gltf/).

--- a/core/frontend/src/tile/I3dmReader.ts
+++ b/core/frontend/src/tile/I3dmReader.ts
@@ -73,8 +73,11 @@ export class I3dmReader extends GltfReader {
 
   private constructor(private _featureBinary: Uint8Array, private _featureJson: any, private _batchTableJson: any, props: GltfReaderProps,
     iModel: IModelConnection, modelId: Id64String, is3d: boolean, system: RenderSystem, private _range: ElementAlignedBox3d,
-    private _isLeaf: boolean, isCanceled?: ShouldAbortReadGltf, private _idMap?: BatchedTileIdMap, deduplicateVertices=false) {
-    super(props, iModel, is3d, system, BatchType.Primary, isCanceled, deduplicateVertices);
+    private _isLeaf: boolean, shouldAbort?: ShouldAbortReadGltf, private _idMap?: BatchedTileIdMap, deduplicateVertices=false) {
+    super({
+      props, iModel, system, shouldAbort, deduplicateVertices,
+      is2d: !is3d,
+    });
     this._modelId = modelId;
   }
 

--- a/core/frontend/src/tile/I3dmReader.ts
+++ b/core/frontend/src/tile/I3dmReader.ts
@@ -7,7 +7,7 @@
  */
 import { ByteStream, Id64String, JsonUtils, utf8ToString } from "@itwin/core-bentley";
 import { AxisOrder, Matrix3d, Point3d, Vector3d } from "@itwin/core-geometry";
-import { BatchType, ElementAlignedBox3d, Feature, FeatureTable, I3dmHeader, TileReadStatus } from "@itwin/core-common";
+import { ElementAlignedBox3d, Feature, FeatureTable, I3dmHeader, TileReadStatus } from "@itwin/core-common";
 import { IModelConnection } from "../IModelConnection";
 import { InstancedGraphicParams } from "../render/InstancedGraphicParams";
 import { Mesh } from "../render/primitives/mesh/MeshPrimitives";


### PR DESCRIPTION
1. A RealityMeshPrimitive was always produced for textured meshes. Reality meshes don't support lighting, so these meshes appeared unlit despite having normals.
	- Added a "vertex table required" flag to force creation of a lit mesh. readGltfGraphics() sets this flag. This remains a problem for 3d tilesets that want lighting though.
2. Some images and other data were not being loaded because `byteOffset` was omitted. This property is optional and defaults to zero.
3. Incidental cleanup related to the above.