### PR TITLE
Add packageRoot directory to Typedoc output

### DIFF
--- a/common/changes/@itwin/build-tools/packageroot-on-docs_2022-01-26-22-19.json
+++ b/common/changes/@itwin/build-tools/packageroot-on-docs_2022-01-26-22-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Added packageRoot property to Typedoc output",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/scripts/docs.js
+++ b/tools/build/scripts/docs.js
@@ -12,6 +12,7 @@ const cpx = require("cpx2");
 const fs = require("fs");
 const { spawn, handleInterrupts } = require("./utils/simpleSpawn");
 const { validateTags } = require("./utils/validateTags");
+const { addSourceDir } = require("./utils/addSourceDir");
 const argv = require("yargs").argv;
 
 // Makes the script crash on unhandled rejections instead of silently
@@ -87,6 +88,9 @@ spawn(require.resolve(".bin/typedoc"), args).then((code) => {
   if (fs.existsSync(path.join(process.cwd(), 'CHANGELOG.json'))) {
     cpx.copySync(path.join(process.cwd(), 'CHANGELOG.json'), outputDir);
   }
+
+  // Append the directory of the package to the output
+  addSourceDir(json, process.cwd());
 
   if (code === 0) {
     let tagErrors = validateTags(json);

--- a/tools/build/scripts/utils/addSourceDir.js
+++ b/tools/build/scripts/utils/addSourceDir.js
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+const FS = require('fs-extra');
+const rootPackageJson = require('../../../../package.json');
+
+// Appends the directory of the package root to the Typedoc JSON output
+function addSourceDir(file, directory) {
+  if (FS.existsSync(file) && FS.statSync(file).isFile()) {
+    const contents = FS.readFileSync(file, 'utf-8');
+    let packageRoot = directory.substring(directory.indexOf(rootPackageJson.name) + rootPackageJson.name.length + 1);
+    let jsonContents = JSON.parse(contents);
+    jsonContents['packageRoot'] = packageRoot.endsWith('src') ? packageRoot : `${packageRoot}\\${'src'}`;
+    FS.writeFileSync(file, Buffer.from(JSON.stringify(jsonContents, null, 2)));
+  }
+}
+
+module.exports = {
+  addSourceDir
+};


### PR DESCRIPTION
- Adds the root directory of the package to the Typedoc output
- This is needed for the "Defined In" links on API reference pages
  - The data currently in Typedoc output is sometimes relative to repo's root and other times relative to package root. Likely due to Typedoc's file discovery algorithm.