### PR TITLE
V2 download log improvement

### DIFF
--- a/common/changes/@itwin/core-backend/v2-download-log-improvement_2022-01-03-19-12.json
+++ b/common/changes/@itwin/core-backend/v2-download-log-improvement_2022-01-03-19-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Improved log message when v2 checkpoint downloaded is not for the changeset requested",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -200,7 +200,10 @@ export class CheckpointManager {
     try {
       // first see if there's a V2 checkpoint available.
       const changesetId = await V2CheckpointManager.downloadCheckpoint(request);
-      Logger.logInfo(loggerCategory, `Downloaded v2 checkpoint: IModel=${request.checkpoint.iModelId}, changeset=${request.checkpoint.changeset.id}`);
+      if (changesetId !== request.checkpoint.changeset.id)
+        Logger.logInfo(loggerCategory, `Downloaded previous v2 checkpoint because checkpoint for ${request.checkpoint.changeset.id} not found.  Downloaded: IModel=${request.checkpoint.iModelId}, changeset=${changesetId}`);
+      else
+        Logger.logInfo(loggerCategory, `Downloaded v2 checkpoint: IModel=${request.checkpoint.iModelId}, changeset=${request.checkpoint.changeset.id}`);
       return changesetId;
     } catch (error) {
       if (error instanceof IModelError && error.errorNumber === IModelStatus.NotFound) // No V2 checkpoint available, try a v1 checkpoint


### PR DESCRIPTION
Incorrectly logged the id of the changeset downloaded if the requested version does not exist and a previous checkpoint exists