### PR TITLE
Improve glTF spec conformance

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3675,9 +3675,7 @@ export class GltfGraphicsReader extends GltfReader {
     // (undocumented)
     get scenes(): GltfDictionary<GltfScene>;
     // (undocumented)
-    get textures(): GltfDictionary<GltfTexture & {
-        resolvedTexture?: RenderTexture;
-    }>;
+    get textures(): GltfDictionary<GltfTexture>;
 }
 
 // @internal
@@ -3702,7 +3700,7 @@ export type GltfId = Gltf1Id | Gltf2Id;
 export class GltfMeshData {
     constructor(props: Mesh);
     // (undocumented)
-    indices?: Uint16Array | Uint32Array;
+    indices?: Uint8Array | Uint16Array | Uint32Array;
     // (undocumented)
     normals?: Uint16Array;
     // (undocumented)
@@ -3740,11 +3738,11 @@ export abstract class GltfReader {
     // (undocumented)
     protected _computedContentRange?: ElementAlignedBox3d;
     // (undocumented)
-    protected createDisplayParams(materialJson: GltfMaterial, hasBakedLighting: boolean): DisplayParams | undefined;
+    protected createDisplayParams(material: GltfMaterial, hasBakedLighting: boolean): DisplayParams | undefined;
     // (undocumented)
     protected readonly _deduplicateVertices: boolean;
     // (undocumented)
-    protected findTextureMapping(textureId: string): TextureMapping | undefined;
+    protected findTextureMapping(id: string, isTransparent: boolean): TextureMapping | undefined;
     // (undocumented)
     getBufferView(json: {
         [k: string]: any;
@@ -3825,9 +3823,7 @@ export abstract class GltfReader {
     // (undocumented)
     protected readonly _system: RenderSystem;
     // (undocumented)
-    protected get _textures(): GltfDictionary<GltfTexture & {
-        resolvedTexture?: RenderTexture;
-    }>;
+    protected get _textures(): GltfDictionary<GltfTexture>;
     traverseNodes(nodeIds: Iterable<GltfId>): Iterable<GltfNode>;
     traverseScene(): Iterable<GltfNode>;
     // (undocumented)

--- a/common/changes/@itwin/core-frontend/fix-gltf-bugs_2022-01-03-15-46.json
+++ b/common/changes/@itwin/core-frontend/fix-gltf-bugs_2022-01-03-15-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Improve conformance with the glTF 2.0 spec.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/primitives/Primitives.ts
+++ b/core/frontend/src/render/primitives/Primitives.ts
@@ -99,7 +99,8 @@ export class TriangleList {
 
     this._flags.push(flags);
   }
-  public addFromTypedArray(indices: Uint16Array | Uint32Array, flags: number = 0) {
+
+  public addFromTypedArray(indices: Uint8Array | Uint16Array | Uint32Array, flags: number = 0) {
     for (let i = 0; i < indices.length;) {
       this.indices.push(indices[i++]);
       this.indices.push(indices[i++]);

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -307,11 +307,4 @@ describe("GltfReader", () => {
     expectCycle(2);
     expectCycle(3);
   });
-
-  it("loads only (and all of) the textures referenced by the scene exactly once", async () => {
-  });
-
-  it("relaxes spec to tolerate misaligned buffer data", () => {
-    // ScalableMesh tile publisher apparently sometimes fails to align their buffers to 32-bit boundaries; we accommodate them...
-  });
 });

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -367,7 +367,7 @@ interface Gltf2Material extends GltfChildOfRootProperty {
   doubleSided?: boolean;
   extensions?: GltfExtensions & {
     /** The [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit) extension
-     * indicates that the material should be displayed without lighting. The extension adds no additional properties - it is effectively a boolean flag.
+     * indicates that the material should be displayed without lighting. The extension adds no additional properties; it is effectively a boolean flag.
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     KHR_materials_unlit?: { };

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1239,8 +1239,8 @@ export abstract class GltfReader {
       }
     }
 
-    const id = extractId(material.emissiveTexture?.index);
-    return id ?? extractId(material.pbrMetallicRoughness?.baseColorTexture?.index);
+    const id = extractId(material.pbrMetallicRoughness?.baseColorTexture?.index);
+    return id ?? extractId(material.emissiveTexture?.index);
   }
 
   private isMaterialTransparent(material: GltfMaterial): boolean {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -311,6 +311,12 @@ interface GltfSampler extends  GltfChildOfRootProperty {
   wrapT?: GltfWrapMode;
 }
 
+/** GL states that can be enabled by a [[GltfTechnique]]. Only those queried by this implementation are enumerated. */
+enum GltfTechniqueState {
+  /** Enables alpha blending. */
+  Blend = 3042,
+}
+
 /** For glTF 1.0 only, describes shader programs and shader state associated with a [[Gltf1Material]], used to render meshes associated with the material.
  * This implementation uses it strictly to identify techniques that require alpha blending.
  */
@@ -318,9 +324,9 @@ interface GltfTechnique extends GltfChildOfRootProperty {
   /** GL render states to be applied by the technique. */
   states?: {
     /** An array of integers corresponding to boolean GL states that should be enabled using GL's `enable` function.
-     * For example, the value `3042` indicates that blending should be enabled.
+     * For example, the value [[GltfTechniqueState.Blend]] (3042) indicates that blending should be enabled.
      */
-    enable?: number[];
+    enable?: GltfTechniqueState[];
   };
 }
 
@@ -1725,7 +1731,7 @@ export abstract class GltfReader {
           const technique = this._glTF.techniques[material.technique];
           if (technique?.states?.enable) {
             for (const enable of technique.states.enable) {
-              if (3042 === enable) { // 3042 = BLEND
+              if (GltfTechniqueState.Blend === enable) {
                 transparentTextures.add(material.values.tex.toString());
                 break;
               }

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -299,7 +299,10 @@ interface GltfTexture extends GltfChildOfRootProperty {
   source?: GltfId;
 }
 
-/** Describes the filtering and wrapping behavior to be applied to a [[GltfTexture]]. */
+/** Describes the filtering and wrapping behavior to be applied to a [[GltfTexture]].
+ * @note The implementation currently does not support MirroredRepeat and does not support different wrapping for U and V;
+ * effectively, unless `wrapS` or `wrapT` is set to ClampToEdge, the sampler will use GltfWrapMode.Repeat.
+ */
 interface GltfSampler extends  GltfChildOfRootProperty {
   /** Magnification filter. */
   magFilter?: GltfMagFilter;

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -305,9 +305,9 @@ interface GltfSampler extends  GltfChildOfRootProperty {
   magFilter?: GltfMagFilter;
   /** Minification filter. */
   minFilter?: GltfMinFilter;
-  /** S (U) wrapping mode. */
+  /** S (U) wrapping mode. Default: Repeat. */
   wrapS?: GltfWrapMode;
-  /** T (V) wrapping mode. */
+  /** T (V) wrapping mode. Default: Repeat. */
   wrapT?: GltfWrapMode;
 }
 
@@ -1752,7 +1752,9 @@ export abstract class GltfReader {
 
     const samplerId = texture.sampler;
     const sampler = undefined !== samplerId ? this._samplers[samplerId] : undefined;
-    const textureType = undefined !== sampler?.wrapS || undefined !== sampler?.wrapT ? RenderTexture.Type.TileSection : RenderTexture.Type.Normal;
+    // ###TODO: RenderTexture should support different wrapping behavior for U vs V, and support mirrored repeat.
+    // For now, repeat unless either explicitly clamps.
+    const textureType = GltfWrapMode.ClampToEdge === sampler?.wrapS || GltfWrapMode.ClampToEdge === sampler?.wrapT ? RenderTexture.Type.TileSection : RenderTexture.Type.Normal;
     texture.resolvedTexture = this._system.createTexture({
       type: textureType,
       image: {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -354,6 +354,11 @@ interface Gltf2Material extends GltfChildOfRootProperty {
   alphaCutoff?: number;
   doubleSided?: boolean;
   extensions?: GltfExtensions & {
+    /** The [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit) extension
+     * indicates that the material should be displayed without lighting. The extension adds no additional properties - it is effectively a boolean flag.
+     */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    KHR_materials_unlit?: { }
     /** The [KHR_techniques_webgl extension](https://github.com/KhronosGroup/glTF/blob/c1c12bd100e88ff468ccef1cb88cfbec56a69af2/extensions/2.0/Khronos/KHR_techniques_webgl/README.md)
      * allows "techniques" to be associated with [[GltfMaterial]]s. Techniques can supply custom shader programs to render geometry; this was a core feature of glTF 1.0 (see [[GltfTechnique]]).
      * Here, it is only used to extract uniform values.
@@ -1214,10 +1219,13 @@ export abstract class GltfReader {
 
   protected readMeshPrimitive(primitive: GltfMeshPrimitive, featureTable?: FeatureTable, pseudoRtcBias?: Vector3d): GltfMeshData | undefined {
     const materialName = JsonUtils.asString(primitive.material);
-    const hasBakedLighting = undefined === primitive.attributes.NORMAL;
     const material = 0 < materialName.length ? this._materials[materialName] : undefined;
+    if (!material)
+      return undefined;
+
+    const hasBakedLighting = undefined === primitive.attributes.NORMAL || undefined !== material.extensions?.KHR_materials_unlit;
     const displayParams = material ? this.createDisplayParams(material, hasBakedLighting) : undefined;
-    if (undefined === displayParams)
+    if (!displayParams)
       return undefined;
 
     let primitiveType: number = -1;

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -370,7 +370,7 @@ interface Gltf2Material extends GltfChildOfRootProperty {
      * indicates that the material should be displayed without lighting. The extension adds no additional properties - it is effectively a boolean flag.
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    KHR_materials_unlit?: { }
+    KHR_materials_unlit?: { };
     /** The [KHR_techniques_webgl extension](https://github.com/KhronosGroup/glTF/blob/c1c12bd100e88ff468ccef1cb88cfbec56a69af2/extensions/2.0/Khronos/KHR_techniques_webgl/README.md)
      * allows "techniques" to be associated with [[GltfMaterial]]s. Techniques can supply custom shader programs to render geometry; this was a core feature of glTF 1.0 (see [[GltfTechnique]]).
      * Here, it is only used to extract uniform values.

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -283,7 +283,10 @@ interface GltfImage extends GltfChildOfRootProperty {
 interface GltfTextureInfo extends GltfProperty {
   /** The Id of the [[GltfTexture]]. */
   index: GltfId;
-  /** The set index of the texture's TEXCOORD attribute used for texture coordinate mapping. */
+  /** The set index of the texture's TEXCOORD attribute used for texture coordinate mapping.
+   * For example, if `texCoord` is `2`, an attribute named `TEXCOORD_2` must exist containing the texture coordinates.
+   * Default: 0.
+   */
   texCoord?: number;
 }
 
@@ -1360,8 +1363,13 @@ export abstract class GltfReader {
         if (!displayParams.ignoreLighting && !this.readNormals(mesh, primitive.attributes, "NORMAL"))
           return undefined;
 
-        if (!mesh.uvs)
-          this.readUVParams(mesh, primitive.attributes, "TEXCOORD_0");
+        if (!mesh.uvs) {
+          let texCoordIndex = 0;
+          if (!isGltf1Material(material) && undefined !== material.pbrMetallicRoughness?.baseColorTexture?.texCoord)
+            texCoordIndex = JsonUtils.asInt(material.pbrMetallicRoughness.baseColorTexture.texCoord);
+
+          this.readUVParams(mesh, primitive.attributes, `TEXCOORD_${texCoordIndex}`);
+        }
 
         if (this._deduplicateVertices && !this.deduplicateVertices(mesh))
           return undefined;


### PR DESCRIPTION
Khronos supplies a wide variety of [sample glTF models](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0) to test spec conformance. Our current implementation fails many of them.
Some of those failures we don't intend to rectify any time soon - e.g., PBR materials, animations, etc.
This PR addresses the following that are likely to affect iTwin.js users:

- BoxTextured: texture sampler shouldn't clamp to edge unless explicitly specified.
- UnlitTest: support the KHR_materials_unlit extension indicating the mesh should be displayed without lighting.
- AlphaBlendModeTest: support 8-bit vertex indices.
- AlphaBlendModeTest: render transparent IFF material explicitly requests alpha blending.
- Fox: manufacture vertex indices for non-indexed mesh vertices.
- Lantern: prefer baseColorTexture if present.
- MultiUVTest, ToyCar: If texture info defines `texCoord`, use it when looking up TEXCOORD_n attribute.