### PR TITLE
Improved validation of ESRI services before adding map layer

### DIFF
--- a/common/changes/@itwin/core-frontend/geo-validateEsriMapService_2022-03-08-20-15.json
+++ b/common/changes/@itwin/core-frontend/geo-validateEsriMapService_2022-03-08-20-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Improved validation of ESRI services before adding map layer",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/map/ArcGisUtilities.ts
+++ b/core/frontend/src/tile/map/ArcGisUtilities.ts
@@ -140,6 +140,19 @@ export class ArcGisUtilities {
         return { status: MapLayerSourceStatus.InvalidCredentials, authInfo: { authMethod: MapLayerAuthType.EsriToken } };
     }
 
+    // Check this service support map queries
+    let hasMapCapability = false;
+    try {
+      if (json.capabilities
+        && typeof json.capabilities === "string"
+        && json.capabilities.toLowerCase().includes("map")) {
+        hasMapCapability = true;
+      }
+    } catch { }
+    if (!hasMapCapability) {
+      return { status: MapLayerSourceStatus.InvalidFormat};
+    }
+
     let subLayers;
     if (json.layers) {
 


### PR DESCRIPTION
The actual implementation of ESRI service supports request of type 'Map'.  If a service only support feature requests, map layer will be added successfully but further tile requests will fail.