### PR TITLE
Update to latest Rush and pnpm versions

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -6,16 +6,14 @@
       "commandKind": "global",
       "summary": "Runs npm audit for the entire monorepo",
       "description": "Scans the entire monorepo for security vulnerabilities via npm audit",
-      "shellCommand": "node tools/internal/scripts/rush/audit.js",
-      "allowWarningsInSuccessfulBuild": true
+      "shellCommand": "node tools/internal/scripts/rush/audit.js"
     },
     {
       "name": "fix-copyrights",
       "commandKind": "global",
       "summary": "Fixes whitespace-only changes caused by broken copyright linter",
       "description": "Manually runs the new copyright linter on all files changed between the current branch and master.",
-      "shellCommand": "node common/scripts/copyright-linter.js --fix",
-      "allowWarningsInSuccessfulBuild": true
+      "shellCommand": "node common/scripts/copyright-linter.js --fix"
     },
     {
       "name": "clean",

--- a/common/scripts/install-run-rush.js
+++ b/common/scripts/install-run-rush.js
@@ -16,7 +16,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -42,7 +42,7 @@ function _getRushVersion() {
         console.log(`Using Rush version from environment variable ${RUSH_PREVIEW_VERSION}=${rushPreviewVersion}`);
         return rushPreviewVersion;
     }
-    const rushJsonFolder = install_run_1.findRushJsonFolder();
+    const rushJsonFolder = (0, install_run_1.findRushJsonFolder)();
     const rushJsonPath = path.join(rushJsonFolder, install_run_1.RUSH_JSON_FILENAME);
     try {
         const rushJsonContents = fs.readFileSync(rushJsonPath, 'utf-8');
@@ -76,10 +76,10 @@ function _run() {
         }
         process.exit(1);
     }
-    install_run_1.runWithErrorAndStatusCode(() => {
+    (0, install_run_1.runWithErrorAndStatusCode)(() => {
         const version = _getRushVersion();
         console.log(`The rush.json configuration requests Rush version ${version}`);
-        return install_run_1.installAndRun(PACKAGE_NAME, version, bin, packageBinArgs);
+        return (0, install_run_1.installAndRun)(PACKAGE_NAME, version, bin, packageBinArgs);
     });
 }
 _run();

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -16,7 +16,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/rush.json
+++ b/rush.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-  "rushVersion": "5.51.1",
-  "pnpmVersion": "6.13.0",
+  "rushVersion": "5.58.0",
+  "pnpmVersion": "6.24.4",
   "nodeSupportedVersionRange": ">=12.17.0 <17.0.0",
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,


### PR DESCRIPTION
Move to the latest Rush version to pick up some fixes (referenced [here](https://github.com/microsoft/rushstack/issues/2418)) that should make life easier with the peer dependency hell introduced in #2912.

Updated pnpm to keep both up-to-date.