### PR TITLE
Supply missing 'iModelJs' namespace in some calls to getLocalizedString

### DIFF
--- a/common/changes/@itwin/core-frontend/frontend-missing-localization-namespace_2022-02-08-00-00.json
+++ b/common/changes/@itwin/core-frontend/frontend-missing-localization-namespace_2022-02-08-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Supplied missing 'iModelJs' namespace in some calls to getLocalizedString.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -417,7 +417,7 @@ export class AccuSnap implements Decorator {
     if (!this.errorKey)
       return;
 
-    this.explanation = IModelApp.localization.getLocalizedString(this.errorKey);
+    this.explanation = IModelApp.localization.getLocalizedStringWithNamespace("iModelJs", this.errorKey);
     if (!this.explanation)
       return;
 
@@ -642,7 +642,7 @@ export class AccuSnap implements Decorator {
       if (appearance.dontSnap) {
         if (out) {
           out.snapStatus = SnapStatus.NotSnappable;
-          out.explanation = IModelApp.localization.getLocalizedString(ElementLocateManager.getFailureMessageKey("NotSnappableSubCategory"));
+          out.explanation = IModelApp.localization.getLocalizedStringWithNamespace("iModelJs", ElementLocateManager.getFailureMessageKey("NotSnappableSubCategory"));
         }
         return undefined;
       }

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -642,7 +642,7 @@ export class AccuSnap implements Decorator {
       if (appearance.dontSnap) {
         if (out) {
           out.snapStatus = SnapStatus.NotSnappable;
-          out.explanation = IModelApp.localization.getLocalizedStringWithNamespace("iModelJs", ElementLocateManager.getFailureMessageKey("NotSnappableSubCategory"));
+          out.explanation = IModelApp.localization.getLocalizedString(`iModelJs:${ElementLocateManager.getFailureMessageKey("NotSnappableSubCategory")}`);
         }
         return undefined;
       }

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -417,7 +417,7 @@ export class AccuSnap implements Decorator {
     if (!this.errorKey)
       return;
 
-    this.explanation = IModelApp.localization.getLocalizedStringWithNamespace("iModelJs", this.errorKey);
+    this.explanation = IModelApp.localization.getLocalizedString(`iModelJs:${this.errorKey}`);
     if (!this.explanation)
       return;
 

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -675,7 +675,7 @@ export class IModelApp {
   public static makeIModelJsLogoCard() {
     return this.makeLogoCard({
       iconSrc: `${this.publicPath}images/about-imodeljs.svg`,
-      heading: `<span style="font-weight:normal">${this.localization.getLocalizedString("Notices.PoweredBy")}</span>&nbsp;iTwin.js`,
+      heading: `<span style="font-weight:normal">${this.localization.getLocalizedString("iModelJs:Notices.PoweredBy")}</span>&nbsp;iTwin.js`,
       notice: `${require("../../package.json").version}<br>${copyrightNotice}`, // eslint-disable-line @typescript-eslint/no-var-requires
     });
   }
@@ -710,6 +710,6 @@ export class IModelApp {
         key = { scope: "Errors", val: "Status", status: status.toString() };
     }
 
-    return this.localization.getLocalizedString(`${key.scope}.${key.val}`, key);
+    return this.localization.getLocalizedString(`iModelJs:${key.scope}.${key.val}`, key);
   }
 }

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -740,7 +740,7 @@ export abstract class ViewState extends ElementState {
 
   /** @internal */
   public outputStatusMessage(status: ViewStatus): ViewStatus {
-    IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, IModelApp.localization.getLocalizedString(`Viewing.${ViewStatus[status]}`)));
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, IModelApp.localization.getLocalizedString(`iModelJs:Viewing.${ViewStatus[status]}`)));
     return status;
   }
 

--- a/core/frontend/src/tile/map/CesiumTerrainProvider.ts
+++ b/core/frontend/src/tile/map/CesiumTerrainProvider.ts
@@ -76,14 +76,14 @@ function notifyTerrainError(detailedDescription?: string): void {
     return;
 
   notifiedTerrainError = true;
-  IModelApp.notifications.displayMessage(MessageSeverity.Information, IModelApp.localization.getLocalizedString(`BackgroundMap.CannotObtainTerrain`), detailedDescription);
+  IModelApp.notifications.displayMessage(MessageSeverity.Information, IModelApp.localization.getLocalizedString(`iModelJs:BackgroundMap.CannotObtainTerrain`), detailedDescription);
 }
 
 /** @internal */
 export async function getCesiumTerrainProvider(iModel: IModelConnection, modelId: Id64String, wantSkirts: boolean, wantNormals: boolean, exaggeration: number): Promise<TerrainMeshProvider | undefined> {
   const accessTokenAndEndpointUrl = await getCesiumAccessTokenAndEndpointUrl();
   if (!accessTokenAndEndpointUrl.token || !accessTokenAndEndpointUrl.url) {
-    notifyTerrainError(IModelApp.localization.getLocalizedString(`BackgroundMap.MissingCesiumToken`));
+    notifyTerrainError(IModelApp.localization.getLocalizedString(`iModelJs:BackgroundMap.MissingCesiumToken`));
     return undefined;
   }
 

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -98,7 +98,7 @@ export abstract class ViewTool extends InteractiveTool {
   public override async run(..._args: any[]): Promise<boolean> {
     const toolAdmin = IModelApp.toolAdmin;
     if (undefined !== this.viewport && this.viewport === toolAdmin.markupView) {
-      IModelApp.notifications.outputPromptByKey("Viewing.NotDuringMarkup");
+      IModelApp.notifications.outputPromptByKey("iModelJs:Viewing.NotDuringMarkup");
       return false;
     }
 


### PR DESCRIPTION
The 'iModelJs' namespace was missing in some calls to getLocalizedString in core-frontend. This resulted in untranslated strings in Design Review. 