### PR TITLE
Revert shader support for unquantized vertex tables

### DIFF
--- a/core/frontend/src/render/primitives/VertexTable.ts
+++ b/core/frontend/src/render/primitives/VertexTable.ts
@@ -551,14 +551,46 @@ namespace Unquantized { // eslint-disable-line @typescript-eslint/no-redeclare
     public get qparams() { return this._qparams3d; }
 
     public appendVertex(vertIndex: number): void {
-      this.appendPosition(vertIndex);
-      this.appendFeatureIndex(vertIndex);
+      // this.appendPosition(vertIndex);
+      // this.appendFeatureIndex(vertIndex);
+      this.appendTransPosAndFeatureNdx(vertIndex);
       this.appendColorIndex(vertIndex);
     }
 
     private appendFloat32(val: number) {
       f32Array[0] = val;
       this.append32(u32Array[0]);
+    }
+
+    private convertFloat32(val: number): number {
+      f32Array[0] = val;
+      return u32Array[0];
+    }
+
+    protected appendTransPosAndFeatureNdx(vertIndex: number) {
+      // transpose position xyz vals into [0].xyz - [3].xyz, and add feature index at .w
+      // this is to order things to let shader code access much more efficiently
+      const pt = this._points[vertIndex];
+      const x = this.convertFloat32 (pt.x);
+      const y = this.convertFloat32 (pt.y);
+      const z = this.convertFloat32 (pt.z);
+      const featID = (this.args.features.featureIDs) ? this.args.features.featureIDs[vertIndex] : 0;
+      this.append8(x & 0x000000ff);
+      this.append8(y & 0x000000ff);
+      this.append8(z & 0x000000ff);
+      this.append8(featID & 0x000000ff);
+      this.append8((x >>> 8) & 0x000000ff);
+      this.append8((y >>> 8) & 0x000000ff);
+      this.append8((z >>> 8) & 0x000000ff);
+      this.append8((featID >>> 8) & 0x000000ff);
+      this.append8((x >>> 16) & 0x000000ff);
+      this.append8((y >>> 16) & 0x000000ff);
+      this.append8((z >>> 16) & 0x000000ff);
+      this.append8((featID >>> 16) & 0x000000ff);
+      this.append8(x >>> 24);
+      this.append8(y >>> 24);
+      this.append8(z >>> 24);
+      this.append8(featID >>> 24);
     }
 
     protected appendPosition(vertIndex: number) {

--- a/core/frontend/src/render/primitives/VertexTable.ts
+++ b/core/frontend/src/render/primitives/VertexTable.ts
@@ -551,9 +551,7 @@ namespace Unquantized { // eslint-disable-line @typescript-eslint/no-redeclare
     public get qparams() { return this._qparams3d; }
 
     public appendVertex(vertIndex: number): void {
-      // this.appendPosition(vertIndex);
-      // this.appendFeatureIndex(vertIndex);
-      this.appendTransPosAndFeatureNdx(vertIndex);
+      this.appendTransposePosAndFeatureNdx(vertIndex);
       this.appendColorIndex(vertIndex);
     }
 
@@ -567,7 +565,7 @@ namespace Unquantized { // eslint-disable-line @typescript-eslint/no-redeclare
       return u32Array[0];
     }
 
-    protected appendTransPosAndFeatureNdx(vertIndex: number) {
+    protected appendTransposePosAndFeatureNdx(vertIndex: number) {
       // transpose position xyz vals into [0].xyz - [3].xyz, and add feature index at .w
       // this is to order things to let shader code access much more efficiently
       const pt = this._points[vertIndex];

--- a/core/frontend/src/render/primitives/mesh/MeshBuilderMap.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshBuilderMap.ts
@@ -132,7 +132,7 @@ export class MeshBuilderMap extends Dictionary<MeshBuilderMap.Key, MeshBuilder> 
     const { facetAreaTolerance, tolerance, is2d, range } = this;
     const key = this.getKey(displayParams, type, hasNormals, isPlanar);
 
-    const quantizePositions = false; // ###TODO should this be configurable?
+    const quantizePositions = true; // ###TODO should this be configurable?
     return this.getBuilderFromKey(key, {
       displayParams,
       type,

--- a/core/frontend/src/render/webgl/glsl/Color.ts
+++ b/core/frontend/src/render/webgl/glsl/Color.ts
@@ -14,7 +14,7 @@ import { addInstanceColor } from "./Instancing";
 // NB: Color in color table has pre-multiplied alpha - revert it.
 const computeElementColor = `
   float colorTableStart = u_vertParams.z * u_vertParams.w; // num rgba per-vertex times num vertices
-  float colorIndex = decodeUInt16(g_usesQuantizedPosition ? g_vertLutData[1].zw : g_vertLutData[4].xy);
+  float colorIndex = decodeUInt16(g_usesQuantizedPosition ? g_vertLutData1.zw : g_vertLutData4.xy);
   vec2 tc = computeLUTCoords(colorTableStart+colorIndex, u_vertParams.xy, g_vert_center, 1.0);
   vec4 lutColor = TEXTURE(u_vertLUT, tc);
   lutColor.rgb /= max(0.0001, lutColor.a);

--- a/core/frontend/src/render/webgl/glsl/Color.ts
+++ b/core/frontend/src/render/webgl/glsl/Color.ts
@@ -14,7 +14,7 @@ import { addInstanceColor } from "./Instancing";
 // NB: Color in color table has pre-multiplied alpha - revert it.
 const computeElementColor = `
   float colorTableStart = u_vertParams.z * u_vertParams.w; // num rgba per-vertex times num vertices
-  float colorIndex = decodeUInt16(g_usesQuantizedPosition ? g_vertLutData1.zw : g_vertLutData4.xy);
+  float colorIndex = decodeUInt16(g_vertLutData1.zw);
   vec2 tc = computeLUTCoords(colorTableStart+colorIndex, u_vertParams.xy, g_vert_center, 1.0);
   vec4 lutColor = TEXTURE(u_vertLUT, tc);
   lutColor.rgb /= max(0.0001, lutColor.a);

--- a/core/frontend/src/render/webgl/glsl/Decode.ts
+++ b/core/frontend/src/render/webgl/glsl/Decode.ts
@@ -94,12 +94,27 @@ export function addUnpackAndNormalize2Bytes(builder: ShaderBuilder): void {
 export const decodeFloat32 = `
 float decodeFloat32(vec4 packedFloat) {
   float sign = 1.0 - step(128.0, packedFloat[3]) * 2.0;
-  float exponent = 2.0 * mod(packedFloat[3], 128.0) + step(128.0, packedFloat[2]) - 127.0;    
+  float exponent = 2.0 * mod(packedFloat[3], 128.0) + step(128.0, packedFloat[2]) - 127.0;
   if (exponent == -127.0)
     return 0.0;
 
   float mantissa = mod(packedFloat[2], 128.0) * 65536.0 + packedFloat[1] * 256.0 + packedFloat[0] + float(0x800000);
   float result = sign * exp2(exponent - 23.0) * mantissa;
+  return result;
+}
+`;
+
+export const decode3Float32 = `
+// This expects an array of 4 vec3s, where each vec4 contains a slice of all 3 of the packed floats in .xyz
+// pf0 is in [0].x, pf1 is in [0].y, and pf2 in [0].z
+// e.g.: packedFloat[0] = vec3(pf0.x, pf1.x, pf2.x)
+// likewise .y info is in [1], .z in [2], and .w in [3]
+vec3 decode3Float32(vec3 packedFloat[4]) {
+  vec3 sign = 1.0 - step(128.0, packedFloat[3].xyz) * 2.0;
+  vec3 exponent = 2.0 * mod(packedFloat[3].xyz, 128.0) + step(128.0, packedFloat[2].xyz) - 127.0;
+  vec3 zeroFlag = vec3(notEqual(vec3(-127.0), exponent));
+  vec3 mantissa = mod(packedFloat[2].xyz, 128.0) * 65536.0 + packedFloat[1].xyz * 256.0 + packedFloat[0].xyz + float(0x800000);
+  vec3 result = sign * exp2(exponent - 23.0) * mantissa * zeroFlag;
   return result;
 }
 `;

--- a/core/frontend/src/render/webgl/glsl/Edge.ts
+++ b/core/frontend/src/render/webgl/glsl/Edge.ts
@@ -30,20 +30,8 @@ const computeOtherPos = `
   vec4 enc0 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
   tc.x += g_vert_stepX;
   vec4 enc1 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
-  if (g_usesQuantizedPosition) {
-    vec3 qpos = vec3(decodeUInt16(enc0.xy), decodeUInt16(enc0.zw), decodeUInt16(enc1.xy));
-    g_otherPos = unquantizePosition(qpos, u_qOrigin, u_qScale);
-  } else {
-    uvec3 vux = uvec3(enc0.xyz);
-    uvec3 vuy = uvec3(enc1.xyz);
-    tc.x += g_vert_stepX;
-    uvec3 vuz = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
-    tc.x += g_vert_stepX;
-    uvec3 vuw = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
-    uvec3 u = (vuw << 24) | (vuz << 16) | (vuy << 8) | vux;
-    g_otherPos.xyz = uintBitsToFloat(u);
-    g_otherPos.w = 1.0;
-  }
+  vec3 qpos = vec3(decodeUInt16(enc0.xy), decodeUInt16(enc0.zw), decodeUInt16(enc1.xy));
+  g_otherPos = unquantizePosition(qpos, u_qOrigin, u_qScale);
 `;
 
 const decodeEndPointAndQuadIndices = `

--- a/core/frontend/src/render/webgl/glsl/Edge.ts
+++ b/core/frontend/src/render/webgl/glsl/Edge.ts
@@ -27,18 +27,21 @@ export type EdgeBuilderType = "SegmentEdge" | "Silhouette" | "IndexedEdge";
 
 const computeOtherPos = `
   vec2 tc = computeLUTCoords(g_otherIndex, u_vertParams.xy, g_vert_center, u_vertParams.z);
+  vec4 enc0 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+  tc.x += g_vert_stepX;
+  vec4 enc1 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
   if (g_usesQuantizedPosition) {
-    vec4 enc1 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
-    tc.x += g_vert_stepX;
-    vec4 enc2 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
-    vec3 qpos = vec3(decodeUInt16(enc1.xy), decodeUInt16(enc1.zw), decodeUInt16(enc2.xy));
+    vec3 qpos = vec3(decodeUInt16(enc0.xy), decodeUInt16(enc0.zw), decodeUInt16(enc1.xy));
     g_otherPos = unquantizePosition(qpos, u_qOrigin, u_qScale);
   } else {
-    for (int i = 0; i < 3; i++) {
-      g_otherPos[i] = decodeFloat32(floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5));
-      tc.x += g_vert_stepX;
-    }
-
+    uvec3 vux = uvec3(enc0.xyz);
+    uvec3 vuy = uvec3(enc1.xyz);
+    tc.x += g_vert_stepX;
+    uvec3 vuz = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
+    tc.x += g_vert_stepX;
+    uvec3 vuw = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
+    uvec3 u = (vuw << 24) | (vuz << 16) | (vuy << 8) | vux;
+    g_otherPos.xyz = uintBitsToFloat(u);
     g_otherPos.w = 1.0;
   }
 `;

--- a/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
+++ b/core/frontend/src/render/webgl/glsl/FeatureSymbology.ts
@@ -19,7 +19,7 @@ import { decodeDepthRgb, decodeUint24 } from "./Decode";
 import { addWindowToTexCoords, assignFragColor, computeLinearDepth } from "./Fragment";
 import { addLookupTable } from "./LookupTable";
 import { addRenderPass } from "./RenderPass";
-import { addAlpha, addFeatureAndMaterialLookup, addLineWeight, replaceLineCode, replaceLineWeight } from "./Vertex";
+import { addAlpha, addLineWeight, replaceLineCode, replaceLineWeight } from "./Vertex";
 
 /* eslint-disable no-restricted-syntax */
 
@@ -142,9 +142,6 @@ function addFeatureIndex(vert: VertexShaderBuilder): void {
 
   vert.addFunction(decodeUint24);
   vert.addFunction(getFeatureIndex(vert));
-
-  if (vert.usesVertexTable && !vert.usesInstancedGeometry)
-    addFeatureAndMaterialLookup(vert);
 }
 
 // Discards vertex if feature is invisible; or rendering opaque during translucent pass or vice-versa

--- a/core/frontend/src/render/webgl/glsl/Polyline.ts
+++ b/core/frontend/src/render/webgl/glsl/Polyline.ts
@@ -211,19 +211,8 @@ vec4 decodePosition(vec3 baseIndex) {
   vec4 e0 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
   tc.x += g_vert_stepX;
   vec4 e1 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
-  if (g_usesQuantizedPosition) {
-    vec3 qpos = vec3(decodeUInt16(e0.xy), decodeUInt16(e0.zw), decodeUInt16(e1.xy));
-    return unquantizePosition(qpos, u_qOrigin, u_qScale);
-  } else {
-    uvec3 vux = uvec3(e0.xyz);
-    uvec3 vuy = uvec3(e1.xyz);
-    tc.x += g_vert_stepX;
-    uvec3 vuz = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
-    tc.x += g_vert_stepX;
-    uvec3 vuw = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
-    uvec3 u = (vuw << 24) | (vuz << 16) | (vuy << 8) | vux;
-    return vec4(uintBitsToFloat(u), 1.0);
-  }
+  vec3 qpos = vec3(decodeUInt16(e0.xy), decodeUInt16(e0.zw), decodeUInt16(e1.xy));
+  return unquantizePosition(qpos, u_qOrigin, u_qScale);
 }
 `;
 

--- a/core/frontend/src/render/webgl/glsl/Polyline.ts
+++ b/core/frontend/src/render/webgl/glsl/Polyline.ts
@@ -208,22 +208,22 @@ const decodePosition = `
 vec4 decodePosition(vec3 baseIndex) {
   float index = decodeUInt24(baseIndex);
   vec2 tc = compute_vert_coords(index);
+  vec4 e0 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+  tc.x += g_vert_stepX;
+  vec4 e1 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
   if (g_usesQuantizedPosition) {
-    vec4 e0 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
-    tc.x += g_vert_stepX;
-    vec4 e1 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
     vec3 qpos = vec3(decodeUInt16(e0.xy), decodeUInt16(e0.zw), decodeUInt16(e1.xy));
     return unquantizePosition(qpos, u_qOrigin, u_qScale);
-  }
-
-  vec4 position;
-  for (int i = 0; i < 3; i++) {
-    position[i] = decodeFloat32(floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5));
+  } else {
+    uvec3 vux = uvec3(e0.xyz);
+    uvec3 vuy = uvec3(e1.xyz);
     tc.x += g_vert_stepX;
+    uvec3 vuz = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
+    tc.x += g_vert_stepX;
+    uvec3 vuw = uvec3(floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5));
+    uvec3 u = (vuw << 24) | (vuz << 16) | (vuy << 8) | vux;
+    return vec4(uintBitsToFloat(u), 1.0);
   }
-
-  position.w = 1.0;
-  return position;
 }
 `;
 

--- a/core/frontend/src/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/render/webgl/glsl/Surface.ts
@@ -133,7 +133,12 @@ const computeMaterial = `
   }
 `;
 
-function addMaterial(builder: ProgramBuilder): void {
+const computeMaterialInstanced = `
+  decodeMaterialColor(u_materialColor);
+  g_materialParams = u_materialParams;
+`;
+
+function addMaterial(builder: ProgramBuilder, instanced: boolean): void {
   const frag = builder.frag;
   assert(undefined !== frag.find("v_surfaceFlags"));
 
@@ -175,20 +180,21 @@ function addMaterial(builder: ProgramBuilder): void {
     });
   });
 
-  // Material atlas
-  addFeatureAndMaterialLookup(vert);
-  vert.addFunction(unpackFloat);
-  vert.addFunction(readMaterialAtlas);
-  vert.addUniform("u_numColors", VariableType.Float, (prog) => {
-    prog.addGraphicUniform("u_numColors", (uniform, params) => {
-      const info = params.geometry.materialInfo;
-      const numColors = undefined !== info && info.isAtlas ? info.vertexTableOffset : 0;
-      uniform.setUniform1f(numColors);
+  if (!instanced) {
+    // Material atlas
+    addFeatureAndMaterialLookup(vert);
+    vert.addFunction(unpackFloat);
+    vert.addFunction(readMaterialAtlas);
+    vert.addUniform("u_numColors", VariableType.Float, (prog) => {
+      prog.addGraphicUniform("u_numColors", (uniform, params) => {
+        const info = params.geometry.materialInfo;
+        const numColors = undefined !== info && info.isAtlas ? info.vertexTableOffset : 0;
+        uniform.setUniform1f(numColors);
+      });
     });
-  });
-
+  }
   vert.addGlobal("g_materialParams", VariableType.Vec4);
-  vert.set(VertexShaderComponent.ComputeMaterial, computeMaterial);
+  vert.set(VertexShaderComponent.ComputeMaterial, instanced ? computeMaterialInstanced : computeMaterial);
   vert.set(VertexShaderComponent.ApplyMaterialColor, applyMaterialColor);
   builder.addFunctionComputedVarying("v_materialParams", VariableType.Vec4, "computeMaterialParams", computeMaterialParams);
 }
@@ -601,7 +607,7 @@ export function createSurfaceBuilder(flags: TechniqueFlags): ProgramBuilder {
     addTransparencyDiscard(builder.frag);
 
   addSurfaceMonochrome(builder.frag);
-  addMaterial(builder);
+  addMaterial(builder, flags.isInstanced === IsInstanced.Yes);
 
   if (flags.isWiremesh)
     addWiremesh(builder);

--- a/core/frontend/src/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/render/webgl/glsl/Surface.ts
@@ -35,7 +35,7 @@ import { addRenderPass } from "./RenderPass";
 import { addSolarShadowMap } from "./SolarShadowMapping";
 import { addThematicDisplay, getComputeThematicIndex } from "./Thematic";
 import { addTranslucency } from "./Translucency";
-import { addFeatureAndMaterialLookup, addModelViewMatrix, addNormalMatrix, addProjectionMatrix } from "./Vertex";
+import { addModelViewMatrix, addNormalMatrix, addProjectionMatrix } from "./Vertex";
 import { wantMaterials } from "../SurfaceGeometry";
 import { addWiremesh } from "./Wiremesh";
 
@@ -182,7 +182,6 @@ function addMaterial(builder: ProgramBuilder, instanced: boolean): void {
 
   if (!instanced) {
     // Material atlas
-    addFeatureAndMaterialLookup(vert);
     vert.addFunction(unpackFloat);
     vert.addFunction(readMaterialAtlas);
     vert.addUniform("u_numColors", VariableType.Float, (prog) => {

--- a/core/frontend/src/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/render/webgl/glsl/Surface.ts
@@ -357,10 +357,7 @@ const computeNormal = `
   if (!u_surfaceFlags[kSurfaceBitIndex_HasNormals])
     return vec3(0.0);
   vec2 normal;
-  if (u_surfaceFlags[kSurfaceBitIndex_HasColorAndNormal])
-    normal = g_usesQuantizedPosition ? g_vertLutData3.xy : g_vertLutData4.zw;
-  else
-    normal = g_usesQuantizedPosition ? g_vertLutData1.zw : g_vertLutData5.xy;
+  normal = (u_surfaceFlags[kSurfaceBitIndex_HasColorAndNormal]) ? g_vertLutData3.xy : g_vertLutData1.zw;
   return normalize(MAT_NORM * octDecodeNormal(normal));
 `;
 
@@ -374,7 +371,7 @@ const applyBackgroundColor = `
 `;
 
 const computeTexCoord = `
-  vec4 rgba = g_usesQuantizedPosition ? g_vertLutData3 : g_vertLutData4;
+  vec4 rgba = g_vertLutData3;
   vec2 qcoords = vec2(decodeUInt16(rgba.xy), decodeUInt16(rgba.zw));
   return chooseVec2WithBitFlag(vec2(0.0), unquantize2d(qcoords, u_qTexCoordParams), surfaceFlags, kSurfaceBit_HasTexture);
 `;

--- a/core/frontend/src/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/render/webgl/glsl/Surface.ts
@@ -356,13 +356,11 @@ vec3 octDecodeNormal(vec2 e) {
 const computeNormal = `
   if (!u_surfaceFlags[kSurfaceBitIndex_HasNormals])
     return vec3(0.0);
-
   vec2 normal;
   if (u_surfaceFlags[kSurfaceBitIndex_HasColorAndNormal])
-    normal = g_usesQuantizedPosition ? g_vertLutData[3].xy : g_vertLutData[4].zw;
+    normal = g_usesQuantizedPosition ? g_vertLutData3.xy : g_vertLutData4.zw;
   else
-    normal = g_usesQuantizedPosition ? g_vertLutData[1].zw : g_vertLutData[5].xy;
-
+    normal = g_usesQuantizedPosition ? g_vertLutData1.zw : g_vertLutData5.xy;
   return normalize(MAT_NORM * octDecodeNormal(normal));
 `;
 
@@ -376,7 +374,7 @@ const applyBackgroundColor = `
 `;
 
 const computeTexCoord = `
-  vec4 rgba = g_usesQuantizedPosition ? g_vertLutData[3] : g_vertLutData[4];
+  vec4 rgba = g_usesQuantizedPosition ? g_vertLutData3 : g_vertLutData4;
   vec2 qcoords = vec2(decodeUInt16(rgba.xy), decodeUInt16(rgba.zw));
   return chooseVec2WithBitFlag(vec2(0.0), unquantize2d(qcoords, u_qTexCoordParams), surfaceFlags, kSurfaceBit_HasTexture);
 `;

--- a/core/frontend/src/render/webgl/glsl/Vertex.ts
+++ b/core/frontend/src/render/webgl/glsl/Vertex.ts
@@ -31,17 +31,25 @@ export const unquantizeVertexPosition = `
 vec4 unquantizeVertexPosition(vec3 pos, vec3 origin, vec3 scale) { return unquantizePosition(pos, origin, scale); }
 `;
 
-// Need to read 2 rgba values to obtain 6 16-bit integers for position
+// Need to read 2 rgba values to obtain 6 16-bit integers for unquantize position
 const unquantizeVertexPositionFromLUT = `
 vec4 unquantizeVertexPosition(vec3 encodedIndex, vec3 origin, vec3 scale) {
   if (g_usesQuantizedPosition) {
-    vec4 enc1 = g_vertLutData[0];
-    vec4 enc2 = g_vertLutData[1];
-    vec3 qpos = vec3(decodeUInt16(enc1.xy), decodeUInt16(enc1.zw), decodeUInt16(enc2.xy));
+    vec3 qpos = vec3(decodeUInt16(g_vertLutData0.xy), decodeUInt16(g_vertLutData0.zw), decodeUInt16(g_vertLutData1.xy));
+    g_featureAndMaterialIndex = g_vertLutData2;
     return unquantizePosition(qpos, origin, scale);
+  } else {
+    uvec3 vux = uvec3(g_vertLutData0.xyz);
+    g_featureAndMaterialIndex.x = g_vertLutData0.w;
+    uvec3 vuy = uvec3(g_vertLutData1.xyz);
+    g_featureAndMaterialIndex.y = g_vertLutData1.w;
+    uvec3 vuz = uvec3(g_vertLutData2.xyz);
+    g_featureAndMaterialIndex.z = g_vertLutData2.w;
+    uvec3 vuw = uvec3(g_vertLutData3.xyz);
+    g_featureAndMaterialIndex.w = g_vertLutData3.w;
+    uvec3 u = (vuw << 24) | (vuz << 16) | (vuy << 8) | vux;
+    return vec4(uintBitsToFloat(u), 1.0);
   }
-
-  return vec4(decodeFloat32(g_vertLutData[0]), decodeFloat32(g_vertLutData[1]), decodeFloat32(g_vertLutData[2]), 1.0);
 }
 `;
 
@@ -164,7 +172,7 @@ function addPositionFromLUT(vert: VertexShaderBuilder) {
 
   vert.addFunction(decodeUint24);
   vert.addFunction(decodeUint16);
-  vert.addFunction(decodeFloat32);
+  // vert.addFunction(decodeFloat32);
   vert.addFunction(unquantizeVertexPositionFromLUT);
 
   vert.addUniform("u_vertLUT", VariableType.Sampler2D, (prog) => {
@@ -189,19 +197,39 @@ function addPositionFromLUT(vert: VertexShaderBuilder) {
   addLookupTable(vert, "vert", "u_vertParams.z");
   vert.addInitializer(initializeVertLUTCoords);
 
-  assert(undefined !== vert.maxRgbaPerVertex);
-  const maxRgbaPerVertex = vert.maxRgbaPerVertex.toString();
-  vert.addGlobal(`g_vertLutData[${maxRgbaPerVertex}]`, VariableType.Vec4);
+  // assert(undefined !== vert.maxRgbaPerVertex);
+  // const maxRgbaPerVertex = vert.maxRgbaPerVertex.toString();
+  // vert.addGlobal(`g_vertLutData[${maxRgbaPerVertex}]`, VariableType.Vec4);
+  vert.addGlobal(`g_vertLutData0`, VariableType.Vec4);
+  vert.addGlobal(`g_vertLutData1`, VariableType.Vec4);
+  vert.addGlobal(`g_vertLutData2`, VariableType.Vec4);
+  vert.addGlobal(`g_vertLutData3`, VariableType.Vec4);
+  vert.addGlobal(`g_vertLutData4`, VariableType.Vec4);
+  vert.addGlobal(`g_vertLutData5`, VariableType.Vec4);
   vert.addGlobal("g_usesQuantizedPosition", VariableType.Boolean);
+  vert.addGlobal("g_featureAndMaterialIndex", VariableType.Vec4);
 
   // Read the vertex data from the vertex table up front. If using WebGL 2, only read the number of RGBA values we actually need for this vertex table.
-  const loopStart = `for (int i = 0; i < ${System.instance.capabilities.isWebGL2 ? "int(u_vertParams.z)" : maxRgbaPerVertex}; i++)`;
+  // const loopStart = `for (int i = 0; i < ${System.instance.capabilities.isWebGL2 ? "int(u_vertParams.z)" : maxRgbaPerVertex}; i++)`;
   vert.addInitializer(`
     g_usesQuantizedPosition = u_qScale.x >= 0.0;
     vec2 tc = g_vertexBaseCoords;
-    ${loopStart} {
-      g_vertLutData[i] = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    g_vertLutData0 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    tc.x += g_vert_stepX;
+    g_vertLutData1 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    tc.x += g_vert_stepX;
+    g_vertLutData2 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    if (3.0 < u_vertParams.z) {
       tc.x += g_vert_stepX;
+      g_vertLutData3 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    }
+    if (4.0 < u_vertParams.z) {
+      tc.x += g_vert_stepX;
+      g_vertLutData4 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    }
+    if (5.0 < u_vertParams.z) {
+      tc.x += g_vert_stepX;
+      g_vertLutData5 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
     }
   `);
 }
@@ -292,11 +320,10 @@ export function replaceLineCode(vert: VertexShaderBuilder, func: string): void {
 
 /** @internal */
 export function addFeatureAndMaterialLookup(vert: VertexShaderBuilder): void {
-  if (undefined !== vert.find("g_featureAndMaterialIndex"))
-    return;
+  // if (undefined !== vert.find("g_featureAndMaterialIndex"))
+  //   return;
 
   const computeFeatureAndMaterialIndex = `
-    g_featureAndMaterialIndex = g_usesQuantizedPosition ? g_vertLutData[2] : g_vertLutData[3];
   `;
 
   vert.addGlobal("g_featureAndMaterialIndex", VariableType.Vec4);

--- a/core/frontend/src/render/webgl/glsl/Vertex.ts
+++ b/core/frontend/src/render/webgl/glsl/Vertex.ts
@@ -34,22 +34,9 @@ vec4 unquantizeVertexPosition(vec3 pos, vec3 origin, vec3 scale) { return unquan
 // Need to read 2 rgba values to obtain 6 16-bit integers for unquantize position
 const unquantizeVertexPositionFromLUT = `
 vec4 unquantizeVertexPosition(vec3 encodedIndex, vec3 origin, vec3 scale) {
-  if (g_usesQuantizedPosition) {
-    vec3 qpos = vec3(decodeUInt16(g_vertLutData0.xy), decodeUInt16(g_vertLutData0.zw), decodeUInt16(g_vertLutData1.xy));
-    g_featureAndMaterialIndex = g_vertLutData2;
-    return unquantizePosition(qpos, origin, scale);
-  } else {
-    uvec3 vux = uvec3(g_vertLutData0.xyz);
-    g_featureAndMaterialIndex.x = g_vertLutData0.w;
-    uvec3 vuy = uvec3(g_vertLutData1.xyz);
-    g_featureAndMaterialIndex.y = g_vertLutData1.w;
-    uvec3 vuz = uvec3(g_vertLutData2.xyz);
-    g_featureAndMaterialIndex.z = g_vertLutData2.w;
-    uvec3 vuw = uvec3(g_vertLutData3.xyz);
-    g_featureAndMaterialIndex.w = g_vertLutData3.w;
-    uvec3 u = (vuw << 24) | (vuz << 16) | (vuy << 8) | vux;
-    return vec4(uintBitsToFloat(u), 1.0);
-  }
+  vec3 qpos = vec3(decodeUInt16(g_vertLutData0.xy), decodeUInt16(g_vertLutData0.zw), decodeUInt16(g_vertLutData1.xy));
+  g_featureAndMaterialIndex = g_vertLutData2;
+  return unquantizePosition(qpos, origin, scale);
 }
 `;
 
@@ -204,15 +191,15 @@ function addPositionFromLUT(vert: VertexShaderBuilder) {
   vert.addGlobal(`g_vertLutData1`, VariableType.Vec4);
   vert.addGlobal(`g_vertLutData2`, VariableType.Vec4);
   vert.addGlobal(`g_vertLutData3`, VariableType.Vec4);
-  vert.addGlobal(`g_vertLutData4`, VariableType.Vec4);
-  vert.addGlobal(`g_vertLutData5`, VariableType.Vec4);
-  vert.addGlobal("g_usesQuantizedPosition", VariableType.Boolean);
+  // vert.addGlobal(`g_vertLutData4`, VariableType.Vec4);
+  // vert.addGlobal(`g_vertLutData5`, VariableType.Vec4);
+  // vert.addGlobal("g_usesQuantizedPosition", VariableType.Boolean);
   vert.addGlobal("g_featureAndMaterialIndex", VariableType.Vec4);
 
   // Read the vertex data from the vertex table up front. If using WebGL 2, only read the number of RGBA values we actually need for this vertex table.
   // const loopStart = `for (int i = 0; i < ${System.instance.capabilities.isWebGL2 ? "int(u_vertParams.z)" : maxRgbaPerVertex}; i++)`;
   vert.addInitializer(`
-    g_usesQuantizedPosition = u_qScale.x >= 0.0;
+    // g_usesQuantizedPosition = u_qScale.x >= 0.0;
     vec2 tc = g_vertexBaseCoords;
     g_vertLutData0 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
     tc.x += g_vert_stepX;
@@ -223,14 +210,14 @@ function addPositionFromLUT(vert: VertexShaderBuilder) {
       tc.x += g_vert_stepX;
       g_vertLutData3 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
     }
-    if (4.0 < u_vertParams.z) {
-      tc.x += g_vert_stepX;
-      g_vertLutData4 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
-    }
-    if (5.0 < u_vertParams.z) {
-      tc.x += g_vert_stepX;
-      g_vertLutData5 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
-    }
+    // if (4.0 < u_vertParams.z) {
+    //   tc.x += g_vert_stepX;
+    //   g_vertLutData4 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    // }
+    // if (5.0 < u_vertParams.z) {
+    //   tc.x += g_vert_stepX;
+    //   g_vertLutData5 = floor(TEXTURE(u_vertLUT, tc) * 255.0 + 0.5);
+    // }
   `);
 }
 


### PR DESCRIPTION
The PR for Support unquantized vertex tables #3288 caused GPU slowdowns on performance testing, particularly on slower GPUs.  After a lot of investigation and optimizing GPU code, it was found that even after optimization, there was still enough difference to justify splitting the unquantized support into separate shaders, which will be done in a separate PR.

This PR removes support for unquantized vertex tables from the current shaders, and turns off the flag to use unquantized.  It does keep an optimized version of shader code for pre-loading the vertex tables, that was also introduced in 3288.

TODO: Fix bug with decorators moving (zoom dependent) in this version.

Also learned during this investigation:
- Indexing a vector (rather than accessing its components, at least in cases where it can't be directly replaced by the component version) causes a performance hit and causes zingers on at least some Intel Integrated graphics.  An example of this is declaring a "vec4 v", then using it inside a loop  like "v[i] = func ();" where i is expected to address x, y, z, w components of the vector sequentially.
- Using a global array (which at assembly level uses an indexable temp register instead of a regular temp register) is a performance hit over separately declared vars.  E.g.: using "vec4 g_temp0; vec4 g_temp1; vec4 g_temp2" is better than using "vec4 g_temp[3];"