### PR TITLE
Autohide popups from the toolbar

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -3684,6 +3684,9 @@ export class ToolbarPanelAlignmentHelpers {
 }
 
 // @public
+export const ToolbarPopupAutoHideContext: React.Context<boolean>;
+
+// @public
 export const ToolbarPopupContext: React.Context<ToolbarPopupContextProps>;
 
 // @public (undocumented)
@@ -4210,6 +4213,9 @@ export function useRenderedStringValue(record: PropertyRecord, stringValueCalcul
     stringValue?: string;
     element: React.ReactNode;
 };
+
+// @public
+export function useToolbarPopupAutoHideContext(): boolean;
 
 // @public
 export function useToolbarPopupContext(): ToolbarPopupContextProps;

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -404,6 +404,7 @@ public;ToolbarOpacitySetting
 internal;ToolbarOverflowContextProps
 public;ToolbarPanelAlignment
 internal;ToolbarPanelAlignmentHelpers
+public;ToolbarPopupAutoHideContext: React.Context
 public;ToolbarPopupContext: React.Context
 public;ToolbarPopupContextProps
 public;ToolbarProps 
@@ -466,6 +467,7 @@ beta;usePropertyGridEventHandler(props:
 beta;usePropertyGridModel(props:
 beta;usePropertyGridModelSource(props:
 internal;useRenderedStringValue(record: PropertyRecord, stringValueCalculator: (record: PropertyRecord) => string | Promise
+public;useToolbarPopupAutoHideContext(): boolean
 public;useToolbarPopupContext(): ToolbarPopupContextProps
 internal;useToolbarWithOverflowDirectionContext(): ToolbarOverflowContextProps
 internal;useToolItemEntryContext(): ToolbarItemContextArgs

--- a/common/changes/@itwin/appui-react/ui-fixAutoHideOfToolPanels_2022-02-11-20-21.json
+++ b/common/changes/@itwin/appui-react/ui-fixAutoHideOfToolPanels_2022-02-11-20-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Update ToolbarAutoHidePopup context when widgets autohide.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/ui-fixAutoHideOfToolPanels_2022-02-11-20-21.json
+++ b/common/changes/@itwin/components-react/ui-fixAutoHideOfToolPanels_2022-02-11-20-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Use ToolbarAutoHidePopupContext to monitor widgets' authoidden state.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -87,6 +87,7 @@ export * from "./appui-react/hooks/useAnalysisAnimationDataProvider";
 export * from "./appui-react/hooks/useFrameworkVersion";
 export * from "./appui-react/hooks/useScheduleAnimationDataProvider";
 export * from "./appui-react/hooks/useSolarDataProvider";
+export * from "./appui-react/hooks/useUiVisibility";
 
 export * from "./appui-react/imodel-components/spatial-tree/SpatialContainmentTree";
 export * from "./appui-react/imodel-components/category-tree/CategoriesTree";

--- a/ui/appui-react/src/appui-react/hooks/useUiVisibility.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useUiVisibility.tsx
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Hooks
+ */
+
+import { useEffect, useState } from "react";
+import { UiFramework, UiVisibilityEventArgs } from "../UiFramework";
+
+/** @internal */
+// istanbul ignore next
+export function useUiVisibility() {
+  const [uiIsVisible, setUiIsVisible] = useState(UiFramework.getIsUiVisible());
+  useEffect(() => {
+    const handleUiVisibilityChanged = ((args: UiVisibilityEventArgs): void => setUiIsVisible(args.visible));
+    UiFramework.onUiVisibilityChanged.addListener(handleUiVisibilityChanged);
+    return () => {
+      UiFramework.onUiVisibilityChanged.removeListener(handleUiVisibilityChanged);
+    };
+  }, []);
+  return uiIsVisible;
+}

--- a/ui/appui-react/src/appui-react/uiprovider/DefaultDialogGridContainer.scss
+++ b/ui/appui-react/src/appui-react/uiprovider/DefaultDialogGridContainer.scss
@@ -207,6 +207,9 @@ div.nz-toolSettings-docked .uifw-default-editor:last-child {
 
 /* Override the GridLayout case where width is 100% */
 div.nz-toolSettings-docked {
+  border-top: none;
+  border-left: none;
+  border-right: none;
   select.uicore-inputs-select.components-cell-editor.components-enum-editor {
     width: auto;
   }

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -16,6 +16,7 @@ import * as React from "react";
 import { assert, Logger, ProcessDetector } from "@itwin/core-bentley";
 import { StagePanelLocation, UiItemsManager, WidgetState } from "@itwin/appui-abstract";
 import { Size, SizeProps, UiStateStorageResult, UiStateStorageStatus } from "@itwin/core-react";
+import { ToolbarPopupAutoHideContext } from "@itwin/components-react";
 import {
   addPanelWidget, addTab, addWidgetTabToFloatingPanel, convertAllPopupWidgetContainersToFloating, createNineZoneState, createTabsState, createTabState,
   createWidgetState, findTab, findWidget, floatingWidgetBringToFront, FloatingWidgetHomeState, FloatingWidgets, getUniqueId, isFloatingLocation,
@@ -41,24 +42,29 @@ import { ToolSettingsContent, WidgetPanelsToolSettings } from "./ToolSettings";
 import { useEscapeSetFocusToHome } from "../hooks/useEscapeSetFocusToHome";
 import { FrameworkRootState } from "../redux/StateManager";
 import { useSelector } from "react-redux";
+import { useUiVisibility } from "../hooks/useUiVisibility";
 
 const panelZoneKeys: StagePanelZoneDefKeys[] = ["start", "middle", "end"];
 
 // istanbul ignore next
 const WidgetPanelsFrontstageComponent = React.memo(function WidgetPanelsFrontstageComponent() { // eslint-disable-line @typescript-eslint/naming-convention, no-shadow
   const activeModalFrontstageInfo = useActiveModalFrontstageInfo();
+  const uiIsVisible = useUiVisibility();
+
   return (
     <>
-      <ModalFrontstageComposer stageInfo={activeModalFrontstageInfo} />
-      <WidgetPanelsToolSettings />
-      <WidgetPanels
-        className="uifw-widgetPanels"
-        centerContent={<WidgetPanelsToolbars />}
-      >
-        <WidgetPanelsFrontstageContent />
-      </WidgetPanels>
-      <WidgetPanelsStatusBar />
-      <FloatingWidgets />
+      <ToolbarPopupAutoHideContext.Provider value={!uiIsVisible}>
+        <ModalFrontstageComposer stageInfo={activeModalFrontstageInfo} />
+        <WidgetPanelsToolSettings />
+        <WidgetPanels
+          className="uifw-widgetPanels"
+          centerContent={<WidgetPanelsToolbars />}
+        >
+          <WidgetPanelsFrontstageContent />
+        </WidgetPanels>
+        <WidgetPanelsStatusBar />
+        <FloatingWidgets />
+      </ToolbarPopupAutoHideContext.Provider>
     </>
   );
 });
@@ -221,17 +227,17 @@ export function ActiveFrontstageDefProvider({ frontstageDef }: { frontstageDef: 
       onKeyDown={handleKeyDown}
       role="presentation"
     >
-      <NineZone
-        dispatch={dispatch}
-        labels={labels}
-        state={nineZone}
-        tab={tabElement}
-        showWidgetIcon={showWidgetIcon}
-        toolSettingsContent={toolSettingsContent}
-        widgetContent={widgetContent}
-      >
-        {widgetPanelsFrontstage}
-      </NineZone>
+        <NineZone
+          dispatch={dispatch}
+          labels={labels}
+          state={nineZone}
+          tab={tabElement}
+          showWidgetIcon={showWidgetIcon}
+          toolSettingsContent={toolSettingsContent}
+          widgetContent={widgetContent}
+        >
+          {widgetPanelsFrontstage}
+        </NineZone>
     </div>
   );
 }

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -227,17 +227,17 @@ export function ActiveFrontstageDefProvider({ frontstageDef }: { frontstageDef: 
       onKeyDown={handleKeyDown}
       role="presentation"
     >
-        <NineZone
-          dispatch={dispatch}
-          labels={labels}
-          state={nineZone}
-          tab={tabElement}
-          showWidgetIcon={showWidgetIcon}
-          toolSettingsContent={toolSettingsContent}
-          widgetContent={widgetContent}
-        >
-          {widgetPanelsFrontstage}
-        </NineZone>
+      <NineZone
+        dispatch={dispatch}
+        labels={labels}
+        state={nineZone}
+        tab={tabElement}
+        showWidgetIcon={showWidgetIcon}
+        toolSettingsContent={toolSettingsContent}
+        widgetContent={widgetContent}
+      >
+        {widgetPanelsFrontstage}
+      </NineZone>
     </div>
   );
 }

--- a/ui/appui-react/src/appui-react/widgets/BasicNavigationWidget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/BasicNavigationWidget.tsx
@@ -12,7 +12,7 @@ import { CommonToolbarItem, ToolbarOrientation, ToolbarUsage } from "@itwin/appu
 import { CoreTools } from "../tools/CoreToolDefinitions";
 import { ToolbarComposer } from "../toolbar/ToolbarComposer";
 import { ToolbarHelper } from "../toolbar/ToolbarHelper";
-import { useUiVisibility } from "./BasicToolWidget";
+import { useUiVisibility } from "../hooks/useUiVisibility";
 import { NavigationWidgetComposer } from "./NavigationWidgetComposer";
 
 /** Properties that can be used to append items to the default set of toolbar items of [[DefaultNavigationWidget]].

--- a/ui/appui-react/src/appui-react/widgets/BasicToolWidget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/BasicToolWidget.tsx
@@ -13,9 +13,9 @@ import { CoreTools } from "../tools/CoreToolDefinitions";
 import { SelectionContextToolDefinitions } from "../selection/SelectionContextItemDef";
 import { ToolbarComposer } from "../toolbar/ToolbarComposer";
 import { ToolbarHelper } from "../toolbar/ToolbarHelper";
-import { UiFramework, UiVisibilityEventArgs } from "../UiFramework";
 import { ToolWidgetComposer } from "./ToolWidgetComposer";
 import { BackstageAppButton } from "./BackstageAppButton";
+import { useUiVisibility } from "../hooks/useUiVisibility";
 
 /** Properties that can be used to append items to the default set of toolbar items of [[ReviewToolWidget]].
  * @public
@@ -29,20 +29,6 @@ export interface BasicToolWidgetProps {
   additionalHorizontalItems?: CommonToolbarItem[];
   /** optional set of additional items to include in vertical toolbar */
   additionalVerticalItems?: CommonToolbarItem[];
-}
-
-/** @internal */
-// istanbul ignore next
-export function useUiVisibility() {
-  const [uiIsVisible, setUiIsVisible] = React.useState(UiFramework.getIsUiVisible());
-  React.useEffect(() => {
-    const handleUiVisibilityChanged = ((args: UiVisibilityEventArgs): void => setUiIsVisible(args.visible));
-    UiFramework.onUiVisibilityChanged.addListener(handleUiVisibilityChanged);
-    return () => {
-      UiFramework.onUiVisibilityChanged.removeListener(handleUiVisibilityChanged);
-    };
-  }, []);
-  return uiIsVisible;
 }
 
 /** Default Tool Widget for standard "review" applications. Provides standard tools to review, and measure elements.

--- a/ui/appui-react/src/appui-react/widgets/ContentToolWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/ContentToolWidgetComposer.tsx
@@ -11,7 +11,7 @@ import * as React from "react";
 import { ToolbarOrientation, ToolbarUsage } from "@itwin/appui-abstract";
 import { ToolbarComposer } from "../toolbar/ToolbarComposer";
 import { ToolWidgetComposer } from "./ToolWidgetComposer";
-import { useUiVisibility } from "./BasicToolWidget";
+import { useUiVisibility } from "../hooks/useUiVisibility";
 
 /**
  * Props for [[ContentToolWidgetComposer]].

--- a/ui/appui-react/src/appui-react/widgets/ViewToolWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/ViewToolWidgetComposer.tsx
@@ -10,7 +10,7 @@ import classnames from "classnames";
 import * as React from "react";
 import { ToolbarOrientation, ToolbarUsage } from "@itwin/appui-abstract";
 import { ToolbarComposer } from "../toolbar/ToolbarComposer";
-import { useUiVisibility } from "./BasicToolWidget";
+import { useUiVisibility } from "../hooks/useUiVisibility";
 import { NavigationWidgetComposer } from "./NavigationWidgetComposer";
 
 /**

--- a/ui/components-react/src/components-react/toolbar/Overflow.scss
+++ b/ui/components-react/src/components-react/toolbar/Overflow.scss
@@ -46,4 +46,11 @@
   background: none;
 
   @include uicore-z-index(toolbar-panels);
+
+  transition: visibility 0.5s ease, opacity 0.5s ease;
+
+  &.nz-hidden {
+    opacity: 0;
+    visibility: hidden;
+  }
 }

--- a/ui/components-react/src/components-react/toolbar/Overflow.tsx
+++ b/ui/components-react/src/components-react/toolbar/Overflow.tsx
@@ -10,7 +10,7 @@ import "./Overflow.scss";
 import classnames from "classnames";
 import * as React from "react";
 import { CommonProps, NoChildrenProps, Popup, useRefState } from "@itwin/core-react";
-import { useToolItemEntryContext } from "./ToolbarWithOverflow";
+import { useToolbarPopupAutoHideContext, useToolItemEntryContext } from "./ToolbarWithOverflow";
 import { useResizeObserverSingleDimension } from "./ItemWrapper";
 import { Direction } from "./utilities/Direction";
 import { RelativePosition } from "@itwin/appui-abstract";
@@ -40,6 +40,11 @@ export function ToolbarOverflowButton(props: ToolbarOverflowButtonProps) {
   const { onResize, useHeight } = useToolItemEntryContext();
   const [targetRef, target] = useRefState<HTMLDivElement>();
   const ref = useResizeObserverSingleDimension<HTMLButtonElement>(onResize, useHeight);
+  const isHidden = useToolbarPopupAutoHideContext();
+  const popupClassName = classnames(
+    "components-toolbar-overflow_popup",
+    isHidden && "nz-hidden");
+
   const className = classnames(
     "components-toolbar-item-container",
     "components-toolbar-overflow-button",
@@ -66,7 +71,7 @@ export function ToolbarOverflowButton(props: ToolbarOverflowButtonProps) {
         </div>
       </button>
       <Popup
-        className="components-toolbar-overflow_popup"
+        className={popupClassName}
         offset={0}
         showShadow={false}
         isOpen={props.open}

--- a/ui/components-react/src/components-react/toolbar/PopupItem.scss
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.scss
@@ -14,14 +14,14 @@
   $arrow-shadow: $icon-shadow;
   position: relative;
 
-  > * {
+  >* {
     &:not(.components-triangle) {
       height: 100%;
       width: 100%;
     }
   }
 
-  > .components-triangle {
+  >.components-triangle {
     border-radius: 0;
     position: absolute;
     right: $margin-from-triangle-to-stroke;
@@ -36,7 +36,7 @@
     );
   }
 
-  &:active > .components-triangle {
+  &:active >.components-triangle {
     filter: $no-shadow;
 
     @include triangle-bottom-right-color($pressed-icon-color);
@@ -44,7 +44,7 @@
 
   &.components-active {
     &:not(:active):not(.components-disabled) {
-      > .components-triangle {
+      >.components-triangle {
         filter: $no-shadow;
 
         @include triangle-bottom-right-color($active-icon-color);
@@ -53,7 +53,7 @@
   }
 
   &.components-disabled {
-    > .components-triangle {
+    >.components-triangle {
       @include triangle-bottom-right-color($disabled-icon-color);
     }
   }
@@ -63,7 +63,7 @@
       color: $disabled-icon-color;
     }
 
-    > .components-triangle {
+    >.components-triangle {
       @include triangle-bottom-right-color($disabled-icon-color);
     }
   }

--- a/ui/components-react/src/components-react/toolbar/PopupItem.scss
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.scss
@@ -36,7 +36,7 @@
     );
   }
 
-  &:active >.components-triangle {
+  &:active>.components-triangle {
     filter: $no-shadow;
 
     @include triangle-bottom-right-color($pressed-icon-color);
@@ -59,7 +59,7 @@
   }
 
   &.components-disabled-drag {
-    > .components-icon {
+    >.components-icon {
       color: $disabled-icon-color;
     }
 

--- a/ui/components-react/src/components-react/toolbar/PopupItem.scss
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.scss
@@ -14,14 +14,14 @@
   $arrow-shadow: $icon-shadow;
   position: relative;
 
-  >* {
+  > * {
     &:not(.components-triangle) {
       height: 100%;
       width: 100%;
     }
   }
 
-  >.components-triangle {
+  > .components-triangle {
     border-radius: 0;
     position: absolute;
     right: $margin-from-triangle-to-stroke;
@@ -29,10 +29,14 @@
     filter: $arrow-shadow;
     pointer-events: none;
 
-    @include triangle-bottom-right($width: $triangle-width, $height: $triangle-height, $color: $buic-icon-color);
+    @include triangle-bottom-right(
+      $width: $triangle-width,
+      $height: $triangle-height,
+      $color: $buic-icon-color
+    );
   }
 
-  &:active>.components-triangle {
+  &:active > .components-triangle {
     filter: $no-shadow;
 
     @include triangle-bottom-right-color($pressed-icon-color);
@@ -40,7 +44,7 @@
 
   &.components-active {
     &:not(:active):not(.components-disabled) {
-      >.components-triangle {
+      > .components-triangle {
         filter: $no-shadow;
 
         @include triangle-bottom-right-color($active-icon-color);
@@ -49,17 +53,17 @@
   }
 
   &.components-disabled {
-    >.components-triangle {
+    > .components-triangle {
       @include triangle-bottom-right-color($disabled-icon-color);
     }
   }
 
   &.components-disabled-drag {
-    >.components-icon {
+    > .components-icon {
       color: $disabled-icon-color;
     }
 
-    >.components-triangle {
+    > .components-triangle {
       @include triangle-bottom-right-color($disabled-icon-color);
     }
   }
@@ -73,4 +77,11 @@
   border-width: 1px;
   border-style: solid;
   border-radius: 3px;
+
+  transition: visibility 0.5s ease, opacity 0.5s ease;
+
+  &.nz-hidden {
+    opacity: 0;
+    visibility: hidden;
+  }
 }

--- a/ui/components-react/src/components-react/toolbar/PopupItem.tsx
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.tsx
@@ -15,6 +15,21 @@ import { ToolbarButtonItemProps } from "./Item";
 import { useToolbarWithOverflowDirectionContext, useToolItemEntryContext } from "./ToolbarWithOverflow";
 import { toToolbarPopupRelativePosition } from "./PopupItemWithDrag";
 
+/**
+ * Context used by Toolbar items to know if popup panel should be hidden - via AutoHide.
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const ToolbarPopupAutoHideContext = React.createContext<boolean>(false);
+
+/**
+ * React hook used to retrieve the ToolbarPopupAutoHideContext.
+ *  @public
+ */
+export function useToolbarPopupAutoHideContext() {
+  return React.useContext(ToolbarPopupAutoHideContext);
+}
+
 /** @public */
 export interface ToolbarPopupContextProps {
   readonly closePanel: () => void;
@@ -144,8 +159,13 @@ interface PopupItemPopupProps {
 
 /** @internal */
 export function PopupItemPopup(props: PopupItemPopupProps) {
+  const isHidden = useToolbarPopupAutoHideContext();
+  const className = classnames(
+    "components-toolbar-popupItem_popupItemPopup",
+    isHidden && "nz-hidden");
+
   return <Popup
-    className="components-toolbar-popupItem_popupItemPopup"
+    className={className}
     offset={0}
     showShadow={false}
     {...props}

--- a/ui/components-react/src/components-react/toolbar/PopupItem.tsx
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.tsx
@@ -12,23 +12,8 @@ import * as React from "react";
 import { ActionButton, RelativePosition } from "@itwin/appui-abstract";
 import { Popup, useRefState } from "@itwin/core-react";
 import { ToolbarButtonItemProps } from "./Item";
-import { useToolbarWithOverflowDirectionContext, useToolItemEntryContext } from "./ToolbarWithOverflow";
+import { useToolbarPopupAutoHideContext, useToolbarWithOverflowDirectionContext, useToolItemEntryContext } from "./ToolbarWithOverflow";
 import { toToolbarPopupRelativePosition } from "./PopupItemWithDrag";
-
-/**
- * Context used by Toolbar items to know if popup panel should be hidden - via AutoHide.
- * @public
- */
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const ToolbarPopupAutoHideContext = React.createContext<boolean>(false);
-
-/**
- * React hook used to retrieve the ToolbarPopupAutoHideContext.
- *  @public
- */
-export function useToolbarPopupAutoHideContext() {
-  return React.useContext(ToolbarPopupAutoHideContext);
-}
 
 /** @public */
 export interface ToolbarPopupContextProps {

--- a/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
@@ -38,6 +38,21 @@ export interface CustomToolbarItem extends CustomButtonDefinition {
   keepContentsLoaded?: boolean;
 }
 
+/**
+ * Context used by Toolbar items to know if popup panel should be hidden - via AutoHide.
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const ToolbarPopupAutoHideContext = React.createContext<boolean>(false);
+
+/**
+ * React hook used to retrieve the ToolbarPopupAutoHideContext.
+ *  @public
+ */
+export function useToolbarPopupAutoHideContext() {
+  return React.useContext(ToolbarPopupAutoHideContext);
+}
+
 /** Describes toolbar item.
  * @public
  */


### PR DESCRIPTION
When the tool widgets are hidden automatically because of inactivity, any open popups were left visible. Add a React context to monitor the status of the parent tool widgets and hide popups with them.