### PR TITLE
Partial backport of texture size limit from Fix large textures (partial bp #2244)

### DIFF
--- a/common/api/webgl-compatibility.api.md
+++ b/common/api/webgl-compatibility.api.md
@@ -32,6 +32,8 @@ export class Capabilities {
     // (undocumented)
     get maxRenderType(): RenderType;
     // (undocumented)
+    get maxTexSizeAllow(): number;
+    // (undocumented)
     get maxTextureSize(): number;
     // (undocumented)
     get maxVaryingVectors(): number;

--- a/common/changes/@bentley/imodeljs-frontend/backport-tex-limit_2022-04-07-20-37.json
+++ b/common/changes/@bentley/imodeljs-frontend/backport-tex-limit_2022-04-07-20-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-frontend",
+      "comment": "Partial backport of texture size limit",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-frontend",
+  "email": "48810710+DStradley@users.noreply.github.com"
+}

--- a/common/changes/@bentley/webgl-compatibility/backport-tex-limit_2022-04-07-20-37.json
+++ b/common/changes/@bentley/webgl-compatibility/backport-tex-limit_2022-04-07-20-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webgl-compatibility",
+      "comment": "Partial backport of texture size limit",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webgl-compatibility",
+  "email": "48810710+DStradley@users.noreply.github.com"
+}

--- a/core/frontend/src/render/webgl/Texture.ts
+++ b/core/frontend/src/render/webgl/Texture.ts
@@ -555,7 +555,7 @@ export class ExternalTextureLoader { /* currently exported for tests only */
 
     try {
       if (!req.imodel.isClosed) {
-        const maxTextureSize = System.instance.capabilities.maxTextureSize;
+        const maxTextureSize = System.instance.capabilities.maxTexSizeAllow;
         const texBytes = await req.imodel.getTextureImage({ name: req.name, maxTextureSize });
         if (undefined !== texBytes) {
           const imageSource = new ImageSource(texBytes, req.format);

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -63,6 +63,8 @@ export enum DepthType {
   // TextureFloat32Stencil8,       // core to WeBGL2
 }
 
+const maxTexSizeAllowed = 4096; // many devices and browsers have issues with source textures larger than this
+
 // Regexes to match Intel UHD/HD 620/630 integrated GPUS that suffer from GraphicsDriverBugs.fragDepthDoesNotDisableEarlyZ.
 const buggyIntelMatchers = [
   // Original unmasked renderer string when workaround we implemented.
@@ -89,17 +91,19 @@ export class Capabilities {
   private _canRenderDepthWithoutColor: boolean = false;
   private _maxAnisotropy?: number;
   private _maxAntialiasSamples: number = 1;
+  private _maxTexSizeAllow: number = maxTexSizeAllowed;
 
   private _extensionMap: { [key: string]: any } = {}; // Use this map to store actual extension objects retrieved from GL.
   private _presentFeatures: WebGLFeature[] = []; // List of features the system can support (not necessarily dependent on extensions)
 
   private _isWebGL2: boolean = false;
   private _isMobile: boolean = false;
-  private _driverBugs: GraphicsDriverBugs = { };
+  private _driverBugs: GraphicsDriverBugs = {};
 
   public get maxRenderType(): RenderType { return this._maxRenderType; }
   public get maxDepthType(): DepthType { return this._maxDepthType; }
   public get maxTextureSize(): number { return this._maxTextureSize; }
+  public get maxTexSizeAllow(): number { return this._maxTexSizeAllow; }
   public get maxColorAttachments(): number { return this._maxColorAttachments; }
   public get maxDrawBuffers(): number { return this._maxDrawBuffers; }
   public get maxFragTextureUnits(): number { return this._maxFragTextureUnits; }
@@ -232,6 +236,7 @@ export class Capabilities {
     this._isMobile = ProcessDetector.isMobileBrowser;
 
     this._maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    this._maxTexSizeAllow = Math.min(this._maxTextureSize, maxTexSizeAllowed);
     this._maxFragTextureUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
     this._maxVertTextureUnits = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);
     this._maxVertAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);


### PR DESCRIPTION
Partial backport of [#2244](https://github.com/iTwin/itwinjs-core/pull/2244).

This resolves [a bug on iOS for 2.19](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/861470).  On 3.0, iTwin.js enforces a limit of 4096 for textures.  On 2.19, this is not the case.
This can cause canvas draws to fail on iOS -- iOS has a 4096x4096 canvas limit.