### PR TITLE
Reinstate implementations of LinearlyLocatedBase.

### DIFF
--- a/common/api/linear-referencing-backend.api.md
+++ b/common/api/linear-referencing-backend.api.md
@@ -79,7 +79,7 @@ export class LinearElement {
 }
 
 // @beta
-export class LinearLocation extends LinearLocationElement {
+export class LinearLocation extends LinearLocationElement implements LinearlyLocatedBase {
     constructor(props: GeometricElement3dProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;
@@ -258,7 +258,7 @@ export class Referent extends ReferentElement {
     }
 
 // @beta
-export abstract class ReferentElement extends SpatialLocationElement {
+export abstract class ReferentElement extends SpatialLocationElement implements LinearlyLocatedBase {
     constructor(props: ReferentElementProps, iModel: IModelDb);
     // @internal (undocumented)
     static get className(): string;

--- a/common/changes/@itwin/linear-referencing-backend/reinstate-linearly-located-base-impl_2022-01-25-12-07.json
+++ b/common/changes/@itwin/linear-referencing-backend/reinstate-linearly-located-base-impl_2022-01-25-12-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/linear-referencing-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-backend"
+}

--- a/domains/linear-referencing/backend/src/LinearReferencingElements.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElements.ts
@@ -57,7 +57,7 @@ export abstract class LinearLocationElement extends SpatialLocationElement imple
 /** Linear Referencing Location attached to an Element not inherently Linearly Referenced.
  * @beta
  */
-export class LinearLocation extends LinearLocationElement {
+export class LinearLocation extends LinearLocationElement implements LinearlyLocatedBase {
   /** @internal */
   public static override get className(): string { return "LinearLocation"; }
   public constructor(props: GeometricElement3dProps, iModel: IModelDb) {
@@ -129,7 +129,7 @@ export abstract class LinearPhysicalElement extends PhysicalElement {
 /** Spatial Location Element that can play the role of a Referent (known location along a Linear-Element).
  * @beta
  */
-export abstract class ReferentElement extends SpatialLocationElement {
+export abstract class ReferentElement extends SpatialLocationElement implements LinearlyLocatedBase {
   /** @internal */
   public static override get className(): string { return "ReferentElement"; }
 


### PR DESCRIPTION
#3052 erroneously removed "implements LinearlyLocatedBase" when removing implementations of ElementProps.
This has no functional impact but explicit interface implementations provide better type-checking and clear documentation.