### PR TITLE
Fix unhandled exception on iOS when exitPointerLock is called.

### DIFF
--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -2003,7 +2003,7 @@ class ViewLookAndMove extends ViewNavigate {
       document.removeEventListener("pointerlockchange", this._pointerLockChangeListener, false);
       this._pointerLockChangeListener = undefined;
     }
-    if (null !== document.pointerLockElement)
+    if (null !== document.pointerLockElement && undefined !== document.exitPointerLock)
       document.exitPointerLock();
   }
 
@@ -2128,7 +2128,7 @@ class ViewLookAndMove extends ViewNavigate {
         if (pixel.distanceFraction < 0)
           continue; // No geometry at location...
 
-        const hitPointWorld = vp.getPixelDataWorldPoint({pixels, x: testPoint.x, y: testPoint.y, preserveModelDisplayTransforms: true});
+        const hitPointWorld = vp.getPixelDataWorldPoint({ pixels, x: testPoint.x, y: testPoint.y, preserveModelDisplayTransforms: true });
         if (undefined === hitPointWorld)
           continue;
 


### PR DESCRIPTION
I don't know why document.exitPointerLock is undefined when running on iOS, but this should prevent it from being called if it is undefined.