### PR TITLE
only expose IModelAppForDebugger in development

### DIFF
--- a/common/changes/@itwin/core-frontend/imodelapp-debugger_2022-02-15-15-34.json
+++ b/common/changes/@itwin/core-frontend/imodelapp-debugger_2022-02-15-15-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -333,8 +333,10 @@ export class IModelApp {
     opts = opts ?? {};
     this._securityOptions = opts.security ?? {};
 
-    // Make IModelApp globally accessible for debugging purposes. We'll remove it on shutdown.
-    (window as IModelAppForDebugger).iModelAppForDebugger = this;
+    if (process.env.NODE_ENV === "development") {
+      // Make IModelApp globally accessible for debugging purposes. We'll remove it on shutdown.
+      (window as IModelAppForDebugger).iModelAppForDebugger = this;
+    }
 
     this.sessionId = opts.sessionId ?? Guid.createValue();
     this._applicationId = opts.applicationId ?? "2686";  // Default to product id of iTwin.js
@@ -409,7 +411,9 @@ export class IModelApp {
     this.onBeforeShutdown.raiseEvent();
     this.onBeforeShutdown.clear();
 
-    (window as IModelAppForDebugger).iModelAppForDebugger = undefined;
+    if (process.env.NODE_ENV === "development") {
+      (window as IModelAppForDebugger).iModelAppForDebugger = undefined;
+    }
 
     this._wantEventLoop = false;
     window.removeEventListener("resize", IModelApp.requestNextAnimation);

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -333,7 +333,7 @@ export class IModelApp {
     opts = opts ?? {};
     this._securityOptions = opts.security ?? {};
 
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV === "development") {
       // Make IModelApp globally accessible for debugging purposes. We'll remove it on shutdown.
       (window as IModelAppForDebugger).iModelAppForDebugger = this;
     }
@@ -411,7 +411,7 @@ export class IModelApp {
     this.onBeforeShutdown.raiseEvent();
     this.onBeforeShutdown.clear();
 
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV === "development") {
       (window as IModelAppForDebugger).iModelAppForDebugger = undefined;
     }
 

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -333,7 +333,7 @@ export class IModelApp {
     opts = opts ?? {};
     this._securityOptions = opts.security ?? {};
 
-    if (process.env.NODE_ENV === "development") {
+    if (process.env.NODE_ENV !== "production") {
       // Make IModelApp globally accessible for debugging purposes. We'll remove it on shutdown.
       (window as IModelAppForDebugger).iModelAppForDebugger = this;
     }
@@ -411,7 +411,7 @@ export class IModelApp {
     this.onBeforeShutdown.raiseEvent();
     this.onBeforeShutdown.clear();
 
-    if (process.env.NODE_ENV === "development") {
+    if (process.env.NODE_ENV !== "production") {
       (window as IModelAppForDebugger).iModelAppForDebugger = undefined;
     }
 

--- a/core/frontend/src/test/IModelApp.test.ts
+++ b/core/frontend/src/test/IModelApp.test.ts
@@ -162,7 +162,7 @@ describe("IModelApp", () => {
     expect(IModelApp.renderSystem).instanceof(MockRender.System);
   });
 
-  it("Is globally accessible via window while active", async () => {
+  it("Is globally accessible via window while active when not in production", async () => {
     const debug = window as { iModelAppForDebugger?: typeof IModelApp };
     expect(debug.iModelAppForDebugger).not.to.be.undefined;
     expect(debug.iModelAppForDebugger).to.equal(IModelApp);

--- a/core/frontend/src/test/IModelApp.test.ts
+++ b/core/frontend/src/test/IModelApp.test.ts
@@ -161,20 +161,4 @@ describe("IModelApp", () => {
     expect(IModelApp.hasRenderSystem).to.be.true;
     expect(IModelApp.renderSystem).instanceof(MockRender.System);
   });
-
-  it("Is globally accessible via window while active when not in production", async () => {
-    const debug = window as { iModelAppForDebugger?: typeof IModelApp };
-    expect(debug.iModelAppForDebugger).not.to.be.undefined;
-    expect(debug.iModelAppForDebugger).to.equal(IModelApp);
-    const viewMgr = debug.iModelAppForDebugger!.viewManager;
-    expect(viewMgr).to.equal(IModelApp.viewManager);
-
-    await TestApp.shutdown();
-    expect(debug.iModelAppForDebugger).to.be.undefined;
-
-    await TestApp.startup();
-    expect(debug.iModelAppForDebugger).not.to.be.undefined;
-    expect(debug.iModelAppForDebugger!.viewManager).to.equal(IModelApp.viewManager);
-    expect(debug.iModelAppForDebugger!.viewManager).not.to.equal(viewMgr);
-  });
 });


### PR DESCRIPTION
Prevent users from having access to IModelApp via the console in production apps by default. Should still be possible for apps to add it on the window on their end if they choose to, but not recommended. 