### PR TITLE
Fix framebuffer resize issue that causes WebGL errors

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -7339,6 +7339,7 @@ export class OnScreenTarget extends Target {
     protected _assignDC(): boolean;
     // (undocumented)
     protected _beginPaint(fbo: FrameBuffer): void;
+    checkFboDimensions(): boolean;
     // (undocumented)
     collectStatistics(stats: RenderMemory.Statistics): void;
     // (undocumented)
@@ -10289,6 +10290,8 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
     endPerfMetricFrame(readPixels?: boolean): void;
     // (undocumented)
     endPerfMetricRecord(readPixels?: boolean): void;
+    // (undocumented)
+    protected _fbo?: FrameBuffer;
     // (undocumented)
     get flashed(): Id64.Uint32Pair | undefined;
     // (undocumented)

--- a/common/changes/@itwin/core-frontend/markschlosser-fix-fbo-resize-errors_2022-03-28-14-00.json
+++ b/common/changes/@itwin/core-frontend/markschlosser-fix-fbo-resize-errors_2022-03-28-14-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix WebGL framebuffer errors that can occur when resizing viewport.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -3356,7 +3356,11 @@ export class ScreenViewport extends Viewport {
       _clear2dCanvas(this.canvas);
     }
 
-    this.target.updateViewRect();
+    const resized = this.target.updateViewRect();
+    if (resized) {
+      this.target.onResized();
+      this.invalidateController();
+    }
     this.invalidateRenderPlan();
   }
 }

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -101,7 +101,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   private _renderCommands: RenderCommands;
   private _overlayRenderState: RenderState;
   protected _compositor: SceneCompositor;
-  private _fbo?: FrameBuffer;
+  protected _fbo?: FrameBuffer;
   private _dcAssigned = false;
   public performanceMetrics?: PerformanceMetrics;
   public readonly decorationsState = BranchState.createForDecorations(); // Used when rendering view background and view/world overlays.
