### PR TITLE
Web IPC fix

### DIFF
--- a/common/changes/@itwin/core-common/web-ipc-fix_2022-01-06-15-45.json
+++ b/common/changes/@itwin/core-common/web-ipc-fix_2022-01-06-15-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Concurrency fix within web IPC transport system.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}


### PR DESCRIPTION
Since the process of reading IPC message data is async (in the browser), we can only store bookkeeping data about the incoming message sequence in local variables associated with the async call site.