### PR TITLE
Restore Mobile Authorization

### DIFF
--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -236,6 +236,8 @@ export class MobileFileHandler {
 
 // @beta (undocumented)
 export class MobileHost {
+    // @internal (undocumented)
+    static get authorization(): import("@itwin/core-common").AuthorizationClient | undefined;
     // (undocumented)
     static get device(): MobileDevice;
     // @internal (undocumented)
@@ -264,6 +266,7 @@ export interface MobileHostOpts extends NativeHostOpts {
         device?: MobileDevice;
         rpcInterfaces?: RpcInterfaceDefinition[];
         authConfig?: MobileAppAuthorizationConfiguration;
+        noInitializeAuthClient?: boolean;
     };
 }
 

--- a/common/changes/@itwin/core-frontend/restore-mobile-auth_2022-04-06-18-12.json
+++ b/common/changes/@itwin/core-frontend/restore-mobile-auth_2022-04-06-18-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-mobile/master_2022-04-05-18-49.json
+++ b/common/changes/@itwin/core-mobile/master_2022-04-05-18-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "Restore authorization support in MobileHost.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/frontend/src/test/ToolRegistry.test.ts
+++ b/core/frontend/src/test/ToolRegistry.test.ts
@@ -144,7 +144,7 @@ describe("ToolRegistry", () => {
     testKeyinArgs(`  uccalc   one two  three   "four"     "five six" seven`, ["one", "two", "three", "four", "five six", "seven"]);
     testKeyinArgs(`uccalc one"two"three four""five"`, [`one"two"three`, `four""five"`]);
     testKeyinArgs("\tuccalc\none\t \ttwo \n three", ["one", "two", "three"]);
-  });
+  }).timeout(8000);
 
   it("Should find the MicroStation inputmanager training command", async () => {
     const command = IModelApp.tools.findExactMatch("inputmanager training");


### PR DESCRIPTION
This logic was stripped out of core/mobile prematurely, and we didn't have a replacement API in place to restore functionality to mobile applications. This resulted in some difficult workarounds in mobile-samples. It can be removed again when auth is addressed more comprehensively in 3.2