### PR TITLE
Revisited the way map layers authentication is handled in the UI.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5509,6 +5509,24 @@ export class MapCartoRectangle extends Range2d {
 }
 
 // @internal (undocumented)
+export interface MapLayerAuthenticationInfo {
+    // (undocumented)
+    authMethod: MapLayerAuthType;
+    // (undocumented)
+    tokenEndpoint?: MapLayerTokenEndpoint;
+}
+
+// @beta (undocumented)
+export enum MapLayerAuthType {
+    // (undocumented)
+    Basic = 2,
+    // (undocumented)
+    EsriToken = 3,
+    // (undocumented)
+    None = 1
+}
+
+// @internal (undocumented)
 export class MapLayerFormat {
     // (undocumented)
     static createImageryProvider(_settings: MapLayerSettings): MapLayerImageryProvider | undefined;
@@ -5725,6 +5743,8 @@ export enum MapLayerSourceStatus {
 // @internal (undocumented)
 export interface MapLayerSourceValidation {
     // (undocumented)
+    authInfo?: MapLayerAuthenticationInfo;
+    // (undocumented)
     status: MapLayerSourceStatus;
     // (undocumented)
     subLayers?: MapSubLayerProps[];
@@ -5746,6 +5766,14 @@ export abstract class MapLayerTileTreeReference extends TileTreeReference {
     protected _layerSettings: MapLayerSettings;
     // (undocumented)
     protected get _transparency(): number | undefined;
+}
+
+// @internal (undocumented)
+export interface MapLayerTokenEndpoint {
+    // (undocumented)
+    getLoginUrl(stateData?: string): string | undefined;
+    // (undocumented)
+    getUrl(): string;
 }
 
 // @internal (undocumented)

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -330,6 +330,8 @@ internal;LRUTileListNode
 public;ManipulatorToolEvent
 internal;MapBoxLayerImageryProvider 
 internal;MapCartoRectangle 
+internal;MapLayerAuthenticationInfo
+beta;MapLayerAuthType
 internal;MapLayerFormat
 internal;MapLayerFormatRegistry
 internal;MapLayerFormatType = typeof MapLayerFormat
@@ -341,6 +343,7 @@ internal;MapLayerSources
 internal;MapLayerSourceStatus
 internal;MapLayerSourceValidation
 internal;class MapLayerTileTreeReference 
+internal;MapLayerTokenEndpoint
 internal;MapTile 
 internal;MapTiledGraphicsProvider 
 internal;MapTileLoader 

--- a/common/changes/@itwin/core-frontend/geo-maplayers_auth_refactor_2022-01-10-14-48.json
+++ b/common/changes/@itwin/core-frontend/geo-maplayers_auth_refactor_2022-01-10-14-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Revisited the way map layers authentication is handled in the UI.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/geo-maplayers_auth_refactor_2022-01-10-14-48.json
+++ b/common/changes/@itwin/core-frontend/geo-maplayers_auth_refactor_2022-01-10-14-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Revisited the way map layers authentication is handled in the UI.",
+      "comment": "Improved map layers validation when authentication is required.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/map-layers/geo-maplayers_auth_refactor_2022-01-10-14-48.json
+++ b/common/changes/@itwin/map-layers/geo-maplayers_auth_refactor_2022-01-10-14-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/map-layers",
-      "comment": "Revisited the way map layers authentication is handled in the UI.",
+      "comment": "No longer display username/password fields by default in the custom map layers dialog: If validation fails and reports authentication is needed, we then ask end-user for credentials.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/map-layers/geo-maplayers_auth_refactor_2022-01-10-14-48.json
+++ b/common/changes/@itwin/map-layers/geo-maplayers_auth_refactor_2022-01-10-14-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers",
+      "comment": "Revisited the way map layers authentication is handled in the UI.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers"
+}

--- a/core/frontend/src/core-frontend.ts
+++ b/core/frontend/src/core-frontend.ts
@@ -218,4 +218,8 @@ export * from "./RealityDataSource";
  * APIs for working with user preferences in an iModelApp.
  * See [the learning articles]($docs/learning/frontend/preferences.md).
  */
+/**
+ * @docs-group-description MapLayers
+ * Classes supporting map layers display.
+ */
 

--- a/core/frontend/src/tile/internal.ts
+++ b/core/frontend/src/tile/internal.ts
@@ -47,6 +47,7 @@ export * from "./I3dmReader";
 export * from "./B3dmReader";
 export * from "./ImdlReader";
 export * from "./map/ArcGISTileMap";
+export * from "./map/MapLayerAuthentication";
 export * from "./map/ArcGisTokenGenerator";
 export * from "./map/ArcGisTokenManager";
 export * from "./map/MapLayerFormatRegistry";

--- a/core/frontend/src/tile/map/ArcGisUtilities.ts
+++ b/core/frontend/src/tile/map/ArcGisUtilities.ts
@@ -6,7 +6,7 @@ import { Angle } from "@itwin/core-geometry";
 import { MapSubLayerProps } from "@itwin/core-common";
 import { getJson, request, RequestBasicCredentials, RequestOptions, Response } from "@bentley/itwin-client";
 import {
-  ArcGisTokenClientType, ArcGisTokenManager, MapCartoRectangle, MapLayerSource, MapLayerSourceStatus, MapLayerSourceValidation,
+  ArcGisTokenClientType, ArcGisTokenManager, MapCartoRectangle, MapLayerAuthType, MapLayerSource, MapLayerSourceStatus, MapLayerSourceValidation,
 } from "../internal";
 
 /** @packageDocumentation
@@ -119,14 +119,22 @@ export class ArcGisUtilities {
   }
 
   public static async validateSource(url: string, credentials?: RequestBasicCredentials, ignoreCache?: boolean): Promise<MapLayerSourceValidation> {
+
+    let authMethod: MapLayerAuthType = MapLayerAuthType.None;
+
     const json = await this.getServiceJson(url, credentials, ignoreCache);
     if (json === undefined) {
       return { status: MapLayerSourceStatus.InvalidUrl };
     } else if (json.error !== undefined) {
+
+      // If we got a 'Token Required' error, lets check what authentification methods this ESRI service offers
+      // and return information needed to initiate the authentification process... the end-user
+      // will have to provide his credentials before we can fully validate this source.
       if (json.error.code === ArcGisErrorCode.TokenRequired) {
-        return { status: MapLayerSourceStatus.RequireAuth };
+        authMethod = MapLayerAuthType.EsriToken;
+        return { status: MapLayerSourceStatus.RequireAuth, authInfo: { authMethod, tokenEndpoint: undefined } };
       } else if (json.error.code === ArcGisErrorCode.InvalidCredentials)
-        return { status: MapLayerSourceStatus.InvalidCredentials };
+        return { status: MapLayerSourceStatus.InvalidCredentials, authInfo: { authMethod: MapLayerAuthType.EsriToken } };
     }
 
     let subLayers;
@@ -141,8 +149,8 @@ export class ArcGisUtilities {
       }
     }
     return { status: MapLayerSourceStatus.Valid, subLayers };
-
   }
+
   private static _serviceCache = new Map<string, any>();
   public static async getServiceJson(url: string, credentials?: RequestBasicCredentials, ignoreCache?: boolean): Promise<any> {
     if (!ignoreCache) {

--- a/core/frontend/src/tile/map/MapLayerAuthentication.ts
+++ b/core/frontend/src/tile/map/MapLayerAuthentication.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module DisplayStyles
+ */
+
+/** @beta */
+export enum MapLayerAuthType {
+  None = 1,
+  Basic = 2,
+  EsriToken = 3
+}
+/** @internal */
+export interface MapLayerTokenEndpoint {
+  getLoginUrl(stateData?: string): string|undefined;
+  getUrl(): string;
+}
+
+/** @internal */
+export interface MapLayerAuthenticationInfo {
+  authMethod: MapLayerAuthType;
+  tokenEndpoint?: MapLayerTokenEndpoint;
+}

--- a/core/frontend/src/tile/map/MapLayerAuthentication.ts
+++ b/core/frontend/src/tile/map/MapLayerAuthentication.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 /** @packageDocumentation
- * @module DisplayStyles
+ * @module MapLayers
  */
 
 /** @beta */

--- a/core/frontend/src/tile/map/MapLayerFormatRegistry.ts
+++ b/core/frontend/src/tile/map/MapLayerFormatRegistry.ts
@@ -2,7 +2,9 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-/** @module Views */
+/** @packageDocumentation
+ * @module MapLayers
+ */
 
 import { assert } from "@itwin/core-bentley";
 import { MapLayerKey, MapLayerSettings, MapSubLayerProps } from "@itwin/core-common";

--- a/core/frontend/src/tile/map/MapLayerFormatRegistry.ts
+++ b/core/frontend/src/tile/map/MapLayerFormatRegistry.ts
@@ -8,7 +8,7 @@ import { assert } from "@itwin/core-bentley";
 import { MapLayerKey, MapLayerSettings, MapSubLayerProps } from "@itwin/core-common";
 import { IModelApp } from "../../IModelApp";
 import { IModelConnection } from "../../IModelConnection";
-import { ImageryMapLayerTreeReference, internalMapLayerImageryFormats, MapLayerImageryProvider, MapLayerSourceStatus, MapLayerTileTreeReference } from "../internal";
+import { ImageryMapLayerTreeReference, internalMapLayerImageryFormats, MapLayerAuthenticationInfo, MapLayerImageryProvider, MapLayerSourceStatus, MapLayerTileTreeReference } from "../internal";
 import { RequestBasicCredentials } from "@bentley/itwin-client";
 
 /** @internal */
@@ -30,6 +30,7 @@ export type MapLayerFormatType = typeof MapLayerFormat;
 export interface MapLayerSourceValidation {
   status: MapLayerSourceStatus;
   subLayers?: MapSubLayerProps[];
+  authInfo?: MapLayerAuthenticationInfo;
 }
 
 /**

--- a/core/frontend/src/tile/map/MapLayerImageryFormats.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryFormats.ts
@@ -16,6 +16,8 @@ import {
   BingMapsImageryLayerProvider,
   ImageryMapLayerTreeReference,
   MapBoxLayerImageryProvider,
+  MapLayerAuthenticationInfo,
+  MapLayerAuthType,
   MapLayerFormat,
   MapLayerImageryProvider,
   MapLayerSourceStatus,
@@ -93,10 +95,12 @@ class WmsMapLayerFormat extends ImageryMapLayerFormat {
       return { status: MapLayerSourceStatus.Valid, subLayers };
     } catch (err: any) {
       let status = MapLayerSourceStatus.InvalidUrl;
+      let authInfo: MapLayerAuthenticationInfo|undefined;
       if (err?.status === 401) {
         status = (credentials ? MapLayerSourceStatus.InvalidCredentials : MapLayerSourceStatus.RequireAuth);
+        authInfo = {authMethod: MapLayerAuthType.Basic};
       }
-      return { status };
+      return { status, authInfo};
     }
   }
 }

--- a/core/frontend/src/tile/map/MapLayerImageryFormats.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryFormats.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 /** @packageDocumentation
- * @module Tiles
+ * @module MapLayers
  */
 
 import { MapLayerSettings, MapSubLayerProps } from "@itwin/core-common";

--- a/core/frontend/src/tile/map/MapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryProvider.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 /** @packageDocumentation
- * @module Tiles
+ * @module MapLayers
  */
 
 import { BeEvent } from "@itwin/core-bentley";

--- a/core/frontend/src/tile/map/MapLayerSources.ts
+++ b/core/frontend/src/tile/map/MapLayerSources.ts
@@ -2,7 +2,9 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-/** @module Views */
+/** @packageDocumentation
+ * @module MapLayers
+ */
 
 import { compareStrings } from "@itwin/core-bentley";
 import { Point2d } from "@itwin/core-geometry";

--- a/extensions/map-layers/src/test/MapUrlDialog.test.tsx
+++ b/extensions/map-layers/src/test/MapUrlDialog.test.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { EmptyLocalization, MapLayerSettings, MapSubLayerProps } from "@itwin/core-common";
-import { DisplayStyle3dState, IModelApp, IModelConnection, MapLayerSource, MapLayerSourceStatus, MockRender,
+import { DisplayStyle3dState, IModelApp, IModelConnection, MapLayerAuthType, MapLayerSource, MapLayerSourceStatus, MockRender,
   NotifyMessageDetails, OutputMessagePriority, ScreenViewport, ViewState3d } from "@itwin/core-frontend";
 import { Select } from "@itwin/itwinui-react";
 import { assert, expect } from "chai";
@@ -22,7 +22,7 @@ describe("MapUrlDialog", () => {
   const displayStyleMock = moq.Mock.ofType<DisplayStyle3dState>();
   const imodelMock = moq.Mock.ofType<IModelConnection>();
 
-  const sampleWmsSubLayers: MapSubLayerProps[] = [{ name: "subLayer1" }, { name: "subLayer1" }];
+  const sampleWmsSubLayers: MapSubLayerProps[] = [{ name: "subLayer1" }, { name: "subLayer2" }];
   const sampleWmsLayerSettings = MapLayerSettings.fromJSON({
     formatId: "WMS",
     name: "Test Map",
@@ -34,12 +34,76 @@ describe("MapUrlDialog", () => {
     transparency: 0,
     url: "https://server/wms",
   });
-  sampleWmsLayerSettings?.setCredentials("testUser", "TestPassword");
+  const sampleWmsLayerSettingsCred = sampleWmsLayerSettings?.clone({});
+  sampleWmsLayerSettingsCred?.setCredentials("testUser", "TestPassword");
+
+  const testAddAuthLayer = async (authMethod: MapLayerAuthType) => {
+    const spyMessage = sandbox.spy(IModelApp.notifications, "outputMessage");
+    const validateSourceStub = sandbox.stub(MapLayerSource.prototype, "validateSource").callsFake(async function (_ignoreCache?: boolean) {
+      return Promise.resolve({
+        status: MapLayerSourceStatus.RequireAuth,
+        authInfo: { authMethod, tokenEndpoint: undefined },
+      });
+    });
+
+    const component = enzyme.mount(<MapUrlDialog isOverlay={false} activeViewport={viewportMock.object} onOkResult={mockModalUrlDialogOk} />);
+    const layerTypeSelect = component.find(Select);
+    await (layerTypeSelect.props() as any).onChange("WMS");
+
+    // First, lets fill the 'Name' and 'URL' fields
+    const allInputs = component.find("input");
+    expect(allInputs.length).to.equals(2);
+    allInputs.at(0).simulate("change", { target: { value: sampleWmsLayerSettingsCred?.name } });
+    allInputs.at(1).simulate("change", { target: { value: sampleWmsLayerSettingsCred?.url } });
+
+    // We need to click the 'Ok' button a first time to trigger the layer source
+    // validation and make the credentials fields appear
+    let okButton = component.find(".core-dialog-buttons").childAt(0);
+    expect(okButton.length).to.equals(1);
+    okButton.simulate("click");
+
+    await TestUtils.flushAsyncOperations();
+
+    component.update();
+    if (authMethod !== MapLayerAuthType.None) {
+      const allInputs2 = component.find("input");
+      expect(allInputs2.length).to.equals(4);
+
+      // Fill the credentials fields
+      allInputs2.at(2).simulate("change", { target: { value: sampleWmsLayerSettingsCred?.userName } });
+      allInputs2.at(3).simulate("change", { target: { value: sampleWmsLayerSettingsCred?.password } });
+    }
+    // We need to fake 'valideSource' again, this time we want to simulate a successfully validation
+    validateSourceStub.restore();
+    sandbox.stub(MapLayerSource.prototype, "validateSource").callsFake(async function (_ignoreCache?: boolean) {
+      return Promise.resolve({
+        status: MapLayerSourceStatus.Valid,
+        subLayers: sampleWmsSubLayers,
+      });
+    });
+
+    // By cliking the 'ok' button we expect the layer to be added to the display style
+    okButton = component.find(".core-dialog-buttons").childAt(0);
+    expect(okButton.length).to.equals(1);
+    okButton.simulate("click");
+
+    await TestUtils.flushAsyncOperations();
+
+    if (!sampleWmsLayerSettings)
+      assert.fail("Invalid layer settings");
+
+    if (authMethod !== MapLayerAuthType.None) {
+      displayStyleMock.verify((x) => x.attachMapLayerSettings(sampleWmsLayerSettingsCred, false, undefined), moq.Times.once());
+
+      spyMessage.calledWithExactly(new NotifyMessageDetails(OutputMessagePriority.Info, "Messages.MapLayerAttached"));
+    }
+    component.unmount();
+  };
 
   before(async () => {
     await TestUtils.initialize();
-
     await MockRender.App.startup({localization: new EmptyLocalization()});
+
   });
 
   after(async () => {
@@ -65,11 +129,21 @@ describe("MapUrlDialog", () => {
   };
 
   it("renders", () => {
-    const wrapper = enzyme.mount(<MapUrlDialog activeViewport={viewportMock.object} isOverlay={false} onOkResult={mockModalUrlDialogOk} />);
-    wrapper.unmount();
+    const component = enzyme.mount(<MapUrlDialog activeViewport={viewportMock.object} isOverlay={false} onOkResult={mockModalUrlDialogOk} />);
+    const allInputs = component.find("input");
+
+    expect(allInputs.length).to.equals(2);
+
+    const layerTypeSelect = component.find(Select);
+    expect(layerTypeSelect.length).to.equals(1);
+
+    const allButtons = component.find("button");
+    expect(allButtons.length).to.equals(3);
+
+    component.unmount();
   });
 
-  it("attach a valid WMS layer (with sublayers) to display style", async () => {
+  it("attach a valid WMS layer (with sublayers)", async () => {
 
     const spyMessage = sandbox.spy(IModelApp.notifications, "outputMessage");
 
@@ -82,20 +156,18 @@ describe("MapUrlDialog", () => {
     await (layerTypeSelect.props() as any).onChange("WMS");
 
     const allInputs = component.find("input");
-    expect(allInputs.length).to.equals(4);
+    expect(allInputs.length).to.equals(2);
     allInputs.at(0).simulate("change", { target: { value: sampleWmsLayerSettings?.name } });
     allInputs.at(1).simulate("change", { target: { value: sampleWmsLayerSettings?.url } });
-    allInputs.at(2).simulate("change", { target: { value: sampleWmsLayerSettings?.userName } });
-    allInputs.at(3).simulate("change", { target: { value: sampleWmsLayerSettings?.password } });
 
-    const allButtons = component.find("button");
-    expect(allButtons.length).to.equals(3);
-    allButtons.at(1).simulate("click");
+    const okButton = component.find(".core-dialog-buttons").childAt(0);
+    expect(okButton.length).to.equals(1);
+    okButton.simulate("click");
 
     await TestUtils.flushAsyncOperations();
 
     if (!sampleWmsLayerSettings)
-      assert.fail("Invalid layer  settings");
+      assert.fail("Invalid layer settings");
     displayStyleMock.verify((x) => x.attachMapLayerSettings(sampleWmsLayerSettings, false, undefined), moq.Times.once());
 
     spyMessage.calledWithExactly(new NotifyMessageDetails(OutputMessagePriority.Info, "Messages.MapLayerAttached"));
@@ -103,58 +175,11 @@ describe("MapUrlDialog", () => {
     component.unmount();
   });
 
-  it("attempt to attach a WMS layer requiring credentials", async () => {
-
-    sandbox.stub(IModelApp.notifications, "outputMessage");
-
-    const validateSourceStub = sandbox.stub(MapLayerSource.prototype, "validateSource").callsFake(async function (_ignoreCache?: boolean) {
-      return Promise.resolve({ status: MapLayerSourceStatus.RequireAuth });
-    });
-
-    const component = enzyme.mount(<MapUrlDialog
-      isOverlay={false}
-      activeViewport={viewportMock.object}
-      mapTypesOptions={{ supportTileUrl: false, supportWmsAuthentication: true }}
-      onOkResult={mockModalUrlDialogOk} />);
-    const layerTypeSelect = component.find(Select);
-    await (layerTypeSelect.props() as any).onChange("WMS");
-    await TestUtils.flushAsyncOperations();
-
-    let allInputs = component.find("input");
-    expect(allInputs.length).to.equals(4);
-    allInputs.at(0).simulate("change", { target: { value: sampleWmsLayerSettings?.name } });
-    allInputs.at(1).simulate("change", { target: { value: sampleWmsLayerSettings?.url } });
-
-    let allButtons = component.find("button");
-    expect(allButtons.length).to.equals(3);
-
-    // Click the OK button
-    allButtons.at(1).simulate("click");
-    await TestUtils.flushAsyncOperations();
-    let warnMessage = component.find("div.map-layer-source-warnMessage");
-    expect(warnMessage.html().includes("CustomAttach.MissingCredentials")).to.be.true;
-
-    // Make validateSource returns validateSource returns InvalidCredentials now
-    validateSourceStub.restore();
-    sandbox.stub(MapLayerSource.prototype, "validateSource").callsFake(async function (_ignoreCache?: boolean) {
-      return Promise.resolve({ status: MapLayerSourceStatus.InvalidCredentials });
-    });
-
-    // Set username/password
-    allInputs = component.find("input");
-    expect(allInputs.length).to.equals(4);
-    allInputs.at(2).simulate("change", { target: { value: sampleWmsLayerSettings?.userName } });
-    allInputs.at(3).simulate("change", { target: { value: sampleWmsLayerSettings?.password } });
-
-    // Click again the same button
-    allButtons = component.find("button");
-    expect(allButtons.length).to.equals(3);
-    allButtons.at(1).simulate("click");
-    await TestUtils.flushAsyncOperations();
-    warnMessage = component.find("div.map-layer-source-warnMessage");
-    expect(warnMessage.html().includes("CustomAttach.InvalidCredentials")).to.be.true;
-
-    component.unmount();
+  it("attach a WMS layer requiring basic auth to display style", async () => {
+    await testAddAuthLayer(MapLayerAuthType.Basic);
   });
 
+  it("attach a layer requiring EsriToken", async () => {
+    await testAddAuthLayer(MapLayerAuthType.EsriToken);
+  });
 });

--- a/extensions/map-layers/src/ui/widget/MapUrlDialog.tsx
+++ b/extensions/map-layers/src/ui/widget/MapUrlDialog.tsx
@@ -5,14 +5,14 @@
 // cSpell:ignore Modeless WMTS
 
 import * as React from "react";
-import { Input, LabeledInput, ProgressLinear, Radio, Select, SelectOption } from "@itwin/itwinui-react";
-import { Dialog, Icon, InputStatus } from "@itwin/core-react";
+import { Dialog, Icon } from "@itwin/core-react";
 import { ModalDialogManager } from "@itwin/appui-react";
+import { Input, LabeledInput, ProgressLinear, Radio, Select, SelectOption } from "@itwin/itwinui-react";
 import { MapLayersUiItemsProvider } from "../MapLayersUiItemsProvider";
 import { MapTypesOptions } from "../Interfaces";
 import {
-  IModelApp, MapLayerImageryProviderStatus, MapLayerSource,
-  MapLayerSourceStatus, NotifyMessageDetails, OutputMessagePriority, ScreenViewport,
+  IModelApp, MapLayerAuthType, MapLayerImageryProviderStatus, MapLayerSource,
+  MapLayerSourceStatus, MapLayerSourceValidation, NotifyMessageDetails, OutputMessagePriority, ScreenViewport,
 } from "@itwin/core-frontend";
 import { MapLayerProps } from "@itwin/core-common";
 import "./MapUrlDialog.scss";
@@ -43,7 +43,6 @@ interface MapUrlDialogProps {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function MapUrlDialog(props: MapUrlDialogProps) {
   const { isOverlay, onOkResult, mapTypesOptions } = props;
-  const supportWmsAuthentication = (mapTypesOptions?.supportWmsAuthentication ? true : false);
 
   const getMapUrlFromProps = React.useCallback(() => {
     if (props.mapLayerSourceToEdit) {
@@ -82,10 +81,15 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
   const [modelSettingsLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.StoreOnModelSettings"));
   const [missingCredentialsLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.MissingCredentials"));
   const [invalidCredentialsLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.InvalidCredentials"));
-  const [serverRequireCredentials, setServerRequireCredentials] = React.useState(props.layerRequiringCredentials ?? false);
+  const [externalLoginTitle] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLogin"));
+  const [externalLoginFailedMsg] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginFailed"));
+  const [externalLoginSucceededMsg] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginSucceeded"));
+  const [externalLoginWaitingMsg] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginWaiting"));
+  const [externalLoginTryAgainLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginTryAgain"));
+  const [serverRequireCredentials, setServerRequireCredentials] = React.useState(false);
   const [invalidCredentialsProvided, setInvalidCredentialsProvided] = React.useState(false);
   const [layerAttachPending, setLayerAttachPending] = React.useState(false);
-  const [warningMessage, setWarningMessage] = React.useState(props.layerRequiringCredentials ? missingCredentialsLabel : undefined);
+  const [layerAuthPending, setLayerAuthPending] = React.useState(false);
   const [mapUrl, setMapUrl] = React.useState(getMapUrlFromProps());
   const [mapName, setMapName] = React.useState(getMapNameFromProps());
   const [userName, setUserName] = React.useState("");
@@ -96,6 +100,8 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
   const [userNameLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:AuthenticationInputs.Username"));
   const [userNameRequiredLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:AuthenticationInputs.UsernameRequired"));
   const [settingsStorage, setSettingsStorageRadio] = React.useState("iTwin");
+  const [layerAuthMethod, setLayerAuthMethod] = React.useState(MapLayerAuthType.None);
+  const [authTokenUrl, setAuthTokenUrl] = React.useState<string|undefined>();
 
   const [mapType, setMapType] = React.useState(getFormatFromProps() ?? MAP_TYPES.arcGis);
 
@@ -126,12 +132,6 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
   // we don't always want to enable it in the UI.
   const [settingsStorageDisabled] = React.useState(!isSettingsStorageAvailable || props.mapLayerSourceToEdit !== undefined || props.layerRequiringCredentials !== undefined);
 
-  const isAuthSupported = React.useCallback(() => {
-    return ((mapType === MAP_TYPES.wms || mapType === MAP_TYPES.wms) && supportWmsAuthentication)
-      || mapType === MAP_TYPES.arcGis;
-  }, [mapType, supportWmsAuthentication]);
-
-  // const [layerIdxToEdit] = React.useState((): number | undefined => {
   const [layerRequiringCredentialsIdx] = React.useState((): number | undefined => {
     if (props.layerRequiringCredentials === undefined || !props.layerRequiringCredentials.name || !props.layerRequiringCredentials.url) {
       return undefined;
@@ -146,19 +146,18 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
   });
 
   // Update warning message based on the dialog state and server response
-  React.useEffect(() => {
-    if (invalidCredentialsProvided) {
-      setWarningMessage(invalidCredentialsLabel);
-    } else if (serverRequireCredentials && (!userName || !password)) {
-      setWarningMessage(missingCredentialsLabel);
-    } else {
-      setWarningMessage(undefined);
-    }
-  }, [invalidCredentialsProvided, invalidCredentialsLabel, missingCredentialsLabel, serverRequireCredentials, userName, password, setWarningMessage]);
-
   const handleMapTypeSelection = React.useCallback((newValue: string) => {
     setMapType(newValue);
-  }, [setMapType]);
+
+    // Reset few states
+    if (invalidCredentialsProvided)
+      setInvalidCredentialsProvided(false);
+
+    if (layerAuthMethod !== MapLayerAuthType.None) {
+      setLayerAuthMethod(MapLayerAuthType.None);
+    }
+
+  }, [invalidCredentialsProvided, layerAuthMethod]);
 
   const handleCancel = React.useCallback(() => {
     if (props.onCancelResult) {
@@ -180,92 +179,118 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
       setInvalidCredentialsProvided(false);
   }, [setPassword, invalidCredentialsProvided, setInvalidCredentialsProvided]);
 
-  const doAttach = React.useCallback(async (source: MapLayerSource): Promise<boolean> => {
-    // Returns a promise, When true, the dialog should closed
-    return new Promise<boolean>((resolve, _reject) => {
-      const vp = props?.activeViewport;
-      if (vp === undefined || source === undefined) {
-        resolve(true);
-        return;
-      }
+  // return true if authorization is needed
+  const updateAuthState = React.useCallback((sourceValidation: MapLayerSourceValidation) => {
+    const sourceRequireAuth = (sourceValidation.status === MapLayerSourceStatus.RequireAuth);
+    const invalidCredentials = (sourceValidation.status === MapLayerSourceStatus.InvalidCredentials);
+    if (sourceRequireAuth && sourceValidation.authInfo?.authMethod !== undefined) {
+      setLayerAuthMethod(sourceValidation.authInfo?.authMethod);
+    }
+    if (invalidCredentials) {
+      setInvalidCredentialsProvided(true);
+    } else if (invalidCredentialsProvided) {
+      setInvalidCredentialsProvided(false);  // flag reset
+    }
 
-      const storeOnIModel = "Model" === settingsStorage;
-      source.validateSource(true).then(async (validation) => {
-        if (validation.status === MapLayerSourceStatus.Valid
-          || validation.status === MapLayerSourceStatus.RequireAuth
-          || validation.status === MapLayerSourceStatus.InvalidCredentials) {
-          const sourceRequireAuth = (validation.status === MapLayerSourceStatus.RequireAuth);
-          const invalidCredentials = (validation.status === MapLayerSourceStatus.InvalidCredentials);
-          const closeDialog = !sourceRequireAuth && !invalidCredentials;
-          resolve(closeDialog);
+    return sourceRequireAuth || invalidCredentials;
+  }, [invalidCredentialsProvided]);
 
-          if (sourceRequireAuth && !serverRequireCredentials) {
-            setServerRequireCredentials(true);
-          }
-          if (invalidCredentials) {
-            setInvalidCredentialsProvided(true);
-            return;
-          } else if (invalidCredentialsProvided) {
-            setInvalidCredentialsProvided(false);  // flag reset
-          }
+  const updateAttachedLayer = React.useCallback(async (source: MapLayerSource, validation: MapLayerSourceValidation) => {
+    const vp = props?.activeViewport;
+    if (vp === undefined || source === undefined || layerRequiringCredentialsIdx === undefined)   {
+      const error = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerAttachMissingViewOrSource");
+      const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerAttachError", { error, sourceUrl: source.url });
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
+      return true;
+    }
 
-          if (validation.status === MapLayerSourceStatus.Valid) {
-            // Attach layer and update settings service (only if editing)
-            if (layerRequiringCredentialsIdx !== undefined) {
-              // Update username / password
-              vp.displayStyle.changeMapLayerProps({
-                subLayers: validation.subLayers,
-              }, layerRequiringCredentialsIdx, isOverlay);
-              vp.displayStyle.changeMapLayerCredentials(layerRequiringCredentialsIdx, isOverlay, source.userName, source.password);
+    // Layer is already attached,
+    vp.displayStyle.changeMapLayerProps({
+      subLayers: validation.subLayers,
+    }, layerRequiringCredentialsIdx, isOverlay);
+    vp.displayStyle.changeMapLayerCredentials(layerRequiringCredentialsIdx, isOverlay, source.userName, source.password);
 
-              // Reset the provider's status
-              const provider = vp.getMapLayerImageryProvider(layerRequiringCredentialsIdx, isOverlay);
-              if (provider && provider.status !== MapLayerImageryProviderStatus.Valid) {
-                provider.status = MapLayerImageryProviderStatus.Valid;
-              }
-            } else {
-              // Update service settings if storage is available and we are not prompting user for credentials
-              if (!settingsStorageDisabled && !props.layerRequiringCredentials) {
-                if (!(await MapLayerPreferences.storeSource(source, storeOnIModel, vp.iModel.iTwinId!, vp.iModel.iModelId!))) {
-                  const msgError = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerPreferencesStoreFailed");
-                  IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msgError));
-                }
-              }
-              const layerSettings = source.toLayerSettings(validation.subLayers);
-              if (layerSettings) {
-                vp.displayStyle.attachMapLayerSettings(layerSettings, isOverlay, undefined);
+    // Reset the provider's status
+    const provider = vp.getMapLayerImageryProvider(layerRequiringCredentialsIdx, isOverlay);
+    if (provider && provider.status !== MapLayerImageryProviderStatus.Valid) {
+      provider.status = MapLayerImageryProviderStatus.Valid;
+    }
 
-                const msg = IModelApp.localization.getLocalizedString("mapLayers:Messages.MapLayerAttached", { sourceName: source.name, sourceUrl: source.url });
-                IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, msg));
-              } else {
-                const msgError = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerLayerSettingsConversionError");
-                const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.MapLayerAttachError", { error: msgError, sourceUrl: source.url });
-                IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
-              }
-            }
+    vp.invalidateRenderPlan();
 
-            vp.invalidateRenderPlan();
-          }
+    // This handler will close the layer source handler, and therefore the MapUrl dialog.
+    // don't call it if the dialog needs to remains open.
+    onOkResult();
 
-          if (closeDialog) {
-            // This handler will close the layer source handler, and therefore the MapUrl dialog.
-            // don't call it if the dialog needs to remains open.
-            onOkResult();
-          }
+    return true;
+  }, [isOverlay, layerRequiringCredentialsIdx, onOkResult, props.activeViewport]);
 
+  // Returns true if no further input is needed from end-user.
+  const doAttach = React.useCallback(async (source: MapLayerSource, validation: MapLayerSourceValidation): Promise<boolean> => {
+    const vp = props?.activeViewport;
+    if (vp === undefined || source === undefined) {
+      const error = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerAttachMissingViewOrSource");
+      const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerAttachError", { error, sourceUrl: source.url });
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
+      return true;
+    }
+
+    // Update service settings if storage is available and we are not prompting user for credentials
+    if (!settingsStorageDisabled && !props.layerRequiringCredentials) {
+    	const storeOnIModel = "Model" === settingsStorage;
+      if (!(await MapLayerPreferences.storeSource(source, storeOnIModel, vp.iModel.iTwinId!, vp.iModel.iModelId!))) {
+        const msgError = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerPreferencesStoreFailed");
+        IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msgError));
+	  }
+    }
+    const layerSettings = source.toLayerSettings(validation.subLayers);
+    if (layerSettings) {
+      vp.displayStyle.attachMapLayerSettings(layerSettings, isOverlay, undefined);
+
+      const msg = IModelApp.localization.getLocalizedString("mapLayers:Messages.MapLayerAttached", { sourceName: source.name, sourceUrl: source.url });
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, msg));
+    } else {
+      const msgError = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerLayerSettingsConversionError");
+      const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.MapLayerAttachError", { error: msgError, sourceUrl: source.url });
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
+    }
+
+    vp.invalidateRenderPlan();
+
+    // This handler will close the layer source handler, and therefore the MapUrl dialog.
+    // don't call it if the dialog needs to remains open.
+    onOkResult();
+
+    return true;
+  }, [isOverlay, onOkResult, props?.activeViewport, props.layerRequiringCredentials, settingsStorage, settingsStorageDisabled]);
+
+  // Validate the layer source and attempt to attach (or update) the layer.
+  // Returns true if no further input is needed from end-user (i.e. close the dialog)
+  const attemptAttachSource = React.useCallback(async (source: MapLayerSource): Promise<boolean> => {
+    try {
+      const validation = await source.validateSource(true);
+
+      if (validation.status === MapLayerSourceStatus.Valid) {
+        if (layerRequiringCredentialsIdx === undefined ) {
+          return await doAttach(source, validation);
         } else {
-          const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ValidationError");
-          IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, `${msg} ${source.url}`));
-          resolve(true);
+          return await updateAttachedLayer(source, validation);
         }
-        resolve(false);
-      }).catch((error) => {
-        const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.MapLayerAttachError", { error, sourceUrl: source.url });
-        IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
-        resolve(true);
-      });
-    });
-  }, [props.activeViewport, props.layerRequiringCredentials, settingsStorage, serverRequireCredentials, invalidCredentialsProvided, onOkResult, layerRequiringCredentialsIdx, isOverlay, settingsStorageDisabled]);
+      } else if (updateAuthState(validation)) {
+        return false;
+      } else {
+        const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ValidationError");
+        IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, `${msg} ${source.url}`));
+        return true;
+      }
+      return false;
+    } catch (error) {
+      const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerAttachError", { error, sourceUrl: source.url });
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
+      return true;
+    }
+
+  }, [updateAuthState, doAttach, layerRequiringCredentialsIdx, updateAttachedLayer]);
 
   const onNameChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setMapName(event.target.value);
@@ -279,80 +304,107 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
     setMapUrl(event.target.value);
   }, [setMapUrl]);
 
-  const handleOk = React.useCallback(() => {
+  const createSource = React.useCallback(() => {
     let source: MapLayerSource | undefined;
     if (mapUrl && mapName) {
       source = MapLayerSource.fromJSON({
         url: mapUrl,
         name: mapName,
         formatId: mapType,
-        userName,
-        password,
-      });
+        userName: userName||undefined,  // When there is no value, empty string is always returned, in this case force it to undefined,
+        password: password||undefined});
+    }
+    return source;
+  }, [mapName, mapType, mapUrl, password, userName]);
 
-      if (source === undefined || props.mapLayerSourceToEdit) {
+  const handleOk = React.useCallback(() => {
+    const source = createSource();
+    if (source === undefined || props.mapLayerSourceToEdit) {
 
-        ModalDialogManager.closeDialog();
+      ModalDialogManager.closeDialog();
 
-        if (source === undefined) {
-          // Close the dialog and inform end user something went wrong.
-          const msgError = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerLayerSourceCreationFailed");
-          const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.MapLayerAttachError", { error: msgError, sourceUrl: mapUrl });
-          IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
-          return;
-        }
-
-        // Simply change the source definition in the setting service
-        if (props.mapLayerSourceToEdit !== undefined) {
-          const vp = props.activeViewport;
-          void (async () => {
-            if (isSettingsStorageAvailable && vp) {
-              try {
-                await MapLayerPreferences.replaceSource(props.mapLayerSourceToEdit!, source, vp.iModel.iTwinId!, vp.iModel.iModelId!);
-              } catch (err: any) {
-                const errorMessage = IModelApp.localization.getLocalizedString("mapLayers:Messages.MapLayerEditError", { layerName: props.mapLayerSourceToEdit?.name });
-                IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, errorMessage));
-                return;
-              }
-            }
-          })();
-          return;
-        }
+      if (source === undefined) {
+        // Close the dialog and inform end user something went wrong.
+        const msgError = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerLayerSourceCreationFailed");
+        const msg = MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:Messages.MapLayerAttachError", { error: msgError, sourceUrl: mapUrl });
+        IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, msg));
+        return;
       }
 
-      setLayerAttachPending(true);
-
-      void (async () => {
-        // Code below is executed in the an async manner but
-        // I don't necessarily  want to mark the handler as async
-        // so Im wrapping it un in a void wrapper.
-        try {
-          const closeDialog = await doAttach(source);
-          if (isMounted.current) {
-            setLayerAttachPending(false);
+      // Simply change the source definition in the setting service
+      if (props.mapLayerSourceToEdit !== undefined) {
+        const vp = props.activeViewport;
+        void (async () => {
+          if (isSettingsStorageAvailable && vp) {
+            try {
+              await MapLayerPreferences.replaceSource(props.mapLayerSourceToEdit!, source, vp.iModel.iTwinId!, vp.iModel.iModelId!);
+            } catch (err: any) {
+              const errorMessage = IModelApp.localization.getLocalizedString("mapLayers:Messages.MapLayerEditError", { layerName: props.mapLayerSourceToEdit?.name });
+              IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, errorMessage));
+              return;
+            }
           }
-
-          // In theory the modal dialog should always get closed by the parent
-          // AttachLayerPanel's 'onOkResult' handler.  We close it here just in case.
-          if (closeDialog) {
-            ModalDialogManager.closeDialog();
-          }
-        } catch (_error) {
-          ModalDialogManager.closeDialog();
-        }
-      })();
+        })();
+        return;
+      }
     }
 
-  }, [mapUrl, mapName, mapType, userName, password, props.mapLayerSourceToEdit, props.activeViewport, isSettingsStorageAvailable, doAttach]);
+    setLayerAttachPending(true);
+
+    // Attach source asynchronously.
+    void (async () => {
+      try {
+        const closeDialog = await attemptAttachSource(source);
+        if (isMounted.current) {
+          setLayerAttachPending(false);
+        }
+
+        // In theory the modal dialog should always get closed by the parent
+        // AttachLayerPanel's 'onOkResult' handler.  We close it here just in case.
+        if (closeDialog) {
+          ModalDialogManager.closeDialog();
+        }
+      } catch (_error) {
+        ModalDialogManager.closeDialog();
+      }
+    })();
+
+  }, [createSource, props.mapLayerSourceToEdit, props.activeViewport, mapUrl, isSettingsStorageAvailable, attemptAttachSource]);
+
+  // The first time the dialog is loaded and we already know the layer requires auth. (i.e ImageryProvider already made an attempt)
+  // makes a request to discover the authentification types and adjust UI accordingly (i.e. username/password fields, Oauth popup)
+  // Without this effect, user would have to manually click the 'OK' button in order to trigger the layer connection.
+  React.useEffect(() => {
+    // Attach source asynchronously.
+    void (async () => {
+      if (props.layerRequiringCredentials?.url !== undefined && props.layerRequiringCredentials?.name !== undefined) {
+        try {
+          const source = MapLayerSource.fromJSON({url: props.layerRequiringCredentials.url, name: props.layerRequiringCredentials.name,formatId: props.layerRequiringCredentials.formatId});
+          if (source !== undefined) {
+            setLayerAttachPending(true);
+            const validation = await source.validateSource(true);
+            if (isMounted.current) {
+              setLayerAttachPending(false);
+            }
+            updateAuthState(validation);
+          }
+        } catch (_error) {}
+      }
+    })();
+
+  // Only run this effect when the dialog is initialized, otherwise it will it creates undesirable side-effects when 'OK' button is clicked.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const dialogContainer = React.useRef<HTMLDivElement>(null);
 
   const readyToSave = React.useCallback(() => {
     const credentialsSet = !!userName && !!password;
     return (!!mapUrl && !!mapName)
-      && (!serverRequireCredentials || (serverRequireCredentials && credentialsSet) && !layerAttachPending)
-      && !invalidCredentialsProvided;
-  }, [mapUrl, mapName, userName, password, layerAttachPending, invalidCredentialsProvided, serverRequireCredentials]);
+      && !layerAttachPending
+      && (!serverRequireCredentials || credentialsSet)
+      && !invalidCredentialsProvided ;
+  }, [userName, password, mapUrl, mapName, serverRequireCredentials, layerAttachPending, invalidCredentialsProvided]);
 
   const buttonCluster = React.useMemo(() => [
     { type: DialogButtonType.OK, onClick: handleOk, disabled: !readyToSave() },
@@ -365,6 +417,39 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
         handleOk();
     }
   }, [handleOk, readyToSave]);
+
+  //
+  // Monitors authentication method changes
+  React.useEffect(() => {
+    setServerRequireCredentials(layerAuthMethod === MapLayerAuthType.Basic || layerAuthMethod === MapLayerAuthType.EsriToken);
+  }, [layerAuthMethod]);
+
+  // Utility function to get warning message section
+  function renderWarningMessage(): React.ReactNode {
+    let node: React.ReactNode;
+    let warningMessage: string|undefined;
+
+    // Get the proper warning message
+    if (invalidCredentialsProvided) {
+      warningMessage = invalidCredentialsLabel;
+    } else if (serverRequireCredentials && (!userName || !password))  {
+      warningMessage = missingCredentialsLabel;
+    }
+
+    // Sometimes we want to add an extra node, such as a button
+    let extraNode: React.ReactNode;
+    if (warningMessage !== undefined) {
+      return(
+        <div className="map-layer-source-warnMessage">
+          <Icon className="map-layer-source-warnMessage-icon" iconSpec="icon-status-warning" />
+          <span className="map-layer-source-warnMessage-label">{warningMessage}</span >
+          {extraNode}
+        </div>);
+    } else {
+      return (<span className="map-layer-source-placeholder">&nbsp;</span>);
+    }
+    return node;
+  }
 
   return (
     <div ref={dialogContainer}>
@@ -391,30 +476,33 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
               className="map-layer-source-select"
               options={mapTypes}
               value={mapType}
-              disabled={props.layerRequiringCredentials !== undefined || props.mapLayerSourceToEdit !== undefined}
+              disabled={props.layerRequiringCredentials !== undefined || props.mapLayerSourceToEdit !== undefined || layerAttachPending || layerAuthPending}
               onChange={handleMapTypeSelection}
               size="small"/>
             <span className="map-layer-source-label">{nameLabel}</span>
-            <Input className="map-layer-source-input" placeholder={nameInputPlaceHolder} onChange={onNameChange} value={mapName} disabled={props.layerRequiringCredentials !== undefined} size="small" />
+            <Input className="map-layer-source-input"  placeholder={nameInputPlaceHolder} onChange={onNameChange} value={mapName} disabled={props.layerRequiringCredentials !== undefined || layerAttachPending || layerAuthPending} />
             <span className="map-layer-source-label">{urlLabel}</span>
-            <Input className="map-layer-source-input" placeholder={urlInputPlaceHolder} onKeyPress={handleOnKeyDown} onChange={onUrlChange} disabled={props.mapLayerSourceToEdit !== undefined} value={mapUrl} size="small" />
-            {isAuthSupported() && props.mapLayerSourceToEdit === undefined &&
+            <Input className="map-layer-source-input" placeholder={urlInputPlaceHolder} onKeyPress={handleOnKeyDown} onChange={onUrlChange} disabled={props.mapLayerSourceToEdit !== undefined || layerAttachPending || layerAuthPending} value={mapUrl} />
+            {serverRequireCredentials
+             && (layerAuthMethod === MapLayerAuthType.Basic ||  layerAuthMethod === MapLayerAuthType.EsriToken)
+             && props.mapLayerSourceToEdit === undefined &&
               <>
                 <span className="map-layer-source-label">{userNameLabel}</span>
-                <LabeledInput
-                  className="map-layer-source-input"
+                <LabeledInput className="map-layer-source-input"
                   displayStyle="inline"
                   placeholder={serverRequireCredentials ? userNameRequiredLabel : userNameLabel}
-                  status={!userName && serverRequireCredentials ? InputStatus.Warning : undefined}
+                  status={!userName && serverRequireCredentials ? "warning" : undefined}
+                  disabled={layerAttachPending || layerAuthPending}
                   onChange={onUsernameChange}
                   size="small" />
 
                 <span className="map-layer-source-label">{passwordLabel}</span>
-                <LabeledInput
-                  className="map-layer-source-input"
+                <LabeledInput className="map-layer-source-input"
+
                   displayStyle="inline"
                   type="password" placeholder={serverRequireCredentials ? passwordRequiredLabel : passwordLabel}
-                  status={!password && serverRequireCredentials ? InputStatus.Warning : undefined}
+                  status={!password && serverRequireCredentials ? "warning" : undefined}
+                  disabled={layerAttachPending || layerAuthPending}
                   onChange={onPasswordChange}
                   onKeyPress={handleOnKeyDown}
                   size="small" />
@@ -436,20 +524,10 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
         </div>
 
         {/* Warning message */}
-        <div className="map-layer-source-warnMessage">
-          {warningMessage ?
-            <>
-              <Icon className="map-layer-source-warnMessage-icon" iconSpec="icon-status-warning" />
-              <span className="map-layer-source-warnMessage-label">{warningMessage}</span >
-            </>
-            :
-            // Place holder to avoid dialog resize
-            <span className="map-layer-source-placeholder">&nbsp;</span>
-          }
-        </div>
+        {renderWarningMessage()}
 
         {/* Progress bar */}
-        {layerAttachPending &&
+        {(layerAttachPending || layerAuthPending) &&
           <div className="map-layer-source-progressBar">
             <ProgressLinear indeterminate />
           </div>

--- a/extensions/map-layers/src/ui/widget/MapUrlDialog.tsx
+++ b/extensions/map-layers/src/ui/widget/MapUrlDialog.tsx
@@ -469,13 +469,13 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
               className="map-layer-source-select"
               options={mapTypes}
               value={mapType}
-              disabled={props.layerRequiringCredentials !== undefined || props.mapLayerSourceToEdit !== undefined || layerAttachPending || layerAuthPending}
+              disabled={props.layerRequiringCredentials !== undefined || props.mapLayerSourceToEdit !== undefined || layerAttachPending}
               onChange={handleMapTypeSelection}
               size="small"/>
             <span className="map-layer-source-label">{nameLabel}</span>
-            <Input className="map-layer-source-input"  placeholder={nameInputPlaceHolder} onChange={onNameChange} value={mapName} disabled={props.layerRequiringCredentials !== undefined || layerAttachPending || layerAuthPending} />
+            <Input className="map-layer-source-input"  placeholder={nameInputPlaceHolder} onChange={onNameChange} value={mapName} disabled={props.layerRequiringCredentials !== undefined || layerAttachPending} />
             <span className="map-layer-source-label">{urlLabel}</span>
-            <Input className="map-layer-source-input" placeholder={urlInputPlaceHolder} onKeyPress={handleOnKeyDown} onChange={onUrlChange} disabled={props.mapLayerSourceToEdit !== undefined || layerAttachPending || layerAuthPending} value={mapUrl} />
+            <Input className="map-layer-source-input" placeholder={urlInputPlaceHolder} onKeyPress={handleOnKeyDown} onChange={onUrlChange} disabled={props.mapLayerSourceToEdit !== undefined || layerAttachPending} value={mapUrl} />
             {serverRequireCredentials
              && (layerAuthMethod === MapLayerAuthType.Basic ||  layerAuthMethod === MapLayerAuthType.EsriToken)
              && props.mapLayerSourceToEdit === undefined &&
@@ -485,7 +485,7 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
                   displayStyle="inline"
                   placeholder={serverRequireCredentials ? userNameRequiredLabel : userNameLabel}
                   status={!userName && serverRequireCredentials ? "warning" : undefined}
-                  disabled={layerAttachPending || layerAuthPending}
+                  disabled={layerAttachPending}
                   onChange={onUsernameChange}
                   size="small" />
 
@@ -495,7 +495,7 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
                   displayStyle="inline"
                   type="password" placeholder={serverRequireCredentials ? passwordRequiredLabel : passwordLabel}
                   status={!password && serverRequireCredentials ? "warning" : undefined}
-                  disabled={layerAttachPending || layerAuthPending}
+                  disabled={layerAttachPending}
                   onChange={onPasswordChange}
                   onKeyPress={handleOnKeyDown}
                   size="small" />
@@ -520,7 +520,7 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
         {renderWarningMessage()}
 
         {/* Progress bar */}
-        {(layerAttachPending || layerAuthPending) &&
+        {(layerAttachPending) &&
           <div className="map-layer-source-progressBar">
             <ProgressLinear indeterminate />
           </div>

--- a/extensions/map-layers/src/ui/widget/MapUrlDialog.tsx
+++ b/extensions/map-layers/src/ui/widget/MapUrlDialog.tsx
@@ -81,15 +81,9 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
   const [modelSettingsLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.StoreOnModelSettings"));
   const [missingCredentialsLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.MissingCredentials"));
   const [invalidCredentialsLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.InvalidCredentials"));
-  const [externalLoginTitle] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLogin"));
-  const [externalLoginFailedMsg] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginFailed"));
-  const [externalLoginSucceededMsg] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginSucceeded"));
-  const [externalLoginWaitingMsg] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginWaiting"));
-  const [externalLoginTryAgainLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:CustomAttach.ExternalLoginTryAgain"));
   const [serverRequireCredentials, setServerRequireCredentials] = React.useState(false);
   const [invalidCredentialsProvided, setInvalidCredentialsProvided] = React.useState(false);
   const [layerAttachPending, setLayerAttachPending] = React.useState(false);
-  const [layerAuthPending, setLayerAuthPending] = React.useState(false);
   const [mapUrl, setMapUrl] = React.useState(getMapUrlFromProps());
   const [mapName, setMapName] = React.useState(getMapNameFromProps());
   const [userName, setUserName] = React.useState("");
@@ -101,7 +95,6 @@ export function MapUrlDialog(props: MapUrlDialogProps) {
   const [userNameRequiredLabel] = React.useState(MapLayersUiItemsProvider.localization.getLocalizedString("mapLayers:AuthenticationInputs.UsernameRequired"));
   const [settingsStorage, setSettingsStorageRadio] = React.useState("iTwin");
   const [layerAuthMethod, setLayerAuthMethod] = React.useState(MapLayerAuthType.None);
-  const [authTokenUrl, setAuthTokenUrl] = React.useState<string|undefined>();
 
   const [mapType, setMapType] = React.useState(getFormatFromProps() ?? MAP_TYPES.arcGis);
 


### PR DESCRIPTION
No longer display username/password fields by default  in the custom map layers dialog:  If validation fails and reports authentication is needed, we then ask end-user for credentials.