### PR TITLE
IModelTransformer optionally embeds and deletes single-reference geometry parts

### DIFF
--- a/common/api/core-transformer.api.md
+++ b/common/api/core-transformer.api.md
@@ -111,14 +111,15 @@ export class IModelImporter implements Required<IModelImportOptions> {
     protected onUpdateElementAspect(aspectProps: ElementAspectProps): void;
     protected onUpdateModel(modelProps: ModelProps): void;
     protected onUpdateRelationship(relationshipProps: RelationshipProps): void;
+    optimizeGeometry(options: OptimizeGeometryOptions): void;
     readonly options: Required<IModelImportOptions>;
     // @deprecated
-    get preserveElementIdsForFiltering(): Required<IModelImportOptions>["preserveElementIdsForFiltering"];
-    set preserveElementIdsForFiltering(val: Required<IModelImportOptions>["preserveElementIdsForFiltering"]);
+    get preserveElementIdsForFiltering(): boolean;
+    set preserveElementIdsForFiltering(val: boolean);
     progressInterval: number;
     // @deprecated
-    get simplifyElementGeometry(): Required<IModelImportOptions>["simplifyElementGeometry"];
-    set simplifyElementGeometry(val: Required<IModelImportOptions>["simplifyElementGeometry"]);
+    get simplifyElementGeometry(): boolean;
+    set simplifyElementGeometry(val: boolean);
     readonly targetDb: IModelDb;
     }
 
@@ -192,9 +193,15 @@ export interface IModelTransformOptions {
     isReverseSynchronization?: boolean;
     loadSourceGeometry?: boolean;
     noProvenance?: boolean;
+    optimizeGeometry?: OptimizeGeometryOptions;
     preserveElementIdsForFiltering?: boolean;
     targetScopeElementId?: Id64String;
     wasSourceIModelCopiedToTarget?: boolean;
+}
+
+// @beta
+export interface OptimizeGeometryOptions {
+    inlineUniqueGeometryParts?: boolean;
 }
 
 // @beta

--- a/common/api/summary/core-transformer.exports.csv
+++ b/common/api/summary/core-transformer.exports.csv
@@ -6,5 +6,6 @@ beta;IModelImporter
 beta;IModelImportOptions
 beta;IModelTransformer 
 beta;IModelTransformOptions
+beta;OptimizeGeometryOptions
 beta;TemplateModelCloner 
 public;TransformerLoggerCategory

--- a/common/changes/@itwin/core-backend/inline-geom-part-refs_2022-02-24-22-06.json
+++ b/common/changes/@itwin/core-backend/inline-geom-part-refs_2022-02-24-22-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/inline-geom-part-refs_2022-02-24-22-06.json
+++ b/common/changes/@itwin/core-common/inline-geom-part-refs_2022-02-24-22-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix bugs in GeometryStreamIterator in which values for properties like color, transparency, and displayPriority were being ignored.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-transformer/inline-geom-part-refs_2022-02-24-22-06.json
+++ b/common/changes/@itwin/core-transformer/inline-geom-part-refs_2022-02-24-22-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "Add an option to IModelImporter to optimize geometry by identifying geometry parts with only one reference and embedding the part's geometry directly into the referencing element's geometry stream.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { Guid, Id64 } from "@itwin/core-bentley";
+import { IModel } from "@itwin/core-common";
+import { GenericSchema, PhysicalModel, PhysicalPartition, SnapshotDb, SubjectOwnsPartitionElements } from "../../core-backend";
+import { IModelTestUtils } from "../IModelTestUtils";
+
+describe.only("DgnDb.inlineGeometryPartReferences", () => {
+  let imodel: SnapshotDb;
+  let modelId: string;
+
+  beforeEach(() => {
+    imodel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("InlineGeomParts", `${Guid.createValue()}.bim`), {
+      rootSubject: { name: "InlineGeomParts", description: "InlineGeomParts" },
+    });
+
+    GenericSchema.registerSchema();
+    const partitionId = imodel.elements.insertElement({
+      classFullName: PhysicalPartition.classFullName,
+      model: IModel.repositoryModelId,
+      parent: new SubjectOwnsPartitionElements(IModel.rootSubjectId),
+      code: PhysicalPartition.createCode(imodel, IModel.rootSubjectId, `PhysicalPartition_${Guid.createValue()}`),
+    });
+
+    expect(Id64.isValidId64(partitionId)).to.be.true;
+    const model = imodel.models.createModel({
+      classFullName: PhysicalModel.classFullName,
+      modeledElement: { id: partitionId },
+    });
+
+    expect(model).instanceOf(PhysicalModel);
+
+    modelId = imodel.models.insertModel(model.toJSON());
+    expect(Id64.isValidId64(modelId)).to.be.true;
+  });
+
+  afterEach(() => {
+    imodel.close();
+  });
+
+  it("inlines and deletes unique parts", () => {
+  });
+
+  it("ignores non-unique parts", () => {
+  });
+
+  it("applies part transform", () => {
+  });
+
+  it("inlines multiple references in a single element", () => {
+  });
+
+  it("resets element symbology", () => {
+  });
+
+  it("has no effect if inlining fails", () => {
+  });
+});

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -189,8 +189,11 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     return partId;
   }
 
