### PR TITLE
Add the additional url-parse to the list of audit exceptions

### DIFF
--- a/common/changes/@bentley/build-tools/ignore-webpack-audit-err_2022-03-07-15-23.json
+++ b/common/changes/@bentley/build-tools/ignore-webpack-audit-err_2022-03-07-15-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/build-tools",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/tools/build/scripts/rush/audit.js
+++ b/tools/build/scripts/rush/audit.js
@@ -45,7 +45,8 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-74fj-2j2h-c42q", // https://github.com/advisories/GHSA-74fj-2j2h-c42q
     "GHSA-w5p7-h5w8-2hfq", // https://github.com/advisories/GHSA-w5p7-h5w8-2hfq
     "GHSA-wpg7-2c88-r8xv", // https://github.com/advisories/GHSA-wpg7-2c88-r8xv
-    "GHSA-rqff-837h-mm52" // https://github.com/advisories/GHSA-rqff-837h-mm52
+    "GHSA-rqff-837h-mm52", // https://github.com/advisories/GHSA-rqff-837h-mm52
+    "GHSA-hgjh-723h-mx2j" // https://github.com/advisories/GHSA-hgjh-723h-mx2j
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
The url-parse error is an additional audit error for a previously reported url-parse. Both issues are due to the dependencies on webpack-dev-server