### PR TITLE
UI: Deprecate broken `IMutableGridCategoryItem` methods

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -1246,9 +1246,9 @@ export function getVisibleDescendants(model: TreeModel, parentNode: TreeModelNod
 export interface GridCategoryItem extends FlatGridItemBase {
     // (undocumented)
     readonly derivedCategory: PropertyCategory;
-    // (undocumented)
+    // @deprecated (undocumented)
     getChildCategories(): GridCategoryItem[];
-    // (undocumented)
+    // @deprecated (undocumented)
     getDescendantCategoriesAndSelf(): GridCategoryItem[];
     // (undocumented)
     readonly name: string;
@@ -1493,9 +1493,9 @@ export interface IMutableFlatPropertyGridItem {
 export interface IMutableGridCategoryItem extends IMutableFlatPropertyGridItem {
     // (undocumented)
     derivedCategory: PropertyCategory;
-    // (undocumented)
+    // @deprecated (undocumented)
     getChildCategories(): IMutableGridCategoryItem[];
-    // (undocumented)
+    // @deprecated (undocumented)
     getDescendantCategoriesAndSelf(): IMutableGridCategoryItem[];
     // (undocumented)
     isRootCategory: boolean;

--- a/common/changes/@itwin/components-react/ui-property-grid_2022-03-01-16-01.json
+++ b/common/changes/@itwin/components-react/ui-property-grid_2022-03-01-16-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/FlatGridItem.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/FlatGridItem.ts
@@ -40,9 +40,9 @@ export interface GridCategoryItem extends FlatGridItemBase {
   readonly name: string;
   readonly derivedCategory: PropertyCategory;
 
-  /** @deprecated Use getChildren and filter categories yourself. */
+  /** @deprecated Use [[getChildren]] and filter categories yourself. */
   getChildCategories(): GridCategoryItem[];
-  /** @deprecated Use getDescendantsAndSelf and filter categories yourself. */
+  /** @deprecated Use [[getDescendantsAndSelf]] and filter categories yourself. */
   getDescendantCategoriesAndSelf(): GridCategoryItem[];
 }
 

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/FlatGridItem.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/FlatGridItem.ts
@@ -40,7 +40,9 @@ export interface GridCategoryItem extends FlatGridItemBase {
   readonly name: string;
   readonly derivedCategory: PropertyCategory;
 
+  /** @deprecated Use getChildren and filter categories yourself. */
   getChildCategories(): GridCategoryItem[];
+  /** @deprecated Use getDescendantsAndSelf and filter categories yourself. */
   getDescendantCategoriesAndSelf(): GridCategoryItem[];
 }
 

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableFlatGridItem.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableFlatGridItem.ts
@@ -191,13 +191,11 @@ export interface IMutableGridCategoryItem extends IMutableFlatPropertyGridItem {
   isRootCategory: boolean;
 
   /**
-   * @deprecated Use getChildren and filter categories yourself. Do not use this method to mutate the grid model, as
-   * this may lead to unexpected outcomes.
+   * @deprecated Use [[getChildren]] and filter categories yourself. Do not use this method to mutate the grid model, as this may lead to unexpected outcomes.
    */
   getChildCategories(): IMutableGridCategoryItem[];
   /**
-   * @deprecated Use getDescendantsAndSelf and filter categories yourself. Do not use this method to mutate the grid
-   * model, as this may lead to unexpected outcomes.
+   * @deprecated Use [[getDescendantsAndSelf]] and filter categories yourself. Do not use this method to mutate the grid model, as this may lead to unexpected outcomes.
    */
   getDescendantCategoriesAndSelf(): IMutableGridCategoryItem[];
 }

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableFlatGridItem.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableFlatGridItem.ts
@@ -190,7 +190,15 @@ export interface IMutableGridCategoryItem extends IMutableFlatPropertyGridItem {
   derivedCategory: PropertyCategory;
   isRootCategory: boolean;
 
+  /**
+   * @deprecated Use getChildren and filter categories yourself. Do not use this method to mutate the grid model, as
+   * this may lead to unexpected outcomes.
+   */
   getChildCategories(): IMutableGridCategoryItem[];
+  /**
+   * @deprecated Use getDescendantsAndSelf and filter categories yourself. Do not use this method to mutate the grid
+   * model, as this may lead to unexpected outcomes.
+   */
   getDescendantCategoriesAndSelf(): IMutableGridCategoryItem[];
 }
 

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableGridCategory.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableGridCategory.ts
@@ -104,6 +104,7 @@ export class MutableGridCategory extends MutableFlatPropertyGridItem implements 
    */
   public getDescendantCategoriesAndSelf(): IMutableGridCategoryItem[] {
     const descendants: IMutableGridCategoryItem[] = [];
+    // eslint-disable-next-line deprecation/deprecation
     this._childCategories.forEach((value) => descendants.push(...value.getDescendantCategoriesAndSelf()));
 
     return [this, ...descendants];

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/GridCategory.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/GridCategory.test.ts
@@ -512,12 +512,14 @@ describe("GridCategory", () => {
       expect(gridCategory.parentCategorySelectionKey).to.be.equal(parentSelectionKey);
 
       // Test current gridCategory descendants against flattened propertyCategory
+      // eslint-disable-next-line deprecation/deprecation
       const descendants = gridCategory.getDescendantCategoriesAndSelf();
       const flattenedPropertyCategories = GridUtils.flattenPropertyCategories([propertyCategory], {});
       expect(descendants.length).to.be.equal(flattenedPropertyCategories.length);
       descendants.forEach((descendant, index) => GridUtils.assertCategoryEquals(descendant, flattenedPropertyCategories[index].item as PropertyCategory));
 
       // Test current gridCategory children parent-child category relationship (recursive)
+      // eslint-disable-next-line deprecation/deprecation
       const childCategories = gridCategory.getChildCategories();
       const childPropertyCategories = propertyCategory.childCategories ?? [];
       expect(childCategories.length).to.be.equal(childPropertyCategories.length);
@@ -536,8 +538,10 @@ describe("GridCategory", () => {
 
         const gridCategory = new MutableGridCategory(propertyCategory, categoryRecords, gridItemFactory);
 
+        // eslint-disable-next-line deprecation/deprecation
         const childCategories = gridCategory.getChildCategories();
         expect(gridCategory.getChildren()).to.deep.equal(childCategories);
+        // eslint-disable-next-line deprecation/deprecation
         expect(gridCategory.getDescendantCategoriesAndSelf()).to.deep.equal([gridCategory, ...childCategories]);
         expect(gridCategory.getDescendantsAndSelf()).to.deep.equal([gridCategory, ...childCategories]);
 
@@ -557,8 +561,10 @@ describe("GridCategory", () => {
 
         const gridCategory = new MutableGridCategory(propertyCategory, categoryRecords, gridItemFactory);
 
+        // eslint-disable-next-line deprecation/deprecation
         const childCategories = gridCategory.getChildCategories();
         expect(gridCategory.getChildren()).to.deep.equal(childCategories);
+        // eslint-disable-next-line deprecation/deprecation
         expect(gridCategory.getDescendantCategoriesAndSelf()).to.deep.equal([gridCategory, ...childCategories]);
         expect(gridCategory.getDescendantsAndSelf()).to.deep.equal([gridCategory, ...childCategories]);
 

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/MutableCustomGridCategory.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/MutableCustomGridCategory.test.ts
@@ -59,6 +59,7 @@ describe("MutableCustomGridCategory", () => {
   describe("getChildCategories", () => {
     it("returns empty array", () => {
       const categoryItem = new MutableCustomGridCategory(category, recordsDict, factoryStub, undefined, 0);
+      // eslint-disable-next-line deprecation/deprecation
       expect(categoryItem.getChildCategories()).to.be.empty;
     });
   });
@@ -66,6 +67,7 @@ describe("MutableCustomGridCategory", () => {
   describe("getDescendantCategoriesAndSelf", () => {
     it("returns array containing only this object", () => {
       const categoryItem = new MutableCustomGridCategory(category, recordsDict, factoryStub, undefined, 0);
+      // eslint-disable-next-line deprecation/deprecation
       expect(categoryItem.getDescendantCategoriesAndSelf()).to.be.deep.equal([categoryItem]);
     });
   });


### PR DESCRIPTION
`getChildCategories` and `getDescendantCategoriesAndSelf` methods make use of duplicated state and do not play well with [immer](https://github.com/immerjs/immer). Attempting to mutate the returned arrays will leave `IMutableGridCategoryItem` in an invalid, partially updated state.