### PR TITLE
Request next animation frame when selection set changes

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-rerender-on-selection-set-change_2022-03-31-11-35.json
+++ b/common/changes/@itwin/core-frontend/pmc-rerender-on-selection-set-change_2022-03-31-11-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Ensure the render loop is processed immediately after the selection set changes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ViewManager.ts
+++ b/core/frontend/src/ViewManager.ts
@@ -350,6 +350,8 @@ export class ViewManager implements Iterable<ScreenViewport> {
   public onSelectionSetChanged(_iModel: IModelConnection) {
     for (const vp of this)
       vp.markSelectionSetDirty();
+
+    IModelApp.requestNextAnimation();
   }
 
   /** @internal */

--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -100,6 +100,9 @@
       "ignore-styles"
     ],
     "checkLeaks": true,
+    "globals": [
+      "requestAnimationFrame"
+    ],
     "timeout": 60000,
     "file": [
       "lib/setup.js"

--- a/full-stack-tests/presentation/src/IntegrationTests.ts
+++ b/full-stack-tests/presentation/src/IntegrationTests.ts
@@ -7,6 +7,7 @@ import chaiSubset from "chai-subset";
 import * as cpx from "cpx2";
 import * as fs from "fs";
 import * as path from "path";
+import sinon from "sinon";
 import sinonChai from "sinon-chai";
 import { Logger, LogLevel } from "@itwin/core-bentley";
 import { IModelApp, IModelAppOptions, NoRenderApp } from "@itwin/core-frontend";
@@ -121,6 +122,10 @@ const initializeCommon = async (props: { backendTimeout?: number, useClientServi
   };
 
   await initializeTesting(presentationTestingInitProps);
+
+  global.requestAnimationFrame = sinon.fake((cb: FrameRequestCallback) => {
+    return window.setTimeout(cb, 0);
+  });
 };
 
 export const initialize = async (backendTimeout: number = 0) => {
@@ -132,6 +137,7 @@ export const initializeWithClientServices = async () => {
 };
 
 export const terminate = async () => {
+  delete (global as any).requestAnimationFrame;
   await terminateTesting();
 };
 


### PR DESCRIPTION
Eliminate delay between calling, e.g., `iModel.hilited.clear()` and seeing the viewport update.