### PR TITLE
Update devcontainer base to Debian 11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE.md in the project root for license terms.
 #----------------------------------------------------------------------------------------------
 
-FROM debian:10
+FROM docker.io/library/debian:11
 
 RUN \
   apt-get update \
@@ -15,7 +15,7 @@ RUN \
   libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 \
   libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
   libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-  fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget \
+  fonts-liberation libayatana-appindicator1 libnss3 lsb-release xdg-utils wget \
   && apt-get install -y git nodejs locales zsh procps \
   && npm install -g @microsoft/rush \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,8 @@ RUN \
   libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 \
   libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
   libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-  fonts-liberation libayatana-appindicator1 libnss3 lsb-release xdg-utils wget \
+  fonts-liberation libayatana-appindicator1 libnss3 libsecret-1-0 \
+  lsb-release xdg-utils wget \
   && apt-get install -y git nodejs locales zsh procps \
   && npm install -g @microsoft/rush \
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
The version of Git packaged with Debian 10 (2.20.1) is too old for the
current version of Rush (which requires at least 2.30.0).