### PR TITLE
Fix terrain when changing display style

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5702,7 +5702,7 @@ export class MapTile extends RealityTile {
 
 // @internal (undocumented)
 export class MapTiledGraphicsProvider implements TiledGraphicsProvider {
-    constructor(_vp: Viewport);
+    constructor(viewportId: number, displayStyle: DisplayStyleState);
     // (undocumented)
     readonly backgroundDrapeMap: MapTileTreeReference;
     // (undocumented)
@@ -5719,7 +5719,7 @@ export class MapTiledGraphicsProvider implements TiledGraphicsProvider {
     readonly overlayMap: MapTileTreeReference;
     // (undocumented)
     setView(newView: ViewState): void;
-    }
+}
 
 // @internal
 export class MapTileLoader extends RealityTileLoader {

--- a/common/changes/@itwin/core-frontend/fix-map-provider-listener_2021-12-21-16-25.json
+++ b/common/changes/@itwin/core-frontend/fix-map-provider-listener_2021-12-21-16-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix viewport using terrain settings from previous display style when display style is reassigned.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -966,7 +966,7 @@ export abstract class Viewport implements IDisposable {
     this.registerDisplayStyleListeners(this.view.displayStyle);
     this.registerViewListeners();
     this.view.attachToViewport(this);
-    this._mapTiledGraphicsProvider = new MapTiledGraphicsProvider(this);
+    this._mapTiledGraphicsProvider = new MapTiledGraphicsProvider(this.viewportId, this.displayStyle);
   }
 
   private registerViewListeners(): void {
@@ -990,7 +990,7 @@ export abstract class Viewport implements IDisposable {
       this.invalidateRenderPlan();
 
       this.detachFromDisplayStyle();
-      this._mapTiledGraphicsProvider = new MapTiledGraphicsProvider(this);
+      this._mapTiledGraphicsProvider = new MapTiledGraphicsProvider(this.viewportId, newStyle);
       this.registerDisplayStyleListeners(newStyle);
     }));
 

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { BeDuration, UnexpectedErrors } from "@itwin/core-bentley";
+import { UnexpectedErrors } from "@itwin/core-bentley";
 import { AnalysisStyle } from "@itwin/core-common";
 import { ScreenViewport } from "../Viewport";
 import { DisplayStyle3dState } from "../DisplayStyleState";
@@ -133,7 +133,7 @@ describe("Viewport", () => {
       expect(viewport.backgroundMap!.settings.applyTerrain).to.equal(expected);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       expectBackgroundMap(false);
       expectTerrain(false);
 
@@ -142,7 +142,7 @@ describe("Viewport", () => {
       expectTerrain(false);
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       viewport.view.displayStyle = new DisplayStyle3dState({} as any, viewport.iModel);
       expectBackgroundMap(false);
       expectTerrain(false);

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -4,9 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { UnexpectedErrors } from "@itwin/core-bentley";
+import { BeDuration, UnexpectedErrors } from "@itwin/core-bentley";
 import { AnalysisStyle } from "@itwin/core-common";
 import { ScreenViewport } from "../Viewport";
+import { DisplayStyle3dState } from "../DisplayStyleState";
 import { IModelApp } from "../IModelApp";
 import { openBlankViewport } from "./openBlankViewport";
 
@@ -119,6 +120,69 @@ describe("Viewport", () => {
 
       expectChangedEvent("undefined", () => viewport.displayStyle.settings.analysisStyle = undefined);
       expectChangedEvent("none", () => viewport.displayStyle.settings.analysisStyle = undefined);
+    });
+  });
+
+  describe("background map", () => {
+    function expectBackgroundMap(expected: boolean) {
+      expect(viewport.viewFlags.backgroundMap).to.equal(expected);
+    }
+
+    function expectTerrain(expected: boolean) {
+      expect(viewport.backgroundMap).not.to.be.undefined; // this is *never* undefined despite type annotation...
+      expect(viewport.backgroundMap!.settings.applyTerrain).to.equal(expected);
+    }
+
+    beforeEach(async () => {
+      expectBackgroundMap(false);
+      expectTerrain(false);
+
+      viewport.viewFlags = viewport.viewFlags.with("backgroundMap", true);
+      expectBackgroundMap(true);
+      expectTerrain(false);
+    });
+
+    afterEach(async () => {
+      viewport.view.displayStyle = new DisplayStyle3dState({} as any, viewport.iModel);
+      expectBackgroundMap(false);
+      expectTerrain(false);
+    });
+
+    it("updates when display style is assigned to", () => {
+      let style = viewport.displayStyle.clone();
+      style.viewFlags = style.viewFlags.with("backgroundMap", false);
+      viewport.displayStyle = style;
+      expectBackgroundMap(false);
+      expectTerrain(false);
+
+      style = style.clone();
+      style.viewFlags = style.viewFlags.with("backgroundMap", true);
+      style.settings.applyOverrides({ backgroundMap: { applyTerrain: true } });
+      viewport.displayStyle = style;
+      expectBackgroundMap(true);
+      expectTerrain(true);
+
+      style = style.clone();
+      style.settings.applyOverrides({ backgroundMap: { applyTerrain: false } });
+      viewport.displayStyle = style;
+      expectBackgroundMap(true);
+      expectTerrain(false);
+    });
+
+    it("updates when settings are modified", () => {
+      const style = viewport.displayStyle;
+      style.viewFlags = style.viewFlags.with("backgroundMap", false);
+      expectBackgroundMap(false);
+      expectTerrain(false);
+
+      style.viewFlags = style.viewFlags.with("backgroundMap", true);
+      style.settings.applyOverrides({ backgroundMap: { applyTerrain: true } });
+      expectBackgroundMap(true);
+      expectTerrain(true);
+
+      style.settings.applyOverrides({ backgroundMap: { applyTerrain: false } });
+      expectBackgroundMap(true);
+      expectTerrain(false);
     });
   });
 });

--- a/core/frontend/src/tile/map/MapTiledGraphicsProvider.ts
+++ b/core/frontend/src/tile/map/MapTiledGraphicsProvider.ts
@@ -8,8 +8,9 @@
 
 import { Id64String } from "@itwin/core-bentley";
 import { MapImagerySettings, MapLayerSettings } from "@itwin/core-common";
-import { Viewport } from "../../Viewport";
+import { DisplayStyleState } from "../../DisplayStyleState";
 import { ViewState } from "../../ViewState";
+import { Viewport } from "../../Viewport";
 import { MapLayerImageryProvider, MapTileTreeReference, TiledGraphicsProvider, TileTreeReference } from "../internal";
 
 /** @internal */
@@ -25,13 +26,12 @@ export class MapTiledGraphicsProvider implements TiledGraphicsProvider {
       func(this.overlayMap);
     }
   }
