### PR TITLE
Remove limit for categories query in display-test-app

### DIFF
--- a/test-apps/display-test-app/src/frontend/IdPicker.ts
+++ b/test-apps/display-test-app/src/frontend/IdPicker.ts
@@ -245,7 +245,7 @@ export class CategoryPicker extends IdPicker {
     const ecsql = view.is3d() ? selectSpatialCategoryProps : selectDrawingCategoryProps;
     const bindings = view.is2d() ? [view.baseModelId] : undefined;
     const rows: any[] = [];
-    for await (const row of view.iModel.query(`${ecsql}`, QueryBinder.from(bindings), { rowFormat: QueryRowFormat.UseJsPropertyNames, limit: { count: 10000 } })) {
+    for await (const row of view.iModel.query(`${ecsql}`, QueryBinder.from(bindings), { rowFormat: QueryRowFormat.UseJsPropertyNames })) {
       rows.push(row);
     }
     rows.sort((lhs, rhs) => {

--- a/test-apps/display-test-app/src/frontend/IdPicker.ts
+++ b/test-apps/display-test-app/src/frontend/IdPicker.ts
@@ -245,7 +245,7 @@ export class CategoryPicker extends IdPicker {
     const ecsql = view.is3d() ? selectSpatialCategoryProps : selectDrawingCategoryProps;
     const bindings = view.is2d() ? [view.baseModelId] : undefined;
     const rows: any[] = [];
-    for await (const row of view.iModel.query(`${ecsql}`, QueryBinder.from(bindings), { rowFormat: QueryRowFormat.UseJsPropertyNames, limit: { count: 1000 } })) {
+    for await (const row of view.iModel.query(`${ecsql}`, QueryBinder.from(bindings), { rowFormat: QueryRowFormat.UseJsPropertyNames, limit: { count: 10000 } })) {
       rows.push(row);
     }
     rows.sort((lhs, rhs) => {


### PR DESCRIPTION
Due to limit in # of categories on query (1,000), some categories were getting turned off on larger models when recalling a saved view (8,000+ categories) so I just removed the limit.