### PR TITLE
Presentation: Optimize ModelsTree search ruleset

### DIFF
--- a/common/changes/@itwin/appui-react/presentation-models-tree-search-ruleset-change_2022-02-28-08-02.json
+++ b/common/changes/@itwin/appui-react/presentation-models-tree-search-ruleset-change_2022-02-28-08-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Optimize ModelsTree search ruleset",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-Search.PresentationRuleSet.json
+++ b/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-Search.PresentationRuleSet.json
@@ -127,7 +127,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -171,7 +171,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -211,7 +211,7 @@
               }
             }
           ],
-          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }

--- a/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsTreeSearch.json
+++ b/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsTreeSearch.json
@@ -127,7 +127,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -171,7 +171,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -211,7 +211,7 @@
               }
             }
           ],
-          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }


### PR DESCRIPTION
Use `bis.Element` instead of `bis.GeometricElement3d` elements for filtering-out `bis.GeometricModel3d` models that have no elements. The models should contain only geometric elements anyway, and filtering by `Element` is quicker as it doesn't require joining the geometric elements' table.