### PR TITLE
Fix node versions in integration tests

### DIFF
--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -30,7 +30,7 @@ jobs:
           nodeVersion: 12.x
         Linux_node_14_x:
           imageName: ubuntu-latest
-          nodeVersion: 12.x
+          nodeVersion: 14.x
         # linux_node_16_x:
         #   imageName: ubuntu-latest
         #   nodeVersion: 16.x
@@ -42,7 +42,7 @@ jobs:
           nodeVersion: 12.x
         Windows_node_14_x:
           imageName: windows-latest
-          nodeVersion: 12.x
+          nodeVersion: 14.x
         # Windows_node_16_x:
         #   imageName: windows-latest
         #   nodeVersion: 16.x
@@ -54,7 +54,7 @@ jobs:
           nodeVersion: 12.x
         MacOS_node_14_x:
           imageName: macos-latest
-          nodeVersion: 12.x
+          nodeVersion: 14.x
         # MacOS_node_16_x:
         #   imageName: macos-latest
         #   nodeVersion: 16.x

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -42,13 +42,13 @@ steps:
   - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run test:integration
     workingDirectory: "full-stack-tests/core"
     displayName: "Run Core Full Stack Tests"
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
 
   # MacOS and Windows agents work without any virtual display
   - script: npm run test:integration
     workingDirectory: "full-stack-tests/core"
     displayName: "Run Core Full Stack Tests"
-    condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
+    condition: and(succeededOrFailed(), ne(variables['Agent.OS'], 'Linux'))
 
   - script: npm run test:integration
     workingDirectory: "full-stack-tests/rpc-interface"


### PR DESCRIPTION
Fixes a few mistakes from https://github.com/iTwin/itwinjs-core/pull/3208. The backports of this PR have already been corrected and this change is only needed in master.