### PR TITLE
Improve reality tile purge and preloading

### DIFF
--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -6,7 +6,7 @@
  * @module Tiles
  */
 
-import { assert, BeTimePoint } from "@itwin/core-bentley";
+import { assert, BeTimePoint, ProcessDetector } from "@itwin/core-bentley";
 import {
   Matrix3d, Point3d, Range3d, Transform, Vector3d, XYZProps,
 } from "@itwin/core-geometry";
@@ -185,7 +185,7 @@ export class RealityTileTree extends TileTree {
 
   public prune(): void {
     const olderThan = BeTimePoint.now().minus(this.expirationTime);
-    this.rootTile.purgeContents(olderThan);
+    this.rootTile.purgeContents(olderThan, !ProcessDetector.isMobileBrowser);
   }
 
   public draw(args: TileDrawArgs): void {

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -10,7 +10,7 @@ import { assert, BeTimePoint } from "@itwin/core-bentley";
 import {
   Matrix3d, Point3d, Range3d, Transform, Vector3d, XYZProps,
 } from "@itwin/core-geometry";
-import { Cartographic, ColorDef, Frustum, FrustumPlanes, GeoCoordStatus, ViewFlagOverrides } from "@itwin/core-common";
+import { Cartographic, ColorDef, GeoCoordStatus, ViewFlagOverrides } from "@itwin/core-common";
 import { BackgroundMapGeometry } from "../BackgroundMapGeometry";
 import { GeoConverter } from "../GeoServices";
 import { IModelApp } from "../IModelApp";
@@ -18,7 +18,7 @@ import { GraphicBranch } from "../render/GraphicBranch";
 import { GraphicBuilder } from "../render/GraphicBuilder";
 import { SceneContext } from "../ViewContext";
 import {
-  GraphicsCollectorDrawArgs, MapTile, RealityTile, RealityTileDrawArgs, RealityTileLoader, RealityTileParams, Tile, TileDrawArgs, TileGeometryCollector,
+  GraphicsCollectorDrawArgs, MapTile, RealityTile, RealityTileLoader, RealityTileParams, Tile, TileDrawArgs, TileGeometryCollector,
   TileGraphicType, TileParams, TileTree, TileTreeParams,
 } from "./internal";
 
@@ -109,8 +109,6 @@ export class TraversalSelectionContext {
   }
 }
 
-const scratchFrustum = new Frustum();
-const scratchFrustumPlanes = new FrustumPlanes();
 const scratchCarto = Cartographic.createZero();
 const scratchPoint = Point3d.createZero(), scratchOrigin = Point3d.createZero();
 const scratchRange = Range3d.createNull();
@@ -384,7 +382,7 @@ export class RealityTileTree extends TileTree {
         rootTile.preloadRealityTilesAtDepth(baseDepth, context, args);
 
       if (!freezeTiles)
-        this.preloadTilesForScene(args, context, undefined);
+        rootTile.preloadProtectedTiles(args, context);
     }
 
     if (!freezeTiles)
@@ -418,22 +416,6 @@ export class RealityTileTree extends TileTree {
 
     IModelApp.tileAdmin.addTilesForUser(args.context.viewport, selected, args.readyTiles);
     return selected;
-  }
-
-  public preloadTilesForScene(args: TileDrawArgs, context: TraversalSelectionContext, frustumTransform?: Transform) {
-    const preloadFrustum = args.viewingSpace.getPreloadFrustum(frustumTransform, scratchFrustum);
-    const preloadFrustumPlanes = new FrustumPlanes(preloadFrustum);
-    const worldToNpc = preloadFrustum.toMap4d();
-    const preloadWorldToViewMap = args.viewingSpace.calcNpcToView().multiplyMapMap(worldToNpc!);
-    const preloadArgs = new RealityTileDrawArgs(args, preloadWorldToViewMap, preloadFrustumPlanes);
-
-    scratchFrustumPlanes.init(preloadFrustum);
-    if (context.preloadDebugBuilder) {
-      context.preloadDebugBuilder.setSymbology(ColorDef.blue, ColorDef.blue, 2, 0);
-      context.preloadDebugBuilder.addFrustum(preloadFrustum);
-    }
-
-    this.rootTile.preloadTilesInFrustum(preloadArgs, context, 2);
   }
 
   protected logTiles(label: string, tiles: IterableIterator<Tile>) {

--- a/core/frontend/src/tile/TileUsageMarker.ts
+++ b/core/frontend/src/tile/TileUsageMarker.ts
@@ -28,7 +28,17 @@ export class TileUsageMarker {
 
   /** Returns true if this tile is currently in use by no [[TileUser]]s and its timestamp pre-dates `expirationTime`. */
   public isExpired(expirationTime: BeTimePoint): boolean {
-    return this._timePoint.before(expirationTime) && !IModelApp.tileAdmin.isTileInUse(this);
+    return this.isTimestampExpired(expirationTime) && !this.getIsTileInUse();
+  }
+
+  /** Returns true if this tile is currently in use by a [[TileUser]]s. */
+  public getIsTileInUse(): boolean {
+    return IModelApp.tileAdmin.isTileInUse(this);
+  }
+
+  /** Returns true if this tile's timestamp pre-dates `expirationTime`, without checking if it is in use. */
+  public isTimestampExpired(expirationTime: BeTimePoint): boolean {
+    return this._timePoint.before(expirationTime);
   }
 
   /** Updates the timestamp to the specified time and marks the tile as being in use by the specified [[TileUser]]. */

--- a/core/frontend/src/tile/map/MapTile.ts
+++ b/core/frontend/src/tile/map/MapTile.ts
@@ -538,15 +538,19 @@ export class MapTile extends RealityTile {
    * they apparently intersect view frustum.   To avoid this force loading of terrain tiles if they exceed "_maxParentHightDepth".
    * @internal
    */
-
-  public override forceSelectRealityTile(): boolean {
-
+  protected override forceSelectRealityTile(): boolean {
     let parentHeightDepth = 0;
+
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     for (let parent: MapTile = this; parent !== undefined && parent._heightRange === undefined; parent = parent.parent as MapTile)
       parentHeightDepth++;
 
     return parentHeightDepth > MapTile._maxParentHeightDepth;
+  }
+
+  /** @internal */
+  protected override minimumVisibleFactor(): Number {
+    return 0.25;
   }
 
   private static _scratchThisDiagonal = Vector2d.create();


### PR DESCRIPTION
This PR improves how the tile managements for ``RealityTile``s. Its primary goal is to prevent holes to appear on reality models by making sure that there is always a parent to show if a children is not ready.

It ensure that, for each used tile, every parents, siblings and siblings of parents is loaded. This way, if a tile that should be displayed is not ready, one of its parents can be displayed instead without leaving a hole.

To do so, the ``purgeContents`` function has been modified to prevent disposing the content of these required tiles. A function to preload them has also been added. Similarly to frustum culling, it is not used on mobile or if ``freezeTiles`` is set.

I named in the code these non-selected tiles that are kept around "protected tiles", but I am not sure of the pertinence of this naming.

Because we always have a tile that can be displayed for any situation, the memory expensive frustum preloading can be disabled without significant quality change. The PR removes it as well.

Edit:
This PR also modifies the reality tile selection functions in order to fix cases in which holes were displayed while tiles were loading without using the parent as placeholder. Some changes have also been made to make it easier to read.