### PR TITLE
temporarily skip a new audit error

### DIFF
--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -43,7 +43,9 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-33f9-j839-rf8h", // https://github.com/advisories/GHSA-33f9-j839-rf8h.
     "GHSA-c36v-fmgq-m8hx", // https://github.com/advisories/GHSA-c36v-fmgq-m8hx.
     "GHSA-4jqc-8m5r-9rpr", // https://github.com/advisories/GHSA-4jqc-8m5r-9rpr.
-    "GHSA-whgm-jr23-g3j9", // https://github.com/advisories/GHSA-whgm-jr23-g3j9.
+    "GHSA-whgm-jr23-g3j9", // https://github.com/advisories/GHSA-whgm-jr23-g3j9
+    "GHSA-5v2h-r2cx-5xgj", // https://github.com/advisories/GHSA-5v2h-r2cx-5xgj.
+    "GHSA-rrrm-qjm4-v8hf", // https://github.com/advisories/GHSA-rrrm-qjm4-v8hf
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
The new audit error is with a dev dependency of our build-tools package for typedoc. @williamkbentley is look into it and hopefully will have a fix soon. In the meantime, ignore the audit issue to allow PRs.