### PR TITLE
react to breaking change in 3.0 wrt ecsql query row format

### DIFF
--- a/common/changes/@itwin/appui-react/fix-categories-trees_2022-02-22-20-47.json
+++ b/common/changes/@itwin/appui-react/fix-categories-trees_2022-02-22-20-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "React to 3.0 breaking change w.r.t ECSQL Query Row Format",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/core-frontend/fix-categories-trees_2022-02-22-20-47.json
+++ b/common/changes/@itwin/core-frontend/fix-categories-trees_2022-02-22-20-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/CategorySelectorState.ts
+++ b/core/frontend/src/CategorySelectorState.ts
@@ -71,7 +71,7 @@ export class CategorySelectorState extends ElementState {
   public get name(): string { return this.code.value; }
 
   /** Determine whether this CategorySelector includes the specified categoryId string */
-  public has(id: Id64String): boolean { return this.categories.has(id.toString()); }
+  public has(id: Id64String): boolean { return this.categories.has(id); }
 
   /** Determine whether this CategorySelector includes the specified category */
   public isCategoryViewed(categoryId: Id64String): boolean { return this.has(categoryId); }

--- a/ui/appui-react/src/appui-react/imodel-components/category-tree/CategoryVisibilityHandler.tsx
+++ b/ui/appui-react/src/appui-react/imodel-components/category-tree/CategoryVisibilityHandler.tsx
@@ -8,6 +8,7 @@
 
 import * as React from "react";
 import { BeEvent } from "@itwin/core-bentley";
+import { QueryRowFormat } from "@itwin/core-common";
 import { IModelConnection, PerModelCategoryVisibility, ViewManager, Viewport } from "@itwin/core-frontend";
 import { NodeKey } from "@itwin/presentation-common";
 import { TreeNodeItem, useAsyncValue } from "@itwin/components-react";
@@ -40,7 +41,7 @@ export async function loadCategoriesFromViewport(iModel?: IModelConnection, vp?:
 
   // istanbul ignore else
   if (iModel) {
-    const rowIterator = iModel.query(ecsql2);
+    const rowIterator = iModel.query(ecsql2, undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames });
     // istanbul ignore next
     for await (const row of rowIterator) {
       const subCategoryIds = iModel.subcategories.getSubCategories(row.id);

--- a/ui/appui-react/src/test/imodel-components/category-tree/CategoriesTree.test.tsx
+++ b/ui/appui-react/src/test/imodel-components/category-tree/CategoriesTree.test.tsx
@@ -67,7 +67,7 @@ describe("CategoryTree", () => {
       return;
     }
 
-    imodelMock.setup((x) => x.query(moq.It.isAny())).returns(() => generator());
+    imodelMock.setup((x) => x.query(moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).returns(() => generator());
     viewportMock.setup((x) => x.view).returns(() => viewStateMock.object);
     viewStateMock.setup((x) => x.is3d()).returns(() => true);
 
@@ -412,7 +412,7 @@ describe("CategoryTree", () => {
         return;
       }
 
-      imodelMock.setup((x) => x.query(moq.It.isAny())).returns(() => generator());
+      imodelMock.setup((x) => x.query(moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).returns(() => generator());
       imodelMock.setup((x) => x.subcategories).returns(() => subcategoriesCacheMock.object);
     });
 


### PR DESCRIPTION
Categories Tree has been broken in 3.0 due to the breaking change wrt [ecsql query row format](https://www.itwinjs.org/changehistory/#changes-to-ecsql-apis)