### PR TITLE
provide way to reset to basic units provider

### DIFF
--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -562,6 +562,10 @@ export class QuantityFormatter implements UnitsProvider {
     this.onUnitsProviderChanged.emit();
   }
 
+  public resetToUseInternalUnitsProvider() {
+    this.unitsProvider = new BasicUnitsProvider();
+  }
+
   public async registerQuantityType(entry: CustomQuantityTypeDefinition, replace?: boolean) {
     if (!replace && this._quantityTypeRegistry.has(entry.key))
       return false;

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -390,12 +390,17 @@ export class SampleAppIModelApp {
     let stageId: string;
     const defaultFrontstage = this.allowWrite ? EditFrontstage.stageId : ViewsFrontstage.stageId;
 
+    try{
     // Reset QuantityFormatter UnitsProvider with new iModelConnection
-    const schemaLocater = new ECSchemaRpcLocater(iModelConnection);
-    const context = new SchemaContext();
-    context.addLocater(schemaLocater);
-    IModelApp.quantityFormatter.unitsProvider = new SchemaUnitProvider(context);
-    await IModelApp.quantityFormatter.onInitialized();
+      const schemaLocater = new ECSchemaRpcLocater(iModelConnection);
+      const context = new SchemaContext();
+      context.addLocater(schemaLocater);
+      IModelApp.quantityFormatter.unitsProvider = new SchemaUnitProvider(context);
+      await IModelApp.quantityFormatter.onInitialized();
+    } catch (_) {
+      IModelApp.quantityFormatter.resetToUseInternalUnitsProvider(); // this resets it to internal BasicUnitsProvider
+      await IModelApp.quantityFormatter.onInitialized();
+    }
 
     // store the IModelConnection in the sample app store - this may trigger redux connected components
     UiFramework.setIModelConnection(iModelConnection, true);


### PR DESCRIPTION
@christophermlawson - Chris here is an update we need to be able to reset to BasicUnitsProvider for both BlankIModelConnections and IModelConnections that may not have a units schema... of which I have several.