### PR TITLE
Do not produce illegal filenames on windows.

### DIFF
--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -761,6 +761,7 @@ export class TestRunner {
     testName += configs.iModelName.replace(/\.[^/.]+$/, "");
     testName += `_${configs.viewName}`;
     testName += configs.displayStyle ? `_${configs.displayStyle.trim()}` : "";
+    testName = testName.replace(/[/\\?%*:|"<>]/g, '-');
 
     const renderMode = getRenderMode(test.viewport);
     if (renderMode)

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -761,7 +761,7 @@ export class TestRunner {
     testName += configs.iModelName.replace(/\.[^/.]+$/, "");
     testName += `_${configs.viewName}`;
     testName += configs.displayStyle ? `_${configs.displayStyle.trim()}` : "";
-    testName = testName.replace(/[/\\?%*:|"<>]/g, '-');
+    testName = testName.replace(/[/\\?%*:|"<>]/g, "-");
 
     const renderMode = getRenderMode(test.viewport);
     if (renderMode)


### PR DESCRIPTION
Revit connector has begun including colons in their view names.
display-performance-test-app creates filenames from iModel and view names.
Replace illegal characters with hyphens.