### PR TITLE
Presentation: Fix tile links in the documentation index page

### DIFF
--- a/docs/presentation/index.md
+++ b/docs/presentation/index.md
@@ -2,11 +2,11 @@
 
 The Presentation library provides means to declaratively get data from iModels in a format that's ready to be displayed to end users. That includes creating hierarchical structures and content for components like list, table, property grid and others. See the [motivation page](./motivation/index.md) for more details.
 
-[!bwc tile heading="Motivation" linkTo="index subPath=/motivation" contents="What is the purpose of the Presentation Library and why it should be used" icon="new.svg" step="13" width="28%"]
-[!bwc tile heading="Setting Up" linkTo="index subPath=/setup" contents="How to set up backend and frontend for using Presentation Library" icon="developer.svg" step="13" width="28%"]
+[!bwc tile heading="Motivation" linkTo="index path=presentation/motivation/index subPath=/motivation" contents="What is the purpose of the Presentation Library and why it should be used" icon="new.svg" step="13" width="28%"]
+[!bwc tile heading="Setting Up" linkTo="index path=presentation/setup/index subPath=/setup" contents="How to set up backend and frontend for using Presentation Library" icon="developer.svg" step="13" width="28%"]
 
-[!bwc tile heading="Content" linkTo="index subPath=/content" contents="Learn presentation rules for producing content for tables, property grids, list views" icon="properties-list.svg" step="13" width="28%"]
-[!bwc tile heading="Hierarchies" linkTo="index subPath=/hierarchies" contents="Learn presentation rules for producing hierarchies" icon="tree.svg" step="13" width="28%"]
-[!bwc tile heading="Customization" linkTo="index subPath=/customization" contents="Learn about customization of how instances are displayed" icon="palette.svg" step="13" width="28%"]
-[!bwc tile heading="Unified Selection" linkTo="index subPath=/unified-selection" contents="Learn about sharing selection across UI components" icon="isolate.svg" step="13" width="28%"]
-[!bwc tile heading="Advanced" linkTo="index subPath=/advanced" contents="Learn advanced topics about Presentation Library" icon="puzzle.svg" step="13" width="28%"]
+[!bwc tile heading="Content" linkTo="index path=presentation/content/index subPath=/content" contents="Learn presentation rules for producing content for tables, property grids, list views" icon="properties-list.svg" step="13" width="28%"]
+[!bwc tile heading="Hierarchies" linkTo="index path=presentation/hierarchies/index subPath=/hierarchies" contents="Learn presentation rules for producing hierarchies" icon="tree.svg" step="13" width="28%"]
+[!bwc tile heading="Customization" linkTo="index path=presentation/customization/index subPath=/customization" contents="Learn about customization of how instances are displayed" icon="palette.svg" step="13" width="28%"]
+[!bwc tile heading="Unified Selection" linkTo="index path=presentation/unified-selection/index subPath=/unified-selection" contents="Learn about sharing selection across UI components" icon="isolate.svg" step="13" width="28%"]
+[!bwc tile heading="Advanced" linkTo="index path=presentation/advanced/index subPath=/advanced" contents="Learn advanced topics about Presentation Library" icon="puzzle.svg" step="13" width="28%"]


### PR DESCRIPTION
Some tiles in https://www.itwinjs.org/presentation/ link to specific rule/specification rather than category index. For example the "Content" tile should link to https://www.itwinjs.org/presentation/content/, but links to https://www.itwinjs.org/presentation/content/contentinstancesofspecificclasses/