### PR TITLE
BriefcaseConnection.activeSettings

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1032,17 +1032,6 @@ export enum ActivationEvent {
     onStartup = "onStartup"
 }
 
-// @beta
-export class ActiveBriefcaseSettings {
-    // (undocumented)
-    get category(): Id64String | undefined;
-    set category(category: Id64String | undefined);
-    get model(): Id64String | undefined;
-    set model(model: Id64String | undefined);
-    readonly onCategoryChanged: BeEvent<(previousCategory: Id64String | undefined) => void>;
-    readonly onModelChanged: BeEvent<(previousModel: Id64String | undefined) => void>;
-}
-
 // @public
 export class ActivityMessageDetails {
     constructor(showProgressBar: boolean, showPercentInMessage: boolean, supportsCancellation: boolean, showDialogInitially?: boolean);
@@ -1681,10 +1670,10 @@ export interface BlankConnectionProps {
 // @public
 export class BriefcaseConnection extends IModelConnection {
     protected constructor(props: IModelConnectionProps, openMode: OpenMode);
-    // @beta
-    readonly activeSettings: ActiveBriefcaseSettings;
     close(): Promise<void>;
     get editingScope(): GraphicalEditingScope | undefined;
+    // @alpha
+    readonly editorToolSettings: BriefcaseEditorToolSettings;
     enterEditingScope(): Promise<GraphicalEditingScope>;
     hasPendingTxns(): Promise<boolean>;
     get iModelId(): GuidString;
@@ -1703,6 +1692,16 @@ export class BriefcaseConnection extends IModelConnection {
     saveChanges(description?: string): Promise<void>;
     supportsGraphicalEditing(): Promise<boolean>;
     readonly txns: BriefcaseTxns;
+}
+
+// @alpha
+export class BriefcaseEditorToolSettings {
+    get category(): Id64String | undefined;
+    set category(category: Id64String | undefined);
+    get model(): Id64String | undefined;
+    set model(model: Id64String | undefined);
+    readonly onCategoryChanged: BeEvent<(previousCategory: Id64String | undefined) => void>;
+    readonly onModelChanged: BeEvent<(previousModel: Id64String | undefined) => void>;
 }
 
 // @public

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1032,6 +1032,17 @@ export enum ActivationEvent {
     onStartup = "onStartup"
 }
 
+// @beta
+export class ActiveBriefcaseSettings {
+    // (undocumented)
+    get category(): Id64String | undefined;
+    set category(category: Id64String | undefined);
+    get model(): Id64String | undefined;
+    set model(model: Id64String | undefined);
+    readonly onCategoryChanged: BeEvent<(previousCategory: Id64String | undefined) => void>;
+    readonly onModelChanged: BeEvent<(previousModel: Id64String | undefined) => void>;
+}
+
 // @public
 export class ActivityMessageDetails {
     constructor(showProgressBar: boolean, showPercentInMessage: boolean, supportsCancellation: boolean, showDialogInitially?: boolean);
@@ -1670,6 +1681,8 @@ export interface BlankConnectionProps {
 // @public
 export class BriefcaseConnection extends IModelConnection {
     protected constructor(props: IModelConnectionProps, openMode: OpenMode);
+    // @beta
+    readonly activeSettings: ActiveBriefcaseSettings;
     close(): Promise<void>;
     get editingScope(): GraphicalEditingScope | undefined;
     enterEditingScope(): Promise<GraphicalEditingScope>;
@@ -7756,6 +7769,7 @@ export interface PreferenceKeyArg {
 // @public
 export abstract class PrimitiveTool extends InteractiveTool {
     autoLockTarget(): void;
+    get briefcase(): BriefcaseConnection | undefined;
     // (undocumented)
     exitTool(): Promise<void>;
     getPrompt(): string;
@@ -11501,8 +11515,6 @@ export class Tool {
 export class ToolAdmin {
     acsContextLock: boolean;
     acsPlaneSnapLock: boolean;
-    // @alpha
-    readonly activeSettings: ToolAdmin.ActiveSettings;
     get activeTool(): InteractiveTool | undefined;
     readonly activeToolChanged: BeEvent<(tool: Tool, start: StartOrResume) => void>;
     // @internal
@@ -11647,15 +11659,6 @@ export class ToolAdmin {
     // (undocumented)
     get viewTool(): ViewTool | undefined;
     }
-
-// @public (undocumented)
-export namespace ToolAdmin {
-    // @alpha
-    export interface ActiveSettings {
-        category?: Id64String;
-        model?: Id64String;
-    }
-}
 
 // @public
 export class ToolAssistance {

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -25,7 +25,6 @@ public;AccuSnap
 public;ACSDisplayOptions
 public;ACSType
 alpha;ActivationEvent
-beta;ActiveBriefcaseSettings
 public;ActivityMessageDetails
 public;ActivityMessageEndReason
 internal;addRangeGraphic(builder: GraphicBuilder, range: Range3d, is2d: boolean): void
@@ -73,6 +72,7 @@ internal;BingMapsImageryLayerProvider
 public;BlankConnection 
 public;BlankConnectionProps
 public;BriefcaseConnection 
+alpha;BriefcaseEditorToolSettings
 public;class BriefcaseNotificationHandler 
 public;BriefcaseTxns 
 alpha;BuildExtensionManifest 

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -25,6 +25,7 @@ public;AccuSnap
 public;ACSDisplayOptions
 public;ACSType
 alpha;ActivationEvent
+beta;ActiveBriefcaseSettings
 public;ActivityMessageDetails
 public;ActivityMessageEndReason
 internal;addRangeGraphic(builder: GraphicBuilder, range: Range3d, is2d: boolean): void
@@ -641,8 +642,6 @@ public;TileVisibility
 beta;TokenArg
 public;Tool
 public;ToolAdmin
-public;ToolAdmin
-alpha;ActiveSettings
 public;ToolAssistance
 public;ToolAssistanceImage
 public;ToolAssistanceInputMethod

--- a/common/changes/@itwin/core-frontend/briefcase-active-settings_2022-03-11-11-43.json
+++ b/common/changes/@itwin/core-frontend/briefcase-active-settings_2022-03-11-11-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Move ToolAdmin.activeSettings to BriefcaseConnection and add PrimitiveTool.briefcase.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/editor-frontend/briefcase-active-settings_2022-03-11-11-43.json
+++ b/common/changes/@itwin/editor-frontend/briefcase-active-settings_2022-03-11-11-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -151,7 +151,8 @@ class ModelChangeMonitor {
  * determine into which model and category to insert the elements.
  * Specialized tools are free to ignore these settings.
  * @see [[BriefcaseConnection.activeSettings]] to query or modify the current settings for a briefcase.
- * @beta
+ * @see [CreateElementTool]($editor-frontend) for an example of a tool that uses these settings.
+ * @alpha
  */
 export class ActiveBriefcaseSettings {
   private _category?: Id64String;
@@ -163,9 +164,10 @@ export class ActiveBriefcaseSettings {
   /** An event raised just after the active [[model]] is changed. */
   public readonly onModelChanged = new BeEvent<(previousModel: Id64String | undefined) => void>();
 
-  /* The [Category]($backend) into which new elements should be inserted by default.
-   * Specialized tools are free to ignore this setting.
+  /** The [Category]($backend) into which new elements should be inserted by default.
+   * Specialized tools are free to ignore this setting and instead use their own logic to select an appropriate category.
    * @see [[onCategoryChanged]] to be notified when this property is modified.
+   * @see [CreateElementTool.targetCategory]($editor-frontend) for an example of a tool that uses this setting.
    */
   public get category(): Id64String | undefined {
     return this._category;
@@ -179,8 +181,9 @@ export class ActiveBriefcaseSettings {
   }
 
   /** The [Model]($backend) into which new elements should be inserted by default.
-   * Specialized tools are free to ignore this setting.
+   * Specialized tools are free to ignore this setting and instead use their own logic to select an appropriate model.
    * @see [[onModelChanged]] to be notified when this property is modified.
+   * @see [CreateElementTool.targetModel]($editor-frontend) for an example of a tool that uses this setting.
    */
   public get model(): Id64String | undefined {
     return this._model;
@@ -202,7 +205,7 @@ export class BriefcaseConnection extends IModelConnection {
   protected _isClosed?: boolean;
   private readonly _modelsMonitor: ModelChangeMonitor;
   /** Default settings that can be used to control the behavior of [[Tool]]s that modify this briefcase.
-   * @beta
+   * @alpha
    */
   public readonly activeSettings = new ActiveBriefcaseSettings();
 

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -146,22 +146,22 @@ class ModelChangeMonitor {
   }
 }
 
-/** Default settings that can be used to control the behavior of [[Tool]]s that modify a [[BriefcaseConnection]].
- * For example, tools that want to create new elements can consult the briefcase's active settings to
+/** Settings that can be used to control the behavior of [[Tool]]s that modify a [[BriefcaseConnection]].
+ * For example, tools that want to create new elements can consult the briefcase's editor tool settings to
  * determine into which model and category to insert the elements.
  * Specialized tools are free to ignore these settings.
- * @see [[BriefcaseConnection.activeSettings]] to query or modify the current settings for a briefcase.
+ * @see [[BriefcaseConnection.editorToolSettings]] to query or modify the current settings for a briefcase.
  * @see [CreateElementTool]($editor-frontend) for an example of a tool that uses these settings.
  * @alpha
  */
-export class ActiveBriefcaseSettings {
+export class BriefcaseEditorToolSettings {
   private _category?: Id64String;
   private _model?: Id64String;
 
-  /** An event raised just after the active [[category]] is changed. */
+  /** An event raised just after the default [[category]] is changed. */
   public readonly onCategoryChanged = new BeEvent<(previousCategory: Id64String | undefined) => void>();
 
-  /** An event raised just after the active [[model]] is changed. */
+  /** An event raised just after the default [[model]] is changed. */
   public readonly onModelChanged = new BeEvent<(previousModel: Id64String | undefined) => void>();
 
   /** The [Category]($backend) into which new elements should be inserted by default.
@@ -207,7 +207,7 @@ export class BriefcaseConnection extends IModelConnection {
   /** Default settings that can be used to control the behavior of [[Tool]]s that modify this briefcase.
    * @alpha
    */
-  public readonly activeSettings = new ActiveBriefcaseSettings();
+  public readonly editorToolSettings = new BriefcaseEditorToolSettings();
 
   /** Manages local changes to the briefcase via [Txns]($docs/learning/InteractiveEditing.md). */
   public readonly txns: BriefcaseTxns;

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -146,6 +146,52 @@ class ModelChangeMonitor {
   }
 }
 
+/** Default settings that can be used to control the behavior of [[Tool]]s that modify a [[BriefcaseConnection]].
+ * For example, tools that want to create new elements can consult the briefcase's active settings to
+ * determine into which model and category to insert the elements.
+ * Specialized tools are free to ignore these settings.
+ * @see [[BriefcaseConnection.activeSettings]] to query or modify the current settings for a briefcase.
+ * @beta
+ */
+export class ActiveBriefcaseSettings {
+  private _category?: Id64String;
+  private _model?: Id64String;
+
+  /** An event raised just after the active [[category]] is changed. */
+  public readonly onCategoryChanged = new BeEvent<(previousCategory: Id64String | undefined) => void>();
+
+  /** An event raised just after the active [[model]] is changed. */
+  public readonly onModelChanged = new BeEvent<(previousModel: Id64String | undefined) => void>();
+
+  /* The [Category]($backend) into which new elements should be inserted.
+   * @see [[onCategoryChanged]] to be notified when this property is modified.
+   */
+  public get category(): Id64String | undefined {
+    return this._category;
+  }
+  public set category(category: Id64String | undefined) {
+    const previousCategory = this.category;
+    if (category !== this.category) {
+      this._category = category;
+      this.onCategoryChanged.raiseEvent(previousCategory);
+    }
+  }
+
+  /** The [Model]($backend) into which new elements should be inserted.
+   * @see [[onModelChanged]] to be notified when this property is modified.
+   */
+  public get model(): Id64String | undefined {
+    return this._model;
+  }
+  public set model(model: Id64String | undefined) {
+    const previousModel = this.model;
+    if (model !== this.model) {
+      this.model = model;
+      this.onModelChanged.raiseEvent(previousModel);
+    }
+  }
+}
+
 /** A connection to an editable briefcase on the backend. This class uses [Ipc]($docs/learning/IpcInterface.md) to communicate
  * to the backend and may only be used by [[IpcApp]]s.
  * @public
@@ -153,6 +199,10 @@ class ModelChangeMonitor {
 export class BriefcaseConnection extends IModelConnection {
   protected _isClosed?: boolean;
   private readonly _modelsMonitor: ModelChangeMonitor;
+  /** Default settings that can be used to control the behavior of [[Tool]]s that modify this briefcase.
+   * @beta
+   */
+  public readonly activeSettings = new ActiveBriefcaseSettings();
 
   /** Manages local changes to the briefcase via [Txns]($docs/learning/InteractiveEditing.md). */
   public readonly txns: BriefcaseTxns;

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -163,7 +163,8 @@ export class ActiveBriefcaseSettings {
   /** An event raised just after the active [[model]] is changed. */
   public readonly onModelChanged = new BeEvent<(previousModel: Id64String | undefined) => void>();
 
-  /* The [Category]($backend) into which new elements should be inserted.
+  /* The [Category]($backend) into which new elements should be inserted by default.
+   * Specialized tools are free to ignore this setting.
    * @see [[onCategoryChanged]] to be notified when this property is modified.
    */
   public get category(): Id64String | undefined {
@@ -177,7 +178,8 @@ export class ActiveBriefcaseSettings {
     }
   }
 
-  /** The [Model]($backend) into which new elements should be inserted.
+  /** The [Model]($backend) into which new elements should be inserted by default.
+   * Specialized tools are free to ignore this setting.
    * @see [[onModelChanged]] to be notified when this property is modified.
    */
   public get model(): Id64String | undefined {

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -188,7 +188,7 @@ export class ActiveBriefcaseSettings {
   public set model(model: Id64String | undefined) {
     const previousModel = this.model;
     if (model !== this.model) {
-      this.model = model;
+      this._model = model;
       this.onModelChanged.raiseEvent(previousModel);
     }
   }

--- a/core/frontend/src/tools/PrimitiveTool.ts
+++ b/core/frontend/src/tools/PrimitiveTool.ts
@@ -7,6 +7,7 @@
  */
 
 import { assert } from "@itwin/core-bentley";
+import {BriefcaseConnection} from "../BriefcaseConnection";
 import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";
 import { NotifyMessageDetails, OutputMessagePriority } from "../NotificationManager";
@@ -34,6 +35,12 @@ export abstract class PrimitiveTool extends InteractiveTool {
   public get iModel(): IModelConnection {
     assert(undefined !== this.targetView);
     return this.targetView.view.iModel;
+  }
+
+  /** Get the briefcase on which this tool operates, if the tool has successfully installed and [[iModel]] is a briefcase. */
+  public get briefcase(): BriefcaseConnection | undefined {
+    const iModel = this.targetView?.view.iModel;
+    return iModel?.isBriefcaseConnection() ? iModel : undefined;
   }
 
   /**

--- a/core/frontend/src/tools/PrimitiveTool.ts
+++ b/core/frontend/src/tools/PrimitiveTool.ts
@@ -37,7 +37,7 @@ export abstract class PrimitiveTool extends InteractiveTool {
     return this.targetView.view.iModel;
   }
 
-  /** Get the briefcase on which this tool operates, if the tool has successfully installed and [[iModel]] is a briefcase. */
+  /** Get the briefcase on which this tool operates, if the tool has successfully installed and the target [[iModel]] is a briefcase. */
   public get briefcase(): BriefcaseConnection | undefined {
     const iModel = this.targetView?.view.iModel;
     return iModel?.isBriefcaseConnection() ? iModel : undefined;

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -6,7 +6,7 @@
  * @module Tools
  */
 
-import { AbandonedError, assert, BeEvent, Id64String, IModelStatus, Logger } from "@itwin/core-bentley";
+import { AbandonedError, assert, BeEvent, IModelStatus, Logger } from "@itwin/core-bentley";
 import { Matrix3d, Point2d, Point3d, Transform, Vector3d, XAndY } from "@itwin/core-geometry";
 import { Easing, GeometryStreamProps, NpcCenter } from "@itwin/core-common";
 import { DialogItemValue, DialogPropertyItem, DialogPropertySyncItem } from "@itwin/appui-abstract";

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -315,11 +315,6 @@ export class ToolAdmin {
   private _saveLocateCircle = false;
   private _defaultToolId = "Select";
   private _defaultToolArgs?: any[];
-  /**
-   * The active settings that placement tools will use.
-   * @alpha
-   */
-  public readonly activeSettings: ToolAdmin.ActiveSettings = { };
 
   /** The name of the [[PrimitiveTool]] to use as the default tool. Defaults to "Select", referring to [[SelectionTool]].
    * @see [[startDefaultTool]] to activate the default tool.
@@ -1888,21 +1883,5 @@ export class WheelEventProcessor {
     // if we scrolled out, we may have invalidated the current AccuSnap path
     await IModelApp.accuSnap.reEvaluate();
     return status;
-  }
-}
-
-/**
- * @public
- */
-export namespace ToolAdmin { // eslint-disable-line no-redeclare
-  /** Active settings that placement tools will use.
-   * @alpha
-   */
-  export interface ActiveSettings {
-    /** The category to which newly created elements will be assigned. */
-    category?: Id64String;
-
-    /** The model that will contain newly created elements. */
-    model?: Id64String;
   }
 }

--- a/editor/frontend/src/CreateElementTool.ts
+++ b/editor/frontend/src/CreateElementTool.ts
@@ -175,21 +175,23 @@ export class DynamicGraphicsProvider {
 /** @alpha Placement tool base class for creating new elements. */
 export abstract class CreateElementTool extends PrimitiveTool {
   public get targetCategory(): Id64String {
-    if (IModelApp.toolAdmin.activeSettings.category === undefined)
+    const category = this.briefcase?.activeSettings.category;
+    if (undefined === category)
       throw new IModelError(IModelStatus.InvalidCategory, "");
-    return IModelApp.toolAdmin.activeSettings.category;
+
+    return category;
   }
 
   public override get targetModelId(): Id64String {
-    if (IModelApp.toolAdmin.activeSettings.model === undefined)
+    const model = this.briefcase?.activeSettings.model;
+    if (undefined === model)
       throw new IModelError(IModelStatus.BadModel, "");
-    return IModelApp.toolAdmin.activeSettings.model;
+
+    return model;
   }
 
   public override isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean {
-    if (IModelApp.toolAdmin.activeSettings.model === undefined)
-      return false;
-    return super.isCompatibleViewport(vp, isSelectedViewChange);
+    return undefined !== this.briefcase?.activeSettings.model && super.isCompatibleViewport(vp, isSelectedViewChange);
   }
 
   /** Whether [[setupAndPromptForNextAction]] should call [[AccuSnap.enableSnap]] for current tool phase.

--- a/editor/frontend/src/CreateElementTool.ts
+++ b/editor/frontend/src/CreateElementTool.ts
@@ -175,7 +175,7 @@ export class DynamicGraphicsProvider {
 /** @alpha Placement tool base class for creating new elements. */
 export abstract class CreateElementTool extends PrimitiveTool {
   public get targetCategory(): Id64String {
-    const category = this.briefcase?.activeSettings.category;
+    const category = this.briefcase?.editorToolSettings.category;
     if (undefined === category)
       throw new IModelError(IModelStatus.InvalidCategory, "");
 
@@ -183,7 +183,7 @@ export abstract class CreateElementTool extends PrimitiveTool {
   }
 
   public override get targetModelId(): Id64String {
-    const model = this.briefcase?.activeSettings.model;
+    const model = this.briefcase?.editorToolSettings.model;
     if (undefined === model)
       throw new IModelError(IModelStatus.BadModel, "");
 
@@ -194,7 +194,7 @@ export abstract class CreateElementTool extends PrimitiveTool {
     if (!vp?.iModel.isBriefcaseConnection())
       return false;
 
-    return undefined !== vp.iModel.activeSettings.model && super.isCompatibleViewport(vp, isSelectedViewChange);
+    return undefined !== vp.iModel.editorToolSettings.model && super.isCompatibleViewport(vp, isSelectedViewChange);
   }
 
   /** Whether [[setupAndPromptForNextAction]] should call [[AccuSnap.enableSnap]] for current tool phase.

--- a/editor/frontend/src/CreateElementTool.ts
+++ b/editor/frontend/src/CreateElementTool.ts
@@ -191,7 +191,10 @@ export abstract class CreateElementTool extends PrimitiveTool {
   }
 
   public override isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean {
-    return undefined !== this.briefcase?.activeSettings.model && super.isCompatibleViewport(vp, isSelectedViewChange);
+    if (!vp?.iModel.isBriefcaseConnection())
+      return false;
+
+    return undefined !== vp.iModel.activeSettings.model && super.isCompatibleViewport(vp, isSelectedViewChange);
   }
 
   /** Whether [[setupAndPromptForNextAction]] should call [[AccuSnap.enableSnap]] for current tool phase.

--- a/editor/frontend/src/SketchTools.ts
+++ b/editor/frontend/src/SketchTools.ts
@@ -753,7 +753,7 @@ export abstract class CreateOrContinuePathTool extends CreateElementTool {
   }
 }
 
-/** @alpha Creates a line string or shape. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
+/** @alpha Creates a line string or shape. Uses model and category from [[BriefcaseConnection.editorToolSettings]]. */
 export class CreateLineStringTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateLineString";
   public static override iconSpec = "icon-snaps"; // Need better icon...
@@ -835,7 +835,7 @@ export enum ArcMethod {
   StartEndMid = 3,
 }
 
-/** @alpha Creates an arc. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
+/** @alpha Creates an arc. Uses model and category from [[BriefcaseConnection.editorToolSettings]]. */
 export class CreateArcTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateArc";
   public static override iconSpec = "icon-three-points-circular-arc";
@@ -1333,7 +1333,7 @@ export enum CircleMethod {
   Edge = 1,
 }
 
-/** @alpha Creates a circle. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
+/** @alpha Creates a circle. Uses model and category from [[BriefcaseConnection.editorToolSettings]]. */
 export class CreateCircleTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateCircle";
   public static override iconSpec = "icon-circle";
@@ -1594,7 +1594,7 @@ export class CreateCircleTool extends CreateOrContinuePathTool {
   }
 }
 
-/** @alpha Creates an ellipse. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
+/** @alpha Creates an ellipse. Uses model and category from [[BriefcaseConnection.editorToolSettings]]. */
 export class CreateEllipseTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateEllipse";
   public static override iconSpec = "icon-ellipse";
@@ -1682,7 +1682,7 @@ export class CreateEllipseTool extends CreateOrContinuePathTool {
   }
 }
 
-/** @alpha Creates a rectangle by corner points. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
+/** @alpha Creates a rectangle by corner points. Uses model and category from [[BriefcaseConnection.editorToolSettings]]. */
 export class CreateRectangleTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateRectangle";
   public static override iconSpec = "icon-rectangle";
@@ -1860,7 +1860,7 @@ export enum BCurveMethod {
   ThroughPoints = 1,
 }
 
-/** @alpha Creates a bspline curve by poles or through points. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
+/** @alpha Creates a bspline curve by poles or through points. Uses model and category from [[BriefcaseConnection.editorToolSettings]]. */
 export class CreateBCurveTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateBCurve";
   public static override iconSpec = "icon-snaps-nearest"; // Need better icon...

--- a/editor/frontend/src/SketchTools.ts
+++ b/editor/frontend/src/SketchTools.ts
@@ -753,7 +753,7 @@ export abstract class CreateOrContinuePathTool extends CreateElementTool {
   }
 }
 
-/** @alpha Creates a line string or shape. Uses model and category from ToolAdmin.ActiveSettings. */
+/** @alpha Creates a line string or shape. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
 export class CreateLineStringTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateLineString";
   public static override iconSpec = "icon-snaps"; // Need better icon...
@@ -835,7 +835,7 @@ export enum ArcMethod {
   StartEndMid = 3,
 }
 
-/** @alpha Creates an arc. Uses model and category from ToolAdmin.ActiveSettings. */
+/** @alpha Creates an arc. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
 export class CreateArcTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateArc";
   public static override iconSpec = "icon-three-points-circular-arc";
@@ -1333,7 +1333,7 @@ export enum CircleMethod {
   Edge = 1,
 }
 
-/** @alpha Creates a circle. Uses model and category from ToolAdmin.ActiveSettings. */
+/** @alpha Creates a circle. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
 export class CreateCircleTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateCircle";
   public static override iconSpec = "icon-circle";
@@ -1594,7 +1594,7 @@ export class CreateCircleTool extends CreateOrContinuePathTool {
   }
 }
 
-/** @alpha Creates an ellipse. Uses model and category from ToolAdmin.ActiveSettings. */
+/** @alpha Creates an ellipse. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
 export class CreateEllipseTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateEllipse";
   public static override iconSpec = "icon-ellipse";
@@ -1682,7 +1682,7 @@ export class CreateEllipseTool extends CreateOrContinuePathTool {
   }
 }
 
-/** @alpha Creates a rectangle by corner points. Uses model and category from ToolAdmin.ActiveSettings. */
+/** @alpha Creates a rectangle by corner points. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
 export class CreateRectangleTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateRectangle";
   public static override iconSpec = "icon-rectangle";
@@ -1860,7 +1860,7 @@ export enum BCurveMethod {
   ThroughPoints = 1,
 }
 
-/** @alpha Creates a bspline curve by poles or through points. Uses model and category from ToolAdmin.ActiveSettings. */
+/** @alpha Creates a bspline curve by poles or through points. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
 export class CreateBCurveTool extends CreateOrContinuePathTool {
   public static override toolId = "CreateBCurve";
   public static override iconSpec = "icon-snaps-nearest"; // Need better icon...

--- a/test-apps/display-test-app/src/frontend/EditingTools.ts
+++ b/test-apps/display-test-app/src/frontend/EditingTools.ts
@@ -45,7 +45,7 @@ export class EditingScopeTool extends Tool {
   }
 }
 
-/** Places a line string. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
+/** Places a line string. Uses model and category from [[BriefcaseConnection.editorToolSettings]]. */
 export class PlaceLineStringTool extends CreateElementTool {
   public static override toolId = "PlaceLineString";
   private readonly _points: Point3d[] = [];

--- a/test-apps/display-test-app/src/frontend/EditingTools.ts
+++ b/test-apps/display-test-app/src/frontend/EditingTools.ts
@@ -45,7 +45,7 @@ export class EditingScopeTool extends Tool {
   }
 }
 
-/** Places a line string. Uses model and category from ToolAdmin.ActiveSettings. */
+/** Places a line string. Uses model and category from [[BriefcaseConnection.activeSettings]]. */
 export class PlaceLineStringTool extends CreateElementTool {
   public static override toolId = "PlaceLineString";
   private readonly _points: Point3d[] = [];

--- a/test-apps/display-test-app/src/frontend/IdPicker.ts
+++ b/test-apps/display-test-app/src/frontend/IdPicker.ts
@@ -161,8 +161,10 @@ export abstract class IdPicker extends ToolBarDropDown {
         this.hiliteEnabled("Hilite" === which);
         return;
       case "SetFirstActive":
-        const first = Array.from(this._enabledIds)[0];
-        IModelApp.toolAdmin.activeSettings[this._settingsType] = first;
+        if (this._vp.iModel.isBriefcaseConnection()) {
+          const first = Array.from(this._enabledIds)[0];
+          this._vp.iModel.activeSettings[this._settingsType] = first;
+        }
         return;
       case "":
         return;

--- a/test-apps/display-test-app/src/frontend/IdPicker.ts
+++ b/test-apps/display-test-app/src/frontend/IdPicker.ts
@@ -47,7 +47,7 @@ export abstract class IdPicker extends ToolBarDropDown {
       { name: "Hide Selected", value: "Hide" },
       { name: "Hilite Enabled", value: "Hilite" },
       { name: "Un-hilite Enabled", value: "Dehilite" },
-      // Set [[BriefcaseConnection.activeSettings]].model/category to first enabled entry.
+      // Set [[BriefcaseConnection.editorToolSettings]].model/category to first enabled entry.
       { name: "Set First Active", value: "SetFirstActive" },
     ];
   }
@@ -163,7 +163,7 @@ export abstract class IdPicker extends ToolBarDropDown {
       case "SetFirstActive":
         if (this._vp.iModel.isBriefcaseConnection()) {
           const first = Array.from(this._enabledIds)[0];
-          this._vp.iModel.activeSettings[this._settingsType] = first;
+          this._vp.iModel.editorToolSettings[this._settingsType] = first;
         }
         return;
       case "":

--- a/test-apps/display-test-app/src/frontend/IdPicker.ts
+++ b/test-apps/display-test-app/src/frontend/IdPicker.ts
@@ -47,7 +47,7 @@ export abstract class IdPicker extends ToolBarDropDown {
       { name: "Hide Selected", value: "Hide" },
       { name: "Hilite Enabled", value: "Hilite" },
       { name: "Un-hilite Enabled", value: "Dehilite" },
-      // Set ToolAdmin.activeSettings.model/category to first enabled entry.
+      // Set [[BriefcaseConnection.activeSettings]].model/category to first enabled entry.
       { name: "Set First Active", value: "SetFirstActive" },
     ];
   }

--- a/test-apps/display-test-app/src/frontend/IdPicker.ts
+++ b/test-apps/display-test-app/src/frontend/IdPicker.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { assert, compareStringsOrUndefined, Id64, Id64Arg } from "@itwin/core-bentley";
 import { GeometricModel3dProps, QueryBinder, QueryRowFormat } from "@itwin/core-common";
-import { GeometricModel3dState, IModelApp, ScreenViewport, SpatialViewState, ViewManip } from "@itwin/core-frontend";
+import { GeometricModel3dState, ScreenViewport, SpatialViewState, ViewManip } from "@itwin/core-frontend";
 import { CheckBox, ComboBoxEntry, createButton, createCheckBox, createComboBox, createTextBox } from "@itwin/frontend-devtools";
 import { ToolBarDropDown } from "./ToolBar";
 

--- a/test-apps/display-test-app/src/frontend/Viewer.ts
+++ b/test-apps/display-test-app/src/frontend/Viewer.ts
@@ -351,7 +351,7 @@ export class Viewer extends Window {
     if (!view.iModel.isBriefcaseConnection())
       return;
 
-    const settings = view.iModel.activeSettings;
+    const settings = view.iModel.editorToolSettings;
     if (undefined === settings.category || !view.viewsCategory(settings.category)) {
       settings.category = undefined;
       for (const catId of view.categorySelector.categories) {

--- a/test-apps/display-test-app/src/frontend/Viewer.ts
+++ b/test-apps/display-test-app/src/frontend/Viewer.ts
@@ -348,8 +348,10 @@ export class Viewer extends Window {
   private updateActiveSettings(): void {
     // NOTE: First category/model is fine for testing purposes...
     const view = this.viewport.view;
-    const settings = IModelApp.toolAdmin.activeSettings;
+    if (!view.iModel.isBriefcaseConnection())
+      return;
 
+    const settings = view.iModel.activeSettings;
     if (undefined === settings.category || !view.viewsCategory(settings.category)) {
       settings.category = undefined;
       for (const catId of view.categorySelector.categories) {

--- a/test-apps/ui-test-app/src/frontend/appui/widgets/editing/ActiveSettingsWidget.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/widgets/editing/ActiveSettingsWidget.tsx
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { Id64String } from "@itwin/core-bentley";
-import { IModelApp } from "@itwin/core-frontend";
 import { ConfigurableCreateInfo, ConfigurableUiManager, WidgetControl } from "@itwin/appui-react";
 import { ActiveSettingsManager, iModelInfoAvailableEvent } from "../../../api/ActiveSettingsManager";
 
@@ -22,19 +21,21 @@ export class ActiveSettingsComponent extends React.Component<{}, ActiveSettingsC
   }
 
   private updateState() {
-    this.setState((prev) => ({ ...prev, modelId: IModelApp.toolAdmin.activeSettings.model, categoryId: IModelApp.toolAdmin.activeSettings.category }));
+    this.setState((prev) => ({
+      ...prev,
+      modelId: ActiveSettingsManager.briefcase?.editorToolSettings.model,
+      categoryId: ActiveSettingsManager.briefcase?.editorToolSettings.category,
+    }));
   }
 
   private get activeModelName(): string {
-    if (IModelApp.toolAdmin.activeSettings.model === undefined)
-      return "";
-    return ActiveSettingsManager.models.getNameFromId(IModelApp.toolAdmin.activeSettings.model) || "";
+    const model = ActiveSettingsManager.briefcase?.editorToolSettings.model;
+    return model ? ActiveSettingsManager.models.getNameFromId(model) ?? "" : "";
   }
 
   private get activeCategoryName(): string {
-    if (IModelApp.toolAdmin.activeSettings.category === undefined)
-      return "";
-    return ActiveSettingsManager.categories.getNameFromId(IModelApp.toolAdmin.activeSettings.category) || "";
+    const category = ActiveSettingsManager.briefcase?.editorToolSettings.category;
+    return category ? ActiveSettingsManager.categories.getNameFromId(category) ?? "" : "";
   }
 
   private getAllModels(): JSX.Element[] {
@@ -44,7 +45,9 @@ export class ActiveSettingsComponent extends React.Component<{}, ActiveSettingsC
   }
 
   private onSelectModel(event: React.FormEvent<HTMLSelectElement>) {
-    IModelApp.toolAdmin.activeSettings.model = event.currentTarget.options[event.currentTarget.selectedIndex].id;
+    if (ActiveSettingsManager.briefcase)
+      ActiveSettingsManager.briefcase.editorToolSettings.model = event.currentTarget.options[event.currentTarget.selectedIndex].id;
+
     this.updateState();
   }
 
@@ -55,7 +58,9 @@ export class ActiveSettingsComponent extends React.Component<{}, ActiveSettingsC
   }
 
   private onSelectCategory(event: React.FormEvent<HTMLSelectElement>) {
-    IModelApp.toolAdmin.activeSettings.category = event.currentTarget.options[event.currentTarget.selectedIndex].id;
+    if (ActiveSettingsManager.briefcase)
+      ActiveSettingsManager.briefcase.editorToolSettings.category = event.currentTarget.options[event.currentTarget.selectedIndex].id;
+
     this.updateState();
   }
 


### PR DESCRIPTION
Previously ToolAdmin.activeSettings specified the default model and category for use by placement tools, but those Ids are specific to an iModel.
Conceivably apps could contain multiple viewports in which editing tools can be used, but more realistically leftover Ids might remain when switching between iModels producing surprising results.
Moved the settings to BriefcaseConnection. Added events to notify when they change.
Note these settings are only defaults; more specialized tools will have their own logic for determining category and model.