### PR TITLE
Enhance SaveImageTool

### DIFF
--- a/common/changes/@itwin/core-frontend/dta-save-image_2022-02-02-15-26.json
+++ b/common/changes/@itwin/core-frontend/dta-save-image_2022-02-02-15-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix openImageDataUrlInNewWindow displaying an empty window in Electron.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ImageUtil.ts
+++ b/core/frontend/src/ImageUtil.ts
@@ -6,7 +6,6 @@
  * @module Rendering
  */
 
-import { ProcessDetector } from "@itwin/core-bentley";
 import { Point2d } from "@itwin/core-geometry";
 import { ImageBuffer, ImageBufferFormat, ImageSource, ImageSourceFormat } from "@itwin/core-common";
 import { ViewRect } from "./ViewRect";
@@ -274,19 +273,15 @@ export function imageBufferToBase64EncodedPng(buffer: ImageBuffer, preserveAlpha
  * @beta
  */
 export function openImageDataUrlInNewWindow(url: string, title?: string): void {
-  if (ProcessDetector.isElectronAppFrontend) {
-    window.open(url, title);
-  } else {
-    const win = window.open();
-    if (null === win)
-      return;
+  const win = window.open();
+  if (null === win)
+    return;
 
-    const div = win.document.createElement("div");
-    div.innerHTML = `<img src='${url}'/>`;
-    win.document.body.append(div);
-    if (undefined !== title)
-      win.document.title = title;
-  }
+  const div = win.document.createElement("div");
+  div.innerHTML = `<img src='${url}'/>`;
+  win.document.body.append(div);
+  if (undefined !== title)
+    win.document.title = title;
 }
 
 /** Determine the maximum [[ViewRect]] that can be fitted and centered in specified ViewRect given a required aspect ratio.

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -208,7 +208,11 @@ display-test-app has access to all key-ins defined in the `@itwin/core-frontend`
 * `vp clone` *viewportId* - create a new viewport looking at the same view as the specified or currently-selected viewport.
 * `dta gltf` *assetUrl* - load a glTF asset from the specified URL and display it at the center of the project extents in the currently-selected viewport. If no URL is provided, a file picker allows selection of an asset from the local file system; in this case the asset must be fully self-contained (no references to other files).
 * `dta version compare` - emulate version comparison.
-* `dta save image` - open a new window containing a snapshot of the contents of the selected viewport.
+* `dta save image` - capture the contents of the selected viewport as a PNG image. By default, opens a new window to display the image. Accepts any of the following arguments:
+  * `w=width` - the desired width of the image in pixels. e.g. `w=640`.
+  * `h=height` - the desired height of the image in pixels. e.g. `h=480`.
+  * `d=dimensions` - the desired width and height of the image in pixels. The image will be square. e.g. `d=768`.
+  * `c=0|1` - if `1`, instead of opening a new window to display the image, the image will be copied to the clipboard. NOTE: this probably doesn't work in Firefox.
 * `dta record fps` *numFrames* - record average frames-per-second over the specified number of frames (default: 150) and output to status bar.
 * `dta zoom selected` - zoom the selected viewport to the elements in the selection set.
 * `dta incident markers` - toggle incident marker demo in the selected viewport.

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -46,9 +46,10 @@ import {
 import { SyncViewportFrustaTool, SyncViewportsTool } from "./SyncViewportsTool";
 import { TimePointComparisonTool } from "./TimePointComparison";
 import { UiManager } from "./UiManager";
-import { MarkupTool, ModelClipTool, SaveImageTool, ZoomToSelectedElementsTool } from "./Viewer";
+import { MarkupTool, ModelClipTool, ZoomToSelectedElementsTool } from "./Viewer";
 import { MacroTool } from "./MacroTools";
 import { TerrainDrapeTool } from "./TerrainDrapeTool";
+import { SaveImageTool } from "./SaveImageTool";
 
 class DisplayTestAppAccuSnap extends AccuSnap {
   private readonly _activeSnaps: SnapMode[] = [SnapMode.NearestKeypoint];

--- a/test-apps/display-test-app/src/frontend/SaveImageTool.ts
+++ b/test-apps/display-test-app/src/frontend/SaveImageTool.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { ProcessDetector } from "@itwin/core-bentley";
+import { Point2d } from "@itwin/core-geometry";
+import { imageBufferToPngDataUrl, IModelApp, openImageDataUrlInNewWindow, Tool } from "@itwin/core-frontend";
+import { parseArgs } from "@itwin/frontend-devtools";
+
+interface SaveImageOptions {
+  copyToClipboard?: boolean;
+  width?: number;
+  height?: number;
+}
+
+export class SaveImageTool extends Tool {
+  public static override toolId = "SaveImage";
+  public static override get minArgs() { return 0; }
+  public static override get maxArgs() { return 3; }
+
+  public override async run(opts?: SaveImageOptions): Promise<boolean> {
+    const vp = IModelApp.viewManager.selectedView;
+    if (!vp)
+      return false;
+
+    const width = opts?.width ?? vp.viewRect.width;
+    const height = opts?.height ?? vp.viewRect.height;
+    if (width <= 0 || height <= 0) {
+      alert("Invalid image dimensions");
+      return true;
+    }
+
+    const copy = opts?.copyToClipboard ?? false;
+
+    const buffer = vp.readImageBuffer({ size: new Point2d(width, height) });
+    if (!buffer) {
+      alert("Failed to read image");
+      return true;
+    }
+
+    const url = imageBufferToPngDataUrl(buffer, false);
+    if (!url) {
+      alert("Failed to produce PNG");
+      return true;
+    }
+
+    if (!copy) {
+      openImageDataUrlInNewWindow(url, "Saved View");
+      return true;
+    }
+
+    try {
+      const getBlob = async () => {
+        const png = await fetch(url);
+        return png.blob();
+      };
+
+      // ClipboardItem currently unsupported in Firefox. Chrome expects a resolved promise; safari (and typescript type definitions) an unresolved promise.
+      // Tested only in chrome+electron.
+      const blob = ProcessDetector.isChromium ? (await getBlob()) as unknown as Promise<ClipboardItemDataType> : getBlob();
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "image/png": blob,
+        }),
+      ]);
+    } catch (_) {
+      alert("Failed to copy to clipboard");
+    }
+
+    return true;
+  }
+
+  public override async parseAndRun(...input: string[]): Promise<boolean> {
+    const args = parseArgs(input);
+    const opts: SaveImageOptions = {
+      copyToClipboard: args.getBoolean("c"),
+    };
+
+    const dimension = args.getInteger("d");
+    if (undefined !== dimension) {
+      opts.width = opts.height = dimension;
+    } else {
+      opts.width = args.getInteger("w");
+      opts.height = args.getInteger("h");
+    }
+
+    return this.run(opts);
+  }
+}

--- a/test-apps/display-test-app/src/frontend/Viewer.ts
+++ b/test-apps/display-test-app/src/frontend/Viewer.ts
@@ -3,10 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Id64String } from "@itwin/core-bentley";
-import { ClipPlane, ClipPrimitive, ClipVector, ConvexClipPlaneSet, Point2d, Vector3d } from "@itwin/core-geometry";
+import { ClipPlane, ClipPrimitive, ClipVector, ConvexClipPlaneSet, Vector3d } from "@itwin/core-geometry";
 import { ModelClipGroup, ModelClipGroups } from "@itwin/core-common";
 import {
-  imageBufferToPngDataUrl, IModelApp, IModelConnection, NotifyMessageDetails, openImageDataUrlInNewWindow, OutputMessagePriority, ScreenViewport,
+  IModelApp, IModelConnection, NotifyMessageDetails, openImageDataUrlInNewWindow, OutputMessagePriority, ScreenViewport,
   Tool, Viewport, ViewState,
 } from "@itwin/core-frontend";
 import { MarkupApp, MarkupData } from "@itwin/core-markup";
@@ -28,22 +28,6 @@ import { openIModel } from "./openIModel";
 
 // cspell:ignore savedata topdiv savedview viewtop
 
-function saveImage(vp: Viewport) {
-  const buffer = vp.readImageBuffer({ size: new Point2d(768, 768) });
-  if (undefined === buffer) {
-    alert("Failed to read image");
-    return;
-  }
-
-  const url = imageBufferToPngDataUrl(buffer, false);
-  if (undefined === url) {
-    alert("Failed to produce PNG");
-    return;
-  }
-
-  openImageDataUrlInNewWindow(url, "Saved View");
-}
-
 async function zoomToSelectedElements(vp: Viewport) {
   const elems = vp.iModel.selectionSet.elements;
   if (0 < elems.size)
@@ -56,17 +40,6 @@ export class ZoomToSelectedElementsTool extends Tool {
     const vp = IModelApp.viewManager.selectedView;
     if (undefined !== vp)
       await zoomToSelectedElements(vp);
-
-    return true;
-  }
-}
-
-export class SaveImageTool extends Tool {
-  public static override toolId = "SaveImage";
-  public override async run(_args: any[]): Promise<boolean> {
-    const vp = IModelApp.viewManager.selectedView;
-    if (undefined !== vp)
-      saveImage(vp);
 
     return true;
   }


### PR DESCRIPTION
`dta save image` stopped working in electron a while ago (it is supposed to display the captured image in a new window, but was displaying a blank window instead). Fix that.
Add option to copy image directly to clipboard.
Add option to specify image dimensions. If none specified, capture at full size.

This is extraordinarily useful for capturing images for comparison with ImageDiffs and for creating snapshots for documentation etc.