### PR TITLE
Add "getMassPropertiesPerCandidate" RPC operation

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -4549,6 +4549,8 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
     // (undocumented)
     getMassProperties(_iModelToken: IModelRpcProps, _props: MassPropertiesRequestProps): Promise<MassPropertiesResponseProps>;
     // (undocumented)
+    getMassPropertiesPerCandidate(_iModelToken: IModelRpcProps, _props: MassPropertiesPerCandidateRequestProps): Promise<MassPropertiesPerCandidateResponseProps[]>;
+    // (undocumented)
     getModelProps(_iModelToken: IModelRpcProps, _modelIds: Id64String[]): Promise<ModelProps[]>;
     // (undocumented)
     getToolTipMessage(_iModelToken: IModelRpcProps, _elementId: string): Promise<string[]>;
@@ -5243,6 +5245,20 @@ export enum MassPropertiesOperation {
     AccumulateAreas = 1,
     AccumulateLengths = 0,
     AccumulateVolumes = 2
+}
+
+// @public
+export interface MassPropertiesPerCandidateRequestProps {
+    // (undocumented)
+    candidates: CompressedId64Set;
+    // (undocumented)
+    operations: MassPropertiesOperation[];
+}
+
+// @public
+export interface MassPropertiesPerCandidateResponseProps extends MassPropertiesResponseProps {
+    // (undocumented)
+    candidate: Id64String;
 }
 
 // @public

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -408,6 +408,8 @@ public;mapToGeoServiceStatus(s: GeoCoordStatus): GeoServiceStatus
 internal;MarshalingBinaryMarker
 internal;MarshalingBinaryMarker
 public;MassPropertiesOperation
+public;MassPropertiesPerCandidateRequestProps
+public;MassPropertiesPerCandidateResponseProps 
 public;MassPropertiesRequestProps
 public;MassPropertiesResponseProps
 public;MaterialProps

