### PR TITLE
Bug: MessageBoxIconType.NoSymbol shows Success icon instead of no symbol

### DIFF
--- a/common/changes/@itwin/appui-abstract/ui-no-symbol-error_2022-01-06-20-09.json
+++ b/common/changes/@itwin/appui-abstract/ui-no-symbol-error_2022-01-06-20-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-abstract",
+      "comment": "Fix bug that sets the icon on MessageBox.NoSymbol the Success icon.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-abstract"
+}

--- a/common/changes/@itwin/appui-react/ui-no-symbol-error_2022-01-06-20-09.json
+++ b/common/changes/@itwin/appui-react/ui-no-symbol-error_2022-01-06-20-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix bug that sets the icon on MessageBox.NoSymbol the Success icon.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/core-frontend/ui-no-symbol-error_2022-01-06-20-09.json
+++ b/common/changes/@itwin/core-frontend/ui-no-symbol-error_2022-01-06-20-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix bug that sets the icon on MessageBox.NoSymbol the Success icon.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-react/ui-no-symbol-error_2022-01-06-20-09.json
+++ b/common/changes/@itwin/core-react/ui-no-symbol-error_2022-01-06-20-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Fix bug that sets the icon on MessageBox.NoSymbol the Success icon.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/core/frontend/src/NotificationManager.ts
+++ b/core/frontend/src/NotificationManager.ts
@@ -34,6 +34,7 @@ export enum OutputMessageType {
  */
 export enum OutputMessagePriority {
   None = 0,
+  Success = 1,
   Error = 10,
   Warning = 11,
   Info = 12,
@@ -79,6 +80,7 @@ export enum MessageBoxIconType {
   Question = 2,   // Question Mark
   Warning = 3,   // Exclamation Point
   Critical = 4,   // Stop Sign
+  Success = 5, // check mark
 }
 
 /** Describes the possible return values produced when the user clicks a button in a messagebox opened using [[NotificationManager.openMessageBox]].

--- a/test-apps/ui-test-app/src/frontend/appui/frontstages/Frontstage4.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/frontstages/Frontstage4.tsx
@@ -423,7 +423,7 @@ export class Frontstage4 extends FrontstageProvider {
               labelKey="SampleApp:buttons.toolGroup"
               iconSpec="icon-placeholder"
               items={[
-                AppTools.successMessageBoxCommand, AppTools.informationMessageBoxCommand, AppTools.questionMessageBoxCommand,
+                AppTools.noIconMessageBoxCommand, AppTools.successMessageBoxCommand, AppTools.informationMessageBoxCommand, AppTools.questionMessageBoxCommand,
                 AppTools.warningMessageBoxCommand, AppTools.errorMessageBoxCommand, AppTools.openMessageBoxCommand, AppTools.openMessageBoxCommand2,
                 this._spinnerTestDialogItem,
                 this._sampleModelessDialogItem,

--- a/test-apps/ui-test-app/src/frontend/tools/ToolSpecifications.tsx
+++ b/test-apps/ui-test-app/src/frontend/tools/ToolSpecifications.tsx
@@ -646,13 +646,20 @@ export class AppTools {
       execute: () => ModalDialogManager.openDialog(AppTools._messageBox(MessageSeverity.Error, IModelApp.localization.getLocalizedString("SampleApp:buttons.errorMessageBox"))),
     });
   }
+  public static get noIconMessageBoxCommand() {
+    return new CommandItemDef({
+      commandId: "noIconMessage",
+      labelKey: "SampleApp:buttons.noIconMessageBox",
+      execute: () => ModalDialogManager.openDialog(AppTools._messageBox(MessageSeverity.None, IModelApp.localization.getLocalizedString("SampleApp:buttons.noIconMessageBox"))),
+    });
+  }
 
   public static get successMessageBoxCommand() {
     return new CommandItemDef({
       commandId: "successMessage",
       iconSpec: "icon-status-success",
       labelKey: "SampleApp:buttons.successMessageBox",
-      execute: () => ModalDialogManager.openDialog(AppTools._messageBox(MessageSeverity.None, IModelApp.localization.getLocalizedString("SampleApp:buttons.successMessageBox"))),
+      execute: () => ModalDialogManager.openDialog(AppTools._messageBox(MessageSeverity.Success, IModelApp.localization.getLocalizedString("SampleApp:buttons.successMessageBox"))),
     });
   }
 

--- a/ui/appui-abstract/src/appui-abstract/notification/MessageSeverity.ts
+++ b/ui/appui-abstract/src/appui-abstract/notification/MessageSeverity.ts
@@ -16,4 +16,5 @@ export enum MessageSeverity {
   Warning = 3,
   Error = 4,
   Fatal = 5,
+  Success = 6,
 }

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -509,7 +509,7 @@ export class UiFramework {
   }
 
   public static get showWidgetIcon(): boolean {
-    return UiFramework.frameworkState ? UiFramework.frameworkState.configurableUiState.showWidgetIcon : false;
+    return UiFramework.frameworkState ? UiFramework.frameworkState.configurableUiState.showWidgetIcon : /* istanbul ignore next */ false;
   }
 
   public static setShowWidgetIcon(value: boolean) {
@@ -531,7 +531,7 @@ export class UiFramework {
    * @public
    */
   public static get viewOverlayDisplay() {
-    return UiFramework.frameworkState ? UiFramework.frameworkState.configurableUiState.viewOverlayDisplay : true;
+    return UiFramework.frameworkState ? UiFramework.frameworkState.configurableUiState.viewOverlayDisplay : /* istanbul ignore next */ true;
   }
   /** Set the variable that controls display of the view overlay. Applies to all viewports in the app
  * @public
@@ -561,14 +561,6 @@ export class UiFramework {
       await IModelApp.telemetry.postTelemetry(activity, telemetryEvent);
     } catch { }
   }
-  private static _handleFrameworkVersionChangedEvent = (args: FrameworkVersionChangedEventArgs) => {
-    // Log Ui Version used
-    Logger.logInfo(UiFramework.loggerCategory(UiFramework), `Ui Version changed to ${args.version} `);
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    UiFramework.postTelemetry(`Ui Version changed to ${args.version} `, "F2772C81-962D-4755-807C-2D675A5FF399");
-    UiFramework.setUiVersion(args.version);
-  };
-
   /** Determines whether a ContextMenu is open
    * @alpha
    * */

--- a/ui/appui-react/src/appui-react/dialog/StandardMessageBox.tsx
+++ b/ui/appui-react/src/appui-react/dialog/StandardMessageBox.tsx
@@ -89,6 +89,9 @@ export class StandardMessageBox extends React.PureComponent<StandardMessageBoxPr
       case MessageBoxIconType.Critical:
         severity = MessageSeverity.Error;
         break;
+      case MessageBoxIconType.Success:
+        severity = MessageSeverity.Success;
+        break;
     }
 
     return (

--- a/ui/appui-react/src/appui-react/messages/MessageManager.tsx
+++ b/ui/appui-react/src/appui-react/messages/MessageManager.tsx
@@ -374,6 +374,9 @@ export class MessageManager {
       case OutputMessagePriority.None:
         severity = MessageSeverity.None;
         break;
+      case OutputMessagePriority.Success:
+        severity = MessageSeverity.Success;
+        break;
       case OutputMessagePriority.Info:
         severity = MessageSeverity.Information;
         break;
@@ -398,6 +401,9 @@ export class MessageManager {
     switch (details.priority) {
       case OutputMessagePriority.None:
         iconType = MessageBoxIconType.NoSymbol;
+        break;
+      case OutputMessagePriority.Success:
+        iconType = MessageBoxIconType.Success;
         break;
       case OutputMessagePriority.Info:
         iconType = MessageBoxIconType.Information;

--- a/ui/appui-react/src/appui-react/messages/MessageManager.tsx
+++ b/ui/appui-react/src/appui-react/messages/MessageManager.tsx
@@ -372,7 +372,7 @@ export class MessageManager {
 
     switch (details.priority) {
       case OutputMessagePriority.None:
-        severity = MessageSeverity.None;
+        severity = MessageSeverity.Success;
         break;
       case OutputMessagePriority.Success:
         severity = MessageSeverity.Success;

--- a/ui/appui-react/src/test/UiFramework.test.ts
+++ b/ui/appui-react/src/test/UiFramework.test.ts
@@ -235,6 +235,10 @@ describe("UiFramework localStorage Wrapper", () => {
       const displayOverlay = false;
       UiFramework.setViewOverlayDisplay(displayOverlay);
       expect(UiFramework.viewOverlayDisplay).to.eql(displayOverlay);
+      // test workflow that doesn't change the item
+      const currentDisplay = UiFramework.viewOverlayDisplay;
+      UiFramework.setViewOverlayDisplay(displayOverlay);
+      expect(UiFramework.viewOverlayDisplay).to.eql(currentDisplay);
 
       TestUtils.terminateUiFramework();
 

--- a/ui/appui-react/src/test/dialog/StandardMessageBox.test.tsx
+++ b/ui/appui-react/src/test/dialog/StandardMessageBox.test.tsx
@@ -136,7 +136,7 @@ describe("StandardMessageBox", () => {
     const reactNode = <StandardMessageBox
       opened={true}
       title="My Title"
-      iconType={MessageBoxIconType.NoSymbol}
+      iconType={MessageBoxIconType.Success}
       messageBoxType={MessageBoxType.Ok}
       onResult={spyOnEscape}
     />;

--- a/ui/appui-react/src/test/messages/MessageManager.test.tsx
+++ b/ui/appui-react/src/test/messages/MessageManager.test.tsx
@@ -81,7 +81,10 @@ describe("MessageManager", () => {
     expect(MessageManager.getSeverity(details)).to.eq(MessageSeverity.Fatal);
 
     details = new NotifyMessageDetails(OutputMessagePriority.None, "A brief message.");
-    expect(MessageManager.getSeverity(details)).to.eq(MessageSeverity.None);
+    expect(MessageManager.getSeverity(details)).to.eq(MessageSeverity.Success);
+
+    details = new NotifyMessageDetails(OutputMessagePriority.Success, "A brief message.");
+    expect(MessageManager.getSeverity(details)).to.eq(MessageSeverity.Success);
   });
 
   it("non-duplicate message should be added to Message Center", () => {

--- a/ui/core-react/src/core-react/messagebox/MessageBox.tsx
+++ b/ui/core-react/src/core-react/messagebox/MessageBox.tsx
@@ -98,6 +98,9 @@ export class MessageContainer extends React.PureComponent<MessageContainerProps>
 
     switch (severity) {
       case MessageSeverity.None:
+        iconClassName = " ";
+        break;
+      case MessageSeverity.Success:
         iconClassName = hollow ? "icon-status-success-hollow" : "icon-status-success" + " core-message-box-success";
         break;
       case MessageSeverity.Information:

--- a/ui/core-react/src/test/messagebox/MessageBox.test.tsx
+++ b/ui/core-react/src/test/messagebox/MessageBox.test.tsx
@@ -57,8 +57,14 @@ describe("MessageBox", () => {
     it("MessageSeverity.None", () => {
       const wrapper = mount(<MessageBox opened={true} severity={MessageSeverity.None} buttonCluster={buttonCluster} />);
       const icon = wrapper.find("div.core-message-box-success");
+      expect(icon.length).to.eq(0);
+    });
+    it("MessageSeverity.Success", () => {
+      const wrapper = mount(<MessageBox opened={true} severity={MessageSeverity.Success} buttonCluster={buttonCluster} />);
+      const icon = wrapper.find("div.core-message-box-success");
       expect(icon.length).to.eq(1);
     });
+
   });
 
   describe("MessageContainer.getIconClassName with hollow param", () => {
@@ -69,6 +75,7 @@ describe("MessageBox", () => {
       expect(MessageContainer.getIconClassName(MessageSeverity.Warning, true).length).to.not.eq(0);
       expect(MessageContainer.getIconClassName(MessageSeverity.Error, true).length).to.not.eq(0);
       expect(MessageContainer.getIconClassName(MessageSeverity.Fatal, true).length).to.not.eq(0);
+      expect(MessageContainer.getIconClassName(MessageSeverity.Success, true).length).to.not.eq(0);
     });
   });
 


### PR DESCRIPTION
In NotificationManager:
-- add specific Success icon type
-- add specific Success message priority 

In StandardMessageBox and MessageBox:
-- don't specify and icon for MessageSeverity.None message boxes

Don't change the behavior for MessageCenter messages, because ToastMessage does not support no icon mode.
