### PR TITLE
Ignore bulk EOL change in GitLens blames

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -115,4 +115,8 @@
     "editor.action.fixAll": true, // Run the default formatter before eslint, it handles whitespace better
     "source.fixAll.eslint": true // then run ESLint auto-fix
   },
+  "gitlens.advanced.blame.customArguments": [
+    "--ignore-rev",
+    "007be59f93813bc5525b1fe2afc48f20761bca56"
+  ]
 }


### PR DESCRIPTION
The end-of-line normalization introduced in #2428 was great for consistency and a real quality-of-life improvement in many ways.  But one unfortunate side effect of such a wide-reaching bulk update has been to make git blames slightly harder to follow.

Since many of us use the GitLens VS Code extension, I thought it would be helpful to have it use the [--ignore-rev](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt) option to skip that particular commit in blames.

I should note that there's also a setting, `gitlens.blame.ignoreWhitespace` which can be have a similar effect, but skipping _all_ whitespace changes in blames seemed to me to be more of a personal preference.  Definitely open to feedback on that though.

| **Before:** ![image](https://user-images.githubusercontent.com/33036725/159027578-f58bcc99-6a28-4119-b2e5-08cf52556d8c.png) | **After:** ![image](https://user-images.githubusercontent.com/33036725/159027758-a0f794eb-2cdf-41ed-b3ba-ff9195dc718d.png) |
|---|---|