### PR TITLE
Control active model/category in display-test-app

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -11651,7 +11651,7 @@ export class ToolAdmin {
 // @public (undocumented)
 export namespace ToolAdmin {
     // @alpha
-    export class ActiveSettings {
+    export interface ActiveSettings {
         category?: Id64String;
         model?: Id64String;
     }

--- a/common/changes/@itwin/core-frontend/dta-active-settings_2022-03-09-12-59.json
+++ b/common/changes/@itwin/core-frontend/dta-active-settings_2022-03-09-12-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -319,7 +319,7 @@ export class ToolAdmin {
    * The active settings that placement tools will use.
    * @alpha
    */
-  public readonly activeSettings = new ToolAdmin.ActiveSettings();
+  public readonly activeSettings: ToolAdmin.ActiveSettings = { };
 
   /** The name of the [[PrimitiveTool]] to use as the default tool. Defaults to "Select", referring to [[SelectionTool]].
    * @see [[startDefaultTool]] to activate the default tool.
@@ -1895,18 +1895,14 @@ export class WheelEventProcessor {
  * @public
  */
 export namespace ToolAdmin { // eslint-disable-line no-redeclare
-
-  /**
-   * Active settings that placement tools will use.
+  /** Active settings that placement tools will use.
    * @alpha
    */
-  export class ActiveSettings {
+  export interface ActiveSettings {
+    /** The category to which newly created elements will be assigned. */
+    category?: Id64String;
 
-    /** The active category */
-    public category?: Id64String;
-
-    /** The target model */
-    public model?: Id64String;
+    /** The model that will contain newly created elements. */
+    model?: Id64String;
   }
-
 }

--- a/test-apps/display-test-app/src/frontend/IdPicker.ts
+++ b/test-apps/display-test-app/src/frontend/IdPicker.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { assert, compareStringsOrUndefined, Id64, Id64Arg } from "@itwin/core-bentley";
 import { GeometricModel3dProps, QueryBinder, QueryRowFormat } from "@itwin/core-common";
-import { GeometricModel3dState, ScreenViewport, SpatialViewState, ViewManip } from "@itwin/core-frontend";
+import { GeometricModel3dState, IModelApp, ScreenViewport, SpatialViewState, ViewManip } from "@itwin/core-frontend";
 import { CheckBox, ComboBoxEntry, createButton, createCheckBox, createComboBox, createTextBox } from "@itwin/frontend-devtools";
 import { ToolBarDropDown } from "./ToolBar";
 
@@ -18,6 +18,7 @@ export abstract class IdPicker extends ToolBarDropDown {
   protected readonly _availableIds = new Set<string>();
 
   protected abstract get _elementType(): "Model" | "Category";
+  protected get _settingsType(): "model" | "category" { return this._elementType.toLowerCase() as "model" | "category"; }
   protected get _showIn2d(): boolean { return true; }
   protected abstract get _enabledIds(): Set<string>;
   protected abstract changeDisplay(ids: Id64Arg, enabled: boolean): void;
@@ -46,6 +47,8 @@ export abstract class IdPicker extends ToolBarDropDown {
       { name: "Hide Selected", value: "Hide" },
       { name: "Hilite Enabled", value: "Hilite" },
       { name: "Un-hilite Enabled", value: "Dehilite" },
+      // Set ToolAdmin.activeSettings.model/category to first enabled entry.
+      { name: "Set First Active", value: "SetFirstActive" },
     ];
   }
 
@@ -156,6 +159,10 @@ export abstract class IdPicker extends ToolBarDropDown {
       case "Hilite":
       case "Dehilite":
         this.hiliteEnabled("Hilite" === which);
+        return;
+      case "SetFirstActive":
+        const first = Array.from(this._enabledIds)[0];
+        IModelApp.toolAdmin.activeSettings[this._settingsType] = first;
         return;
       case "":
         return;

--- a/test-apps/display-test-app/src/frontend/Viewer.ts
+++ b/test-apps/display-test-app/src/frontend/Viewer.ts
@@ -348,20 +348,26 @@ export class Viewer extends Window {
   private updateActiveSettings(): void {
     // NOTE: First category/model is fine for testing purposes...
     const view = this.viewport.view;
+    const settings = IModelApp.toolAdmin.activeSettings;
 
-    IModelApp.toolAdmin.activeSettings.category = undefined;
-    for (const catId of view.categorySelector.categories) {
-      IModelApp.toolAdmin.activeSettings.category = catId;
-      break;
+    if (undefined === settings.category || !view.viewsCategory(settings.category)) {
+      settings.category = undefined;
+      for (const catId of view.categorySelector.categories) {
+        settings.category = catId;
+        break;
+      }
     }
 
-    if (view.is2d()) {
-      IModelApp.toolAdmin.activeSettings.model = view.baseModelId;
-    } else if (view.isSpatialView()) {
-      IModelApp.toolAdmin.activeSettings.model = undefined;
-      for (const modId of view.modelSelector.models) {
-        IModelApp.toolAdmin.activeSettings.model = modId;
-        break;
+    if (undefined === settings.model || !view.viewsModel(settings.model)) {
+      settings.model = undefined;
+      if (view.is2d()) {
+        settings.model = view.baseModelId;
+      } else if (view.isSpatialView()) {
+        settings.model = undefined;
+        for (const modId of view.modelSelector.models) {
+          settings.model = modId;
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
The active model and category for tools that insert elements can now be specified in display-test-app via the category and model pickers.
Also, the current settings will be preserved when switching views as long as the model/category remains viewed by the view.
Also, there's no reason for ActiveSettings to be a class. Make it an interface so we have flexibility to alter implementation later.