### PR TITLE
Make it easier to sketch on faces of solids.

### DIFF
--- a/common/changes/@itwin/editor-frontend/accudraw-smart-rotation_2022-01-25-13-24.json
+++ b/common/changes/@itwin/editor-frontend/accudraw-smart-rotation_2022-01-25-13-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "Make it easier to sketch on faces of solids.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/editor/frontend/src/SketchTools.ts
+++ b/editor/frontend/src/SketchTools.ts
@@ -51,11 +51,11 @@ export abstract class CreateOrContinuePathTool extends CreateElementTool {
   protected override get wantAccuSnap(): boolean { return true; }
   protected override get wantDynamics(): boolean { return true; }
 
-  protected get allowJoin(): boolean { return this.isControlDown; } // These could be tool settings...
+  protected get allowJoin(): boolean { return this.isControlDown; }
   protected get allowClosure(): boolean { return this.isControlDown; }
   protected get allowSimplify(): boolean { return true; }
 
-  protected get wantSmartRotation(): boolean { return this.isContinueExistingPath; }
+  protected get wantSmartRotation(): boolean { return this.isContinueExistingPath || this.isControlDown; }
   protected get wantPickableDynamics(): boolean { return false; }
   protected get wantJoin(): boolean { return this.allowJoin; }
   protected get wantClosure(): boolean { return this.isContinueExistingPath && this.allowClosure; }


### PR DESCRIPTION
Simple change to allow ctrl+data to orient AccuDraw from snap even when not continuing an existing open path.