### PR TITLE
Presentation: Empty selection set after clear and replace

### DIFF
--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -503,6 +503,8 @@ export class SelectionManager implements ISelectionProvider {
     getHiliteSet(imodel: IModelConnection): Promise<HiliteSet>;
     getSelection(imodel: IModelConnection, level?: number): Readonly<KeySet>;
     getSelectionLevels(imodel: IModelConnection): number[];
+    // @internal (undocumented)
+    getToolSelectionSyncHandler(imodel: IModelConnection): ToolSelectionSyncHandler | undefined;
     removeFromSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;
     removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     replaceSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;

--- a/common/changes/@itwin/presentation-frontend/presentation-empty-selection-set-after-clear-and-replace_2022-01-13-09-21.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-empty-selection-set-after-clear-and-replace_2022-01-13-09-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Fix hilite set provider somtimes caching results with wrong GUID, causing invalid hilite set being returned afterwards.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/full-stack-tests/presentation/src/frontend/UnifiedSelection.test.ts
+++ b/full-stack-tests/presentation/src/frontend/UnifiedSelection.test.ts
@@ -148,6 +148,27 @@ describe("Unified Selection", () => {
       expect(imodel.selectionSet.has(instances.transientElement.key.id)).to.be.true;
     });
 
+    it.only("hilites transient element after clearing selection", async () => {
+      // set up the selection to contain a transient element
+      Presentation.selection.addToSelection("", imodel, new KeySet([instances.transientElement.key]));
+      await waitForAllAsyncs([handler]);
+      expect(imodel.selectionSet.size).to.eq(1);
+      expect(Presentation.selection.getSelection(imodel).instanceKeysCount).to.eq(1);
+
+      // clear the selection set and add back the transient element
+      imodel.selectionSet.emptyAll();
+      imodel.selectionSet.replace(instances.transientElement.key.id);
+      await waitForAllAsyncs([handler]);
+
+      // expect the transient element to be both hilited and selected
+      expect(imodel.hilited.models.isEmpty).to.be.true;
+      expect(imodel.hilited.subcategories.isEmpty).to.be.true;
+      expect(imodel.hilited.elements.size).to.eq(1);
+      expect(imodel.hilited.elements.hasId(instances.transientElement.key.id)).to.be.true;
+      expect(imodel.selectionSet.size).to.eq(1);
+      expect(imodel.selectionSet.has(instances.transientElement.key.id)).to.be.true;
+    });
+
     it("hilites after re-initializing Presentation", async () => {
       handler.dispose();
       Presentation.terminate();

--- a/full-stack-tests/presentation/src/frontend/UnifiedSelection.test.ts
+++ b/full-stack-tests/presentation/src/frontend/UnifiedSelection.test.ts
@@ -74,7 +74,7 @@ describe("Unified Selection", () => {
 
     it("hilites subject", async () => {
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.subject.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.size).to.eq(instances.subject.nestedModelIds.length);
       instances.subject.nestedModelIds.forEach((id: Id64String) => expect(imodel.hilited.models.hasId(id)).to.be.true);
       expect(imodel.hilited.subcategories.isEmpty).to.be.true;
@@ -84,7 +84,7 @@ describe("Unified Selection", () => {
 
     it("hilites model", async () => {
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.model.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.size).to.eq(1 + instances.model.nestedModelIds.length);
       expect(imodel.hilited.models.hasId(instances.model.key.id)).to.be.true;
       instances.model.nestedModelIds.forEach((id: Id64String) => expect(imodel.hilited.models.hasId(id)).to.be.true);
@@ -95,7 +95,7 @@ describe("Unified Selection", () => {
 
     it("hilites category", async () => {
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.category.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.isEmpty).to.be.true;
       expect(imodel.hilited.subcategories.size).to.eq(instances.category.subCategoryIds.length);
       instances.category.subCategoryIds.forEach((id: Id64String) => expect(imodel.hilited.subcategories.hasId(id)).to.be.true);
@@ -105,7 +105,7 @@ describe("Unified Selection", () => {
 
     it("hilites subcategory", async () => {
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.subcategory.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.isEmpty).to.be.true;
       expect(imodel.hilited.subcategories.size).to.eq(1);
       expect(imodel.hilited.subcategories.hasId(instances.subcategory.key.id)).to.be.true;
@@ -115,7 +115,7 @@ describe("Unified Selection", () => {
 
     it("hilites assembly element", async () => {
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.assemblyElement.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.isEmpty).to.be.true;
       expect(imodel.hilited.subcategories.isEmpty).to.be.true;
       expect(imodel.hilited.elements.size).to.eq(1 + instances.assemblyElement.childElementIds.length);
@@ -128,7 +128,7 @@ describe("Unified Selection", () => {
 
     it("hilites leaf element", async () => {
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.leafElement.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.isEmpty).to.be.true;
       expect(imodel.hilited.subcategories.isEmpty).to.be.true;
       expect(imodel.hilited.elements.size).to.eq(1);
@@ -139,7 +139,7 @@ describe("Unified Selection", () => {
 
     it("hilites transient element", async () => {
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.transientElement.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.isEmpty).to.be.true;
       expect(imodel.hilited.subcategories.isEmpty).to.be.true;
       expect(imodel.hilited.elements.size).to.eq(1);
@@ -148,17 +148,17 @@ describe("Unified Selection", () => {
       expect(imodel.selectionSet.has(instances.transientElement.key.id)).to.be.true;
     });
 
-    it.only("hilites transient element after clearing selection", async () => {
+    it("hilites transient element after removing and adding it back", async () => {
       // set up the selection to contain a transient element
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.transientElement.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.selectionSet.size).to.eq(1);
       expect(Presentation.selection.getSelection(imodel).instanceKeysCount).to.eq(1);
 
-      // clear the selection set and add back the transient element
-      imodel.selectionSet.emptyAll();
+      // remove and add back the transient element
+      imodel.selectionSet.remove(instances.transientElement.key.id);
       imodel.selectionSet.replace(instances.transientElement.key.id);
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
 
       // expect the transient element to be both hilited and selected
       expect(imodel.hilited.models.isEmpty).to.be.true;
@@ -176,7 +176,7 @@ describe("Unified Selection", () => {
       handler = new ViewportSelectionHandler({ imodel });
 
       Presentation.selection.addToSelection("", imodel, new KeySet([instances.leafElement.key]));
-      await waitForAllAsyncs([handler]);
+      await waitForAllAsyncs([handler, Presentation.selection.getToolSelectionSyncHandler(imodel)!]);
       expect(imodel.hilited.models.isEmpty).to.be.true;
       expect(imodel.hilited.subcategories.isEmpty).to.be.true;
       expect(imodel.hilited.elements.size).to.eq(1);

--- a/presentation/frontend/src/presentation-frontend/selection/HiliteSetProvider.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/HiliteSetProvider.ts
@@ -105,7 +105,8 @@ export class HiliteSetProvider {
    * for the same input doesn't cost.
    */
   public async getHiliteSet(selection: Readonly<KeySet>): Promise<HiliteSet> {
-    if (!this._cached || this._cached.keysGuid !== selection.guid) {
+    const selectionGuid = selection.guid;
+    if (!this._cached || this._cached.keysGuid !== selectionGuid) {
       // need to create a new set without transients
       const transientIds = new Array<Id64String>();
       const keys = new KeySet();
@@ -118,7 +119,7 @@ export class HiliteSetProvider {
       });
       const records = await this.getRecords(keys);
       const result = this.createHiliteSet(records, transientIds);
-      this._cached = { keysGuid: selection.guid, result };
+      this._cached = { keysGuid: selectionGuid, result };
     }
     return this._cached.result;
   }

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -64,6 +64,10 @@ export class SelectionManager implements ISelectionProvider {
     return selectionContainer;
   }
 
+  /** @internal */
+  // istanbul ignore next
+  public getToolSelectionSyncHandler(imodel: IModelConnection) { return this._imodelToolSelectionSyncHandlers.get(imodel)?.handler; }
+
   /**
    * Request the manager to sync with imodel's tool selection (see `IModelConnection.selectionSet`).
    */


### PR DESCRIPTION
We were caching the hilite set with guid of selection **after** retrieving the hilite set. If selection changed during the async request, we cached the result with GUID of the new selection. Then, if someone asked a hilite set for the new selection, we'd take whatever we have cached, which is not correct for the new selection.