### PR TITLE
move `ProgressInfo` & `ProgressCallback` into common

### DIFF
--- a/clients/imodelhub/src/IModelHubBackend.ts
+++ b/clients/imodelhub/src/IModelHubBackend.ts
@@ -8,7 +8,6 @@
 
 import { join } from "path";
 import { UserCancelledError } from "./itwin-client/FileHandler";
-import { ProgressCallback, ProgressInfo } from "./itwin-client/Request";
 import {
   AcquireNewBriefcaseIdArg, BackendHubAccess, BriefcaseDbArg, BriefcaseIdArg, BriefcaseLocalValue, BriefcaseManager, ChangesetArg, ChangesetRangeArg, CheckpointArg,
   CheckpointProps, CreateNewIModelProps, IModelDb, IModelHost, IModelIdArg, IModelJsFs, IModelNameArg, ITwinIdArg, LockMap, LockProps, LockState, SnapshotDb, TokenArg,
@@ -16,7 +15,7 @@ import {
 } from "@itwin/core-backend";
 import { BentleyError, BriefcaseStatus, GuidString, Id64String, IModelHubStatus, IModelStatus, Logger, OpenMode } from "@itwin/core-bentley";
 import {
-  BriefcaseIdValue, ChangesetFileProps, ChangesetId, ChangesetIndex, ChangesetIndexAndId, ChangesetProps, CodeProps, IModelError, IModelVersion, LocalDirName,
+  BriefcaseIdValue, ChangesetFileProps, ChangesetId, ChangesetIndex, ChangesetIndexAndId, ChangesetProps, CodeProps, IModelError, IModelVersion, LocalDirName, ProgressCallback, ProgressInfo,
 } from "@itwin/core-common";
 import { IModelBankClient } from "./imodelbank/IModelBankClient";
 import { IModelClient } from "./IModelClient";

--- a/clients/imodelhub/src/imodelhub/Briefcases.ts
+++ b/clients/imodelhub/src/imodelhub/Briefcases.ts
@@ -8,7 +8,6 @@
 
 import { AccessToken, GuidString, IModelHubStatus, Logger } from "@itwin/core-bentley";
 import { CancelRequest, FileHandler } from "../itwin-client/FileHandler";
-import { ProgressCallback } from "../itwin-client/Request";
 import { IModelClient } from "../IModelClient";
 import { IModelHubClientLoggerCategory } from "../IModelHubClientLoggerCategories";
 import { ECJsonTypeMap, WsgInstance } from "../wsg/ECJsonTypeMap";
@@ -17,6 +16,7 @@ import { IModelBaseHandler } from "./BaseHandler";
 import { ArgumentCheck, IModelHubClientError, IModelHubError } from "./Errors";
 import { addSelectApplicationData, addSelectFileAccessKey } from "./HubQuery";
 import { LockQuery } from "./Locks";
+import { ProgressCallback } from "@itwin/core-common";
 
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 

--- a/clients/imodelhub/src/imodelhub/ChangeSets.ts
+++ b/clients/imodelhub/src/imodelhub/ChangeSets.ts
@@ -8,13 +8,14 @@
 
 import { AccessToken, GuidString, Logger } from "@itwin/core-bentley";
 import { DownloadFailed, FileHandler, SasUrlExpired } from "../itwin-client/FileHandler";
-import { ProgressCallback, ProgressInfo, RequestQueryOptions } from "../itwin-client/Request";
+import { RequestQueryOptions } from "../itwin-client/Request";
 import { ECJsonTypeMap, WsgInstance } from "../wsg/ECJsonTypeMap";
 import { ChunkedQueryContext } from "../wsg/ChunkedQueryContext";
 import { IModelHubClientLoggerCategory } from "../IModelHubClientLoggerCategories";
 import { IModelBaseHandler } from "./BaseHandler";
 import { ArgumentCheck, IModelHubClientError } from "./Errors";
 import { addSelectApplicationData, addSelectFileAccessKey, StringIdQuery } from "./HubQuery";
+import { ProgressCallback, ProgressInfo } from "@itwin/core-common";
 
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 

--- a/clients/imodelhub/src/imodelhub/Checkpoints.ts
+++ b/clients/imodelhub/src/imodelhub/Checkpoints.ts
@@ -8,7 +8,6 @@
 
 import { AccessToken, GuidString, Logger, PerfLogger } from "@itwin/core-bentley";
 import { CancelRequest, FileHandler } from "../itwin-client/FileHandler";
-import { ProgressCallback } from "../itwin-client/Request";
 import { IModelHubClientLoggerCategory } from "../IModelHubClientLoggerCategories";
 import { ECJsonTypeMap, WsgInstance } from "../wsg/ECJsonTypeMap";
 import { WsgQuery } from "../wsg/WsgQuery";
@@ -16,6 +15,7 @@ import { IModelBaseHandler } from "./BaseHandler";
 import { ArgumentCheck, IModelHubClientError } from "./Errors";
 import { addSelectFileAccessKey } from "./HubQuery";
 import { InitializationState } from "./iModels";
+import { ProgressCallback } from "@itwin/core-common";
 
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 

--- a/clients/imodelhub/src/imodelhub/iModels.ts
+++ b/clients/imodelhub/src/imodelhub/iModels.ts
@@ -9,12 +9,12 @@
 import deepAssign from "deep-assign";
 import { AccessToken, BentleyError, GuidString, IModelHubStatus, Logger } from "@itwin/core-bentley";
 import { FileHandler } from "../itwin-client/FileHandler";
-import { ProgressCallback } from "../itwin-client/Request";
 import { ECJsonTypeMap, WsgInstance } from "../wsg/ECJsonTypeMap";
 import { IModelHubClientLoggerCategory } from "../IModelHubClientLoggerCategories";
 import { IModelBaseHandler } from "./BaseHandler";
 import { ArgumentCheck, IModelHubClientError, IModelHubError } from "./Errors";
 import { addSelectFileAccessKey, InstanceIdQuery } from "./HubQuery";
+import { ProgressCallback } from "@itwin/core-common";
 
 const loggerCategory: string = IModelHubClientLoggerCategory.IModelHub;
 

--- a/clients/imodelhub/src/itwin-client/AzureFileHandler.ts
+++ b/clients/imodelhub/src/itwin-client/AzureFileHandler.ts
@@ -15,12 +15,13 @@ import { Transform, TransformCallback } from "stream";
 import {
   CancelRequest, DownloadFailed, FileHandler, SasUrlExpired, UserCancelledError,
 } from "./FileHandler";
-import { ProgressCallback, ProgressInfo, request, RequestOptions } from "./Request";
+import { request, RequestOptions } from "./Request";
 import { AccessToken, Logger } from "@itwin/core-bentley";
 import { ArgumentCheck } from "../imodelhub/Errors";
 import { IModelHubClientLoggerCategory } from "../IModelHubClientLoggerCategories";
 import { AzCopy, InitEventArgs, ProgressEventArgs, StringEventArgs } from "./AzCopy";
 import { BlobDownloader, ConfigData, ProgressData } from "./BlobDownloader";
+import { ProgressCallback, ProgressInfo } from "@itwin/core-common";
 
 const loggerCategory: string = IModelHubClientLoggerCategory.FileHandlers;
 

--- a/clients/imodelhub/src/itwin-client/FileHandler.ts
+++ b/clients/imodelhub/src/itwin-client/FileHandler.ts
@@ -7,7 +7,7 @@
  */
 import * as https from "https";
 import { AccessToken, BentleyError, GetMetaDataFunction } from "@itwin/core-bentley";
-import { ProgressCallback } from "./Request";
+import { ProgressCallback } from "@itwin/core-common";
 
 /** Interface to cancel a request
   * @beta

--- a/clients/imodelhub/src/itwin-client/LocalhostFileHandler.ts
+++ b/clients/imodelhub/src/itwin-client/LocalhostFileHandler.ts
@@ -11,9 +11,9 @@ import * as https from "https";
 import * as pathLib from "path";
 import * as url from "url";
 import { AccessToken, Logger } from "@itwin/core-bentley";
-import { ProgressCallback } from "./Request";
 import { FileHandler } from "../itwin-client/FileHandler";
 import { IModelHubClientLoggerCategory } from "../IModelHubClientLoggerCategories";
+import { ProgressCallback } from "@itwin/core-common";
 
 const loggerCategory: string = IModelHubClientLoggerCategory.FileHandlers;
 

--- a/clients/imodelhub/src/itwin-client/Request.ts
+++ b/clients/imodelhub/src/itwin-client/Request.ts
@@ -12,6 +12,7 @@ import { IStringifyOptions, stringify } from "qs";
 import * as sarequest from "superagent";
 import { BentleyError, GetMetaDataFunction, HttpStatus, Logger, LogLevel } from "@itwin/core-bentley";
 import { IModelHubClientLoggerCategory } from "../IModelHubClientLoggerCategories";
+import { ProgressCallback } from "@itwin/core-common";
 
 const loggerCategory: string = IModelHubClientLoggerCategory.Request;
 
@@ -121,16 +122,6 @@ export interface Response {
   header: any; // Parsed headers of response
   status: number; // Status code of response
 }
-
-/** @internal */
-export interface ProgressInfo {
-  percent?: number;
-  total?: number;
-  loaded: number;
-}
-
-/** @internal */
-export type ProgressCallback = (progress: ProgressInfo) => void;
 
 /** @internal */
 export class RequestGlobalOptions {

--- a/clients/imodelhub/src/itwin-client/UrlFileHandler.ts
+++ b/clients/imodelhub/src/itwin-client/UrlFileHandler.ts
@@ -12,9 +12,9 @@ import * as https from "https";
 import * as path from "path";
 import { URL } from "url";
 import { CancelRequest, FileHandler } from "../itwin-client/FileHandler";
-import { ProgressCallback } from "./Request";
 import { downloadFileAtomic } from "./downloadFileAtomic";
 import { AccessToken } from "@itwin/core-bentley";
+import { ProgressCallback } from "@itwin/core-common";
 
 /**
  * Provides methods to upload and download files from the Internet

--- a/clients/imodelhub/src/itwin-client/downloadFileAtomic.ts
+++ b/clients/imodelhub/src/itwin-client/downloadFileAtomic.ts
@@ -6,11 +6,12 @@ import got from "got";
 import { PassThrough, pipeline as pipeline_callback } from "stream";
 import { promisify } from "util";
 import { BriefcaseStatus } from "@itwin/core-bentley";
-import { ProgressCallback, ResponseError } from "./Request";
+import { ResponseError } from "./Request";
 import { CancelRequest, DownloadFailed, UserCancelledError } from "../itwin-client/FileHandler";
 import { BufferedStream } from "./AzureFileHandler";
 
 import WriteStreamAtomic from "fs-write-stream-atomic";
+import { ProgressCallback } from "@itwin/core-common";
 
 const pipeline = promisify(pipeline_callback);
 

--- a/clients/imodelhub/src/test/FileHandlers.test.ts
+++ b/clients/imodelhub/src/test/FileHandlers.test.ts
@@ -9,9 +9,9 @@ import * as fs from "fs-extra";
 import nock from "nock";
 import * as path from "path";
 import { AsyncMutex, BeEvent } from "@itwin/core-bentley";
-import { ProgressInfo } from "../itwin-client/Request";
 import { CancelRequest } from "../itwin-client/FileHandler";
 import { AzureFileHandler } from "../itwin-client/AzureFileHandler";
+import { ProgressInfo } from "@itwin/core-common";
 
 const testValidUrl = "https://example.com/";
 const testErrorUrl = "http://bad.example.com/";  // NB: This is not automatically mocked - each test should use nock as-needed.

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -6205,10 +6205,10 @@ export enum ProfileOptions {
     Upgrade = 1
 }
 
-// @public
+// @public (undocumented)
 export type ProgressCallback = (progress: ProgressInfo) => void;
 
-// @public
+// @public (undocumented)
 export interface ProgressInfo {
     // (undocumented)
     loaded: number;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -6206,6 +6206,19 @@ export enum ProfileOptions {
 }
 
 // @public
+export type ProgressCallback = (progress: ProgressInfo) => void;
+
+// @public
+export interface ProgressInfo {
+    // (undocumented)
+    loaded: number;
+    // (undocumented)
+    percent?: number;
+    // (undocumented)
+    total?: number;
+}
+
+// @public
 export class Projection implements ProjectionProps {
     constructor(_data?: ProjectionProps);
     readonly affine?: AffineTransform;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -212,6 +212,7 @@ import { PolylineEdgeArgs } from '@itwin/core-common';
 import { PolylineFlags } from '@itwin/core-common';
 import { PolylineTypeFlags } from '@itwin/core-common';
 import { PrimaryTileTreeId } from '@itwin/core-common';
+import { ProgressCallback } from '@itwin/core-common';
 import { PromiseReturnType } from '@itwin/core-bentley';
 import { PropertyDescription } from '@itwin/appui-abstract';
 import { QParams2d } from '@itwin/core-common';

--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -14,6 +14,7 @@ import * as https from 'https';
 import { IModelAppOptions } from '@itwin/core-frontend';
 import { NativeAppOpts } from '@itwin/core-frontend';
 import { NativeHostOpts } from '@itwin/core-backend';
+import { ProgressCallback } from '@itwin/core-common';
 import { PromiseReturnType } from '@itwin/core-bentley';
 import { RpcConfiguration } from '@itwin/core-common';
 import { RpcEndpoint } from '@itwin/core-common';

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -502,6 +502,8 @@ internal;PrimaryTileTreeId
 beta;PrimitiveTypeCode
 public;PriorityPlanarClipMaskArgs 
 beta;ProfileOptions
+public;ProgressCallback = (progress: ProgressInfo) => void
+public;ProgressInfo
 public;Projection 
 public;ProjectionMethod = "None" | "TransverseMercator" | "SouthOrientedTransverseMercator" | "TransverseMercatorWisconsin" | "TransverseMercatorMinnesota" | "TransverseMercatorAffine" | "MercatorStandardParallel" | "Mercator" | "UniversalTransverseMercator" | "LambertConformalConicTwoParallels" | "LambertConformalConicBelgium" | "LambertConformalConicAffine" | "LambertConformalConicWisconsin" | "LambertConformalConicMinnesota" | "LambertConformalConicMichigan" | "LambertConformalConicOneParallel" | "AlbersEqualArea" | "NewZealandNationalGrid" | "ObliqueMercator1" | "ObliqueMercator2" | "TransverseMercatorOSTN97" | "TransverseMercatorOSTN02" | "TransverseMercatorOSTN15" | "Krovak" | "KrovakModified" | "ObliqueCylindricalSwiss" | "TransverseMercatorDenmarkSystem34" | "TransverseMercatorDenmarkSystem3499" | "TransverseMercatorDenmarkSystem3401" | "Cassini" | "Sinusoidal" | "VanDerGrinten" | "Bonne" | "Mollweide" | "EckertIV" | "EckertVI" | "GoodeHomolosine" | "Robinson" | "PlateCarree" | "MillerCylindrical" | "WinkelTripel" | "AzimuthalEqualArea" | "ObliqueStereographic" | "RectifiedSkewOrthomorphicCentered" | "RectifiedSkewOrthomorphicOrigin" | "ObliqueCylindricalHungary" | "Orthographic" | "AmericanPolyconic" | "LambertEquidistantAzimuthal" | "ObliqueMercatorMinnesota"
 public;ProjectionProps

--- a/common/changes/@bentley/imodelbank-client/export-progress-info_2022-01-20-02-27.json
+++ b/common/changes/@bentley/imodelbank-client/export-progress-info_2022-01-20-02-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodelbank-client",
+      "comment": "use ProgressInfo and ProgressCallback from core-common",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodelbank-client"
+}

--- a/common/changes/@itwin/core-common/export-progress-info_2022-01-20-02-27.json
+++ b/common/changes/@itwin/core-common/export-progress-info_2022-01-20-02-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Add ProgressInfo and ProgressCallback",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/export-progress-info_2022-01-20-02-27.json
+++ b/common/changes/@itwin/core-frontend/export-progress-info_2022-01-20-02-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "use ProgressInfo and ProgressCallback from core-common",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-mobile/export-progress-info_2022-01-20-02-27.json
+++ b/common/changes/@itwin/core-mobile/export-progress-info_2022-01-20-02-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "use ProgressInfo and ProgressCallback from core-common",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/common/src/Request.ts
+++ b/core/common/src/Request.ts
@@ -3,12 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-/** @@public */
+/** @public */
 export interface ProgressInfo {
   percent?: number;
   total?: number;
   loaded: number;
 }
 
-/** @@public */
+/** @public */
 export type ProgressCallback = (progress: ProgressInfo) => void;

--- a/core/common/src/Request.ts
+++ b/core/common/src/Request.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+export interface ProgressInfo {
+  percent?: number;
+  total?: number;
+  loaded: number;
+}
+
+export type ProgressCallback = (progress: ProgressInfo) => void;

--- a/core/common/src/Request.ts
+++ b/core/common/src/Request.ts
@@ -2,10 +2,13 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
+/** @@public */
 export interface ProgressInfo {
   percent?: number;
   total?: number;
   loaded: number;
 }
 
+/** @@public */
 export type ProgressCallback = (progress: ProgressInfo) => void;

--- a/core/common/src/core-common.ts
+++ b/core/common/src/core-common.ts
@@ -91,6 +91,7 @@ export * from "./Render";
 export * from "./RenderMaterial";
 export * from "./RenderSchedule";
 export * from "./RenderTexture";
+export * from "./Request";
 export * from "./RgbColor";
 export * from "./rpc/core/RpcConfiguration";
 export * from "./rpc/DevToolsRpcInterface";

--- a/core/frontend/src/NativeApp.ts
+++ b/core/frontend/src/NativeApp.ts
@@ -12,10 +12,11 @@ import {
   nativeAppChannel, NativeAppFunctions, NativeAppNotifications, nativeAppNotify, OverriddenBy,
   RequestNewBriefcaseProps, StorageValue, SyncMode,
 } from "@itwin/core-common";
-import { ProgressCallback, RequestGlobalOptions } from "./request/Request";
+import { RequestGlobalOptions } from "./request/Request";
 import { FrontendLoggerCategory } from "./FrontendLoggerCategory";
 import { IpcApp, IpcAppOptions, NotificationHandler } from "./IpcApp";
 import { NativeAppLogger } from "./NativeAppLogger";
+import { ProgressCallback } from "@itwin/core-common";
 
 /** Properties for specifying the BriefcaseId for downloading. May either specify a BriefcaseId directly (preferable) or, for
  * backwards compatibility, a [SyncMode]($common). If [SyncMode.PullAndPush]($common) is supplied, a new briefcaseId will be acquired.

--- a/core/frontend/src/request/Request.ts
+++ b/core/frontend/src/request/Request.ts
@@ -12,6 +12,7 @@ import { IStringifyOptions, stringify } from "qs";
 import * as sarequest from "superagent";
 import { BentleyError, GetMetaDataFunction, HttpStatus, Logger, LogLevel } from "@itwin/core-bentley";
 import { FrontendLoggerCategory } from "../FrontendLoggerCategory";
+import { ProgressCallback } from "@itwin/core-common";
 
 const loggerCategory: string = FrontendLoggerCategory.Request;
 
@@ -121,16 +122,6 @@ export interface Response {
   header: any; // Parsed headers of response
   status: number; // Status code of response
 }
-
-/** @internal */
-export interface ProgressInfo {
-  percent?: number;
-  total?: number;
-  loaded: number;
-}
-
-/** @internal */
-export type ProgressCallback = (progress: ProgressInfo) => void;
 
 /** @internal */
 export class RequestGlobalOptions {

--- a/core/mobile/src/backend/MobileFileHandler.ts
+++ b/core/mobile/src/backend/MobileFileHandler.ts
@@ -10,9 +10,10 @@ import * as fs from "fs";
 import * as https from "https";
 import * as path from "path";
 import { AccessToken, BentleyError, GetMetaDataFunction, Logger } from "@itwin/core-bentley";
-import { ProgressCallback, ProgressInfo, request, RequestOptions } from "./Request";
+import { request, RequestOptions } from "./Request";
 import { MobileHost } from "./MobileHost";
 import { Base64 } from "js-base64";
+import { ProgressCallback, ProgressInfo } from "@itwin/core-common";
 
 const loggerCategory: string = "mobile.filehandler";
 

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -10,13 +10,13 @@ import {
   SnapshotIModelRpcInterface,
 } from "@itwin/core-common";
 import { CancelRequest, DownloadFailed, UserCancelledError } from "./MobileFileHandler";
-import { ProgressCallback } from "./Request";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { mobileAppChannel } from "../common/MobileAppChannel";
 import { BatteryState, DeviceEvents,  MobileAppFunctions, Orientation } from "../common/MobileAppProps";
 import { MobileRpcManager } from "../common/MobileRpcManager";
 import { MobileAppAuthorizationConfiguration } from "./MobileAuthorizationBackend";
 import { setupMobileRpc } from "./MobileRpcServer";
+import { ProgressCallback } from "@itwin/core-common";
 
 /** @beta */
 export type MobileCompletionCallback = (downloadUrl: string, downloadFileUrl: string, cancelled: boolean, err?: string) => void;

--- a/core/mobile/src/backend/Request.ts
+++ b/core/mobile/src/backend/Request.ts
@@ -11,6 +11,7 @@ import * as https from "https";
 import { IStringifyOptions, stringify } from "qs";
 import * as sarequest from "superagent";
 import { BentleyError, GetMetaDataFunction, HttpStatus, Logger, LogLevel } from "@itwin/core-bentley";
+import { ProgressCallback } from "@itwin/core-common";
 
 const loggerCategory: string = "core-mobile-backend.Request";
 
@@ -110,16 +111,6 @@ export interface Response {
   header: any; // Parsed headers of response
   status: number; // Status code of response
 }
-
-/** @internal */
-export interface ProgressInfo {
-  percent?: number;
-  total?: number;
-  loaded: number;
-}
-
-/** @internal */
-export type ProgressCallback = (progress: ProgressInfo) => void;
 
 /** Error object that's thrown/rejected if the Request fails due to a network error, or if the status is *not* in the range of 200-299 (inclusive)
  * @internal

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -22,7 +22,7 @@ import {
 } from "@itwin/appui-react";
 import { BeDragDropContext } from "@itwin/components-react";
 import { Id64String, Logger, LogLevel, ProcessDetector, UnexpectedErrors } from "@itwin/core-bentley";
-import { BentleyCloudRpcManager, BentleyCloudRpcParams, IModelVersion, RpcConfiguration, SyncMode } from "@itwin/core-common";
+import { BentleyCloudRpcManager, BentleyCloudRpcParams, IModelVersion, ProgressInfo, RpcConfiguration, SyncMode } from "@itwin/core-common";
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { ElectronRendererAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronRenderer";
 import {
@@ -153,12 +153,6 @@ interface SampleIModelParams {
   iModelId: string;
   viewIds?: string[];
   stageId?: string;
-}
-
-interface ProgressInfo {
-  percent?: number;
-  total?: number;
-  loaded: number;
 }
 
 export class SampleAppIModelApp {


### PR DESCRIPTION
These were originally a part of the now-removed itwin-client. They were moved into each consuming pkg as a local internal implementation. Moved them into core-common for re-use and marked as public (this part is debateable). need to backport this into the release/3.0 branch