### PR TITLE
Fix flickering in TwoWayViewportSync

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-animated-viewport-sync_2022-01-07-14-29.json
+++ b/common/changes/@itwin/core-frontend/fix-animated-viewport-sync_2022-01-07-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix flickering with TwoWayViewportSync when one of the viewport's frustum is animated.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
@@ -9,7 +9,7 @@ import {
   AmbientOcclusion, AnalysisStyle, ClipStyle, ColorDef, FeatureAppearance, ModelClipGroup, ModelClipGroups, MonochromeMode, PlanProjectionSettings, SubCategoryOverride, ThematicDisplay, ViewFlags,
 } from "@itwin/core-common";
 import {
-  ChangeFlag, FeatureSymbology, PerModelCategoryVisibility, ScreenViewport, SnapshotConnection, SpatialViewState, StandardViewId, Viewport,
+  ChangeFlag, FeatureSymbology, PerModelCategoryVisibility, ScreenViewport, SnapshotConnection, SpatialViewState, StandardViewId, Viewport, ViewState,
 } from "@itwin/core-frontend";
 import { ViewportChangedHandler, ViewportState } from "../ViewportChangedHandler";
 import { TestUtility } from "../TestUtility";
@@ -338,6 +338,10 @@ describe("Viewport changed events", async () => {
     });
   });
 
+  function changeView(viewport: Viewport, view: ViewState): void {
+    viewport.changeView(view, { animateFrustumChange: false });
+  }
+
   it("should be dispatched when displayed 2d models change", async () => {
     vp = ScreenViewport.create(viewDiv, await testImodel.views.load(id64(0x20))); // views model 0x19
 
@@ -351,16 +355,16 @@ describe("Viewport changed events", async () => {
 
       // Switching to a different 2d view of the same model should not produce model-changed event
       const view20 = await testImodel.views.load(id64(0x20)); // views model 0x1e
-      mon.expect(ChangeFlag.ViewState, ViewportState.Controller, () => vp.changeView(view20));
+      mon.expect(ChangeFlag.ViewState, ViewportState.Controller, () => changeView(vp, view20));
 
       // Switching to a different 2d view of a different model should produce model-changed event
       // Note: new view also has different categories enabled.
       const view35 = await testImodel.views.load(id64(0x35)); // views model 0x1e
-      mon.expect(ChangeFlag.ViewedModels | ChangeFlag.ViewedCategories | ChangeFlag.DisplayStyle | ChangeFlag.ViewState, ViewportState.Controller, () => vp.changeView(view35));
+      mon.expect(ChangeFlag.ViewedModels | ChangeFlag.ViewedCategories | ChangeFlag.DisplayStyle | ChangeFlag.ViewState, ViewportState.Controller, () => changeView(vp, view35));
 
       // Switch back to previous view.
-      // Note: changeView() clears undo stack so cannot/needn't test undo/redo here.
-      mon.expect(ChangeFlag.ViewedModels | ChangeFlag.ViewedCategories | ChangeFlag.DisplayStyle | ChangeFlag.ViewState, ViewportState.Controller, () => vp.changeView(view20.clone()));
+      // Note: changeView(vp, ) clears undo stack so cannot/needn't test undo/redo here.
+      mon.expect(ChangeFlag.ViewedModels | ChangeFlag.ViewedCategories | ChangeFlag.DisplayStyle | ChangeFlag.ViewState, ViewportState.Controller, () => changeView(vp, view20.clone()));
     });
   });
 
@@ -445,11 +449,11 @@ describe("Viewport changed events", async () => {
 
       // Switching to a different view with same category selector produces no category-changed event
       const view13 = await testImodel.views.load(id64(0x13));
-      mon.expect(ChangeFlag.ViewState | ChangeFlag.DisplayStyle, ViewportState.Controller, () => vp.changeView(view13));
+      mon.expect(ChangeFlag.ViewState | ChangeFlag.DisplayStyle, ViewportState.Controller, () => changeView(vp, view13));
 
       // Switching to a different view with different category selector produces event
       const view17 = await testImodel.views.load(id64(0x17));
-      mon.expect(ChangeFlag.ViewState | ChangeFlag.DisplayStyle | ChangeFlag.ViewedCategories, ViewportState.Controller, () => vp.changeView(view17));
+      mon.expect(ChangeFlag.ViewState | ChangeFlag.DisplayStyle | ChangeFlag.ViewedCategories, ViewportState.Controller, () => changeView(vp, view17));
 
       // Changing category selector, then switching to a view with same categories enabled produces no event.
       mon.expect(ChangeFlag.ViewedCategories, undefined, () => {
@@ -457,7 +461,7 @@ describe("Viewport changed events", async () => {
         vp.changeCategoryDisplay(view13.categorySelector.categories, true);
       });
 
-      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.DisplayStyle, ViewportState.Controller, () => vp.changeView(view13));
+      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.DisplayStyle, ViewportState.Controller, () => changeView(vp, view13));
     });
   });
 
