### PR TITLE
Run integration tests on all platforms

### DIFF
--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -6,7 +6,9 @@
 #
 # Note: Currently a subset of all integration tests
 
-trigger: none
+trigger:
+  - master
+  - release/*
 pr:
   autoCancel: true
   drafts: false

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -23,7 +23,7 @@ variables:
   - group: iTwin.js Integration Test Users
 
 jobs:
-  - job: Node_14_x
+  - job: Integration Tests
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     strategy:
       matrix:
@@ -71,7 +71,7 @@ jobs:
           Node_Version: $(nodeVersion)
 
   # Pull request validation
-  - job: Node_14_x
+  - job: Integration Tests (PR Validation)
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     pool:
       vmImage: ubuntu-latest

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -6,11 +6,8 @@
 #
 # Note: Currently a subset of all integration tests
 
-trigger:
-  - master
-  - release/*
-
 pr:
+  autoCancel: true
   drafts: false
   branches:
     include:
@@ -23,7 +20,6 @@ variables:
 
 jobs:
   - job: Integration_Tests_PR_Validation
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     pool:
       vmImage: ubuntu-latest
     steps:

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -6,6 +6,7 @@
 #
 # Note: Currently a subset of all integration tests
 
+trigger: none
 pr:
   autoCancel: true
   drafts: false

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -5,7 +5,6 @@
 # All other versions are run on `master` and `release/*` branches.
 #
 # Note: Currently a subset of all integration tests
-#
 
 trigger:
   - master
@@ -23,54 +22,6 @@ variables:
   - group: iTwin.js Integration Test Users
 
 jobs:
-  - job: Integration_Tests_Full
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    strategy:
-      matrix:
-        Linux_node_12_7:
-          imageName: ubuntu-latest
-          nodeVersion: 12.17.0
-        Linux_node_12_x:
-          imageName: ubuntu-latest
-          nodeVersion: 12.x
-        Linux_node_14_x:
-          imageName: ubuntu-latest
-          nodeVersion: 12.x
-        # linux_node_16_x:
-        #   imageName: ubuntu-latest
-        #   nodeVersion: 16.x
-        Windows_node_12_7:
-          imageName: windows-latest
-          nodeVersion: 12.17.0
-        Windows_node_12_x:
-          imageName: windows-latest
-          nodeVersion: 12.x
-        Windows_node_14_x:
-          imageName: windows-latest
-          nodeVersion: 12.x
-        # Windows_node_16_x:
-        #   imageName: windows-latest
-        #   nodeVersion: 16.x
-        MacOS_node_12_7:
-          imageName: macos-latest
-          nodeVersion: 12.17.0
-        MacOS_node_12_x:
-          imageName: macos-latest
-          nodeVersion: 12.x
-        MacOS_node_14_x:
-          imageName: macos-latest
-          nodeVersion: 12.x
-        # MacOS_node_16_x:
-        #   imageName: macos-latest
-        #   nodeVersion: 16.x
-    pool:
-      vmImage: $(imageName)
-    steps:
-      - template: templates/integration-test-steps.yaml
-        parameters:
-          Node_Version: $(nodeVersion)
-
-  # Pull request validation
   - job: Integration_Tests_PR_Validation
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     pool:

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -23,7 +23,7 @@ variables:
   - group: iTwin.js Integration Test Users
 
 jobs:
-  - job: Integration Tests
+  - job: Integration_Tests_Full
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     strategy:
       matrix:
@@ -71,7 +71,7 @@ jobs:
           Node_Version: $(nodeVersion)
 
   # Pull request validation
-  - job: Integration Tests (PR Validation)
+  - job: Integration_Tests_PR_Validation
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     pool:
       vmImage: ubuntu-latest

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -23,35 +23,59 @@ variables:
   - group: iTwin.js Integration Test Users
 
 jobs:
-  # - job: Node_16_x
-  #   condition: succeeded()
-  #   pool:
-  #     vmImage: ubuntu-latest
-  #   steps:
-  #     - template: templates/integration-test-steps.yaml
-  #       parameters:
-  #         Node_Version: 16.x
   - job: Node_14_x
-    condition: succeeded()
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    strategy:
+      matrix:
+        Linux_node_12_7:
+          imageName: ubuntu-latest
+          nodeVersion: 12.17.0
+        Linux_node_12_x:
+          imageName: ubuntu-latest
+          nodeVersion: 12.x
+        Linux_node_14_x:
+          imageName: ubuntu-latest
+          nodeVersion: 12.x
+        # linux_node_16_x:
+        #   imageName: ubuntu-latest
+        #   nodeVersion: 16.x
+        Windows_node_12_7:
+          imageName: windows-latest
+          nodeVersion: 12.17.0
+        Windows_node_12_x:
+          imageName: windows-latest
+          nodeVersion: 12.x
+        Windows_node_14_x:
+          imageName: windows-latest
+          nodeVersion: 12.x
+        # Windows_node_16_x:
+        #   imageName: windows-latest
+        #   nodeVersion: 16.x
+        MacOS_node_12_7:
+          imageName: macos-latest
+          nodeVersion: 12.17.0
+        MacOS_node_12_x:
+          imageName: macos-latest
+          nodeVersion: 12.x
+        MacOS_node_14_x:
+          imageName: macos-latest
+          nodeVersion: 12.x
+        # MacOS_node_16_x:
+        #   imageName: macos-latest
+        #   nodeVersion: 16.x
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: templates/integration-test-steps.yaml
+        parameters:
+          Node_Version: $(nodeVersion)
+
+  # Pull request validation
+  - job: Node_14_x
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     pool:
       vmImage: ubuntu-latest
     steps:
       - template: templates/integration-test-steps.yaml
         parameters:
           Node_Version: 14.x
-  - job: Node_12_x
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-      - template: templates/integration-test-steps.yaml
-        parameters:
-          Node_Version: 12.x
-  - job: Node_12_17
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-      - template: templates/integration-test-steps.yaml
-        parameters:
-          Node_Version: 12.17.0

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -18,7 +18,6 @@ variables:
 
 jobs:
   - job: Integration_Tests_Full
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     strategy:
       maxParallel: 3
       matrix:

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -4,6 +4,7 @@
 # Runs against master on a weekly schedule, in the future this should be a required check before bumping versions.
 
 trigger: none
+pr: none
 
 schedules:
 - cron: "0 0 * * Sun"

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -1,0 +1,66 @@
+# iTwin.js Core Integration Validation Build
+#
+# This integration test job currently runs on all supported operating systems and node versions of iTwin.js.
+# Runs against master on a weekly schedule, in the future this should be a required check before bumping versions.
+
+trigger: none
+
+schedules:
+- cron: "0 0 * * Sun"
+  displayName: Weekly Sunday build
+  branches:
+    include:
+    - master
+
+variables:
+  - group: iTwin.js non-secret config variables
+  - group: iTwin.js Integration Test Users
+
+jobs:
+  - job: Integration_Tests_Full
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    strategy:
+      maxParallel: 3
+      matrix:
+        Linux_node_12_7:
+          imageName: ubuntu-latest
+          nodeVersion: 12.17.0
+        Linux_node_12_x:
+          imageName: ubuntu-latest
+          nodeVersion: 12.x
+        Linux_node_14_x:
+          imageName: ubuntu-latest
+          nodeVersion: 12.x
+        # linux_node_16_x:
+        #   imageName: ubuntu-latest
+        #   nodeVersion: 16.x
+        Windows_node_12_7:
+          imageName: windows-latest
+          nodeVersion: 12.17.0
+        Windows_node_12_x:
+          imageName: windows-latest
+          nodeVersion: 12.x
+        Windows_node_14_x:
+          imageName: windows-latest
+          nodeVersion: 12.x
+        # Windows_node_16_x:
+        #   imageName: windows-latest
+        #   nodeVersion: 16.x
+        MacOS_node_12_7:
+          imageName: macos-latest
+          nodeVersion: 12.17.0
+        MacOS_node_12_x:
+          imageName: macos-latest
+          nodeVersion: 12.x
+        MacOS_node_14_x:
+          imageName: macos-latest
+          nodeVersion: 12.x
+        # MacOS_node_16_x:
+        #   imageName: macos-latest
+        #   nodeVersion: 16.x
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: templates/integration-test-steps.yaml
+        parameters:
+          Node_Version: $(nodeVersion)

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -5,6 +5,7 @@ trigger:
   - release/*
 
 pr:
+  autoCancel: true
   drafts: false
   branches:
     include:

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -33,22 +33,29 @@ steps:
       node ./common/scripts/install-run-rush build -v --to presentation-full-stack-tests
     displayName: "Rush build"
 
-  - script: "npm run test:integration"
+  - script: npm run test:integration
     workingDirectory: "full-stack-tests/backend"
     displayName: "Run Backend Tests"
     condition: succeededOrFailed()
 
-  - script: "npm run test:integration"
+  # Linux agents do not have a real display so use the virtual framebuffer
+  - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run test:integration
     workingDirectory: "full-stack-tests/core"
     displayName: "Run Core Full Stack Tests"
-    condition: succeededOrFailed()
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-  - script: "npm run test:integration"
+  # MacOS and Windows agents work without any virtual display
+  - script: npm run test:integration
+    workingDirectory: "full-stack-tests/core"
+    displayName: "Run Core Full Stack Tests"
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
+
+  - script: npm run test:integration
     workingDirectory: "full-stack-tests/rpc-interface"
     displayName: "Run RPC Interface Full Stack Tests"
     condition: succeededOrFailed()
 
-  - script: "npm run test:integration"
+  - script: npm run test:integration
     workingDirectory: "full-stack-tests/presentation"
     displayName: "Run Presentation Full Stack Tests"
     condition: succeededOrFailed()

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -38,7 +38,7 @@ steps:
     displayName: "Run Backend Tests"
     condition: succeededOrFailed()
 
-  - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run test:integration
+  - script: "npm run test:integration"
     workingDirectory: "full-stack-tests/core"
     displayName: "Run Core Full Stack Tests"
     condition: succeededOrFailed()


### PR DESCRIPTION
This PR splits the full set of integration tests out of the PR validation build and sets up a set a new pipeline to run our integration test on all supported operating systems and node versions on a weekly schedule (currently set to run every Sunday at midnight).

This also enables autocancel on our integration and core builds, which will cancel and replace an ongoing PR build if a new commit is pushed to a PR branch.