### PR TITLE
Entity is not an EntityProps.

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -255,7 +255,7 @@ export class AnnotationElement2d extends GraphicalElement2d {
 }
 
 // @public
-export abstract class AuxCoordSystem extends DefinitionElement implements AuxCoordSystemProps {
+export abstract class AuxCoordSystem extends DefinitionElement {
     constructor(props: AuxCoordSystemProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;
@@ -266,7 +266,7 @@ export abstract class AuxCoordSystem extends DefinitionElement implements AuxCoo
 }
 
 // @public
-export class AuxCoordSystem2d extends AuxCoordSystem implements AuxCoordSystem2dProps {
+export class AuxCoordSystem2d extends AuxCoordSystem {
     constructor(props: AuxCoordSystem2dProps, iModel: IModelDb);
     // (undocumented)
     angle: number;
@@ -278,7 +278,7 @@ export class AuxCoordSystem2d extends AuxCoordSystem implements AuxCoordSystem2d
 }
 
 // @public
-export class AuxCoordSystem3d extends AuxCoordSystem implements AuxCoordSystem3dProps {
+export class AuxCoordSystem3d extends AuxCoordSystem {
     constructor(props: AuxCoordSystem3dProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;
@@ -519,14 +519,14 @@ export class BriefcaseManager {
     }
 
 // @public
-export abstract class Callout extends DetailingSymbol implements CalloutProps {
+export abstract class Callout extends DetailingSymbol {
     constructor(props: CalloutProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;
 }
 
 // @public
-export class Category extends DefinitionElement implements CategoryProps {
+export class Category extends DefinitionElement {
     // @internal
     constructor(props: CategoryProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -549,7 +549,7 @@ export class CategoryOwnsSubCategories extends ElementOwnsChildElements {
 }
 
 // @public
-export class CategorySelector extends DefinitionElement implements CategorySelectorProps {
+export class CategorySelector extends DefinitionElement {
     // @internal
     constructor(props: CategorySelectorProps, iModel: IModelDb);
     categories: Id64String[];
@@ -825,7 +825,7 @@ export class DefinitionContainer extends DefinitionSet {
 }
 
 // @public
-export abstract class DefinitionElement extends InformationContentElement implements DefinitionElementProps {
+export abstract class DefinitionElement extends InformationContentElement {
     // @internal
     constructor(props: DefinitionElementProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -945,7 +945,7 @@ export class DictionaryModel extends DefinitionModel {
 export type DictionaryName = string;
 
 // @public
-export abstract class DisplayStyle extends DefinitionElement implements DisplayStyleProps {
+export abstract class DisplayStyle extends DefinitionElement {
     // @internal
     protected constructor(props: DisplayStyleProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -974,7 +974,7 @@ export class DisplayStyle2d extends DisplayStyle {
     }
 
 // @public
-export class DisplayStyle3d extends DisplayStyle implements DisplayStyle3dProps {
+export class DisplayStyle3d extends DisplayStyle {
     // @internal
     constructor(props: DisplayStyle3dProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -1330,7 +1330,7 @@ export class EditableWorkspaceDb extends ITwinWorkspaceDb {
     }
 
 // @public
-export class Element extends Entity implements ElementProps {
+export class Element extends Entity {
     // @internal
     constructor(props: ElementProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -1412,7 +1412,7 @@ export class Element extends Entity implements ElementProps {
 }
 
 // @public
-export class ElementAspect extends Entity implements ElementAspectProps {
+export class ElementAspect extends Entity {
     // @internal
     constructor(props: ElementAspectProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -1436,7 +1436,7 @@ export class ElementAspect extends Entity implements ElementAspectProps {
 }
 
 // @beta
-export class ElementDrivesElement extends Relationship implements ElementDrivesElementProps {
+export class ElementDrivesElement extends Relationship {
     // @internal
     constructor(props: ElementDrivesElementProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -1445,6 +1445,8 @@ export class ElementDrivesElement extends Relationship implements ElementDrivesE
     static create<T extends ElementRefersToElements>(iModel: IModelDb, sourceId: Id64String, targetId: Id64String, priority?: number): T;
     priority: number;
     status: number;
+    // (undocumented)
+    toJSON(): ElementDrivesElementProps;
 }
 
 // @beta
@@ -1541,7 +1543,7 @@ export class EmbeddedFileLink extends LinkElement {
 }
 
 // @public
-export class Entity implements EntityProps {
+export class Entity {
     // @internal
     constructor(props: EntityProps, iModel: IModelDb);
     // @internal
@@ -1553,11 +1555,11 @@ export class Entity implements EntityProps {
     forEachProperty(func: PropertyCallback, includeCustom?: boolean): void;
     id: Id64String;
     iModel: IModelDb;
+    readonly isInstanceOfEntity: true;
     // @internal (undocumented)
     static get protectedOperations(): string[];
     static schema: typeof Schema;
     get schemaName(): string;
-    // @internal (undocumented)
     toJSON(): EntityProps;
 }
 
@@ -1723,7 +1725,7 @@ export class ExternalSource extends InformationReferenceElement {
 }
 
 // @public
-export class ExternalSourceAspect extends ElementMultiAspect implements ExternalSourceAspectProps {
+export class ExternalSourceAspect extends ElementMultiAspect {
     // @internal
     constructor(props: ExternalSourceAspectProps, iModel: IModelDb);
     checksum?: string;
@@ -1852,7 +1854,7 @@ export class FunctionalComposite extends FunctionalBreakdownElement {
 }
 
 // @public
-export abstract class FunctionalElement extends RoleElement implements FunctionalElementProps {
+export abstract class FunctionalElement extends RoleElement {
     // @internal
     constructor(props: FunctionalElementProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -1954,7 +1956,7 @@ export class GenericSchema extends Schema {
 }
 
 // @public
-export abstract class GeometricElement extends Element implements GeometricElementProps {
+export abstract class GeometricElement extends Element {
     // @internal
     constructor(props: GeometricElementProps, iModel: IModelDb);
     // (undocumented)
@@ -1971,12 +1973,11 @@ export abstract class GeometricElement extends Element implements GeometricEleme
     is2d(): this is GeometricElement2d;
     is3d(): this is GeometricElement3d;
     abstract get placement(): Placement2d | Placement3d;
-    // @internal (undocumented)
     toJSON(): GeometricElementProps;
 }
 
 // @public
-export abstract class GeometricElement2d extends GeometricElement implements GeometricElement2dProps {
+export abstract class GeometricElement2d extends GeometricElement {
     // @internal
     constructor(props: GeometricElement2dProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -1999,7 +2000,7 @@ export class GeometricElement2dHasTypeDefinition extends TypeDefinition {
 }
 
 // @public
-export abstract class GeometricElement3d extends GeometricElement implements GeometricElement3dProps {
+export abstract class GeometricElement3d extends GeometricElement {
     // @internal
     constructor(props: GeometricElement3dProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -2022,7 +2023,7 @@ export class GeometricElement3dHasTypeDefinition extends TypeDefinition {
 }
 
 // @public
-export class GeometricModel extends Model implements GeometricModelProps {
+export class GeometricModel extends Model {
     // @internal
     constructor(props: GeometricModelProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -2033,7 +2034,7 @@ export class GeometricModel extends Model implements GeometricModelProps {
 }
 
 // @public
-export abstract class GeometricModel2d extends GeometricModel implements GeometricModel2dProps {
+export abstract class GeometricModel2d extends GeometricModel {
     // @internal
     constructor(props: GeometricModel2dProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -2044,7 +2045,7 @@ export abstract class GeometricModel2d extends GeometricModel implements Geometr
 }
 
 // @public
-export abstract class GeometricModel3d extends GeometricModel implements GeometricModel3dProps {
+export abstract class GeometricModel3d extends GeometricModel {
     // @internal
     constructor(props: GeometricModel3dProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -2057,7 +2058,7 @@ export abstract class GeometricModel3d extends GeometricModel implements Geometr
 }
 
 // @public
-export class GeometryPart extends DefinitionElement implements GeometryPartProps {
+export class GeometryPart extends DefinitionElement {
     // @internal
     constructor(props: GeometryPartProps, iModel: IModelDb);
     // (undocumented)
@@ -2603,7 +2604,7 @@ export abstract class InformationModel extends Model {
 }
 
 // @public
-export abstract class InformationPartitionElement extends InformationContentElement implements InformationPartitionElementProps {
+export abstract class InformationPartitionElement extends InformationContentElement {
     // @internal
     constructor(props: InformationPartitionElementProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -2794,7 +2795,7 @@ export class KnownLocations {
 }
 
 // @internal
-export class LightLocation extends SpatialLocationElement implements LightLocationProps {
+export class LightLocation extends SpatialLocationElement {
     constructor(props: LightLocationProps, iModel: IModelDb);
     // (undocumented)
     static get className(): string;
@@ -2802,7 +2803,7 @@ export class LightLocation extends SpatialLocationElement implements LightLocati
 }
 
 // @public
-export class LineStyle extends DefinitionElement implements LineStyleProps {
+export class LineStyle extends DefinitionElement {
     // @internal
     constructor(props: LineStyleProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3055,7 +3056,7 @@ export class MetaDataRegistry {
     }
 
 // @public
-export class Model extends Entity implements ModelProps {
+export class Model extends Entity {
     // @internal
     constructor(props: ModelProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3115,7 +3116,7 @@ export class Model extends Entity implements ModelProps {
 }
 
 // @public
-export class ModelSelector extends DefinitionElement implements ModelSelectorProps {
+export class ModelSelector extends DefinitionElement {
     // @internal
     constructor(props: ModelSelectorProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3425,7 +3426,7 @@ export abstract class RecipeDefinitionElement extends DefinitionElement {
 }
 
 // @public
-export class Relationship extends Entity implements RelationshipProps {
+export class Relationship extends Entity {
     // @internal
     constructor(props: RelationshipProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3462,7 +3463,7 @@ export class Relationships {
 }
 
 // @public
-export class RenderMaterialElement extends DefinitionElement implements RenderMaterialProps {
+export class RenderMaterialElement extends DefinitionElement {
     // @internal
     constructor(props: RenderMaterialProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3522,7 +3523,7 @@ export class RenderTimeline extends InformationRecordElement {
 }
 
 // @public
-export class RepositoryLink extends UrlLink implements RepositoryLinkProps {
+export class RepositoryLink extends UrlLink {
     // @internal
     constructor(props: RepositoryLinkProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3737,7 +3738,7 @@ export class SettingsSpecRegistry {
 export type SettingType = JSONSchemaType;
 
 // @public
-export class Sheet extends Document implements SheetProps {
+export class Sheet extends Document {
     // @internal
     constructor(props: SheetProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3756,7 +3757,7 @@ export class Sheet extends Document implements SheetProps {
 }
 
 // @public
-export class SheetBorderTemplate extends Document implements SheetBorderTemplateProps {
+export class SheetBorderTemplate extends Document {
     // @internal
     constructor(props: SheetBorderTemplateProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3774,7 +3775,7 @@ export class SheetModel extends GraphicalModel2d {
 }
 
 // @public
-export class SheetTemplate extends Document implements SheetTemplateProps {
+export class SheetTemplate extends Document {
     // @internal
     constructor(props: SheetTemplateProps, iModel: IModelDb);
     // (undocumented)
@@ -3892,7 +3893,7 @@ export abstract class SpatialModel extends GeometricModel3d {
 }
 
 // @public
-export class SpatialViewDefinition extends ViewDefinition3d implements SpatialViewDefinitionProps {
+export class SpatialViewDefinition extends ViewDefinition3d {
     // @internal
     constructor(props: SpatialViewDefinitionProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -4046,7 +4047,7 @@ export class SubCategory extends DefinitionElement {
 }
 
 // @public
-export class Subject extends InformationReferenceElement implements SubjectProps {
+export class Subject extends InformationReferenceElement {
     // @internal
     constructor(props: SubjectProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -4273,7 +4274,7 @@ export class TxnManager {
 }
 
 // @public
-export abstract class TypeDefinitionElement extends DefinitionElement implements TypeDefinitionElementProps {
+export abstract class TypeDefinitionElement extends DefinitionElement {
     // @internal
     constructor(props: TypeDefinitionElementProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -4291,7 +4292,7 @@ export interface UpdateModelOptions extends ModelProps {
 }
 
 // @public
-export class UrlLink extends LinkElement implements UrlLinkProps {
+export class UrlLink extends LinkElement {
     // @internal
     constructor(props: UrlLinkProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -4342,7 +4343,7 @@ export interface ValidationError {
 }
 
 // @public
-export class ViewAttachment extends GraphicalElement2d implements ViewAttachmentProps {
+export class ViewAttachment extends GraphicalElement2d {
     constructor(props: ViewAttachmentProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;
@@ -4353,14 +4354,14 @@ export class ViewAttachment extends GraphicalElement2d implements ViewAttachment
 }
 
 // @public
-export class ViewAttachmentLabel extends DetailingSymbol implements ViewAttachmentLabelProps {
+export class ViewAttachmentLabel extends DetailingSymbol {
     constructor(props: ViewAttachmentLabelProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;
 }
 
 // @public
-export abstract class ViewDefinition extends DefinitionElement implements ViewDefinitionProps {
+export abstract class ViewDefinition extends DefinitionElement {
     // @internal
     protected constructor(props: ViewDefinitionProps, iModel: IModelDb);
     categorySelectorId: Id64String;
@@ -4386,7 +4387,7 @@ export abstract class ViewDefinition extends DefinitionElement implements ViewDe
 }
 
 // @public
-export class ViewDefinition2d extends ViewDefinition implements ViewDefinition2dProps {
+export class ViewDefinition2d extends ViewDefinition {
     // @internal
     constructor(props: ViewDefinition2dProps, iModel: IModelDb);
     angle: Angle;
@@ -4404,7 +4405,7 @@ export class ViewDefinition2d extends ViewDefinition implements ViewDefinition2d
 }
 
 // @public
-export abstract class ViewDefinition3d extends ViewDefinition implements ViewDefinition3dProps {
+export abstract class ViewDefinition3d extends ViewDefinition {
     // @internal
     constructor(props: ViewDefinition3dProps, iModel: IModelDb);
     angles: YawPitchRollAngles;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2833,6 +2833,7 @@ export interface EntityMetaDataProps {
 export interface EntityProps {
     classFullName: string;
     id?: Id64String;
+    readonly isInstanceOfEntity?: never;
     jsonProperties?: {
         [key: string]: any;
     };
@@ -3719,9 +3720,9 @@ export class GeometryStreamIterator implements IterableIterator<GeometryStreamIt
     [Symbol.iterator](): IterableIterator<GeometryStreamIteratorEntry>;
     constructor(geometryStream: GeometryStreamProps, categoryOrGeometryParams?: Id64String | GeometryParams, localToWorld?: Transform);
     readonly flags: GeometryStreamFlags;
-    static fromGeometricElement2d(element: GeometricElement2dProps): GeometryStreamIterator;
-    static fromGeometricElement3d(element: GeometricElement3dProps): GeometryStreamIterator;
-    static fromGeometryPart(geomPart: GeometryPartProps, geomParams?: GeometryParams, partTransform?: Transform): GeometryStreamIterator;
+    static fromGeometricElement2d(element: Pick<GeometricElement2dProps, "geom" | "placement" | "category">): GeometryStreamIterator;
+    static fromGeometricElement3d(element: Pick<GeometricElement3dProps, "geom" | "placement" | "category">): GeometryStreamIterator;
+    static fromGeometryPart(geomPart: Pick<GeometryPartProps, "geom">, geomParams?: GeometryParams, partTransform?: Transform): GeometryStreamIterator;
     geometryStream: GeometryStreamProps;
     // @internal (undocumented)
     get isViewIndependent(): boolean;

--- a/common/api/linear-referencing-backend.api.md
+++ b/common/api/linear-referencing-backend.api.md
@@ -118,7 +118,7 @@ export class LinearlyLocated {
 }
 
 // @beta
-export abstract class LinearlyLocatedAttribution extends SpatialLocationElement implements LinearlyLocatedAttributionProps, LinearlyLocatedBase {
+export abstract class LinearlyLocatedAttribution extends SpatialLocationElement {
     constructor(props: LinearlyLocatedAttributionProps, iModel: IModelDb);
     // (undocumented)
     attributedElement?: ILinearlyLocatedAttributesElement;
@@ -167,7 +167,7 @@ export interface LinearlyLocatedSingleFromTo extends LinearlyLocatedBase {
 }
 
 // @beta
-export class LinearlyReferencedAtLocation extends LinearlyReferencedLocation implements LinearlyReferencedAtLocationAspectProps {
+export class LinearlyReferencedAtLocation extends LinearlyReferencedLocation {
     constructor(props: LinearlyReferencedAtLocationAspectProps, iModel: IModelDb);
     // (undocumented)
     atPosition: DistanceExpression;
@@ -196,7 +196,7 @@ export class LinearlyReferencedFromPositionRefersToReferent extends RelatedEleme
 }
 
 // @beta
-export class LinearlyReferencedFromToLocation extends LinearlyReferencedLocation implements LinearlyReferencedFromToLocationAspectProps {
+export class LinearlyReferencedFromToLocation extends LinearlyReferencedLocation {
     constructor(props: LinearlyReferencedFromToLocationAspectProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;
@@ -258,7 +258,7 @@ export class Referent extends ReferentElement {
     }
 
 // @beta
-export abstract class ReferentElement extends SpatialLocationElement implements ReferentElementProps, LinearlyLocatedBase {
+export abstract class ReferentElement extends SpatialLocationElement {
     constructor(props: ReferentElementProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -109,7 +109,7 @@ public;ElementRefersToElements
 public;ElementUniqueAspect 
 public;ElevationCallout 
 public;EmbeddedFileLink 
-public;Entity 
+public;Entity
 public;EntityClassType
 public;ExportGraphics
 public;ExportGraphicsFunction = (info: ExportGraphicsInfo) => void

--- a/common/changes/@itwin/analytical-backend/entity-is-not-entityprops_2022-01-18-14-16.json
+++ b/common/changes/@itwin/analytical-backend/entity-is-not-entityprops_2022-01-18-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/analytical-backend"
+}

--- a/common/changes/@itwin/core-backend/entity-is-not-entityprops_2022-01-18-14-16.json
+++ b/common/changes/@itwin/core-backend/entity-is-not-entityprops_2022-01-18-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Entity no longer implements EntityProps.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/entity-is-not-entityprops_2022-01-18-14-16.json
+++ b/common/changes/@itwin/core-common/entity-is-not-entityprops_2022-01-18-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Added non-existent property to EntityProps to make the compiler discriminate between EntityProps and Entity.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-transformer/entity-is-not-entityprops_2022-01-18-14-16.json
+++ b/common/changes/@itwin/core-transformer/entity-is-not-entityprops_2022-01-18-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/common/changes/@itwin/editor-backend/entity-is-not-entityprops_2022-01-18-14-16.json
+++ b/common/changes/@itwin/editor-backend/entity-is-not-entityprops_2022-01-18-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-backend"
+}

--- a/common/changes/@itwin/linear-referencing-backend/entity-is-not-entityprops_2022-01-18-14-16.json
+++ b/common/changes/@itwin/linear-referencing-backend/entity-is-not-entityprops_2022-01-18-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/linear-referencing-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-backend"
+}

--- a/common/changes/@itwin/presentation-backend/entity-is-not-entityprops_2022-01-18-14-16.json
+++ b/common/changes/@itwin/presentation-backend/entity-is-not-entityprops_2022-01-18-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/core/backend/src/Category.ts
+++ b/core/backend/src/Category.ts
@@ -198,9 +198,9 @@ export class DrawingCategory extends Category {
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {
     const category = this.create(iModelDb, definitionModelId, name);
     const elements = iModelDb.elements;
-    const categoryId = elements.insertElement(category.toJSON());
+    category.id = elements.insertElement(category.toJSON());
     category.setDefaultAppearance(defaultAppearance);
-    return categoryId;
+    return category.id;
   }
 }
 
@@ -264,8 +264,8 @@ export class SpatialCategory extends Category {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {
     const category = this.create(iModelDb, definitionModelId, name);
-    const categoryId = iModelDb.elements.insertElement(category.toJSON());
+    category.id = iModelDb.elements.insertElement(category.toJSON());
     category.setDefaultAppearance(defaultAppearance);
-    return categoryId;
+    return category.id;
   }
 }

--- a/core/backend/src/Category.ts
+++ b/core/backend/src/Category.ts
@@ -93,14 +93,14 @@ export class SubCategory extends DefinitionElement {
    */
   public static insert(iModelDb: IModelDb, parentCategoryId: Id64String, name: string, appearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {
     const subCategory = this.create(iModelDb, parentCategoryId, name, appearance);
-    return iModelDb.elements.insertElement(subCategory);
+    return iModelDb.elements.insertElement(subCategory.toJSON());
   }
 }
 
 /** A Category element is the target of the `category` member of [[GeometricElement]].
  * @public
  */
-export class Category extends DefinitionElement implements CategoryProps {
+export class Category extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "Category"; }
   public rank: Rank = Rank.User;
@@ -132,7 +132,7 @@ export class Category extends DefinitionElement implements CategoryProps {
 
     const subCat = this.iModel.elements.getElement<SubCategory>(this.myDefaultSubCategoryId());
     subCat.appearance = new SubCategoryAppearance(props);
-    this.iModel.elements.updateElement(subCat);
+    this.iModel.elements.updateElement(subCat.toJSON());
   }
 }
 
@@ -198,7 +198,7 @@ export class DrawingCategory extends Category {
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {
     const category = this.create(iModelDb, definitionModelId, name);
     const elements = iModelDb.elements;
-    const categoryId = elements.insertElement(category);
+    const categoryId = elements.insertElement(category.toJSON());
     category.setDefaultAppearance(defaultAppearance);
     return categoryId;
   }
@@ -264,7 +264,7 @@ export class SpatialCategory extends Category {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {
     const category = this.create(iModelDb, definitionModelId, name);
-    const categoryId = iModelDb.elements.insertElement(category);
+    const categoryId = iModelDb.elements.insertElement(category.toJSON());
     category.setDefaultAppearance(defaultAppearance);
     return categoryId;
   }

--- a/core/backend/src/DisplayStyle.ts
+++ b/core/backend/src/DisplayStyle.ts
@@ -20,7 +20,7 @@ import { IModelDb } from "./IModelDb";
  * Many ViewDefinitions may share the same DisplayStyle.
  * @public
  */
-export abstract class DisplayStyle extends DefinitionElement implements DisplayStyleProps {
+export abstract class DisplayStyle extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "DisplayStyle"; }
   public abstract get settings(): DisplayStyleSettings;
@@ -177,7 +177,7 @@ export class DisplayStyle2d extends DisplayStyle {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string): Id64String {
     const displayStyle = this.create(iModelDb, definitionModelId, name);
-    return iModelDb.elements.insertElement(displayStyle);
+    return iModelDb.elements.insertElement(displayStyle.toJSON());
   }
 }
 
@@ -201,7 +201,7 @@ export interface DisplayStyleCreationOptions extends Omit<DisplayStyle3dSettings
  * See [how to create a DisplayStyle3d]$(docs/learning/backend/CreateElements.md#DisplayStyle3d).
  * @public
  */
-export class DisplayStyle3d extends DisplayStyle implements DisplayStyle3dProps {
+export class DisplayStyle3d extends DisplayStyle {
   /** @internal */
   public static override get className(): string { return "DisplayStyle3d"; }
   private readonly _settings: DisplayStyle3dSettings;
@@ -299,6 +299,6 @@ export class DisplayStyle3d extends DisplayStyle implements DisplayStyle3dProps 
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, options?: DisplayStyleCreationOptions): Id64String {
     const displayStyle = this.create(iModelDb, definitionModelId, name, options);
-    return iModelDb.elements.insertElement(displayStyle);
+    return iModelDb.elements.insertElement(displayStyle.toJSON());
   }
 }

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -440,7 +440,7 @@ export abstract class GeometricElement extends Element {
   public getPlacementTransform(): Transform { return this.placement.transform; }
   public calculateRange3d(): AxisAlignedBox3d { return this.placement.calculateRange(); }
 
-  /** @internal */
+  /** Obtain the JSON representation of this element. */
   public override toJSON(): GeometricElementProps {
     const val = super.toJSON() as GeometricElementProps;
     val.category = this.category;
@@ -448,6 +448,7 @@ export abstract class GeometricElement extends Element {
       val.geom = this.geom;
     return val;
   }
+
   /** @internal */
   protected override collectPredecessorIds(predecessorIds: Id64Set): void {
     super.collectPredecessorIds(predecessorIds);

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -401,7 +401,7 @@ export class Element extends Entity {
   }
 
   /** Insert this Element into the iModel. */
-  public insert() { return this.iModel.elements.insertElement(this.toJSON()); }
+  public insert() { return this.id = this.iModel.elements.insertElement(this.toJSON()); }
   /** Update this Element in the iModel. */
   public update() { this.iModel.elements.updateElement(this.toJSON()); }
   /** Delete this Element from the iModel. */

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -103,7 +103,7 @@ export interface OnSubModelIdArg extends OnElementArg {
  * * [Creating elements]($docs/learning/backend/CreateElements.md)
  * @public
  */
-export class Element extends Entity implements ElementProps {
+export class Element extends Entity {
   /** @internal */
   public static override get className(): string { return "Element"; }
   /** @internal */
@@ -401,9 +401,9 @@ export class Element extends Entity implements ElementProps {
   }
 
   /** Insert this Element into the iModel. */
-  public insert() { return this.iModel.elements.insertElement(this); }
+  public insert() { return this.iModel.elements.insertElement(this.toJSON()); }
   /** Update this Element in the iModel. */
-  public update() { this.iModel.elements.updateElement(this); }
+  public update() { this.iModel.elements.updateElement(this.toJSON()); }
   /** Delete this Element from the iModel. */
   public delete() { this.iModel.elements.deleteElement(this.id); }
 }
@@ -411,7 +411,7 @@ export class Element extends Entity implements ElementProps {
 /** An abstract base class to model real world entities that intrinsically have geometry.
  * @public
  */
-export abstract class GeometricElement extends Element implements GeometricElementProps {
+export abstract class GeometricElement extends Element {
   /** @internal */
   public static override get className(): string { return "GeometricElement"; }
   /** The Id of the [[Category]] for this GeometricElement. */
@@ -460,7 +460,7 @@ export abstract class GeometricElement extends Element implements GeometricEleme
  * See [how to create a GeometricElement3d]($docs/learning/backend/CreateElements.md#GeometricElement3d).
  * @public
  */
-export abstract class GeometricElement3d extends GeometricElement implements GeometricElement3dProps {
+export abstract class GeometricElement3d extends GeometricElement {
   /** @internal */
   public static override get className(): string { return "GeometricElement3d"; }
   public placement: Placement3d;
@@ -502,7 +502,7 @@ export abstract class GraphicalElement3d extends GeometricElement3d {
 /** An abstract base class to model information entities that intrinsically have 2d geometry.
  * @public
  */
-export abstract class GeometricElement2d extends GeometricElement implements GeometricElement2dProps {
+export abstract class GeometricElement2d extends GeometricElement {
   /** @internal */
   public static override get className(): string { return "GeometricElement2d"; }
   public placement: Placement2d;
@@ -695,7 +695,7 @@ export abstract class InformationReferenceElement extends InformationContentElem
  * See [how to create a Subject element]$(docs/learning/backend/CreateElements.md#Subject).
  * @public
  */
-export class Subject extends InformationReferenceElement implements SubjectProps {
+export class Subject extends InformationReferenceElement {
   /** @internal */
   public static override get className(): string { return "Subject"; }
   public description?: string;
@@ -742,7 +742,7 @@ export class Subject extends InformationReferenceElement implements SubjectProps
    */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string, description?: string): Id64String {
     const subject = this.create(iModelDb, parentSubjectId, name, description);
-    return iModelDb.elements.insertElement(subject);
+    return iModelDb.elements.insertElement(subject.toJSON());
   }
 }
 
@@ -797,7 +797,7 @@ export class Drawing extends Document {
       classFullName: DrawingModel.classFullName,
       modeledElement: { id: drawingId },
     });
-    return iModelDb.models.insertModel(model);
+    return iModelDb.models.insertModel(model.toJSON());
   }
 }
 
@@ -870,7 +870,7 @@ export class SectionDrawing extends Drawing {
 /** The template for a SheetBorder
  * @public
  */
-export class SheetBorderTemplate extends Document implements SheetBorderTemplateProps {
+export class SheetBorderTemplate extends Document {
   /** @internal */
   public static override get className(): string { return "SheetBorderTemplate"; }
   public height?: number;
@@ -882,7 +882,7 @@ export class SheetBorderTemplate extends Document implements SheetBorderTemplate
 /** The template for a [[Sheet]]
  * @public
  */
-export class SheetTemplate extends Document implements SheetTemplateProps {
+export class SheetTemplate extends Document {
   /** @internal */
   public static override get className(): string { return "SheetTemplate"; }
   public height?: number;
@@ -900,7 +900,7 @@ export class SheetTemplate extends Document implements SheetTemplateProps {
 /** A digital representation of a *sheet of paper*. Modeled by a [[SheetModel]].
  * @public
  */
-export class Sheet extends Document implements SheetProps {
+export class Sheet extends Document {
   /** @internal */
   public static override get className(): string { return "Sheet"; }
   public height: number;
@@ -945,7 +945,7 @@ export abstract class InformationRecordElement extends InformationContentElement
 /** A Definition Element holds configuration-related information that is meant to be referenced / shared.
  * @public
  */
-export abstract class DefinitionElement extends InformationContentElement implements DefinitionElementProps {
+export abstract class DefinitionElement extends InformationContentElement {
   /** @internal */
   public static override get className(): string { return "DefinitionElement"; }
   /** If true, don't show this DefinitionElement in user interface lists. */
@@ -1005,7 +1005,7 @@ export class DefinitionContainer extends DefinitionSet {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, code: Code, isPrivate?: boolean): Id64String {
     const containerElement = this.create(iModelDb, definitionModelId, code, isPrivate);
-    const containerElementId = iModelDb.elements.insertElement(containerElement);
+    const containerElementId = iModelDb.elements.insertElement(containerElement.toJSON());
     const containerSubModelProps: ModelProps = {
       classFullName: DefinitionModel.classFullName,
       modeledElement: { id: containerElementId },
@@ -1046,7 +1046,7 @@ export class DefinitionGroup extends DefinitionSet {
 /** Defines a set of properties (the *type*) that may be associated with an element.
  * @public
  */
-export abstract class TypeDefinitionElement extends DefinitionElement implements TypeDefinitionElementProps {
+export abstract class TypeDefinitionElement extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "TypeDefinitionElement"; }
   public recipe?: RelatedElement;
@@ -1163,7 +1163,7 @@ export class TemplateRecipe3d extends RecipeDefinitionElement {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String {
     const element = this.create(iModelDb, definitionModelId, name, isPrivate);
-    const modeledElementId: Id64String = iModelDb.elements.insertElement(element);
+    const modeledElementId: Id64String = iModelDb.elements.insertElement(element.toJSON());
     const modelProps: GeometricModel3dProps = {
       classFullName: PhysicalModel.classFullName,
       modeledElement: { id: modeledElementId },
@@ -1235,7 +1235,7 @@ export class TemplateRecipe2d extends RecipeDefinitionElement {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String {
     const element = this.create(iModelDb, definitionModelId, name, isPrivate);
-    const modeledElementId: Id64String = iModelDb.elements.insertElement(element);
+    const modeledElementId: Id64String = iModelDb.elements.insertElement(element.toJSON());
     const modelProps: GeometricModel2dProps = {
       classFullName: DrawingModel.classFullName,
       modeledElement: { id: modeledElementId },
@@ -1250,7 +1250,7 @@ export class TemplateRecipe2d extends RecipeDefinitionElement {
  * @see [iModel Information Hierarchy]($docs/bis/intro/top-of-the-world), [[Subject]], [[Model]]
  * @public
  */
-export abstract class InformationPartitionElement extends InformationContentElement implements InformationPartitionElementProps {
+export abstract class InformationPartitionElement extends InformationContentElement {
   /** @internal */
   public static override get className(): string { return "InformationPartitionElement"; }
   /** A human-readable string describing the intent of the partition. */
@@ -1379,7 +1379,7 @@ export abstract class LinkElement extends InformationReferenceElement {
 /** An information element that specifies a URL link.
  * @public
  */
-export class UrlLink extends LinkElement implements UrlLinkProps {
+export class UrlLink extends LinkElement {
   /** @internal */
   public static override get className(): string { return "UrlLink"; }
   public description?: string;
@@ -1413,7 +1413,7 @@ export class FolderLink extends UrlLink {
 /** An information element that links to a repository.
  * @public
  */
-export class RepositoryLink extends UrlLink implements RepositoryLinkProps {
+export class RepositoryLink extends UrlLink {
   /** @internal */
   public static override get className(): string { return "RepositoryLink"; }
   public repositoryGuid?: GuidString;
@@ -1458,7 +1458,7 @@ export abstract class RoleElement extends Element {
  * Element instances. Leveraging Geometry Parts can help reduce file size and improve display performance.
  * @public
  */
-export class GeometryPart extends DefinitionElement implements GeometryPartProps {
+export class GeometryPart extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "GeometryPart"; }
   public geom?: GeometryStreamProps;
@@ -1497,7 +1497,7 @@ export class GeometryPart extends DefinitionElement implements GeometryPartProps
 /** The definition element for a line style
  * @public
  */
-export class LineStyle extends DefinitionElement implements LineStyleProps {
+export class LineStyle extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "LineStyle"; }
   public description?: string;

--- a/core/backend/src/ElementAspect.ts
+++ b/core/backend/src/ElementAspect.ts
@@ -39,7 +39,7 @@ export interface OnAspectIdArg extends OnAspectArg {
  * BIS Guideline: Subclass ElementUniqueAspect or ElementMultiAspect rather than subclassing ElementAspect directly.
  * @public
  */
-export class ElementAspect extends Entity implements ElementAspectProps {
+export class ElementAspect extends Entity {
   /** @internal */
   public static override get className(): string { return "ElementAspect"; }
   public element: RelatedElement;
@@ -152,7 +152,7 @@ export class ChannelRootAspect extends ElementUniqueAspect {
  * @note The associated ECClass was added to the BisCore schema in version 1.0.2
  * @public
  */
-export class ExternalSourceAspect extends ElementMultiAspect implements ExternalSourceAspectProps {
+export class ExternalSourceAspect extends ElementMultiAspect {
   /** @internal */
   public static override get className(): string { return "ExternalSourceAspect"; }
 

--- a/core/backend/src/Entity.ts
+++ b/core/backend/src/Entity.ts
@@ -11,11 +11,16 @@ import { EntityProps, PropertyCallback, PropertyMetaData } from "@itwin/core-com
 import { IModelDb } from "./IModelDb";
 import { Schema } from "./Schema";
 
-/** Base class for all Entities in an iModel. Every subclass of Entity handles one BIS class.
+/** Represents an entity in an [[IModelDb]] such as an [[Element]], [[Model]], or [[Relationship]].
+ * Every subclass of Entity represents one BIS [ECClass]($ecschema-metadata).
+ * An Entity is typically instantiated from an [EntityProps]($common) and can be converted back to this representation via [[Entity.toJSON]].
  * @public
  */
 export class Entity {
-  public readonly isEntityObject: true = true;
+  /** An immutable property used to discriminate between [[Entity]] and [EntityProps]($common), used to inform the TypeScript compiler that these two types
+   * are never substitutable for one another. To obtain an EntityProps from an Entity, use [[Entity.toJSON]].
+   */
+  public readonly isInstanceOfEntity: true = true;
   /** The Schema that defines this class. */
   public static schema: typeof Schema;
 
@@ -54,7 +59,9 @@ export class Entity {
     this.forEachProperty((propName: string, meta: PropertyMetaData) => (this as any)[propName] = meta.createProperty((props as any)[propName]), false);
   }
 
-  /** @internal */
+  /** Obtain the JSON representation of this Entity. Subclasses of [[Entity]] typically override this method to return their corresponding sub-type of [EntityProps]($common) -
+   * for example, [[GeometricElement.toJSON]] returns a [GeometricElementProps]($common).
+   */
   public toJSON(): EntityProps {
     const val: any = {};
     val.classFullName = this.classFullName;

--- a/core/backend/src/Entity.ts
+++ b/core/backend/src/Entity.ts
@@ -14,7 +14,8 @@ import { Schema } from "./Schema";
 /** Base class for all Entities in an iModel. Every subclass of Entity handles one BIS class.
  * @public
  */
-export class Entity implements EntityProps {
+export class Entity {
+  public readonly isEntityObject: true = true;
   /** The Schema that defines this class. */
   public static schema: typeof Schema;
 

--- a/core/backend/src/GeometrySummary.ts
+++ b/core/backend/src/GeometrySummary.ts
@@ -11,7 +11,7 @@ import {
   TransitionSpiral3d, UVSelect,
 } from "@itwin/core-geometry";
 import {
-  BRepEntity, GeometricElement3dProps, GeometryParams, GeometryStreamIterator, GeometrySummaryRequestProps, GeometrySummaryVerbosity, ImagePrimitive,
+  BRepEntity, GeometryParams, GeometryStreamIterator, GeometrySummaryRequestProps, GeometrySummaryVerbosity, ImagePrimitive,
   IModelError, TextStringPrimitive,
 } from "@itwin/core-common";
 import { Element, GeometricElement, GeometryPart } from "./Element";

--- a/core/backend/src/GeometrySummary.ts
+++ b/core/backend/src/GeometrySummary.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { BentleyError, Id64Array, Id64String, IModelStatus } from "@itwin/core-bentley";
+import { assert, BentleyError, Id64Array, Id64String, IModelStatus } from "@itwin/core-bentley";
 import {
   AkimaCurve3d, AnyGeometryQuery, Arc3d, BezierCurveBase, Box, BSplineCurve3d, Cone, CurveChainWithDistanceIndex, CurveCollection, CurvePrimitive, IModelJson,
   InterpolationCurve3d,
@@ -128,10 +128,12 @@ class ResponseGenerator {
     let geometricElement: GeometricElement | undefined;
     if (elem instanceof GeometricElement) {
       geometricElement = elem;
-      if (geometricElement.is2d())
+      if (geometricElement.is2d()) {
         iterator = GeometryStreamIterator.fromGeometricElement2d(geometricElement);
-      else
-        iterator = GeometryStreamIterator.fromGeometricElement3d(geometricElement as GeometricElement3dProps);
+      } else {
+        assert(geometricElement.is3d());
+        iterator = GeometryStreamIterator.fromGeometricElement3d(geometricElement);
+      }
     } else if (elem instanceof GeometryPart) {
       iterator = GeometryStreamIterator.fromGeometryPart(elem);
     }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1289,14 +1289,14 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @see getModel
      */
     public tryGetModel<T extends Model>(modelId: Id64String, modelClass?: EntityClassType<Model>): T | undefined {
-      const modelProps = this.tryGetModelProps<T>(modelId);
-      if (undefined === modelProps) {
+      const modelProps = this.tryGetModelProps<ModelProps>(modelId);
+      if (undefined === modelProps)
         return undefined; // no Model with that modelId found
-      }
+
       const model = this._iModel.constructEntity<T>(modelProps);
-      if (undefined === modelClass) {
+      if (undefined === modelClass)
         return model; // modelClass was not specified, cannot call instanceof to validate
-      }
+
       return model instanceof modelClass ? model : undefined;
     }
 
@@ -1371,7 +1371,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertModel(props: ModelProps): Id64String {
       try {
-        return props.id = this._iModel.nativeDb.insertModel(props instanceof Model ? props.toJSON() : props);
+        return props.id = this._iModel.nativeDb.insertModel(props);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error inserting model [${err.message}], class=${props.classFullName}`);
       }
@@ -1383,7 +1383,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateModel(props: UpdateModelOptions): void {
       try {
-        this._iModel.nativeDb.updateModel(props instanceof Model ? props.toJSON() : props);
+        this._iModel.nativeDb.updateModel(props);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `error updating model [${err.message}] id=${props.id}`);
       }
@@ -1501,19 +1501,19 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @see getElement
      */
     public tryGetElement<T extends Element>(elementId: Id64String | GuidString | Code | ElementLoadProps, elementClass?: EntityClassType<Element>): T | undefined {
-      if (typeof elementId === "string") {
+      if (typeof elementId === "string")
         elementId = Id64.isId64(elementId) ? { id: elementId } : { federationGuid: elementId };
-      } else if (elementId instanceof Code) {
+      else if (elementId instanceof Code)
         elementId = { code: elementId };
-      }
-      const elementProps = this.tryGetElementJson<T>(elementId);
-      if (undefined === elementProps) {
+
+      const elementProps = this.tryGetElementJson<ElementProps>(elementId);
+      if (undefined === elementProps)
         return undefined; // no Element with that elementId found
-      }
+
       const element = this._iModel.constructEntity<T>(elementProps);
-      if (undefined === elementClass) {
+      if (undefined === elementClass)
         return element; // elementClass was not specified, cannot call instanceof to validate
-      }
+
       return element instanceof elementClass ? element : undefined;
     }
 
@@ -1572,7 +1572,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertElement(elProps: ElementProps): Id64String {
       try {
-        return elProps.id = this._iModel.nativeDb.insertElement(elProps instanceof Element ? elProps.toJSON() : elProps);
+        return elProps.id = this._iModel.nativeDb.insertElement(elProps);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `insertElement with class=${elProps.classFullName}: ${err.message}`,);
       }
@@ -1587,7 +1587,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateElement(elProps: ElementProps): void {
       try {
-        this._iModel.nativeDb.updateElement(elProps instanceof Element ? elProps.toJSON() : elProps);
+        this._iModel.nativeDb.updateElement(elProps);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error updating element [${err.message}], id:${elProps.id}`);
       }

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -50,7 +50,7 @@ export abstract class PhysicalMaterial extends DefinitionElement {
  * @note See [[PhysicalMaterial]] for the DefinitionElement used to define the matter that makes up physical elements.
  * @public
  */
-export class RenderMaterialElement extends DefinitionElement implements RenderMaterialProps {
+export class RenderMaterialElement extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "RenderMaterial"; }
 
@@ -135,7 +135,7 @@ export class RenderMaterialElement extends DefinitionElement implements RenderMa
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, materialName: string, params: RenderMaterialElement.Params): Id64String {
     const renderMaterial = this.create(iModelDb, definitionModelId, materialName, params);
-    return iModelDb.elements.insertElement(renderMaterial);
+    return iModelDb.elements.insertElement(renderMaterial.toJSON());
   }
 }
 

--- a/core/backend/src/Model.ts
+++ b/core/backend/src/Model.ts
@@ -64,7 +64,7 @@ export interface OnElementInModelIdArg extends OnModelIdArg {
  * See [Creating models]($docs/learning/backend/CreateModels.md)
  * @public
  */
-export class Model extends Entity implements ModelProps {
+export class Model extends Entity {
   /** @internal */
   public static override get className(): string { return "Model"; }
   /** @internal */
@@ -210,9 +210,9 @@ export class Model extends Entity implements ModelProps {
   public setJsonProperty(name: string, value: any) { this.jsonProperties[name] = value; }
 
   /** Insert this Model in the iModel */
-  public insert() { return this.iModel.models.insertModel(this); }
+  public insert() { return this.iModel.models.insertModel(this.toJSON()); }
   /** Update this Model in the iModel. */
-  public update() { this.iModel.models.updateModel(this); }
+  public update() { this.iModel.models.updateModel(this.toJSON()); }
   /** Delete this Model from the iModel. */
   public delete() { this.iModel.models.deleteModel(this.id); }
 }
@@ -220,7 +220,7 @@ export class Model extends Entity implements ModelProps {
 /** A container for persisting geometric elements.
  * @public
  */
-export class GeometricModel extends Model implements GeometricModelProps {
+export class GeometricModel extends Model {
   public geometryGuid?: GuidString; // Initialized by the Entity constructor
 
   /** @internal */
@@ -238,7 +238,7 @@ export class GeometricModel extends Model implements GeometricModelProps {
 /** A container for persisting 3d geometric elements.
  * @public
  */
-export abstract class GeometricModel3d extends GeometricModel implements GeometricModel3dProps {
+export abstract class GeometricModel3d extends GeometricModel {
   /** If true, then the elements in this GeometricModel3d are expected to be in an XY plane.
    * @note The associated ECProperty was added to the BisCore schema in version 1.0.8
    */
@@ -270,7 +270,7 @@ export abstract class GeometricModel3d extends GeometricModel implements Geometr
 /** A container for persisting 2d geometric elements.
  * @public
  */
-export abstract class GeometricModel2d extends GeometricModel implements GeometricModel2dProps {
+export abstract class GeometricModel2d extends GeometricModel {
   /** The actual coordinates of (0,0) in modeling coordinates. An offset applied to all modeling coordinates. */
   public globalOrigin?: Point2d; // Initialized by the Entity constructor
   /** @internal */

--- a/core/backend/src/Model.ts
+++ b/core/backend/src/Model.ts
@@ -210,7 +210,7 @@ export class Model extends Entity {
   public setJsonProperty(name: string, value: any) { this.jsonProperties[name] = value; }
 
   /** Insert this Model in the iModel */
-  public insert() { return this.iModel.models.insertModel(this.toJSON()); }
+  public insert() { return this.id = this.iModel.models.insertModel(this.toJSON()); }
   /** Update this Model in the iModel. */
   public update() { this.iModel.models.updateModel(this.toJSON()); }
   /** Delete this Model from the iModel. */

--- a/core/backend/src/Relationship.ts
+++ b/core/backend/src/Relationship.ts
@@ -17,7 +17,7 @@ export type { SourceAndTarget, RelationshipProps } from "@itwin/core-common"; //
 /** Base class for all link table ECRelationships
  * @public
  */
-export class Relationship extends Entity implements RelationshipProps {
+export class Relationship extends Entity {
   /** @internal */
   public static override get className(): string { return "Relationship"; }
   public readonly sourceId: Id64String;
@@ -56,11 +56,11 @@ export class Relationship extends Entity implements RelationshipProps {
   public static onDeletedDependency(_props: RelationshipProps, _iModel: IModelDb): void { }
 
   /** Insert this Relationship into the iModel. */
-  public insert(): Id64String { return this.iModel.relationships.insertInstance(this); }
+  public insert(): Id64String { return this.iModel.relationships.insertInstance(this.toJSON()); }
   /** Update this Relationship in the iModel. */
-  public update() { this.iModel.relationships.updateInstance(this); }
+  public update() { this.iModel.relationships.updateInstance(this.toJSON()); }
   /** Delete this Relationship from the iModel. */
-  public delete() { this.iModel.relationships.deleteInstance(this); }
+  public delete() { this.iModel.relationships.deleteInstance(this.toJSON()); }
 
   public static getInstance<T extends Relationship>(iModel: IModelDb, criteria: Id64String | SourceAndTarget): T { return iModel.relationships.getInstance(this.classFullName, criteria); }
 }
@@ -88,7 +88,7 @@ export class ElementRefersToElements extends Relationship {
    */
   public static insert<T extends ElementRefersToElements>(iModel: IModelDb, sourceId: Id64String, targetId: Id64String): Id64String {
     const relationship: T = this.create(iModel, sourceId, targetId);
-    return iModel.relationships.insertInstance(relationship);
+    return iModel.relationships.insertInstance(relationship.toJSON());
   }
 }
 
@@ -373,7 +373,7 @@ export interface ElementDrivesElementProps extends RelationshipProps {
  *
  * @beta
  */
-export class ElementDrivesElement extends Relationship implements ElementDrivesElementProps {
+export class ElementDrivesElement extends Relationship {
   /** @internal */
   public static override get className(): string { return "ElementDrivesElement"; }
   /** Relationship status
@@ -501,7 +501,7 @@ export class Relationships {
    * @see getInstance
    */
   public tryGetInstance<T extends Relationship>(relClassFullName: string, criteria: Id64String | SourceAndTarget): T | undefined {
-    const relationshipProps = this.tryGetInstanceProps<T>(relClassFullName, criteria);
+    const relationshipProps = this.tryGetInstanceProps<RelationshipProps>(relClassFullName, criteria);
     return undefined !== relationshipProps ? this._iModel.constructEntity<T>(relationshipProps) : undefined;
   }
 }

--- a/core/backend/src/Relationship.ts
+++ b/core/backend/src/Relationship.ts
@@ -396,6 +396,13 @@ export class ElementDrivesElement extends Relationship {
     const props: ElementDrivesElementProps = { sourceId, targetId, priority, status: 0, classFullName: this.classFullName };
     return iModel.relationships.createInstance(props) as T;
   }
+
+  public override toJSON(): ElementDrivesElementProps {
+    const props = super.toJSON() as ElementDrivesElementProps;
+    props.status = this.status;
+    props.priority = this.priority;
+    return props;
+  }
 }
 
 /** Manages [[Relationship]]s.

--- a/core/backend/src/Relationship.ts
+++ b/core/backend/src/Relationship.ts
@@ -56,7 +56,7 @@ export class Relationship extends Entity {
   public static onDeletedDependency(_props: RelationshipProps, _iModel: IModelDb): void { }
 
   /** Insert this Relationship into the iModel. */
-  public insert(): Id64String { return this.iModel.relationships.insertInstance(this.toJSON()); }
+  public insert(): Id64String { return this.id = this.iModel.relationships.insertInstance(this.toJSON()); }
   /** Update this Relationship in the iModel. */
   public update() { this.iModel.relationships.updateInstance(this.toJSON()); }
   /** Delete this Relationship from the iModel. */

--- a/core/backend/src/Texture.ts
+++ b/core/backend/src/Texture.ts
@@ -96,6 +96,6 @@ export class Texture extends DefinitionElement {
    */
   public static insertTexture(iModelDb: IModelDb, definitionModelId: Id64String, name: string, format: ImageSourceFormat, data: Uint8Array | Base64EncodedString, description?: string): Id64String {
     const texture = this.createTexture(iModelDb, definitionModelId, name, format, data, description);
-    return iModelDb.elements.insertElement(texture);
+    return iModelDb.elements.insertElement(texture.toJSON());
   }
 }

--- a/core/backend/src/ViewDefinition.ts
+++ b/core/backend/src/ViewDefinition.ts
@@ -25,7 +25,7 @@ import { DisplayStyle, DisplayStyle2d, DisplayStyle3d } from "./DisplayStyle";
  * See [how to create a ModelSelector]$(docs/learning/backend/CreateElements.md#ModelSelector).
  * @public
  */
-export class ModelSelector extends DefinitionElement implements ModelSelectorProps {
+export class ModelSelector extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "ModelSelector"; }
 
@@ -83,7 +83,7 @@ export class ModelSelector extends DefinitionElement implements ModelSelectorPro
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, models: Id64Array): Id64String {
     const modelSelector = this.create(iModelDb, definitionModelId, name, models);
-    return iModelDb.elements.insertElement(modelSelector);
+    return iModelDb.elements.insertElement(modelSelector.toJSON());
   }
 }
 
@@ -92,7 +92,7 @@ export class ModelSelector extends DefinitionElement implements ModelSelectorPro
  * See [how to create a CategorySelector]$(docs/learning/backend/CreateElements.md#CategorySelector).
  * @public
  */
-export class CategorySelector extends DefinitionElement implements CategorySelectorProps {
+export class CategorySelector extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "CategorySelector"; }
   /** The array of element Ids of the Categories selected by this CategorySelector */
@@ -149,7 +149,7 @@ export class CategorySelector extends DefinitionElement implements CategorySelec
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, categories: Id64Array): Id64String {
     const categorySelector = this.create(iModelDb, definitionModelId, name, categories);
-    return iModelDb.elements.insertElement(categorySelector);
+    return iModelDb.elements.insertElement(categorySelector.toJSON());
   }
 }
 
@@ -167,7 +167,7 @@ export class CategorySelector extends DefinitionElement implements CategorySelec
  * @note ViewDefinition is only available in the backend. See [ViewState]($frontend) for usage in the frontend.
  * @public
  */
-export abstract class ViewDefinition extends DefinitionElement implements ViewDefinitionProps {
+export abstract class ViewDefinition extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "ViewDefinition"; }
   /** The element Id of the [[CategorySelector]] for this ViewDefinition */
@@ -262,7 +262,7 @@ export abstract class ViewDefinition extends DefinitionElement implements ViewDe
 /** Defines a view of one or more 3d models.
  * @public
  */
-export abstract class ViewDefinition3d extends ViewDefinition implements ViewDefinition3dProps {
+export abstract class ViewDefinition3d extends ViewDefinition {
   private readonly _details: ViewDetails3d;
   /** @internal */
   public static override get className(): string { return "ViewDefinition3d"; }
@@ -318,7 +318,7 @@ export abstract class ViewDefinition3d extends ViewDefinition implements ViewDef
  *        * CategoryIds -----> SpatialCategories <----------GeometricElement3d.Category
  * @public
  */
-export class SpatialViewDefinition extends ViewDefinition3d implements SpatialViewDefinitionProps {
+export class SpatialViewDefinition extends ViewDefinition3d {
   /** @internal */
   public static override get className(): string { return "SpatialViewDefinition"; }
   /** The Id of the [[ModelSelector]] for this SpatialViewDefinition. */
@@ -402,7 +402,7 @@ export class SpatialViewDefinition extends ViewDefinition3d implements SpatialVi
    */
   public static insertWithCamera(iModelDb: IModelDb, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView = StandardViewIndex.Iso, cameraAngle = Angle.piOver2Radians): Id64String {
     const viewDefinition = this.createWithCamera(iModelDb, definitionModelId, name, modelSelectorId, categorySelectorId, displayStyleId, range, standardView, cameraAngle);
-    return iModelDb.elements.insertElement(viewDefinition);
+    return iModelDb.elements.insertElement(viewDefinition.toJSON());
   }
 }
 
@@ -462,7 +462,7 @@ export class OrthographicViewDefinition extends SpatialViewDefinition {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView = StandardViewIndex.Iso): Id64String {
     const viewDefinition = this.create(iModelDb, definitionModelId, name, modelSelectorId, categorySelectorId, displayStyleId, range, standardView);
-    return iModelDb.elements.insertElement(viewDefinition);
+    return iModelDb.elements.insertElement(viewDefinition.toJSON());
   }
   /** Set a new viewed range without changing the rotation or any other properties. */
   public setRange(range: Range3d): void {
@@ -477,7 +477,7 @@ export class OrthographicViewDefinition extends SpatialViewDefinition {
 /** Defines a view of a single 2d model. Each 2d model has its own coordinate system, so only one may appear per view.
  * @public
  */
-export class ViewDefinition2d extends ViewDefinition implements ViewDefinition2dProps {
+export class ViewDefinition2d extends ViewDefinition {
   private readonly _details: ViewDetails;
 
   /** @internal */
@@ -572,7 +572,7 @@ export class DrawingViewDefinition extends ViewDefinition2d {
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, baseModelId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range2d): Id64String {
     const viewDefinition = this.create(iModelDb, definitionModelId, name, baseModelId, categorySelectorId, displayStyleId, range);
-    return iModelDb.elements.insertElement(viewDefinition);
+    return iModelDb.elements.insertElement(viewDefinition.toJSON());
   }
 }
 
@@ -604,7 +604,7 @@ export class TemplateViewDefinition3d extends ViewDefinition3d {
  * coordinate information in different units and/or orientations.
  * @public
  */
-export abstract class AuxCoordSystem extends DefinitionElement implements AuxCoordSystemProps {
+export abstract class AuxCoordSystem extends DefinitionElement {
   /** @internal */
   public static override get className(): string { return "AuxCoordSystem"; }
   public type!: number;
@@ -615,7 +615,7 @@ export abstract class AuxCoordSystem extends DefinitionElement implements AuxCoo
 /** A 2d auxiliary coordinate system.
  * @public
  */
-export class AuxCoordSystem2d extends AuxCoordSystem implements AuxCoordSystem2dProps {
+export class AuxCoordSystem2d extends AuxCoordSystem {
   /** @internal */
   public static override get className(): string { return "AuxCoordSystem2d"; }
   public origin?: Point2d;
@@ -636,7 +636,7 @@ export class AuxCoordSystem2d extends AuxCoordSystem implements AuxCoordSystem2d
 /** A 3d auxiliary coordinate system.
  * @public
  */
-export class AuxCoordSystem3d extends AuxCoordSystem implements AuxCoordSystem3dProps {
+export class AuxCoordSystem3d extends AuxCoordSystem {
   /** @internal */
   public static override get className(): string { return "AuxCoordSystem3d"; }
   public origin?: Point3d;
@@ -676,7 +676,7 @@ export class AuxCoordSystemSpatial extends AuxCoordSystem3d {
 /** Represents an *attachment* of a [[ViewDefinition]] to a [[Sheet]].
  * @public
  */
-export class ViewAttachment extends GraphicalElement2d implements ViewAttachmentProps {
+export class ViewAttachment extends GraphicalElement2d {
   /** @internal */
   public static override get className(): string { return "ViewAttachment"; }
   public view: RelatedElement;
@@ -695,7 +695,7 @@ export class ViewAttachment extends GraphicalElement2d implements ViewAttachment
 /** The position in space of a Light.
  * @internal
  */
-export class LightLocation extends SpatialLocationElement implements LightLocationProps {
+export class LightLocation extends SpatialLocationElement {
   /** @internal */
   public static override get className(): string { return "LightLocation"; }
   /** Whether this light is currently turned on. */

--- a/core/backend/src/domains/FunctionalElements.ts
+++ b/core/backend/src/domains/FunctionalElements.ts
@@ -63,7 +63,7 @@ export class FunctionalModel extends RoleModel {
 /** A FunctionalElement captures functional requirements that will ultimately be fulfilled by a PhysicalElement.
  * @public
  */
-export abstract class FunctionalElement extends RoleElement implements FunctionalElementProps {
+export abstract class FunctionalElement extends RoleElement {
   /** @internal */
   public static override get className(): string { return "FunctionalElement"; }
   /** @internal */

--- a/core/backend/src/domains/GenericElements.ts
+++ b/core/backend/src/domains/GenericElements.ts
@@ -45,7 +45,7 @@ export class TitleText extends DetailingSymbol {
 /** A graphical DetailingSymbol that contains a view attachment label.
  * @public
  */
-export class ViewAttachmentLabel extends DetailingSymbol implements ViewAttachmentLabelProps {
+export class ViewAttachmentLabel extends DetailingSymbol {
   /** @internal */
   public static override get className(): string { return "ViewAttachmentLabel"; }
   public constructor(props: ViewAttachmentLabelProps, iModel: IModelDb) {
@@ -56,7 +56,7 @@ export class ViewAttachmentLabel extends DetailingSymbol implements ViewAttachme
 /** A graphical DetailingSymbol that calls out a reference to another drawing.
  *  @public
  */
-export abstract class Callout extends DetailingSymbol implements CalloutProps {
+export abstract class Callout extends DetailingSymbol {
   /** @internal */
   public static override get className(): string { return "Callout"; }
   public constructor(props: CalloutProps, iModel: IModelDb) {

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -350,7 +350,7 @@ export class IModelTestUtils {
   /** Create and insert a PhysicalPartition element (in the repositoryModel) and an associated PhysicalModel. */
   public static createAndInsertPhysicalModel(testDb: IModelDb, modeledElementRef: RelatedElement, privateModel: boolean = false): Id64String {
     const newModel = testDb.models.createModel({ modeledElement: modeledElementRef, classFullName: PhysicalModel.classFullName, isPrivate: privateModel });
-    const newModelId = testDb.models.insertModel(newModel.toJSON());
+    const newModelId = newModel.id = testDb.models.insertModel(newModel.toJSON());
     assert.isTrue(Id64.isValidId64(newModelId));
     assert.isTrue(Id64.isValidId64(newModel.id));
     assert.deepEqual(newModelId, newModel.id);
@@ -360,7 +360,7 @@ export class IModelTestUtils {
   /** Create and insert a PhysicalPartition element (in the repositoryModel) and an associated PhysicalModel. */
   public static async createAndInsertPhysicalModelAsync(testDb: IModelDb, modeledElementRef: RelatedElement, privateModel: boolean = false): Promise<Id64String> {
     const newModel = testDb.models.createModel({ modeledElement: modeledElementRef, classFullName: PhysicalModel.classFullName, isPrivate: privateModel });
-    const newModelId = testDb.models.insertModel(newModel.toJSON());
+    const newModelId = newModel.insert();
     assert.isTrue(Id64.isValidId64(newModelId));
     assert.isTrue(Id64.isValidId64(newModel.id));
     assert.deepEqual(newModelId, newModel.id);
@@ -407,7 +407,7 @@ export class IModelTestUtils {
   /** Create and insert a DrawingModel associated with Drawing Partition. */
   public static createAndInsertDrawingModel(testDb: IModelDb, modeledElementRef: RelatedElement, privateModel: boolean = false): Id64String {
     const newModel = testDb.models.createModel({ modeledElement: modeledElementRef, classFullName: DrawingModel.classFullName, isPrivate: privateModel });
-    const newModelId = testDb.models.insertModel(newModel.toJSON());
+    const newModelId = newModel.insert();
     assert.isTrue(Id64.isValidId64(newModelId));
     assert.isTrue(Id64.isValidId64(newModel.id));
     assert.deepEqual(newModelId, newModel.id);

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -57,7 +57,7 @@ export class TestBim extends Schema {
 export interface TestRelationshipProps extends RelationshipProps {
   property1: string;
 }
-export class TestElementDrivesElement extends ElementDrivesElement implements TestRelationshipProps {
+export class TestElementDrivesElement extends ElementDrivesElement {
   public static override get className(): string { return "TestElementDrivesElement"; }
   public property1!: string;
   public static rootChanged = new BeEvent<(props: RelationshipProps, imodel: IModelDb) => void>();
@@ -68,7 +68,7 @@ export class TestElementDrivesElement extends ElementDrivesElement implements Te
 export interface TestPhysicalObjectProps extends PhysicalElementProps {
   intProperty: number;
 }
-export class TestPhysicalObject extends PhysicalElement implements TestPhysicalObjectProps {
+export class TestPhysicalObject extends PhysicalElement {
   public static override get className(): string { return "TestPhysicalObject"; }
   public intProperty!: number;
   public static beforeOutputsHandled = new BeEvent<(id: Id64String, imodel: IModelDb) => void>();
@@ -328,7 +328,7 @@ export class IModelTestUtils {
       code: newModelCode,
     };
     const modeledElement: Element = testDb.elements.createElement(modeledElementProps);
-    return testDb.elements.insertElement(modeledElement);
+    return testDb.elements.insertElement(modeledElement.toJSON());
   }
 
   /** Create and insert a PhysicalPartition element (in the repositoryModel) and an associated PhysicalModel. */
@@ -344,13 +344,13 @@ export class IModelTestUtils {
     };
     const modeledElement = testDb.elements.createElement(modeledElementProps);
     await testDb.locks.acquireLocks({ shared: model });
-    return testDb.elements.insertElement(modeledElement);
+    return testDb.elements.insertElement(modeledElement.toJSON());
   }
 
   /** Create and insert a PhysicalPartition element (in the repositoryModel) and an associated PhysicalModel. */
   public static createAndInsertPhysicalModel(testDb: IModelDb, modeledElementRef: RelatedElement, privateModel: boolean = false): Id64String {
     const newModel = testDb.models.createModel({ modeledElement: modeledElementRef, classFullName: PhysicalModel.classFullName, isPrivate: privateModel });
-    const newModelId = testDb.models.insertModel(newModel);
+    const newModelId = testDb.models.insertModel(newModel.toJSON());
     assert.isTrue(Id64.isValidId64(newModelId));
     assert.isTrue(Id64.isValidId64(newModel.id));
     assert.deepEqual(newModelId, newModel.id);
@@ -360,7 +360,7 @@ export class IModelTestUtils {
   /** Create and insert a PhysicalPartition element (in the repositoryModel) and an associated PhysicalModel. */
   public static async createAndInsertPhysicalModelAsync(testDb: IModelDb, modeledElementRef: RelatedElement, privateModel: boolean = false): Promise<Id64String> {
     const newModel = testDb.models.createModel({ modeledElement: modeledElementRef, classFullName: PhysicalModel.classFullName, isPrivate: privateModel });
-    const newModelId = testDb.models.insertModel(newModel);
+    const newModelId = testDb.models.insertModel(newModel.toJSON());
     assert.isTrue(Id64.isValidId64(newModelId));
     assert.isTrue(Id64.isValidId64(newModel.id));
     assert.deepEqual(newModelId, newModel.id);
@@ -401,13 +401,13 @@ export class IModelTestUtils {
       code: newModelCode,
     };
     const modeledElement: Element = testDb.elements.createElement(modeledElementProps);
-    return testDb.elements.insertElement(modeledElement);
+    return testDb.elements.insertElement(modeledElement.toJSON());
   }
 
   /** Create and insert a DrawingModel associated with Drawing Partition. */
   public static createAndInsertDrawingModel(testDb: IModelDb, modeledElementRef: RelatedElement, privateModel: boolean = false): Id64String {
     const newModel = testDb.models.createModel({ modeledElement: modeledElementRef, classFullName: DrawingModel.classFullName, isPrivate: privateModel });
-    const newModelId = testDb.models.insertModel(newModel);
+    const newModelId = testDb.models.insertModel(newModel.toJSON());
     assert.isTrue(Id64.isValidId64(newModelId));
     assert.isTrue(Id64.isValidId64(newModel.id));
     assert.deepEqual(newModelId, newModel.id);
@@ -1007,7 +1007,7 @@ export class ExtensiveTestScenario {
       sourceId: spatialCategorySelectorId,
       targetId: drawingCategorySelectorId,
     });
-    const relationshipId1 = sourceDb.relationships.insertInstance(relationship1);
+    const relationshipId1 = sourceDb.relationships.insertInstance(relationship1.toJSON());
     assert.isTrue(Id64.isValidId64(relationshipId1));
     // Insert instance of RelWithProps to test relationship property remapping
     const relationship2: Relationship = sourceDb.relationships.createInstance({
@@ -1019,7 +1019,7 @@ export class ExtensiveTestScenario {
       sourceLong: spatialCategoryId,
       sourceGuid: Guid.createValue(),
     } as any);
-    const relationshipId2 = sourceDb.relationships.insertInstance(relationship2);
+    const relationshipId2 = sourceDb.relationships.insertInstance(relationship2.toJSON());
     assert.isTrue(Id64.isValidId64(relationshipId2));
   }
 
@@ -1029,7 +1029,7 @@ export class ExtensiveTestScenario {
     assert.isTrue(Id64.isValidId64(subjectId));
     const subject = sourceDb.elements.getElement<Subject>(subjectId);
     subject.description = "Subject description (Updated)";
-    sourceDb.elements.updateElement(subject);
+    sourceDb.elements.updateElement(subject.toJSON());
     // Update spatialCategory element
     const definitionModelId = sourceDb.elements.queryElementIdByCode(InformationPartitionElement.createCode(sourceDb, subjectId, "Definition"))!;
     assert.isTrue(Id64.isValidId64(definitionModelId));
@@ -1037,7 +1037,7 @@ export class ExtensiveTestScenario {
     assert.isTrue(Id64.isValidId64(spatialCategoryId));
     const spatialCategory: SpatialCategory = sourceDb.elements.getElement<SpatialCategory>(spatialCategoryId);
     spatialCategory.federationGuid = Guid.createValue();
-    sourceDb.elements.updateElement(spatialCategory);
+    sourceDb.elements.updateElement(spatialCategory.toJSON());
     // Update relationship properties
     const spatialCategorySelectorId = sourceDb.elements.queryElementIdByCode(CategorySelector.createCode(sourceDb, definitionModelId, "SpatialCategories"))!;
     assert.isTrue(Id64.isValidId64(spatialCategorySelectorId));
@@ -1058,12 +1058,12 @@ export class ExtensiveTestScenario {
     assert.equal(sourceUniqueAspects.length, 1);
     sourceUniqueAspects[0].asAny.commonString += "-Updated";
     sourceUniqueAspects[0].asAny.sourceString += "-Updated";
-    sourceDb.elements.updateAspect(sourceUniqueAspects[0]);
+    sourceDb.elements.updateAspect(sourceUniqueAspects[0].toJSON());
     const sourceMultiAspects: ElementAspect[] = sourceDb.elements.getAspects(physicalObjectId1, "ExtensiveTestScenario:SourceMultiAspect");
     assert.equal(sourceMultiAspects.length, 2);
     sourceMultiAspects[1].asAny.commonString += "-Updated";
     sourceMultiAspects[1].asAny.sourceString += "-Updated";
-    sourceDb.elements.updateAspect(sourceMultiAspects[1]);
+    sourceDb.elements.updateAspect(sourceMultiAspects[1].toJSON());
     // clear NavigationProperty of PhysicalElement1
     const physicalElementId1 = IModelTestUtils.queryByUserLabel(sourceDb, "PhysicalElement1");
     let physicalElement1: PhysicalElement = sourceDb.elements.getElement(physicalElementId1);

--- a/core/backend/src/test/TestChangeSetUtility.ts
+++ b/core/backend/src/test/TestChangeSetUtility.ts
@@ -37,8 +37,8 @@ export class TestChangeSetUtility {
   }
 
   private async addTestElements(): Promise<void> {
-    this._iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(this._iModel, this._modelId, this._categoryId));
-    this._iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(this._iModel, this._modelId, this._categoryId));
+    this._iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(this._iModel, this._modelId, this._categoryId).toJSON());
+    this._iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(this._iModel, this._modelId, this._categoryId).toJSON());
     this._iModel.saveChanges("Added test elements");
   }
 

--- a/core/backend/src/test/changesets/ChangeMerging.test.ts
+++ b/core/backend/src/test/changesets/ChangeMerging.test.ts
@@ -74,7 +74,7 @@ describe("ChangeMerging", () => {
       const dictionary: DictionaryModel = firstDb.models.getModel<DictionaryModel>(IModel.dictionaryId);
       const newCategoryCode = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory");
       spatialCategoryId = SpatialCategory.insert(dictionary.iModel, dictionary.id, newCategoryCode.value, new SubCategoryAppearance({ color: 0xff0000 }));
-      el1 = firstDb.elements.insertElement(IModelTestUtils.createPhysicalObject(firstDb, modelId, spatialCategoryId));
+      el1 = firstDb.elements.insertElement(IModelTestUtils.createPhysicalObject(firstDb, modelId, spatialCategoryId).toJSON());
       firstDb.saveChanges();
       csHistory.push(createChangeset(firstDb));
       firstParent = csHistory.length - 1;
@@ -102,7 +102,7 @@ describe("ChangeMerging", () => {
     if (true) {
       const el1cc = firstDb.elements.getElement(el1);
       expectedValueOfEl1UserLabel = el1cc.userLabel = `${el1cc.userLabel} -> changed by first`;
-      firstDb.elements.updateElement(el1cc);
+      firstDb.elements.updateElement(el1cc.toJSON());
       firstDb.saveChanges("first modified el1.userLabel");
       csHistory.push(createChangeset(firstDb));
       firstParent = csHistory.length - 1;
@@ -112,7 +112,7 @@ describe("ChangeMerging", () => {
     if (true) {
       const el1before: Element = secondDb.elements.getElement(el1);
       el1before.userLabel = `${el1before.userLabel} -> changed by first`;
-      secondDb.elements.updateElement(el1before);
+      secondDb.elements.updateElement(el1before.toJSON());
       secondDb.saveChanges("second modified el1.userLabel");
 
       // merge => take second's change (RejectIncomingChange). That's because the default updateVsUpdate setting is RejectIncomingChange

--- a/core/backend/src/test/element/ElementAspect.test.ts
+++ b/core/backend/src/test/element/ElementAspect.test.ts
@@ -161,7 +161,7 @@ describe("ElementAspect", () => {
     assert.isTrue(found);
 
     aspects[foundIndex].asAny.testMultiAspectProperty = "MultiAspectInsertTest1-Updated";
-    iModel.elements.updateAspect(aspects[foundIndex]);
+    iModel.elements.updateAspect(aspects[foundIndex].toJSON());
 
     const aspectsUpdated: ElementAspect[] = iModel.elements.getAspects(element.id, aspectProps.classFullName);
     assert.equal(aspectsUpdated.length, aspects.length);
@@ -188,7 +188,7 @@ describe("ElementAspect", () => {
     assert.equal(aspects[0].asAny.testUniqueAspectProperty, aspectProps.testUniqueAspectProperty);
 
     aspects[0].asAny.testUniqueAspectProperty = "UniqueAspectInsertTest1-Updated";
-    iModel.elements.updateAspect(aspects[0]);
+    iModel.elements.updateAspect(aspects[0].toJSON());
     const aspectsUpdated: ElementAspect[] = iModel.elements.getAspects(element.id, aspectProps.classFullName);
     assert.equal(aspectsUpdated.length, 1);
     assert.equal(aspectsUpdated[0].asAny.testUniqueAspectProperty, "UniqueAspectInsertTest1-Updated");

--- a/core/backend/src/test/element/ElementDependencyGraph.test.ts
+++ b/core/backend/src/test/element/ElementDependencyGraph.test.ts
@@ -101,7 +101,7 @@ class TestHelper {
   public updateElement(elid: Id64String, newLabel: string) {
     const ed2 = this.db.elements.getElement({ id: elid });
     ed2.userLabel = newLabel;
-    this.db.elements.updateElement(ed2);
+    this.db.elements.updateElement(ed2.toJSON());
   }
 
   public fmtElem(elId: Id64String) { return this.db.elements.getElement(elId).code.value; }
@@ -193,7 +193,7 @@ describe("ElementDependencyGraph", () => {
     helper.db.saveChanges(); // this will react to EDE inserts only.
     assert.deepEqual(helper.dres.beforeOutputs, []); // only roots get this callback, and only if they have been directly changed.
     assert.deepEqual(helper.dres.allInputsHandled, []); // No input elements have changed
-    assertRels(helper.dres.rootChanged, [ede_1_2, ede_2_3]); // we send out this callback even if only the relationship itself is new or changed.
+    assertRels(helper.dres.rootChanged, [ede_1_2.toJSON(), ede_2_3.toJSON()]); // we send out this callback even if only the relationship itself is new or changed.
 
     helper.updateElement(e1id, "change e1");
 
@@ -202,7 +202,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [e1id]); // only called on directly changed root elements.
     assert.deepEqual(helper.dres.allInputsHandled, [e2id, e3id]);
-    assertRels(helper.dres.rootChanged, [ede_1_2, ede_2_3]);
+    assertRels(helper.dres.rootChanged, [ede_1_2.toJSON(), ede_2_3.toJSON()]);
 
     helper.terminate();
   });
@@ -274,7 +274,7 @@ describe("ElementDependencyGraph", () => {
     helper.db.saveChanges(); // this will react to EDE inserts only.
     assert.deepEqual(helper.dres.beforeOutputs, []); // only roots get this callback, and only if they have been directly changed.
     assert.deepEqual(helper.dres.allInputsHandled, []); // No input elements have changed
-    assertRels(helper.dres.rootChanged, [ede_1_2, ede_2_3, ede_p2_p3]); // we send out this callback even if only the relationship itself is new or changed.
+    assertRels(helper.dres.rootChanged, [ede_1_2.toJSON(), ede_2_3.toJSON(), ede_p2_p3.toJSON()]); // we send out this callback even if only the relationship itself is new or changed.
 
     helper.updateElement(e1id, "change e1");
 
@@ -283,7 +283,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [e1id]); // only called on directly changed root elements.
     assert.deepEqual(helper.dres.allInputsHandled, [e2id, p2id, e3id, p3id]);
-    assertRels(helper.dres.rootChanged, [ede_1_2, ede_2_3, ede_p2_p3]);
+    assertRels(helper.dres.rootChanged, [ede_1_2.toJSON(), ede_2_3.toJSON(), ede_p2_p3.toJSON()]);
 
     helper.updateElement(p2id, "change p2");
 
@@ -292,7 +292,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [p2id]); // only called on directly changed root elements.
     assert.deepEqual(helper.dres.allInputsHandled, [p3id]);
-    assertRels(helper.dres.rootChanged, [ede_p2_p3]);
+    assertRels(helper.dres.rootChanged, [ede_p2_p3.toJSON()]);
 
     helper.updateElement(e2id, "change e2");
 
@@ -301,7 +301,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [e2id]); // only called on directly changed root elements.
     assert.deepEqual(helper.dres.allInputsHandled, [e3id]);
-    assertRels(helper.dres.rootChanged, [ede_2_3]);
+    assertRels(helper.dres.rootChanged, [ede_2_3.toJSON()]);
 
     helper.terminate();
   });
@@ -339,7 +339,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [material]); // only called on directly changed root elements.
     assert.deepEqual(helper.dres.allInputsHandled, [materialDepthRange, borehole, boreholeSource, groundGeneration]);
-    assertRels(helper.dres.rootChanged, [ede_material_materialDepthRange, ede_boreholeSource_groundGeneration]);
+    assertRels(helper.dres.rootChanged, [ede_material_materialDepthRange.toJSON(), ede_boreholeSource_groundGeneration.toJSON()]);
 
     helper.terminate();
   });
@@ -381,7 +381,7 @@ describe("ElementDependencyGraph", () => {
     helper.db.saveChanges();
     assert.deepEqual(helper.dres.beforeOutputs, [e1id, e11id, e21id]); // only called on directly changed root elements.
     assert.deepEqual(helper.dres.allInputsHandled, [e2id, e3id, e4id]);
-    assertRels(helper.dres.rootChanged, [ede_1_2, ede_11_2, ede_2_3, ede_21_3, ede_3_4]);
+    assertRels(helper.dres.rootChanged, [ede_1_2.toJSON(), ede_11_2.toJSON(), ede_2_3.toJSON(), ede_21_3.toJSON(), ede_3_4.toJSON()]);
 
     // modify e4 directly. That is a leaf. None of its inputs are changed.
     // resulting subgraph:
@@ -413,7 +413,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [e3id]); // only called on directly changed root elements.
     assert.deepEqual(helper.dres.allInputsHandled, [e4id]);
-    assertRels(helper.dres.rootChanged, [ede_3_4]);
+    assertRels(helper.dres.rootChanged, [ede_3_4.toJSON()]);
 
     // modify e2 directly. That is a node in middle of the graph. None of its inputs is modified.
     // resulting subgraph:
@@ -430,7 +430,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [e2id]); // only called on directly changed root elements
     assert.deepEqual(helper.dres.allInputsHandled, [e3id, e4id],);
-    assertRels(helper.dres.rootChanged, [ede_2_3, ede_3_4]);
+    assertRels(helper.dres.rootChanged, [ede_2_3.toJSON(), ede_3_4.toJSON()]);
 
     // Modify e1 directly. That should propagate to the rest of the nodes. Each should get an _onAllInputsHandled callback
     // resulting graph:
@@ -445,7 +445,7 @@ describe("ElementDependencyGraph", () => {
 
     assert.deepEqual(helper.dres.beforeOutputs, [e1id]); // only called on directly changed root elements
     assert.deepEqual(helper.dres.allInputsHandled, [e2id, e3id, e4id]);
-    assertRels(helper.dres.rootChanged, [ede_1_2, ede_2_3, ede_3_4]);
+    assertRels(helper.dres.rootChanged, [ede_1_2.toJSON(), ede_2_3.toJSON(), ede_3_4.toJSON()]);
 
     // Modify e11 directly. That should propagate to the rest of the nodes. Each should get an _onAllInputsHandled callback
     // resulting graph:
@@ -464,7 +464,7 @@ describe("ElementDependencyGraph", () => {
     // assert.deepEqual(helper.dres.directChange, []); // only called on directly changed non-root elements that have no directly changed inputs
     assert.deepEqual(helper.dres.beforeOutputs, [e11id]); // only called on directly changed root elements
     assert.deepEqual(helper.dres.allInputsHandled, [e2id, e3id, e4id]);
-    assertRels(helper.dres.rootChanged, [ede_11_2, ede_2_3, ede_3_4]);
+    assertRels(helper.dres.rootChanged, [ede_11_2.toJSON(), ede_2_3.toJSON(), ede_3_4.toJSON()]);
     // assertRels(helper.dres.validateOutput, [ede_1_2, ede_21_3]); // this callback is made only on rels that not in the graph but share an output with another rel or have an output that was directly changed
 
     helper.terminate();

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -488,7 +488,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
 
     // insert a element
     const geomElement = imodel.elements.createElement(expectedValue);
-    const id = imodel.elements.insertElement(geomElement);
+    const id = imodel.elements.insertElement(geomElement.toJSON());
     assert.isTrue(Id64.isValidId64(id), "insert worked");
     imodel.saveChanges();
 
@@ -556,7 +556,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
 
     // insert a element
     const geomElement = imodel.elements.createElement(expectedValue);
-    const elId = imodel.elements.insertElement(geomElement);
+    const elId = imodel.elements.insertElement(geomElement.toJSON());
     assert.isTrue(Id64.isValidId64(elId), "insert worked");
 
     const expectedAspectValue = initElementAspectProps("TestElementAspect", imodel, elId, {
@@ -571,7 +571,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     imodel.saveChanges();
 
     // verify inserted element aspect properties
-    const actualAspectValue: ElementAspectProps[] = imodel.elements.getAspects(elId, expectedAspectValue.classFullName);
+    const actualAspectValue: ElementAspectProps[] = imodel.elements.getAspects(elId, expectedAspectValue.classFullName).map((x) => x.toJSON());
     assert.equal(actualAspectValue.length, 1);
     verifyTestElementAspect(actualAspectValue[0], expectedAspectValue);
 
@@ -603,7 +603,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     imodel.saveChanges();
 
     // verify updated values
-    const updatedAspectValue: ElementAspectProps[] = imodel.elements.getAspects(elId, expectedAspectValue.classFullName);
+    const updatedAspectValue: ElementAspectProps[] = imodel.elements.getAspects(elId, expectedAspectValue.classFullName).map((x) => x.toJSON());
     assert.equal(updatedAspectValue.length, 1);
     verifyTestElementAspect(updatedAspectValue[0], actualAspectValue[0]);
 
@@ -643,10 +643,10 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     const element2 = initElemProps("TestElement", imodel, newModelId, spatialCategoryId!, {}) as TestElement;
 
     const geomElement1 = imodel.elements.createElement(element1);
-    const elId1 = imodel.elements.insertElement(geomElement1);
+    const elId1 = imodel.elements.insertElement(geomElement1.toJSON());
     assert.isTrue(Id64.isValidId64(elId1), "insert of element 1 worked");
     const geomElement2 = imodel.elements.createElement(element2);
-    const elId2 = imodel.elements.insertElement(geomElement2);
+    const elId2 = imodel.elements.insertElement(geomElement2.toJSON());
     assert.isTrue(Id64.isValidId64(elId2), "insert of element 2 worked");
 
     // TODO: Skipping structs here, because of a bug that prevents querying from link tables that have an overflow table, by skipping the struct we reduce the amount of used columns
@@ -658,7 +658,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     });
 
     const instance = expectedRelationshipValue; // imodel.relationships.createInstance(expectedRelationshipValue);
-    const relationshipId: Id64String = imodel.relationships.insertInstance(instance);
+    const relationshipId: Id64String = imodel.relationships.insertInstance(instance.toJSON());
     imodel.saveChanges();
 
     // verify inserted properties
@@ -693,7 +693,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     });
 
     // update
-    imodel.relationships.updateInstance(updatedExpectedValue);
+    imodel.relationships.updateInstance(updatedExpectedValue.toJSON());
     imodel.saveChanges();
 
     // verify updated values

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -658,7 +658,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     });
 
     const instance = expectedRelationshipValue; // imodel.relationships.createInstance(expectedRelationshipValue);
-    const relationshipId: Id64String = imodel.relationships.insertInstance(instance.toJSON());
+    const relationshipId: Id64String = imodel.relationships.insertInstance(instance as any); // initElementRefersToElementsProps lies about return type.
     imodel.saveChanges();
 
     // verify inserted properties

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -662,7 +662,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     imodel.saveChanges();
 
     // verify inserted properties
-    const actualRelationshipValue: TestElementRefersToElements = imodel.relationships.getInstanceProps(expectedRelationshipValue.classFullName, relationshipId);
+    const actualRelationshipValue = imodel.relationships.getInstance<TestElementRefersToElements>(expectedRelationshipValue.classFullName, relationshipId);
     assert.exists(actualRelationshipValue);
 
     verifyTestElementRefersToElements(actualRelationshipValue, expectedRelationshipValue);
@@ -697,7 +697,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     imodel.saveChanges();
 
     // verify updated values
-    const updatedValue: TestElementRefersToElements = imodel.relationships.getInstanceProps(expectedRelationshipValue.classFullName, relationshipId);
+    const updatedValue = imodel.relationships.getInstance<TestElementRefersToElements>(expectedRelationshipValue.classFullName, relationshipId);
     verifyTestElementRefersToElements(updatedValue, updatedExpectedValue);
 
     // verify via concurrent query

--- a/core/backend/src/test/element/ExcludedElements.test.ts
+++ b/core/backend/src/test/element/ExcludedElements.test.ts
@@ -51,7 +51,7 @@ describe("ExcludedElements", () => {
 
       const getStyle = (compressExcludedElementIds?: boolean) => {
         const loadProps = { id: styleId, displayStyle: { compressExcludedElementIds } };
-        return imodel.elements.getElementJson<DisplayStyle3d>(loadProps);
+        return imodel.elements.getElement<DisplayStyle3d>(loadProps);
       };
 
       // Unless compressed Ids explicitly requested, the Ids are always decompressed regardless of how they are stored.

--- a/core/backend/src/test/element/UrlLink.test.ts
+++ b/core/backend/src/test/element/UrlLink.test.ts
@@ -27,12 +27,12 @@ describe("UrlLink tests", () => {
     };
 
     const linkElement = imodel.elements.createElement(linkProps);
-    const id = imodel.elements.insertElement(linkElement);
+    const id = imodel.elements.insertElement(linkElement.toJSON());
     assert.isTrue(Id64.isValidId64(id), "insert worked");
     imodel.saveChanges();
 
     // verify inserted element properties
-    const actualValue = imodel.elements.getElementProps<RepositoryLink>(id);
+    const actualValue = imodel.elements.getElement<RepositoryLink>(id);
     assert.equal(actualValue.url, linkProps.url, "Repository link url not set as expected");
     assert.equal(actualValue.description, linkProps.description, "Repository link description not set as expected");
     assert.equal(actualValue.repositoryGuid, linkProps.repositoryGuid, "Repository link guid not set as expected.");

--- a/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
+++ b/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
@@ -143,7 +143,7 @@ describe("BriefcaseManager", async () => {
 
     const rootEl: Element = iModelPullAndPush.elements.getRootSubject();
     rootEl.userLabel = `${rootEl.userLabel}changed`;
-    iModelPullAndPush.elements.updateElement(rootEl);
+    iModelPullAndPush.elements.updateElement(rootEl.toJSON());
 
     assert.isTrue(iModelPullAndPush.nativeDb.hasUnsavedChanges());
     assert.isFalse(iModelPullAndPush.nativeDb.hasPendingTxns());

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -229,7 +229,7 @@ describe("iModel", () => {
 
     const newEl = el3;
     newEl.federationGuid = undefined;
-    const newId = imodel2.elements.insertElement(newEl);
+    const newId = imodel2.elements.insertElement(newEl.toJSON());
     assert.isTrue(Id64.isValidId64(newId), "insert worked");
   });
 
@@ -293,7 +293,7 @@ describe("iModel", () => {
       const element: Element = imodel2.elements.createElement(elementProps);
       element.setUserProperties("performanceTest", { s: `String-${i}`, n: i });
 
-      const elementId = imodel2.elements.insertElement(element);
+      const elementId = imodel2.elements.insertElement(element.toJSON());
       assert.isTrue(Id64.isValidId64(elementId));
     }
   });
@@ -886,7 +886,7 @@ describe("iModel", () => {
     newTestElem.asAny.dtUtc = new Date("2015-03-25");
     newTestElem.asAny.p3d = new Point3d(1, 2, 3);
 
-    const newTestElemId = imodel4.elements.insertElement(newTestElem);
+    const newTestElemId = imodel4.elements.insertElement(newTestElem.toJSON());
 
     assert.isTrue(Id64.isValidId64(newTestElemId), "insert worked");
 
@@ -908,7 +908,7 @@ describe("iModel", () => {
     const editElem = newTestElemFetched;
     editElem.asAny.location = loc2;
     try {
-      imodel4.elements.updateElement(editElem);
+      imodel4.elements.updateElement(editElem.toJSON());
     } catch (_err) {
       assert.fail("Element.update failed");
     }
@@ -921,7 +921,7 @@ describe("iModel", () => {
     assert.equal(afterUpdateElemFetched.asAny.arrayOfInt.length, 300);
 
     afterUpdateElemFetched.asAny.arrayOfInt = [99, 3];
-    imodel4.elements.updateElement(afterUpdateElemFetched);
+    imodel4.elements.updateElement(afterUpdateElemFetched.toJSON());
 
     const afterShortenArray = imodel4.elements.getElement(afterUpdateElemFetched.id);
     assert.equal(afterUpdateElemFetched.asAny.arrayOfInt.length, 2);
@@ -929,7 +929,7 @@ describe("iModel", () => {
 
     // Make array longer
     afterShortenArray.asAny.arrayOfInt = [1, 2, 3];
-    imodel4.elements.updateElement(afterShortenArray);
+    imodel4.elements.updateElement(afterShortenArray.toJSON());
     const afterLengthenArray = imodel4.elements.getElement(afterShortenArray.id);
     assert.equal(afterLengthenArray.asAny.arrayOfInt.length, 3);
     assert.deepEqual(afterLengthenArray.asAny.arrayOfInt, [1, 2, 3]);
@@ -1312,7 +1312,7 @@ describe("iModel", () => {
 
     // Update the model
     newModelPersist.isPrivate = false;
-    testImodel.models.updateModel(newModelPersist);
+    testImodel.models.updateModel(newModelPersist.toJSON());
     //  ... and check that it updated the model in the db
     const newModelPersist2 = testImodel.models.getModel(newModelId);
     assert.isFalse(newModelPersist2.isPrivate);
@@ -1483,7 +1483,7 @@ describe("iModel", () => {
         code: Code.createEmpty(),
       };
 
-      id1 = testImodel.elements.insertElement(testImodel.elements.createElement(elementProps));
+      id1 = testImodel.elements.insertElement(testImodel.elements.createElement(elementProps).toJSON());
       assert.isTrue(Id64.isValidId64(id1));
 
       // The second one should point to the first.
@@ -1492,7 +1492,7 @@ describe("iModel", () => {
       elementProps.parent = { id: id1, relClassName: trelClassName };
       (elementProps as any).longProp = 4294967295;     // make sure that we can save values in the range 0 ... UINT_MAX
 
-      id2 = testImodel.elements.insertElement(testImodel.elements.createElement(elementProps));
+      id2 = testImodel.elements.insertElement(testImodel.elements.createElement(elementProps).toJSON());
       assert.isTrue(Id64.isValidId64(id2));
     }
 
@@ -1514,7 +1514,7 @@ describe("iModel", () => {
       // Change el2 to point to itself.
       const el2Modified = testImodel.elements.getElement(id2);
       el2Modified.asAny.relatedElement = { id: id2, relClassName: trelClassName };
-      testImodel.elements.updateElement(el2Modified);
+      testImodel.elements.updateElement(el2Modified.toJSON());
       // Test that el2 points to itself.
       const el2after: Element = testImodel.elements.getElement(id2);
       assert.deepEqual(el2after.asAny.relatedElement.id, id2);
@@ -1525,7 +1525,7 @@ describe("iModel", () => {
       // Test that we can null out the navigation property
       const el2Modified = testImodel.elements.getElement(id2);
       el2Modified.asAny.relatedElement = null;
-      testImodel.elements.updateElement(el2Modified);
+      testImodel.elements.updateElement(el2Modified.toJSON());
       // Test that el2 has no relatedElement property value
       const el2after: Element = testImodel.elements.getElement(id2);
       assert.isUndefined(el2after.asAny.relatedElement);

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -57,7 +57,7 @@ function createGeometryPart(geom: GeometryStreamProps, imodel: SnapshotDb): Id64
 function createGeometricElem(geom: GeometryStreamProps, placement: Placement3dProps, imodel: SnapshotDb, seedElement: GeometricElement): Id64String {
   const elementProps = createPhysicalElementProps(seedElement, placement, geom);
   const el = imodel.elements.createElement<GeometricElement>(elementProps);
-  return imodel.elements.insertElement(el);
+  return imodel.elements.insertElement(el.toJSON());
 }
 
 function createPartElem(partId: Id64String, origin: Point3d, angles: YawPitchRollAngles, imodel: SnapshotDb, seedElement: GeometricElement, isRelative = false): Id64String {
@@ -862,7 +862,7 @@ describe("GeometryStream", () => {
 
     const elementProps = createPhysicalElementProps(seedElement, { origin: testOrigin, angles: testAngles }, builder.geometryStream);
     const testElem = imodel.elements.createElement(elementProps);
-    const newId = imodel.elements.insertElement(testElem);
+    const newId = imodel.elements.insertElement(testElem.toJSON());
     imodel.saveChanges();
 
     // Extract and test value returned, text transform should now be identity as it is accounted for by element's placement...
@@ -920,7 +920,7 @@ describe("GeometryStream", () => {
 
     const partProps = createGeometryPartProps(partBuilder.geometryStream);
     const testPart = imodel.elements.createElement(partProps);
-    const partId = imodel.elements.insertElement(testPart);
+    const partId = imodel.elements.insertElement(testPart.toJSON());
     imodel.saveChanges();
 
     // Extract and test value returned
@@ -965,7 +965,7 @@ describe("GeometryStream", () => {
 
     const elementProps = createPhysicalElementProps(seedElement, undefined, builder.geometryStream);
     const testElem = imodel.elements.createElement(elementProps);
-    const newId = imodel.elements.insertElement(testElem);
+    const newId = imodel.elements.insertElement(testElem.toJSON());
     imodel.saveChanges();
 
     // Extract and test value returned
@@ -999,7 +999,7 @@ describe("GeometryStream", () => {
 
     const partProps = createGeometryPartProps(partBuilder.geometryStream);
     const testPart = imodel.elements.createElement(partProps);
-    const partId = imodel.elements.insertElement(testPart);
+    const partId = imodel.elements.insertElement(testPart.toJSON());
     imodel.saveChanges();
 
     const builder = new GeometryStreamBuilder();
@@ -1013,7 +1013,7 @@ describe("GeometryStream", () => {
 
     const elementProps = createPhysicalElementProps(seedElement, { origin: testOrigin, angles: testAngles }, builder.geometryStream);
     const testElem = imodel.elements.createElement(elementProps);
-    const newId = imodel.elements.insertElement(testElem);
+    const newId = imodel.elements.insertElement(testElem.toJSON());
     imodel.saveChanges();
 
     // Extract and test value returned
@@ -1110,7 +1110,7 @@ describe("GeometryStream", () => {
 
     const elementProps = createPhysicalElementProps(seedElement, { origin: testOrigin, angles: testAngles }, builder.geometryStream);
     const testElem = imodel.elements.createElement(elementProps);
-    const newId = imodel.elements.insertElement(testElem);
+    const newId = imodel.elements.insertElement(testElem.toJSON());
     imodel.saveChanges();
 
     // Extract and test value returned
@@ -1188,7 +1188,7 @@ describe("GeometryStream", () => {
 
       const partProps = createGeometryPartProps(builder.geometryStream);
       const part = imodel.elements.createElement(partProps);
-      const partId = imodel.elements.insertElement(part);
+      const partId = imodel.elements.insertElement(part.toJSON());
       imodel.saveChanges();
 
       const json = imodel.elements.getElementProps<GeometryPartProps>({ id: partId, wantGeometry: true });
@@ -1983,7 +1983,7 @@ describe("ElementGeometry", () => {
 
     const partid = imodel.elements.insertElement(partProps);
 
-    let persistentPartProps = imodel.elements.getElementProps<GeometryPart>({ id: partid, wantGeometry: true });
+    let persistentPartProps = imodel.elements.getElementProps<GeometryPartProps>({ id: partid, wantGeometry: true });
     assert.isDefined(persistentPartProps.geom);
 
     for (const entry of new GeometryStreamIterator(persistentPartProps.geom!)) {
@@ -1999,7 +1999,7 @@ describe("ElementGeometry", () => {
 
     imodel.elements.updateElement(persistentPartProps);
 
-    persistentPartProps = imodel.elements.getElementProps<GeometryPart>({ id: partid, wantGeometry: true });
+    persistentPartProps = imodel.elements.getElementProps<GeometryPartProps>({ id: partid, wantGeometry: true });
     assert.isDefined(persistentPartProps.geom);
 
     for (const entry of new GeometryStreamIterator(persistentPartProps.geom!)) {
@@ -2561,7 +2561,7 @@ describe("BRepGeometry", () => {
 
       const elementProps = createPhysicalElementProps(seedElement, { origin: Point3d.create(5, 10, 0), angles: YawPitchRollAngles.createDegrees(45, 0, 0) }, gsBuilder.geometryStream);
       const testElem = imodel.elements.createElement(elementProps);
-      const newId = imodel.elements.insertElement(testElem);
+      const newId = imodel.elements.insertElement(testElem.toJSON());
       imodel.saveChanges();
 
       // Extract and test value returned
@@ -2615,7 +2615,7 @@ describe("Mass Properties", () => {
 
     const elementProps = createPhysicalElementProps(seedElement, undefined, builder.geometryStream);
     const testElem = imodel.elements.createElement(elementProps);
-    const newId = imodel.elements.insertElement(testElem);
+    const newId = imodel.elements.insertElement(testElem.toJSON());
     imodel.saveChanges();
 
     const requestProps: MassPropertiesRequestProps = {
@@ -2642,7 +2642,7 @@ describe("Mass Properties", () => {
 
     const elementProps = createPhysicalElementProps(seedElement, undefined, builder.geometryStream);
     const testElem = imodel.elements.createElement(elementProps);
-    const newId = imodel.elements.insertElement(testElem);
+    const newId = imodel.elements.insertElement(testElem.toJSON());
     imodel.saveChanges();
 
     const requestProps: MassPropertiesRequestProps = {

--- a/core/backend/src/test/standalone/IModelWrite.test.ts
+++ b/core/backend/src/test/standalone/IModelWrite.test.ts
@@ -27,7 +27,7 @@ export async function createNewModelAndCategory(rwIModel: BriefcaseDb, parent?: 
   const dictionary: DictionaryModel = rwIModel.models.getModel<DictionaryModel>(IModel.dictionaryId);
   const newCategoryCode = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory");
   const category = SpatialCategory.create(rwIModel, IModel.dictionaryId, newCategoryCode.value);
-  const spatialCategoryId = rwIModel.elements.insertElement(category);
+  const spatialCategoryId = rwIModel.elements.insertElement(category.toJSON());
   category.setDefaultAppearance(new SubCategoryAppearance({ color: 0xff0000 }));
   // const spatialCategoryId: Id64String = SpatialCategory.insert(rwIModel, IModel.dictionaryId, newCategoryCode.value!, new SubCategoryAppearance({ color: 0xff0000 }));
 

--- a/core/backend/src/test/standalone/SectionDrawing.test.ts
+++ b/core/backend/src/test/standalone/SectionDrawing.test.ts
@@ -30,7 +30,7 @@ describe("SectionDrawing", () => {
       classFullName: DrawingModel.classFullName,
       modeledElement: { id: drawingId },
     });
-    const modelId = imodel.models.insertModel(model);
+    const modelId = imodel.models.insertModel(model.toJSON());
     expect(Id64.isValidId64(modelId)).to.be.true;
 
     let drawing = imodel.elements.getElement<SectionDrawing>(drawingId);

--- a/core/backend/src/test/standalone/ServerBasedLocks.test.ts
+++ b/core/backend/src/test/standalone/ServerBasedLocks.test.ts
@@ -182,9 +182,9 @@ describe("Server-based locks", () => {
     assertExclusiveLocks(bc1Locks, newElId);
 
     childEl.userLabel = "new user label";
-    assert.throws(() => bc1.elements.updateElement(childEl), "exclusive lock");
+    assert.throws(() => bc1.elements.updateElement(childEl.toJSON()), "exclusive lock");
     await bc1Locks.acquireLocks({ exclusive: child1 });
-    bc1.elements.updateElement(childEl);
+    bc1.elements.updateElement(childEl.toJSON());
     bc1.saveChanges();
 
     bc1.elements.deleteElement(child1); // make sure delete now works

--- a/core/backend/src/test/standalone/TileTree.test.ts
+++ b/core/backend/src/test/standalone/TileTree.test.ts
@@ -61,7 +61,7 @@ function insertPhysicalModel(db: IModelDb): Id64String {
 
   expect(model instanceof PhysicalModel).to.be.true;
 
-  const modelId = db.models.insertModel(model);
+  const modelId = db.models.insertModel(model.toJSON());
   expect(Id64.isValidId64(modelId)).to.be.true;
   return modelId;
 }
@@ -126,7 +126,7 @@ describe("tile tree", () => {
       model: IModel.dictionaryId,
       code: Code.createEmpty(),
     }, db);
-    renderTimelineId = db.elements.insertElement(renderTimeline);
+    renderTimelineId = db.elements.insertElement(renderTimeline.toJSON());
     expect(Id64.isValid(renderTimelineId)).to.be.true;
   });
 

--- a/core/backend/src/test/standalone/ViewDefinition.test.ts
+++ b/core/backend/src/test/standalone/ViewDefinition.test.ts
@@ -15,7 +15,7 @@ function createNewModelAndCategory(rwIModel: IModelDb, parent?: Id64String) {
   const newCategoryCode = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory");
   const category = SpatialCategory.create(rwIModel, IModel.dictionaryId, newCategoryCode.value);
 
-  const spatialCategoryId = rwIModel.elements.insertElement(category);
+  const spatialCategoryId = rwIModel.elements.insertElement(category.toJSON());
   category.setDefaultAppearance(new SubCategoryAppearance({ color: 0xff0000 }));
   return { modelId, spatialCategoryId };
 }
@@ -74,7 +74,7 @@ describe("ViewDefinition", () => {
     // Better way to create and insert
     const props: SpatialViewDefinitionProps = { ...basicProps, modelSelectorId, categorySelectorId, displayStyleId };
     const viewDefinition = iModel.elements.createElement<SpatialViewDefinition>(props);
-    let viewDefinitionId = iModel.elements.insertElement(viewDefinition);
+    let viewDefinitionId = iModel.elements.insertElement(viewDefinition.toJSON());
     assert.isNotEmpty(viewDefinitionId);
     assert.isTrue(Id64.isValid(viewDefinitionId));
 

--- a/core/backend/src/test/standalone/ViewDefinition.test.ts
+++ b/core/backend/src/test/standalone/ViewDefinition.test.ts
@@ -15,7 +15,7 @@ function createNewModelAndCategory(rwIModel: IModelDb, parent?: Id64String) {
   const newCategoryCode = IModelTestUtils.getUniqueSpatialCategoryCode(dictionary, "ThisTestSpatialCategory");
   const category = SpatialCategory.create(rwIModel, IModel.dictionaryId, newCategoryCode.value);
 
-  const spatialCategoryId = rwIModel.elements.insertElement(category.toJSON());
+  const spatialCategoryId = category.insert();
   category.setDefaultAppearance(new SubCategoryAppearance({ color: 0xff0000 }));
   return { modelId, spatialCategoryId };
 }

--- a/core/common/src/EntityProps.ts
+++ b/core/common/src/EntityProps.ts
@@ -14,6 +14,7 @@ import { RelatedElement } from "./ElementProps";
  * @public
  */
 export interface EntityProps {
+  readonly isEntityObject?: never;
   /** The full name of the [ECClass]($docs/bis/intro/glossary/#ecclass) for this entity, in the form "Schema:ClassName" */
   classFullName: string;
   /** The Id of the entity. Must be present for SELECT, UPDATE, or DELETE, ignored for INSERT. */

--- a/core/common/src/EntityProps.ts
+++ b/core/common/src/EntityProps.ts
@@ -10,11 +10,17 @@ import { Id64, Id64String } from "@itwin/core-bentley";
 import { Point2d, Point3d } from "@itwin/core-geometry";
 import { RelatedElement } from "./ElementProps";
 
-/** The properties of an [Entity]($backend) as they are read/stored from/to the iModel.
+/** The persistent format of an [Entity]($backend), also used as the "wire format" when transmitting information about entities
+ * between the backend and frontend.
+ * EntityProps and all of its sub-types like [[ElementProps]] are "plain old Javascript objects" - that is, objects containing
+ * no methods and no properties of `class` type.
  * @public
  */
 export interface EntityProps {
-  readonly isEntityObject?: never;
+  /** A non-existent property used to discriminate between [[EntityProps]] and [Entity]($backend).
+   * @see [Entity.isInstanceOfEntity]($backend).
+   */
+  readonly isInstanceOfEntity?: never;
   /** The full name of the [ECClass]($docs/bis/intro/glossary/#ecclass) for this entity, in the form "Schema:ClassName" */
   classFullName: string;
   /** The Id of the entity. Must be present for SELECT, UPDATE, or DELETE, ignored for INSERT. */

--- a/core/common/src/geometry/GeometryStream.ts
+++ b/core/common/src/geometry/GeometryStream.ts
@@ -544,7 +544,7 @@ export class GeometryStreamIterator implements IterableIterator<GeometryStreamIt
    * If [[GeometricElement3dProps.placement]] is not undefined, placement relative entries will be returned transformed to world coordinates.
    * @throws [[IModelError]] if element.geom is undefined.
    */
-  public static fromGeometricElement3d(element: GeometricElement3dProps) {
+  public static fromGeometricElement3d(element: Pick<GeometricElement3dProps, "geom" | "placement" | "category">) {
     if (element.geom === undefined)
       throw new IModelError(IModelStatus.NoGeometry, "GeometricElement has no geometry or geometry wasn't requested");
 
@@ -559,7 +559,7 @@ export class GeometryStreamIterator implements IterableIterator<GeometryStreamIt
    * If [[GeometricElement2dProps.placement]] is not undefined, placement relative entries will be returned transformed to world coordinates.
    * @throws [[IModelError]] if element.geom is undefined.
    */
-  public static fromGeometricElement2d(element: GeometricElement2dProps) {
+  public static fromGeometricElement2d(element: Pick<GeometricElement2dProps, "geom" | "placement" | "category">) {
     if (element.geom === undefined)
       throw new IModelError(IModelStatus.NoGeometry, "GeometricElement has no geometry or geometry wasn't requested");
 
@@ -580,7 +580,7 @@ export class GeometryStreamIterator implements IterableIterator<GeometryStreamIt
    * Supply the partToLocal transform to return the part geometry relative to the [[GeometricElement]]'s placement.
    * @throws [[IModelError]] if geomPart.geom is undefined.
    */
-  public static fromGeometryPart(geomPart: GeometryPartProps, geomParams?: GeometryParams, partTransform?: Transform) {
+  public static fromGeometryPart(geomPart: Pick<GeometryPartProps, "geom">, geomParams?: GeometryParams, partTransform?: Transform) {
     if (geomPart.geom === undefined)
       throw new IModelError(IModelStatus.NoGeometry, "GeometryPart has no geometry or geometry wasn't requested");
 

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -367,7 +367,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
   }
 
   /** Format an ElementAspect for the Logger. */
-  private formatElementAspectForLogger(elementAspectProps: ElementAspectProps): string {
+  private formatElementAspectForLogger(elementAspectProps: ElementAspectProps | ElementAspect): string {
     return `${elementAspectProps.classFullName} elementId=[${elementAspectProps.element.id}]`;
   }
 

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -356,7 +356,7 @@ export class IModelTransformer extends IModelExportHandler {
   }
 
   /** Format an Element for the Logger. */
-  private formatElementForLogger(elementProps: ElementProps): string {
+  private formatElementForLogger(elementProps: ElementProps | Element): string {
     const namePiece: string = elementProps.code.value ? `${elementProps.code.value} ` : elementProps.userLabel ? `${elementProps.userLabel} ` : "";
     return `${elementProps.classFullName} ${namePiece}[${elementProps.id!}]`;
   }
@@ -687,7 +687,7 @@ export class IModelTransformer extends IModelExportHandler {
         if (undefined !== json.targetRelInstanceId) {
           const targetRelationship = this.targetDb.relationships.tryGetInstance(ElementRefersToElements.classFullName, json.targetRelInstanceId);
           if (targetRelationship) {
-            this.importer.deleteRelationship(targetRelationship);
+            this.importer.deleteRelationship(targetRelationship.toJSON());
           }
           this.targetDb.elements.deleteAspect(statement.getValue(0).getId());
         }
@@ -715,7 +715,7 @@ export class IModelTransformer extends IModelExportHandler {
           const json: any = JSON.parse(statement.getValue(2).getString());
           if (undefined !== json.targetRelInstanceId) {
             const targetRelationship: Relationship = this.targetDb.relationships.getInstance(ElementRefersToElements.classFullName, json.targetRelInstanceId);
-            this.importer.deleteRelationship(targetRelationship);
+            this.importer.deleteRelationship(targetRelationship.toJSON());
           }
           aspectDeleteIds.push(statement.getValue(0).getId());
         }

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1076,7 +1076,7 @@ describe("IModelTransformer", () => {
       classFullName: DrawingModel.classFullName,
       modeledElement: { id: drawing2Id },
     });
-    const drawingModel2Id = sourceDb.models.insertModel(drawingModel1.toJSON());
+    const drawingModel2Id = sourceDb.models.insertModel(drawingModel2.toJSON());
 
     const modelCodeSpec = sourceDb.codeSpecs.insert(CodeSpec.create(sourceDb, "ModelCodeSpec", CodeScopeSpec.Type.Model));
     const relatedCodeSpecId = sourceDb.codeSpecs.insert(CodeSpec.create(sourceDb, "RelatedCodeSpec", CodeScopeSpec.Type.RelatedElement));

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1013,7 +1013,7 @@ describe("IModelTransformer", () => {
       classFullName: DrawingModel.classFullName,
       modeledElement: { id: drawingId },
     });
-    sourceDb.models.insertModel(model);
+    sourceDb.models.insertModel(model.toJSON());
 
     const myCodeSpecId = sourceDb.codeSpecs.insert(CodeSpec.create(sourceDb, "MyCodeSpec", CodeScopeSpec.Type.RelatedElement));
 
@@ -1070,13 +1070,13 @@ describe("IModelTransformer", () => {
       classFullName: DrawingModel.classFullName,
       modeledElement: { id: drawing1Id },
     });
-    const drawingModel1Id = sourceDb.models.insertModel(drawingModel1);
+    const drawingModel1Id = sourceDb.models.insertModel(drawingModel1.toJSON());
 
     const drawingModel2 = sourceDb.models.createModel({
       classFullName: DrawingModel.classFullName,
       modeledElement: { id: drawing2Id },
     });
-    const drawingModel2Id = sourceDb.models.insertModel(drawingModel2);
+    const drawingModel2Id = sourceDb.models.insertModel(drawingModel1.toJSON());
 
     const modelCodeSpec = sourceDb.codeSpecs.insert(CodeSpec.create(sourceDb, "ModelCodeSpec", CodeScopeSpec.Type.Model));
     const relatedCodeSpecId = sourceDb.codeSpecs.insert(CodeSpec.create(sourceDb, "RelatedCodeSpec", CodeScopeSpec.Type.RelatedElement));

--- a/core/transformer/src/test/standalone/RenderTimelineRemap.test.ts
+++ b/core/transformer/src/test/standalone/RenderTimelineRemap.test.ts
@@ -59,7 +59,7 @@ describe("RenderTimeline Remap", () => {
 
     expect(model instanceof PhysicalModel).to.be.true;
 
-    const modelId = db.models.insertModel(model);
+    const modelId = db.models.insertModel(model.toJSON());
     expect(Id64.isValidId64(modelId)).to.be.true;
     return modelId;
   }

--- a/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
+++ b/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
@@ -187,7 +187,7 @@ describe("AnalyticalSchema", () => {
       classFullName: TestAnalyticalModel.classFullName,
       modeledElement: { id: analyticalPartitionId },
     });
-    const analyticalModelId: Id64String = iModelDb.models.insertModel(analyticalModel);
+    const analyticalModelId: Id64String = iModelDb.models.insertModel(analyticalModel.toJSON());
     assert.isTrue(Id64.isValidId64(analyticalModelId));
 
     // Create a Test Analytical element

--- a/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
@@ -46,7 +46,7 @@ export class LinearlyReferencedLocation extends ElementMultiAspect {
 /** Concrete multi-aspect class carrying 'at' linearly-referenced positions along a Linear-Element.
  * @beta
  */
-export class LinearlyReferencedAtLocation extends LinearlyReferencedLocation implements LinearlyReferencedAtLocationAspectProps {
+export class LinearlyReferencedAtLocation extends LinearlyReferencedLocation {
   /** @internal */
   public static override get className(): string { return "LinearlyReferencedAtLocation"; }
 
@@ -84,7 +84,7 @@ export class LinearlyReferencedAtLocation extends LinearlyReferencedLocation imp
 /** Concrete multi-aspect class carrying 'from-to' linearly-referenced positions along a Linear-Element.
  * @beta
  */
-export class LinearlyReferencedFromToLocation extends LinearlyReferencedLocation implements LinearlyReferencedFromToLocationAspectProps {
+export class LinearlyReferencedFromToLocation extends LinearlyReferencedLocation {
   /** @internal */
   public static override get className(): string { return "LinearlyReferencedFromToLocation"; }
 

--- a/domains/linear-referencing/backend/src/LinearReferencingElements.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElements.ts
@@ -22,7 +22,7 @@ import {
 /** Base class for Spatial Location Element subclasses representing properties whose value is located along a Linear-Element and only applies to a portion of an Element.
  * @beta
  */
-export abstract class LinearlyLocatedAttribution extends SpatialLocationElement implements LinearlyLocatedAttributionProps, LinearlyLocatedBase {
+export abstract class LinearlyLocatedAttribution extends SpatialLocationElement {
   /** @internal */
   public static override get className(): string { return "LinearlyLocatedAttribution"; }
 
@@ -89,7 +89,7 @@ export class LinearLocation extends LinearLocationElement {
   }
 
   public insertFromTo(iModel: IModelDb, linearElementId: Id64String, fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String {
-    const newId = LinearlyLocated.insertFromTo(iModel, this, linearElementId, fromToPosition);
+    const newId = LinearlyLocated.insertFromTo(iModel, this.toJSON(), linearElementId, fromToPosition);
 
     ILinearLocationLocatesElement.insert(iModel, newId, locatedElementId);
 
@@ -106,7 +106,7 @@ export class LinearLocation extends LinearLocationElement {
   }
 
   public insertAt(iModel: IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String {
-    const newId = LinearlyLocated.insertAt(iModel, this, linearElementId, atPosition);
+    const newId = LinearlyLocated.insertAt(iModel, this.toJSON(), linearElementId, atPosition);
 
     ILinearLocationLocatesElement.insert(iModel, newId, locatedElementId);
 
@@ -129,7 +129,7 @@ export abstract class LinearPhysicalElement extends PhysicalElement {
 /** Spatial Location Element that can play the role of a Referent (known location along a Linear-Element).
  * @beta
  */
-export abstract class ReferentElement extends SpatialLocationElement implements ReferentElementProps, LinearlyLocatedBase {
+export abstract class ReferentElement extends SpatialLocationElement {
   /** @internal */
   public static override get className(): string { return "ReferentElement"; }
 
@@ -177,7 +177,7 @@ export class Referent extends ReferentElement {
   }
 
   public insertAt(iModel: IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps): Id64String {
-    return LinearlyLocated.insertAt(iModel, this, linearElementId, atPosition);
+    return LinearlyLocated.insertAt(iModel, this.toJSON(), linearElementId, atPosition);
   }
 }
 

--- a/domains/linear-referencing/backend/src/test/LinearReferencingSchema.test.ts
+++ b/domains/linear-referencing/backend/src/test/LinearReferencingSchema.test.ts
@@ -117,7 +117,7 @@ describe("LinearReferencing Domain", () => {
       classFullName: PhysicalModel.classFullName,
       modeledElement: { id: physicalPartitionId },
     });
-    const physicalModelId: Id64String = iModelDb.models.insertModel(physicalModel);
+    const physicalModelId: Id64String = iModelDb.models.insertModel(physicalModel.toJSON());
     assert.isTrue(Id64.isValidId64(physicalModelId));
 
     // Create a Test Feature element

--- a/editor/backend/src/EditBuiltInCommand.ts
+++ b/editor/backend/src/EditBuiltInCommand.ts
@@ -42,7 +42,7 @@ export class BasicManipulationCommand extends EditCommand implements BasicManipu
         continue; // Ignore assembly parents w/o geometry, etc...
 
       element.placement.multiplyTransform(transform);
-      this.iModel.elements.updateElement(element);
+      this.iModel.elements.updateElement(element.toJSON());
     }
 
     return IModelStatus.Success;
@@ -64,7 +64,7 @@ export class BasicManipulationCommand extends EditCommand implements BasicManipu
       const transform = Transform.createFixedPointAndMatrix(fixedPoint, matrix);
 
       element.placement.multiplyTransform(transform);
-      this.iModel.elements.updateElement(element);
+      this.iModel.elements.updateElement(element.toJSON());
     }
 
     return IModelStatus.Success;
@@ -93,7 +93,7 @@ export class BasicManipulationCommand extends EditCommand implements BasicManipu
     if (typeof propsOrId === "string") {
       if (undefined === data)
         throw new IModelError(DbResult.BE_SQLITE_ERROR, "Flatbuffer data required for update by id");
-      props = this.iModel.elements.getElement<GeometricElement>(propsOrId);
+      props = this.iModel.elements.getElementProps<GeometricElementProps>(propsOrId);
     } else {
       props = propsOrId;
     }

--- a/example-code/app/src/backend/RobotWorldEngine.ts
+++ b/example-code/app/src/backend/RobotWorldEngine.ts
@@ -84,7 +84,7 @@ export class RobotWorldEngine {
   public static moveRobot(iModelDb: IModelDb, id: Id64String, location: Point3d) {
     const r = iModelDb.elements.getElement<Robot>(id);
     r.placement.origin = location;
-    iModelDb.elements.updateElement(r);
+    iModelDb.elements.updateElement(r.toJSON());
   }
 
   // __PUBLISH_EXTRACT_START__ Element.createGeometricElement3d.example-code

--- a/example-code/snippets/src/backend/WireFormat.test.ts
+++ b/example-code/snippets/src/backend/WireFormat.test.ts
@@ -7,7 +7,7 @@ import { assert, expect } from "chai";
 import { Id64 } from "@itwin/core-bentley";
 import { Angle, AngleSweep, Arc3d, LineString3d, Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { SnapshotDb } from "@itwin/core-backend";
-import { Code, GeometricElement3dProps, GeometryStreamBuilder, IModel, ModelProps, Placement3dProps } from "@itwin/core-common";
+import { Code, GeometricElement3dProps, GeometryStreamBuilder, IModel, Placement3dProps } from "@itwin/core-common";
 import { IModelTestUtils } from "./IModelTestUtils";
 
 /** Example code organized as tests to make sure that it builds and runs successfully.

--- a/example-code/snippets/src/backend/WireFormat.test.ts
+++ b/example-code/snippets/src/backend/WireFormat.test.ts
@@ -54,7 +54,7 @@ describe("Wire Format Snippets", () => {
 
   it("RepositoryModel", () => {
     // __PUBLISH_EXTRACT_START__ WireFormat_RepositoryModel.code
-    const modelProps = iModel.models.getModel(IModel.repositoryModelId) as ModelProps;
+    const modelProps = iModel.models.getModel(IModel.repositoryModelId).toJSON();
     const json = JSON.stringify(modelProps, undefined, 2);
     // __PUBLISH_EXTRACT_END__
     assert.isDefined(modelProps);

--- a/full-stack-tests/backend/src/integration/ChangeSummary.test.ts
+++ b/full-stack-tests/backend/src/integration/ChangeSummary.test.ts
@@ -381,15 +381,15 @@ describe("ChangeSummary", () => {
     iModel.saveChanges("Added test model");
     const categoryId = SpatialCategory.insert(iModel, IModel.dictionaryId, "TestSpatialCategory", new SubCategoryAppearance({ color: ColorDef.fromString("rgb(255,0,0)").toJSON() }));
     iModel.saveChanges("Added test category");
-    const elementId1: Id64String = iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(iModel, modelId, categoryId));
-    const elementId2: Id64String = iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(iModel, modelId, categoryId));
-    const elementId3: Id64String = iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(iModel, modelId, categoryId));
+    const elementId1: Id64String = iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(iModel, modelId, categoryId).toJSON());
+    const elementId2: Id64String = iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(iModel, modelId, categoryId).toJSON());
+    const elementId3: Id64String = iModel.elements.insertElement(IModelTestUtils.createPhysicalObject(iModel, modelId, categoryId).toJSON());
     iModel.saveChanges("Added test elements");
 
     // Setup the hierarchy as element3 -> element1
     const element3 = iModel.elements.getElement(elementId3);
     element3.parent = new ElementOwnsChildElements(elementId1);
-    iModel.elements.updateElement(element3);
+    iModel.elements.updateElement(element3.toJSON());
     iModel.saveChanges("Updated element1 as the parent of element3");
 
     // Push changes to the hub
@@ -397,7 +397,7 @@ describe("ChangeSummary", () => {
 
     // Modify the hierarchy to element3 -> element2
     element3.parent = new ElementOwnsChildElements(elementId2);
-    iModel.elements.updateElement(element3);
+    iModel.elements.updateElement(element3.toJSON());
     iModel.saveChanges("Updated element2 as the parent of element3");
 
     // Push changes to the hub

--- a/full-stack-tests/backend/src/perftest/ElementAspect.test.ts
+++ b/full-stack-tests/backend/src/perftest/ElementAspect.test.ts
@@ -67,7 +67,7 @@ describe("ElementAspectPerformance", () => {
     for (let m = 0; m < count1; ++m) {
       // insert simple element with no aspect
       const startTime1 = new Date().getTime();
-      eleId = iModelDb.elements.insertElement(IModelTestUtils.createPhysicalObject(iModelDb, r.modelId, r.spatialCategoryId));
+      eleId = iModelDb.elements.insertElement(IModelTestUtils.createPhysicalObject(iModelDb, r.modelId, r.spatialCategoryId).toJSON());
       const endTime1 = new Date().getTime();
       const elapsedTime1 = (endTime1 - startTime1) / 1000.0;
       totalTimeInsertSimpELeGet = totalTimeInsertSimpELeGet + elapsedTime1;
@@ -84,7 +84,7 @@ describe("ElementAspectPerformance", () => {
       const startTime2 = new Date().getTime();
       const returnEle1 = iModelDb.elements.getElement(eleId);
       returnEle1.userLabel = `${returnEle1.userLabel}updated`;
-      iModelDb.elements.updateElement(returnEle1);
+      iModelDb.elements.updateElement(returnEle1.toJSON());
       const endTime2 = new Date().getTime();
       const elapsedTime2 = (endTime2 - startTime2) / 1000.0;
       totalTimeUpdateSimpELeGet = totalTimeUpdateSimpELeGet + elapsedTime2;
@@ -111,7 +111,7 @@ describe("ElementAspectPerformance", () => {
     assert.exists(iModelDb);
 
     interface TestAspectProps extends ElementAspectProps { testUniqueAspectProperty: string }
-    class TestAspect extends ElementAspect implements ElementAspectProps { public testUniqueAspectProperty: string = ""; }
+    class TestAspect extends ElementAspect { public testUniqueAspectProperty: string = ""; }
 
     const count1 = 10000;
     let eleId: Id64String;
@@ -126,7 +126,7 @@ describe("ElementAspectPerformance", () => {
     for (let m = 0; m < count1; ++m) {
       // insert element with unique aspect
       const startTime1 = new Date().getTime();
-      eleId = iModelDb.elements.insertElement(IModelTestUtils.createPhysicalObject(iModelDb, r.modelId, r.spatialCategoryId));
+      eleId = iModelDb.elements.insertElement(IModelTestUtils.createPhysicalObject(iModelDb, r.modelId, r.spatialCategoryId).toJSON());
       aspectProps = {
         classFullName: "DgnPlatformTest:TestUniqueAspectNoHandler",
         element: { id: eleId },
@@ -152,10 +152,10 @@ describe("ElementAspectPerformance", () => {
       const startTime2 = new Date().getTime();
       const returnEle2 = iModelDb.elements.getElement(eleId);
       returnEle1.userLabel = `${returnEle1.userLabel}updated`;
-      iModelDb.elements.updateElement(returnEle1);
+      iModelDb.elements.updateElement(returnEle1.toJSON());
       const aspects = iModelDb.elements.getAspects(returnEle2.id, aspectProps.classFullName) as TestAspect[];
       aspects[0].testUniqueAspectProperty = "UniqueAspectInsertTest1-Updated";
-      iModelDb.elements.updateAspect(aspects[0]);
+      iModelDb.elements.updateAspect(aspects[0].toJSON());
       const endTime2 = new Date().getTime();
       const elapsedTime2 = (endTime2 - startTime2) / 1000.0;
       const aspectsUpdated = iModelDb.elements.getAspects(eleId, aspectProps.classFullName) as TestAspect[];
@@ -195,7 +195,7 @@ describe("ElementAspectPerformance", () => {
     for (let m = 0; m < count1; ++m) {
       // insert element with multi aspect
       const startTime1 = new Date().getTime();
-      eleId = iModelDb.elements.insertElement(IModelTestUtils.createPhysicalObject(iModelDb, r.modelId, r.spatialCategoryId));
+      eleId = iModelDb.elements.insertElement(IModelTestUtils.createPhysicalObject(iModelDb, r.modelId, r.spatialCategoryId).toJSON());
       assert.exists(eleId);
       const aspectProps = {
         classFullName: "DgnPlatformTest:TestMultiAspectNoHandler",
@@ -232,10 +232,10 @@ describe("ElementAspectPerformance", () => {
       const startTime2 = new Date().getTime();
       const returnEle2 = iModelDb.elements.getElement(eleId);
       returnEle2.userLabel = `${returnEle2.userLabel}updated`;
-      iModelDb.elements.updateElement(returnEle2);
+      iModelDb.elements.updateElement(returnEle2.toJSON());
       const aspects1: ElementAspect[] = iModelDb.elements.getAspects(returnEle2.id, aspectProps.classFullName);
       (aspects1[foundIndex] as any).testMultiAspectProperty = "MultiAspectInsertTest1-Updated";
-      iModelDb.elements.updateAspect(aspects1[foundIndex]);
+      iModelDb.elements.updateAspect(aspects1[foundIndex].toJSON());
       const endTime2 = new Date().getTime();
       const elapsedTime2 = (endTime2 - startTime2) / 1000.0;
       totalTimeUpdate = totalTimeUpdate + elapsedTime2;

--- a/full-stack-tests/backend/src/perftest/ElementCRUD.test.ts
+++ b/full-stack-tests/backend/src/perftest/ElementCRUD.test.ts
@@ -143,7 +143,7 @@ describe("PerformanceElementsTests", () => {
         for (let m = 0; m < size; ++m) {
           const elementProps = createElemProps(name, seedIModel, newModelId, spatialCategoryId);
           const geomElement = seedIModel.elements.createElement(elementProps);
-          const id = seedIModel.elements.insertElement(geomElement);
+          const id = seedIModel.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert worked");
         }
 
@@ -178,7 +178,7 @@ describe("PerformanceElementsTests", () => {
             const elementProps = createElemProps(name, perfimodel, newModelId, spatialCategoryId);
             const geomElement = perfimodel.elements.createElement(elementProps);
             const startTime = new Date().getTime();
-            const id = perfimodel.elements.insertElement(geomElement);
+            const id = perfimodel.elements.insertElement(geomElement.toJSON());
             const endTime = new Date().getTime();
             assert.isTrue(Id64.isValidId64(id), "insert worked");
             const elapsedTime = (endTime - startTime) / 1000.0;
@@ -295,7 +295,7 @@ describe("PerformanceElementsTests", () => {
             (editElem as any).baseStr = "PerfElement - UpdatedValue";
             editElem.setUserProperties("geom", geometryStream);
             try {
-              perfimodel.elements.updateElement(editElem);
+              perfimodel.elements.updateElement(editElem.toJSON());
             } catch (_err) {
               assert.fail("Element.update failed");
             }
@@ -353,7 +353,7 @@ describe("PerformanceElementsTests2d", () => {
         for (let m = 0; m < size; ++m) {
           const elementProps = createElemProps(name, seedIModel, newModelId, drawingCategoryId);
           const geomElement = seedIModel.elements.createElement(elementProps);
-          const id = seedIModel.elements.insertElement(geomElement);
+          const id = seedIModel.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert worked");
         }
 
@@ -390,7 +390,7 @@ describe("PerformanceElementsTests2d", () => {
             const elementProps = createElemProps(name, perfimodel, newModelId, drawingCategoryId);
             const geomElement = perfimodel.elements.createElement(elementProps);
             const startTime = new Date().getTime();
-            const id = perfimodel.elements.insertElement(geomElement);
+            const id = perfimodel.elements.insertElement(geomElement.toJSON());
             const endTime = new Date().getTime();
             assert.isTrue(Id64.isValidId64(id), "insert worked");
             const elapsedTime = (endTime - startTime) / 1000.0;
@@ -506,7 +506,7 @@ describe("PerformanceElementsTests2d", () => {
             (editElem as any).baseStr = "PerfElement - UpdatedValue";
             editElem.setUserProperties("geom", geometryStream);
             try {
-              perfimodel.elements.updateElement(editElem);
+              perfimodel.elements.updateElement(editElem.toJSON());
             } catch (_err) {
               assert.fail("Element.update failed");
             }

--- a/full-stack-tests/backend/src/perftest/MixinImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/MixinImpact.test.ts
@@ -139,7 +139,7 @@ describe("SchemaDesignPerf Impact of Mixins", () => {
           let elementProps = createElemProps(seedIModel, newModelId, spatialCategoryId, "TestMixinSchema:propElement");
           let geomElement = seedIModel.elements.createElement(elementProps);
           setPropVals(geomElement, propCount);
-          let id = seedIModel.elements.insertElement(geomElement);
+          let id = seedIModel.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert failed");
           // create elements of base upto required level
           for (let j = 0; j < hCount; ++j) {
@@ -147,7 +147,7 @@ describe("SchemaDesignPerf Impact of Mixins", () => {
             elementProps = createElemProps(seedIModel, newModelId, spatialCategoryId, `TestMixinSchema:${className}`);
             geomElement = seedIModel.elements.createElement(elementProps);
             setPropVal(geomElement, `${className}PrimProp`, "AChild Value");
-            id = seedIModel.elements.insertElement(geomElement);
+            id = seedIModel.elements.insertElement(geomElement.toJSON());
             assert.isTrue(Id64.isValidId64(id), "insert failed");
           }
           for (let j = 0; j < hCount; ++j) {
@@ -156,7 +156,7 @@ describe("SchemaDesignPerf Impact of Mixins", () => {
             geomElement = seedIModel.elements.createElement(elementProps);
             setPropVal(geomElement, `${className}PrimProp`, "BChild Value");
             setPropVals(geomElement, propCount, "mixinProp", "Mixin Value");
-            id = seedIModel.elements.insertElement(geomElement);
+            id = seedIModel.elements.insertElement(geomElement.toJSON());
             assert.isTrue(Id64.isValidId64(id), "insert failed");
           }
         }

--- a/full-stack-tests/backend/src/perftest/PolymorphicQuery.test.ts
+++ b/full-stack-tests/backend/src/perftest/PolymorphicQuery.test.ts
@@ -143,7 +143,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
           let elementProps = createElemProps(seedIModel, newModelId, spatialCategoryId, "TestPolySchema:testElement");
           let geomElement = seedIModel.elements.createElement(elementProps);
           setPropVal(geomElement, "propBase", "Base Value");
-          let id = seedIModel.elements.insertElement(geomElement);
+          let id = seedIModel.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert failed");
           // create elements of Child up to required level
           for (let j = 0; j < hCount; ++j) {
@@ -152,7 +152,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
             geomElement = seedIModel.elements.createElement(elementProps);
             setPropVal(geomElement, "propBase", "Base Value");
             setPropVal(geomElement, "propChild", "Child Value");
-            id = seedIModel.elements.insertElement(geomElement);
+            id = seedIModel.elements.insertElement(geomElement.toJSON());
             assert.isTrue(Id64.isValidId64(id), "insert failed");
           }
         }
@@ -180,7 +180,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
         let elementProps = createElemProps(seedIModel2, newModelId, spatialCategoryId, "TestPolySchema:testElement");
         let geomElement = seedIModel2.elements.createElement(elementProps);
         setPropVal(geomElement, "propBase", "Base Value");
-        let id = seedIModel2.elements.insertElement(geomElement);
+        let id = seedIModel2.elements.insertElement(geomElement.toJSON());
         assert.isTrue(Id64.isValidId64(id), "insert failed");
         // create elements of Child up to required level
         for (let j = 0; j < multiHierarchyCount; ++j) {
@@ -189,7 +189,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
           geomElement = seedIModel2.elements.createElement(elementProps);
           setPropVal(geomElement, "propBase", "Base Value");
           setPropVals(geomElement, j + 1, "propChild");
-          id = seedIModel2.elements.insertElement(geomElement);
+          id = seedIModel2.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert failed");
         }
       }

--- a/full-stack-tests/backend/src/perftest/PropertiesImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/PropertiesImpact.test.ts
@@ -107,7 +107,7 @@ describe("SchemaDesignPerf Impact of Properties", () => {
           const elementProps = createElemProps(seedIModel, newModelId, spatialCategoryId);
           const geomElement = seedIModel.elements.createElement(elementProps);
           setPropVals(geomElement, pCount);
-          const id = seedIModel.elements.insertElement(geomElement);
+          const id = seedIModel.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert failed");
         }
         seedIModel.saveChanges();
@@ -138,7 +138,7 @@ describe("SchemaDesignPerf Impact of Properties", () => {
         const geomElement = perfimodel.elements.createElement(elementProps);
         setPropVals(geomElement, propCount);
         const startTime = new Date().getTime();
-        const id = perfimodel.elements.insertElement(geomElement);
+        const id = perfimodel.elements.insertElement(geomElement.toJSON());
         const endTime = new Date().getTime();
         assert.isTrue(Id64.isValidId64(id), "insert failed");
         const elapsedTime = (endTime - startTime) / 1000.0;
@@ -358,7 +358,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
           const elementProps = createElemProps(seedIModel, newModelId, spatialCategoryId, "TestIndexSchema:PropElement");
           const geomElement = seedIModel.elements.createElement(elementProps);
           setPropVals(geomElement, propCounts);
-          const id = seedIModel.elements.insertElement(geomElement);
+          const id = seedIModel.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert failed");
         }
         seedIModel.saveChanges();
@@ -385,7 +385,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
           const elementProps = createElemProps(seedIModel, newModelId, spatialCategoryId, "TestIndexSchema:PropElement0");
           const geomElement = seedIModel.elements.createElement(elementProps);
           setPropVals(geomElement, propCounts);
-          const id = seedIModel.elements.insertElement(geomElement);
+          const id = seedIModel.elements.insertElement(geomElement.toJSON());
           assert.isTrue(Id64.isValidId64(id), "insert failed");
         }
         seedIModel.saveChanges();
@@ -419,7 +419,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
         const geomElement = perfimodel.elements.createElement(elementProps);
         setPropVals(geomElement, propCounts);
         const startTime = new Date().getTime();
-        const id = perfimodel.elements.insertElement(geomElement);
+        const id = perfimodel.elements.insertElement(geomElement.toJSON());
         const endTime = new Date().getTime();
         assert.isTrue(Id64.isValidId64(id), "insert failed");
         const elapsedTime = (endTime - startTime) / 1000.0;
@@ -447,7 +447,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
         const geomElement = perfimodel.elements.createElement(elementProps);
         setPropVals(geomElement, propCounts);
         const startTime = new Date().getTime();
-        const id = perfimodel.elements.insertElement(geomElement);
+        const id = perfimodel.elements.insertElement(geomElement.toJSON());
         const endTime = new Date().getTime();
         assert.isTrue(Id64.isValidId64(id), "insert failed");
         const elapsedTime = (endTime - startTime) / 1000.0;

--- a/full-stack-tests/backend/src/perftest/RelationshipImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/RelationshipImpact.test.ts
@@ -112,7 +112,7 @@ describe("SchemaDesignPerf Relationship Comparison", () => {
     setPropVal(geomElement, "propBase", "Test Value");
     const cType: string = cName.substring(cName.length - 1);
     setPropVal(geomElement, `propChild${cType}`, `${cType} Value`);
-    const id = imodel.elements.insertElement(geomElement);
+    const id = imodel.elements.insertElement(geomElement.toJSON());
     assert.isTrue(Id64.isValidId64(id), "insert failed");
     return id;
   }
@@ -178,7 +178,7 @@ describe("SchemaDesignPerf Relationship Comparison", () => {
         const geomElement = seedIModel.elements.createElement(elementProps);
         setPropVal(geomElement, "propBase", "Test Value");
         setPropVal(geomElement, "propChildA", "A Value");
-        const id3 = seedIModel.elements.insertElement(geomElement);
+        const id3 = seedIModel.elements.insertElement(geomElement.toJSON());
         assert.isTrue(Id64.isValidId64(id3), "insert failed");
 
         validateRel(seedIModel, idC, idD);
@@ -228,7 +228,7 @@ describe("SchemaDesignPerf Relationship Comparison", () => {
       const geomElement = perfimodel.elements.createElement(elementProps);
       setPropVal(geomElement, "propBase", "Test Value");
       setPropVal(geomElement, "propChildA", "A Value");
-      const idA = perfimodel.elements.insertElement(geomElement);
+      const idA = perfimodel.elements.insertElement(geomElement.toJSON());
       assert.isTrue(Id64.isValidId64(idA), "insert failed");
       const endTime1 = new Date().getTime();
       totalTimeNav = totalTimeNav + ((endTime1 - startTime1) / 1000.0);

--- a/full-stack-tests/core/src/backend/backend.ts
+++ b/full-stack-tests/core/src/backend/backend.ts
@@ -67,7 +67,7 @@ class FullStackTestIpcHandler extends IpcHandler implements FullStackTestIpc {
   public async createAndInsertSpatialCategory(key: string, scopeModelId: Id64String, categoryName: string, appearance: SubCategoryAppearance.Props): Promise<Id64String> {
     const iModelDb = IModelDb.findByKey(key);
     const category = SpatialCategory.create(iModelDb, scopeModelId, categoryName);
-    const categoryId = iModelDb.elements.insertElement(category.toJSON());
+    const categoryId = category.insert();
     category.setDefaultAppearance(appearance);
     return categoryId;
   }

--- a/full-stack-tests/core/src/backend/backend.ts
+++ b/full-stack-tests/core/src/backend/backend.ts
@@ -53,7 +53,7 @@ class FullStackTestIpcHandler extends IpcHandler implements FullStackTestIpc {
       code: newModelCode,
     };
     const modeledElement = iModelDb.elements.createElement(modeledElementProps);
-    return iModelDb.elements.insertElement(modeledElement);
+    return iModelDb.elements.insertElement(modeledElement.toJSON());
   }
 
   public async createAndInsertPhysicalModel(key: string, newModelCode: CodeProps): Promise<Id64String> {
@@ -61,13 +61,13 @@ class FullStackTestIpcHandler extends IpcHandler implements FullStackTestIpc {
     const eid = await FullStackTestIpcHandler.createAndInsertPartition(iModelDb, newModelCode);
     const modeledElementRef = new RelatedElement({ id: eid });
     const newModel = iModelDb.models.createModel({ modeledElement: modeledElementRef, classFullName: PhysicalModel.classFullName, isPrivate: false });
-    return iModelDb.models.insertModel(newModel);
+    return iModelDb.models.insertModel(newModel.toJSON());
   }
 
   public async createAndInsertSpatialCategory(key: string, scopeModelId: Id64String, categoryName: string, appearance: SubCategoryAppearance.Props): Promise<Id64String> {
     const iModelDb = IModelDb.findByKey(key);
     const category = SpatialCategory.create(iModelDb, scopeModelId, categoryName);
-    const categoryId = iModelDb.elements.insertElement(category);
+    const categoryId = iModelDb.elements.insertElement(category.toJSON());
     category.setDefaultAppearance(appearance);
     return categoryId;
   }

--- a/full-stack-tests/presentation/src/backend/RulesetsEmbedding.test.ts
+++ b/full-stack-tests/presentation/src/backend/RulesetsEmbedding.test.ts
@@ -120,7 +120,7 @@ describe("RulesEmbedding", () => {
 
     const rulesetElement = imodel.elements.getElement(insertId);
     rulesetElement.setJsonProperty("id", faker.random.uuid());
-    imodel.elements.updateElement(rulesetElement);
+    imodel.elements.updateElement(rulesetElement.toJSON());
 
     rootNodes = await Presentation.getManager().getNodes({ imodel, rulesetOrId: RULESET_1.id });
     expect(rootNodes.length).to.be.equal(1);

--- a/presentation/backend/src/test/SelectionScopesHelper.test.ts
+++ b/presentation/backend/src/test/SelectionScopesHelper.test.ts
@@ -398,7 +398,7 @@ describe("SelectionScopesHelper", () => {
           model: model.id!,
           category: createRandomId(),
           code: { scope: faker.random.word(), spec: faker.random.word() },
-        }, imodelMock.object);
+        }, imodelMock.object).toJSON();
         elementsMock.setup((x) => x.tryGetElementProps(elementId)).returns(() => element);
         modelsMock.setup((x) => x.tryGetModelProps(model.id!)).returns(() => model);
 
@@ -423,7 +423,7 @@ describe("SelectionScopesHelper", () => {
           model: modelId,
           category: createRandomId(),
           code: { scope: faker.random.word(), spec: faker.random.word() },
-        }, imodelMock.object);
+        }, imodelMock.object).toJSON();
         elementsMock.setup((x) => x.tryGetElementProps(elementId)).returns(() => element);
         modelsMock.setup((x) => x.tryGetModelProps(modelId)).returns(() => undefined);
 
@@ -440,7 +440,7 @@ describe("SelectionScopesHelper", () => {
           model: model.id!,
           category: createRandomId(),
           code: { scope: faker.random.word(), spec: faker.random.word() },
-        }, imodelMock.object);
+        }, imodelMock.object).toJSON();
         elementsMock.setup((x) => x.tryGetElementProps(elementId)).returns(() => element);
         modelsMock.setup((x) => x.tryGetModelProps(model.id!)).returns(() => model);
 

--- a/test-apps/imodel-from-geojson/src/GeoJsonImporter.ts
+++ b/test-apps/imodel-from-geojson/src/GeoJsonImporter.ts
@@ -108,7 +108,7 @@ export class GeoJsonImporter {
     this.iModelDb.views.iterateViews({ from: "BisCore.SpatialViewDefinition" }, ((view: ViewDefinition) => {
       const categorySelector = this.iModelDb.elements.getElement<CategorySelector>(view.categorySelectorId);
       categorySelector.categories.push(categoryId);
-      this.iModelDb.elements.updateElement(categorySelector);
+      this.iModelDb.elements.updateElement(categorySelector.toJSON());
 
       return true;
     }));


### PR DESCRIPTION
Far too many bugs result from people passing an instance of a subclass of Entity to functions expecting an EntityProps.
In most cases, while those two base types are compatible the types derived from each (e.g., SubCategory and SubCategoryProps) are not compatible.
Functions like `insertElement` and `updateElement` call `toJSON` if the input is an Element instead of an ElementProps. Bugs ensue if subclasses fail to implement toJSON.

Add a discriminator field `isInstanceOfEntity` to Entity and EntityProps, with incompatible types (`true` vs `never | undefined`).
Adjust all code that was previously relying on type compatibility to explicitly call `toJSON`.

This is a breaking API change affecting only backend code. It is extremely useful for detecting bugs in existing code.