### PR TITLE
Fix blank rendering when dropping and immediately re-adding the same viewport

### DIFF
--- a/common/changes/@itwin/core-frontend/markschlosser-fix-drop-add-viewport-bug_2022-04-05-19-06.json
+++ b/common/changes/@itwin/core-frontend/markschlosser-fix-drop-add-viewport-bug_2022-04-05-19-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Prevent 0-dimension assignment in CanvasState.updateDimensions. This resolved a blank rendering issue when dropping and re-adding a viewport with the same size.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -1185,7 +1185,11 @@ class CanvasState {
   public updateDimensions(pixelRatio: number): boolean {
     const w = Math.floor(this.canvas.clientWidth * pixelRatio);
     const h = Math.floor(this.canvas.clientHeight * pixelRatio);
-    if (w === this._width && h === this._height)
+
+    // Do not update the dimensions if not needed, or if new width or height is 0, which is invalid.
+    // NB: the 0-dimension check indirectly resolves an issue when a viewport is dropped and immediately re-added
+    // to the view manager. See ViewManager.test.ts for more details.
+    if (w === this._width && h === this._height || (0 === w || 0 === h))
       return false;
 
     // Must ensure internal bitmap grid dimensions of on-screen canvas match its own on-screen appearance.

--- a/core/frontend/src/test/ViewManager.test.ts
+++ b/core/frontend/src/test/ViewManager.test.ts
@@ -8,6 +8,8 @@ import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";
 import { createBlankConnection } from "./createBlankConnection";
 import { openBlankViewport } from "./openBlankViewport";
+import { expectColors } from "./ExpectColors";
+import { ColorDef } from "@itwin/core-common";
 
 describe("ViewManager", () => {
   let imodel: IModelConnection;
@@ -30,6 +32,31 @@ describe("ViewManager", () => {
     IModelApp.viewManager.dropViewport(vp, false);
     vp.renderFrame();
     expect((vp.target as OnScreenTarget).checkFboDimensions()).to.be.true;
+    vp.dispose();
+  });
+
+  /** Dropping and immediately re-adding an unresized viewport to the view manager would result in a black rendering
+   * until the viewport was manually resized. This happened because when the viewport was removed it would have a 0,0
+   * dimension, which was internally recorded (but not acted upon with regard to framebuffers). Once re-adding the viewport,
+   * it would be flagged as having a size change because its dimensions were no longer 0 (they became the original
+   * dimensions). Disposing and recreating the framebuffers with the same dimensions as the previous framebuffers caused the
+   * black rendering in the particular case of re-adding the viewport.
+   *
+   * We resolved this problem by adding a check to not record a dimension change if the new dimensions are 0 -- we really
+   * do not want to create framebuffers with those dimensions anyway, because that is invalid.
+   *
+   * This test verifies that this problem has been resolved.
+   */
+  it("should not render black when dropping and re-adding viewport with same dimensions", async () => {
+    const vp = openBlankViewport({ width: 32, height: 32 });
+    vp.displayStyle.backgroundColor = ColorDef.red;
+    IModelApp.viewManager.addViewport(vp);
+    vp.renderFrame();
+    expectColors(vp, [ColorDef.red]);
+    IModelApp.viewManager.dropViewport(vp, false);
+    IModelApp.viewManager.addViewport(vp);
+    vp.renderFrame();
+    expectColors(vp, [ColorDef.red]);
     vp.dispose();
   });
 });


### PR DESCRIPTION
Dropping and immediately re-adding an unresized viewport to the view manager would result in a black rendering until the viewport was manually resized. This happened because when the viewport was removed it would have a 0,0 dimension, which was internally recorded (but not acted upon with regard to framebuffers). Once re-adding the viewport, it would be flagged as having a size change because its dimensions were no longer 0 (they became the original dimensions). Disposing and recreating the framebuffers with the same dimensions as the previous framebuffers caused the black rendering in the particular case of re-adding the viewport.

We resolve this problem by adding a check to not record a dimension change if the new dimensions are 0 -- we really do not want to create framebuffers with those dimensions anyway, because that is invalid.