### PR TITLE
Add the ability to skip the cross origin check

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -4560,7 +4560,7 @@ export function imageBufferToPngDataUrl(buffer: ImageBuffer, preserveAlpha?: boo
 export function imageElementFromImageSource(source: ImageSource): Promise<HTMLImageElement>;
 
 // @public
-export function imageElementFromUrl(url: string): Promise<HTMLImageElement>;
+export function imageElementFromUrl(url: string, skipCrossOriginCheck?: boolean): Promise<HTMLImageElement>;
 
 // @internal
 export class ImageryMapLayerFormat extends MapLayerFormat {
@@ -11944,7 +11944,7 @@ export class TraversalSelectionContext {
 }
 
 // @public
-export function tryImageElementFromUrl(url: string): Promise<HTMLImageElement | undefined>;
+export function tryImageElementFromUrl(url: string, skipCrossOriginCheck?: boolean): Promise<HTMLImageElement | undefined>;
 
 // @public
 export class TwoWayViewportFrustumSync extends TwoWayViewportSync {

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -282,7 +282,7 @@ public;imageBufferToBase64EncodedPng(buffer: ImageBuffer, preserveAlpha?: boolea
 public;imageBufferToCanvas(buffer: ImageBuffer, preserveAlpha?: boolean): HTMLCanvasElement | undefined
 public;imageBufferToPngDataUrl(buffer: ImageBuffer, preserveAlpha?: boolean): string | undefined
 public;imageElementFromImageSource(source: ImageSource): Promise
-public;imageElementFromUrl(url: string): Promise
+public;imageElementFromUrl(url: string, skipCrossOriginCheck?: boolean): Promise
 internal;ImageryMapLayerFormat 
 internal;ImageryMapLayerTreeReference 
 internal;ImageryMapTile 
@@ -663,7 +663,7 @@ internal;TouchCursor
 internal;TraversalChildrenDetails
 internal;TraversalDetails
 internal;TraversalSelectionContext
-public;tryImageElementFromUrl(url: string): Promise
+public;tryImageElementFromUrl(url: string, skipCrossOriginCheck?: boolean): Promise
 public;TwoWayViewportFrustumSync 
 public;TwoWayViewportSync
 public;Uniform

--- a/common/changes/@itwin/core-frontend/tcobbs-bentley-image-cross-origin_2022-03-18-21-58.json
+++ b/common/changes/@itwin/core-frontend/tcobbs-bentley-image-cross-origin_2022-03-18-21-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add skipCrossOriginCheck parameter (default false) to imageElementFromUrl and tryImageElementFromUrl.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ImageUtil.ts
+++ b/core/frontend/src/ImageUtil.ts
@@ -196,15 +196,18 @@ export async function imageElementFromImageSource(source: ImageSource): Promise<
 
 /** Create an html Image element from a URL.
  * @param url The URL pointing to the image data.
+ * @param skipCrossOriginCheck Set this to true to allow an image from a different origin than the web app to load. Default is false.
  * @returns A Promise resolving to an HTMLImageElement when the image data has been loaded from the URL.
  * @see tryImageElementFromUrl.
  * @public
  */
-export async function imageElementFromUrl(url: string): Promise<HTMLImageElement> {
+export async function imageElementFromUrl(url: string, skipCrossOriginCheck = false): Promise<HTMLImageElement> {
   // We must set crossorigin property so that images loaded from same origin can be used with texImage2d.
   // We must do that outside of the promise constructor or it won't work, for reasons.
   const image = new Image();
-  image.crossOrigin = "anonymous";
+  if (!skipCrossOriginCheck) {
+    image.crossOrigin = "anonymous";
+  }
   return new Promise((resolve: (image: HTMLImageElement) => void, reject) => {
     image.onload = () => resolve(image);
 
@@ -216,13 +219,14 @@ export async function imageElementFromUrl(url: string): Promise<HTMLImageElement
 
 /** Try to create an html Image element from a URL.
  * @param url The URL pointing to the image data.
+ * @param skipCrossOriginCheck Set this to true to allow an image from a different origin than the web app to load. Default is false.
  * @returns A Promise resolving to an HTMLImageElement when the image data has been loaded from the URL, or to `undefined` if an exception occurred.
  * @see imageElementFromUrl
  * @public
  */
-export async function tryImageElementFromUrl(url: string): Promise<HTMLImageElement | undefined> {
+export async function tryImageElementFromUrl(url: string, skipCrossOriginCheck = false): Promise<HTMLImageElement | undefined> {
   try {
-    return await imageElementFromUrl(url);
+    return await imageElementFromUrl(url, skipCrossOriginCheck);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
Update imageElementFromUrl and tryImageElementFromUrl to have a new optional parameter (default false) that when set to true will skip the cross origin check when loading the image.

Note: we are using this in a mobile app that uses a custom URL scheme to load images from the local device, and this fails the cross origin check.