### PR TITLE
Support unquantized vertex tables

### DIFF
--- a/core/frontend/src/render/ParticleCollectionBuilder.ts
+++ b/core/frontend/src/render/ParticleCollectionBuilder.ts
@@ -9,7 +9,7 @@
 import { Id64String } from "@itwin/core-bentley";
 import { Matrix3d, Point2d, Point3d, Range3d, Transform, Vector2d, XAndY, XYAndZ } from "@itwin/core-geometry";
 import {
-  ColorDef, Feature, FeatureTable, PackedFeatureTable, QParams3d, QPoint3dList, RenderTexture,
+  ColorDef, ColorIndex, Feature, FeatureIndex, FeatureTable, FillFlags, PackedFeatureTable, QParams3d, QPoint3dList, RenderTexture,
 } from "@itwin/core-common";
 import { Viewport } from "../Viewport";
 import { RenderGraphic } from "./RenderGraphic";
@@ -343,19 +343,29 @@ function createQuad(size: XAndY, texture: RenderTexture, transparency: number): 
     new Point3d(-halfWidth, halfHeight, 0), new Point3d(halfWidth, halfHeight, 0),
   ];
 
-  const quadArgs = new MeshArgs();
   const range = new Range3d();
   range.low = corners[0];
   range.high = corners[3];
-  quadArgs.points = new QPoint3dList(QParams3d.fromRange(range));
-  for (const corner of corners)
-    quadArgs.points.add(corner);
 
-  quadArgs.vertIndices = [0, 1, 2, 2, 1, 3];
-  quadArgs.textureUv = [new Point2d(0, 1), new Point2d(1, 1), new Point2d(0, 0), new Point2d(1, 0)];
-  quadArgs.texture = texture;
-  quadArgs.colors.initUniform(ColorDef.white.withTransparency(transparency));
-  quadArgs.isPlanar = true;
+  const points = new QPoint3dList(QParams3d.fromRange(range));
+  for (const corner of corners)
+    points.add(corner);
+
+  const colors = new ColorIndex();
+  colors.initUniform(ColorDef.white.withTransparency(transparency));
+
+  const quadArgs: MeshArgs = {
+    points,
+    vertIndices: [0, 1, 2, 2, 1, 3],
+    fillFlags: FillFlags.None,
+    isPlanar: true,
+    colors,
+    features: new FeatureIndex(),
+    textureMapping: {
+      texture,
+      uvParams: [new Point2d(0, 1), new Point2d(1, 1), new Point2d(0, 0), new Point2d(1, 0)],
+    },
+  };
 
   return MeshParams.create(quadArgs);
 }

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -8,7 +8,7 @@
 
 import { base64StringToUint8Array, Id64String, IDisposable } from "@itwin/core-bentley";
 import {
-  ColorDef, ElementAlignedBox3d, FeatureIndexType, Frustum, Gradient, ImageBuffer, ImageBufferFormat, ImageSource, ImageSourceFormat,
+  ColorDef, ColorIndex, ElementAlignedBox3d, FeatureIndex, FeatureIndexType, FillFlags, Frustum, Gradient, ImageBuffer, ImageBufferFormat, ImageSource, ImageSourceFormat,
   isValidImageSourceFormat, PackedFeatureTable, QParams3d, QPoint3dList, RenderMaterial, RenderTexture, SkyGradient, TextureProps, TextureTransparency,
 } from "@itwin/core-common";
 import { ClipVector, Matrix3d, Point2d, Point3d, Range2d, Range3d, Transform, Vector2d, XAndY } from "@itwin/core-geometry";