@@ -594,25 +598,25 @@ describe("Viewport changed events", async () => {
     vp = ScreenViewport.create(viewDiv, view2d20.clone());
     ViewportChangedHandler.test(vp, (mon) => {
       // No effective change to view
-      mon.expect(ChangeFlag.ViewState, ViewportState.Controller, () => vp.changeView(view2d20.clone()));
+      mon.expect(ChangeFlag.ViewState, ViewportState.Controller, () => changeView(vp, view2d20.clone()));
 
       // 2d => 2d
-      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.ViewedModels | ChangeFlag.DisplayStyle, ViewportState.Controller, () => vp.changeView(view2d2e.clone()));
+      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.ViewedModels | ChangeFlag.DisplayStyle, ViewportState.Controller, () => changeView(vp, view2d2e.clone()));
 
       // 2d => 3d
-      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.ViewedModels | ChangeFlag.DisplayStyle, ViewportState.Controller, () => vp.changeView(view3d15.clone()));
+      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.ViewedModels | ChangeFlag.DisplayStyle, ViewportState.Controller, () => changeView(vp, view3d15.clone()));
 
       // No effective change
-      mon.expect(ChangeFlag.ViewState, ViewportState.Controller, () => vp.changeView(view3d15.clone()));
+      mon.expect(ChangeFlag.ViewState, ViewportState.Controller, () => changeView(vp, view3d15.clone()));
 
       // 3d => 3d - same model selector, same display style, different category selector
-      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories, ViewportState.Controller, () => vp.changeView(view3d17.clone()));
+      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories, ViewportState.Controller, () => changeView(vp, view3d17.clone()));
 
       // 3d => 2d
-      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.ViewedModels | ChangeFlag.DisplayStyle, ViewportState.Controller, () => vp.changeView(view2d20.clone()));
+      mon.expect(ChangeFlag.ViewState | ChangeFlag.ViewedCategories | ChangeFlag.ViewedModels | ChangeFlag.DisplayStyle, ViewportState.Controller, () => changeView(vp, view2d20.clone()));
 
       // Pass the exact same ViewState reference => no "ViewState changed" event.
-      mon.expect(ChangeFlag.None, undefined, () => vp.changeView(vp.view));
+      mon.expect(ChangeFlag.None, undefined, () => changeView(vp, vp.view));
     });
 
     // Test the immediately-fire onChangeView event.
@@ -620,15 +624,15 @@ describe("Viewport changed events", async () => {
     const removeListener = vp.onChangeView.addListener(() => ++numEvents);
 
     // Same ViewState reference => no event
-    vp.changeView(vp.view);
+    changeView(vp, vp.view);
     expect(numEvents).to.equal(0);
 
     // Different ViewState reference => event
-    vp.changeView(view2d20.clone());
+    changeView(vp, view2d20.clone());
     expect(numEvents).to.equal(1);
 
     // Different ViewState reference to an logically identical ViewState => event
-    vp.changeView(view2d20);
+    changeView(vp, view2d20);
     expect(numEvents).to.equal(2);
 
     removeListener();


### PR DESCRIPTION
As described in #2999.
When we animate a frustum change in a Viewport, we first set the viewport's frustum to the *final* frustum, then invalidate its render plan. This causes renderFrame to be invoked on the next frame, which invokes the animator to set up the first stage of the frustum animation.
However if the viewport is synced with another viewport then the other viewport only sees the final frustum, until the animator is invoked, at which point it will see the intermediate frustum.
If the "source" viewport renders before the "target" viewport, this works fine, because the first viewport will invoke its animator, updating the second's frustum before it renders.
If the target viewport renders before the source viewport, it will render the *final* frustum on the first frame of the animation.

Fix: when installing a new animator, immediately invoke its animate method to set up the initial frustum.