### PR TITLE
Presentation: Avoid making the same request to PresentationManager

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1929,12 +1929,16 @@ export type PresentationRpcRequestOptions<TManagerRequestOptions> = Omit<TManage
 };
 
 // @public
-export type PresentationRpcResponse<TResult = undefined> = Promise<{
-    statusCode: PresentationStatus;
+export type PresentationRpcResponse<TResult = undefined> = Promise<PresentationRpcResponseData<TResult>>;
+
+// @public
+export interface PresentationRpcResponseData<TResult = undefined> {
+    // @alpha (undocumented)
+    diagnostics?: DiagnosticsScopeLogs[];
     errorMessage?: string;
     result?: TResult;
-    diagnostics?: DiagnosticsScopeLogs[];
-}>;
+    statusCode: PresentationStatus;
+}
 
 // @public
 export enum PresentationStatus {
@@ -2453,6 +2457,8 @@ export class RpcRequestsHandler implements IDisposable {
     getPagedNodes(options: Paged<HierarchyRequestOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>): Promise<PagedResponse<NodeJSON>>;
     // (undocumented)
     getSelectionScopes(options: SelectionScopeRequestOptions<IModelRpcProps>): Promise<SelectionScope[]>;
+    // (undocumented)
+    readonly maxRequestRepeatCount: number;
     request<TResult, TOptions extends RequestOptions<IModelRpcProps>, TArg = any>(func: (token: IModelRpcProps, options: PresentationRpcRequestOptions<TOptions>, ...args: TArg[]) => PresentationRpcResponse<TResult>, options: TOptions, ...additionalOptions: TArg[]): Promise<TResult>;
     }
 

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -256,6 +256,8 @@ alpha;PresentationIpcEvents
 internal;PresentationIpcInterface
 public;PresentationRpcInterface 
 public;PresentationRpcRequestOptions
+public;PresentationRpcResponse
+public;PresentationRpcResponseData
 public;PresentationStatus
 public;PrimitivePropertyValue = string | number | boolean | Point | InstanceKey | undefined
 public;PrimitiveTypeDescription 

--- a/common/changes/@itwin/presentation-backend/presentation-avoid-repeating-requests_2021-12-17-14-51.json
+++ b/common/changes/@itwin/presentation-backend/presentation-avoid-repeating-requests_2021-12-17-14-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-avoid-repeating-requests_2021-12-17-14-51.json
+++ b/common/changes/@itwin/presentation-common/presentation-avoid-repeating-requests_2021-12-17-14-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-testing/presentation-avoid-repeating-requests_2021-12-27-09-06.json
+++ b/common/changes/@itwin/presentation-testing/presentation-avoid-repeating-requests_2021-12-27-09-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-testing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-testing"
+}

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -7,21 +7,21 @@
  */
 
 import { IModelDb } from "@itwin/core-backend";
-import { Id64String, Logger } from "@itwin/core-bentley";
+import { assert, Id64String, IDisposable, Logger } from "@itwin/core-bentley";
 import { IModelRpcProps } from "@itwin/core-common";
 import {
   ContentDescriptorRpcRequestOptions, ContentFlags, ContentInstanceKeysRpcRequestOptions, ContentRpcRequestOptions, ContentSourcesRpcRequestOptions,
   ContentSourcesRpcResult, DescriptorJSON, DiagnosticsOptions, DiagnosticsScopeLogs, DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions,
-  DisplayValueGroup, DisplayValueGroupJSON, DistinctValuesRpcRequestOptions, ElementProperties,
-  FilterByInstancePathsHierarchyRpcRequestOptions, FilterByTextHierarchyRpcRequestOptions, HierarchyRpcRequestOptions,
-  InstanceKey, ItemJSON, KeySet, KeySetJSON, LabelDefinition, LabelDefinitionJSON,
-  Node, NodeJSON, NodeKey, NodeKeyJSON, NodePathElement, NodePathElementJSON, Paged, PagedResponse,
-  PageOptions, PresentationError, PresentationRpcInterface, PresentationRpcResponse, PresentationStatus, Ruleset, RulesetVariable,
-  RulesetVariableJSON, SelectClassInfo, SelectionScope, SelectionScopeRpcRequestOptions, SingleElementPropertiesRpcRequestOptions,
+  DisplayValueGroup, DisplayValueGroupJSON, DistinctValuesRpcRequestOptions, ElementProperties, FilterByInstancePathsHierarchyRpcRequestOptions,
+  FilterByTextHierarchyRpcRequestOptions, HierarchyRpcRequestOptions, InstanceKey, ItemJSON, KeySet, KeySetJSON, LabelDefinition, LabelDefinitionJSON,
+  Node, NodeJSON, NodeKey, NodeKeyJSON, NodePathElement, NodePathElementJSON, Paged, PagedResponse, PageOptions, PresentationError,
+  PresentationRpcInterface, PresentationRpcResponse, PresentationRpcResponseData, PresentationStatus, Ruleset, RulesetVariable, RulesetVariableJSON,
+  SelectClassInfo, SelectionScope, SelectionScopeRpcRequestOptions, SingleElementPropertiesRpcRequestOptions,
 } from "@itwin/presentation-common";
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { Presentation } from "./Presentation";
 import { PresentationManager } from "./PresentationManager";
+import { TemporaryStorage } from "./TemporaryStorage";
 
 type ContentGetter<TResult = any, TOptions = any> = (requestOptions: TOptions) => TResult;
 
@@ -42,16 +42,33 @@ export const MAX_ALLOWED_KEYS_PAGE_SIZE = 10000;
  *
  * @internal
  */
