### PR TITLE
Fix unquantized vertex read for WebGL 1.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-unquantized-webgl-1_2022-03-31-17-34.json
+++ b/common/changes/@itwin/core-frontend/pmc-unquantized-webgl-1_2022-03-31-17-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/glsl/Vertex.ts
+++ b/core/frontend/src/render/webgl/glsl/Vertex.ts
@@ -114,8 +114,11 @@ function getSamplePosition(type: PositionType): string {
     ${prelude}
       vec3 pf[4];
       pf[0] = floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5);
+      tc.x += g_vert_stepX;
       pf[1] = floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5);
+      tc.x += g_vert_stepX;
       pf[2] = floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5);
+      tc.x += g_vert_stepX;
       pf[3] = floor(TEXTURE(u_vertLUT, tc).xyz * 255.0 + 0.5);
       return vec4(decode3Float32(pf), 1.0);
     }`;


### PR DESCRIPTION
#3445 was failing to increment texture coordinates when reading unquantized vertex data in WebGL 1.