### PR TITLE
fix the setup of the test-apps in a disconnected workflow

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3092,6 +3092,7 @@ importers:
       '@itwin/imodel-components-react': workspace:*
       '@itwin/imodels-access-backend': ^1.0.1
       '@itwin/imodels-access-frontend': ^1.0.1
+      '@itwin/imodels-client-authoring': ^1.0.1
       '@itwin/imodels-client-management': ^1.0.1
       '@itwin/itwinui-css': 0.44.1
       '@itwin/itwinui-react': 1.29.3
@@ -3163,6 +3164,7 @@ importers:
       '@itwin/imodel-components-react': link:../../ui/imodel-components-react
       '@itwin/imodels-access-backend': 1.0.1
       '@itwin/imodels-access-frontend': 1.0.1
+      '@itwin/imodels-client-authoring': 1.0.1
       '@itwin/imodels-client-management': 1.0.1
       '@itwin/itwinui-css': 0.44.1
       '@itwin/itwinui-react': 1.29.3_react-dom@17.0.2+react@17.0.2
@@ -9572,8 +9574,8 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  /ajv/8.9.0:
-    resolution: {integrity: sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==}
+  /ajv/8.10.0:
+    resolution: {integrity: sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -9925,7 +9927,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.14.7
+      follow-redirects: 1.14.7_debug@4.3.3
     transitivePeerDependencies:
       - debug
 
@@ -13542,6 +13544,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
 
   /follow-redirects/1.14.7_debug@4.3.3:
     resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
@@ -21052,7 +21055,7 @@ packages:
     resolution: {integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      ajv: 8.9.0
+      ajv: 8.10.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3

--- a/test-apps/display-performance-test-app/src/backend/backend.ts
+++ b/test-apps/display-performance-test-app/src/backend/backend.ts
@@ -42,9 +42,9 @@ export async function initializeBackend() {
     let authClient;
     if (process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID && process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI && process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES) {
       authClient = new ElectronMainAuthorization({
-        clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
-        redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
-        scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
+        clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID,
+        redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI,
+        scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES,
       });
       iModelHost.authorizationClient = authClient;
     }

--- a/test-apps/display-performance-test-app/src/backend/backend.ts
+++ b/test-apps/display-performance-test-app/src/backend/backend.ts
@@ -39,13 +39,15 @@ export async function initializeBackend() {
 
   if (ProcessDetector.isElectronAppBackend) {
     const rpcInterfaces = [DisplayPerfRpcInterface, IModelTileRpcInterface, SnapshotIModelRpcInterface, IModelReadRpcInterface];
-    const authClient = new ElectronMainAuthorization({
-      clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
-      redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
-      scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
-    });
-    await authClient.signInSilent();
-    iModelHost.authorizationClient = authClient;
+    let authClient;
+    if (process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID && process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI && process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES) {
+      authClient = new ElectronMainAuthorization({
+        clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
+        redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
+        scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
+      });
+      iModelHost.authorizationClient = authClient;
+    }
     await ElectronHost.startup({
       electronHost: {
         webResourcesPath: path.join(__dirname, "..", "..", "build"),

--- a/test-apps/display-test-app/src/backend/Backend.ts
+++ b/test-apps/display-test-app/src/backend/Backend.ts
@@ -193,15 +193,18 @@ export const initializeDtaBackend = async (hostOpts?: ElectronHostOptions & Mobi
   /** register the implementation of our RPCs. */
   RpcManager.registerImpl(DtaRpcInterface, DisplayTestAppRpc);
   if (ProcessDetector.isElectronAppBackend) {
-    const authClient = new ElectronMainAuthorization({
-      clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
-      redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
-      scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
-    });
-    await authClient.signInSilent();
-    opts.iModelHost.authorizationClient = authClient;
+    let authClient;
+    if (process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID && process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI && process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES) {
+      authClient = new ElectronMainAuthorization({
+        clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
+        redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
+        scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
+      });
+      opts.iModelHost.authorizationClient = authClient;
+    }
     await ElectronHost.startup(opts);
-    await authClient.signInSilent();
+    if (authClient)
+      await authClient.signInSilent();
     EditCommandAdmin.registerModule(editorBuiltInCommands);
   } else if (ProcessDetector.isIOSAppBackend) {
     await IOSHost.startup(opts);

--- a/test-apps/display-test-app/src/backend/Backend.ts
+++ b/test-apps/display-test-app/src/backend/Backend.ts
@@ -196,9 +196,9 @@ export const initializeDtaBackend = async (hostOpts?: ElectronHostOptions & Mobi
     let authClient;
     if (process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID && process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI && process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES) {
       authClient = new ElectronMainAuthorization({
-        clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
-        redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
-        scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
+        clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID,
+        redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI,
+        scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES,
       });
       opts.iModelHost.authorizationClient = authClient;
     }

--- a/test-apps/presentation-test-app/src/backend/electron/ElectronMain.ts
+++ b/test-apps/presentation-test-app/src/backend/electron/ElectronMain.ts
@@ -22,17 +22,20 @@ export default async function initialize(rpcInterfaces: RpcInterfaceDefinition[]
     ipcHandlers: [SampleIpcHandler],
   };
   const iModelHost = new IModelHostConfiguration();
-  const authClient = new ElectronMainAuthorization({
-    clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
-    redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
-    scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
 
-  });
-  await authClient.signInSilent();
-  iModelHost.authorizationClient = authClient;
+  let authClient;
+  if (process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID && process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI && process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES) {
+    authClient = new ElectronMainAuthorization({
+      clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID,
+      redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI,
+      scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES,
+    });
+    iModelHost.authorizationClient = authClient;
+  }
 
   await ElectronHost.startup({ electronHost, iModelHost });
-  await authClient.signInSilent();
+  if (authClient)
+    await authClient.signInSilent();
   await ElectronHost.openMainWindow();
 
   // __PUBLISH_EXTRACT_END__

--- a/test-apps/ui-test-app/package.json
+++ b/test-apps/ui-test-app/package.json
@@ -76,6 +76,7 @@
     "@bentley/icons-generic": "^1.0.15",
     "@itwin/imodels-access-backend": "^1.0.1",
     "@itwin/imodels-access-frontend": "^1.0.1",
+    "@itwin/imodels-client-authoring": "^1.0.1",
     "@itwin/imodels-client-management": "^1.0.1",
     "@itwin/reality-data-client": "^0.7.0",
     "@itwin/appui-abstract": "workspace:*",

--- a/test-apps/ui-test-app/src/backend/electron/ElectronMain.ts
+++ b/test-apps/ui-test-app/src/backend/electron/ElectronMain.ts
@@ -28,17 +28,21 @@ export async function initializeElectron(opts?: IModelHostConfiguration) {
     iModelHost: opts,
   };
 
-  const authClient = new ElectronMainAuthorization({
-    clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID ?? "",
-    redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI ?? "",
-    scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES ?? "",
-  });
-  await authClient.signInSilent();
-  if (opt.iModelHost?.authorizationClient)
-    opt.iModelHost.authorizationClient = authClient;
+  let authClient;
+  if (process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID && process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI && process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES) {
+    authClient = new ElectronMainAuthorization({
+      clientId: process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID,
+      redirectUri: process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI,
+      scope: process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES,
+    });
+    await authClient.signInSilent();
+    if (opt.iModelHost?.authorizationClient)
+      opt.iModelHost.authorizationClient = authClient;
+  }
 
   await ElectronHost.startup(opt);
-  await authClient.signInSilent();
+  if (authClient)
+    await authClient.signInSilent();
   EditCommandAdmin.registerModule(editorBuiltInCommands);
 
   // Handle custom keyboard shortcuts

--- a/test-apps/ui-test-app/src/backend/main.ts
+++ b/test-apps/ui-test-app/src/backend/main.ts
@@ -6,14 +6,15 @@ import * as fs from "fs";
 import * as path from "path";
 import { IModelHostConfiguration } from "@itwin/core-backend";
 import { Logger, ProcessDetector } from "@itwin/core-bentley";
+import { AndroidHost, IOSHost } from "@itwin/core-mobile/lib/cjs/MobileBackend";
+import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
+import { IModelsClient } from "@itwin/imodels-client-authoring";
 import { Presentation } from "@itwin/presentation-backend";
+import { getSupportedRpcs } from "../common/rpcs";
+import { loggerCategory } from "../common/TestAppConfiguration";
+import { initializeElectron } from "./electron/ElectronMain";
 import { initializeLogging } from "./logging";
 import { initializeWeb } from "./web/BackendServer";
-import { initializeElectron } from "./electron/ElectronMain";
-import { loggerCategory } from "../common/TestAppConfiguration";
-import { AndroidHost, IOSHost } from "@itwin/core-mobile/lib/cjs/MobileBackend";
-import { getSupportedRpcs } from "../common/rpcs";
-import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 
 (async () => { // eslint-disable-line @typescript-eslint/no-floating-promises
   try {
@@ -27,7 +28,8 @@ import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
     initializeLogging();
 
     const iModelHost = new IModelHostConfiguration();
-    iModelHost.hubAccess = new BackendIModelsAccess();
+    const iModelClient = new  IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels`}});
+    iModelHost.hubAccess = new BackendIModelsAccess(iModelClient);
 
     // invoke platform-specific initialization
     if (ProcessDetector.isElectronAppBackend) {

--- a/test-apps/ui-test-app/tsconfig.json
+++ b/test-apps/ui-test-app/tsconfig.json
@@ -25,8 +25,7 @@
   },
   "include": [
     "./src/**/*.ts",
-    "./src/**/*.tsx",
-    "../../ui/framework/src/test/frontstage/StandardFrontstage.tsx"
+    "./src/**/*.tsx"
   ],
   "exclude": [
     "./src/backend/**/*.ts"


### PR DESCRIPTION
With a recent change to the Electron auth client to not allow an empty string to be provided as a client id, fix the test apps to only setup Electron auth if the configuration exists. 