### PR TITLE
Fix the use of the previousVer variable

### DIFF
--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -119,6 +119,7 @@ steps:
      packagesToPublish = False
      localVer = ""
      latestVer = ""
+     previousVer = ""
      for artifact in artifactPaths:
        baseName = os.path.basename(artifact)
        print ("")


### PR DESCRIPTION
The previousVer variable is not available to the determineDistTag function since it's only defined within the for loop. Instantiate the variable prior to the for loop like the other two variables.

Test build here: https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=1250045&view=results