### PR TITLE
Test rush change -v

### DIFF
--- a/core/common/src/Gradient.ts
+++ b/core/common/src/Gradient.ts
@@ -96,6 +96,8 @@ export namespace Gradient {
     public thematicSettings?: ThematicGradientSettings;
     public keys: KeyColor[] = [];
 
+    public get tintPlusShift(): number { return this.shift + (this.tint ?? 42); }
+
     /** create a GradientSymb from a json object. */
     public static fromJSON(json?: SymbProps) {
       const result = new Symb();


### PR DESCRIPTION
Ignore - testing.
On #3062, `rush change -v` did not produce an error in the CI job, but did when run locally.
Testing this PR to see if CI job produces error on `rush change -v`. Running locally does.