### PR TITLE
Change the type of ToolAdmin.idleTool from IdleTool to InteractiveTool

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -11569,8 +11569,8 @@ export class ToolAdmin {
     getDecorationGeometry(hit: HitDetail): GeometryStreamProps | undefined;
     getToolTip(hit: HitDetail): Promise<HTMLElement | string>;
     gridLock: boolean;
-    get idleTool(): IdleTool;
-    set idleTool(idleTool: IdleTool);
+    get idleTool(): InteractiveTool;
+    set idleTool(idleTool: InteractiveTool);
     // (undocumented)
     get isLocateCircleOn(): boolean;
     readonly manipulatorToolEvent: BeEvent<(tool: Tool, event: ManipulatorToolEvent) => void>;

--- a/common/changes/@itwin/core-frontend/idle-tool-type_2022-02-28-10-41.json
+++ b/common/changes/@itwin/core-frontend/idle-tool-type_2022-02-28-10-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Change the type of ToolAdmin.idleTool from IdleTool to InteractiveTool",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -6,7 +6,7 @@
  * @module Tools
  */
 
-import { AbandonedError, BeEvent, Id64String, IModelStatus, Logger } from "@itwin/core-bentley";
+import { AbandonedError, assert, BeEvent, Id64String, IModelStatus, Logger } from "@itwin/core-bentley";
 import { Matrix3d, Point2d, Point3d, Transform, Vector3d, XAndY } from "@itwin/core-geometry";
 import { Easing, GeometryStreamProps, NpcCenter } from "@itwin/core-common";
 import { DialogItemValue, DialogPropertyItem, DialogPropertySyncItem } from "@itwin/appui-abstract";
@@ -310,7 +310,7 @@ export class ToolAdmin {
   private _suspendedByInputCollector?: SuspendedToolState;
   private _viewTool?: ViewTool;
   private _primitiveTool?: PrimitiveTool;
-  private _idleTool?: IdleTool;
+  private _idleTool?: InteractiveTool;
   private _inputCollector?: InputCollector;
   private _saveCursor?: string;
   private _saveLocateCircle = false;
@@ -449,7 +449,7 @@ export class ToolAdmin {
     if (typeof document === "undefined")
       return;    // if document isn't defined, we're probably running in a test environment. At any rate, we can't have interactive tools.
 
-    this._idleTool = IModelApp.tools.create("Idle") as IdleTool;
+    this._idleTool = IModelApp.tools.create("Idle") as InteractiveTool;
 
     ["keydown", "keyup"].forEach((type) => {
       document.addEventListener(type, ToolAdmin._keyEventHandler as EventListener, false);
@@ -788,8 +788,13 @@ export class ToolAdmin {
   }
 
   /** The idleTool handles events that are not otherwise processed. */
-  public get idleTool(): IdleTool { return this._idleTool!; }
-  public set idleTool(idleTool: IdleTool) { this._idleTool = idleTool; }
+  public get idleTool(): InteractiveTool {
+    assert(undefined !== this._idleTool);
+    return this._idleTool;
+  }
+  public set idleTool(idleTool: InteractiveTool) {
+    this._idleTool = idleTool;
+  }
 
   /** Return true to filter (ignore) events to the given viewport */
   protected filterViewport(vp: ScreenViewport) {

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -23,7 +23,6 @@ import { OnViewExtentsError, ViewChangeOptions } from "../ViewAnimation";
 import { DecorateContext, DynamicsContext } from "../ViewContext";
 import { ScreenViewport, Viewport } from "../Viewport";
 import { ViewStatus } from "../ViewStatus";
-import { IdleTool } from "./IdleTool";
 import { PrimitiveTool } from "./PrimitiveTool";
 import {
   BeButton, BeButtonEvent, BeButtonState, BeModifierKeys, BeTouchEvent, BeWheelEvent, CoordinateLockOverrides, CoordSource, EventHandled,

--- a/docs/learning/frontend/Tools.md
+++ b/docs/learning/frontend/Tools.md
@@ -37,11 +37,11 @@ The [ToolAdmin]($frontend) class supervises the collection of low-level input fr
 Routing of the interpreted, high-level events is as follows:
 
 - If there is an active tool, the events are directed to it. The active tool can either handle a particular event or ignore it.
-- If the active tool does not handle a particular event, it *may* be directed to the [Idle Tool](#idle-tool).
+- If the active tool does not handle a particular event, it *may* be directed to the [idle tool](#idle-tool).
 
 As mentioned above a View tool or Input Collector can temporarily interrupt a Primitive tool. The ToolAdmin handles that sequence transparently such that the Primitive tool does not have to be aware of the interruption.
 
-A Primitive tool ends when another Primitive tool is run. The ToolAdmin establishes [Select Tool](#selection-tool) as the *default* Primitive tool. When a default tool is provided, it becomes the active tool when the iTwin.js application starts or a Primitive tool wishes to exit. Having a default tool is optional, an application can instead choose to have the [Idle Tool](#idle-tool) handle input that would normally only be directed to the active tool, like data points and resets.
+A Primitive tool ends when another Primitive tool is run. The ToolAdmin establishes [Select Tool](#selection-tool) as the *default* Primitive tool. When a default tool is provided, it becomes the active tool when the iTwin.js application starts or a Primitive tool wishes to exit. Having a default tool is optional, an application can instead choose to have the [idle tool](#idle-tool) handle input that would normally only be directed to the active tool, like data points and resets.
 
 ## Idle Tool
 
@@ -62,6 +62,8 @@ For touch devices, the Idle tool associates the following touch events with view
 - Two-finger drag to pan the view
 - Double tap to fit the view
 - Pinch to zoom the view in and out
+
+An application can override the standard idle tool by supplying its own customized tool to [ToolAdmin.idleTool]($frontend).
 
 ## Selection Tool
 


### PR DESCRIPTION
As discussed in #3246. `IdleTool` is structurally identical to `InteractiveTool`; the current typing leads users to believe they must subclass and manually override all of IdleTool's behavior if they want to replace the default idle tool.