### PR TITLE
Transparency+shadows workaround for Galaxy Note 8

### DIFF
--- a/common/changes/@itwin/webgl-compatibility/workaround-mali-gp7-mp20-bug_2022-02-18-11-45.json
+++ b/common/changes/@itwin/webgl-compatibility/workaround-mali-gp7-mp20-bug_2022-02-18-11-45.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/webgl-compatibility",
-      "comment": "Apply workaround for failure to render shadows and transparency on Mali-G71 MP20 (Samsung Galaxy Note 8).\"",
+      "comment": "Apply workaround for failure to render shadows and transparency on Mali-G71 MP20 (Samsung Galaxy Note 8).",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/webgl-compatibility/workaround-mali-gp7-mp20-bug_2022-02-18-11-45.json
+++ b/common/changes/@itwin/webgl-compatibility/workaround-mali-gp7-mp20-bug_2022-02-18-11-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "Apply workaround for failure to render shadows and transparency on Mali-G71 MP20 (Samsung Galaxy Note 8).\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}


### PR DESCRIPTION
Apply same workaround as for iOS >= 15 from #2552.
In future, we need to investigate whether this is truly a driver bug or a deficiency in our renderer.