### PR TITLE
Fix import ordering in core-geometry

### DIFF
--- a/common/changes/@itwin/core-geometry/fix-geom-barrel_2022-02-25-23-37.json
+++ b/common/changes/@itwin/core-geometry/fix-geom-barrel_2022-02-25-23-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/package.json
+++ b/core/geometry/package.json
@@ -7,7 +7,9 @@
   "typings": "lib/cjs/core-geometry",
   "imodeljsSharedLibrary": true,
   "license": "MIT",
-  "sideEffects": false,
+  "sideEffects": [
+    "./lib/esm/core-geometry.js"
+  ],
   "scripts": {
     "build": "npm run -s build:cjs",
     "build:ci": "npm run -s build && npm run -s build:esm",


### PR DESCRIPTION
Optimized builds of display-test-app are currently broken with a runtime error `Cannot access 'CurveCollection_CurveChain' before initialization`, which seems to be caused by the following circular dependency: 

> `CurveChain` _uses_ `LineString3d` _which uses_ `OffsetOptions` _which uses_ `Loop` _which extends_ `CurveChain`

This is actually even reproducible in node without webpack:

```js
import { CurveChain } from "@itwin/core-geometry/lib/cjs/curve/CurveCollection";
abstract class X extends CurveChain {} // throws TypeError: Class extends value undefined is not a constructor or null
```

However, as you can probably tell from that example, the ordering of imports in the core-geometry barrel file manages to avoid that error, my guess is by (indirectly) importing `LineString3d` before `CurveCollection`:

```js
import "@itwin/core-geometry/lib/cjs/curve/LineString3d";
import { CurveChain } from "@itwin/core-geometry/lib/cjs/curve/CurveCollection";
abstract class X extends CurveChain {} // No runtime error
```

But DTA (and its dependencies) are obviously using the core-geometry barrel, so why would we ever hit this?  Well, since I marked core-geometry’s package.json with `"sideEffects": false` (in #2686), webpack is able to tree-shake core-geometry, which involves identifying and removing unnecessary `export * from ...` statements.  After some digging thru webpack issues, I found [this comment](https://github.com/webpack/webpack/issues/12724#issuecomment-782680753) which seems to clarify things (emphasis added):

> Also note that execution order might change in side effect free modules… so you might get different behavior. There are cases where code with circular dependencies depends on a certain execution order to work properly. **This kind of code has an implicit side effect of putting some modules into the module cache.**

I’d hate to revert #2686, since that will really bloat every extension using tiny pieces of core-geometry.  But after a bit of experimentation, it turns out that marking _just the barrel file_ as having side effects fixes the import ordering so it’s consistent with our CJS/unoptimized builds, but still preserves all the bundle size improvements that tree-shaking was getting us.