### PR TITLE
Presentation: Initialize schemas preloading on Presentation.initialize

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -108,10 +108,9 @@ export interface MultiElementPropertiesResponse {
 }
 
 // @public
-export interface MultiManagerPresentationProps extends PresentationManagerProps {
+export interface MultiManagerPresentationProps extends PresentationPropsBase {
     // @internal
     clientManagerFactory?: (clientId: string, props: PresentationManagerProps) => PresentationManager;
-    requestTimeout?: number;
     unusedClientLifetime?: number;
 }
 
@@ -228,6 +227,7 @@ export interface PresentationManagerProps {
     };
     defaultLocale?: string;
     defaultUnitSystem?: UnitSystemKey;
+    // @deprecated
     enableSchemasPreload?: boolean;
     // @internal
     id?: string;
@@ -248,6 +248,12 @@ export interface PresentationManagerProps {
 
 // @public
 export type PresentationProps = MultiManagerPresentationProps | SingleManagerPresentationProps;
+
+// @public
+export interface PresentationPropsBase extends PresentationManagerProps {
+    enableSchemasPreload?: boolean;
+    requestTimeout?: number;
+}
 
 // @beta
 export class RulesetEmbedder {
@@ -333,8 +339,7 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
 }
 
 // @public
-export interface SingleManagerPresentationProps extends PresentationManagerProps {
-    requestTimeout?: number;
+export interface SingleManagerPresentationProps extends PresentationPropsBase {
     // @alpha
     useSingleManager?: boolean;
 }

--- a/common/api/summary/presentation-backend.exports.csv
+++ b/common/api/summary/presentation-backend.exports.csv
@@ -20,6 +20,7 @@ public;PresentationManager
 public;PresentationManagerMode
 public;PresentationManagerProps
 public;PresentationProps = MultiManagerPresentationProps | SingleManagerPresentationProps
+public;PresentationPropsBase 
 beta;RulesetEmbedder
 public;RulesetEmbedderProps
 beta;RulesetInsertOptions

--- a/common/changes/@itwin/presentation-backend/presentation-schemas_preloading_on_initialize_2022-04-04-14-56.json
+++ b/common/changes/@itwin/presentation-backend/presentation-schemas_preloading_on_initialize_2022-04-04-14-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Move schemas preloading logic from PresentationManager to Presentation.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/Presentation.ts
+++ b/presentation/backend/src/presentation-backend/Presentation.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { IModelHost, IpcHost } from "@itwin/core-backend";
+import { BriefcaseDb, IModelHost, IpcHost } from "@itwin/core-backend";
 import { DisposeFunc, Logger } from "@itwin/core-bentley";
 import { RpcManager } from "@itwin/core-common";
 import { PresentationError, PresentationRpcInterface, PresentationStatus } from "@itwin/presentation-common";
@@ -19,22 +19,35 @@ import { FactoryBasedTemporaryStorage } from "./TemporaryStorage";
 const defaultRequestTimeout: number = 90000;
 
 /**
+ * Base props for initializing the [[Presentation]] library.
+ *
+ * @public
+ */
+export interface PresentationPropsBase extends PresentationManagerProps {
+  /**
+   * Time in milliseconds after which the request will timeout.
+   */
+  requestTimeout?: number;
+
+  /**
+   * Should schemas preloading be enabled. If true, [[Presentation]] library listens
+   * for `BriefcaseDb.onOpened` event and force pre-loads all ECSchemas.
+   */
+  enableSchemasPreload?: boolean;
+}
+
+/**
  * Props for initializing the [[Presentation]] library for using multiple [[PresentationManager]]
  * instances, one for each frontend.
  *
  * @public
  */
-export interface MultiManagerPresentationProps extends PresentationManagerProps {
+export interface MultiManagerPresentationProps extends PresentationPropsBase {
   /**
    * Factory method for creating separate managers for each client
    * @internal
    */
   clientManagerFactory?: (clientId: string, props: PresentationManagerProps) => PresentationManager;
-
-  /**
-   * Time in milliseconds after which the request will timeout.
-   */
-  requestTimeout?: number;
 
   /**
    * How much time should an unused client manager be stored in memory
@@ -49,13 +62,7 @@ export interface MultiManagerPresentationProps extends PresentationManagerProps 
  *
  * @public
  */
-export interface SingleManagerPresentationProps extends PresentationManagerProps {
-  /**
-   * How much time should an unused client manager be stored in memory
-   * before it's disposed.
-   */
-  requestTimeout?: number;
-
+export interface SingleManagerPresentationProps extends PresentationPropsBase {
   /**
    * Specifies to use single manager for all clients.
    * @alpha
@@ -89,6 +96,7 @@ export class Presentation {
   private static _clientsStorage: FactoryBasedTemporaryStorage<ClientStoreItem> | undefined;
   private static _disposeIpcHandler: DisposeFunc | undefined;
   private static _shutdownListener: DisposeFunc | undefined;
+  private static _disposeIModelOpenedListener: DisposeFunc | undefined;
   private static _manager: PresentationManager | undefined;
   private static _rpcImpl: PresentationRpcImpl | undefined;
 
@@ -136,6 +144,9 @@ export class Presentation {
         onDisposedAll: /* istanbul ignore next */() => Logger.logInfo(PresentationBackendLoggerCategory.PresentationManager, `Disposed all PresentationManager instances.`),
       });
     }
+
+    if (this._initProps.enableSchemasPreload)
+      this._disposeIModelOpenedListener = BriefcaseDb.onOpened.addListener(this.onIModelOpened);
   }
 
   /**
@@ -146,6 +157,10 @@ export class Presentation {
     if (this._clientsStorage) {
       this._clientsStorage.dispose();
       this._clientsStorage = undefined;
+    }
+    if (this._disposeIModelOpenedListener) {
+      this._disposeIModelOpenedListener();
+      this._disposeIModelOpenedListener = undefined;
     }
     if (this._shutdownListener) {
       this._shutdownListener();
@@ -201,6 +216,13 @@ export class Presentation {
       throw new PresentationError(PresentationStatus.NotInitialized, "Presentation must be first initialized by calling Presentation.initialize");
     return this._rpcImpl.requestTimeout;
   }
+
+  private static onIModelOpened = (imodel: BriefcaseDb) => {
+    const manager = this.getManager();
+    const imodelAddon = manager.getNativePlatform().getImodelAddon(imodel);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    manager.getNativePlatform().forceLoadSchemas(imodelAddon);
+  };
 }
 
 function isSingleManagerProps(props: PresentationProps): props is SingleManagerPresentationProps {

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -8,7 +8,7 @@
 
 import * as hash from "object-hash";
 import * as path from "path";
-import { BriefcaseDb, IModelDb, IModelJsNative, IpcHost } from "@itwin/core-backend";
+import { IModelDb, IModelJsNative, IpcHost } from "@itwin/core-backend";
 import { Id64String } from "@itwin/core-bentley";
 import { FormatProps, UnitSystemKey } from "@itwin/core-quantity";
 import {
@@ -240,6 +240,8 @@ export interface PresentationManagerProps {
   /**
    * Should schemas preloading be enabled. If true, presentation manager listens
    * for `BriefcaseDb.onOpened` event and force pre-loads all ECSchemas.
+   *
+   * @deprecated Use [[PresentationPropsBase.enableSchemasPreload]] instead.
    */
   enableSchemasPreload?: boolean;
 
@@ -312,7 +314,6 @@ export class PresentationManager {
   private _nativePlatform?: NativePlatformDefinition;
   private _rulesets: RulesetManager;
   private _isDisposed: boolean;
-  private _disposeIModelOpenedListener?: () => void;
   private _updatesTracker?: UpdatesTracker;
   private _onManagerUsed?: () => void;
 
@@ -358,9 +359,6 @@ export class PresentationManager {
 
     this._rulesets = new RulesetManagerImpl(this.getNativePlatform);
 
-    if (this._props.enableSchemasPreload)
-      this._disposeIModelOpenedListener = BriefcaseDb.onOpened.addListener(this.onIModelOpened);
-
     if (IpcHost.isValid && isChangeTrackingEnabled) {
       this._updatesTracker = UpdatesTracker.create({
         nativePlatformGetter: this.getNativePlatform,
@@ -377,9 +375,6 @@ export class PresentationManager {
       this.getNativePlatform().dispose();
       this._nativePlatform = undefined;
     }
-
-    if (this._disposeIModelOpenedListener)
-      this._disposeIModelOpenedListener();
 
     if (this._updatesTracker) {
       this._updatesTracker.dispose();
@@ -409,13 +404,6 @@ export class PresentationManager {
   public vars(rulesetId: string): RulesetVariablesManager {
     return new RulesetVariablesManagerImpl(this.getNativePlatform, rulesetId);
   }
-
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private onIModelOpened = (imodel: BriefcaseDb) => {
-    const imodelAddon = this.getNativePlatform().getImodelAddon(imodel);
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.getNativePlatform().forceLoadSchemas(imodelAddon);
-  };
 
   /** @internal */
   public getNativePlatform = (): NativePlatformDefinition => {

--- a/presentation/backend/src/test/Presentation.test.ts
+++ b/presentation/backend/src/test/Presentation.test.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import * as faker from "faker";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
-import { IModelHost, IpcHost } from "@itwin/core-backend";
+import { BriefcaseDb, IModelHost, IpcHost } from "@itwin/core-backend";
 import { assert } from "@itwin/core-bentley";
 import { RpcManager } from "@itwin/core-common";
 import { PresentationError } from "@itwin/presentation-common";
@@ -15,6 +15,7 @@ import { PresentationIpcHandler } from "../presentation-backend/PresentationIpcH
 import { PresentationManager } from "../presentation-backend/PresentationManager";
 import { PresentationRpcImpl } from "../presentation-backend/PresentationRpcImpl";
 import { TemporaryStorage } from "../presentation-backend/TemporaryStorage";
+import { NativePlatformDefinition } from "../presentation-backend/NativePlatform";
 
 describe("Presentation", () => {
 
@@ -47,6 +48,14 @@ describe("Presentation", () => {
       expect(() => Presentation.getManager()).to.throw(PresentationError);
       Presentation.initialize();
       expect(Presentation.getManager()).to.be.instanceof(PresentationManager);
+    });
+
+    it("subscribes for `BriefcaseDb.onOpened` event if `enableSchemasPreload` is set", () => {
+      Presentation.initialize({enableSchemasPreload: false});
+      expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(0);
+      Presentation.terminate();
+      Presentation.initialize({enableSchemasPreload: true});
+      expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(1);
     });
 
     describe("props handling", () => {
@@ -116,6 +125,29 @@ describe("Presentation", () => {
       expect(unregisterSpy).to.not.be.called;
       Presentation.terminate();
       expect(unregisterSpy).to.be.calledOnce;
+    });
+
+    it("unsubscribes from `BriefcaseDb.onOpened` event if `enableSchemasPreload` is set", () => {
+      Presentation.initialize({enableSchemasPreload: true});
+      expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(1);
+      Presentation.terminate();
+      expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(0);
+    });
+
+  });
+
+  describe("preloading schemas", () => {
+
+    it("calls addon's `forceLoadSchemas` on `BriefcaseDb.onOpened` events", () => {
+      const imodelMock = moq.Mock.ofType<BriefcaseDb>();
+      const nativePlatformMock = moq.Mock.ofType<NativePlatformDefinition>();
+      const managerMock = moq.Mock.ofType<PresentationManager>();
+      managerMock.setup((x) => x.getNativePlatform).returns(() => () => nativePlatformMock.object);
+      nativePlatformMock.setup((x) => x.getImodelAddon(imodelMock.object)).verifiable(moq.Times.atLeastOnce());
+
+      Presentation.initialize({enableSchemasPreload: true, clientManagerFactory: () => managerMock.object});
+      BriefcaseDb.onOpened.raiseEvent(imodelMock.object, {} as any);
+      nativePlatformMock.verify(async (x) => x.forceLoadSchemas(moq.It.isAny()), moq.Times.once());
     });
 
   });


### PR DESCRIPTION
Add listener for `BriefcaseDb.onOpened` from `Presentation.initialize` instead of `PresentationManager` constructor because there might be no `PresentationManager` created when `BriefcaseDb` is opened.