### PR TITLE
fix super call in automatic collectPredecessorIds impl and make stricter conditions for auto-implementing collectPredecessorIds

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1557,6 +1557,8 @@ export class Entity {
     id: Id64String;
     iModel: IModelDb;
     static is(otherClass: typeof Entity): boolean;
+    // @internal
+    static get isGeneratedClass(): boolean;
     readonly isInstanceOfEntity: true;
     // @internal (undocumented)
     static get protectedOperations(): string[];

--- a/core/backend/src/ClassRegistry.ts
+++ b/core/backend/src/ClassRegistry.ts
@@ -134,6 +134,9 @@ export class ClassRegistry {
               predecessorIds.add(relatedElem.id);
             }
           },
+          // defaults for methods on a prototype (required for sinon to stub out methods on tests)
+          writable: true,
+          configurable: true,
         }
       );
     }

--- a/core/backend/src/ClassRegistry.ts
+++ b/core/backend/src/ClassRegistry.ts
@@ -91,11 +91,17 @@ export class ClassRegistry {
         generatedClass.prototype,
         "collectPredecessorIds",
         {
-          value(this: typeof generatedClass, predecessorIds: Id64Set) {
-            // first prototype of `this` is the current class, second is its superclass
-            const superImpl: Element["collectPredecessorIds"] = Object.getPrototypeOf(Object.getPrototypeOf(this)).collectPredecessorIds;
-            // we know it is valid because `generatedClass.is(Element)` and generatedClass is defined here so it can't be Element itself
-            superImpl.call(this, predecessorIds);
+          // first prototype of `this` is its class
+          value(this: typeof generatedClass, predecessorIds: Id64Set, _lastSuper: Element = Object.getPrototypeOf(this)) {
+            // get the super
+            // we must keep the previous super in order to propagate super calls down the chain
+            _lastSuper = Object.getPrototypeOf(_lastSuper);
+            type HackedCollectPredecessorsIds = (...args: [...Parameters<Element["collectPredecessorIds"]>, Element]) => void;
+            // eslint-disable-next-line @typescript-eslint/dot-notation
+            const superImpl: HackedCollectPredecessorsIds = _lastSuper["collectPredecessorIds"];
+            // we know the super object will have collectPredecessorIds because `generatedClass.is(Element)` means it either is a subclass of Element
+            // or is Element, and it is not Element because it is declared in this function, so the super class must be Element or a subclass of it
+            superImpl.call(this, predecessorIds, _lastSuper);
             for (const navProp of navigationProps) {
               const relatedElem: RelatedElement | undefined = (this as any)[navProp]; // cast to any since subclass can have any extensions
               if (!relatedElem || !Id64.isValid(relatedElem.id)) continue;

--- a/core/backend/src/ClassRegistry.ts
+++ b/core/backend/src/ClassRegistry.ts
@@ -117,7 +117,7 @@ export class ClassRegistry {
     // a class only gets an automatic `collectPredecessorIds` implementation if:
     // - it derives from `BisCore:Element`
     // - it is not in the `BisCore` schema
-    // - there are no manually registered JS implementations of any base classes, (excluding BisCore base classes)
+    // - there are no ancestors with manually registered JS implementations, (excluding BisCore base classes)
     if (!generatedClassHasNonGeneratedNonCoreAncestor && isElement(superclass)) {
       Object.defineProperty(
         generatedClass.prototype,

--- a/core/backend/src/ClassRegistry.ts
+++ b/core/backend/src/ClassRegistry.ts
@@ -82,7 +82,7 @@ export class ClassRegistry {
 
     // override `hasNonGeneratedNonCoreBaseClass` for this subclass if the condition is met, or just propagate the parent's override
     const generatedClassHasCustomNonCoreBaseClass =
-      (superclass.schema.schemaName !== "BisCore" && superclass.isGeneratedClass) ||
+      (superclass.schema.schemaName !== "BisCore" && !superclass.isGeneratedClass) ||
       superclass.hasNonGeneratedNonCoreBaseClass;
 
     const generatedClass = class extends superclass {

--- a/core/backend/src/Entity.ts
+++ b/core/backend/src/Entity.ts
@@ -95,12 +95,6 @@ export class Entity {
    */
   public static is(otherClass: typeof Entity): boolean { return isSubclassOf(this, otherClass); }
 
-  /** overridden by subclasses to indicate if there are generated non-core schema classes in the inheritance path
-   * BisCore classes are never considered to have been generated
-   * @internal
-   */
-  public static get hasNonGeneratedNonCoreBaseClass() { return false; }
-
   /** whether this JavaScript class was generated for this ECClass because there was no registered custom implementation
    * ClassRegistry overrides this when generating a class
    * @internal

--- a/core/backend/src/Entity.ts
+++ b/core/backend/src/Entity.ts
@@ -90,8 +90,22 @@ export class Entity {
   /** return whether this Entity class is a subclass of another Entity class
    * @note the subclass-ness is checked according to JavaScript inheritance, to check the underlying raw EC class's
    * inheritance, you can use [ECClass.is]($ecschema-metadata)
+   * @note this should have a type of `is<T extends typeof Entity>(otherClass: T): this is T` but can't because of
+   * typescript's restriction on the `this` type in static methods
    */
   public static is(otherClass: typeof Entity): boolean { return isSubclassOf(this, otherClass); }
+
+  /** overridden by subclasses to indicate if there are generated non-core schema classes in the inheritance path
+   * BisCore classes are never considered to have been generated
+   * @internal
+   */
+  public static get hasNonGeneratedNonCoreBaseClass() { return false; }
+
+  /** whether this JavaScript class was generated for this ECClass because there was no registered custom implementation
+   * ClassRegistry overrides this when generating a class
+   * @internal
+   */
+  public static get isGeneratedClass() { return false; }
 }
 
 /** Parameter type that can accept both abstract constructor types and non-abstract constructor types for `instanceof` to test.

--- a/core/backend/src/test/assets/TestGeneratedClasses.ecschema.xml
+++ b/core/backend/src/test/assets/TestGeneratedClasses.ecschema.xml
@@ -50,4 +50,24 @@
         <ECNavigationProperty propertyName="derivedNavProp" relationshipName="DerivedElemRel" direction="Forward"/>
     </ECEntityClass>
 
+    <ECEntityClass typeName="Derived2">
+        <BaseClass>DerivedWithNavProp</BaseClass>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="Derived3">
+        <BaseClass>Derived2</BaseClass>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="Derived4">
+        <BaseClass>Derived3</BaseClass>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="Derived5">
+        <BaseClass>Derived4</BaseClass>
+    </ECEntityClass>
+
+    <ECEntityClass typeName="Derived6">
+        <BaseClass>Derived5</BaseClass>
+    </ECEntityClass>
+
 </ECSchema>

--- a/core/backend/src/test/schema/ClassRegistry.test.ts
+++ b/core/backend/src/test/schema/ClassRegistry.test.ts
@@ -377,6 +377,36 @@ describe.only("Class Registry - generated classes", () => {
     }
     MyTestGeneratedClasses.registerSchema();
 
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const MyDerived3 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived3");
+    const MyDerived5 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived5");
+    const MyDerived6 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived6");
+    /* eslint-enable @typescript-eslint/no-redeclare */
+
+    expect(TestElementWithNavProp.hasNonGeneratedNonCoreBaseClass).to.be.false;
+    expect(DerivedWithNavProp.hasNonGeneratedNonCoreBaseClass).to.be.false;
+    expect(MyDerived2.hasNonGeneratedNonCoreBaseClass).to.be.false;
+    expect(MyDerived3.hasNonGeneratedNonCoreBaseClass).to.be.true;
+    expect(MyDerived4.hasNonGeneratedNonCoreBaseClass).to.be.true;
+    expect(MyDerived5.hasNonGeneratedNonCoreBaseClass).to.be.true;
+    expect(MyDerived6.hasNonGeneratedNonCoreBaseClass).to.be.true;
+
+    expect(TestElementWithNavProp.isGeneratedClass).to.be.false;
+    expect(DerivedWithNavProp.hasNonGeneratedNonCoreBaseClass).to.be.false;
+    expect(MyDerived2.hasNonGeneratedNonCoreBaseClass).to.be.true;
+    expect(MyDerived3.hasNonGeneratedNonCoreBaseClass).to.be.false;
+    expect(MyDerived4.hasNonGeneratedNonCoreBaseClass).to.be.true;
+    expect(MyDerived5.hasNonGeneratedNonCoreBaseClass).to.be.false;
+    expect(MyDerived6.hasNonGeneratedNonCoreBaseClass).to.be.false;
+
+    assert.hasAllKeys(TestElementWithNavProp.prototype, ["getPredecessorIds"]);
+    assert.hasAllKeys(DerivedWithNavProp.prototype, ["getPredecessorIds"]);
+    assert.hasAllKeys(MyDerived2.prototype, ["getPredecessorIds"]);
+    assert.doesNotHaveAnyKeys(MyDerived3.prototype, ["getPredecessorIds"]); // base is generated so it shouldn't get the automatic impl
+    assert.hasAllKeys(MyDerived4.prototype, ["getPredecessorIds"]); // manually implements so it should have the method
+    assert.doesNotHaveAnyKeys(MyDerived5.prototype, ["getPredecessorIds"]);
+    assert.doesNotHaveAnyKeys(MyDerived6.prototype, ["getPredecessorIds"]);
+
     const testEntity1Id = imodel.elements.insertElement({
       classFullName: "TestGeneratedClasses:Derived6",
       prop: "sample-value-1",

--- a/core/backend/src/test/schema/ClassRegistry.test.ts
+++ b/core/backend/src/test/schema/ClassRegistry.test.ts
@@ -356,7 +356,7 @@ describe.only("Class Registry - generated classes", () => {
     MyTestGeneratedClasses.unregisterSchema();
   });
 
-  it.only("should work along a complex chain of overrides", async () => {
+  it("should work along a complex chain of overrides", async () => {
     class MyDerived2 extends Derived2 {
       public override collectPredecessorIds(predecessorIds: Id64Set) {
         super.collectPredecessorIds(predecessorIds);

--- a/core/backend/src/test/schema/ClassRegistry.test.ts
+++ b/core/backend/src/test/schema/ClassRegistry.test.ts
@@ -100,7 +100,7 @@ describe("Class Registry", () => {
   });
 });
 
-describe.only("Class Registry - generated classes", () => {
+describe("Class Registry - generated classes", () => {
   let imodel: SnapshotDb;
   const testSchemaPath = path.join(KnownTestLocations.assetsDir, "TestGeneratedClasses.ecschema.xml");
 
@@ -341,12 +341,11 @@ describe.only("Class Registry - generated classes", () => {
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     assert.isDefined(ActualDerivedWithNavProp.prototype.getPredecessorIds);
-    // This demonstrates that if a non-generated class has a registered non-biscore base, it will still get a generated impl,
-    // which will not include navigation properties of base classes as predecessors if the base class chose to ignore them
+    // This demonstrates that if a non-generated class has a registered non-biscore base, it will not get a generated impl,
     expect(
       [...derivedElemWithNavProp.getPredecessorIds()]
     ).to.have.members(
-      [elemWithNavProp.model, elemWithNavProp.code.scope, elemWithNavProp.parent?.id, testImplPredecessorId, testEntity2Id].filter((x) => x !== undefined)
+      [elemWithNavProp.model, elemWithNavProp.code.scope, elemWithNavProp.parent?.id, testImplPredecessorId].filter((x) => x !== undefined)
     );
     // explicitly check we called the super function
     // (we already know its implementation was called, because testImplPredecessorId is in the derived call's result)

--- a/core/backend/src/test/schema/ClassRegistry.test.ts
+++ b/core/backend/src/test/schema/ClassRegistry.test.ts
@@ -100,7 +100,7 @@ describe("Class Registry", () => {
   });
 });
 
-describe("Class Registry - generated classes", () => {
+describe.only("Class Registry - generated classes", () => {
   let imodel: SnapshotDb;
   const testSchemaPath = path.join(KnownTestLocations.assetsDir, "TestGeneratedClasses.ecschema.xml");
 
@@ -167,6 +167,12 @@ describe("Class Registry - generated classes", () => {
       this.derivedNavProp = new RelatedElement(props.derivedNavProp);
     }
   }
+
+  class Derived2 extends DerivedWithNavProp {}
+  class Derived3 extends Derived2 {}
+  class Derived4 extends Derived3 {}
+  class Derived5 extends Derived4 {}
+  class Derived6 extends Derived5 {}
 
   // if a single inherited class is not generated, the entire hierarchy is considered not-generated
   it("should only generate automatic collectPredecessorIds implementations for generated classes", async () => {

--- a/core/backend/src/test/schema/ClassRegistry.test.ts
+++ b/core/backend/src/test/schema/ClassRegistry.test.ts
@@ -372,40 +372,36 @@ describe.only("Class Registry - generated classes", () => {
     class MyTestGeneratedClasses extends TestGeneratedClasses {
       public static override get classes() {
         // leaving Derived3,5,6 generated
-        return [ TestElementWithNavProp, MyDerived2, MyDerived4 ];
+        return [TestElementWithNavProp, MyDerived2, MyDerived4];
       }
     }
     MyTestGeneratedClasses.registerSchema();
 
     /* eslint-disable @typescript-eslint/naming-convention */
-    const MyDerived3 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived3");
-    const MyDerived5 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived5");
-    const MyDerived6 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived6");
+    const ActualTestElementWithNavProp = imodel.getJsClass<typeof Element>("TestGeneratedClasses:TestElementWithNavProp");
+    const ActualDerivedWithNavProp = imodel.getJsClass<typeof Element>("TestGeneratedClasses:DerivedWithNavProp");
+    const ActualDerived2 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived2");
+    const ActualDerived3 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived3");
+    const ActualDerived4 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived4");
+    const ActualDerived5 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived5");
+    const ActualDerived6 = imodel.getJsClass<typeof Element>("TestGeneratedClasses:Derived6");
     /* eslint-enable @typescript-eslint/no-redeclare */
 
-    expect(TestElementWithNavProp.hasNonGeneratedNonCoreBaseClass).to.be.false;
-    expect(DerivedWithNavProp.hasNonGeneratedNonCoreBaseClass).to.be.false;
-    expect(MyDerived2.hasNonGeneratedNonCoreBaseClass).to.be.false;
-    expect(MyDerived3.hasNonGeneratedNonCoreBaseClass).to.be.true;
-    expect(MyDerived4.hasNonGeneratedNonCoreBaseClass).to.be.true;
-    expect(MyDerived5.hasNonGeneratedNonCoreBaseClass).to.be.true;
-    expect(MyDerived6.hasNonGeneratedNonCoreBaseClass).to.be.true;
+    expect(ActualTestElementWithNavProp.isGeneratedClass).to.be.false;
+    expect(ActualDerivedWithNavProp.isGeneratedClass).to.be.true;
+    expect(ActualDerived2.isGeneratedClass).to.be.false;
+    expect(ActualDerived3.isGeneratedClass).to.be.true;
+    expect(ActualDerived4.isGeneratedClass).to.be.false;
+    expect(ActualDerived5.isGeneratedClass).to.be.true;
+    expect(ActualDerived6.isGeneratedClass).to.be.true;
 
-    expect(TestElementWithNavProp.isGeneratedClass).to.be.false;
-    expect(DerivedWithNavProp.hasNonGeneratedNonCoreBaseClass).to.be.false;
-    expect(MyDerived2.hasNonGeneratedNonCoreBaseClass).to.be.true;
-    expect(MyDerived3.hasNonGeneratedNonCoreBaseClass).to.be.false;
-    expect(MyDerived4.hasNonGeneratedNonCoreBaseClass).to.be.true;
-    expect(MyDerived5.hasNonGeneratedNonCoreBaseClass).to.be.false;
-    expect(MyDerived6.hasNonGeneratedNonCoreBaseClass).to.be.false;
-
-    assert.hasAllKeys(TestElementWithNavProp.prototype, ["getPredecessorIds"]);
-    assert.hasAllKeys(DerivedWithNavProp.prototype, ["getPredecessorIds"]);
-    assert.hasAllKeys(MyDerived2.prototype, ["getPredecessorIds"]);
-    assert.doesNotHaveAnyKeys(MyDerived3.prototype, ["getPredecessorIds"]); // base is generated so it shouldn't get the automatic impl
-    assert.hasAllKeys(MyDerived4.prototype, ["getPredecessorIds"]); // manually implements so it should have the method
-    assert.doesNotHaveAnyKeys(MyDerived5.prototype, ["getPredecessorIds"]);
-    assert.doesNotHaveAnyKeys(MyDerived6.prototype, ["getPredecessorIds"]);
+    assert.doesNotHaveAllKeys(ActualTestElementWithNavProp.prototype, ["getPredecessorIds"]); // manually does not implement it
+    assert.hasAllKeys(ActualDerivedWithNavProp.prototype, ["getPredecessorIds"]);
+    assert.hasAllKeys(ActualDerived2.prototype, ["getPredecessorIds"]);
+    assert.doesNotHaveAnyKeys(ActualDerived3.prototype, ["getPredecessorIds"]); // base is generated so it shouldn't get the automatic impl
+    assert.hasAllKeys(ActualDerived4.prototype, ["getPredecessorIds"]); // manually implements so it should have the method
+    assert.doesNotHaveAnyKeys(ActualDerived5.prototype, ["getPredecessorIds"]);
+    assert.doesNotHaveAnyKeys(ActualDerived6.prototype, ["getPredecessorIds"]);
 
     const testEntity1Id = imodel.elements.insertElement({
       classFullName: "TestGeneratedClasses:Derived6",


### PR DESCRIPTION
- the previous method of getting the super class of `this` causes infinite recursion in deep class hierarchies. Instead, reference the super class's method directly so the call propagates up the prototype chain.
- because users may choose to not manually register a class in a hierarchy where they do manually register other classes, do not automatically implement `collectPredecessorIds` for generated classes that have a non-BisCore, manually-registered ancestor. This leaves the responsibility to the implementer to make sure they report all necessary predecessors. 
   
   When a user registers custom javascript classes for some schema, but "skips" implementing one class, (for example having A superclasses B superclasses C in the schema, and registering custom classes for A and C but leaving B generated), they will probably in javascript have their `class C extend A`, which means the super method would in fact be from `A`, not from the generated `B`.
   
   Since we cannot make `C` call `B`'s method for the supercall without requiring them to manually get the generated class from the registry, I have opted to disable generating the automatic method implementation for this case where they have a manually registered ancestor
- add tests of a deep hierarchy with mixed generated and registered classes

@pmconne this should probably be part of the pending 3.1.3 addon since the bug exists there, hence this js-only fix targeting the imodel02 branch