-  function insertElement(geom: GeomWriterEntry[]): string {
+  function insertElement(geom: GeomWriterEntry[], viewIndependent = false): string {
     const writer = new GeomWriter({ categoryId });
+    if (viewIndependent)
+      writer.builder.isViewIndependent = true;
+
     for (const entry of geom)
       writer.append(entry);
 
@@ -456,5 +459,11 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
   });
 
   it("preserves element header flags", () => {
+    const partId = insertGeometryPart([{ pos: 1 }]);
+    const elemId = insertElement([{ partId }], true);
+    expect(readElementGeom(elemId).viewIndependent).to.be.true;
+
+    expect(inlinePartRefs()).to.equal(1);
+    expect(readElementGeom(elemId).viewIndependent).to.be.true;
   });
 });

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -218,7 +218,15 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expect(actual).to.deep.equal(expected);
   }
 
+  function inlinePartRefs(): number {
+    const result = imodel.nativeDb.inlineGeometryPartReferences();
+    expect(result.numCandidateParts).to.equal(result.numPartsDeleted);
+    expect(result.numRefsInlined).to.equal(result.numCandidateParts);
+    return result.numRefsInlined;
+  }
+
   it.only("inlines and deletes a simple unique part reference", () => {
+    // Create single reference to a part and perform sanity checks on our geometry validation code.
     const partId = insertGeometryPart([{ pos: 123 }]);
     expectGeom(readElementGeom(partId), [
       { categoryId: "0", subCategoryId: "0" },
@@ -230,6 +238,9 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
       { categoryId, subCategoryId: blueSubCategoryId },
       { partId },
     ]);
+
+    // Inline and delete the part.
+    expect(inlinePartRefs()).to.equal(1);
   });
 
   it("inlines and deletes unique parts, ignoring non-unique parts", () => {

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -86,7 +86,7 @@ function readGeomStream(iter: GeometryStreamIterator): GeomStreamEntry[] {
     if (entry.localRange) {
       expect(entry.localRange.low.y).to.equal(0);
       expect(entry.localRange.low.z).to.equal(0);
-      expect(entry.localRange.high.y).to.equal(0);
+      expect(entry.localRange.high.y).to.equal(1);
       expect(entry.localRange.high.z).to.equal(0);
       expect(entry.localRange.high.x - entry.localRange.low.x).to.equal(1);
 
@@ -263,8 +263,8 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expect(inlinePartRefs()).to.equal(2);
 
     const symb = { categoryId, subCategoryId: blueSubCategoryId };
-    expectGeom(readElementGeom(elem1), [symb, { pos: 1 }]);
-    expectGeom(readElementGeom(elem2), [symb, { pos: 2 }, symb, { partId: part3 }]);
+    expectGeom(readElementGeom(elem1), [symb, { low: 1 }, { pos: 1 }]);
+    expectGeom(readElementGeom(elem2), [symb, { low: 2 }, { pos: 2 }, symb, { partId: part3 }]);
     expectGeom(readElementGeom(elem3), [symb, { partId: part3 }]);
     expectGeom(readElementGeom(elem4), [symb, { partId: part4 }]);
     expectGeom(readElementGeom(elem5), [symb, { partId: part4 }]);
@@ -276,6 +276,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expect(inlinePartRefs()).to.equal(1);
     expectGeom(readElementGeom(elemId), [
       { categoryId, subCategoryId: blueSubCategoryId },
+      { low: 42 },
       { pos: 42 },
     ]);
   });
@@ -283,7 +284,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
   it("inlines multiple references in a single element", () => {
   });
 
-  it.only("resets element symbology", () => {
+  it("resets element symbology", () => {
     const part1 = insertGeometryPart([
       { pos: 1 },
       { color: ColorDef.green },
@@ -329,24 +330,33 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
       { categoryId, subCategoryId: blueSubCategoryId },
       { pos: -1 },
       { categoryId, subCategoryId: redSubCategoryId },
+      { low: 1},
       { pos: 1 },
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.green },
+      { low: 1.5 },
       { pos: 1.5 },
       { categoryId, subCategoryId: redSubCategoryId },
+      { low: -2 },
       { pos: -2 },
 
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black },
+      { low: 2 },
       { pos: 2 },
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black, materialId },
+      { low: 2.5 },
       { pos: 2.5 },
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black },
+      { low: -3 },
       { pos: -3 },
 
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black, materialId },
+      { low: 3 },
       { pos: 3 },
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.white },
+      { low: 3.5 },
       { pos: 3.5 },
       {categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black, materialId },
+      { low: -4 },
       { pos: -4 },
     ]);
   });
@@ -363,6 +373,6 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
   it("applies transform to patterns and line styles", () => {
   });
 
-  it("does not inline if header flags do not match", () => {
+  it("preserves element header flags", () => {
   });
 });

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -225,7 +225,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     return result.numRefsInlined;
   }
 
