### PR TITLE
Presentation: Get correct child specifications

### DIFF
--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -50,7 +50,7 @@ Example:
       "type": "child-1",
       "label": "Child 1",
       "nestedRules": [{
-        "ruleType": "ChildNodes", // this rule now also returns children for `Child 1.2.1`
+        "ruleType": "ChildNodes",
         "specifications": [{
           "specType": "CustomNode",
           "type": "child-1.1",

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -36,7 +36,7 @@ It is now possible to set property specification [`isDisplayed` attribute](../pr
 
 ### Fixed nested hierarchy rules handling
 
-There was a bug with how [nested child node rules](../presentation/Hierarchies/Terminology.md#nested-rule) were handled. When creating children for a node created by a nested child node rule, the bug caused the library to only look for child node rules that are nested under the rule that created the parent node. The issue is now fixed and the library looks for all child node rules available at the current context.
+There was a bug with how [nested child node rules](../presentation/Hierarchies/Terminology.md#nested-rule) were handled. When creating children for a node created by a nested child node rule, the bug caused the library to only look for child node rules that are nested under the rule that created the parent node. The issue is now fixed and the library looks for child node rules nested under the parent node rule and at the root level of the ruleset.
 
 Example:
 
@@ -81,7 +81,7 @@ Example:
 }
 ```
 
-With the above ruleset, when creating children for `Child 1.2.1` node, the library would've found no child node rules, because there are no nested rules for its specification. After the change, the library also looks at other child node rules available in the context of the specification that created the node. The rules that are now handled are marked with a comment in the above example. If the effect is not desirable, rules should have [conditions](../presentation/Hierarchies/ChildNodeRule.md#attribute-condition) that specify what parent node they return children for.
+With the above ruleset, when creating children for `Child 1.2.1` node, the library would've found no child node rules, because there are no nested rules for its specification. After the change, the library also looks at child node rules at the root level of the ruleset. The rules that are now handled are marked with a comment in the above example. If the effect is not desirable, rules should have [conditions](../presentation/Hierarchies/ChildNodeRule.md#attribute-condition) that specify what parent node they return children for.
 
 ### Detecting integrated graphics
 

--- a/full-stack-tests/presentation/src/frontend/Hierarchies.test.snap
+++ b/full-stack-tests/presentation/src/frontend/Hierarchies.test.snap
@@ -145,7 +145,7 @@ Array [
         "node": Object {
           "key": Object {
             "pathFromRoot": Array [
-              "8aaa6ad3ca43d5a8f0efbe6d6c1a44eb",
+              "d6448d44e7ee51c4d1a0b76895384418",
               "f311dfef4c5ea495ef7ad9f8142a297d",
             ],
             "type": "nodeType11",
@@ -171,8 +171,8 @@ Array [
             "node": Object {
               "key": Object {
                 "pathFromRoot": Array [
-                  "8aaa6ad3ca43d5a8f0efbe6d6c1a44eb",
-                  "1840960bee8f9ffe2b2214722a7e36f5",
+                  "d6448d44e7ee51c4d1a0b76895384418",
+                  "0ec5e9f1ddd4f09eff9151fa39a98d16",
                   "ff569b1cf07f2eda7114084df402b1e1",
                 ],
                 "type": "nodeType131",
@@ -196,8 +196,8 @@ Array [
           "hasChildren": true,
           "key": Object {
             "pathFromRoot": Array [
-              "8aaa6ad3ca43d5a8f0efbe6d6c1a44eb",
-              "1840960bee8f9ffe2b2214722a7e36f5",
+              "d6448d44e7ee51c4d1a0b76895384418",
+              "0ec5e9f1ddd4f09eff9151fa39a98d16",
             ],
             "type": "nodeType13",
             "version": 2,
@@ -220,7 +220,7 @@ Array [
       "hasChildren": true,
       "key": Object {
         "pathFromRoot": Array [
-          "8aaa6ad3ca43d5a8f0efbe6d6c1a44eb",
+          "d6448d44e7ee51c4d1a0b76895384418",
         ],
         "type": "nodeType1",
         "version": 2,
@@ -245,7 +245,7 @@ Array [
         "node": Object {
           "key": Object {
             "pathFromRoot": Array [
-              "0b080d7ad6331f500b02cc7264f1d9e8",
+              "fafa795f43ac3379cd1392ee8375888d",
               "4fe547d202499bac6d5fb0b38876540e",
             ],
             "type": "nodeType32",
@@ -269,7 +269,7 @@ Array [
       "hasChildren": true,
       "key": Object {
         "pathFromRoot": Array [
-          "0b080d7ad6331f500b02cc7264f1d9e8",
+          "fafa795f43ac3379cd1392ee8375888d",
         ],
         "type": "nodeType3",
         "version": 2,

--- a/full-stack-tests/presentation/src/frontend/Hierarchies.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Hierarchies.test.ts
@@ -43,7 +43,6 @@ describe("Hierarchies", () => {
               label: "filter r1",
               nestedRules: [{
                 ruleType: RuleTypes.ChildNodes,
-                condition: `ParentNode.Type = "nodeType1"`,
                 specifications: [{
                   specType: ChildNodeSpecificationTypes.CustomNode,
                   type: "nodeType11",
@@ -58,7 +57,6 @@ describe("Hierarchies", () => {
                   label: "other ch3",
                   nestedRules: [{
                     ruleType: RuleTypes.ChildNodes,
-                    condition: `ParentNode.Type = "nodeType13"`,
                     specifications: [{
                       specType: ChildNodeSpecificationTypes.CustomNode,
                       type: "nodeType131",
@@ -77,7 +75,6 @@ describe("Hierarchies", () => {
               label: "other r3",
               nestedRules: [{
                 ruleType: RuleTypes.ChildNodes,
-                condition: `ParentNode.Type = "nodeType3"`,
                 specifications: [{
                   specType: ChildNodeSpecificationTypes.CustomNode,
                   type: "nodeType31",


### PR DESCRIPTION
Adjusted NextVersion.md to match fixed child specifications handling. 

Related [native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/239921)