### PR TITLE
Provide an error message when IModelHost.hubAccess is undefined

### DIFF
--- a/common/changes/@itwin/core-backend/error-on-no-hub-access_2022-03-21-15-17.json
+++ b/common/changes/@itwin/core-backend/error-on-no-hub-access_2022-03-21-15-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Improved error message for undefined IModelHost.hubAccess",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -322,7 +322,15 @@ export class IModelHost {
   /** Provides access to the IModelHub for this IModelHost
    * @beta
    */
-  public static get hubAccess(): BackendHubAccess { return this._hubAccess; }
+  public static get hubAccess(): BackendHubAccess {
+    // Strictly speaking, _hubAccess should be marked as possibly undefined since it's not needed for Snapshot iModels.
+    // However, a decision was made to not provide that type annotation so callers aren't forced to constantly check for
+    // something that's required in all other workflows.
+    // This check is here to provide a better error message when hubAccess is inadvertently undefined.
+    if (this._hubAccess === undefined)
+      throw new IModelError(IModelStatus.BadRequest, "IModelHost.hubAccess is undefined. Specify an implementation in your IModelHostConfiguration");
+    return this._hubAccess;
+  }
 
   private static _isValid = false;
   /** Returns true if IModelHost is started.  */

--- a/core/backend/src/test/HubMock.ts
+++ b/core/backend/src/test/HubMock.ts
@@ -80,7 +80,11 @@ export class HubMock {
     this.mockRoot = join(KnownTestLocations.outputDir, "HubMock", mockName);
     IModelJsFs.recursiveMkDirSync(this.mockRoot);
     IModelJsFs.purgeDirSync(this.mockRoot);
-    this._saveHubAccess = IModelHost.hubAccess;
+    try {
+      this._saveHubAccess = IModelHost.hubAccess;
+    } catch (error) {
+      // See note in IModelHost.hubAccess. hubAccess can in fact be undefined, but that is not annotated in type system.
+    }
     IModelHost.setHubAccess(this);
     HubMock._iTwinId = Guid.createValue(); // all iModels for this test get the same "iTwinId"
   }

--- a/core/backend/src/test/IModelHost.test.ts
+++ b/core/backend/src/test/IModelHost.test.ts
@@ -192,4 +192,9 @@ describe("IModelHost", () => {
 
   });
 
+  it("should throw if hubAccess is undefined and getter is called", async () => {
+    await IModelHost.startup();
+    expect(() => IModelHost.hubAccess).throws("IModelHost.hubAccess is undefined. Specify an implementation in your IModelHostConfiguration");
+  });
+
 });


### PR DESCRIPTION
Strictly speaking, IModelHost._hubAccess should be marked as possibly undefined since it's not needed for Snapshot iModels, and IModelHostConfiguration doesn't require the hubAccess property to be defined.

However, a decision was made to not provide that type annotation so callers aren't forced to constantly check for something that's required in all other workflows.

Unfortunately this leads to a poor error message if a developer inadvertently doesn't define this property. This PR tries to improve the error message within our existing constraints.


