### PR TITLE
Replace Viewport.readImage

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -7017,8 +7017,6 @@ export class NullTarget extends RenderTarget {
     // (undocumented)
     overrideFeatureSymbology(): void;
     // (undocumented)
-    readImage(): undefined;
-    // (undocumented)
     readPixels(): void;
     // (undocumented)
     get renderSystem(): any;
@@ -7779,6 +7777,13 @@ export interface ReadGltfGraphicsArgs {
     pickableOptions?: PickableGraphicOptions & {
         modelId?: Id64String;
     };
+}
+
+// @public
+export interface ReadImageBufferArgs {
+    rect?: ViewRect;
+    size?: XAndY;
+    upsideDown?: boolean;
 }
 
 // @internal
@@ -8759,7 +8764,10 @@ export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer
     // (undocumented)
     pickOverlayDecoration(_pt: XAndY): CanvasDecoration | undefined;
     queryVisibleTileFeatures(_options: QueryTileFeaturesOptions, _iModel: IModelConnection, callback: QueryVisibleFeaturesCallback): void;
+    // @deprecated (undocumented)
     readImage(_rect: ViewRect, _targetSize: Point2d, _flipVertically: boolean): ImageBuffer | undefined;
+    // (undocumented)
+    readImageBuffer(_args?: ReadImageBufferArgs): ImageBuffer | undefined;
     // (undocumented)
     readImageToCanvas(): HTMLCanvasElement;
     abstract readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable: boolean): void;
@@ -10059,6 +10067,8 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
     // (undocumented)
     queryVisibleTileFeatures(options: QueryTileFeaturesOptions, iModel: IModelConnection, callback: QueryVisibleFeaturesCallback): void;
     readImage(wantRectIn: ViewRect, targetSizeIn: Point2d, flipVertically: boolean): ImageBuffer | undefined;
+    // (undocumented)
+    readImageBuffer(args?: ReadImageBufferArgs): ImageBuffer | undefined;
     // (undocumented)
     protected readImagePixels(out: Uint8Array, x: number, y: number, w: number, h: number): boolean;
     // (undocumented)
@@ -12777,7 +12787,9 @@ export abstract class Viewport implements IDisposable {
     pointToGrid(point: Point3d): void;
     // @beta
     queryVisibleFeatures(options: QueryVisibleFeaturesOptions, callback: QueryVisibleFeaturesCallback): void;
+    // @deprecated
     readImage(rect?: ViewRect, targetSize?: Point2d, flipVertically?: boolean): ImageBuffer | undefined;
+    readImageBuffer(args?: ReadImageBufferArgs): ImageBuffer | undefined;
     readImageToCanvas(): HTMLCanvasElement;
     readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable?: boolean): void;
     // @internal

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -449,6 +449,7 @@ internal;rangeToCartographicArea(view3d: ViewState3d, range: Range3d): GlobalLoc
 public;readElementGraphics(bytes: Uint8Array, iModel: IModelConnection, modelId: Id64String, is3d: boolean, options?: BatchOptions | false): Promise
 public;readGltfGraphics(args: ReadGltfGraphicsArgs): Promise
 public;ReadGltfGraphicsArgs
+public;ReadImageBufferArgs
 internal;readPointCloudTileContent(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, _is3d: boolean, range: ElementAlignedBox3d, system: RenderSystem): RenderGraphic | undefined
 beta;RealityDataSource
 beta;RealityDataSource

