### PR TITLE
Suppress npm audit failure 

### DIFF
--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -45,6 +45,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-4jqc-8m5r-9rpr", // https://github.com/advisories/GHSA-4jqc-8m5r-9rpr.
     "GHSA-whgm-jr23-g3j9", // https://github.com/advisories/GHSA-whgm-jr23-g3j9.
     "GHSA-r683-j2x4-v87g", // https://github.com/advisories/GHSA-r683-j2x4-v87g
+    "GHSA-rqff-837h-mm52" // https://github.com/advisories/GHSA-rqff-837h-mm52
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
Build is failing due to https://github.com/advisories/GHSA-rqff-837h-mm52. This is a deeply nested dependency to something used in one of our test apps, suppress the failure to allow the build to pass.