### PR TITLE
Reality tile priority on zoom target

### DIFF
--- a/common/changes/@itwin/core-frontend/reality-tile-priority-on-target-center_2022-04-01-14-54.json
+++ b/common/changes/@itwin/core-frontend/reality-tile-priority-on-target-center_2022-04-01-14-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Use zoom target on reality tile priority calculation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}


### PR DESCRIPTION
Prior to this pull request, tile priority calculation was using the point on screen at coordinates (0.5, 0.5) to load in priority tiles close to the center of the screen.

This change uses the last zoom location as center instead of (0.5, 0.5) when possible. This point being more likely the focus of the user attention, it makes sense to prioritize tiles around it.