--- a/common/changes/@itwin/core-frontend/fix-readimage_2022-01-13-13-38.json
+++ b/common/changes/@itwin/core-frontend/fix-readimage_2022-01-13-13-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Deprecated Viewport.readImage in favor of Viewport.readImageBuffer.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ImageUtil.ts
+++ b/core/frontend/src/ImageUtil.ts
@@ -71,7 +71,7 @@ export function canvasToResizedCanvasWithBars(canvasIn: HTMLCanvasElement, targe
 
 /** Create a canvas element with the same dimensions and contents as an image buffer.
  * @param buffer the source [[ImageBuffer]] object from which the [HTMLCanvasElement](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement) object will be constructed.
- * @param preserveAlpha If false, the alpha channel will be set to 255 (fully opaque). This is recommended when converting an already-blended image (e.g., one obtained from [[Viewport.readImage]]).
+ * @param preserveAlpha If false, the alpha channel will be set to 255 (fully opaque). This is recommended when converting an already-blended image (e.g., one obtained from [[Viewport.readImageBuffer]]).
  * @returns an [HTMLCanvasElement](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement) object containing the contents of the source image buffer, or undefined if the conversion fails.
  * @public
  */
@@ -242,7 +242,7 @@ export async function extractImageSourceDimensions(source: ImageSource): Promise
 /**
  * Produces a data url in "image/png" format from the contents of an ImageBuffer.
  * @param buffer The ImageBuffer, of any format.
- * @param preserveAlpha If false, the alpha channel will be set to 255 (fully opaque). This is recommended when converting an already-blended image (e.g., one obtained from [[Viewport.readImage]]).
+ * @param preserveAlpha If false, the alpha channel will be set to 255 (fully opaque). This is recommended when converting an already-blended image (e.g., one obtained from [[Viewport.readImageBuffer]]).
  * @returns a data url as a string suitable for setting as the `src` property of an HTMLImageElement, or undefined if the url could not be created.
  * @public
  */
@@ -255,7 +255,7 @@ export function imageBufferToPngDataUrl(buffer: ImageBuffer, preserveAlpha = tru
 /**
  * Converts the contents of an ImageBuffer to PNG format.
  * @param buffer The ImageBuffer, of any format.
- * @param preserveAlpha If false, the alpha channel will be set to 255 (fully opaque). This is recommended when converting an already-blended image (e.g., one obtained from [[Viewport.readImage]]).
+ * @param preserveAlpha If false, the alpha channel will be set to 255 (fully opaque). This is recommended when converting an already-blended image (e.g., one obtained from [[Viewport.readImageBuffer]]).
  * @returns a base64-encoded string representing the image as a PNG, or undefined if the conversion failed.
  * @public
  */

--- a/core/frontend/src/NoRenderApp.ts
+++ b/core/frontend/src/NoRenderApp.ts
@@ -36,7 +36,6 @@ export class NullTarget extends RenderTarget {
   public override dispose(): void { }
   public updateViewRect(): boolean { return false; }
   public readPixels(): void { }
-  public override readImage() { return undefined; }
   public get screenSpaceEffects(): Iterable<string> { return []; }
   public set screenSpaceEffects(_effects: Iterable<string>) { }
 }

--- a/core/frontend/src/SheetViewState.ts
+++ b/core/frontend/src/SheetViewState.ts
@@ -849,7 +849,7 @@ class RasterAttachment {
     view.setAspectRatioSkew(skew);
 
     if (true !== props.jsonProperties?.displayOptions?.preserveBackground) {
-      // Make background color 100% transparent so that Viewport.readImage() will discard transparent pixels.
+      // Make background color 100% transparent so that Viewport.readImageBuffer() will discard transparent pixels.
       const bgColor = sheetView.displayStyle.backgroundColor.withAlpha(0);
       view.displayStyle.backgroundColor = bgColor;
     }
@@ -924,7 +924,7 @@ class RasterAttachment {
 
   private createGraphics(vp: Viewport): RenderGraphic | undefined {
     // Create a texture from the contents of the view.
-    const image = vp.readImage(vp.viewRect, undefined, false);
+    const image = vp.readImageBuffer({ upsideDown: true });
     if (undefined === image)
       return undefined;
 

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2431,6 +2431,11 @@ export abstract class Viewport implements IDisposable {
     return this.target.readImage(rect, targetSize, flipVertically);
   }
 
+  /** Capture the image currently rendered in this viewport, or a subset thereof.
+   * @param args Describes the region to capture and optional resizing. By default the entire image is captured with no resizing.
+   * @returns The image, or `undefined` if the specified capture rect is not fully contained in [[viewRect], a 2d context could not be obtained, or the resultant image consists entirely
+   * of 100% transparent background pixels.
+   */
   public readImageBuffer(args?: ReadImageBufferArgs): ImageBuffer | undefined {
     return this.target.readImageBuffer(args);
   }

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -198,6 +198,15 @@ export interface GetPixelDataWorldPointArgs {
   out?: Point3d;
 }
 
+/** Arguments supplied to [[Viewport.readImageBuffer]].
+ * @public
+ */
+export interface ReadImageBufferArgs {
+  rect?: ViewRect;
+  size?: XAndY;
+  flipVertically?: boolean;
+}
+
 /** A Viewport renders the contents of one or more [GeometricModel]($backend)s onto an `HTMLCanvasElement`.
  *
  * It holds a [[ViewState]] object that defines its viewing parameters; the ViewState in turn defines the [[DisplayStyleState]],
@@ -2406,13 +2415,18 @@ export abstract class Viewport implements IDisposable {
    * @param flipVertically If true, the image is flipped along the x-axis.
    * @returns The contents of the viewport within the specified rectangle as a bitmap image, or undefined if the image could not be read.
    * @note By default the image is returned with the coordinate (0,0) referring to the bottom-most pixel. Pass `true` for `flipVertically` to flip it along the x-axis.
+   * @deprecated Use readImageBuffer.
    */
   public readImage(rect: ViewRect = new ViewRect(0, 0, -1, -1), targetSize: Point2d = Point2d.createZero(), flipVertically: boolean = false): ImageBuffer | undefined {
     return this.target.readImage(rect, targetSize, flipVertically);
   }
 
+  public readImageBuffer(args?: ReadImageBufferArgs): ImageBuffer | undefined {
+    return this.target.readImageBuffer(args);
+  }
+
   /** Reads the current image from this viewport into an HTMLCanvasElement with a Canvas2dRenderingContext such that additional 2d graphics can be drawn onto it.
-   * @see [[readImage]] to obtain the image as a JPEG or PNG.
+   * @see [[readImageBuffer]] to obtain the image as a JPEG or PNG.
    */
   public readImageToCanvas(): HTMLCanvasElement {
     return this.target.readImageToCanvas();

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2442,7 +2442,7 @@ export abstract class Viewport implements IDisposable {
   }
 
   /** Reads the current image from this viewport into an HTMLCanvasElement with a Canvas2dRenderingContext such that additional 2d graphics can be drawn onto it.
-   * @see [[readImageBuffer]] to obtain the image as a JPEG or PNG.
+   * @see [[readImageBuffer]] to obtain the image as an array of RGBA pixels.
    */
   public readImageToCanvas(): HTMLCanvasElement {
     return this.target.readImageToCanvas();

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2428,6 +2428,7 @@ export abstract class Viewport implements IDisposable {
    * @deprecated Use readImageBuffer.
    */
   public readImage(rect: ViewRect = new ViewRect(0, 0, -1, -1), targetSize: Point2d = Point2d.createZero(), flipVertically: boolean = false): ImageBuffer | undefined {
+    // eslint-disable-next-line deprecation/deprecation
     return this.target.readImage(rect, targetSize, flipVertically);
   }
 
@@ -3333,7 +3334,7 @@ export interface OffScreenViewportOptions {
 
 /** A viewport that draws to an offscreen buffer instead of to the screen. An offscreen viewport is never added to the [[ViewManager]], therefore does not participate in
  * the render loop. Its dimensions are specified directly instead of being derived from an HTMLCanvasElement, and its renderFrame function must be manually invoked.
- * Offscreen viewports can be useful for, e.g., producing an image from the contents of a view (see [[Viewport.readImage]] and [[Viewport.readImageToCanvas]])
+ * Offscreen viewports can be useful for, e.g., producing an image from the contents of a view (see [[Viewport.readImageBuffer]] and [[Viewport.readImageToCanvas]])
  * without drawing to the screen.
  * @public
  */

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -202,9 +202,19 @@ export interface GetPixelDataWorldPointArgs {
  * @public
  */
 export interface ReadImageBufferArgs {
+  /** The region of the viewport's [[ViewRect]] to capture. It must be fully contained within [[Viewport.viewRect]].
+   * If unspecified, the entirety of the viewport's view rect is captured.
+   */
   rect?: ViewRect;
+  /** Optional dimensions to which to resize the captured image. If the aspect ratio of these dimensions does not match that of the captured image,
+   * horizontal or vertical bars will be added to the resized image using the viewport's background color.
+   * If unspecified, the image will not be resized.
+   */
   size?: XAndY;
-  flipVertically?: boolean;
+  /** The image captured by WebGL appears "upside-down" and must be flipped to appear right-side-up; if true, this flipping will not be performed.
+   * This provides a performance optimization for uncommon cases in which an upside-down image is actually preferred.
+   */
+  upsideDown?: boolean;
 }
 
 /** A Viewport renders the contents of one or more [GeometricModel]($backend)s onto an `HTMLCanvasElement`.

--- a/core/frontend/src/render/RenderTarget.ts
+++ b/core/frontend/src/render/RenderTarget.ts
@@ -11,7 +11,7 @@ import { Point2d, XAndY } from "@itwin/core-geometry";
 import { Frustum, ImageBuffer, SpatialClassifier } from "@itwin/core-common";
 import { HiliteSet } from "../SelectionSet";
 import { SceneContext } from "../ViewContext";
-import { Viewport } from "../Viewport";
+import { ReadImageBufferArgs, Viewport } from "../Viewport";
 import { ViewRect } from "../ViewRect";
 import { IModelConnection } from "../IModelConnection";
 import { CanvasDecoration } from "./CanvasDecoration";
@@ -133,6 +133,7 @@ export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer
   public abstract readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable: boolean): void;
   /** `_rect` is specified in *CSS* pixels. */
   public readImage(_rect: ViewRect, _targetSize: Point2d, _flipVertically: boolean): ImageBuffer | undefined { return undefined; }
+  public readImageBuffer(_args?: ReadImageBufferArgs): ImageBuffer | undefined { return undefined; }
   public readImageToCanvas(): HTMLCanvasElement { return document.createElement("canvas"); }
   public collectStatistics(_stats: RenderMemory.Statistics): void { }
 

--- a/core/frontend/src/render/RenderTarget.ts
+++ b/core/frontend/src/render/RenderTarget.ts
@@ -131,7 +131,7 @@ export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer
   public abstract updateViewRect(): boolean; // force a RenderTarget viewRect to resize if necessary since last draw
   /** `rect` is specified in *CSS* pixels. */
   public abstract readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable: boolean): void;
-  /** `_rect` is specified in *CSS* pixels. */
+  /** @deprecated use readImageBuffer */
   public readImage(_rect: ViewRect, _targetSize: Point2d, _flipVertically: boolean): ImageBuffer | undefined { return undefined; }
   public readImageBuffer(_args?: ReadImageBufferArgs): ImageBuffer | undefined { return undefined; }
   public readImageToCanvas(): HTMLCanvasElement { return document.createElement("canvas"); }

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -1059,7 +1059,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
     }
 
     // Our image is upside-down by default. Flip it unless otherwise specified.
-    if (!args?.flipVertically) {
+    if (!args?.upsideDown) {
       const halfHeight = Math.floor(image.height / 2);
       const numBytesPerRow = image.width * 4;
       for (let loY = 0; loY < halfHeight; loY++) {

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -1083,7 +1083,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   }
 
   public copyImageToCanvas(): HTMLCanvasElement {
-    const image = this.readImage(new ViewRect(0, 0, -1, -1), Point2d.createZero(), true);
+    const image = this.readImageBuffer();
     const canvas = undefined !== image ? imageBufferToCanvas(image, false) : undefined;
     const retCanvas = undefined !== canvas ? canvas : document.createElement("canvas");
     const pixelRatio = this.devicePixelRatio;

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -14,7 +14,7 @@ import {
 import { canvasToImageBuffer, canvasToResizedCanvasWithBars, imageBufferToCanvas } from "../../ImageUtil";
 import { HiliteSet } from "../../SelectionSet";
 import { SceneContext } from "../../ViewContext";
-import { Viewport } from "../../Viewport";
+import { ReadImageBufferArgs, Viewport } from "../../Viewport";
 import { ViewRect } from "../../ViewRect";
 import { IModelConnection } from "../../IModelConnection";
 import { CanvasDecoration } from "../CanvasDecoration";
@@ -917,7 +917,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   /** Returns a new size scaled up to a maximum size while maintaining proper aspect ratio.  The new size will be
    * curSize adjusted so that it fits fully within maxSize in one dimension, maintaining its original aspect ratio.
    */
-  private static _applyAspectRatioCorrection(curSize: Point2d, maxSize: Point2d): Point2d {
+  private static _applyAspectRatioCorrection(curSize: XAndY, maxSize: XAndY): Point2d {
     const widthRatio = maxSize.x / curSize.x;
     const heightRatio = maxSize.y / curSize.y;
     const bestRatio = Math.min(widthRatio, heightRatio);
@@ -989,6 +989,77 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
     }
 
     if (flipVertically) {
+      const halfHeight = Math.floor(image.height / 2);
+      const numBytesPerRow = image.width * 4;
+      for (let loY = 0; loY < halfHeight; loY++) {
+        for (let x = 0; x < image.width; x++) {
+          const hiY = (image.height - 1) - loY;
+          const loIdx = loY * numBytesPerRow + x * 4;
+          const hiIdx = hiY * numBytesPerRow + x * 4;
+
+          swapImageByte(image, loIdx, hiIdx);
+          swapImageByte(image, loIdx + 1, hiIdx + 1);
+          swapImageByte(image, loIdx + 2, hiIdx + 2);
+          swapImageByte(image, loIdx + 3, hiIdx + 3);
+        }
+      }
+    }
+
+    return image;
+  }
+
+  public override readImageBuffer(args?: ReadImageBufferArgs): ImageBuffer | undefined {
+    if (!this.assignDC())
+      return undefined;
+
+    // Determine and validate capture rect.
+    const viewRect = this.renderRect; // already has device pixel ratio applied
+    const captureRect = args?.rect ? this.cssViewRectToDeviceViewRect(args.rect) : viewRect;
+    if (captureRect.isNull)
+      return undefined;
+
+    const topLeft = Point3d.create(captureRect.left, captureRect.top);
+    const bottomRight = Point2d.create(captureRect.right - 1, captureRect.bottom - 1);
+    if (!viewRect.containsPoint(topLeft) || !viewRect.containsPoint(bottomRight))
+      return undefined;
+
+    // ViewRect origin is at top-left. GL origin is at bottom-left.
+    const bottom = viewRect.height - captureRect.bottom;
+    const imageData = new Uint8Array(4 * captureRect.width * captureRect.height);
+    if (!this.readImagePixels(imageData, captureRect.left, bottom, captureRect.width, captureRect.height))
+      return undefined;
+
+    // Alpha has already been blended. Make all pixels opaque, *except* for background pixels if background color is fully transparent.
+    const preserveBGAlpha = 0 === this.uniforms.style.backgroundAlpha;
+    let isEmptyImage = true;
+    for (let i = 3; i < imageData.length; i += 4) {
+      const a = imageData[i];
+      if (!preserveBGAlpha || a > 0) {
+        imageData[i] = 0xff;
+        isEmptyImage = false;
+      }
+    }
+
+    // Optimization for view attachments: if image consists entirely of transparent background pixels, don't bother producing an image.
+    let image = !isEmptyImage ? ImageBuffer.create(imageData, ImageBufferFormat.Rgba, captureRect.width) : undefined;
+    if (!image)
+      return undefined;
+
+    // Scale image.
+    if (args?.size && (args.size.x !== captureRect.width || args.size.y !== captureRect.height)) {
+      let canvas = imageBufferToCanvas(image, true);
+      if (!canvas)
+        return undefined;
+
+      const adjustedSize = Target._applyAspectRatioCorrection({ x: captureRect.width, y: captureRect.height }, args.size);
+      canvas = canvasToResizedCanvasWithBars(canvas, adjustedSize, new Point2d(args.size.x - adjustedSize.x, args.size.y - adjustedSize.y), this.uniforms.style.backgroundHexString);
+      image = canvasToImageBuffer(canvas);
+      if (!image)
+        return undefined;
+    }
+
+    // Our image is upside-down by default. Flip it unless otherwise specified.
+    if (!args?.flipVertically) {
       const halfHeight = Math.floor(image.height / 2);
       const numBytesPerRow = image.width * 4;
       for (let loY = 0; loY < halfHeight; loY++) {

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -1047,6 +1047,9 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
 
     // Scale image.
     if (args?.size && (args.size.x !== captureRect.width || args.size.y !== captureRect.height)) {
+      if (args.size.x <= 0 || args.size.y <= 0)
+        return undefined;
+
       let canvas = imageBufferToCanvas(image, true);
       if (!canvas)
         return undefined;

--- a/core/frontend/src/test/ExpectColors.ts
+++ b/core/frontend/src/test/ExpectColors.ts
@@ -11,9 +11,9 @@ import { ViewRect } from "../ViewRect";
 /** A viewport-color-checking function for tests. Tests for the presence of a list of expected colors in the entire viewport or specified ViewRect.
  * @internal
  */
-export function expectColors(viewport: ScreenViewport, expected: ColorDef[], viewRect?: ViewRect): void {
+export function expectColors(viewport: ScreenViewport, expected: ColorDef[], rect?: ViewRect): void {
   viewport.renderFrame();
-  const buf = viewport.readImage(viewRect !== undefined ? viewRect : viewport.viewRect)!;
+  const buf = viewport.readImageBuffer({ rect })!;
   expect(buf).not.to.be.undefined;
 
   const u32 = new Uint32Array(buf.data.buffer);
@@ -34,9 +34,9 @@ export function expectColors(viewport: ScreenViewport, expected: ColorDef[], vie
 /** A viewport-color-checking function for tests. Tests for the presence of a list of any unexpected colors in the entire viewport or specified ViewRect. If any of the colors are found, this function expects them not to be found and will fail the test.
  * @internal
  */
-export function expectNotTheseColors(viewport: ScreenViewport, expected: ColorDef[], viewRect?: ViewRect): void {
+export function expectNotTheseColors(viewport: ScreenViewport, expected: ColorDef[], rect?: ViewRect): void {
   viewport.renderFrame();
-  const buf = viewport.readImage(viewRect !== undefined ? viewRect : viewport.viewRect)!;
+  const buf = viewport.readImageBuffer({ rect })!;
   expect(buf).not.to.be.undefined;
 
   const u32 = new Uint32Array(buf.data.buffer);

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -314,6 +314,7 @@ describe("Viewport", () => {
     describe("readImage", () => {
       it("reads image upside down by default (BUG)", () => {
         test(rgbw2, (viewport) => {
+          // eslint-disable-next-line deprecation/deprecation
           const image = viewport.readImage()!;
           expect(image).not.to.be.undefined;
           expectColors(image, [ ColorDef.blue, ColorDef.white, ColorDef.red, ColorDef.green ]);
@@ -322,6 +323,7 @@ describe("Viewport", () => {
 
       it("flips image vertically if specified", () => {
         test(rgbw2, (viewport) => {
+          // eslint-disable-next-line deprecation/deprecation
           const image = viewport.readImage(undefined, undefined, true)!;
           expect(image).not.to.be.undefined;
           expectColors(image, rgbw2.image);
@@ -330,6 +332,7 @@ describe("Viewport", () => {
 
       it("inverts view rect y (BUG)", () => {
         test(rgbwp1, (viewport) => {
+          // eslint-disable-next-line deprecation/deprecation
           const image = viewport.readImage(new ViewRect(0, 1, 1, 3), undefined, true)!;
           expect(image).not.to.be.undefined;
           expectColors(image, [ ColorDef.blue, ColorDef.white ]);

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -201,7 +201,7 @@ describe("Viewport", () => {
     });
   });
 
-  describe("readImage", () => {
+  describe.only("read images", () => {
     interface TestCase {
       width: number;
       image: ColorDef[];
@@ -278,27 +278,55 @@ describe("Viewport", () => {
       image: [ ColorDef.red, ColorDef.green, ColorDef.blue, ColorDef.white, purple ],
     };
 
-    it("reads image upside down (BUG)", () => {
-      test(rgbw2, (viewport) => {
-        const image = viewport.readImage()!;
-        expect(image).not.to.be.undefined;
-        expectColors(image, [ ColorDef.blue, ColorDef.white, ColorDef.red, ColorDef.green ]);
+    describe("readImage", () => {
+      it("reads image upside down (BUG)", () => {
+        test(rgbw2, (viewport) => {
+          const image = viewport.readImage()!;
+          expect(image).not.to.be.undefined;
+          expectColors(image, [ ColorDef.blue, ColorDef.white, ColorDef.red, ColorDef.green ]);
+        });
+      });
+
+      it("flips image vertically", () => {
+        test(rgbw2, (viewport) => {
+          const image = viewport.readImage(undefined, undefined, true)!;
+          expect(image).not.to.be.undefined;
+          expectColors(image, rgbw2.image);
+        });
+      });
+
+      it("inverts view rect y (BUG)", () => {
+        test(rgbwp1, (viewport) => {
+          const image = viewport.readImage(new ViewRect(0, 1, 1, 3), undefined, true)!;
+          expect(image).not.to.be.undefined;
+          expectColors(image, [ ColorDef.blue, ColorDef.white ]);
+        });
       });
     });
 
-    it("flips image vertically", () => {
-      test(rgbw2, (viewport) => {
-        const image = viewport.readImage(undefined, undefined, true)!;
-        expect(image).not.to.be.undefined;
-        expectColors(image, rgbw2.image);
+    describe("readImageBuffer", () => {
+      it("reads image right-side up", () => {
+        test(rgbw2, (viewport) => {
+          const image = viewport.readImageBuffer()!;
+          expect(image).not.to.be.undefined;
+          expectColors(image, rgbw2.image);
+        });
       });
-    });
 
-    it("inverts view rect y (BUG)", () => {
-      test(rgbwp1, (viewport) => {
-        const image = viewport.readImage(new ViewRect(0, 1, 1, 3), undefined, true)!;
-        expect(image).not.to.be.undefined;
-        expectColors(image, [ ColorDef.blue, ColorDef.white ]);
+      it("flips image vertically", () => {
+        test(rgbw2, (viewport) => {
+          const image = viewport.readImageBuffer({ flipVertically: true })!;
+          expect(image).not.to.be.undefined;
+          expectColors(image, [ ColorDef.blue, ColorDef.white, ColorDef.red, ColorDef.green ]);
+        });
+      });
+
+      it("does not invert view rect", () => {
+        test(rgbwp1, (viewport) => {
+          const image = viewport.readImageBuffer({ rect: new ViewRect(0, 1, 1, 3) })!;
+          expect(image).not.to.be.undefined;
+          expectColors(image, [ ColorDef.green, ColorDef.blue ]);
+        });
       });
     });
   });

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import { UnexpectedErrors } from "@itwin/core-bentley";
 import { Point2d } from "@itwin/core-geometry";
 import { AnalysisStyle, ColorDef, ImageBuffer, ImageBufferFormat } from "@itwin/core-common";
+import { ViewRect } from "../ViewRect";
 import { ScreenViewport } from "../Viewport";
 import { DisplayStyle3dState } from "../DisplayStyleState";
 import { IModelApp } from "../IModelApp";
@@ -215,7 +216,7 @@ describe("Viewport", () => {
         const builder = context.createGraphicBuilder(GraphicType.ViewOverlay);
         for (let x = 0; x < this.width; x++) {
           for (let y = 0; y < this.height; y++) {
-            const color = this.image[x + y * this.height];
+            const color = this.image[x + y * this.width];
             builder.setSymbology(color, color, 1);
             builder.addPointString2d([new Point2d(x + 0.5, y + 0.5)], 0);
           }
@@ -262,7 +263,7 @@ describe("Viewport", () => {
       expect(actual).to.deep.equal(expected);
     }
 
-    const rgbw: TestCase = {
+    const rgbw2: TestCase = {
       width: 2,
       image: [
         ColorDef.red, ColorDef.green,
@@ -270,8 +271,15 @@ describe("Viewport", () => {
       ],
     };
 
+    const purple = ColorDef.from(255, 0, 255);
+
+    const rgbwp1: TestCase = {
+      width: 1,
+      image: [ ColorDef.red, ColorDef.green, ColorDef.blue, ColorDef.white, purple ],
+    };
+
     it("reads image upside down (BUG)", () => {
-      test(rgbw, (viewport) => {
+      test(rgbw2, (viewport) => {
         const image = viewport.readImage()!;
         expect(image).not.to.be.undefined;
         expectColors(image, [ ColorDef.blue, ColorDef.white, ColorDef.red, ColorDef.green ]);
@@ -279,10 +287,18 @@ describe("Viewport", () => {
     });
 
     it("flips image vertically", () => {
-      test(rgbw, (viewport) => {
+      test(rgbw2, (viewport) => {
         const image = viewport.readImage(undefined, undefined, true)!;
         expect(image).not.to.be.undefined;
-        expectColors(image, rgbw.image);
+        expectColors(image, rgbw2.image);
+      });
+    });
+
+    it("inverts view rect y (BUG)", () => {
+      test(rgbwp1, (viewport) => {
+        const image = viewport.readImage(new ViewRect(0, 1, 1, 3), undefined, true)!;
+        expect(image).not.to.be.undefined;
+        expectColors(image, [ ColorDef.blue, ColorDef.white ]);
       });
     });
   });

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -482,7 +482,7 @@ describe("Viewport", () => {
         });
       });
 
-      it("doesn't preserve background alpha when resizing (canvas limitation", () => {
+      it("doesn't preserve background alpha when resizing (canvas limitation)", () => {
         // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData#data_loss_due_to_browser_optimization
         test(rTransp50pct, (viewport) => {
           const image = viewport.readImageBuffer({ size: { x: 2, y: 4 } })!;

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -201,7 +201,7 @@ describe("Viewport", () => {
     });
   });
 
-  describe.only("read images", () => {
+  describe("read images", () => {
     interface TestCase {
       width: number;
       image: ColorDef[];
@@ -318,7 +318,7 @@ describe("Viewport", () => {
 
       it("flips image vertically", () => {
         test(rgbw2, (viewport) => {
-          const image = viewport.readImageBuffer({ flipVertically: true })!;
+          const image = viewport.readImageBuffer({ upsideDown: true })!;
           expect(image).not.to.be.undefined;
           expectColors(image, [ ColorDef.blue, ColorDef.white, ColorDef.red, ColorDef.green ]);
         });

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -9,20 +9,16 @@ import { AnalysisStyle } from "@itwin/core-common";
 import { ScreenViewport } from "../Viewport";
 import { DisplayStyle3dState } from "../DisplayStyleState";
 import { IModelApp } from "../IModelApp";
-import { openBlankViewport } from "./openBlankViewport";
+import { openBlankViewport, testBlankViewport } from "./openBlankViewport";
 
 describe("Viewport", () => {
-  let viewport: ScreenViewport;
-
   before(async () => IModelApp.startup());
   after(async () => IModelApp.shutdown());
-  beforeEach(() => viewport = openBlankViewport());
-  afterEach(() => viewport.dispose());
 
   describe("flashedId", () => {
     type ChangedEvent = [string | undefined, string | undefined];
 
-    function expectFlashedId(expectedId: string | undefined, expectedEvent: ChangedEvent | undefined, func: () => void): void {
+    function expectFlashedId(viewport: ScreenViewport, expectedId: string | undefined, expectedEvent: ChangedEvent | undefined, func: () => void): void {
       let event: ChangedEvent | undefined;
       const removeListener = viewport.onFlashedIdChanged.addListener((vp, arg) => {
         expect(vp).to.equal(viewport);
@@ -38,92 +34,105 @@ describe("Viewport", () => {
     }
 
     it("dispatches events when flashed Id changes", () => {
-      expectFlashedId("0x123", [undefined, "0x123"], () => viewport.flashedId = "0x123");
-      expectFlashedId("0x456", ["0x123", "0x456"], () => viewport.flashedId = "0x456");
-      expectFlashedId("0x456", undefined, () => viewport.flashedId = "0x456");
-      expectFlashedId(undefined, ["0x456", undefined], () => viewport.flashedId = undefined);
-      expectFlashedId(undefined, undefined, () => viewport.flashedId = undefined);
+      testBlankViewport((viewport) => {
+        expectFlashedId(viewport, "0x123", [undefined, "0x123"], () => viewport.flashedId = "0x123");
+        expectFlashedId(viewport, "0x456", ["0x123", "0x456"], () => viewport.flashedId = "0x456");
+        expectFlashedId(viewport, "0x456", undefined, () => viewport.flashedId = "0x456");
+        expectFlashedId(viewport, undefined, ["0x456", undefined], () => viewport.flashedId = undefined);
+        expectFlashedId(viewport, undefined, undefined, () => viewport.flashedId = undefined);
+      });
     });
 
     it("treats invalid Id as undefined", () => {
-      viewport.flashedId = "0x123";
-      expectFlashedId(undefined, ["0x123", undefined], () => viewport.flashedId = "0");
-      viewport.flashedId = "0x123";
-      expectFlashedId(undefined, ["0x123", undefined], () => viewport.flashedId = undefined);
+      testBlankViewport((viewport) => {
+        viewport.flashedId = "0x123";
+        expectFlashedId(viewport, undefined, ["0x123", undefined], () => viewport.flashedId = "0");
+        viewport.flashedId = "0x123";
+        expectFlashedId(viewport, undefined, ["0x123", undefined], () => viewport.flashedId = undefined);
+      });
     });
 
     it("rejects malformed Ids", () => {
-      expectFlashedId(undefined, undefined, () => viewport.flashedId = "not an id");
-      viewport.flashedId = "0x123";
-      expectFlashedId("0x123", undefined, () => viewport.flashedId = "not an id");
+      testBlankViewport((viewport) => {
+        expectFlashedId(viewport, undefined, undefined, () => viewport.flashedId = "not an id");
+        viewport.flashedId = "0x123";
+        expectFlashedId(viewport, "0x123", undefined, () => viewport.flashedId = "not an id");
+      });
     });
 
     it("prohibits assignment from within event callback", () => {
-      const oldHandler = UnexpectedErrors.setHandler(UnexpectedErrors.reThrowImmediate);
-      viewport.onFlashedIdChanged.addOnce(() => viewport.flashedId = "0x12345");
-      expect(() => viewport.flashedId = "0x12345").to.throw(Error, "Cannot assign to Viewport.flashedId from within an onFlashedIdChanged event callback");
-      UnexpectedErrors.setHandler(oldHandler);
+      testBlankViewport((viewport) => {
+        const oldHandler = UnexpectedErrors.setHandler(UnexpectedErrors.reThrowImmediate);
+        viewport.onFlashedIdChanged.addOnce(() => viewport.flashedId = "0x12345");
+        expect(() => viewport.flashedId = "0x12345").to.throw(Error, "Cannot assign to Viewport.flashedId from within an onFlashedIdChanged event callback");
+        UnexpectedErrors.setHandler(oldHandler);
+      });
     });
   });
 
   describe("analysis style changed events", () => {
     it("registers and unregisters for multiple events", () => {
-      function expectListeners(expected: boolean): void {
-        const expectedNum = expected ? 1 : 0;
-        expect(viewport.onChangeView.numberOfListeners).to.equal(expectedNum);
+      testBlankViewport((viewport) => {
+        function expectListeners(expected: boolean): void {
+          const expectedNum = expected ? 1 : 0;
+          expect(viewport.onChangeView.numberOfListeners).to.equal(expectedNum);
 
-        // The viewport registers its own listener for each of these.
-        expect(viewport.view.onDisplayStyleChanged.numberOfListeners).to.equal(expectedNum + 1);
-        expect(viewport.displayStyle.settings.onAnalysisStyleChanged.numberOfListeners).to.equal(expectedNum + 1);
-      }
+          // The viewport registers its own listener for each of these.
+          expect(viewport.view.onDisplayStyleChanged.numberOfListeners).to.equal(expectedNum + 1);
+          expect(viewport.displayStyle.settings.onAnalysisStyleChanged.numberOfListeners).to.equal(expectedNum + 1);
+        }
 
-      expectListeners(false);
-      const removeListener = viewport.addOnAnalysisStyleChangedListener(() => undefined);
-      expectListeners(true);
-      removeListener();
-      expectListeners(false);
+        expectListeners(false);
+        const removeListener = viewport.addOnAnalysisStyleChangedListener(() => undefined);
+        expectListeners(true);
+        removeListener();
+        expectListeners(false);
+      });
     });
 
     it("emits events when analysis style changes", () => {
-      type EventPayload = AnalysisStyle | "undefined" | "none";
-      function expectChangedEvent(expectedPayload: EventPayload, func: () => void): void {
-        let payload: EventPayload = "none";
-        const removeListener = viewport.addOnAnalysisStyleChangedListener((style) => {
-          expect(payload).to.equal("none");
-          payload = style ?? "undefined";
+      testBlankViewport((viewport) => {
+        type EventPayload = AnalysisStyle | "undefined" | "none";
+        function expectChangedEvent(expectedPayload: EventPayload, func: () => void): void {
+          let payload: EventPayload = "none";
+          const removeListener = viewport.addOnAnalysisStyleChangedListener((style) => {
+            expect(payload).to.equal("none");
+            payload = style ?? "undefined";
+          });
+
+          func();
+          removeListener();
+          expect(payload).to.equal(expectedPayload);
+        }
+
+        const a = AnalysisStyle.fromJSON({ normalChannelName: "a" });
+
+        expectChangedEvent(a, () => viewport.displayStyle.settings.analysisStyle = a);
+        expectChangedEvent("none", () => viewport.displayStyle.settings.analysisStyle = a);
+
+        const b = AnalysisStyle.fromJSON({ normalChannelName: "b" });
+        expectChangedEvent(b, () => {
+          const style = viewport.displayStyle.clone();
+          style.settings.analysisStyle = b;
+          viewport.displayStyle = style;
         });
 
-        func();
-        removeListener();
-        expect(payload).to.equal(expectedPayload);
-      }
+        const c = AnalysisStyle.fromJSON({ normalChannelName: "c" });
+        expectChangedEvent(c, () => {
+          const view = viewport.view.clone();
+          expect(view.displayStyle).not.to.equal(viewport.view.displayStyle);
+          view.displayStyle.settings.analysisStyle = c;
+          viewport.changeView(view);
+        });
 
-      const a = AnalysisStyle.fromJSON({ normalChannelName: "a" });
-
-      expectChangedEvent(a, () => viewport.displayStyle.settings.analysisStyle = a);
-      expectChangedEvent("none", () => viewport.displayStyle.settings.analysisStyle = a);
-
-      const b = AnalysisStyle.fromJSON({ normalChannelName: "b" });
-      expectChangedEvent(b, () => {
-        const style = viewport.displayStyle.clone();
-        style.settings.analysisStyle = b;
-        viewport.displayStyle = style;
+        expectChangedEvent("undefined", () => viewport.displayStyle.settings.analysisStyle = undefined);
+        expectChangedEvent("none", () => viewport.displayStyle.settings.analysisStyle = undefined);
       });
-
-      const c = AnalysisStyle.fromJSON({ normalChannelName: "c" });
-      expectChangedEvent(c, () => {
-        const view = viewport.view.clone();
-        expect(view.displayStyle).not.to.equal(viewport.view.displayStyle);
-        view.displayStyle.settings.analysisStyle = c;
-        viewport.changeView(view);
-      });
-
-      expectChangedEvent("undefined", () => viewport.displayStyle.settings.analysisStyle = undefined);
-      expectChangedEvent("none", () => viewport.displayStyle.settings.analysisStyle = undefined);
     });
   });
 
   describe("background map", () => {
+    let viewport: ScreenViewport;
     function expectBackgroundMap(expected: boolean) {
       expect(viewport.viewFlags.backgroundMap).to.equal(expected);
     }
@@ -134,6 +143,7 @@ describe("Viewport", () => {
     }
 
     beforeEach(() => {
+      viewport = openBlankViewport();
       expectBackgroundMap(false);
       expectTerrain(false);
 
@@ -146,6 +156,7 @@ describe("Viewport", () => {
       viewport.view.displayStyle = new DisplayStyle3dState({} as any, viewport.iModel);
       expectBackgroundMap(false);
       expectTerrain(false);
+      viewport.dispose();
     });
 
     it("updates when display style is assigned to", () => {
@@ -184,5 +195,9 @@ describe("Viewport", () => {
       expectBackgroundMap(true);
       expectTerrain(false);
     });
+  });
+
+  describe("readImage", () => {
+
   });
 });

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -302,6 +302,9 @@ describe("Viewport", () => {
           expectColors(image, [ ColorDef.blue, ColorDef.white ]);
         });
       });
+
+      it("discards background alpha when resizing (BUG)", () => {
+      });
     });
 
     describe("readImageBuffer", () => {
@@ -327,6 +330,9 @@ describe("Viewport", () => {
           expect(image).not.to.be.undefined;
           expectColors(image, [ ColorDef.green, ColorDef.blue ]);
         });
+      });
+
+      it("preserves background alpha when resizing", () => {
       });
     });
   });

--- a/core/frontend/src/test/openBlankViewport.ts
+++ b/core/frontend/src/test/openBlankViewport.ts
@@ -18,6 +18,8 @@ export interface BlankViewportOptions {
   width?: number;
   /** iModel. If undefined, a new blank connection will be created. */
   iModel?: BlankConnection;
+  /** The position of the containing div. */
+  position?: "absolute";
 }
 
 /** Open a viewport for a blank spatial view.
@@ -36,6 +38,10 @@ export function openBlankViewport(options?: BlankViewportOptions): ScreenViewpor
   parentDiv.setAttribute("width", wPx);
   parentDiv.style.height = hPx;
   parentDiv.style.width = wPx;
+
+  if (options?.position)
+    parentDiv.style.position = options.position;
+
   document.body.appendChild(parentDiv);
 
   const view = SpatialViewState.createBlank(iModel, { x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 1 });

--- a/core/frontend/src/test/openBlankViewport.ts
+++ b/core/frontend/src/test/openBlankViewport.ts
@@ -62,3 +62,20 @@ export function openBlankViewport(options?: BlankViewportOptions): ScreenViewpor
 
   return viewport;
 }
+
+export type TestBlankViewportOptions = BlankViewportOptions & { test: (vp: ScreenViewport) => void };
+
+/** Open a viewport for a blank spatial view, invoke a test function, then dispose of the viewport and remove it from the DOM.
+ * @internal
+ */
+export function testBlankViewport(args: TestBlankViewportOptions | ((vp: ScreenViewport) => void)): void {
+  const vp = openBlankViewport(typeof args === "function" ? undefined : args);
+  try {
+    if (typeof args === "function")
+      args(vp);
+    else
+      args.test(vp);
+  } finally {
+    vp.dispose();
+  }
+}

--- a/core/frontend/src/test/render/webgl/Decorations.test.ts
+++ b/core/frontend/src/test/render/webgl/Decorations.test.ts
@@ -52,7 +52,7 @@ describe("Decorations", () => {
     viewport = ScreenViewport.create(div, view);
     width = viewport.viewRect.width;
     height = viewport.viewRect.height;
-    boxDecLocRect = new ViewRect(0, 0, width / 2, height / 2);
+    boxDecLocRect = new ViewRect(0, height / 2, width / 2, height);
     sphereDecBgLocRect = new ViewRect(width - 2, height / 2 + 128, width - 2 + 1, height / 2 + 128 + 1);
   });
 
@@ -96,8 +96,6 @@ describe("Decorations", () => {
     dec.drop();
   }).timeout(20000); // macOS is slow.
 
-  // ###TODO: Viewport.readImage is broken. It accepts a ViewRect which defines the origin at the top-left, and passes it to gl.readPixels, which
-  // defines the origin at the bottom-left. Update these tests after fixing that.
   it("rotates about view-independent origin", () => {
     const viewIndependentOrigin = new Point3d(0.5, 0.5, 0);
     const dec = new BoxDecorator({ viewport, color: ColorDef.red, points: shapePoints, viewIndependentOrigin });

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -16,6 +16,7 @@ Table of Contents:
 - [New features](#new-features)
   - [Display System](#display-system)
   - [AppUi Framework](#new-appui-features)
+  - [Presentation](#new-presentation-features)
   - [ECSql](#new-ecsql-features)
 - [Breaking changes](#breaking-changes)
   - [Application Setup](#application-setup)
@@ -187,7 +188,29 @@ Improvements were made to the performance of [ParticleCollectionBuilder]($fronte
 
 Note: `readGltfGraphics` targets the [glTF 2.0 specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html), but implementation of the full specification is an ongoing work in progress. The current implementation can successfully read many glTF assets, but if a particular asset fails to load or display properly, please [file an issue](https://github.com/iTwin/itwinjs-core/issues).
 
-### Presentation system
+#### Replacement for Viewport.readImage
+
+[Viewport.readImage]($frontend) suffers from a cumbersome API and several bugs. In particular, if it is asked to read a sub-region of the image it will calculate the y values incorrectly; and it produces an upside-down image by default. It has been deprecated in favor of [Viewport.readImageBuffer]($frontend). Callers of `readImage` can be upgraded as follows:
+
+```ts
+  // Use default arguments for readImage.
+  viewport.readImage(); // old - upside-down by default!
+  viewport.readImageBuffer({ upsideDown: true }); // new
+
+  // Read the entire image right-side-up - the typical case:
+  viewport.readImage(undefined, undefined, false); // old - must explicitly request right-side-up!
+  viewport.readImageBuffer(); // new
+
+  // Read a sub-rect of the image
+  viewport.readImage(rect); // old - produces incorrect results!
+  viewport.readImageBuffer({ rect }); // new
+
+  // Resize the image
+  viewport.readImage(undefined, size); // old
+  viewport.readImageBuffer({ size });
+```
+
+### New presentation features
 
 #### Presentation rule additions
 

--- a/full-stack-tests/core/src/frontend/TestViewport.ts
+++ b/full-stack-tests/core/src/frontend/TestViewport.ts
@@ -136,7 +136,7 @@ function readPixel(vp: Viewport, x: number, y: number, excludeNonLocatable?: boo
 // Read colors for each pixel; return the unique ones.
 function readUniqueColors(vp: Viewport, readRect?: ViewRect): ColorSet {
   const rect = undefined !== readRect ? readRect : vp.viewRect;
-  const buffer = vp.readImage(rect)!;
+  const buffer = vp.readImageBuffer({ rect })!;
   expect(buffer).not.to.be.undefined;
   const u32 = new Uint32Array(buffer.data.buffer);
   const colors = new ColorSet();

--- a/full-stack-tests/core/src/frontend/standalone/RenderTarget.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/RenderTarget.test.ts
@@ -221,13 +221,13 @@ describe("RenderTarget", () => {
   });
 
   it("should read image at expected sizes", async () => {
-    // NOTE: rect is in CSS pixels. ImageBuffer returned by readImage is in device pixels. vp.target.viewRect is in device pixels.
+    // NOTE: rect is in CSS pixels. ImageBuffer returned by readImageBuffer is in device pixels. vp.target.viewRect is in device pixels.
     const cssRect = new ViewRect(0, 0, 100, 100);
     await testViewportsWithDpr(imodel, cssRect, async (vp) => {
       await vp.waitForAllTilesToRender();
 
       const expectImageDimensions = (readRect: ViewRect | undefined, targetSize: Point2d | undefined, expectedWidth: number, expectedHeight: number) => {
-        const img = vp.readImage(readRect, targetSize)!;
+        const img = vp.readImageBuffer({ rect: readRect, size: targetSize })!;
         expect(img).not.to.be.undefined;
         expect(img.width).to.equal(Math.floor(expectedWidth));
         expect(img.height).to.equal(Math.floor(expectedHeight));
@@ -376,7 +376,7 @@ describe("RenderTarget", () => {
           expect(c.g).to.equal(0);
           expect(c.b).least(0x70);
           expect(c.b).most(0x90);
-          expect(c.a).to.equal(0xff); // The alpha is intentionally not preserved by Viewport.readImage()
+          expect(c.a).to.equal(0xff); // The alpha is intentionally not preserved by Viewport.readImageBuffer()
         }
       }
     });

--- a/full-stack-tests/core/src/frontend/standalone/RenderTarget.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/RenderTarget.test.ts
@@ -237,7 +237,6 @@ describe("RenderTarget", () => {
 
       // Read full image, no resize
       expectImageDimensions(undefined, undefined, devRect.width, devRect.height);
-      expectImageDimensions(new ViewRect(0, 0, -1, -1), undefined, devRect.width, devRect.height);
       expectImageDimensions(undefined, new Point2d(devRect.width, devRect.height), devRect.width, devRect.height);
 
       // Read sub-image, no resize
@@ -251,7 +250,7 @@ describe("RenderTarget", () => {
 
       // Read full image and resize
       expectImageDimensions(undefined, new Point2d(256, 128), 256, 128);
-      expectImageDimensions(new ViewRect(0, 0, -1, -1), new Point2d(50, 200), 50, 200);
+      expectImageDimensions(undefined, new Point2d(50, 200), 50, 200);
       expectImageDimensions(cssRect, new Point2d(10, 10), 10, 10);
       expectImageDimensions(undefined, new Point2d(devRect.width, devRect.height), devRect.width, devRect.height);
 
@@ -525,7 +524,7 @@ describe("RenderTarget", () => {
       IModelApp.viewManager.dropDecorator(decorator);
 
       // expect green blended with black background
-      const testColor = vp.readColor(0, 149); // top left pixel, test vp coords are flipped
+      const testColor = vp.readColor(0, 0); // top left pixel
       expect(testColor.r).equals(0);
       expect(testColor.g).approximately(128, 3);
       expect(testColor.b).equals(0);

--- a/test-apps/display-test-app/src/frontend/Viewer.ts
+++ b/test-apps/display-test-app/src/frontend/Viewer.ts
@@ -29,7 +29,7 @@ import { openIModel } from "./openIModel";
 // cspell:ignore savedata topdiv savedview viewtop
 
 function saveImage(vp: Viewport) {
-  const buffer = vp.readImage(undefined, new Point2d(768, 768), true); // flip vertically...
+  const buffer = vp.readImageBuffer({ size: new Point2d(768, 768) });
   if (undefined === buffer) {
     alert("Failed to read image");
     return;


### PR DESCRIPTION
[Viewport.readImage](https://www.itwinjs.org/reference/imodeljs-frontend/views/viewport/readimage/) is broken:
- If you supply a capture rect smaller than the view rect, it will capture the wrong area due to confusion between ViewRect's origin at top-left and WebGL's origin at bottom-left.
- If you request a resized image it won't preserve background transparency.

It's also confusing and awkward:
- By default, it returns an upside-down image; the caller must explicitly request it to be flipped right-side-up.
- It takes special sigil values like "size = (0, 0) | undefined" to indicate no resizing and "rect = (0, 0, -1, -1) | undefined" to indicate the full image should be captured.

The lack of complaints about these issues suggests few people are relying on this suboptimal behavior (although several unit tests currently do), but we can't be certain.
Deprecate it and replace with `Viewport.readImageBuffer`, which takes all of its arguments as an optional single object, uses sensible defaults, and addresses the issues above.
The issue with transparency of resized images is [not actually addressable](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/putImageData#data_loss_due_to_browser_optimization) without crazy expensive WebGL alternatives; we can consider addressing it when/if a requirement to do so arises.

TODO:
- [x] More tests.
- [x] Update callers of readImage to use readImageBuffer.
- [x] Update docs including NextVersion.md.
- [x] Verify ImageTests results