### PR TITLE
Improve support for WMS  server 1.1.1

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -13977,6 +13977,8 @@ export class WmsCapabilities {
     // (undocumented)
     getSubLayersCrs(subLayerNames: string[]): Map<string, string[]> | undefined;
     // (undocumented)
+    readonly isVersion13: boolean;
+    // (undocumented)
     get json(): any;
     // (undocumented)
     readonly layer?: WmsCapability.Layer;
@@ -13992,7 +13994,7 @@ export class WmsCapabilities {
 export namespace WmsCapability {
     // (undocumented)
     export class Layer {
-        constructor(_json: any);
+        constructor(json: any, capabilities: WmsCapabilities);
         // (undocumented)
         readonly cartoRange?: MapCartoRectangle;
         // (undocumented)
@@ -14026,7 +14028,7 @@ export namespace WmsCapability {
     }
     // (undocumented)
     export class SubLayer {
-        constructor(_json: any, parent?: SubLayer | undefined);
+        constructor(_json: any, capabilities: WmsCapabilities, parent?: SubLayer | undefined);
         // (undocumented)
         readonly cartoRange?: MapCartoRectangle;
         // (undocumented)

--- a/common/changes/@itwin/core-frontend/geo-wms_111_2022-03-30-19-08.json
+++ b/common/changes/@itwin/core-frontend/geo-wms_111_2022-03-30-19-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Improved support for WMS 1.1.1 servers.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/public/assets/wms_capabilities/mapproxy_111.xml
+++ b/core/frontend/src/test/public/assets/wms_capabilities/mapproxy_111.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0"?>
+<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd"
+ [
+ <!ELEMENT VendorSpecificCapabilities EMPTY>
+ ]>  <!-- end of DOCTYPE declaration -->
+<WMT_MS_Capabilities version="1.1.1">
+<Service>
+  <Name>OGC:WMS</Name>
+  <Title>MapProxy WMS</Title>
+  <Abstract></Abstract>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://mapservices.onemap.sg/mapproxy/service"/>
+  <Fees>none</Fees>
+  <AccessConstraints>none</AccessConstraints>
+</Service>
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <Format>application/vnd.ogc.wms_xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://mapservices.onemap.sg/mapproxy/service?"/></Get>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+        <Format>image/png</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://mapservices.onemap.sg/mapproxy/service?"/></Get>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+    <GetFeatureInfo>
+      <Format>text/plain</Format>
+      <Format>text/html</Format>
+      <Format>application/vnd.ogc.gml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://mapservices.onemap.sg/mapproxy/service?"/></Get>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+  </Request>
+  <Exception>
+    <Format>application/vnd.ogc.se_xml</Format>
+    <Format>application/vnd.ogc.se_inimage</Format>
+    <Format>application/vnd.ogc.se_blank</Format>
+  </Exception>
+  <Layer>
+    <Title>MapProxy WMS</Title>
+    <SRS>EPSG:4326</SRS>
+    <SRS>EPSG:3414</SRS>
+    <LatLonBoundingBox minx="103.358857333" miny="1.05386187892" maxx="104.766280454" maxy="1.76023057282" />
+    <BoundingBox SRS="EPSG:4326" minx="103.358857333" miny="1.05386187892" maxx="104.766280454" maxy="1.76023057282" />
+    <Layer>
+      <Name>Default</Name>
+      <Title>Default</Title>
+      <LatLonBoundingBox minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox SRS="EPSG:4326" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+    </Layer>
+    <Layer>
+      <Name>Original</Name>
+      <Title>Original</Title>
+      <LatLonBoundingBox minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox SRS="EPSG:4326" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+    </Layer>
+    <Layer>
+      <Name>Grey</Name>
+      <Title>Grey</Title>
+      <LatLonBoundingBox minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox SRS="EPSG:4326" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+    </Layer>
+    <Layer>
+      <Name>Night</Name>
+      <Title>Night</Title>
+      <LatLonBoundingBox minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox SRS="EPSG:4326" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+    </Layer>
+    <Layer>
+      <Name>singapore_3414_tms</Name>
+      <Title>singapore_3414_tms</Title>
+      <LatLonBoundingBox minx="103.595966412" miny="1.1442806158" maxx="104.165806259" maxy="1.49822231742" />
+      <BoundingBox SRS="EPSG:4326" minx="103.595966412" miny="1.1442806158" maxx="104.165806259" maxy="1.49822231742" />
+    </Layer>
+    <Layer>
+      <Name>singapore_3414_wms</Name>
+      <Title>singapore_3414_wms</Title>
+      <LatLonBoundingBox minx="103.358857333" miny="1.05386187892" maxx="104.766280454" maxy="1.76023057282" />
+      <BoundingBox SRS="EPSG:4326" minx="103.358857333" miny="1.05386187892" maxx="104.766280454" maxy="1.76023057282" />
+    </Layer>
+    <Layer>
+      <Name>singapore_3414_wmts</Name>
+      <Title>singapore_3414_wmts</Title>
+      <LatLonBoundingBox minx="103.595966412" miny="1.1442806158" maxx="104.165806259" maxy="1.49822231742" />
+      <BoundingBox SRS="EPSG:4326" minx="103.595966412" miny="1.1442806158" maxx="104.165806259" maxy="1.49822231742" />
+    </Layer>
+    <Layer>
+      <Name>singapore_landlot_wmts</Name>
+      <Title>singapore_landlot_wmts</Title>
+      <LatLonBoundingBox minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox SRS="EPSG:4326" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+    </Layer>
+  </Layer>
+</Capability>
+</WMT_MS_Capabilities>

--- a/core/frontend/src/test/public/assets/wms_capabilities/mapproxy_130.xml
+++ b/core/frontend/src/test/public/assets/wms_capabilities/mapproxy_130.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" ?>
+<WMS_Capabilities xmlns="http://www.opengis.net/wms" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3.0" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd">
+<Service>
+  <Name>WMS</Name>
+  <Title>MapProxy WMS</Title>
+  <Abstract></Abstract>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://mapservices.onemap.sg/mapproxy/service"/>
+    <Fees>none</Fees>
+    <AccessConstraints>none</AccessConstraints>
+</Service>
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xlink:href="http://mapservices.onemap.sg/mapproxy/service?"/></Get>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+      <Format>image/png</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xlink:href="http://mapservices.onemap.sg/mapproxy/service?"/></Get>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+    <GetFeatureInfo>
+      <Format>text/plain</Format>
+      <Format>text/html</Format>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xlink:href="http://mapservices.onemap.sg/mapproxy/service?"/></Get>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+  </Request>
+  <Exception>
+    <Format>XML</Format>
+    <Format>INIMAGE</Format>
+    <Format>BLANK</Format>
+  </Exception>
+  <Layer>
+    <Title>MapProxy WMS</Title>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3414</CRS>
+    <EX_GeographicBoundingBox>
+      <westBoundLongitude>103.358857333</westBoundLongitude>
+      <eastBoundLongitude>104.766280454</eastBoundLongitude>
+      <southBoundLatitude>1.05386187892</southBoundLatitude>
+      <northBoundLatitude>1.76023057282</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox CRS="CRS:84" minx="103.358857333" miny="1.05386187892" maxx="104.766280454" maxy="1.76023057282" />
+    <BoundingBox CRS="EPSG:4326" minx="1.05386187892" miny="103.358857333" maxx="1.76023057282" maxy="104.766280454" />
+    <Layer>
+      <Name>Default</Name>
+      <Title>Default</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.359</westBoundLongitude>
+        <eastBoundLongitude>104.766</eastBoundLongitude>
+        <southBoundLatitude>1.054</southBoundLatitude>
+        <northBoundLatitude>1.76</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox CRS="EPSG:4326" minx="1.054" miny="103.359" maxx="1.76" maxy="104.766" />
+    </Layer>
+    <Layer>
+      <Name>Original</Name>
+      <Title>Original</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.359</westBoundLongitude>
+        <eastBoundLongitude>104.766</eastBoundLongitude>
+        <southBoundLatitude>1.054</southBoundLatitude>
+        <northBoundLatitude>1.76</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox CRS="EPSG:4326" minx="1.054" miny="103.359" maxx="1.76" maxy="104.766" />
+    </Layer>
+    <Layer>
+      <Name>Grey</Name>
+      <Title>Grey</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.359</westBoundLongitude>
+        <eastBoundLongitude>104.766</eastBoundLongitude>
+        <southBoundLatitude>1.054</southBoundLatitude>
+        <northBoundLatitude>1.76</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox CRS="EPSG:4326" minx="1.054" miny="103.359" maxx="1.76" maxy="104.766" />
+    </Layer>
+    <Layer>
+      <Name>Night</Name>
+      <Title>Night</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.359</westBoundLongitude>
+        <eastBoundLongitude>104.766</eastBoundLongitude>
+        <southBoundLatitude>1.054</southBoundLatitude>
+        <northBoundLatitude>1.76</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox CRS="EPSG:4326" minx="1.054" miny="103.359" maxx="1.76" maxy="104.766" />
+    </Layer>
+    <Layer>
+      <Name>singapore_3414_tms</Name>
+      <Title>singapore_3414_tms</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.595966412</westBoundLongitude>
+        <eastBoundLongitude>104.165806259</eastBoundLongitude>
+        <southBoundLatitude>1.1442806158</southBoundLatitude>
+        <northBoundLatitude>1.49822231742</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.595966412" miny="1.1442806158" maxx="104.165806259" maxy="1.49822231742" />
+      <BoundingBox CRS="EPSG:4326" minx="1.1442806158" miny="103.595966412" maxx="1.49822231742" maxy="104.165806259" />
+    </Layer>
+    <Layer>
+      <Name>singapore_3414_wms</Name>
+      <Title>singapore_3414_wms</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.358857333</westBoundLongitude>
+        <eastBoundLongitude>104.766280454</eastBoundLongitude>
+        <southBoundLatitude>1.05386187892</southBoundLatitude>
+        <northBoundLatitude>1.76023057282</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.358857333" miny="1.05386187892" maxx="104.766280454" maxy="1.76023057282" />
+      <BoundingBox CRS="EPSG:4326" minx="1.05386187892" miny="103.358857333" maxx="1.76023057282" maxy="104.766280454" />
+    </Layer>
+    <Layer>
+      <Name>singapore_3414_wmts</Name>
+      <Title>singapore_3414_wmts</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.595966412</westBoundLongitude>
+        <eastBoundLongitude>104.165806259</eastBoundLongitude>
+        <southBoundLatitude>1.1442806158</southBoundLatitude>
+        <northBoundLatitude>1.49822231742</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.595966412" miny="1.1442806158" maxx="104.165806259" maxy="1.49822231742" />
+      <BoundingBox CRS="EPSG:4326" minx="1.1442806158" miny="103.595966412" maxx="1.49822231742" maxy="104.165806259" />
+    </Layer>
+    <Layer>
+      <Name>singapore_landlot_wmts</Name>
+      <Title>singapore_landlot_wmts</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>103.359</westBoundLongitude>
+        <eastBoundLongitude>104.766</eastBoundLongitude>
+        <southBoundLatitude>1.054</southBoundLatitude>
+        <northBoundLatitude>1.76</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="CRS:84" minx="103.359" miny="1.054" maxx="104.766" maxy="1.76" />
+      <BoundingBox CRS="EPSG:4326" minx="1.054" miny="103.359" maxx="1.76" maxy="104.766" />
+    </Layer>
+  </Layer>
+</Capability>
+</WMS_Capabilities>

--- a/core/frontend/src/test/tile/map/MapLayerImageryProvider.test.ts
+++ b/core/frontend/src/test/tile/map/MapLayerImageryProvider.test.ts
@@ -17,6 +17,7 @@ import {
   WmtsCapabilities,
   WmtsMapLayerImageryProvider,
 } from "../../../tile/internal";
+import { Point2d } from "@itwin/core-geometry";
 
 chai.use(chaiAsPromised);
 
@@ -135,7 +136,7 @@ describe("WmsMapLayerImageryProvider", () => {
 
   });
 
-  it("should create a GetMap requests URL using the right 'CRS'", async () => {
+  it.only("should create a GetMap requests URL using the right 'CRS'", async () => {
     const layerPros: MapLayerProps = {
       formatId: "WMS",
       url: "https://localhost/wms",
@@ -156,7 +157,8 @@ describe("WmsMapLayerImageryProvider", () => {
     let provider = new WmsMapLayerImageryProvider(settings);
     await provider.initialize();
     let url = await provider.constructUrl(0,0,0);
-    chai.expect(url).to.contain("4326");
+    let urlObj = new URL(url);
+    chai.expect(urlObj.searchParams.get("CRS")).to.equals("EPSG:4326");
 
     // Mark 'continents' and 'continents2' visible, in that case the request
     // should still be in EPSG:4326 because continents is only available in in EPSG:4326
@@ -165,7 +167,8 @@ describe("WmsMapLayerImageryProvider", () => {
     provider = new WmsMapLayerImageryProvider(settings);
     await provider.initialize();
     url = await provider.constructUrl(0,0,0);
-    chai.expect(url).to.contain("4326");
+    urlObj = new URL(url);
+    chai.expect(urlObj.searchParams.get("CRS")).to.equals("EPSG:4326");
 
     // Mark 'continents' non visible.
     // URL should now be in EPSG:3857 because continents2 can be displayed in [4326,3857],
@@ -175,7 +178,8 @@ describe("WmsMapLayerImageryProvider", () => {
     provider = new WmsMapLayerImageryProvider(settings);
     await provider.initialize();
     url = await provider.constructUrl(0,0,0);
-    chai.expect(url).to.contain("3857");
+    urlObj = new URL(url);
+    chai.expect(urlObj.searchParams.get("CRS")).to.equals("EPSG:3857");
 
     // Mark 'continents' and 'continents2' non-visible... leaving nothing to display.
     // An empty URL should be created in that case
@@ -186,8 +190,82 @@ describe("WmsMapLayerImageryProvider", () => {
     url = await provider.constructUrl(0,0,0);
     chai.expect(url).to.be.empty;
   });
-});
 
+  it("should create a GetMap requests URL in WMS 1.1.1", async () => {
+    const layerPros: MapLayerProps = {
+      formatId: "WMS",
+      url: "https://localhost/wms",
+      name: "Test WMS",
+      subLayers: [
+        {name: "Default", id:0, visible:true},
+      ]};
+    const settings =ImageMapLayerSettings.fromJSON(layerPros);
+    if (!settings)
+      chai.assert.fail("Could not create settings");
+
+    const fakeCapabilities = await WmsCapabilities.create("assets/wms_capabilities/mapproxy_111.xml");
+    sandbox.stub(WmsCapabilities, "create").callsFake(async function _(_url: string, _credentials?: RequestBasicCredentials, _ignoreCache?: boolean) {
+      return  fakeCapabilities;
+    });
+
+    const provider = new WmsMapLayerImageryProvider(settings);
+    await provider.initialize();
+    const url = await provider.constructUrl(0,0,0);
+    const urlObj = new URL(url);
+    chai.expect(urlObj.searchParams.get("SRS")).to.equals("EPSG:4326");
+    const bbox = urlObj.searchParams.get("BBOX");
+    chai.expect(bbox).to.not.null;
+    if (!bbox)
+      return;
+    const bboxArray = bbox?.split(",").map((value)=>Number(value));
+
+    // check x/y axis is in the right order
+    const p1 = Point2d.create(bboxArray[0], bboxArray[1]);
+    const refPoint1 = Point2d.create(-180, -85.05112878);
+    const p2 = Point2d.create(bboxArray[2], bboxArray[3]);
+    const refPoint2 = Point2d.create(180, 85.05112878);
+    chai.expect(p1.isAlmostEqual(refPoint1)).to.be.true;
+    chai.expect(p2.isAlmostEqual(refPoint2)).to.be.true;
+  });
+
+  it.only("should create a GetMap requests URL in WMS 1.3.0", async () => {
+    const layerPros: MapLayerProps = {
+      formatId: "WMS",
+      url: "https://localhost/wms",
+      name: "Test WMS",
+      subLayers: [
+        {name: "Default", id:0, visible:true},
+      ]};
+    const settings =ImageMapLayerSettings.fromJSON(layerPros);
+    if (!settings)
+      chai.assert.fail("Could not create settings");
+
+    const fakeCapabilities = await WmsCapabilities.create("assets/wms_capabilities/mapproxy_130.xml");
+    sandbox.stub(WmsCapabilities, "create").callsFake(async function _(_url: string, _credentials?: RequestBasicCredentials, _ignoreCache?: boolean) {
+      return  fakeCapabilities;
+    });
+
+    const provider = new WmsMapLayerImageryProvider(settings);
+    await provider.initialize();
+    const url = await provider.constructUrl(0,0,0);
+    const urlObj = new URL(url);
+    // 1.3.0 uses CRS instead of SRS
+    chai.expect(urlObj.searchParams.get("CRS")).to.equals("EPSG:4326");
+
+    // check x/y axis is in the right order
+    const bbox = urlObj.searchParams.get("BBOX");
+    chai.expect(bbox).to.not.null;
+    if (!bbox)
+      return;
+    const bboxArray = bbox?.split(",").map((value)=>Number(value));
+    const p1 = Point2d.create(bboxArray[0], bboxArray[1]);
+    const refPoint1 = Point2d.create(-85.05112878, -180);
+    const p2 = Point2d.create(bboxArray[2], bboxArray[3]);
+    const refPoint2 = Point2d.create(85.05112878, 180);
+    chai.expect(p1.isAlmostEqual(refPoint1)).to.be.true;
+    chai.expect(p2.isAlmostEqual(refPoint2)).to.be.true;
+  });
+});
 //
 // This suite depends on IModelApp
 describe("MapLayerImageryProvider with IModelApp", () => {

--- a/core/frontend/src/test/tile/map/MapLayerImageryProvider.test.ts
+++ b/core/frontend/src/test/tile/map/MapLayerImageryProvider.test.ts
@@ -136,7 +136,7 @@ describe("WmsMapLayerImageryProvider", () => {
 
   });
 
-  it.only("should create a GetMap requests URL using the right 'CRS'", async () => {
+  it("should create a GetMap requests URL using the right 'CRS'", async () => {
     const layerPros: MapLayerProps = {
       formatId: "WMS",
       url: "https://localhost/wms",
@@ -228,7 +228,7 @@ describe("WmsMapLayerImageryProvider", () => {
     chai.expect(p2.isAlmostEqual(refPoint2)).to.be.true;
   });
 
-  it.only("should create a GetMap requests URL in WMS 1.3.0", async () => {
+  it("should create a GetMap requests URL in WMS 1.3.0", async () => {
     const layerPros: MapLayerProps = {
       formatId: "WMS",
       url: "https://localhost/wms",

--- a/core/frontend/src/test/tile/map/WmsCapabilities.test.ts
+++ b/core/frontend/src/test/tile/map/WmsCapabilities.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { WmsCapabilities } from "../../../tile/map/WmsCapabilities";
+
+const mapProxyDatasetNbLayers = 9;
+describe.only("WmsCapabilities", () => {
+
+  it("should parse WMS 1.1.1 capabilities", async () => {
+
+    const capabilities = await WmsCapabilities.create("assets/wms_capabilities/mapproxy_111.xml");
+
+    expect(capabilities).to.not.undefined;
+    if (capabilities === undefined)
+      return;
+
+    // Test GetCapabilities operation metadata
+    expect(capabilities.version).to.not.undefined;
+
+    expect(capabilities.version).to.equals("1.1.1");
+    expect(capabilities.isVersion13).to.equals(false);
+
+    const subLayers = capabilities.getSubLayers(true);
+    expect(subLayers).to.not.undefined;
+    if (subLayers === undefined)
+      return;
+    expect(subLayers?.length).to.equals(mapProxyDatasetNbLayers);
+
+    const subLayerNames = subLayers.map((sub)=>sub.name);
+    const subLayersCrs = capabilities.getSubLayersCrs(subLayerNames);
+    expect(subLayersCrs).to.not.undefined;
+    if (subLayersCrs === undefined)
+      return;
+    for (const subLayerCrs of subLayersCrs.values()) {
+      expect(subLayerCrs).to.include("EPSG:4326");
+    }
+
+  });
+
+  it("should parse WMS 1.3.0 capabilities", async () => {
+
+    const capabilities = await WmsCapabilities.create("assets/wms_capabilities/mapproxy_130.xml");
+
+    expect(capabilities).to.not.undefined;
+    if (capabilities === undefined)
+      return;
+
+    // Test GetCapabilities operation metadata
+    expect(capabilities.version).to.not.undefined;
+
+    expect(capabilities.version).to.equals("1.3.0");
+    expect(capabilities.isVersion13).to.equals(true);
+
+    const subLayers = capabilities.getSubLayers(true);
+    expect(subLayers).to.not.undefined;
+    if (subLayers === undefined)
+      return;
+    expect(subLayers?.length).to.equals(mapProxyDatasetNbLayers);
+
+    const subLayerNames = subLayers.map((sub)=>sub.name);
+    const subLayersCrs = capabilities.getSubLayersCrs(subLayerNames);
+    expect(subLayersCrs).to.not.undefined;
+    if (subLayersCrs === undefined)
+      return;
+    for (const subLayerCrs of subLayersCrs.values()) {
+      expect(subLayerCrs).to.include("EPSG:4326");
+    }
+
+  });
+
+});

--- a/core/frontend/src/test/tile/map/WmsCapabilities.test.ts
+++ b/core/frontend/src/test/tile/map/WmsCapabilities.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { WmsCapabilities } from "../../../tile/map/WmsCapabilities";
 
 const mapProxyDatasetNbLayers = 9;
-describe.only("WmsCapabilities", () => {
+describe("WmsCapabilities", () => {
 
   it("should parse WMS 1.1.1 capabilities", async () => {
 

--- a/core/frontend/src/tile/map/ImageryProviders/WmsMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/WmsMapLayerImageryProvider.ts
@@ -31,7 +31,6 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
   private _subLayerRanges = new Map<string, MapCartoRectangle>();
   private _baseUrl: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  private _isVersion1_1 = false;
   private _crsSupport: WmsCrsSupport|undefined;
 
   constructor(settings: ImageMapLayerSettings) {
@@ -44,7 +43,6 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
       this._capabilities = await WmsCapabilities.create(this._baseUrl);
       if (undefined !== this._capabilities) {
         this._allLayersRange = this._capabilities.cartoRange;
-        this._isVersion1_1 = this._capabilities.version !== undefined && 0 === this._capabilities.version.indexOf("1.1");
         if (this._capabilities.layer && Array.isArray(this._capabilities.layer.subLayers)) {
           const mapCartoRanges = ((subLayer: WmsCapability.SubLayer) => {
             if (Array.isArray(subLayer.children))
@@ -157,8 +155,12 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
     } else if (this._crsSupport?.support4326) {
       // The WMS 1.3.0 specification mandates using the axis ordering as defined in the EPSG database.
       // For instance, for EPSG:4326 the axis ordering is latitude/longitude, or north/east.
-      bboxString = this.getEPSG4326ExtentString(row, column, zoomLevel, true); // lat/long ordering
-      crsString= "EPSG%3A4326";
+      // WMS 1.1.0 always requires the axis ordering to be longitude/latitude. *sigh*
+      if (this._capabilities !== undefined) {
+        bboxString = this.getEPSG4326ExtentString(row, column, zoomLevel, this._capabilities?.isVersion13); // lat/long ordering
+        crsString= "EPSG%3A4326";
+      }
+
     }
 
     const layerString = this.getVisibleLayerString();
@@ -166,7 +168,8 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
     if (bboxString.length === 0 || crsString.length === 0 ||layerString.length === 0)
       return "";
 
-    return `${this._baseUrl}?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=${this.transparentBackgroundString}&LAYERS=${layerString}&WIDTH=${this.tileSize}&HEIGHT=${this.tileSize}&CRS=${crsString}&STYLES=&BBOX=${bboxString}`;
+    const crsParamName = this._capabilities?.isVersion13 ? "CRS" : "SRS";
+    return `${this._baseUrl}?SERVICE=WMS&VERSION=${this._capabilities?.version}&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=${this.transparentBackgroundString}&LAYERS=${layerString}&WIDTH=${this.tileSize}&HEIGHT=${this.tileSize}&${crsParamName}=${crsString}&STYLES=&BBOX=${bboxString}`;
   }
 
   public override async getToolTip(strings: string[], quadId: QuadId, carto: Cartographic, tree: ImageryMapTileTree): Promise<void> {
@@ -185,8 +188,9 @@ export class WmsMapLayerImageryProvider extends MapLayerImageryProvider {
     const fraction = rectangle.worldToLocal(Point2d.create(carto.longitude, carto.latitude, scratchPoint2d))!;
     const x = Math.floor(.5 + fraction.x * this.tileSize);
     const y = Math.floor(.5 + (1.0 - fraction.y) * this.tileSize);
-    const coordinateString = (false && this._isVersion1_1) ? `&x=${x}&y=${y}` : `&i=${x}&j=${y}`;
-    const getFeatureUrl = `${this._baseUrl}?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&LAYERS=${layerString}&WIDTH=${this.tileSize}&HEIGHT=${this.tileSize}&CRS=EPSG%3A3857&BBOX=${bboxString}&QUERY_LAYERS=${layerString}${coordinateString}&info_format=${formatString}`;
+    const coordinateString =  this._capabilities?.isVersion13 ? `&i=${x}&j=${y}` : `&x=${x}&y=${y}`;
+    const crsParamName = this._capabilities?.isVersion13 ? "CRS" : "SRS";
+    const getFeatureUrl = `${this._baseUrl}?SERVICE=WMS&VERSION=${this._capabilities?.version}&REQUEST=GetFeatureInfo&LAYERS=${layerString}&WIDTH=${this.tileSize}&HEIGHT=${this.tileSize}&${crsParamName}=EPSG%3A3857&BBOX=${bboxString}&QUERY_LAYERS=${layerString}${coordinateString}&info_format=${formatString}`;
     return this.toolTipFromUrl(strings, getFeatureUrl);
   }
 }

--- a/core/frontend/src/tile/map/WmsCapabilities.ts
+++ b/core/frontend/src/tile/map/WmsCapabilities.ts
@@ -82,12 +82,12 @@ export namespace WmsCapability {
     public readonly subLayers = new Array<SubLayer>();
     private static readonly PREFIX_SEPARATOR = ":";
 
-    constructor(_json: any, capabilities: WmsCapabilities) {
-      this.queryable = _json.queryable;
-      this.title = _json.title;
-      this.srs = initArray<string>(capabilities.isVersion13 ? _json.CRS : _json.SRS);
-      this.cartoRange = rangeFromJSON(_json);
-      this.subLayers.push(new SubLayer(_json, capabilities));
+    constructor(json: any, capabilities: WmsCapabilities) {
+      this.queryable = json.queryable;
+      this.title = json.title;
+      this.srs = initArray<string>(capabilities.isVersion13 ? json.CRS : json.SRS);
+      this.cartoRange = rangeFromJSON(json);
+      this.subLayers.push(new SubLayer(json, capabilities));
     }
     public getSubLayers(visible = true): MapSubLayerProps[] {
       const subLayers = new Array<MapSubLayerProps>();

--- a/core/frontend/src/tile/map/WmsCapabilities.ts
+++ b/core/frontend/src/tile/map/WmsCapabilities.ts
@@ -82,13 +82,12 @@ export namespace WmsCapability {
     public readonly subLayers = new Array<SubLayer>();
     private static readonly PREFIX_SEPARATOR = ":";
 
-    constructor(_json: any) {
+    constructor(_json: any, capabilities: WmsCapabilities) {
       this.queryable = _json.queryable;
       this.title = _json.title;
-      this.srs = initArray<string>(_json.SRS);
+      this.srs = initArray<string>(capabilities.isVersion13 ? _json.CRS : _json.SRS);
       this.cartoRange = rangeFromJSON(_json);
-      this.subLayers.push(new SubLayer(_json));
-
+      this.subLayers.push(new SubLayer(_json, capabilities));
     }
     public getSubLayers(visible = true): MapSubLayerProps[] {
       const subLayers = new Array<MapSubLayerProps>();
@@ -167,7 +166,7 @@ export namespace WmsCapability {
     public readonly cartoRange?: MapCartoRectangle;
     public readonly children?: SubLayer[];
     public readonly queryable: boolean;
-    public constructor(_json: any, public readonly parent?: SubLayer) {
+    public constructor(_json: any, capabilities: WmsCapabilities, public readonly parent?: SubLayer) {
 
       const getParentCrs = (parentLayer: SubLayer, crsSet: Set<string>) => {
         parentLayer.crs.forEach((parentCrs) => crsSet.add(parentCrs));
@@ -180,7 +179,7 @@ export namespace WmsCapability {
       this.title = _json.Title;
       this.queryable = _json.queryable ? true : false;
       this.cartoRange = rangeFromJSON(_json);
-      this.ownCrs = _json.CRS;
+      this.ownCrs = capabilities.isVersion13 ? _json.CRS : _json.SRS;
       const crs = new Set<string>(this.ownCrs);
       if (parent) {
         getParentCrs(parent, crs);
@@ -190,7 +189,7 @@ export namespace WmsCapability {
       if (Array.isArray(_json.Layer)) {
         this.children = new Array<SubLayer>();
         for (const childLayer of _json.Layer) {
-          this.children.push(new SubLayer(childLayer, this));
+          this.children.push(new SubLayer(childLayer, capabilities, this));
         }
       }
     }
@@ -202,6 +201,7 @@ export class WmsCapabilities {
   private static _capabilitiesCache = new Map<string, WmsCapabilities | undefined>();
   public readonly service: WmsCapability.Service;
   public readonly version?: string;
+  public readonly isVersion13: boolean;
   public readonly layer?: WmsCapability.Layer;
   public get json() { return this._json; }
   public get maxLevel(): number { return this.layer ? this.layer.subLayers.length : - 1; }
@@ -210,9 +210,10 @@ export class WmsCapabilities {
   public get featureInfoFormats(): string[] | undefined { return Array.isArray(this._json.Capability?.Request?.GetFeatureInfo?.Format) ? this._json.Capability?.Request?.GetFeatureInfo?.Format : undefined; }
   constructor(private _json: any) {
     this.version = _json.version;
+    this.isVersion13 = _json.version !== undefined && 0 === _json.version.indexOf("1.3");
     this.service = new WmsCapability.Service(_json.Service);
     if (_json.Capability)
-      this.layer = new WmsCapability.Layer(_json.Capability.Layer);
+      this.layer = new WmsCapability.Layer(_json.Capability.Layer, this);
   }
 
   public static async create(url: string, credentials?: RequestBasicCredentials, ignoreCache?: boolean): Promise<WmsCapabilities | undefined> {


### PR DESCRIPTION
Improved the support for WMS 1.1.1 servers.

**Three main changes:**
1. In 1.1.1 and prior, 'SRS' must be used instead of 'CRS'. This is applicable for the following 2 cases:
  a. GetMap request parameter
  b. When reading the GetCapabilities response, the JSON contains the 'SRS' key instead of 'CRS'
2. The axis order in 1.1.1 is always x/longitude y/latitude.  In 1.3.0 it depends on the coord. sys. definition, for EPSG:4326, it must be x/latitude y/longitude. 
3. The cursor position parameters passed to the 'GetFeatureInfo' request must be i/j for 1.3.0 and x/y for 1.1.1.
