### PR TITLE
Presentation: Optimize Models Tree search ruleset

### DIFF
--- a/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-Search.PresentationRuleSet.json
+++ b/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-Search.PresentationRuleSet.json
@@ -127,7 +127,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -171,7 +171,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -211,7 +211,7 @@
               }
             }
           ],
-          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }

--- a/ui/framework/src/ui-framework/imodel-components/models-tree/ModelsTreeSearch.json
+++ b/ui/framework/src/ui-framework/imodel-components/models-tree/ModelsTreeSearch.json
@@ -127,7 +127,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }
@@ -171,7 +171,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -211,7 +211,7 @@
               }
             }
           ],
-          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "instanceFilter": "NOT this.IsPrivate AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:Element\")",
           "groupByClass": false,
           "groupByLabel": false
         }


### PR DESCRIPTION
Not having to join GeometricElement3d to the Element table in the EXISTS clause seems to improve the overall search performance up to 4 times when deployed. Locally it improved around 25% and there's still around 2 times performance difference between doing the search on deployed backend VS my local backend. So this change is only to help mitigate the critical performance problem, but the work continues investigating why the performance on deployed backend is so much worse compared to local backend.