### PR TITLE
Fix DisplayStyleState.changeBackgroundMapProvider

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -405,6 +405,7 @@ export interface BackgroundMapProps {
 
 // @beta
 export class BackgroundMapProvider {
+    clone(changedProps: BackgroundMapProviderProps): BackgroundMapProvider;
     equals(other: BackgroundMapProvider): boolean;
     // @internal (undocumented)
     static fromBackgroundMapProps(props: DeprecatedBackgroundMapProps): BackgroundMapProvider;

--- a/common/changes/@itwin/core-common/pmc-fix-background-map-ui_2022-03-11-22-25.json
+++ b/common/changes/@itwin/core-common/pmc-fix-background-map-ui_2022-03-11-22-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Add BackgroundMapProvider.clone.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/pmc-fix-background-map-ui_2022-03-11-22-25.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-background-map-ui_2022-03-11-22-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix bug in which DisplayStyleState.changeBackgroundMapProvider failed to preserve previous values as advertised.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/common/src/BackgroundMapProvider.ts
+++ b/core/common/src/BackgroundMapProvider.ts
@@ -80,4 +80,14 @@ export class BackgroundMapProvider {
   public equals(other: BackgroundMapProvider): boolean {
     return this.name === other.name && this.type === other.type;
   }
+
+  /** Produce a copy of this provider with identical properties except for those explicitly specified by `changedProps`.
+   * Any properties explicitly set to `undefined` in `changedProps` will be reset to their default values.
+   */
+  public clone(changedProps: BackgroundMapProviderProps): BackgroundMapProvider {
+    return BackgroundMapProvider.fromJSON({
+      ...this.toJSON(),
+      ...changedProps,
+    });
+  }
 }

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -218,12 +218,13 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
    * @public
    */
   public changeBackgroundMapProvider(props: BackgroundMapProviderProps): void {
-    const provider = BackgroundMapProvider.fromJSON(props);
     const base = this.settings.mapImagery.backgroundBase;
-    if (base instanceof ColorDef)
-      this.settings.mapImagery.backgroundBase = BaseMapLayerSettings.fromProvider(provider);
-    else
+    if (base instanceof ColorDef) {
+      this.settings.mapImagery.backgroundBase = BaseMapLayerSettings.fromProvider(BackgroundMapProvider.fromJSON(props));
+    } else {
+      const provider = base.provider ? base.provider.clone(props) : BackgroundMapProvider.fromJSON(props);
       this.settings.mapImagery.backgroundBase = base.cloneWithProvider(provider);
+    }
 
     this._synchBackgroundMapImagery();
   }


### PR DESCRIPTION
It claims to preserve existing values for any properties not explicitly specified, but recently stopped doing so.