### PR TITLE
Transform spatial view attachment's clip from drawing to sheet.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1251,7 +1251,7 @@ export function areaToEyeHeightFromGcs(view3d: ViewState3d, area: GlobalLocation
 
 // @internal
 export interface AttachToViewportArgs {
-    // (undocumented)
+    drawingToSheetTransform?: Transform;
     invalidateDecorations: () => void;
 }
 
@@ -7108,6 +7108,9 @@ export class OffScreenViewport extends Viewport {
     static create(options: OffScreenViewportOptions): OffScreenViewport;
     // @internal
     static createViewport(view: ViewState, target: RenderTarget, lockAspectRatio?: boolean): OffScreenViewport;
+    // @internal
+    get drawingToSheetTransform(): Transform | undefined;
+    set drawingToSheetTransform(transform: Transform | undefined);
     // @internal (undocumented)
     get isAspectRatioLocked(): boolean;
     // (undocumented)
@@ -12853,6 +12856,8 @@ export abstract class Viewport implements IDisposable, TileUser {
     // @internal
     applyViewState(val: ViewState): void;
     get areAllTileTreesLoaded(): boolean;
+    // @internal
+    protected attachToView(): void;
     // (undocumented)
     get auxCoordSystem(): AuxCoordSystemState;
     // @internal (undocumented)
@@ -12895,6 +12900,8 @@ export abstract class Viewport implements IDisposable, TileUser {
     set debugBoundingBoxes(boxes: TileBoundingBoxes);
     // @internal (undocumented)
     protected _decorationsValid: boolean;
+    // @internal
+    protected detachFromView(): void;
     determineVisibleDepthRange(rect?: ViewRect, result?: DepthRangeNpc): DepthRangeNpc | undefined;
     get devicePixelRatio(): number;
     // @internal

--- a/common/changes/@itwin/core-frontend/spatial-view-attachment-clip-transform_2022-02-16-19-58.json
+++ b/common/changes/@itwin/core-frontend/spatial-view-attachment-clip-transform_2022-02-16-19-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Ensure view attachments referencing section drawings transform the spatial view's clip into sheet coordinates.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/SheetViewState.ts
+++ b/core/frontend/src/SheetViewState.ts
@@ -599,6 +599,11 @@ class OrthographicAttachment {
     this._toSheet = Transform.createRefs(origin, matrix);
     this._fromSheet = this._toSheet.inverse()!;
 
+    // If the attached view is a section drawing, it may itself have an attached spatial view with a clip.
+    // The clip needs to be transformed into sheet space.
+    if (view.isDrawingView())
+      this._viewport.drawingToSheetTransform = this._toSheet;
+
     // ###TODO? If we also apply the attachment's clip to the attached view, we may get additional culling during tile selection.
     // However the attached view's frustum is already clipped by intersection with sheet view's frustum, and additional clipping planes
     // introduce additional computation, so possibly not worth it.

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -157,7 +157,15 @@ const scratchRange2dIntersect = Range2d.createNull();
  * @internal
  */
 export interface AttachToViewportArgs {
+  /** A function that can be invoked to notify the viewport that its decorations should be recreated. */
   invalidateDecorations: () => void;
+  /** A bit of a hack to work around our ill-advised decision to always expect a RenderClipVolume to be defined in world coordinates.
+   * When we attach a section drawing to a sheet view, and the section drawing has a spatial view attached to *it*, the spatial view's clip
+   * is transformed into drawing space - but when we display it we need to transform it into world (sheet) coordinates.
+   * Fixing the actual problem (clips should always be defined in the coordinate space of the graphic branch containing them) would be quite error-prone
+   * and likely to break existing code -- so instead the SheetViewState specifies this transform to be consumed by DrawingViewState.attachToViewport.
+   */
+  drawingToSheetTransform?: Transform;
 }
 
 /** The front-end state of a [[ViewDefinition]] element.

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -984,6 +984,11 @@ export abstract class Viewport implements IDisposable, TileUser {
     this.attachToView();
   }
 
+  /** @internal Invoked when the viewport becomes associated with a new ViewState to register event listeners with the view
+   * and allow the ViewState to set up internal state that is only relevant when associated with a Viewport.
+   * Also invoked after changing OffScreenViewport.drawingToSheetTransform.
+   * @internal
+   */
   protected attachToView(): void {
     this.registerDisplayStyleListeners(this.view.displayStyle);
     this.registerViewListeners();
@@ -1125,6 +1130,12 @@ export abstract class Viewport implements IDisposable, TileUser {
     }
   }
 
+  /** @internal Invoked when the viewport becomes associated with a new ViewState to unregister event listeners for
+   * the previous ViewState and allow the previous ViewState to clean up any internal state that is only relevant while
+   * associated with a Viewport.
+   * Also invoked after changing OffScreenViewport.drawingToSheetTransform.
+   * @internal
+   */
   protected detachFromView(): void {
     this._detachFromView.forEach((f) => f());
     this._detachFromView.length = 0;

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -984,7 +984,7 @@ export abstract class Viewport implements IDisposable, TileUser {
     this.attachToView();
   }
 
-  private attachToView(): void {
+  protected attachToView(): void {
     this.registerDisplayStyleListeners(this.view.displayStyle);
     this.registerViewListeners();
     this.view.attachToViewport(this);
@@ -1125,7 +1125,7 @@ export abstract class Viewport implements IDisposable, TileUser {
     }
   }
 
-  private detachFromView(): void {
+  protected detachFromView(): void {
     this._detachFromView.forEach((f) => f());
     this._detachFromView.length = 0;
 
@@ -3351,6 +3351,17 @@ export interface OffScreenViewportOptions {
  */
 export class OffScreenViewport extends Viewport {
   protected _isAspectRatioLocked = false;
+  /** @internal see AttachToViewportArgs.drawingToSheetTransform. */
+  private _drawingToSheetTransform?: Transform;
+  /** @internal see AttachToViewportArgs.drawingToSheetTransform. */
+  public get drawingToSheetTransform(): Transform | undefined {
+    return this._drawingToSheetTransform;
+  }
+  public set drawingToSheetTransform(transform: Transform | undefined) {
+    this.detachFromView();
+    this._drawingToSheetTransform = transform;
+    this.attachToView();
+  }
 
   public static create(options: OffScreenViewportOptions): OffScreenViewport {
     return this.createViewport(options.view, IModelApp.renderSystem.createOffscreenTarget(options.viewRect), options.lockAspectRatio);


### PR DESCRIPTION
For some reason, we have always defined clip volumes in world coordinates. That seems like a poor (and probably unintentional) choice - really, a clip associated with a node in the scene graph should be defined in that node's coordinate space.
When we display a spatial view within a section drawing view, we transform the spatial view's clip into drawing (world) coordinates.
When we display that section drawing view as a view attachment on a sheet, the clip remains in drawing space - but it needs to be in sheet (world) coordinates.
There were two options for fixing this:
- Rectify the mistake of always defining clips in world coordinates. Far too error-prone and disruptive.
- Allow the sheet view to tell the drawing view how to transform the clip to world coordinates.

The latter is implemented by AttachToViewportArgs.drawingToSheetTransform. It is admittedly a bit of a hack.

Fixes ADO 806159 and 806140.