-  constructor(private readonly _vp: Viewport) {
-    const displayStyle = _vp.displayStyle;
+  constructor(viewportId: number, displayStyle: DisplayStyleState) {
     const mapSettings = displayStyle.backgroundMapSettings;
     const mapImagery = displayStyle.settings.mapImagery;
-    this.backgroundMap = new MapTileTreeReference(mapSettings, mapImagery.backgroundBase, mapImagery.backgroundLayers, displayStyle.iModel, _vp.viewportId, false, false, () => displayStyle.overrideTerrainDisplay());
-    this.overlayMap = new MapTileTreeReference(mapSettings, undefined, mapImagery.overlayLayers, displayStyle.iModel, _vp.viewportId, true, false);
-    this.backgroundDrapeMap = new MapTileTreeReference(mapSettings, mapImagery.backgroundBase, mapImagery.backgroundLayers, displayStyle.iModel, _vp.viewportId, false, true);
+    this.backgroundMap = new MapTileTreeReference(mapSettings, mapImagery.backgroundBase, mapImagery.backgroundLayers, displayStyle.iModel, viewportId, false, false, () => displayStyle.overrideTerrainDisplay());
+    this.overlayMap = new MapTileTreeReference(mapSettings, undefined, mapImagery.overlayLayers, displayStyle.iModel, viewportId, true, false);
+    this.backgroundDrapeMap = new MapTileTreeReference(mapSettings, mapImagery.backgroundBase, mapImagery.backgroundLayers, displayStyle.iModel, viewportId, false, true);
 
     const removals = this._detachFromDisplayStyle;
     removals.push(displayStyle.settings.onBackgroundMapChanged.addListener((settings) => {


### PR DESCRIPTION
Fix terrain bug described in #2608.
Given a Viewport `vp` with a display style that has enabled the background map but disabled terrain display:
```
  vp.overrideDisplayStyle({ backgroundMap: { applyTerrain: true } });
```
...correctly displays 3d terrain.
The following:
```
  const style = vp.,displayStyle.clone();
  vp.displayStyle = style;
  vp.overrideDisplayStyle({ backgroundMap: { applyTerrain: true } });
```
...fails to display 3d terrain - it displays a flat map.
The following:
```
  const style = vp.displayStyle.clone();
  vp.overrideDisplayStyle({ backgroundMap: { applyTerrain: true } });
  vp.displayStyle = style;
```
...incorrectly displays 3d terrain - it should display a flat map, because `style` did not have terrain enabled.

The problem is that Viewport listens for the event dispatched when ViewState.displayStyle is assigned to. That event is called (by design) **before** ViewState.displayStyle is actually updated; it receives the new style as an argument.
The callback was ignoring the new style; instead it looked at the background map settings of and installed event listeners onto the **previous** style.