### PR TITLE
Implement pnts 3d tile spec

### DIFF
--- a/common/changes/@itwin/core-frontend/pnts-spec-conformance_2022-02-10-10-58.json
+++ b/common/changes/@itwin/core-frontend/pnts-spec-conformance_2022-02-10-10-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fully implement the 3d tile specification for point clouds.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/PntsReader.ts
+++ b/core/frontend/src/tile/PntsReader.ts
@@ -58,7 +58,7 @@ interface CommonPntsProps {
   };
 
   // The following are currently ignored.
-  NORMAl?: BinaryBodyReference; // eslint-disable-line @typescript-eslint/naming-convention
+  NORMAL?: BinaryBodyReference; // eslint-disable-line @typescript-eslint/naming-convention
   NORMAL_OCT16P?: BinaryBodyReference; // eslint-disable-line @typescript-eslint/naming-convention
   BATCH_ID?: BinaryBodyReference; // eslint-disable-line @typescript-eslint/naming-convention
   BATCH_LENGTH?: number; // eslint-disable-line @typescript-eslint/naming-convention


### PR DESCRIPTION
@RBBentley's initial implementation required quantized positions; the point cloud to be used in our upcoming hackathon contains unquantized positions so fails to load.
Also, that implementation requires RGB colors or else makes all points white; the spec permits other color formats, including a constant color for all points.

[Specification](https://docs.opengeospatial.org/cs/18-053r2/18-053r2.html#199)
[JSON schema](https://github.com/CesiumGS/3d-tiles/blob/main/specification/schema/pnts.featureTable.schema.json)

TODO in future: we currently ignore alpha channel.