### PR TITLE
Reimplement deprecated getViewThumbnail function to resolve regression

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -4952,7 +4952,7 @@ export namespace IModelConnection {
     export class Views {
         // @internal
         constructor(_iModel: IModelConnection);
-        // @deprecated (undocumented)
+        // @deprecated
         getThumbnail(_viewId: Id64String): Promise<ThumbnailProps>;
         getViewList(queryParams: ViewQueryParams): Promise<ViewSpec[]>;
         load(viewDefinitionId: Id64String): Promise<ViewState>;

--- a/common/changes/@itwin/core-backend/reimplement-get-view-thumbnail_2022-03-07-17-37.json
+++ b/common/changes/@itwin/core-backend/reimplement-get-view-thumbnail_2022-03-07-17-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-frontend/reimplement-get-view-thumbnail_2022-03-07-17-37.json
+++ b/common/changes/@itwin/core-frontend/reimplement-get-view-thumbnail_2022-03-07-17-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/rpcinterface-full-stack-tests/reimplement-get-view-thumbnail_2022-03-07-17-37.json
+++ b/common/changes/@itwin/rpcinterface-full-stack-tests/reimplement-get-view-thumbnail_2022-03-07-17-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/rpcinterface-full-stack-tests"
+}

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -12,7 +12,7 @@ import {
 import {
   AxisAlignedBox3d, Cartographic, CodeProps, CodeSpec, DbQueryRequest, DbResult, EcefLocation, EcefLocationProps, ECSqlReader, ElementLoadOptions,
   ElementProps, EntityQueryParams, FontMap, GeoCoordStatus, GeometryContainmentRequestProps, GeometryContainmentResponseProps,
-  GeometrySummaryRequestProps, IModel, IModelConnectionProps, IModelError, IModelReadRpcInterface, IModelStatus,
+  GeometrySummaryRequestProps, ImageSourceFormat, IModel, IModelConnectionProps, IModelError, IModelReadRpcInterface, IModelStatus,
   mapToGeoServiceStatus, MassPropertiesRequestProps, MassPropertiesResponseProps, ModelProps, ModelQueryParams, NoContentError, Placement, Placement2d, Placement3d,
   QueryBinder, QueryOptions, QueryOptionsBuilder, QueryRowFormat, RpcManager, SnapRequestProps, SnapResponseProps, SnapshotIModelRpcInterface,
   TextureData, TextureLoadProps, ThumbnailProps, ViewDefinitionProps, ViewQueryParams, ViewStateLoadProps,
@@ -1045,11 +1045,20 @@ export namespace IModelConnection { // eslint-disable-line no-redeclare
       return viewState;
     }
 
-    /** @deprecated
-     * @throws This function is deprecated and will always throw a "no content" error.
+    /** Get a thumbnail for a view.
+     * @param viewId The id of the view of the thumbnail.
+     * @returns A Promise of the ThumbnailProps.
+     * @throws "No content" error if invalid thumbnail.
+     * @deprecated
      */
     public async getThumbnail(_viewId: Id64String): Promise<ThumbnailProps> {
-      throw new NoContentError();
+      const val = await IModelReadRpcInterface.getClientForRouting(this._iModel.routingContext.token).getViewThumbnail(this._iModel.getRpcProps(), _viewId.toString());
+      const intValues = new Uint32Array(val.buffer, 0, 4);
+
+      if (intValues[1] !== ImageSourceFormat.Jpeg && intValues[1] !== ImageSourceFormat.Png)
+        throw new NoContentError();
+
+      return { format: intValues[1] === ImageSourceFormat.Jpeg ? "jpeg" : "png", width: intValues[2], height: intValues[3], image: new Uint8Array(val.buffer, 16, intValues[0]) };
     }
   }
 }

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -1052,6 +1052,7 @@ export namespace IModelConnection { // eslint-disable-line no-redeclare
      * @deprecated
      */
     public async getThumbnail(_viewId: Id64String): Promise<ThumbnailProps> {
+      // eslint-disable-next-line deprecation/deprecation
       const val = await IModelReadRpcInterface.getClientForRouting(this._iModel.routingContext.token).getViewThumbnail(this._iModel.getRpcProps(), _viewId.toString());
       const intValues = new Uint32Array(val.buffer, 0, 4);
 

--- a/full-stack-tests/core/src/frontend/standalone/ModelState.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ModelState.test.ts
@@ -153,20 +153,6 @@ describe("ModelState", () => {
     assert.equal(thumbnail.image[3], 224);
     assert.equal(thumbnail.image[18061], 217);
 
-    // thumbnail.format = "png";
-    // thumbnail.height = 100;
-    // thumbnail.width = 200;
-    // thumbnail.image = new Uint8Array(301); // try with odd number of bytes
-    // thumbnail.image.fill(33);
-
-    // await imodel2.views.saveThumbnail("0x24", thumbnail);
-    // const thumbnail2 = await imodel2.views.getThumbnail("0x24");
-    // assert.equal(thumbnail2.format, "png");
-    // assert.equal(thumbnail2.height, 100);
-    // assert.equal(thumbnail2.width, 200);
-    // assert.equal(thumbnail2.image.length, 301);
-    // assert.equal(thumbnail2.image[3], 33);
-
     try {
       // eslint-disable-next-line deprecation/deprecation
       await imodel2.views.getThumbnail("0x25");

--- a/full-stack-tests/core/src/frontend/standalone/ModelState.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ModelState.test.ts
@@ -128,6 +128,7 @@ describe("ModelState", () => {
   });
 
   it("view thumbnails", async () => {
+    // eslint-disable-next-line deprecation/deprecation
     let thumbnail = await imodel3.views.getThumbnail("0x34");
     assert.equal(thumbnail.format, "png", "thumbnail format");
     assert.equal(thumbnail.height, 768, "thumbnail height");
@@ -143,6 +144,7 @@ describe("ModelState", () => {
     assert.equal(image[6], 0x1A);
     assert.equal(image[7], 0x0A);
 
+    // eslint-disable-next-line deprecation/deprecation
     thumbnail = await imodel2.views.getThumbnail("0x24");
     assert.equal(thumbnail.format, "jpeg");
     assert.equal(thumbnail.height, 768);
@@ -166,6 +168,7 @@ describe("ModelState", () => {
     // assert.equal(thumbnail2.image[3], 33);
 
     try {
+      // eslint-disable-next-line deprecation/deprecation
       await imodel2.views.getThumbnail("0x25");
     } catch (_err) {
       return;

--- a/full-stack-tests/core/src/frontend/standalone/ModelState.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ModelState.test.ts
@@ -126,4 +126,50 @@ describe("ModelState", () => {
     assert.isTrue(range.low.isAlmostEqual({ x: 288874.1174466432, y: 3803761.1888925503, z: -0.0005 }));
     assert.isTrue(range.high.isAlmostEqual({ x: 289160.8417204395, y: 3803959.118535, z: 0.0005 }));
   });
+
+  it("view thumbnails", async () => {
+    let thumbnail = await imodel3.views.getThumbnail("0x34");
+    assert.equal(thumbnail.format, "png", "thumbnail format");
+    assert.equal(thumbnail.height, 768, "thumbnail height");
+    assert.equal(thumbnail.width, 768, "thumbnail width");
+    assert.equal(thumbnail.image.length, 19086, "thumbnail length");
+    const image = thumbnail.image;
+    assert.equal(image[0], 0x89);
+    assert.equal(image[1], 0x50);
+    assert.equal(image[2], 0x4E);
+    assert.equal(image[3], 0x47);
+    assert.equal(image[4], 0x0D);
+    assert.equal(image[5], 0x0A);
+    assert.equal(image[6], 0x1A);
+    assert.equal(image[7], 0x0A);
+
+    thumbnail = await imodel2.views.getThumbnail("0x24");
+    assert.equal(thumbnail.format, "jpeg");
+    assert.equal(thumbnail.height, 768);
+    assert.equal(thumbnail.width, 768);
+    assert.equal(thumbnail.image.length, 18062);
+    assert.equal(thumbnail.image[3], 224);
+    assert.equal(thumbnail.image[18061], 217);
+
+    // thumbnail.format = "png";
+    // thumbnail.height = 100;
+    // thumbnail.width = 200;
+    // thumbnail.image = new Uint8Array(301); // try with odd number of bytes
+    // thumbnail.image.fill(33);
+
+    // await imodel2.views.saveThumbnail("0x24", thumbnail);
+    // const thumbnail2 = await imodel2.views.getThumbnail("0x24");
+    // assert.equal(thumbnail2.format, "png");
+    // assert.equal(thumbnail2.height, 100);
+    // assert.equal(thumbnail2.width, 200);
+    // assert.equal(thumbnail2.image.length, 301);
+    // assert.equal(thumbnail2.image[3], 33);
+
+    try {
+      await imodel2.views.getThumbnail("0x25");
+    } catch (_err) {
+      return;
+    } // thumbnail doesn't exist
+    assert.fail("getThumbnail should not return");
+  });
 });

--- a/full-stack-tests/rpc-interface/src/frontend/IModelConnection.test.ts
+++ b/full-stack-tests/rpc-interface/src/frontend/IModelConnection.test.ts
@@ -8,7 +8,7 @@ import { Matrix4d, Point3d, XYZProps, YawPitchRollAngles } from "@itwin/core-geo
 import {
   EcefLocation, GeoCoordStatus, IModelReadRpcInterface, IModelVersion, MassPropertiesOperation, MassPropertiesRequestProps, ModelQueryParams,
 } from "@itwin/core-common";
-import { CheckpointConnection, IModelApp, IModelConnection, SpatialModelState } from "@itwin/core-frontend";
+import { CheckpointConnection, IModelApp, IModelConnection, SpatialModelState, ViewState } from "@itwin/core-frontend";
 import { TestFrontendAuthorizationClient } from "@itwin/oidc-signin-tool/lib/cjs/frontend";
 import { TestContext } from "./setup/TestContext";
 
@@ -170,6 +170,14 @@ describe("IModelReadRpcInterface Methods from an IModelConnection", () => {
   it("getClassHierarchy should work as expected", async () => {
     const result = await iModel.findClassFor("BisCore:LineStyle", undefined);
     expect(result).undefined;
+  });
+
+  it("getViewThumbnail should work as expected", async () => {
+    const modelQueryParams: ModelQueryParams = { limit: 10, from: ViewState.classFullName };
+    const modelProps = await iModel.views.queryProps(modelQueryParams);
+    const viewId = modelProps[0].id!.toString();
+    const result = await iModel.views.getThumbnail(viewId);
+    expect(result).to.not.be.undefined;
   });
 
   it("getIModelCoordinatesFromGeoCoordinates should work as expected", async () => {


### PR DESCRIPTION
More or less reverts #3138.
That PR made getViewThumbnail always throw. It should instead attempt to obtain and return the thumbnail, only throwing if no thumbnail exists.