@@ -441,38 +441,39 @@ export abstract class RenderSystem implements IDisposable {
   public createBackgroundMapDrape(_drapedTree: TileTreeReference, _mapTree: MapTileTreeReference): RenderTextureDrape | undefined { return undefined; }
   /** @internal */
   public createTile(tileTexture: RenderTexture, corners: Point3d[], featureIndex?: number): RenderGraphic | undefined {
-    const rasterTile = new MeshArgs();
-
     // corners
     // [0] [1]
     // [2] [3]
     // Quantize the points according to their range
-    rasterTile.points = new QPoint3dList(QParams3d.fromRange(Range3d.create(...corners)));
-    for (let i = 0; i < 4; ++i)
-      rasterTile.points.add(corners[i]);
+    const points = new QPoint3dList(QParams3d.fromRange(Range3d.create(...corners)));
+    for (let i = 0; i < 4; i++)
+      points.add(corners[i]);
 
     // Now remove the translation from the quantized points and put it into a transform instead.
     // This prevents graphical artifacts when quantization origin is large relative to quantization scale.
     // ###TODO: Would be better not to create a branch for every tile.
-    const qorigin = rasterTile.points.params.origin;
+    const qorigin = points.params.origin;
     const transform = Transform.createTranslationXYZ(qorigin.x, qorigin.y, qorigin.z);
     qorigin.setZero();
 
-    rasterTile.vertIndices = [0, 1, 2, 2, 1, 3];
-    rasterTile.textureUv = [
-      new Point2d(0.0, 0.0),
-      new Point2d(1.0, 0.0),
-      new Point2d(0.0, 1.0),
-      new Point2d(1.0, 1.0),
-    ];
-
-    rasterTile.texture = tileTexture;
-    rasterTile.isPlanar = true;
-
+    const features = new FeatureIndex();
     if (undefined !== featureIndex) {
-      rasterTile.features.featureID = featureIndex;
-      rasterTile.features.type = FeatureIndexType.Uniform;
+      features.featureID = featureIndex;
+      features.type = FeatureIndexType.Uniform;
     }
+
+    const rasterTile: MeshArgs = {
+      points,
+      vertIndices: [0, 1, 2, 2, 1, 3],
+      isPlanar: true,
+      features,
+      colors: new ColorIndex(),
+      fillFlags: FillFlags.None,
+      textureMapping: {
+        uvParams: [new Point2d(0, 0), new Point2d(1, 0), new Point2d(0, 1), new Point2d(1, 1)],
+        texture: tileTexture,
+      },
+    };
 
     const trimesh = this.createTriMesh(rasterTile);
     if (undefined === trimesh)

--- a/core/frontend/src/render/primitives/EdgeParams.ts
+++ b/core/frontend/src/render/primitives/EdgeParams.ts
@@ -293,7 +293,10 @@ export interface EdgeParams {
 export namespace EdgeParams {
   export function fromMeshArgs(meshArgs: MeshArgs, maxWidth?: number): EdgeParams | undefined {
     const args = meshArgs.edges;
-    const doJoints = wantJointTriangles(args.width, meshArgs.is2d);
+    if (!args)
+      return undefined;
+
+    const doJoints = wantJointTriangles(args.width, true === meshArgs.is2d);
     const polylines = doJoints ? TesselatedPolyline.fromMesh(meshArgs) : undefined;
 
     let segments: SegmentEdgeParams | undefined;

--- a/core/frontend/src/render/primitives/PolylineParams.ts
+++ b/core/frontend/src/render/primitives/PolylineParams.ts
@@ -103,12 +103,14 @@ class PolylineTesselator {
   }
 
   public static fromPolyline(args: PolylineArgs): PolylineTesselator {
+    assert(args.points instanceof QPoint3dList); // ###TODO remove
     return new PolylineTesselator(args.polylines, args.points, wantJointTriangles(args.width, args.flags.is2d));
   }
 
   public static fromMesh(args: MeshArgs): PolylineTesselator | undefined {
-    if (undefined !== args.edges.polylines.lines && undefined !== args.points)
-      return new PolylineTesselator(args.edges.polylines.lines, args.points, wantJointTriangles(args.edges.width, args.is2d));
+    assert(args.points instanceof QPoint3dList); // ###TODO remove me
+    if (undefined !== args.edges?.polylines.lines && undefined !== args.points)
+      return new PolylineTesselator(args.edges.polylines.lines, args.points, wantJointTriangles(args.edges.width, true === args.is2d));
 
     return undefined;
   }

--- a/core/frontend/src/render/primitives/VertexKey.ts
+++ b/core/frontend/src/render/primitives/VertexKey.ts
@@ -7,25 +7,36 @@
  */
 
 import { assert, compareWithTolerance, IndexMap } from "@itwin/core-bentley";
-import { Point2d } from "@itwin/core-geometry";
-import { OctEncodedNormal, QPoint3d } from "@itwin/core-common";
+import { Point2d, Point3d } from "@itwin/core-geometry";
+import { OctEncodedNormal } from "@itwin/core-common";
 
 /** @internal */
 export interface VertexKeyProps {
-  position: QPoint3d;
+  position: Point3d;
   fillColor: number;
   normal?: OctEncodedNormal;
   uvParam?: Point2d;
 }
 
+function comparePositions(p0: Point3d, p1: Point3d): number {
+  let diff = compareWithTolerance(p0.x, p1.x);
+  if (0 === diff) {
+    diff = compareWithTolerance(p0.y, p1.y);
+    if (0 === diff)
+      diff = compareWithTolerance(p0.z, p1.z);
+  }
+
+  return diff;
+}
+
 /** @internal */
 export class VertexKey {
-  public readonly position: QPoint3d;
+  public readonly position: Point3d;
   public readonly normal?: OctEncodedNormal;
   public readonly uvParam?: Point2d;
   public readonly fillColor: number;
 
-  public constructor(position: QPoint3d, fillColor: number, normal?: OctEncodedNormal, uvParam?: Point2d) {
+  public constructor(position: Point3d, fillColor: number, normal?: OctEncodedNormal, uvParam?: Point2d) {
     this.position = position.clone();
     this.fillColor = fillColor;
     this.normal = normal;
@@ -44,7 +55,7 @@ export class VertexKey {
         return false;
     }
 
-    if (!this.position.equals(rhs.position))
+    if (!this.position.isAlmostEqual(rhs.position))
       return false;
 
     if (undefined !== this.uvParam) {
@@ -61,7 +72,7 @@ export class VertexKey {
 
     let diff = this.fillColor - rhs.fillColor;
     if (0 === diff) {
-      diff = this.position.compare(rhs.position);
+      diff = comparePositions(this.position, rhs.position);
       if (0 === diff) {
         if (undefined !== this.normal) {
           assert(undefined !== rhs.normal);

--- a/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryAccumulator.ts
@@ -14,7 +14,7 @@ import { RenderGraphic } from "../../RenderGraphic";
 import { RenderSystem } from "../../RenderSystem";
 import { DisplayParams } from "../DisplayParams";
 import { MeshBuilderMap } from "../mesh/MeshBuilderMap";
-import { MeshGraphicArgs, MeshList } from "../mesh/MeshPrimitives";
+import { MeshList } from "../mesh/MeshPrimitives";
 import { GeometryOptions } from "../Primitives";
 import { GeometryList } from "./GeometryList";
 import { Geometry, PrimitiveGeometryType } from "./GeometryPrimitives";
@@ -175,8 +175,6 @@ export class GeometryAccumulator {
     if (0 === meshes.length)
       return undefined;
 
-    const args = new MeshGraphicArgs();
-
     // All of the meshes are quantized to the same range.
     // If that range is small relative to the distance from the origin, quantization errors can produce display artifacts.
     // Remove the translation from the quantization parameters and apply it in the transform instead.
@@ -199,7 +197,7 @@ export class GeometryAccumulator {
         assert(qorigin === undefined);
       }
 
-      const graphic = mesh.getGraphics(args, this.system, this._viewIndependentOrigin);
+      const graphic = mesh.getGraphics(this.system, this._viewIndependentOrigin);
       if (undefined !== graphic)
         branch.add(graphic);
     }

--- a/core/frontend/src/render/primitives/mesh/MeshBuilder.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshBuilder.ts
@@ -119,7 +119,6 @@ export class MeshBuilder {
   public createTriangleVertices(triangleIndex: number, visitor: PolyfaceVisitor, options: MeshBuilder.PolyfaceVisitorOptions): VertexKeyPropsWithIndex[] | undefined {
     const { point, requireNormals } = visitor;
     const { fillColor, haveParam } = options;
-    const qPointParams = this.mesh.points.params;
 
     // If we do not have UVParams stored on the IndexedPolyface, compute them now
     let params: Point2d[] | undefined;
@@ -135,7 +134,7 @@ export class MeshBuilder {
     const vertices = [];
     for (let i = 0; i < 3; ++i) {
       const vertexIndex = 0 === i ? 0 : triangleIndex + i;
-      const position = QPoint3d.create(point.getPoint3dAtUncheckedPointIndex(vertexIndex), qPointParams);
+      const position = point.getPoint3dAtUncheckedPointIndex(vertexIndex);
       const normal = requireNormals ? OctEncodedNormal.fromVector(visitor.getNormal(vertexIndex)!) : undefined;
       const uvParam: Point2d | undefined = params ? params[vertexIndex] : undefined;
       vertices[i] = { position, fillColor, normal, uvParam, sourceIndex: vertexIndex };
@@ -144,7 +143,7 @@ export class MeshBuilder {
     // Previously we would add all 3 vertices to our map, then detect degenerate triangles in AddTriangle().
     // This led to unused vertex data, and caused mismatch in # of vertices when recreating the MeshBuilder from the data in the tile cache.
     // Detect beforehand instead.
-    if (vertices[0].position.equals(vertices[1].position) || vertices[0].position.equals(vertices[2].position) || vertices[1].position.equals(vertices[2].position))
+    if (vertices[0].position.isAlmostEqual(vertices[1].position) || vertices[0].position.isAlmostEqual(vertices[2].position) || vertices[1].position.isAlmostEqual(vertices[2].position))
       return undefined;
 
     return vertices;
@@ -190,12 +189,10 @@ export class MeshBuilder {
   }
 
   /** removed Feature for now */
-  public addPolyline(pts: QPoint3dList | Point3d[], fillColor: number): void {
+  public addPolyline(points: Point3d[], fillColor: number): void {
     const { mesh } = this;
 
     const poly = new MeshPolyline();
-    const points = pts instanceof QPoint3dList ? pts : QPoint3dList.createFrom(pts, mesh.points.params);
-
     for (const position of points)
       poly.addIndex(this.addVertex({ position, fillColor }));
 
@@ -203,10 +200,9 @@ export class MeshBuilder {
   }
 
   /** removed Feature for now */
-  public addPointString(pts: Point3d[], fillColor: number): void {
+  public addPointString(points: Point3d[], fillColor: number): void {
     const { mesh } = this;
     const poly = new MeshPolyline();
-    const points = QPoint3dList.createFrom(pts, mesh.points.params);
 
     for (const position of points)
       poly.addIndex(this.addVertex({ position, fillColor }));

--- a/core/frontend/src/render/primitives/mesh/MeshBuilderMap.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshBuilderMap.ts
@@ -132,7 +132,18 @@ export class MeshBuilderMap extends Dictionary<MeshBuilderMap.Key, MeshBuilder> 
     const { facetAreaTolerance, tolerance, is2d, range } = this;
     const key = this.getKey(displayParams, type, hasNormals, isPlanar);
 
-    return this.getBuilderFromKey(key, { displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance: facetAreaTolerance, features: this.features });
+    const quantizePositions = true; // ###TODO false or configurable
+    return this.getBuilderFromKey(key, {
+      displayParams,
+      type,
+      range,
+      quantizePositions,
+      is2d,
+      isPlanar,
+      tolerance,
+      areaTolerance: facetAreaTolerance,
+      features: this.features,
+    });
   }
 
   public getKey(displayParams: DisplayParams, type: Mesh.PrimitiveType, hasNormals: boolean, isPlanar: boolean): MeshBuilderMap.Key {

--- a/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
@@ -210,12 +210,6 @@ export class MeshArgs {
 }
 
 /** @internal */
-export class MeshGraphicArgs {
-  public polylineArgs = new PolylineArgs();
-  public meshArgs: MeshArgs = new MeshArgs();
-}
-
-/** @internal */
 export class Mesh {
   private readonly _data: TriangleList | MeshPolylineList;
   public readonly points: MeshPointList;
@@ -304,15 +298,23 @@ export class Mesh {
       this.features.toFeatureIndex(index);
   }
 
-  public getGraphics(args: MeshGraphicArgs, system: RenderSystem, instancesOrViewIndependentOrigin?: InstancedGraphicParams | Point3d): RenderGraphic | undefined {
-    if (undefined !== this.triangles && this.triangles.length !== 0) {
-      if (args.meshArgs.init(this))
-        return system.createTriMesh(args.meshArgs, instancesOrViewIndependentOrigin);
-    } else if (undefined !== this.polylines && this.polylines.length !== 0 && args.polylineArgs.init(this)) {
-      return system.createIndexedPolylines(args.polylineArgs, instancesOrViewIndependentOrigin);
-    }
+  public toMeshArgs(): MeshArgs | undefined {
+    const args = this.triangles?.length ? new MeshArgs() : undefined;
+    return args?.init(this) ? args : undefined;
+  }
 
-    return undefined;
+  public toPolylineArgs(): PolylineArgs | undefined {
+    const args = this.polylines?.length ? new PolylineArgs() : undefined;
+    return args?.init(this) ? args : undefined;
+  }
+
+  public getGraphics(system: RenderSystem, instancesOrViewIndependentOrigin?: InstancedGraphicParams | Point3d): RenderGraphic | undefined {
+    const meshArgs = this.toMeshArgs();
+    if (meshArgs)
+      return system.createTriMesh(meshArgs, instancesOrViewIndependentOrigin);
+
+    const plArgs = this.toPolylineArgs();
+    return plArgs ? system.createIndexedPolylines(plArgs, instancesOrViewIndependentOrigin) : undefined;
   }
 
   public addPolyline(poly: MeshPolyline): void {

--- a/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
@@ -341,7 +341,7 @@ export class Mesh {
   public addVertex(props: VertexKeyProps): number {
     const { position, normal, uvParam, fillColor } = props;
 
-    this.points.push(position);
+    this.points.add(position);
 
     if (undefined !== normal)
       this.normals.push(normal);

--- a/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
@@ -180,7 +180,7 @@ export namespace MeshArgs {
       isPlanar: mesh.isPlanar,
       is2d: mesh.is2d,
       hasBakedLighting: true === mesh.hasBakedLighting,
-      hasFixedNormals: false, // ###TODO set elsewhere???
+      hasFixedNormals: false,
       isVolumeClassifier: true === mesh.isVolumeClassifier,
       edges,
       auxChannels: mesh.auxChannels,

--- a/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
@@ -94,6 +94,7 @@ export class PolylineArgs {
     return true;
   }
   public finishInit(mesh: Mesh) {
+    assert(mesh.points instanceof QPoint3dList); // ###TODO remove.
     this.pointParams = mesh.points.params;
     this.points = mesh.points;
     mesh.colorMap.toColorIndex(this.colors, mesh.colors);
@@ -165,6 +166,7 @@ export class MeshArgs {
     assert(0 < mesh.points.length);
 
     this.vertIndices = mesh.triangles.indices;
+    assert(mesh.points instanceof QPoint3dList); // ###TODO remove
     this.points = mesh.points;
 
     if (!mesh.displayParams.ignoreLighting && 0 < mesh.normals.length)

--- a/core/frontend/src/test/render/GraphicBuilder.test.ts
+++ b/core/frontend/src/test/render/GraphicBuilder.test.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import {
   Cone, Point3d, PolyfaceBuilder, Range3d, Sphere, StrokeOptions, Transform,
 } from "@itwin/core-geometry";
-import { ColorByName, QParams3d, QPoint3dList, RenderMode } from "@itwin/core-common";
+import { ColorByName, ColorIndex, FeatureIndex, FillFlags, QParams3d, QPoint3dList, RenderMode } from "@itwin/core-common";
 import { GraphicBuilder, GraphicType, ViewportGraphicBuilderOptions } from "../../render/GraphicBuilder";
 import { IModelApp } from "../../IModelApp";
 import { IModelConnection } from "../../IModelConnection";
@@ -114,15 +114,21 @@ describe("GraphicBuilder", () => {
 
   describe("createTriMesh", () => {
     it("should create a simple mesh graphic", () => {
-      const args = new MeshArgs();
-
       const points = [new Point3d(0, 0, 0), new Point3d(10, 0, 0), new Point3d(0, 10, 0)];
-      args.points = new QPoint3dList(QParams3d.fromRange(Range3d.createArray(points)));
+      const qpoints = new QPoint3dList(QParams3d.fromRange(Range3d.createArray(points)));
       for (const point of points)
-        args.points.add(point);
+        qpoints.add(point);
 
-      args.vertIndices = [0, 1, 2];
-      args.colors.initUniform(ColorByName.tan);
+      const colors = new ColorIndex();
+      colors.initUniform(ColorByName.tan);
+
+      const args: MeshArgs = {
+        points: qpoints,
+        vertIndices: [0, 1, 2],
+        colors,
+        fillFlags: FillFlags.None,
+        features: new FeatureIndex(),
+      };
 
       const graphic = IModelApp.renderSystem.createTriMesh(args);
       expect(graphic).not.to.be.undefined;

--- a/core/frontend/src/test/render/primitives/MeshBuilder.test.ts
+++ b/core/frontend/src/test/render/primitives/MeshBuilder.test.ts
@@ -50,7 +50,7 @@ describe("Mesh Builder Tests", () => {
     const tolerance = 0.15;
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
-    const mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
     expect(mb.currentPolyface).to.be.undefined;
     expect(mb.mesh.displayParams).to.equal(displayParams);
     expect(mb.mesh.type).to.equal(type);
@@ -99,7 +99,7 @@ describe("Mesh Builder Tests", () => {
     const tolerance = 0.15;
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
-    let mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    let mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     // calls addPolyline for each stroke points list in strokes
     expect(mb.mesh.polylines!.length).to.equal(0);
@@ -110,7 +110,7 @@ describe("Mesh Builder Tests", () => {
     expect(lengthA).to.be.lte(lengthB);
     expect(mb.mesh.points.length).to.be.greaterThan(0);
     // calls addPointString for each stroke points list in strokes
-    mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
     expect(mb.mesh.polylines!.length).to.equal(0);
     expect(mb.mesh.points.length).to.equal(0);
     mb.addStrokePointLists(strksPrims, true, fillColor);
@@ -156,7 +156,7 @@ describe("Mesh Builder Tests", () => {
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
     const type = Mesh.PrimitiveType.Mesh;
-    const mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     const includeParams = false;
     const fillColor = ColorDef.white.tbgr;
@@ -204,7 +204,7 @@ describe("Mesh Builder Tests", () => {
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
     const type = Mesh.PrimitiveType.Mesh;
-    const mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     const visitor = pfPrim.indexedPolyface.createVisitor();
     const includeParams = false;
@@ -251,7 +251,7 @@ describe("Mesh Builder Tests", () => {
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
     const type = Mesh.PrimitiveType.Mesh;
-    const mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     const includeParams = false;
     const visitor = pfPrim.indexedPolyface.createVisitor();
@@ -294,7 +294,7 @@ describe("Mesh Builder Tests", () => {
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
     const type = Mesh.PrimitiveType.Mesh;
-    const mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     const includeParams = false;
     const visitor = pfPrim.indexedPolyface.createVisitor();
@@ -316,21 +316,21 @@ describe("Mesh Builder Tests", () => {
     const tolerance = 0.15;
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
-    let mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    let mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     let points = [new Point3d(), new Point3d(100, 100, 100), new Point3d(200, 200, 200)];
     const fillColor = ColorDef.white.tbgr;
 
     points = [new Point3d(), new Point3d(1, 1, 1), new Point3d(2, 2, 2)];
     type = Mesh.PrimitiveType.Polyline;
-    mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     expect(mb.mesh.polylines!.length).to.equal(0);
     mb.addPolyline(points, fillColor);
     expect(mb.mesh.polylines!.length).to.equal(1);
 
     points = [new Point3d()];
-    mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     // if array is less than 1 in length, no polylines added
     expect(mb.mesh.polylines!.length).to.equal(0);
@@ -347,21 +347,21 @@ describe("Mesh Builder Tests", () => {
     const tolerance = 0.15;
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
-    let mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    let mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     let points = [new Point3d(), new Point3d(100, 100, 100), new Point3d(200, 200, 200)];
     const fillColor = ColorDef.white.tbgr;
 
     points = [new Point3d(), new Point3d(1, 1, 1), new Point3d(2, 2, 2)];
     type = Mesh.PrimitiveType.Polyline;
-    mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     expect(mb.mesh.polylines!.length).to.equal(0);
     mb.addPointString(points, fillColor);
     expect(mb.mesh.polylines!.length).to.equal(1);
 
     points = [new Point3d()];
-    mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     // if array is less than 1 in length, no polylines added
     expect(mb.mesh.polylines!.length).to.equal(0);
@@ -381,7 +381,7 @@ describe("Mesh Builder Tests", () => {
     const tolerance = 0.15;
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
 
-    const mb = MeshBuilder.create({ displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const mb = MeshBuilder.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
     expect(mb.mesh.triangles!.length).to.equal(0);
     mb.addTriangle(triangle);
     expect(mb.mesh.triangles!.length).to.equal(1);
@@ -391,6 +391,7 @@ describe("Mesh Builder Tests", () => {
     options = options ?? { };
     const tolerance = options.tolerance ?? 0.15;
     return MeshBuilder.create({
+      quantizePositions: false,
       type,
       range,
       tolerance,

--- a/core/frontend/src/test/render/primitives/MeshBuilder.test.ts
+++ b/core/frontend/src/test/render/primitives/MeshBuilder.test.ts
@@ -11,7 +11,7 @@ import { MockRender } from "../../../render/MockRender";
 import { ScreenViewport } from "../../../Viewport";
 import { DisplayParams } from "../../../render/primitives/DisplayParams";
 import { Geometry } from "../../../render/primitives/geometry/GeometryPrimitives";
-import { Mesh, MeshGraphicArgs } from "../../../render/primitives/mesh/MeshPrimitives";
+import { Mesh } from "../../../render/primitives/mesh/MeshPrimitives";
 import { PolyfacePrimitive, PolyfacePrimitiveList } from "../../../render/primitives/Polyface";
 import { PrimitiveBuilder } from "../../../render/primitives/geometry/GeometryListBuilder";
 import { StrokesPrimitiveList, StrokesPrimitivePointLists } from "../../../render/primitives/Strokes";
@@ -403,9 +403,9 @@ describe("Mesh Builder Tests", () => {
 
   describe("aux data", () => {
     function expectAuxChannelTable(mesh: Mesh, expectedUint16Data: number[]): void {
-      const args = new MeshGraphicArgs();
-      mesh.getGraphics(args, IModelApp.renderSystem);
-      const meshParams = MeshParams.create(args.meshArgs);
+      const args = mesh.toMeshArgs()!;
+      expect(args).not.to.be.undefined;
+      const meshParams = MeshParams.create(args);
       const aux = meshParams.auxChannels!;
       expect(aux).not.to.be.undefined;
       expect(Array.from(new Uint16Array(aux.data.buffer))).to.deep.equal(expectedUint16Data);

--- a/core/frontend/src/test/render/primitives/MeshBuilderMap.test.ts
+++ b/core/frontend/src/test/render/primitives/MeshBuilderMap.test.ts
@@ -436,21 +436,21 @@ describe("MeshBuilderMap Tests", () => {
     const areaTolerance = ToleranceRatio.facetArea * tolerance;
     const map = new MeshBuilderMap(tolerance, range, is2d, new GeometryOptions(GenerateEdges.No));
     const key = map.getKey(displayParams, type, hasNormals, isPlanar);
-    const builder = map.getBuilderFromKey(key, { displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const builder = map.getBuilderFromKey(key, { quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     const builder2 = map.get(key);
 
     // expect same key to return same builder reference
     expect(builder).to.equal(builder2);
 
-    const builder3 = map.getBuilderFromKey(key, { displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const builder3 = map.getBuilderFromKey(key, { quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     // expect same key pass into getBuilderFromKey to not create new instance of builder, but instead return previously stored instance
     expect(builder).to.equal(builder3);
 
     const key2 = map.getKey(displayParams, type, hasNormals, isPlanar);
 
-    const builder4 = map.getBuilderFromKey(key2, { displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
+    const builder4 = map.getBuilderFromKey(key2, { quantizePositions: false, displayParams, type, range, is2d, isPlanar, tolerance, areaTolerance });
 
     // expect an equivalent key (different key instance) to return same builder reference
     expect(builder).to.equal(builder4);

--- a/core/frontend/src/test/render/primitives/MeshPrimitives.test.ts
+++ b/core/frontend/src/test/render/primitives/MeshPrimitives.test.ts
@@ -26,7 +26,7 @@ describe("MeshPrimitive Tests", () => {
     const is2d = false;
     const isPlanar = true;
 
-    let m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    let m = Mesh.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar });
     expect(m.type).to.equal(type);
     expect(m.displayParams).to.equal(displayParams);
     expect(m.features).to.be.undefined;
@@ -38,12 +38,12 @@ describe("MeshPrimitive Tests", () => {
     expect(m.polylines).to.be.undefined;
 
     type = Mesh.PrimitiveType.Polyline;
-    m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    m = Mesh.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar });
     expect(m.polylines).to.not.be.undefined;
     expect(m.triangles).to.be.undefined;
 
     type = Mesh.PrimitiveType.Point;
-    m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    m = Mesh.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar });
     expect(m.polylines).to.not.be.undefined;
     expect(m.triangles).to.be.undefined;
   });
@@ -55,7 +55,7 @@ describe("MeshPrimitive Tests", () => {
     const is2d = false;
     const isPlanar = true;
 
-    let m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    let m = Mesh.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar });
 
     expect(m.polylines!.length).to.equal(0);
     let mp = new MeshPolyline([1, 2, 3]);
@@ -64,7 +64,7 @@ describe("MeshPrimitive Tests", () => {
 
     // doesn't add polyline if meshpolyline indices has a length less that 2
     type = Mesh.PrimitiveType.Polyline;
-    m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    m = Mesh.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar });
     expect(m.polylines!.length).to.equal(0);
     mp = new MeshPolyline([1]);
     m.addPolyline(mp);
@@ -78,7 +78,7 @@ describe("MeshPrimitive Tests", () => {
     const is2d = false;
     const isPlanar = true;
 
-    const m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    const m = Mesh.create({ quantizePositions: false, displayParams, type, range, is2d, isPlanar });
 
     expect(m.triangles!.length).to.equal(0);
     const t = new Triangle();
@@ -93,30 +93,30 @@ describe("MeshPrimitive Tests", () => {
     const is2d = false;
     const isPlanar = true;
 
-    let m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    let m = Mesh.create({ quantizePositions: true, displayParams, type, range, is2d, isPlanar });
 
     expect(m.points.length).to.equal(0);
-    let q = QPoint3d.create(new Point3d(100, 100, 100), m.points.params);
-    let index = m.addVertex({ position: q, fillColor: ColorDef.white.tbgr });
+    let p = new Point3d(100, 100, 100);
+    let index = m.addVertex({ position: p, fillColor: ColorDef.white.tbgr });
     expect(index).to.equal(0);
     expect(m.points.length).to.equal(1);
     expect(m.normals.length).to.equal(0);
     expect(m.uvParams.length).to.equal(0);
 
-    m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
+    m = Mesh.create({ quantizePositions: true, displayParams, type, range, is2d, isPlanar });
     expect(m.normals.length).to.equal(0);
     expect(m.uvParams.length).to.equal(0);
     expect(m.points.length).to.equal(0);
     const oct = new OctEncodedNormal(10);
     const param = new Point2d(10, 10);
-    q = QPoint3d.create(new Point3d(100, 100, 100), m.points.params);
-    index = m.addVertex({ position: q, fillColor: ColorDef.white.tbgr, normal: oct, uvParam: param });
+    p = new Point3d(100, 100, 100);
+    index = m.addVertex({ position: p, fillColor: ColorDef.white.tbgr, normal: oct, uvParam: param });
     expect(m.normals.length).to.equal(1);
     expect(m.uvParams.length).to.equal(1);
     expect(m.points.length).to.equal(1);
 
-    m = Mesh.create({ displayParams, type, range, is2d, isPlanar });
-    const key = new VertexKey(q, ColorDef.white.tbgr, oct, param);
+    m = Mesh.create({ quantizePositions: true, displayParams, type, range, is2d, isPlanar });
+    const key = new VertexKey(p, ColorDef.white.tbgr, oct, param);
     m.addVertex(key);
     expect(m.points.length).to.equal(1);
     expect(m.normals.length).to.equal(1);

--- a/core/frontend/src/test/render/primitives/VertexKey.test.ts
+++ b/core/frontend/src/test/render/primitives/VertexKey.test.ts
@@ -3,14 +3,15 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { OctEncodedNormal, QPoint3d } from "@itwin/core-common";
+import { Point3d } from "@itwin/core-geometry";
+import { OctEncodedNormal } from "@itwin/core-common";
 import { VertexKey } from "../../../render/primitives/VertexKey";
 
 describe("VertexKey", () => {
   it("comparisons work as expected", () => {
-    const key123 = new VertexKey(QPoint3d.fromScalars(1, 2, 3), 456, new OctEncodedNormal(7));
-    const copy123 = new VertexKey(QPoint3d.fromScalars(1, 2, 3), 456, new OctEncodedNormal(7));
-    const key456 = new VertexKey(QPoint3d.fromScalars(4, 5, 6), 456, new OctEncodedNormal(7));
+    const key123 = new VertexKey(new Point3d(1, 2, 3), 456, new OctEncodedNormal(7));
+    const copy123 = new VertexKey(new Point3d(1, 2, 3), 456, new OctEncodedNormal(7));
+    const key456 = new VertexKey(new Point3d(4, 5, 6), 456, new OctEncodedNormal(7));
 
     expect(key123.equals(copy123)).to.be.true;
     expect(key123.equals(key456)).to.be.false;

--- a/core/frontend/src/test/render/webgl/IndexedEdges.test.ts
+++ b/core/frontend/src/test/render/webgl/IndexedEdges.test.ts
@@ -5,9 +5,9 @@
 import { expect } from "chai";
 import { ByteStream } from "@itwin/core-bentley";
 import { Point3d } from "@itwin/core-geometry";
-import { MeshEdge, OctEncodedNormal, OctEncodedNormalPair, PolylineData, QPoint3dList } from "@itwin/core-common";
+import { ColorIndex, FeatureIndex, FillFlags, MeshEdge, OctEncodedNormal, OctEncodedNormalPair, PolylineData, QPoint3dList } from "@itwin/core-common";
 import { IModelApp } from "../../../IModelApp";
-import { MeshArgs } from "../../../render/primitives/mesh/MeshPrimitives";
+import { MeshArgs, MeshArgsEdges, } from "../../../render/primitives/mesh/MeshPrimitives";
 import { VertexIndices } from "../../../render/primitives/VertexTable";
 import { EdgeParams, EdgeTable } from "../../../render/primitives/EdgeParams";
 
@@ -21,20 +21,22 @@ function makeNormalPair(n0: number, n1: number): OctEncodedNormalPair {
  * /__\/__\
  * 0   2   4
  */
-function createMeshArgs(opts?: {
-  is2d?: boolean;
-}): MeshArgs {
-  const args = new MeshArgs();
-  args.points = QPoint3dList.fromPoints([new Point3d(0, 0, 0), new Point3d(1, 1, 0), new Point3d(2, 0, 0), new Point3d(3, 1, 0), new Point3d(4, 0, 0)]);
-  args.vertIndices = [0, 1, 2, 2, 1, 3, 2, 3, 4];
+function createMeshArgs(opts?: { is2d?: boolean }): MeshArgs {
+  const edges = new MeshArgsEdges();
+  edges.edges.edges = [new MeshEdge(0, 1), new MeshEdge(1, 3), new MeshEdge(3, 4)];
+  edges.silhouettes.edges = [new MeshEdge(1, 2), new MeshEdge(2, 3)];
+  edges.silhouettes.normals = [makeNormalPair(0, 0xffff), makeNormalPair(0x1234, 0xfedc)];
+  edges.polylines.lines = [new PolylineData([0, 2, 4]), new PolylineData([2, 4, 3, 1]), new PolylineData([1, 0])];
 
-  args.edges.edges.edges = [new MeshEdge(0, 1), new MeshEdge(1, 3), new MeshEdge(3, 4)];
-  args.edges.silhouettes.edges = [new MeshEdge(1, 2), new MeshEdge(2, 3)];
-  args.edges.silhouettes.normals = [makeNormalPair(0, 0xffff), makeNormalPair(0x1234, 0xfedc)];
-  args.edges.polylines.lines = [new PolylineData([0, 2, 4]), new PolylineData([2, 4, 3, 1]), new PolylineData([1, 0])];
-
-  args.is2d = true === opts?.is2d;
-  return args;
+  return {
+    points: QPoint3dList.fromPoints([new Point3d(0, 0, 0), new Point3d(1, 1, 0), new Point3d(2, 0, 0), new Point3d(3, 1, 0), new Point3d(4, 0, 0)]),
+    vertIndices: [0, 1, 2, 2, 1, 3, 2, 3, 4],
+    edges,
+    fillFlags: FillFlags.None,
+    is2d: true === opts?.is2d,
+    colors: new ColorIndex(),
+    features: new FeatureIndex(),
+  };
 }
 
 function expectIndices(indices: VertexIndices, expected: number[]): void {
@@ -121,7 +123,7 @@ describe("IndexedEdgeParams", () => {
 
     it("are not produced if MeshArgs supplies no edges", () => {
       const args = createMeshArgs();
-      args.edges.clear();
+      args.edges?.clear();
       expect(EdgeParams.fromMeshArgs(args)).to.be.undefined;
     });
 
@@ -138,7 +140,8 @@ describe("IndexedEdgeParams", () => {
 
     it("are not produced for polylines if width > 3", () => {
       const args = createMeshArgs();
-      args.edges.width = 4;
+      expect(args.edges).not.to.be.undefined;
+      args.edges!.width = 4;
 
       const edges = EdgeParams.fromMeshArgs(args)!;
       expect(edges).not.to.be.undefined;
@@ -214,18 +217,20 @@ describe("IndexedEdgeParams", () => {
 
       function makeEdgeTable(nSegs: number, nSils: number): EdgeTable {
         const meshargs = createMeshArgs();
-        meshargs.edges.polylines.clear();
-        meshargs.edges.silhouettes.clear();
+        const edges = meshargs.edges!;
+        expect(edges).not.to.be.undefined;
+        edges.polylines.clear();
+        edges.silhouettes.clear();
 
-        meshargs.edges.edges.edges = [];
+        edges.edges.edges = [];
         for (let i = 0; i < nSegs; i++)
-          meshargs.edges.edges.edges.push(new MeshEdge(0, 1));
+          edges.edges.edges.push(new MeshEdge(0, 1));
 
-        meshargs.edges.silhouettes.edges = [];
-        meshargs.edges.silhouettes.normals = [];
+        edges.silhouettes.edges = [];
+        edges.silhouettes.normals = [];
         for (let i = 0; i < nSils; i++) {
-          meshargs.edges.silhouettes.edges.push(new MeshEdge(2 + i, 3));
-          meshargs.edges.silhouettes.normals.push(makeNormalPair(4, 5));
+          edges.silhouettes.edges.push(new MeshEdge(2 + i, 3));
+          edges.silhouettes.normals.push(makeNormalPair(4, 5));
         }
 
         const edgeParams = EdgeParams.fromMeshArgs(meshargs, 15)!;

--- a/core/frontend/src/test/render/webgl/SurfaceTransparency.test.ts
+++ b/core/frontend/src/test/render/webgl/SurfaceTransparency.test.ts
@@ -5,7 +5,7 @@
 import { expect } from "chai";
 import { Point2d, Point3d, Range3d, Vector3d } from "@itwin/core-geometry";
 import {
-  ColorDef, ImageBuffer, ImageBufferFormat, QParams3d, QPoint3dList, RenderMaterial, RenderMode, RenderTexture, TextureTransparency,
+  ColorDef, ColorIndex, FeatureIndex, FillFlags, ImageBuffer, ImageBufferFormat, QParams3d, QPoint3dList, RenderMaterial, RenderMode, RenderTexture, TextureMapping, TextureTransparency,
 } from "@itwin/core-common";
 import { RenderGraphic } from "../../../render/RenderGraphic";
 import { createRenderPlanFromViewport } from "../../../render/RenderPlan";
@@ -23,26 +23,33 @@ import { MeshParams } from "../../../render/primitives/VertexTable";
 import { createBlankConnection } from "../../createBlankConnection";
 
 function createMesh(transparency: number, mat?: RenderMaterial | RenderTexture): RenderGraphic {
-  const args = new MeshArgs();
-  args.colors.initUniform(ColorDef.from(255, 0, 0, transparency));
-
-  if (mat instanceof RenderMaterial) {
-    args.material = mat;
-    args.texture = args.material.textureMapping?.texture;
-  } else {
-    args.texture = mat;
-  }
-
-  if (args.texture)
-    args.textureUv = [ new Point2d(0, 1), new Point2d(1, 1), new Point2d(0, 0), new Point2d(1, 0) ];
+  const colors = new ColorIndex();
+  colors.initUniform(ColorDef.from(255, 0, 0, transparency));
 
   const points = [ new Point3d(0, 0, 0), new Point3d(1, 0, 0), new Point3d(0, 1, 0), new Point3d(1, 1, 0) ];
-  args.points = new QPoint3dList(QParams3d.fromRange(Range3d.createXYZXYZ(0, 0, 0, 1, 1, 1)));
+  const qpoints = new QPoint3dList(QParams3d.fromRange(Range3d.createXYZXYZ(0, 0, 0, 1, 1, 1)));
   for (const point of points)
-    args.points.add(point);
+    qpoints.add(point);
 
-  args.vertIndices = [0, 1, 2, 2, 1, 3];
-  args.isPlanar = true;
+  const args: MeshArgs = {
+    points: qpoints,
+    vertIndices: [0, 1, 2, 2, 1, 3],
+    isPlanar: true,
+    colors,
+    features: new FeatureIndex(),
+    fillFlags: FillFlags.None,
+  };
+
+  let texture;
+  if (mat instanceof RenderMaterial) {
+    args.material = mat;
+    texture = mat.textureMapping?.texture;
+  } else {
+    texture = mat;
+  }
+
+  if (texture)
+    args.textureMapping = { texture, uvParams: [ new Point2d(0, 1), new Point2d(1, 1), new Point2d(0, 0), new Point2d(1, 0) ] };
 
   const params = MeshParams.create(args);
   return IModelApp.renderSystem.createMesh(params)!;
@@ -101,7 +108,12 @@ describe("Surface transparency", () => {
   });
 
   function createMaterial(alpha?: number, texture?: RenderTexture, textureWeight?: number): RenderMaterial {
-    const material = IModelApp.renderSystem.createRenderMaterial({ alpha, textureMapping: texture ? { texture, weight: textureWeight } : undefined });
+    const params = new RenderMaterial.Params();
+    params.alpha = alpha;
+    if (texture)
+      params.textureMapping = new TextureMapping(texture, new TextureMapping.Params({ textureWeight }));
+
+    const material = IModelApp.renderSystem.createMaterial(params, imodel);
     expect(material).not.to.be.undefined;
     return material!;
   }

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -25,7 +25,7 @@ import { GraphicBranch } from "../render/GraphicBranch";
 import { PickableGraphicOptions } from "../render/GraphicBuilder";
 import { InstancedGraphicParams } from "../render/InstancedGraphicParams";
 import { DisplayParams } from "../render/primitives/DisplayParams";
-import { Mesh, MeshGraphicArgs } from "../render/primitives/mesh/MeshPrimitives";
+import { Mesh } from "../render/primitives/mesh/MeshPrimitives";
 import { RealityMeshPrimitive } from "../render/primitives/mesh/RealityMeshPrimitive";
 import { Triangle } from "../render/primitives/Primitives";
 import { RenderGraphic } from "../render/RenderGraphic";
@@ -1035,9 +1035,9 @@ export abstract class GltfReader {
     return { polyfaces };
   }
 
-  private graphicFromMeshData(gltfMesh: GltfMeshData, meshGraphicArgs: MeshGraphicArgs, instances?: InstancedGraphicParams): RenderGraphic | undefined {
+  private graphicFromMeshData(gltfMesh: GltfMeshData, instances?: InstancedGraphicParams): RenderGraphic | undefined {
     if (!gltfMesh.points || !gltfMesh.pointRange)
-      return gltfMesh.primitive.getGraphics(meshGraphicArgs, this._system, instances);
+      return gltfMesh.primitive.getGraphics(this._system, instances);
 
     const realityMeshPrimitive = (this._vertexTableRequired || instances) ? undefined : RealityMeshPrimitive.createFromGltfMesh(gltfMesh);
     if (realityMeshPrimitive) {
@@ -1063,7 +1063,7 @@ export abstract class GltfReader {
       for (const normal of gltfMesh.normals)
         mesh.normals.push(new OctEncodedNormal(normal));
 
-    return mesh.getGraphics(meshGraphicArgs, this._system, instances);
+    return mesh.getGraphics(this._system, instances);
   }
 
   private readNodeAndCreateGraphics(renderGraphicList: RenderGraphic[], node: GltfNode, featureTable: FeatureTable | undefined, transformStack: TransformStack, instances?: InstancedGraphicParams, pseudoRtcBias?: Vector3d): TileReadStatus {
@@ -1089,17 +1089,16 @@ export abstract class GltfReader {
     for (const meshKey of getNodeMeshIds(node)) {
       const nodeMesh = this._meshes[meshKey];
       if (nodeMesh?.primitives) {
-        const meshGraphicArgs = new MeshGraphicArgs();
         const meshes = this.readMeshPrimitives(node, featureTable, thisTransform, thisBias);
 
         let renderGraphic: RenderGraphic | undefined;
         if (0 !== meshes.length) {
           if (1 === meshes.length) {
-            renderGraphic = this.graphicFromMeshData(meshes[0], meshGraphicArgs, instances);
+            renderGraphic = this.graphicFromMeshData(meshes[0], instances);
           } else {
             const thisList: RenderGraphic[] = [];
             for (const mesh of meshes) {
-              renderGraphic = this.graphicFromMeshData(mesh, meshGraphicArgs, instances);
+              renderGraphic = this.graphicFromMeshData(mesh, instances);
               if (undefined !== renderGraphic)
                 thisList.push(renderGraphic);
             }

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1545,6 +1545,7 @@ export abstract class GltfReader {
         posRange.extendXYZ(pos[i], pos[i + 1], pos[i + 2]);
     }
 
+    assert(mesh.points instanceof QPoint3dList);
     mesh.points.params.setFromRange(posRange);
     const pt = Point3d.createZero();
     for (let i = 0; i < pos.length; i += 3) {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1048,6 +1048,7 @@ export abstract class GltfReader {
 
     const mesh = gltfMesh.primitive;
     const pointCount = gltfMesh.points.length / 3;
+    assert(mesh.points instanceof QPoint3dList);
     mesh.points.fromTypedArray(gltfMesh.pointRange, gltfMesh.points);
     if (mesh.triangles && gltfMesh.indices)
       mesh.triangles.addFromTypedArray(gltfMesh.indices);
@@ -1427,6 +1428,7 @@ export abstract class GltfReader {
       isPlanar: false,
       hasBakedLighting,
       isVolumeClassifier,
+      quantizePositions: false,
     });
 
     const mesh = new GltfMeshData(meshPrimitive);


### PR DESCRIPTION
PR still WIP - please defer review.

Unlike tile graphics, the range and required precision of vertex positions in decoration graphics is unbounded. Quantizing the positions can induce visual artifacts. This can be easily reproduced, for example, by turning on the project extents decoration (`fdt project extents`) in an iModel with large project extents and zooming in on one of the corners - as you zoom closer, the graphics will appear to jitter.

This PR adds support for unquantized 32-bit floating point positions in vertex tables, and makes that the default behavior for graphics created by GraphicBuilder.
The same problem can affect graphics produced on the backend by requestElementGraphics; this is currently manifesting in one of our authoring applications.
Once this PR completes we can work on updating the backend code to generate element graphics with unquantized vertex positions.

[Feature](https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/815517).