### PR TITLE
Define all CI and PR triggers in yaml pipelines

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -14,7 +14,7 @@
 #   `/azp run imodeljs.imodeljs`
 
 trigger: none
-
+pr: none
 schedules:
   - cron: "0 5 * * *"
     displayName: Daily midnight build

--- a/common/config/azure-pipelines/integration-client-regression-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-client-regression-pr-validation.yaml
@@ -5,6 +5,7 @@
 
 trigger:
   - master
+pr: none
 
 variables:
   - group: iModel.js non-secret config variables

--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -7,7 +7,7 @@
 # The current LTS is tested in all normal CI/PR builds so no need to test it here.
 
 trigger: none
-
+pr: none
 schedules:
   - cron: "0 5 * * *"
     displayName: Daily midnight build

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -28,7 +28,7 @@ parameters:
     - releaseCandidate
 
 trigger: none
-
+pr: none
 schedules:
 - cron: "0 5 * * *"
   displayName: Daily midnight build


### PR DESCRIPTION
By default, YAML pipelines in a GitHub repository have CI and PR triggers enabled. This PR defines these values to disable CI/PR triggers where intended.