### PR TITLE
InspectElementTool optionally also reports on part references' geometry.

### DIFF
--- a/common/changes/@itwin/frontend-devtools/recursive-geometry-summary_2022-02-03-11-31.json
+++ b/common/changes/@itwin/frontend-devtools/recursive-geometry-summary_2022-02-03-11-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "Add an option to InspectElementTool to also summarize the geometry of each part reference.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -261,6 +261,7 @@ These keysins control the planar masking of reality models.
   * "refs=0|1" where `1` indicates that if the element is a geometry part, the output should include a list of all geometric elements which reference that geometry part. This is **extremely** inefficient and may take a very long time to process in iModels containing many geometric elements.
   * "modal=0|1" where `1` indicates the output should be displayed in a modal dialog.
   * "copy=0|1" where `1` indicates the output should be copied to the system clipboard.
+  * "explodeparts=0|1" where `1` indicates that a summary of the geometry of each geometry part reference should also be output.
 * `fdt select elements` - given a list of element Ids separated by whitespace, replace the contents of the selection set with those Ids.
 * `fdt toggle skybox` - If the active viewport is displaying a spatial view, toggles display of the skybox.
 * `fdt sky sphere` - set the image used for the skybox as a Url or texture Id.

--- a/core/frontend-devtools/src/tools/InspectElementTool.ts
+++ b/core/frontend-devtools/src/tools/InspectElementTool.ts
@@ -37,6 +37,7 @@ export class InspectElementTool extends PrimitiveTool {
   private _modal = false;
   private _useSelection = false;
   private _doCopy = false;
+  private _explodeParts = false;
 
   constructor(options?: GeometrySummaryOptions, elementIds?: Id64String[]) {
     super();
@@ -138,7 +139,20 @@ export class InspectElementTool extends PrimitiveTool {
     };
     let messageDetails: NotifyMessageDetails;
     try {
-      const str = await IModelReadRpcInterface.getClientForRouting(this.iModel.routingContext.token).getGeometrySummary(this.iModel.getRpcProps(), request);
+      let str = await IModelReadRpcInterface.getClientForRouting(this.iModel.routingContext.token).getGeometrySummary(this.iModel.getRpcProps(), request);
+      if (this._explodeParts) {
+        const regex = /^part id: (0x[a-f0-9]+)/gm;
+        request.elementIds = [];
+        let match;
+        while (null !== (match = regex.exec(str)))
+          request.elementIds.push(match[1]);
+
+        if (request.elementIds.length > 0) {
+          str += `\npart ids: ${JSON.stringify(request.elementIds)}\n`;
+          str += await IModelReadRpcInterface.getClientForRouting(this.iModel.routingContext.token).getGeometrySummary(this.iModel.getRpcProps(), request);
+        }
+      }
+
       if (this._doCopy)
         copyStringToClipboard(str);
 
@@ -213,6 +227,8 @@ export class InspectElementTool extends PrimitiveTool {
     const doCopy = args.getBoolean("c");
     if (undefined !== doCopy)
       this._doCopy = doCopy;
+
+    this._explodeParts = true === args.getBoolean("e");
 
     return this.run();
   }

--- a/core/frontend-devtools/src/tools/InspectElementTool.ts
+++ b/core/frontend-devtools/src/tools/InspectElementTool.ts
@@ -142,12 +142,13 @@ export class InspectElementTool extends PrimitiveTool {
       let str = await IModelReadRpcInterface.getClientForRouting(this.iModel.routingContext.token).getGeometrySummary(this.iModel.getRpcProps(), request);
       if (this._explodeParts) {
         const regex = /^part id: (0x[a-f0-9]+)/gm;
-        request.elementIds = [];
+        const partIds = new Set<string>();
         let match;
         while (null !== (match = regex.exec(str)))
-          request.elementIds.push(match[1]);
+          partIds.add(match[1]);
 
-        if (request.elementIds.length > 0) {
+        if (partIds.size > 0) {
+          request.elementIds = Array.from(partIds);
           str += `\npart ids: ${JSON.stringify(request.elementIds)}\n`;
           str += await IModelReadRpcInterface.getClientForRouting(this.iModel.routingContext.token).getGeometrySummary(this.iModel.getRpcProps(), request);
         }


### PR DESCRIPTION
I find myself debugging elements with hundreds or thousands of part references in their geometry streams.
`fdt inspect element e=1` will include a summary of each part's geometry in the output.