@@ -1284,7 +1284,19 @@ export class OnScreenTarget extends Target {
     const changed2d = this._2dCanvas.updateDimensions(pixelRatio);
     const changedWebGL = this._webglCanvas.updateDimensions(pixelRatio);
     this.renderRect.init(0, 0, this._curCanvas.width, this._curCanvas.height);
-    return this._usingWebGLCanvas ? changedWebGL : changed2d;
+    const changed = this._usingWebGLCanvas ? changedWebGL : changed2d;
+
+    // Certain UI events appear to be able to halt and then restart the execution of the event loop.
+    // This means that updateViewRect() can return true, but the framebuffer could never resize in response to that.
+    // The following code solves that issue by checking for a canvas-framebuffer size mismatch.
+    // Such a mismatch indicates that the framebuffer never reacted to the resize because the event loop was interrupted.
+    if (!changed && undefined !== this._fbo) {
+      const tx = this._fbo.getColor(0);
+      if (tx.width !== this._curCanvas.width || tx.height !== this._curCanvas.height)
+        return true; // Return true so the framebuffer will get recreated
+    }
+
+    return changed;
   }
 
   protected _beginPaint(fbo: FrameBuffer): void {

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -101,7 +101,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   private _renderCommands: RenderCommands;
   private _overlayRenderState: RenderState;
   protected _compositor: SceneCompositor;
-  private _fbo?: FrameBuffer;
+  protected _fbo?: FrameBuffer;
   private _dcAssigned = false;
   public performanceMetrics?: PerformanceMetrics;
   public readonly decorationsState = BranchState.createForDecorations(); // Used when rendering view background and view/world overlays.
@@ -1262,6 +1262,16 @@ export class OnScreenTarget extends Target {
 
   public setViewRect(_rect: ViewRect, _temporary: boolean): void {
     assert(false);
+  }
+
+  /** Internal-only function for testing. Returns true if the FBO dimensions match the canvas dimensions */
+  public checkFboDimensions(): boolean {
+    if (undefined !== this._fbo) {
+      const tx = this._fbo.getColor(0);
+      if (tx.width !== this._curCanvas.width || tx.height !== this._curCanvas.height)
+        return false;
+    }
+    return true;
   }
 
   protected _assignDC(): boolean {

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -101,7 +101,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   private _renderCommands: RenderCommands;
   private _overlayRenderState: RenderState;
   protected _compositor: SceneCompositor;
-  protected _fbo?: FrameBuffer;
+  private _fbo?: FrameBuffer;
   private _dcAssigned = false;
   public performanceMetrics?: PerformanceMetrics;
   public readonly decorationsState = BranchState.createForDecorations(); // Used when rendering view background and view/world overlays.

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -1284,19 +1284,7 @@ export class OnScreenTarget extends Target {
     const changed2d = this._2dCanvas.updateDimensions(pixelRatio);
     const changedWebGL = this._webglCanvas.updateDimensions(pixelRatio);
     this.renderRect.init(0, 0, this._curCanvas.width, this._curCanvas.height);
-    const changed = this._usingWebGLCanvas ? changedWebGL : changed2d;
-
-    // Certain UI events appear to be able to halt and then restart the execution of the event loop.
-    // This means that updateViewRect() can return true, but the framebuffer could never resize in response to that.
-    // The following code solves that issue by checking for a canvas-framebuffer size mismatch.
-    // Such a mismatch indicates that the framebuffer never reacted to the resize because the event loop was interrupted.
-    if (!changed && undefined !== this._fbo) {
-      const tx = this._fbo.getColor(0);
-      if (tx.width !== this._curCanvas.width || tx.height !== this._curCanvas.height)
-        return true; // Return true so the framebuffer will get recreated
-    }
-
-    return changed;
+    return this._usingWebGLCanvas ? changedWebGL : changed2d;
   }
 
   protected _beginPaint(fbo: FrameBuffer): void {

--- a/core/frontend/src/test/ViewManager.test.ts
+++ b/core/frontend/src/test/ViewManager.test.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { OnScreenTarget } from "../core-frontend";
+import { IModelApp } from "../IModelApp";
+import { IModelConnection } from "../IModelConnection";
+import { createBlankConnection } from "./createBlankConnection";
+import { openBlankViewport } from "./openBlankViewport";
+
+describe("ViewManager", () => {
+  let imodel: IModelConnection;
+
+  before(async () => {
+    await IModelApp.startup();
+    imodel = createBlankConnection("view-manager-test");
+  });
+
+  after(async () => {
+    await imodel.close();
+    await IModelApp.shutdown();
+  });
+
+  it("should resize fbo properly after dropping a recently-resized viewport", async () => {
+    const vp = openBlankViewport({ width: 32, height: 32 });
+    IModelApp.viewManager.addViewport(vp);
+    vp.renderFrame();
+    vp.vpDiv.style.width = vp.vpDiv.style.height = "3px";
+    IModelApp.viewManager.dropViewport(vp, false);
+    vp.renderFrame();
+    expect((vp.target as OnScreenTarget).checkFboDimensions()).to.be.true;
+    vp.dispose();
+  });
+});


### PR DESCRIPTION
This PR resolves a problem that can happen when viewports are resized after quickly dropping and adding them.
When a viewport is quickly dropped and added, an internal render-to-screen optimization gets toggled off and on.
The function that does this toggling updates the internally-tracked view rectangle in case of resize.  However, it does not then recreate the WebGL framebuffers with the new dimensions, causing this error to occur.

Work items: [here](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/534091) and [here](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/847343) and [here](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/824046)

Repro steps of the fixed issue:
1. Have display-test-app maximized with a file open (Hong Kong was open for me)
2. Open a new file (I was opening LivingRoom)
3. Immediately double click the title bar of dta to make the window no longer maximized – do this before the new file manages to load  (Or you might need to drag the viewport to be a smaller size instead).
4. The new file will be rendered with the new file rendering inset into the old rendering.
5. You will see WebGL framebuffer errors in the console.
6. This does not fix itself until resizing the window again.

WebGL errors:
![image](https://user-images.githubusercontent.com/47000437/159789825-a15a2458-8c0b-4ffd-97f1-41355eb25e6c.png)