--- a/common/changes/@itwin/core-backend/mindaugas-bulk-mass-properties_2022-03-15-14-53.json
+++ b/common/changes/@itwin/core-backend/mindaugas-bulk-mass-properties_2022-03-15-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added \"getMassPropertiesPerCandidate\" RPC operation to IModelReadRpcInterface which returns mass properties for each candidate separately.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/mindaugas-bulk-mass-properties_2022-03-15-14-53.json
+++ b/common/changes/@itwin/core-common/mindaugas-bulk-mass-properties_2022-03-15-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Added \"getMassPropertiesPerCandidate\" RPC operation to IModelReadRpcInterface which returns mass properties for each candidate separately.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/MassProperties.ts
+++ b/core/common/src/MassProperties.ts
@@ -32,7 +32,7 @@ export interface MassPropertiesRequestProps {
 /** Information required to request mass properties for each element separately from the front end to the back end.
  * @public
  */
-export interface SeparateMassPropertiesRequestProps {
+export interface MassPropertiesPerCandidateRequestProps {
   operations: MassPropertiesOperation[];
   candidates: CompressedId64Set;
 }
@@ -56,6 +56,6 @@ export interface MassPropertiesResponseProps {
 /** Information returned from the back end to the front end holding the result of the mass properties calculation for a single candidate.
  * @public
  */
-export interface SeparateMassPropertiesResponseProps extends MassPropertiesResponseProps {
+export interface MassPropertiesPerCandidateResponseProps extends MassPropertiesResponseProps {
   candidate: Id64String;
 }

--- a/core/common/src/MassProperties.ts
+++ b/core/common/src/MassProperties.ts
@@ -6,7 +6,7 @@
  * @module Geometry
  */
 
-import { BentleyStatus, Id64Array } from "@itwin/core-bentley";
+import { BentleyStatus, CompressedId64Set, Id64Array, Id64String } from "@itwin/core-bentley";
 import { XYZProps } from "@itwin/core-geometry";
 
 /** Specify whether to accumulate volumes, areas, or lengths for the supplied elements.
@@ -29,6 +29,14 @@ export interface MassPropertiesRequestProps {
   candidates?: Id64Array;
 }
 
+/** Information required to request mass properties for each element separately from the front end to the back end.
+ * @public
+ */
+export interface SeparateMassPropertiesRequestProps {
+  operations: MassPropertiesOperation[];
+  candidates: CompressedId64Set;
+}
+
 /** Information returned from the back end to the front end holding the result of the mass properties calculation.
  * @public
  */
@@ -43,4 +51,11 @@ export interface MassPropertiesResponseProps {
   ixz?: number;
   iyz?: number;
   moments?: XYZProps;
+}
+
+/** Information returned from the back end to the front end holding the result of the mass properties calculation for a single candidate.
+ * @public
+ */
+export interface SeparateMassPropertiesResponseProps extends MassPropertiesResponseProps {
+  candidate: Id64String;
 }

--- a/core/common/src/rpc/IModelReadRpcInterface.ts
+++ b/core/common/src/rpc/IModelReadRpcInterface.ts
@@ -19,7 +19,7 @@ import {
 import { GeometryContainmentRequestProps, GeometryContainmentResponseProps } from "../GeometryContainment";
 import { GeometrySummaryRequestProps } from "../GeometrySummary";
 import { IModelConnectionProps, IModelRpcOpenProps, IModelRpcProps } from "../IModel";
-import { MassPropertiesRequestProps, MassPropertiesResponseProps, SeparateMassPropertiesRequestProps, SeparateMassPropertiesResponseProps } from "../MassProperties";
+import { MassPropertiesPerCandidateRequestProps, MassPropertiesPerCandidateResponseProps, MassPropertiesRequestProps, MassPropertiesResponseProps } from "../MassProperties";
 import { ModelProps } from "../ModelProps";
 import { RpcInterface } from "../RpcInterface";
 import { RpcManager } from "../RpcManager";
@@ -79,7 +79,7 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
   public async cancelSnap(_iModelToken: IModelRpcProps, _sessionId: string): Promise<void> { return this.forward(arguments); }
   public async getGeometryContainment(_iModelToken: IModelRpcProps, _props: GeometryContainmentRequestProps): Promise<GeometryContainmentResponseProps> { return this.forward(arguments); }
   public async getMassProperties(_iModelToken: IModelRpcProps, _props: MassPropertiesRequestProps): Promise<MassPropertiesResponseProps> { return this.forward(arguments); }
-  public async getSeparateMassProperties(_iModelToken: IModelRpcProps, _props: SeparateMassPropertiesRequestProps): Promise<SeparateMassPropertiesResponseProps[]> { return this.forward(arguments); }
+  public async getMassPropertiesPerCandidate(_iModelToken: IModelRpcProps, _props: MassPropertiesPerCandidateRequestProps): Promise<MassPropertiesPerCandidateResponseProps[]> { return this.forward(arguments); }
   public async getIModelCoordinatesFromGeoCoordinates(_iModelToken: IModelRpcProps, _props: IModelCoordinatesRequestProps): Promise<IModelCoordinatesResponseProps> { return this.forward(arguments); }
   public async getGeoCoordinatesFromIModelCoordinates(_iModelToken: IModelRpcProps, _props: GeoCoordinatesRequestProps): Promise<GeoCoordinatesResponseProps> { return this.forward(arguments); }
   public async getGeometrySummary(_iModelToken: IModelRpcProps, _props: GeometrySummaryRequestProps): Promise<string> { return this.forward(arguments); }

--- a/core/common/src/rpc/IModelReadRpcInterface.ts
+++ b/core/common/src/rpc/IModelReadRpcInterface.ts
@@ -19,7 +19,7 @@ import {
 import { GeometryContainmentRequestProps, GeometryContainmentResponseProps } from "../GeometryContainment";
 import { GeometrySummaryRequestProps } from "../GeometrySummary";
 import { IModelConnectionProps, IModelRpcOpenProps, IModelRpcProps } from "../IModel";
-import { MassPropertiesRequestProps, MassPropertiesResponseProps } from "../MassProperties";
+import { MassPropertiesRequestProps, MassPropertiesResponseProps, SeparateMassPropertiesRequestProps, SeparateMassPropertiesResponseProps } from "../MassProperties";
 import { ModelProps } from "../ModelProps";
 import { RpcInterface } from "../RpcInterface";
 import { RpcManager } from "../RpcManager";
@@ -79,6 +79,7 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
   public async cancelSnap(_iModelToken: IModelRpcProps, _sessionId: string): Promise<void> { return this.forward(arguments); }
   public async getGeometryContainment(_iModelToken: IModelRpcProps, _props: GeometryContainmentRequestProps): Promise<GeometryContainmentResponseProps> { return this.forward(arguments); }
   public async getMassProperties(_iModelToken: IModelRpcProps, _props: MassPropertiesRequestProps): Promise<MassPropertiesResponseProps> { return this.forward(arguments); }
+  public async getSeparateMassProperties(_iModelToken: IModelRpcProps, _props: SeparateMassPropertiesRequestProps): Promise<SeparateMassPropertiesResponseProps[]> { return this.forward(arguments); }
   public async getIModelCoordinatesFromGeoCoordinates(_iModelToken: IModelRpcProps, _props: IModelCoordinatesRequestProps): Promise<IModelCoordinatesResponseProps> { return this.forward(arguments); }
   public async getGeoCoordinatesFromIModelCoordinates(_iModelToken: IModelRpcProps, _props: GeoCoordinatesRequestProps): Promise<GeoCoordinatesResponseProps> { return this.forward(arguments); }
   public async getGeometrySummary(_iModelToken: IModelRpcProps, _props: GeometrySummaryRequestProps): Promise<string> { return this.forward(arguments); }


### PR DESCRIPTION
This adds the ability to get mass properties for multiple elements separately with just a single request. The existing "getMassProperties" aggregates mass properties of all given candidates.