### PR TITLE
remove use of svg?sprite in core pkgs

### DIFF
--- a/ui/appui-layout-react/package.json
+++ b/ui/appui-layout-react/package.json
@@ -94,6 +94,7 @@
   ],
   "dependencies": {
     "@itwin/itwinui-css": "0.44.1",
+    "@itwin/itwinui-icons-react": "^1.8.0",
     "@itwin/itwinui-react": "1.29.3",
     "classnames": "^2.3.1",
     "immer": "9.0.6",

--- a/ui/appui-layout-react/src/appui-layout-react/widget/PopoutToggle.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/PopoutToggle.tsx
@@ -11,16 +11,14 @@
 import "./PopoutToggle.scss";
 import * as React from "react";
 import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
-import popoutToggleSvg from "./window-popout.svg?sprite";
 import { Icon } from "@itwin/core-react";
-import { IconSpecUtilities } from "@itwin/appui-abstract";
 import { ActiveTabIdContext } from "./Widget";
+import { SvgWindowPopout } from "@itwin/itwinui-icons-react";
 
 /** @internal */
 export const PopoutToggle = React.memo(function PopoutToggle() { // eslint-disable-line @typescript-eslint/naming-convention, no-shadow
   const dispatch = React.useContext(NineZoneDispatchContext);
   const activeTabId = React.useContext(ActiveTabIdContext);
-  const iconSpec = IconSpecUtilities.createSvgIconSpec(popoutToggleSvg);
   const popoutTitle = useLabel("popoutActiveTab");
   return (
     <button
@@ -33,7 +31,7 @@ export const PopoutToggle = React.memo(function PopoutToggle() { // eslint-disab
       }}
       title={popoutTitle}
     >
-      <Icon iconSpec={iconSpec} />
+      <Icon iconSpec={<SvgWindowPopout />} />
     </button >
   );
 });

--- a/ui/appui-layout-react/src/appui-layout-react/widget/window-popout.svg
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/window-popout.svg
@@ -1,1 +1,0 @@
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m16 0v5.4l-1.9-2-8.4 8.4-1.5-1.5 8.3-8.4-1.9-1.9m5.4 16v-9h-1v8h-14v-14h8v-1h-9v16z"/></svg>

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -137,6 +137,7 @@
     "@itwin/core-telemetry": "workspace:*",
     "@itwin/presentation-components": "workspace:*",
     "@itwin/itwinui-css": "0.44.1",
+    "@itwin/itwinui-icons-react": "^1.8.0",
     "@itwin/itwinui-react": "1.29.3",
     "classnames": "^2.3.1",
     "immer": "9.0.6",

--- a/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.tsx
+++ b/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.tsx
@@ -8,7 +8,6 @@
 
 // cSpell:ignore configurableui checkmark
 
-import widowSettingsIconSvg from "@bentley/icons-generic/icons/window-settings.svg?sprite";
 import "./UiSettingsPage.scss";
 import * as React from "react";
 import { SettingsTabEntry } from "@itwin/core-react";
@@ -16,8 +15,9 @@ import { UiFramework } from "../../UiFramework";
 import { ColorTheme, SYSTEM_PREFERRED_COLOR_THEME } from "../../theme/ThemeManager";
 import { UiShowHideManager } from "../../utils/UiShowHideManager";
 import { SyncUiEventDispatcher, SyncUiEventId } from "../../syncui/SyncUiEventDispatcher";
-import { IconSpecUtilities, UiSyncEventArgs } from "@itwin/appui-abstract";
+import { UiSyncEventArgs } from "@itwin/appui-abstract";
 import { Select, SelectOption, Slider, ToggleSwitch } from "@itwin/itwinui-react";
+import { SvgWindowSettings } from "@itwin/itwinui-icons-react";
 
 /** UiSettingsPage displaying the active UI settings. This page lets users set the following settings.
  *
@@ -213,7 +213,7 @@ export function getUiSettingsManagerEntry(itemPriority: number, allowSettingUiFr
   return {
     itemPriority, tabId: "uifw:UiStateStorage",
     label: UiFramework.translate("settings.uiSettingsPage.label"),
-    icon: IconSpecUtilities.createSvgIconSpec(widowSettingsIconSvg),
+    icon: <SvgWindowSettings />,
     page: <UiSettingsPage allowSettingUiFrameworkVersion={!!allowSettingUiFrameworkVersion} />,
     isDisabled: false,
     tooltip: UiFramework.translate("settings.uiSettingsPage.tooltip"),

--- a/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
+++ b/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
@@ -7,14 +7,13 @@
  */
 
 import * as React from "react";
-import widgetIconSvg from "@bentley/icons-generic/icons/home.svg?sprite";
-import { IconSpecUtilities } from "@itwin/appui-abstract";
 import { Icon, useWidgetOpacityContext } from "@itwin/core-react";
 import { AppButton } from "@itwin/appui-layout-react";
 import { BackstageManager } from "../backstage/BackstageManager";
 import { useFrameworkVersion } from "../hooks/useFrameworkVersion";
 import { UiFramework } from "../UiFramework";
 import { UiShowHideManager } from "../utils/UiShowHideManager";
+import { SvgHome } from "@itwin/itwinui-icons-react";
 
 /**
  * Properties for the [[BackstageAppButton]] React component
@@ -36,7 +35,7 @@ export interface BackstageAppButtonProps {
 export function BackstageAppButton(props: BackstageAppButtonProps) {
   const backstageToggleCommand = React.useMemo(() => BackstageManager.getBackstageToggleCommand(props.icon), [props.icon]);
   const backstageLabel = React.useMemo(() => props.label || backstageToggleCommand.tooltip, [backstageToggleCommand.tooltip, props.label]);
-  const [icon, setIcon] = React.useState(props.icon ? props.icon : IconSpecUtilities.createSvgIconSpec(widgetIconSvg));
+  const [icon, setIcon] = React.useState(props.icon ? props.icon : <SvgHome />);
   const isInitialMount = React.useRef(true);
   const useSmallAppButton = "1" !== useFrameworkVersion();
   const divClassName = useSmallAppButton ? "uifw-app-button-small" : undefined;
@@ -56,7 +55,7 @@ export function BackstageAppButton(props: BackstageAppButtonProps) {
       isInitialMount.current = false;
       onElementRef(ref);
     } else {
-      setIcon(props.icon ? props.icon : IconSpecUtilities.createSvgIconSpec(widgetIconSvg));
+      setIcon(props.icon ? props.icon : <SvgHome />);
     }
   }, [props.icon, onElementRef]);
 


### PR DESCRIPTION
We should not be explicitly tying ourselves to svg?Sprites in any of the core pkgs. 

This creates a hard dependency on using our bentley/react-scripts fork which has the svg-sprite-loader. This is ok at an app level, but should not be used in shareable packages. The usage of sprites adds an unnecessary additional level of tooling required for apps that don't use our cra fork, like the sample showcase, and a blocker for using other build tools like vite & esbuild

As long as an IconSpec allows us to pass in a ReactNode we should be ok.
We can start phasing out usage of bentley/icons-generic-webfont, which should be deprecated

There are a bunch of icons we need to add to the itwinui-icons pkg