### PR TITLE
Web IPC fix (support for reloading frontend).

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -4860,8 +4860,6 @@ export namespace IpcWebSocketMessage {
     // (undocumented)
     export function internal(): IpcWebSocketMessage;
     // (undocumented)
-    export function next(): number;
-    // (undocumented)
     export function skip(message: IpcWebSocketMessage): boolean;
 }
 
@@ -4884,7 +4882,9 @@ export enum IpcWebSocketMessageType {
 // @internal (undocumented)
 export abstract class IpcWebSocketTransport {
     // (undocumented)
-    protected notifyIncoming(data: any): Promise<IpcWebSocketMessage>;
+    protected notifyClose(connection: any): void;
+    // (undocumented)
+    protected notifyIncoming(data: any, connection: any): Promise<IpcWebSocketMessage>;
     // (undocumented)
     abstract send(message: IpcWebSocketMessage): void;
     // (undocumented)

--- a/common/changes/@itwin/core-backend/web-ipc-reload-fix_2022-01-25-15-56.json
+++ b/common/changes/@itwin/core-backend/web-ipc-reload-fix_2022-01-25-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Web IPC fix (when reloading frontend).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/web-ipc-reload-fix_2022-01-25-15-56.json
+++ b/common/changes/@itwin/core-common/web-ipc-reload-fix_2022-01-25-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Web IPC fix (when reloading frontend).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/web-ipc-reload-fix_2022-01-25-15-56.json
+++ b/common/changes/@itwin/core-frontend/web-ipc-reload-fix_2022-01-25-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Web IPC fix (when reloading frontend).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/backend/src/LocalhostIpcHost.ts
+++ b/core/backend/src/LocalhostIpcHost.ts
@@ -62,13 +62,20 @@ class LocalTransport extends IpcWebSocketTransport {
 
 /** @internal */
 export class LocalhostIpcHost {
+  private static _initialized = false;
+  private static _socket: IpcWebSocketBackend;
+
   public static connect(connection: ws) {
     (IpcWebSocket.transport as LocalTransport).connect(connection);
   }
 
   public static async startup(opts?: { localhostIpcHost?: LocalhostIpcHostOpts, iModelHost?: IModelHostConfiguration }) {
-    IpcWebSocket.transport = new LocalTransport(opts?.localhostIpcHost ?? {});
-    const socket = new IpcWebSocketBackend();
-    await IpcHost.startup({ ipcHost: { socket }, iModelHost: opts?.iModelHost });
+    if (!this._initialized) {
+      IpcWebSocket.transport = new LocalTransport(opts?.localhostIpcHost ?? {});
+      this._socket = new IpcWebSocketBackend();
+      this._initialized = true;
+    }
+
+    await IpcHost.startup({ ipcHost: { socket: this._socket }, iModelHost: opts?.iModelHost });
   }
 }

--- a/core/common/src/ipc/IpcWebSocketTransport.ts
+++ b/core/common/src/ipc/IpcWebSocketTransport.ts
@@ -22,7 +22,7 @@ export abstract class IpcWebSocketTransport {
     return (typeof (Blob) !== "undefined" && data instanceof Blob) ? data.arrayBuffer() : data;
   }
 
-  protected async notifyIncoming(data: any): Promise<IpcWebSocketMessage> {
+  protected async notifyIncoming(data: any, connection: any): Promise<IpcWebSocketMessage> {
     if (this._partial) {
       this._received.push(data);
       --this._outstanding;
@@ -38,7 +38,7 @@ export abstract class IpcWebSocketTransport {
         const message: IpcWebSocketMessage = JSON.parse(partial, reviver);
         parts.length = 0;
 
-        return InSentOrder.deliver(message);
+        return InSentOrder.deliver(message, connection);
       } else {
         return IpcWebSocketMessage.internal();
       }
@@ -51,7 +51,7 @@ export abstract class IpcWebSocketTransport {
         return IpcWebSocketMessage.internal();
       } else {
         const message: IpcWebSocketMessage = JSON.parse(serialized, reviver);
-        return InSentOrder.deliver(message);
+        return InSentOrder.deliver(message, connection);
       }
     }
   }
@@ -62,6 +62,10 @@ export abstract class IpcWebSocketTransport {
     const value = [JSON.stringify([objects, parts.length]), ...parts];
     parts.length = 0;
     return value;
+  }
+
+  protected notifyClose(connection: any) {
+    InSentOrder.close(connection);
   }
 }
 
@@ -113,28 +117,32 @@ function makePromise<T>() {
 /* Reconstructing the sequence in which messages were sent is necessary since
    the binary data for a message has to be awaited in IpcWebSocketTransport.unwrap. */
 class InSentOrder {
-  private static _queue: InSentOrder[] = [];
-  private static _last = -1;
-  private static get _next() { return this._last + 1; }
+  private static _connections: Map<any, { queue: InSentOrder[], last: number }> = new Map();
 
-  public static async deliver(message: IpcWebSocketMessage): Promise<IpcWebSocketMessage> {
+  public static async deliver(message: IpcWebSocketMessage, connection: any): Promise<IpcWebSocketMessage> {
+    let context = this._connections.get(connection);
+    if (!context) {
+      context = { queue: [], last: -1 };
+      this._connections.set(connection, context);
+    }
+
     const entry = new InSentOrder(message);
-    this._queue.push(entry);
-    this._queue.sort((a, b) => a.sequence - b.sequence);
+    context.queue.push(entry);
+    context.queue.sort((a, b) => a.sequence - b.sequence);
 
-    while (this._queue.length !== 0) {
-      const next = this._queue[0];
-      const duplicate = next.sequence <= this._last;
-      const match = next.sequence === this._next;
+    while (context.queue.length !== 0) {
+      const next = context.queue[0];
+      const duplicate = next.sequence <= context.last;
+      const match = next.sequence === (context.last + 1);
 
       if (duplicate) {
         next.duplicate = true;
       } else if (match) {
-        ++this._last;
+        ++context.last;
       }
 
       if (duplicate || match) {
-        this._queue.shift();
+        context.queue.shift();
         next.release();
       } else {
         break;
@@ -142,6 +150,10 @@ class InSentOrder {
     }
 
     return entry.message;
+  }
+
+  public static close(connection: any) {
+    this._connections.delete(connection);
   }
 
   public release = () => { };

--- a/core/frontend/src/LocalhostIpcApp.ts
+++ b/core/frontend/src/LocalhostIpcApp.ts
@@ -73,6 +73,9 @@ class LocalTransport extends IpcWebSocketTransport {
  *  @internal
  */
 export class LocalhostIpcApp {
+  private static _initialized = false;
+  private static _ipc: IpcWebSocketFrontend;
+
   public static buildUrlForSocket(base: URL, path = "ipc"): URL {
     const url = new URL(base);
     url.protocol = "ws";
@@ -81,8 +84,12 @@ export class LocalhostIpcApp {
   }
 
   public static async startup(opts: LocalHostIpcAppOpts) {
-    IpcWebSocket.transport = new LocalTransport(opts);
-    const ipc = new IpcWebSocketFrontend();
-    await IpcApp.startup(ipc, opts);
+    if (!this._initialized) {
+      IpcWebSocket.transport = new LocalTransport(opts);
+      this._ipc = new IpcWebSocketFrontend();
+      this._initialized = true;
+    }
+
+    await IpcApp.startup(this._ipc, opts);
   }
 }


### PR DESCRIPTION
The bookeeping necessary for tracking the sequence of IPC messages must be connection-specific, not global.

Otherwise, issues will arise like a new frontend (after reload) expecting message 0 but the backend sending whatever message number it was on with the previous (before reload) frontend session.