-export class PresentationRpcImpl extends PresentationRpcInterface {
+export class PresentationRpcImpl extends PresentationRpcInterface implements IDisposable {
 
-  public constructor(_id?: string) {
+  private _requestTimeout: number;
+  private _pendingRequests: TemporaryStorage<PresentationRpcResponse<any>>;
+
+  public constructor(props?: { requestTimeout: number }) {
     super();
+    this._requestTimeout = props?.requestTimeout ?? 90 * 1000;
+    this._pendingRequests = new TemporaryStorage({
+      // remove the pending request after request timeout + 10 seconds - this gives
+      // frontend 10 seconds to re-send the request until it's removed from requests' cache
+      unusedValueLifetime: this._requestTimeout + 10 * 1000,
+
+      // attempt to clean up every second
+      cleanupInterval: 1000,
+
+      cleanupHandler: (id) => {
+        Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Cleaning up request without frontend retrieving it: ${id}.`);
+      },
+    });
   }
 
-  /**
-   * Get the maximum result waiting time.
-   */
-  public get requestTimeout(): number { return Presentation.getRequestTimeout(); }
+  public dispose() {
+    this._pendingRequests.dispose();
+  }
+
+  public get requestTimeout() { return this._requestTimeout; }
 
   /** Returns an ok response with result inside */
   private successResponse<TResult>(result: TResult, diagnostics?: DiagnosticsScopeLogs[]) {
@@ -90,56 +107,87 @@ export class PresentationRpcImpl extends PresentationRpcInterface {
   }
 
   private async makeRequest<TRpcOptions extends { rulesetOrId?: Ruleset | string, clientId?: string, diagnostics?: DiagnosticsOptions, rulesetVariables?: RulesetVariableJSON[] }, TResult>(token: IModelRpcProps, requestId: string, requestOptions: TRpcOptions, request: ContentGetter<Promise<TResult>>): PresentationRpcResponse<TResult> {
-    Logger.logInfo(PresentationBackendLoggerCategory.Rpc, `Received '${requestId}' request. Params: ${JSON.stringify(requestOptions)}`);
-    let imodel: IModelDb;
-    try {
-      imodel = this.getIModel(token);
-    } catch (e) {
-      return this.errorResponse((e as PresentationError).errorNumber, (e as PresentationError).message);
-    }
+    const requestKey = JSON.stringify(requestOptions);
 
-    const { clientId, diagnostics: diagnosticsOptions, rulesetVariables, ...options } = requestOptions; // eslint-disable-line @typescript-eslint/no-unused-vars
-    const managerRequestOptions: any = {
-      ...options,
-      imodel,
-    };
+    Logger.logInfo(PresentationBackendLoggerCategory.Rpc, `Received '${requestId}' request. Params: ${requestKey}`);
 
-    // set up ruleset variables
-    if (rulesetVariables)
-      managerRequestOptions.rulesetVariables = rulesetVariables.map(RulesetVariable.fromJSON);
+    let resultPromise = this._pendingRequests.getValue(requestKey);
+    if (resultPromise) {
+      Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request already pending`);
+    } else {
+      Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request not found, creating a new one`);
+      let imodel: IModelDb;
+      try {
+        imodel = this.getIModel(token);
+      } catch (e) {
+        assert(e instanceof Error);
+        return this.errorResponse(PresentationStatus.InvalidArgument, e.message);
+      }
 
-    // set up diagnostics listener
-    let diagnosticLogs: DiagnosticsScopeLogs[] | undefined;
-    if (diagnosticsOptions) {
-      managerRequestOptions.diagnostics = {
-        ...diagnosticsOptions,
-        handler: (logs: DiagnosticsScopeLogs[]) => {
-          // istanbul ignore else
-          if (!diagnosticLogs)
-            diagnosticLogs = [];
-          diagnosticLogs.push(...logs);
-        },
+      const { clientId: _, diagnostics: diagnosticsOptions, rulesetVariables, ...options } = requestOptions;
+      const managerRequestOptions: any = {
+        ...options,
+        imodel,
       };
+
+      // set up ruleset variables
+      if (rulesetVariables)
+        managerRequestOptions.rulesetVariables = rulesetVariables.map(RulesetVariable.fromJSON);
+
+      // set up diagnostics listener
+      let diagnosticLogs: DiagnosticsScopeLogs[] | undefined;
+      if (diagnosticsOptions) {
+        managerRequestOptions.diagnostics = {
+          ...diagnosticsOptions,
+          handler: (logs: DiagnosticsScopeLogs[]) => {
+            if (!diagnosticLogs)
+              diagnosticLogs = [];
+            diagnosticLogs.push(...logs);
+          },
+        };
+      }
+
+      // initiate request
+      resultPromise = request(managerRequestOptions)
+        .then((result) => this.successResponse(result, diagnosticLogs))
+        .catch((e: PresentationError) => this.errorResponse(e.errorNumber, e.message, diagnosticLogs));
+
+      // store the request promise
+      this._pendingRequests.addValue(requestKey, resultPromise);
     }
 
-    // initiate request
-    const resultPromise = request(managerRequestOptions)
-      .then((result) => this.successResponse(result, diagnosticLogs))
-      .catch((e: PresentationError) => this.errorResponse(e.errorNumber, e.message, diagnosticLogs));
-
-    if (this.requestTimeout === 0)
+    if (this._requestTimeout === 0) {
+      Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request timeout not configured, returning promise without a timeout.`);
+      resultPromise.finally(() => {
+        this._pendingRequests.deleteValue(requestKey);
+      });
       return resultPromise;
+    }
 
     let timeout: NodeJS.Timeout;
     const timeoutPromise = new Promise<any>((_resolve, reject) => {
       timeout = setTimeout(() => {
         reject("Timed out");
-      }, this.requestTimeout);
+      }, this._requestTimeout);
     });
 
-    return Promise.race([resultPromise, timeoutPromise])
-      .catch(() => this.errorResponse(PresentationStatus.BackendTimeout))
-      .finally(() => clearTimeout(timeout));
+    /* eslint-disable @typescript-eslint/indent */
+    Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Returning a promise with a timeout of ${this._requestTimeout}.`);
+    return Promise
+      .race([resultPromise, timeoutPromise])
+      .catch<PresentationRpcResponseData>(() => {
+        Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request timeout, returning "BackendTimeout" status.`);
+        return this.errorResponse(PresentationStatus.BackendTimeout);
+      })
+      .then((response: PresentationRpcResponseData<any>) => {
+        if (response.statusCode !== PresentationStatus.BackendTimeout) {
+          Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request completed, returning result.`);
+          this._pendingRequests.deleteValue(requestKey);
+        }
+        clearTimeout(timeout);
+        return response;
+      });
+    /* eslint-enable @typescript-eslint/indent */
   }
 
   public override async getNodesCount(token: IModelRpcProps, requestOptions: HierarchyRpcRequestOptions): PresentationRpcResponse<number> {

--- a/presentation/backend/src/presentation-backend/TemporaryStorage.ts
+++ b/presentation/backend/src/presentation-backend/TemporaryStorage.ts
@@ -6,20 +6,17 @@
  * @module Core
  */
 
-import { IDisposable } from "@itwin/core-bentley";
+import { assert, IDisposable } from "@itwin/core-bentley";
+import { PresentationError, PresentationStatus } from "@itwin/presentation-common";
 
 /**
  * Configuration properties for [[TemporaryStorage]].
  * @internal
  */
 export interface TemporaryStorageProps<T> {
-  /** A factory method that creates a stored value given it's identifier */
-  factory: (id: string) => T;
-
   /** A method that's called for every value before it's removed from storage */
-  cleanupHandler?: (value: T) => void;
+  cleanupHandler?: (id: string, value: T) => void;
 
-  onCreated?: (id: string, value: T, onValueUsed: () => void) => void;
   onDisposedSingle?: (id: string) => void;
   onDisposedAll?: () => void;
 
@@ -33,16 +30,30 @@ export interface TemporaryStorageProps<T> {
 
   /**
    * Shortest period of time which the value should be kept in storage
-   * unused before it's cleaned up. `0` or `undefined` means values
-   * are removed from the storage on every cleanup (either manual call to
-   * [[TemporaryStorage.disposeOutdatedValues]] or scheduled (controlled
-   * by [[cleanupInterval]]))
+   * unused before it's cleaned up.
+   *
+   * `undefined` means the values may be kept unused in the storage indefinitely.
+   * `0` means the values are removed from the storage on every cleanup (either manual
+   * call to [[TemporaryStorage.disposeOutdatedValues]] or scheduled (controlled
+   * by [[cleanupInterval]])).
    */
-  valueLifetime?: number;
+  unusedValueLifetime?: number;
+
+  /**
+   * The maximum period of time which the value should be kept in storage
+   * before it's cleaned up. The time is measured from the moment the value is added
+   * to the storage.
+   *
+   * `undefined` means the values may be kept indefinitely. `0` means they're removed
+   * up on every cleanup (either manual call to [[TemporaryStorage.disposeOutdatedValues]]
+   * or scheduled (controlled by [[cleanupInterval]])).
+   */
+  maxValueLifetime?: number;
 }
 
 /** Value with know last used time */
 interface TemporaryValue<T> {
+  created: Date;
   lastUsed: Date;
   value: T;
 }
@@ -55,8 +66,8 @@ interface TemporaryValue<T> {
  */
 export class TemporaryStorage<T> implements IDisposable {
 
-  private _values: Map<string, TemporaryValue<T>>;
   private _timer?: NodeJS.Timer;
+  protected _values: Map<string, TemporaryValue<T>>;
   public readonly props: TemporaryStorageProps<T>;
 
   /**
@@ -78,8 +89,8 @@ export class TemporaryStorage<T> implements IDisposable {
       clearInterval(this._timer);
 
     if (this.props.cleanupHandler) {
-      this._values.forEach((v) => {
-        this.props.cleanupHandler!(v.value);
+      this._values.forEach((v, id) => {
+        this.props.cleanupHandler!(id, v.value);
       });
     }
     this._values.clear();
@@ -88,42 +99,72 @@ export class TemporaryStorage<T> implements IDisposable {
 
   /**
    * Cleans up values that are currently outdated (based
-   * on their lifetime specified through [[Props]]).
+   * on their max and unused value lifetimes specified through [[Props]]).
    */
   public disposeOutdatedValues = () => {
     const now = (new Date()).getTime();
     const valuesToDispose: string[] = [];
-    for (const entry of this._values.entries()) {
-      if (!this.props.valueLifetime || ((now - entry["1"].lastUsed.getTime()) > this.props.valueLifetime))
-        valuesToDispose.push(entry["0"]);
+    for (const [key, entry] of this._values.entries()) {
+      if (this.props.maxValueLifetime !== undefined) {
+        if (this.props.maxValueLifetime === 0 || (now - entry.created.getTime()) > this.props.maxValueLifetime) {
+          valuesToDispose.push(key);
+          continue;
+        }
+      }
+      if (this.props.unusedValueLifetime !== undefined) {
+        if (this.props.unusedValueLifetime === 0 || (now - entry.lastUsed.getTime()) > this.props.unusedValueLifetime) {
+          valuesToDispose.push(key);
+          continue;
+        }
+      }
     }
-    for (const id of valuesToDispose) {
-      if (this.props.cleanupHandler)
-        this.props.cleanupHandler(this._values.get(id)!.value);
-      this._values.delete(id);
-      this.props.onDisposedSingle && this.props.onDisposedSingle(id);
-    }
+    for (const id of valuesToDispose)
+      this.deleteExistingEntry(id);
   };
 
+  private deleteExistingEntry(id: string) {
+    assert(this._values.has(id));
+    this.props.cleanupHandler && this.props.cleanupHandler(id, this._values.get(id)!.value);
+    this._values.delete(id);
+    this.props.onDisposedSingle && this.props.onDisposedSingle(id);
+  }
+
   /**
-   * Get a value from the storage. If the value with the
-   * specified id doesn't exist, it gets created.
+   * Get a value from the storage.
    *
-   * **Note:** requesting a value with this method updates
-   * it's last used time.
+   * **Note:** requesting a value with this method updates it's last used time.
    */
-  public getValue(id: string): T {
+  public getValue(id: string): T | undefined {
     if (this._values.has(id)) {
       const v = this._values.get(id)!;
       v.lastUsed = new Date();
       return v.value;
     }
+    return undefined;
+  }
 
-    const value = this.props.factory(id);
-    const entry = { value, lastUsed: new Date() };
-    this._values.set(id, entry);
-    this.props.onCreated && this.props.onCreated(id, value, () => entry.lastUsed = new Date());
-    return value;
+  public notifyValueUsed(id: string) {
+    const entry = this._values.get(id);
+    // istanbul ignore else
+    if (entry)
+      entry.lastUsed = new Date();
+  }
+
+  /**
+   * Adds a value into the storage.
+   * @throws An error when trying to add a value with ID that's already stored in the storage.
+   */
+  public addValue(id: string, value: T) {
+    if (this._values.has(id))
+      throw new PresentationError(PresentationStatus.InvalidArgument, `A value with given ID "${id}" already exists in this storage.`);
+    this._values.set(id, { value, created: new Date(), lastUsed: new Date() });
+  }
+
+  /** Deletes a value with given id. */
+  public deleteValue(id: string) {
+    // istanbul ignore else
+    if (this._values.has(id))
+      this.deleteExistingEntry(id);
   }
 
   /**
@@ -139,4 +180,48 @@ export class TemporaryStorage<T> implements IDisposable {
     return values;
   }
 
+}
+
+/**
+ * Configuration properties for [[FactoryBasedTemporaryStorage]].
+ * @internal
+ */
+export interface FactoryBasedTemporaryStorageProps<T> extends TemporaryStorageProps<T> {
+  /** A factory method that creates a stored value given it's identifier */
+  factory: (id: string, onValueUsed: () => void) => T;
+}
+
+/**
+ * Storage for values that get removed from it after being unused (not-requested
+ * for a specified amount of time).
+ *
+ * @internal
+ */
+export class FactoryBasedTemporaryStorage<T> extends TemporaryStorage<T> {
+
+  public override readonly props: FactoryBasedTemporaryStorageProps<T>;
+
+  /**
+   * Constructor. Creates the storage using supplied params.
+   */
+  constructor(props: FactoryBasedTemporaryStorageProps<T>) {
+    super(props);
+    this.props = props;
+  }
+
+  /**
+   * Get a value from the storage. If the value with the specified id
+   * doesn't exist, it gets created.
+   *
+   * **Note:** requesting a value with this method updates it's last used time.
+   */
+  public override getValue(id: string): T {
+    const existingValue = super.getValue(id);
+    if (existingValue)
+      return existingValue;
+
+    const value = this.props.factory(id, () => this.notifyValueUsed(id));
+    this.addValue(id, value);
+    return value;
+  }
 }

--- a/presentation/backend/src/test/Presentation.test.ts
+++ b/presentation/backend/src/test/Presentation.test.ts
@@ -7,11 +7,13 @@ import * as faker from "faker";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { IModelHost, IpcHost } from "@itwin/core-backend";
+import { assert } from "@itwin/core-bentley";
 import { RpcManager } from "@itwin/core-common";
 import { PresentationError } from "@itwin/presentation-common";
 import { MultiManagerPresentationProps, Presentation } from "../presentation-backend/Presentation";
 import { PresentationIpcHandler } from "../presentation-backend/PresentationIpcHandler";
 import { PresentationManager } from "../presentation-backend/PresentationManager";
+import { PresentationRpcImpl } from "../presentation-backend/PresentationRpcImpl";
 import { TemporaryStorage } from "../presentation-backend/TemporaryStorage";
 
 describe("Presentation", () => {
@@ -52,29 +54,16 @@ describe("Presentation", () => {
       it("sets unused client lifetime provided through props", () => {
         Presentation.initialize({ unusedClientLifetime: faker.random.number() });
         const storage = (Presentation as any)._clientsStorage as TemporaryStorage<PresentationManager>;
-        expect(storage.props.valueLifetime).to.eq((Presentation.initProps! as MultiManagerPresentationProps).unusedClientLifetime);
+        expect(storage.props.unusedValueLifetime).to.eq((Presentation.initProps! as MultiManagerPresentationProps).unusedClientLifetime);
       });
 
-      describe("getRequestTimeout", () => {
-        it("should throw PresentationError if initialize is not called", () => {
-          expect(() => Presentation.getRequestTimeout()).to.throw(PresentationError);
-        });
-
-        it("creates a requestTimeout property with default value", () => {
-          Presentation.initialize();
-          expect(Presentation.getRequestTimeout()).to.equal(90000);
-        });
-
-        it("should use value from initialize method parameters", () => {
-          const randomRequestTimeout = faker.random.number({ min: 1, max: 90000 });
-          Presentation.initialize({ requestTimeout: randomRequestTimeout });
-          expect(Presentation.getRequestTimeout()).to.equal(randomRequestTimeout);
-        });
-
-        it("should use 0 as requestTimeout if value passed to initialize method is 0", () => {
-          Presentation.initialize({ requestTimeout: 0 });
-          expect(Presentation.getRequestTimeout()).to.equal(0);
-        });
+      it("sets request timeout to `PresentationRpcImpl`", () => {
+        const supplyImplSpy = sinon.spy(RpcManager, "supplyImplInstance");
+        Presentation.initialize({ requestTimeout: 123 });
+        const impl = supplyImplSpy.args[0][1];
+        assert(impl instanceof PresentationRpcImpl);
+        expect(impl.requestTimeout).to.eq(123);
+        expect(Presentation.getRequestTimeout()).to.eq(123);
       });
 
       it("uses client manager factory provided through props", () => {
@@ -95,6 +84,14 @@ describe("Presentation", () => {
 
   });
 
+  describe("getRequestTimeout", () => {
+
+    it("should throw PresentationError if initialize is not called", () => {
+      expect(() => Presentation.getRequestTimeout()).to.throw(PresentationError);
+    });
+
+  });
+
   describe("terminate", () => {
 
     it("resets manager instance", () => {
@@ -102,13 +99,6 @@ describe("Presentation", () => {
       expect(Presentation.getManager()).to.be.not.null;
       Presentation.terminate();
       expect(() => Presentation.getManager()).to.throw(PresentationError);
-    });
-
-    it("resets RequestTimeout property", () => {
-      Presentation.initialize();
-      expect(Presentation.getRequestTimeout()).to.be.not.null;
-      Presentation.terminate();
-      expect(() => Presentation.getRequestTimeout()).to.throw(PresentationError);
     });
 
     it("unregisters PresentationRpcInterface impl", () => {

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -7,7 +7,7 @@ import * as faker from "faker";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { IModelDb } from "@itwin/core-backend";
-import { Id64String } from "@itwin/core-bentley";
+import { Id64String, using } from "@itwin/core-bentley";
 import { IModelNotFoundResponse, IModelRpcProps } from "@itwin/core-common";
 import {
   Content, ContentDescriptorRequestOptions, ContentDescriptorRpcRequestOptions, ContentFlags, ContentInstanceKeysRpcRequestOptions,
@@ -15,15 +15,16 @@ import {
   DescriptorOverrides, DiagnosticsScopeLogs, DisplayLabelRequestOptions, DisplayLabelRpcRequestOptions, DisplayLabelsRequestOptions,
   DisplayLabelsRpcRequestOptions, DistinctValuesRequestOptions, DistinctValuesRpcRequestOptions, ElementProperties, FieldDescriptor,
   FieldDescriptorType, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions, HierarchyRequestOptions,
-  HierarchyRpcRequestOptions, InstanceKey, Item, KeySet, Node, NodeKey,
-  NodePathElement, Paged, PageOptions, PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable, RulesetVariableJSON,
-  SelectClassInfo, SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions, SingleElementPropertiesRpcRequestOptions, VariableValueTypes,
+  HierarchyRpcRequestOptions, InstanceKey, Item, KeySet, Node, NodeKey, NodePathElement, Paged, PageOptions, PresentationError,
+  PresentationRpcRequestOptions, PresentationStatus, RulesetVariable, RulesetVariableJSON, SelectClassInfo, SelectionScopeRequestOptions,
+  SingleElementPropertiesRequestOptions, SingleElementPropertiesRpcRequestOptions, VariableValueTypes,
 } from "@itwin/presentation-common";
 import {
   createRandomECInstanceKey, createRandomECInstancesNode, createRandomECInstancesNodeKey, createRandomId, createRandomLabelDefinitionJSON,
   createRandomNodePathElement, createRandomSelectionScope, createTestContentDescriptor, createTestECInstanceKey, createTestSelectClassInfo,
   ResolvablePromise,
 } from "@itwin/presentation-common/lib/cjs/test";
+import { NativePlatformDefinition } from "../presentation-backend/NativePlatform";
 import { Presentation } from "../presentation-backend/Presentation";
 import { PresentationManager } from "../presentation-backend/PresentationManager";
 import { MAX_ALLOWED_KEYS_PAGE_SIZE, MAX_ALLOWED_PAGE_SIZE, PresentationRpcImpl } from "../presentation-backend/PresentationRpcImpl";
@@ -37,23 +38,85 @@ describe("PresentationRpcImpl", () => {
   });
 
   it("uses default PresentationManager implementation if not overridden", () => {
-    Presentation.initialize();
-    const impl = new PresentationRpcImpl();
-    expect(impl.getManager()).is.instanceof(PresentationManager);
+    Presentation.initialize({
+      addon: moq.Mock.ofType<NativePlatformDefinition>().object,
+    });
+    using(new PresentationRpcImpl(), (impl) => {
+      expect(impl.getManager()).is.instanceof(PresentationManager);
+    });
   });
 
-  it("uses default requestWaitTime from the Presentation implementation if it is not overriden", () => {
-    Presentation.initialize();
-    const impl = new PresentationRpcImpl();
-    expect(impl.requestTimeout).to.equal(90000);
-  });
-
-  it("uses custom requestTimeout from the Presentation implementation if it is passed through Presentation.initialize", () => {
+  it("uses custom requestTimeout", () => {
     const randomRequestTimeout = faker.random.number({ min: 0, max: 90000 });
-    Presentation.initialize({ requestTimeout: randomRequestTimeout });
-    const impl = new PresentationRpcImpl();
-    expect(impl.requestTimeout).to.not.throw;
-    expect(impl.requestTimeout).to.equal(randomRequestTimeout);
+    using(new PresentationRpcImpl({ requestTimeout: randomRequestTimeout }), (impl) => {
+      expect(impl.requestTimeout).to.not.throw;
+      expect(impl.requestTimeout).to.equal(randomRequestTimeout);
+    });
+  });
+
+  it("returns all diagnostics when `PresentationManager` calls diagnostics handler multiple times", async () => {
+    const rulesetsMock = moq.Mock.ofType<RulesetManager>();
+    const variablesMock = moq.Mock.ofType<RulesetVariablesManager>();
+    const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
+    presentationManagerMock.setup((x) => x.rulesets()).returns(() => rulesetsMock.object);
+    presentationManagerMock.setup((x) => x.vars(moq.It.isAnyString())).returns(() => variablesMock.object);
+    Presentation.initialize({
+      clientManagerFactory: () => presentationManagerMock.object,
+    });
+
+    const imodelTokenMock = moq.Mock.ofType<IModelRpcProps>();
+    const imodelMock = moq.Mock.ofType<IModelDb>();
+    sinon.stub(IModelDb, "findByKey").returns(imodelMock.object);
+
+    const impl = new PresentationRpcImpl({ requestTimeout: 10 });
+    await using([{ dispose: () => Presentation.terminate() }, impl], async (_) => {
+      presentationManagerMock
+        .setup(async (x) => x.getNodesCount(moq.It.isAny()))
+        .callback((props: HierarchyRequestOptions<IModelDb, NodeKey>) => {
+          props.diagnostics!.handler([{ scope: "1" }]);
+          props.diagnostics!.handler([{ scope: "2" }]);
+        })
+        .returns(async () => 0);
+      const response = await impl.getNodesCount(imodelTokenMock.object, { rulesetOrId: "", diagnostics: { dev: true } });
+      expect(response.diagnostics).to.deep.eq([{
+        scope: "1",
+      }, {
+        scope: "2",
+      }]);
+    });
+  });
+
+  it("returns diagnostics from initial call when same request is repeated multiple times", async () => {
+    const rulesetsMock = moq.Mock.ofType<RulesetManager>();
+    const variablesMock = moq.Mock.ofType<RulesetVariablesManager>();
+    const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
+    presentationManagerMock.setup((x) => x.rulesets()).returns(() => rulesetsMock.object);
+    presentationManagerMock.setup((x) => x.vars(moq.It.isAnyString())).returns(() => variablesMock.object);
+    Presentation.initialize({
+      clientManagerFactory: () => presentationManagerMock.object,
+    });
+
+    const imodelTokenMock = moq.Mock.ofType<IModelRpcProps>();
+    const imodelMock = moq.Mock.ofType<IModelDb>();
+    sinon.stub(IModelDb, "findByKey").returns(imodelMock.object);
+
+    const impl = new PresentationRpcImpl({ requestTimeout: 10 });
+    await using([{ dispose: () => Presentation.terminate() }, impl], async (_) => {
+      let callsCount = 0;
+      const result = new ResolvablePromise<number>();
+      presentationManagerMock
+        .setup(async (x) => x.getNodesCount(moq.It.isAny()))
+        .callback((props: HierarchyRequestOptions<IModelDb, NodeKey>) => {
+          props.diagnostics!.handler([{ scope: `${callsCount++}` }]);
+        })
+        .returns(async () => result);
+      const response1 = await impl.getNodesCount(imodelTokenMock.object, { rulesetOrId: "", diagnostics: { dev: true } });
+      expect(response1.statusCode).to.eq(PresentationStatus.BackendTimeout);
+      await result.resolve(123);
+      const response2 = await impl.getNodesCount(imodelTokenMock.object, { rulesetOrId: "", diagnostics: { dev: true } });
+      expect(response2.statusCode).to.eq(PresentationStatus.Success);
+      expect(response2.diagnostics).to.deep.eq([{ scope: "0" }]);
+    });
   });
 
   describe("calls forwarding", () => {
@@ -73,7 +136,6 @@ describe("PresentationRpcImpl", () => {
       presentationManagerMock.setup((x) => x.vars(moq.It.isAnyString())).returns(() => variablesMock.object);
       presentationManagerMock.setup((x) => x.rulesets()).returns(() => rulesetsMock.object);
       Presentation.initialize({
-        requestTimeout: 10,
         clientManagerFactory: () => presentationManagerMock.object,
       });
       testData = {
@@ -85,7 +147,11 @@ describe("PresentationRpcImpl", () => {
       };
       defaultRpcParams = { clientId: faker.random.uuid() };
       stub_IModelDb_findByKey = sinon.stub(IModelDb, "findByKey").returns(testData.imodelMock.object);
-      impl = new PresentationRpcImpl();
+      impl = new PresentationRpcImpl({ requestTimeout: 10 });
+    });
+
+    afterEach(() => {
+      impl.dispose();
     });
 
     it("returns invalid argument status code when using invalid imodel token", async () => {
@@ -126,12 +192,9 @@ describe("PresentationRpcImpl", () => {
         await result.resolve(999);
       });
 
-      it("should return result if `PresentationStatus.BackendTimeout` is set to 0", async () => {
-        Presentation.terminate();
-        Presentation.initialize({
-          requestTimeout: 0,
-          clientManagerFactory: () => presentationManagerMock.object,
-        });
+      it("should return result if `requestTimeout` is set to 0", async () => {
+        impl.dispose();
+        impl = new PresentationRpcImpl({ requestTimeout: 0 });
         const rpcOptions: HierarchyRpcRequestOptions = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,
@@ -225,12 +288,9 @@ describe("PresentationRpcImpl", () => {
         expect(actualResult.errorMessage).to.eq("test error");
       });
 
-      it("should return error result if manager throws and `PresentationStatus.BackendTimeout` is set to 0", async () => {
-        Presentation.terminate();
-        Presentation.initialize({
-          requestTimeout: 0,
-          clientManagerFactory: () => presentationManagerMock.object,
-        });
+      it("should return error result if manager throws and `requestTimeout` is set to 0", async () => {
+        impl.dispose();
+        impl = new PresentationRpcImpl({ requestTimeout: 0 });
         const rpcOptions: HierarchyRpcRequestOptions = {
           ...defaultRpcParams,
           rulesetOrId: testData.rulesetOrId,

--- a/presentation/backend/src/test/TemporaryStorage.test.ts
+++ b/presentation/backend/src/test/TemporaryStorage.test.ts
@@ -5,9 +5,9 @@
 import { expect } from "chai";
 import * as lolex from "lolex";
 import * as sinon from "sinon";
-import * as moq from "typemoq";
 import { using } from "@itwin/core-bentley";
-import { TemporaryStorage } from "../presentation-backend/TemporaryStorage";
+import { PresentationError } from "@itwin/presentation-common";
+import { FactoryBasedTemporaryStorage, TemporaryStorage } from "../presentation-backend/TemporaryStorage";
 
 describe("TemporaryStorage", () => {
 
@@ -23,21 +23,21 @@ describe("TemporaryStorage", () => {
 
     it("doesn't set up timer callback when interval is not set", () => {
       const s = sinon.spy(clock, "setInterval");
-      using(new TemporaryStorage<string>({ factory: () => "" }), (_r) => {
+      using(new TemporaryStorage<string>({}), (_r) => {
         expect(s).to.not.be.called;
       });
     });
 
     it("doesn't set up timer callback when interval is set to 0", () => {
       const s = sinon.spy(clock, "setInterval");
-      using(new TemporaryStorage<string>({ factory: () => "", cleanupInterval: 0 }), (_r) => {
+      using(new TemporaryStorage<string>({ cleanupInterval: 0 }), (_r) => {
         expect(s).to.not.be.called;
       });
     });
 
     it("sets up timer callback when interval is set to more than 0", () => {
       const s = sinon.spy(clock, "setInterval");
-      using(new TemporaryStorage<string>({ factory: () => "", cleanupInterval: 1 }), (_r) => {
+      using(new TemporaryStorage<string>({ cleanupInterval: 1 }), (_r) => {
         expect(s).to.be.calledOnce;
       });
     });
@@ -48,188 +48,280 @@ describe("TemporaryStorage", () => {
 
     it("stops automatic cleanup when cleanup interval is set", () => {
       const s = sinon.spy(clock, "clearInterval");
-      const storage = new TemporaryStorage<string>({ factory: () => "", cleanupInterval: 1 });
+      const storage = new TemporaryStorage<string>({ cleanupInterval: 1 });
       storage.dispose();
       expect(s).to.be.calledOnce;
     });
 
     it("calls cleanup handler for every value", () => {
-      const cleanupHandlerMock = moq.Mock.ofType<(value: string) => void>();
+      const cleanupHandler = sinon.spy();
       const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
-        cleanupHandler: cleanupHandlerMock.object,
+        cleanupHandler,
       });
 
       const values = ["a", "b", "c"];
-      values.forEach((v) => storage.getValue(v));
+      values.forEach((v) => storage.addValue(v, v));
 
       storage.dispose();
 
-      cleanupHandlerMock.verify((x) => x(moq.It.isAnyString()), moq.Times.exactly(values.length));
-      values.forEach((v) => cleanupHandlerMock.verify((x) => x(v), moq.Times.once()));
+      expect(cleanupHandler.callCount).to.eq(values.length);
+      values.forEach((v, i) => {
+        expect(cleanupHandler.args[i][0]).to.eq(v);
+      });
     });
 
     it("calls `onDisposedAll` callback", () => {
       const spy = sinon.spy();
       const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
         onDisposedAll: spy,
       });
 
       const values = ["a", "b", "c"];
-      values.forEach((v) => storage.getValue(v));
+      values.forEach((v) => storage.addValue(v, v));
 
       storage.dispose();
 
       expect(spy).to.be.calledOnce;
+    });
+
+  });
+
+  describe("addValue", () => {
+
+    let storage: TemporaryStorage<string>;
+    beforeEach(() => {
+      storage = new TemporaryStorage<string>({});
+    });
+    afterEach(() => {
+      storage.dispose();
+    });
+
+    it("adds a new value", () => {
+      storage.addValue("a", "A");
+      expect(storage.values).to.deep.eq(["A"]);
+    });
+
+    it("throws when adding a value with existing id", () => {
+      storage.addValue("a", "A");
+      expect(() => storage.addValue("a", "X")).to.throw(PresentationError);
+      expect(storage.values).to.deep.eq(["A"]);
     });
 
   });
 
   describe("getValue", () => {
 
-    it("creates value if not exists", () => {
-      const factoryMock = moq.Mock.ofType<(id: string) => string>();
-      factoryMock.setup((x) => x(moq.It.isAnyString())).returns((id: string) => id);
-      const onCreatedSpy = sinon.spy();
-      const storage = new TemporaryStorage<string>({
-        factory: factoryMock.object,
-        onCreated: onCreatedSpy,
-      });
-
+    it("returns undefined if value does not exist", () => {
+      const storage = new TemporaryStorage<string>({});
       const value = storage.getValue("a");
-      expect(value).to.eq("a");
-      factoryMock.verify((x) => x("a"), moq.Times.once());
-      expect(onCreatedSpy).to.be.calledOnceWith("a");
+      expect(value).to.be.undefined;
     });
 
-    it("doesn't create value if already exists", () => {
-      const factoryMock = moq.Mock.ofType<(id: string) => string>();
-      factoryMock.setup((x) => x(moq.It.isAnyString())).returns((id: string) => id);
-      const onCreatedSpy = sinon.spy();
-      const storage = new TemporaryStorage<string>({
-        factory: factoryMock.object,
-        onCreated: onCreatedSpy,
-      });
-
-      const value1 = storage.getValue("a");
-      expect(value1).to.eq("a");
-      expect(onCreatedSpy).to.be.calledOnceWith("a");
-      onCreatedSpy.resetHistory();
-
-      const value2 = storage.getValue("a");
-      expect(value2).to.eq("a");
-      expect(onCreatedSpy).to.not.be.called;
-
-      factoryMock.verify((x) => x("a"), moq.Times.once());
-    });
-
-    it("does not dispose value if 'onValueUsed' was called", () => {
-      const spy = sinon.spy();
-      let valueUsed = () => { };
-      const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
-        onCreated: (_id: string, value: string, onValueUsed: () => void) => {
-          if (value === "a")
-            valueUsed = onValueUsed;
-        },
-        onDisposedSingle: spy,
-        valueLifetime: 2,
-      });
-
-      storage.getValue("a");
-      storage.getValue("b");
-      // advance clock and verify values are still there
-      clock.tick(1);
-      expect(storage.values.length).to.eq(2);
-      valueUsed();
-
-      // advance clock and verify one value is still there
-      clock.tick(2);
-      storage.disposeOutdatedValues();
-      expect(storage.values.length).to.eq(1);
-      expect(spy).to.be.calledOnce;
-      expect(spy).to.be.calledWith("b");
+    it("returns value if exists", () => {
+      const storage = new TemporaryStorage<string>({});
+      storage.addValue("a", "A");
+      const value = storage.getValue("a");
+      expect(value).to.eq("A");
     });
 
   });
 
   describe("disposeOutdatedValues", () => {
 
-    it("disposes value immediately if lifetime is unspecified", () => {
-      const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
-      });
-      storage.getValue("a");
-      storage.disposeOutdatedValues();
-      expect(storage.values.length).to.eq(0);
-    });
-
-    it("disposes value immediately if lifetime is 0", () => {
-      const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
-        valueLifetime: 0,
-      });
-      storage.getValue("a");
-      storage.disposeOutdatedValues();
-      expect(storage.values.length).to.eq(0);
-    });
-
-    it("disposes value which is unused for longer than specified lifetime", () => {
-      const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
-        valueLifetime: 1,
-      });
-      storage.getValue("a");
-      // advance clock and verify the value is still there
-      clock.tick(1);
+    it("doesn't dispose value if neither `unusedValueLifetime` nor `maxValueLifetime` are specified", () => {
+      const storage = new TemporaryStorage<string>({});
+      storage.addValue("a", "A");
+      expect(storage.values.length).to.eq(1);
       storage.disposeOutdatedValues();
       expect(storage.values.length).to.eq(1);
-      // advance clock and verify the value gets removed
-      clock.tick(1);
-      storage.disposeOutdatedValues();
-      expect(storage.values.length).to.eq(0);
     });
 
-    it("disposes only values which are unused for longer than specified lifetime", () => {
-      const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
-        valueLifetime: 1,
+    describe("disposing based on `unusedValueLifetime`", () => {
+
+      it("disposes value immediately if `unusedValueLifetime` is 0", () => {
+        const storage = new TemporaryStorage<string>({
+          unusedValueLifetime: 0,
+        });
+        storage.addValue("a", "A");
+        expect(storage.values.length).to.eq(1);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(0);
       });
-      storage.getValue("a");
-      clock.tick(1);
-      storage.getValue("b");
-      clock.tick(1);
-      storage.disposeOutdatedValues();
-      expect(storage.values.length).to.eq(1);
-      expect(storage.values[0]).to.eq("b");
+
+      it("disposes value which is unused for longer than specified `unusedValueLifetime`", () => {
+        const storage = new TemporaryStorage<string>({
+          unusedValueLifetime: 1,
+        });
+        storage.addValue("a", "A");
+        expect(storage.values.length).to.eq(1);
+        // advance clock and verify the value is still there
+        clock.tick(1);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(1);
+        // advance clock and verify the value gets removed
+        clock.tick(1);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(0);
+      });
+
+      it("disposes only values which are unused for longer than specified `unusedValueLifetime`", () => {
+        const storage = new TemporaryStorage<string>({
+          unusedValueLifetime: 1,
+        });
+        storage.addValue("a", "A");
+        clock.tick(1);
+        storage.addValue("b", "B");
+        clock.tick(1);
+        expect(storage.values.length).to.eq(2);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(1);
+        expect(storage.values[0]).to.eq("B");
+      });
+
+      it("doesn't dispose value if `notifyValueUsed` was called", () => {
+        const storage = new TemporaryStorage<string>({
+          unusedValueLifetime: 1,
+        });
+        storage.addValue("a", "A");
+        storage.addValue("b", "B");
+        expect(storage.values.length).to.eq(2);
+
+        // advance clock and verify values are still there
+        clock.tick(1);
+        expect(storage.values.length).to.eq(2);
+
+        storage.notifyValueUsed("b");
+
+        // advance clock and verify only one value is still there
+        clock.tick(1);
+        storage.disposeOutdatedValues();
+        expect(storage.values).to.deep.eq(["B"]);
+      });
+
+    });
+
+    describe("disposing based on `maxValueLifetime`", () => {
+
+      it("disposes value immediately if `maxValueLifetime` is 0", () => {
+        const storage = new TemporaryStorage<string>({
+          maxValueLifetime: 0,
+        });
+        storage.addValue("a", "A");
+        expect(storage.values.length).to.eq(1);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(0);
+      });
+
+      it("disposes value which was created for longer than specified `maxValueLifetime`", () => {
+        const storage = new TemporaryStorage<string>({
+          maxValueLifetime: 1,
+        });
+        storage.addValue("a", "A");
+        expect(storage.values.length).to.eq(1);
+        // advance clock and verify the value is still there
+        clock.tick(1);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(1);
+        // advance clock and verify the value gets removed
+        clock.tick(1);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(0);
+      });
+
+      it("disposes only values which were created for longer than specified `maxValueLifetime`", () => {
+        const storage = new TemporaryStorage<string>({
+          maxValueLifetime: 1,
+        });
+        storage.addValue("a", "A");
+        clock.tick(1);
+        storage.addValue("b", "B");
+        clock.tick(1);
+        expect(storage.values.length).to.eq(2);
+        storage.disposeOutdatedValues();
+        expect(storage.values.length).to.eq(1);
+        expect(storage.values[0]).to.eq("B");
+      });
+
     });
 
     it("calls cleanup handler for disposed values", () => {
-      const cleanupHandlerMock = moq.Mock.ofType<(value: string) => void>();
+      const cleanupHandler = sinon.spy();
       const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
-        cleanupHandler: cleanupHandlerMock.object,
+        maxValueLifetime: 0,
+        cleanupHandler,
       });
-      storage.getValue("a");
+      storage.addValue("a", "A");
+      expect(storage.values.length).to.eq(1);
       storage.disposeOutdatedValues();
       expect(storage.values.length).to.eq(0);
-      cleanupHandlerMock.verify((x) => x("a"), moq.Times.once());
+      expect(cleanupHandler).to.be.calledOnceWith("a", "A");
     });
 
     it("calls `onDisposedSingle` for disposed values", () => {
       const spy = sinon.spy();
       const storage = new TemporaryStorage<string>({
-        factory: (id: string) => id,
+        maxValueLifetime: 0,
         onDisposedSingle: spy,
       });
-      storage.getValue("a");
-      storage.getValue("b");
+      storage.addValue("a", "A");
+      storage.addValue("b", "B");
+      expect(storage.values.length).to.eq(2);
+
       storage.disposeOutdatedValues();
+
       expect(storage.values.length).to.eq(0);
       expect(spy).to.be.calledTwice;
-      expect(spy).to.be.calledWith("a");
-      expect(spy).to.be.calledWith("b");
+      expect(spy.firstCall).to.be.calledWith("a");
+      expect(spy.secondCall).to.be.calledWith("b");
+    });
+
+  });
+
+});
+
+describe("FactoryBasedTemporaryStorage", () => {
+
+  describe("getValue", () => {
+
+    it("creates value if not exists", () => {
+      const factory = sinon.fake((id: string) => id);
+      const storage = new FactoryBasedTemporaryStorage<string>({
+        factory,
+      });
+
+      const value = storage.getValue("a");
+      expect(value).to.eq("a");
+      expect(factory).to.be.calledOnceWith("a", sinon.match((arg) => typeof arg === "function"));
+    });
+
+    it("doesn't create value if already exists", () => {
+      const factory = sinon.fake((id: string) => id);
+      const storage = new FactoryBasedTemporaryStorage<string>({
+        factory,
+      });
+
+      const value1 = storage.getValue("a");
+      expect(value1).to.eq("a");
+      expect(factory).to.be.calledOnceWith("a", sinon.match((arg) => typeof arg === "function"));
+      factory.resetHistory();
+
+      const value2 = storage.getValue("a");
+      expect(value2).to.eq("a");
+      expect(factory).to.not.be.called;
+    });
+
+    it("provides a function to update last used timestamp when calling factory", () => {
+      const factory = sinon.fake((id: string) => id);
+      const storage = new FactoryBasedTemporaryStorage<string>({
+        factory,
+      });
+      storage.getValue("a");
+      const lastUsedTimestampUpdateHandler = factory.args[0][1];
+      expect(lastUsedTimestampUpdateHandler).to.be.a("function");
+
+      const updateSpy = sinon.spy(storage, "notifyValueUsed");
+      lastUsedTimestampUpdateHandler();
+      expect(updateSpy).to.be.calledOnceWith("a");
     });
 
   });

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -22,9 +22,8 @@ import { KeySetJSON } from "./KeySet";
 import { LabelDefinitionJSON } from "./LabelDefinition";
 import {
   ContentDescriptorRequestOptions, ContentInstanceKeysRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions,
-  DisplayLabelsRequestOptions, DistinctValuesRequestOptions, FilterByInstancePathsHierarchyRequestOptions,
-  FilterByTextHierarchyRequestOptions, HierarchyRequestOptions, Paged, SelectionScopeRequestOptions,
-  SingleElementPropertiesRequestOptions,
+  DisplayLabelsRequestOptions, DistinctValuesRequestOptions, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions,
+  HierarchyRequestOptions, Paged, SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions,
 } from "./PresentationManagerOptions";
 import { RulesetVariableJSON } from "./RulesetVariables";
 import { SelectionScope } from "./selection/SelectionScope";
@@ -45,7 +44,7 @@ export type PresentationRpcRequestOptions<TManagerRequestOptions> = Omit<TManage
  * Data structure for presentation RPC responses
  * @public
  */
-export type PresentationRpcResponse<TResult = undefined> = Promise<{
+export interface PresentationRpcResponseData<TResult = undefined> {
   /** Response status code */
   statusCode: PresentationStatus;
   /** In case of an error response, the error message */
@@ -54,7 +53,13 @@ export type PresentationRpcResponse<TResult = undefined> = Promise<{
   result?: TResult;
   /** @alpha */
   diagnostics?: DiagnosticsScopeLogs[];
-}>;
+}
+
+/**
+ * A promise of [[PresentationRpcResponseData]].
+ * @public
+ */
+export type PresentationRpcResponse<TResult = undefined> = Promise<PresentationRpcResponseData<TResult>>;
 
 /**
  * Data structure for hierarchy request options.

--- a/presentation/common/src/presentation-common/RpcRequestsHandler.ts
+++ b/presentation/common/src/presentation-common/RpcRequestsHandler.ts
@@ -22,9 +22,8 @@ import { KeySetJSON } from "./KeySet";
 import { LabelDefinitionJSON } from "./LabelDefinition";
 import {
   ContentDescriptorRequestOptions, ContentInstanceKeysRequestOptions, ContentRequestOptions, ContentSourcesRequestOptions, DisplayLabelRequestOptions,
-  DisplayLabelsRequestOptions, DistinctValuesRequestOptions, FilterByInstancePathsHierarchyRequestOptions,
-  FilterByTextHierarchyRequestOptions, HierarchyRequestOptions, Paged, RequestOptions,
-  SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions,
+  DisplayLabelsRequestOptions, DistinctValuesRequestOptions, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions,
+  HierarchyRequestOptions, Paged, RequestOptions, SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions,
 } from "./PresentationManagerOptions";
 import {
   ContentSourcesRpcResult, PresentationRpcInterface, PresentationRpcRequestOptions, PresentationRpcResponse,
@@ -55,7 +54,7 @@ export interface RpcRequestsHandlerProps {
  * @internal
  */
 export class RpcRequestsHandler implements IDisposable {
-  private _maxRequestRepeatCount: number = 5;
+  public readonly maxRequestRepeatCount: number = 5;
 
   /** ID that identifies this handler as a client */
   public readonly clientId: string;
@@ -81,14 +80,14 @@ export class RpcRequestsHandler implements IDisposable {
       if (response.statusCode === PresentationStatus.Success)
         return response.result!;
 
-      if (response.statusCode === PresentationStatus.BackendTimeout && repeatCount < this._maxRequestRepeatCount)
+      if (response.statusCode === PresentationStatus.BackendTimeout && repeatCount < this.maxRequestRepeatCount)
         shouldRepeat = true;
       else
         error = new PresentationError(response.statusCode, response.errorMessage);
 
     } catch (e) {
       error = e;
-      if (repeatCount < this._maxRequestRepeatCount)
+      if (repeatCount < this.maxRequestRepeatCount)
         shouldRepeat = true;
 
     } finally {

--- a/presentation/testing/src/presentation-testing/Helpers.ts
+++ b/presentation/testing/src/presentation-testing/Helpers.ts
@@ -68,6 +68,9 @@ export const initialize = async (props?: PresentationTestingInitProps) => {
   if (!props)
     props = {};
 
+  // set up rpc interfaces
+  initializeRpcInterfaces([SnapshotIModelRpcInterface, IModelReadRpcInterface, PresentationRpcInterface]);
+
   // init backend
   // make sure backend gets assigned an id which puts its resources into a unique directory
   props.backendProps = props.backendProps ?? {};
@@ -75,9 +78,6 @@ export const initialize = async (props?: PresentationTestingInitProps) => {
     props.backendProps.id = `test-${Guid.createValue()}`;
   await IModelHost.startup();
   PresentationBackend.initialize(props.backendProps);
-
-  // set up rpc interfaces
-  initializeRpcInterfaces([SnapshotIModelRpcInterface, IModelReadRpcInterface, PresentationRpcInterface]);
 
   // init frontend
   if (!props.frontendApp)


### PR DESCRIPTION
Response of the initial request contains the most valuable diagnostics that may give answers to why the request took long in the first place. Throwing it away and repeating the request may return the result, but it loses valuable diagnostics data.

The change makes our RPC implementation store the response promises temporarily just to ensure we return the same promise if the request is repeated within 10 seconds window. If not, the behavior is as before - make a similar request to `PresentationManager`.