-  it.only("inlines and deletes a simple unique part reference", () => {
+  it("inlines and deletes a simple unique part reference", () => {
     // Create single reference to a part and perform sanity checks on our geometry validation code.
     const partId = insertGeometryPart([{ pos: 123 }]);
     expectGeom(readElementGeom(partId), [
@@ -241,9 +241,29 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
 
     // Inline and delete the part.
     expect(inlinePartRefs()).to.equal(1);
+    expect(imodel.elements.tryGetElement(partId)).to.be.undefined;
   });
 
   it("inlines and deletes unique parts, ignoring non-unique parts", () => {
+    const part1 = insertGeometryPart([{ pos: 1 }]);
+    const part2 = insertGeometryPart([{ pos: 2 }]);
+    const part3 = insertGeometryPart([{ pos: 3 }]);
+    const part4 = insertGeometryPart([{ pos: 4 }]);
+
+    const elem1 = insertElement([{ partId: part1 }]);
+    const elem2 = insertElement([{ partId: part2 }, { partId: part3 }]);
+    const elem3 = insertElement([{ partId: part3 }]);
+    const elem4 = insertElement([{ partId: part4 }]);
+    const elem5 = insertElement([{ partId: part4 }]);
+
+    expect(inlinePartRefs()).to.equal(2);
+
+    const symb = { categoryId, subCategoryId: blueSubCategoryId };
+    expectGeom(readElementGeom(elem1), [symb, { pos: 1 }]);
+    expectGeom(readElementGeom(elem2), [symb, { pos: 2 }, symb, { partId: part3 }]);
+    expectGeom(readElementGeom(elem3), [symb, { partId: part3 }]);
+    expectGeom(readElementGeom(elem4), [symb, { partId: part4 }]);
+    expectGeom(readElementGeom(elem5), [symb, { partId: part4 }]);
   });
 
   it("applies part transform", () => {

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -71,7 +71,7 @@ class GeomWriter {
   }
 }
 
-// SubGraphicRange where x dimension is 1 meter and x and z are empty.
+// SubGraphicRange where x dimension is 1 meter and y and z are empty.
 interface SubRange { low: number }
 
 type GeomStreamEntry =

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -4,9 +4,100 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { Guid, Id64 } from "@itwin/core-bentley";
-import { ColorDef, IModel } from "@itwin/core-common";
-import { GenericSchema, PhysicalModel, PhysicalPartition, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements } from "../../core-backend";
+import { CoordinateXYZ, Point3d, Range3dProps } from "@itwin/core-geometry";
+import {
+  ColorDef, GeometryParams, GeometryStreamBuilder, GeometryStreamIterator, IModel,
+} from "@itwin/core-common";
+import {
+  GenericSchema, PhysicalModel, PhysicalPartition, RenderMaterialElement, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements,
+} from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
+
+interface Point { x: number, y: number, z: number };
+
+interface PartRef {
+  partId: string;
+  origin?: Point;
+}
+
+interface Symbology {
+  categoryId?: string;
+  subCategoryId?: string;
+  color?: ColorDef;
+  materialId?: string;
+}
+
+function makeGeomParams(symb: Symbology): GeometryParams {
+  const params = new GeometryParams(symb.categoryId ?? Id64.invalid, symb.subCategoryId);
+  params.fillColor = params.lineColor = symb.color;
+  params.materialId = symb.materialId;
+  return params;
+}
+
+type UnionMember<T, U> = T & { [k in keyof U]?: never };
+
+type GeomWriterEntry =
+  UnionMember<PartRef, Symbology & Point> |
+  UnionMember<Symbology, PartRef & Point> |
+  UnionMember<Point, PartRef & Symbology>;
+
+class GeomWriter {
+  public readonly builder: GeometryStreamBuilder;
+
+  public constructor(symbology?: Symbology) {
+    this.builder = new GeometryStreamBuilder();
+    if (symbology)
+      this.append(symbology);
+  }
+
+  public append(entry: GeomWriterEntry): void {
+    if (entry.partId)
+      this.builder.appendGeometryPart3d(entry.partId, Point3d.fromJSON(entry.origin));
+    else if (entry.subCategoryId || entry.categoryId || entry.color || entry.materialId)
+      this.builder.appendGeometryParamsChange(makeGeomParams(entry));
+    else if (undefined !== entry.x)
+      this.builder.appendGeometry(CoordinateXYZ.createXYZ(entry.x, entry.y, entry.z));
+  }
+}
+
+interface SubRange { lo: Point, hi: Point };
+
+type GeomStreamEntry =
+  "header" |
+  UnionMember<PartRef, Symbology & SubRange & Point> |
+  UnionMember<Symbology, PartRef & SubRange & Point> |
+  UnionMember<SubRange, PartRef & Symbology & Point> |
+  UnionMember<Point, PartRef & Symbology & SubRange>;
+
+function readGeomStream(iter: GeometryStreamIterator): GeomStreamEntry[] {
+  const result: GeomStreamEntry[] = [];
+  for (const entry of iter) {
+    result.push({
+      categoryId: entry.geomParams.categoryId,
+      subCategoryId: entry.geomParams.subCategoryId,
+      color: entry.geomParams.fillColor,
+      materialId: entry.geomParams.materialId,
+    });
+
+    if (entry.localRange) {
+      result.push({
+        lo: { x: entry.localRange.low.x, y: entry.localRange.low.y, z: entry.localRange.low.z },
+        hi: { x: entry.localRange.high.x, y: entry.localRange.high.y, z: entry.localRange.high.z },
+      });
+    }
+
+    expect(entry.primitive.type).to.equal("geometryQuery");
+    if (entry.primitive.type === "geometryQuery") {
+      expect(entry.primitive.geometry.geometryCategory).to.equal("point");
+      if (entry.primitive.geometry.geometryCategory === "point") {
+        const pt = entry.primitive.geometry.point;
+        result.push({ x: pt.x, y: pt.y, z: pt.z });
+      }
+    }
+  }
+
+  return result;
+}
 
 describe.only("DgnDb.inlineGeometryPartReferences", () => {
   let imodel: SnapshotDb;
@@ -46,7 +137,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     redSubCategoryId = SubCategory.insert(imodel, categoryId, "red", { color: ColorDef.red.toJSON() });
     expect(Id64.isValidId64(redSubCategoryId)).to.be.true;
 
-    materialId = RenderMaterialElement.insert(imodel, IModel.dictionaryId, "mat", { paletteName: "pal", color: ColorDef.black });
+    materialId = RenderMaterialElement.insert(imodel, IModel.dictionaryId, "mat", { paletteName: "pal" });
     expect(Id64.isValidId64(materialId)).to.be.true;
   });
 

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -284,7 +284,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
   it("inlines multiple references in a single element", () => {
   });
 
-  it.only("resets element symbology", () => {
+  it("applies element symbology to part and resets element symbology after embedding part", () => {
     const part1 = insertGeometryPart([
       { pos: 1 },
       { color: ColorDef.green },
@@ -342,20 +342,20 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black },
       { low: 2 },
       { pos: 2 },
-      { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black, materialId },
+      { categoryId, subCategoryId: redSubCategoryId, materialId },
       { low: 2.5 },
       { pos: 2.5 },
       { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black },
       { low: -3 },
       { pos: -3 },
 
-      { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black, materialId },
+      { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.white, materialId },
       { low: 3 },
       { pos: 3 },
-      { categoryId, subCategoryId: redSubCategoryId, color: ColorDef.white },
+      { categoryId, subCategoryId: redSubCategoryId, materialId: "0" },
       { low: 3.5 },
       { pos: 3.5 },
-      {categoryId, subCategoryId: redSubCategoryId, color: ColorDef.black, materialId },
+      {categoryId, subCategoryId: redSubCategoryId, color: ColorDef.white, materialId },
       { low: -4 },
       { pos: -4 },
     ]);
@@ -364,10 +364,13 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
   it("has no effect if inlining fails", () => {
   });
 
-  it("preserves subgraphic ranges", () => {
+  it("inserts subgraphic ranges for parts", () => {
   });
 
-  it("inserts subgraphic ranges for subsequent geometry", () => {
+  it("preserves existing subgraphic ranges", () => {
+  });
+
+  it("inserts subgraphic ranges geometry following part", () => {
   });
 
   it("applies transform to patterns and line styles", () => {

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -292,6 +292,14 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
       { pos: 2.5 },
     ]);
 
+    // Sanity check.
+    expectGeom(readElementGeom(part2), [
+      { categoryId: "0", subCategoryId: "0" },
+      { pos: 2 },
+      { categoryId: "0", subCategoryId: "0", materialId },
+      { pos: 2.5 },
+    ]);
+
     const part3 = insertGeometryPart([
       { pos: 3 },
       { materialId: "0" },

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -347,4 +347,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
 
   it("inserts subgraphic ranges for subsequent geometry", () => {
   });
+
+  it("applies transform to patterns and line styles", () => {
+  });
 });

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -296,7 +296,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expectGeom(readElementGeom(part2), [
       { categoryId: "0", subCategoryId: "0" },
       { pos: 2 },
-      { categoryId: "0", subCategoryId: "0", materialId },
+      { categoryId: "0", subCategoryId: "0", materialId }, // fails - comes back with materialId="0"...
       { pos: 2.5 },
     ]);
 

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -4,13 +4,17 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { Guid, Id64 } from "@itwin/core-bentley";
-import { IModel } from "@itwin/core-common";
-import { GenericSchema, PhysicalModel, PhysicalPartition, SnapshotDb, SubjectOwnsPartitionElements } from "../../core-backend";
+import { ColorDef, IModel } from "@itwin/core-common";
+import { GenericSchema, PhysicalModel, PhysicalPartition, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
 describe.only("DgnDb.inlineGeometryPartReferences", () => {
   let imodel: SnapshotDb;
   let modelId: string;
+  let categoryId: string;
+  let blueSubCategoryId: string;
+  let redSubCategoryId: string;
+  let materialId: string;
 
   beforeEach(() => {
     imodel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("InlineGeomParts", `${Guid.createValue()}.bim`), {
@@ -35,16 +39,25 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
 
     modelId = imodel.models.insertModel(model.toJSON());
     expect(Id64.isValidId64(modelId)).to.be.true;
+
+    categoryId = SpatialCategory.insert(imodel, IModel.dictionaryId, "ctgry", { color: ColorDef.blue.toJSON() });
+    expect(Id64.isValidId64(categoryId)).to.be.true;
+    blueSubCategoryId = IModel.getDefaultSubCategoryId(categoryId);
+    redSubCategoryId = SubCategory.insert(imodel, categoryId, "red", { color: ColorDef.red.toJSON() });
+    expect(Id64.isValidId64(redSubCategoryId)).to.be.true;
+
+    materialId = RenderMaterialElement.insert(imodel, IModel.dictionaryId, "mat", { paletteName: "pal", color: ColorDef.black });
+    expect(Id64.isValidId64(materialId)).to.be.true;
   });
 
   afterEach(() => {
     imodel.close();
   });
 
-  it("inlines and deletes unique parts", () => {
+  it("inlines and deletes a simple unique part reference", () => {
   });
 
-  it("ignores non-unique parts", () => {
+  it("inlines and deletes unique parts, ignoring non-unique parts", () => {
   });
 
   it("applies part transform", () => {
@@ -57,5 +70,11 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
   });
 
   it("has no effect if inlining fails", () => {
+  });
+
+  it("preserves subgraphic ranges", () => {
+  });
+
+  it("inserts subgraphic ranges for subsequent geometry", () => {
   });
 });

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -266,7 +266,14 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expectGeom(readElementGeom(elem5), [symb, { partId: part4 }]);
   });
 
-  it("applies part transform", () => {
+  it.only("applies part transform", () => {
+    const partId = insertGeometryPart([{ pos: -8 }]);
+    const elemId = insertElement([{ partId, origin: 50 }]);
+    expect(inlinePartRefs()).to.equal(1);
+    expectGeom(readElementGeom(elemId), [
+      { categoryId, subCategoryId: blueSubCategoryId },
+      { pos: 42 },
+    ]);
   });
 
   it("inlines multiple references in a single element", () => {

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { Guid, Id64 } from "@itwin/core-bentley";
-import { LineString3d, Loop, Point3d, Range3dProps } from "@itwin/core-geometry";
+import { LineString3d, Loop, Point3d } from "@itwin/core-geometry";
 import {
   AreaPattern,
   Code, ColorDef, GeometricElement3dProps, GeometryParams, GeometryPartProps, GeometryStreamBuilder, GeometryStreamIterator, IModel,
@@ -40,7 +40,7 @@ function makeGeomParams(symb: Symbology): GeometryParams {
   return params;
 }
 
-interface AppendSubRanges { appendSubRanges: true };
+interface AppendSubRanges { appendSubRanges: true }
 
 type UnionMember<T, U> = T & { [k in keyof U]?: never };
 
@@ -192,7 +192,7 @@ describe("DgnDb.inlineGeometryPartReferences", () => {
       model: IModel.dictionaryId,
       code: GeometryPart.createCode(imodel, IModel.dictionaryId, Guid.createValue()),
       geom: writer.builder.geometryStream,
-    }
+    };
 
     const partId = imodel.elements.insertElement(props);
     expect(Id64.isValidId64(partId)).to.be.true;

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -386,8 +386,10 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expectGeom(readElementGeom(elem), [
       { categoryId, subCategoryId: blueSubCategoryId },
       { pos: -1 },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { low: 1 },
       { pos: 1 },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { low: 7 },
       { pos: 7 },
     ]);
@@ -406,7 +408,9 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
       { categoryId, subCategoryId: blueSubCategoryId },
       { low: -1 },
       { pos: -1 },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { partId },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { low: 1 },
       { pos: 1 },
     ]);
@@ -417,8 +421,10 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
       { categoryId, subCategoryId: blueSubCategoryId },
       { low: -1 },
       { pos: -1 },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { low: 0 },
       { pos: 0 },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { low: 1 },
       { pos: 1 },
     ]);
@@ -437,8 +443,10 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expectGeom(readElementGeom(elem), [
       { categoryId, subCategoryId: blueSubCategoryId },
       { pos: 0 },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { low: 1 },
       { pos: 1 },
+      { categoryId, subCategoryId: blueSubCategoryId },
       { low: 2 },
       { pos: 2 },
     ]);

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -75,10 +75,10 @@ function readGeomStream(iter: GeometryStreamIterator): GeomStreamEntry[] {
   for (const entry of iter) {
     const symb: Symbology =  { categoryId: entry.geomParams.categoryId, subCategoryId: entry.geomParams.subCategoryId };
 
-    if (entry.geomParams.lineColor)
+    if (undefined !== entry.geomParams.lineColor)
       symb.color = entry.geomParams.lineColor;
 
-    if (entry.geomParams.materialId)
+    if (undefined !== entry.geomParams.materialId)
       symb.materialId = entry.geomParams.materialId;
 
     result.push(symb);
@@ -284,7 +284,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
   it("inlines multiple references in a single element", () => {
   });
 
-  it("resets element symbology", () => {
+  it.only("resets element symbology", () => {
     const part1 = insertGeometryPart([
       { pos: 1 },
       { color: ColorDef.green },

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -300,7 +300,7 @@ describe.only("DgnDb.inlineGeometryPartReferences", () => {
     expectGeom(readElementGeom(part2), [
       { categoryId: "0", subCategoryId: "0" },
       { pos: 2 },
-      { categoryId: "0", subCategoryId: "0", materialId }, // fails - comes back with materialId="0"...
+      { categoryId: "0", subCategoryId: "0", materialId },
       { pos: 2.5 },
     ]);
 

--- a/core/common/src/geometry/GeometryStream.ts
+++ b/core/common/src/geometry/GeometryStream.ts
@@ -610,17 +610,17 @@ export class GeometryStreamIterator implements IterableIterator<GeometryStreamIt
         this.entry.geomParams.resetAppearance();
         if (entry.appearance.subCategory)
           this.entry.geomParams.subCategoryId = Id64.fromJSON(entry.appearance.subCategory);
-        if (entry.appearance.color)
+        if (undefined !== entry.appearance.color)
           this.entry.geomParams.lineColor = ColorDef.fromJSON(entry.appearance.color);
-        if (entry.appearance.weight)
+        if (undefined !== entry.appearance.weight)
           this.entry.geomParams.weight = entry.appearance.weight;
-        if (entry.appearance.style)
+        if (undefined !== entry.appearance.style)
           this.entry.geomParams.styleInfo = new LineStyle.Info(Id64.fromJSON(entry.appearance.style));
-        if (entry.appearance.transparency)
+        if (undefined !== entry.appearance.transparency)
           this.entry.geomParams.elmTransparency = entry.appearance.transparency;
-        if (entry.appearance.displayPriority)
+        if (undefined !== entry.appearance.displayPriority)
           this.entry.geomParams.elmPriority = entry.appearance.displayPriority;
-        if (entry.appearance.geometryClass)
+        if (undefined !== entry.appearance.geometryClass)
           this.entry.geomParams.geometryClass = entry.appearance.geometryClass;
       } else if (entry.styleMod) {
         if (this.entry.geomParams.styleInfo === undefined)

--- a/core/common/src/geometry/GeometryStream.ts
+++ b/core/common/src/geometry/GeometryStream.ts
@@ -603,7 +603,7 @@ export class GeometryStreamIterator implements IterableIterator<GeometryStreamIt
    * Geometric entries are [[TextString]], [[GeometryQuery]], [[GeometryPart]], [[ImageGraphic]], and [[BRepEntity.DataProps]].
    */
   public next(): IteratorResult<GeometryStreamIteratorEntry> {
-    // NOTE: localRange remains valid until new subRange entry is encountered
+    // NOTE: localRange remains valid until we encounter either a new subRange entry or a geometry part reference.
     while (this._index < this.geometryStream.length) {
       const entry = this.geometryStream[this._index++];
       if (entry.appearance) {
@@ -663,6 +663,9 @@ export class GeometryStreamIterator implements IterableIterator<GeometryStreamIt
             transform.multiplyTransformTransform(Transform.createRefs(Point3d.createZero(), Matrix3d.createUniformScale(entry.geomPart.scale)), transform);
         }
 
+        // Subgraphic range doesn't apply to parts. A sane geometry stream (i.e., any that has been through the native layers or GeometryStreamBuilder)
+        // will have a new subgraphic range for any geometric primitive following the part.
+        this.entry.localRange = undefined;
         this.entry.setPartReference(Id64.fromJSON(entry.geomPart.part), transform);
         return { value: this.entry, done: false };
       } else if (entry.textString) {

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -491,9 +491,9 @@ export class IModelImporter implements Required<IModelImportOptions> {
   /** Examine the geometry streams of every [GeometricElement3d]($backend) in the target iModel to identify [GeometryPart]($backend)s that each have exactly
    * one reference to them. Update the geometry stream of each referencing element to embed the part's geometry instead, then delete the part.
    * @note This method is automatically called from [[IModelTransformer.processChanges]] and [[IModelTransformer.processAll]] if
-   * [[IModelTransformOptions.inlineGeometryPartReferences]] is `true`.
+   * [[IModelTransformOptions.optimizeGeometryPartReferences]] is `true`.
    */
-  public inlineGeometryPartReferences(): void {
+  public optimizeGeometryPartReferences(): void {
     const result = this.targetDb.nativeDb.inlineGeometryPartReferences();
     if (result.numCandidateParts > 0)
       Logger.logInfo(loggerCategory, `Inlined ${result.numRefsInlined} references to ${result.numCandidateParts} geometry parts and deleted ${result.numPartsDeleted} parts.`);

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -505,8 +505,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
   public optimizeGeometry(options: OptimizeGeometryOptions): void {
     if (options.inlineUniqueGeometryParts) {
       const result = this.targetDb.nativeDb.inlineGeometryPartReferences();
-      if (result.numCandidateParts > 0)
-        Logger.logInfo(loggerCategory, `Inlined ${result.numRefsInlined} references to ${result.numCandidateParts} geometry parts and deleted ${result.numPartsDeleted} parts.`);
+      Logger.logInfo(loggerCategory, `Inlined ${result.numRefsInlined} references to ${result.numCandidateParts} geometry parts and deleted ${result.numPartsDeleted} parts.`);
     }
   }
 }

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -487,6 +487,17 @@ export class IModelImporter implements Required<IModelImportOptions> {
       }
     }
   }
+
+  /** Examine the geometry streams of every [GeometricElement3d]($backend) in the target iModel to identify [GeometryPart]($backend)s that each have exactly
+   * one reference to them. Update the geometry stream of each referencing element to embed the part's geometry instead, then delete the part.
+   * @note This method is automatically called from [[IModelTransformer.processChanges]] and [[IModelTransformer.processAll]] if
+   * [[IModelTransformOptions.inlineGeometryPartReferences]] is `true`.
+   */
+  public inlineGeometryPartReferences(): void {
+    const result = this.targetDb.nativeDb.inlineGeometryPartReferences();
+    if (result.numCandidateParts > 0)
+      Logger.logInfo(loggerCategory, `Inlined ${result.numRefsInlined} references to ${result.numCandidateParts} geometry parts and deleted ${result.numPartsDeleted} parts.`);
+  }
 }
 
 /** Returns true if a change within an Entity is detected.

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -65,10 +65,10 @@ export class IModelImporter implements Required<IModelImportOptions> {
    * @see [IModelTransformOptions.preserveElementIdsForFiltering]($transformer)
    * @deprecated Use [[IModelImporter.options.preserveElementIdsForFiltering]] instead
    */
-  public get preserveElementIdsForFiltering(): Required<IModelImportOptions>["preserveElementIdsForFiltering"] {
+  public get preserveElementIdsForFiltering(): boolean {
     return this.options.preserveElementIdsForFiltering;
   }
-  public set preserveElementIdsForFiltering(val: Required<IModelImportOptions>["preserveElementIdsForFiltering"]) {
+  public set preserveElementIdsForFiltering(val: boolean) {
     this.options.preserveElementIdsForFiltering = val;
   }
 
@@ -76,11 +76,11 @@ export class IModelImporter implements Required<IModelImportOptions> {
    * @see [[IModelImportOptions.simplifyElementGeometry]]
    * @deprecated Use [[IModelImporter.options.simplifyElementGeometry]] instead
    */
-  public get simplifyElementGeometry(): Required<IModelImportOptions>["simplifyElementGeometry"] {
-    return this.options.preserveElementIdsForFiltering;
+  public get simplifyElementGeometry(): boolean {
+    return this.options.simplifyElementGeometry;
   }
-  public set simplifyElementGeometry(val: Required<IModelImportOptions>["simplifyElementGeometry"]) {
-    this.options.preserveElementIdsForFiltering = val;
+  public set simplifyElementGeometry(val: boolean) {
+    this.options.simplifyElementGeometry = val;
   }
 
   /** The set of elements that should not be updated by this IModelImporter.

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -100,6 +100,12 @@ export interface IModelTransformOptions {
    * @beta
    */
   danglingPredecessorsBehavior?: "reject" | "ignore";
+
+  /** If `true`, then [[IModelImporter.inlineGeometryPartReferences]] will be invoked by [[IModelTransformer.processChanges]] and [[IModelTransformer.processAll]]
+   * to clean up references to geometry parts having only one reference to them.
+   * @beta
+   */
+  inlineGeometryPartReferences?: boolean;
 }
 
 /** Base class used to transform a source iModel into a different target iModel.
@@ -916,6 +922,10 @@ export class IModelTransformer extends IModelExportHandler {
       await this.detectElementDeletes();
       await this.detectRelationshipDeletes();
     }
+
+    if (this._options.inlineGeometryPartReferences)
+      this.importer.inlineGeometryPartReferences();
+
     this.importer.computeProjectExtents();
   }
 
@@ -933,6 +943,10 @@ export class IModelTransformer extends IModelExportHandler {
     this.initFromExternalSourceAspects();
     await this.exporter.exportChanges(accessToken, startChangesetId);
     await this.processDeferredElements();
+
+    if (this._options.inlineGeometryPartReferences)
+      this.importer.inlineGeometryPartReferences();
+
     this.importer.computeProjectExtents();
   }
 }

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -101,11 +101,11 @@ export interface IModelTransformOptions {
    */
   danglingPredecessorsBehavior?: "reject" | "ignore";
 
-  /** If `true`, then [[IModelImporter.inlineGeometryPartReferences]] will be invoked by [[IModelTransformer.processChanges]] and [[IModelTransformer.processAll]]
+  /** If `true`, then [[IModelImporter.optimizeGeometryPartReferences]] will be invoked by [[IModelTransformer.processChanges]] and [[IModelTransformer.processAll]]
    * to clean up references to geometry parts having only one reference to them.
    * @beta
    */
-  inlineGeometryPartReferences?: boolean;
+  optimizeGeometryPartReferences?: boolean;
 }
 
 /** Base class used to transform a source iModel into a different target iModel.
@@ -923,8 +923,8 @@ export class IModelTransformer extends IModelExportHandler {
       await this.detectRelationshipDeletes();
     }
 
-    if (this._options.inlineGeometryPartReferences)
-      this.importer.inlineGeometryPartReferences();
+    if (this._options.optimizeGeometryPartReferences)
+      this.importer.optimizeGeometryPartReferences();
 
     this.importer.computeProjectExtents();
   }
@@ -944,8 +944,8 @@ export class IModelTransformer extends IModelExportHandler {
     await this.exporter.exportChanges(accessToken, startChangesetId);
     await this.processDeferredElements();
 
-    if (this._options.inlineGeometryPartReferences)
-      this.importer.inlineGeometryPartReferences();
+    if (this._options.optimizeGeometryPartReferences)
+      this.importer.optimizeGeometryPartReferences();
 
     this.importer.computeProjectExtents();
   }

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -923,8 +923,8 @@ export class IModelTransformer extends IModelExportHandler {
       await this.detectRelationshipDeletes();
     }
 
-    if (this._options.optimizeGeometryPartReferences)
-      this.importer.optimizeGeometryPartReferences();
+    if (this._options.optimizeGeometry)
+      this.importer.optimizeGeometry(this._options.optimizeGeometry);
 
     this.importer.computeProjectExtents();
   }
@@ -944,8 +944,8 @@ export class IModelTransformer extends IModelExportHandler {
     await this.exporter.exportChanges(accessToken, startChangesetId);
     await this.processDeferredElements();
 
-    if (this._options.optimizeGeometryPartReferences)
-      this.importer.optimizeGeometryPartReferences();
+    if (this._options.optimizeGeometry)
+      this.importer.optimizeGeometry(this._options.optimizeGeometry);
 
     this.importer.computeProjectExtents();
   }

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -21,7 +21,7 @@ import {
   IModelError, ModelProps, Placement2d, Placement3d, PrimitiveTypeCode, PropertyMetaData,
 } from "@itwin/core-common";
 import { IModelExporter, IModelExportHandler } from "./IModelExporter";
-import { IModelImporter } from "./IModelImporter";
+import { IModelImporter, OptimizeGeometryOptions } from "./IModelImporter";
 import { TransformerLoggerCategory } from "./TransformerLoggerCategory";
 
 const loggerCategory: string = TransformerLoggerCategory.IModelTransformer;
@@ -101,11 +101,11 @@ export interface IModelTransformOptions {
    */
   danglingPredecessorsBehavior?: "reject" | "ignore";
 
-  /** If `true`, then [[IModelImporter.optimizeGeometryPartReferences]] will be invoked by [[IModelTransformer.processChanges]] and [[IModelTransformer.processAll]]
-   * to clean up references to geometry parts having only one reference to them.
+  /** If defined, options to be supplied to [[IModelImporter.optimizeGeometry]] by [[IModelTransformer.processChanges]] and [[IModelTransformer.processAll]]
+   * as a post-processing step to optimize the geometry in the iModel.
    * @beta
    */
-  optimizeGeometryPartReferences?: boolean;
+  optimizeGeometry?: OptimizeGeometryOptions;
 }
 
 /** Base class used to transform a source iModel into a different target iModel.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -84,3 +84,24 @@ It is now possible to retrieve `Units` from schemas stored in IModels. The new [
 
     UiFramework.setIModelConnection(iModelConnection, true);
 ```
+
+## Optimization of geometry in IModelImporter
+
+The geometry produced by [connectors](https://www.itwinjs.org/learning/imodel-connectors/) and [transformation workflows]($docs/learning/transformer/index.md) is not always ideal. One common issue is a proliferation of [GeometryPart]($backend)s to which only one reference exists. In most cases, it would be more efficient to embed the part's geometry directly into the referencing element's [geometry stream](https://www.itwinjs.org/learning/common/geometrystream/).
+
+[IModelImporter.optimizeGeometry]($transformer) has been introduced to enable this kind of optimization. It takes an [OptimizeGeometryOptions]($transformer) object specifying which optimizations to apply, and applies them to all of the 3d geometry in the iModel. Currently, only the optimization described above is supported, but more are expected to be added in the future.
+
+If you are using [IModelImporter]($transformer) directly, you can call `optimizeGeometry` directly. Typically you would want to do so as a post-processing step. It's simple:
+
+```ts
+  // Import all of your geometry, then:
+  importer.optimizeGeometry({ inlineUniqueGeometryParts: true });
+```
+
+If you are using [IModelTransformer]($transformer), you can configure automatic geometry optimization via [IModelTransformOptions.optimizeGeometry]($transformer). If this property is defined, then [IModelTransformer.processAll]($transformer) and [IModelTransformer.processChanges]($transformer) will apply the specified optimizations after the transformation process completes. For example:
+
+```ts
+  const options = { inlineUniqueGeometryParts: true };
+  const transformer = new IModelTransformer(sourceIModel, targetIModel, options);
+  transformer.processAll();
+```


### PR DESCRIPTION
Some connectors produce many geometry parts that are referenced only once, as do some transformation workflows. This is inefficient for tile generation and data representation - more often than not, these parts don't really mean anything.
Add an optional post-process step to IModelTransformer to identify these parts. For each, embed the part's geometry stream directly into the referencing element's geometry stream, then delete the part.
In future we may find additional criteria for identifying parts that should be inlined, in which case we can add options. e.g., if the part geometry is so trivial that it would be cheaper to embed regardless of number of references (e.g., we've seen geometry parts consisting of a single point or triangle).

Incidentally fix some bugs in `IModelImporter.preserveElementIdsForFiltering` and GeometryStreamIterator.

[Corresponding native changes](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/229167)

TODO:
- [x] Tests
- [x] NextVersion