### PR TITLE
Fix jumpy view zoom on touch devices

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2360,6 +2360,8 @@ export class DefaultViewTouchTool extends ViewManip implements Animator {
     // (undocumented)
     onTouchMove(ev: BeTouchEvent): Promise<void>;
     // (undocumented)
+    onTouchStart(ev: BeTouchEvent): Promise<void>;
+    // (undocumented)
     static toolId: string;
 }
 

--- a/common/changes/@itwin/core-frontend/touch-zoom-fixes_2022-04-08-11-24.json
+++ b/common/changes/@itwin/core-frontend/touch-zoom-fixes_2022-04-08-11-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix view zoom jumps on touch devices",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -3922,6 +3922,10 @@ export class DefaultViewTouchTool extends ViewManip implements Animator {
 
   public override async onDataButtonDown(_ev: BeButtonEvent) { return EventHandled.Yes; }
   public override async onDataButtonUp(_ev: BeButtonEvent) { return EventHandled.Yes; }
+  public override async onTouchStart(ev: BeTouchEvent): Promise<void> {
+    if (undefined !== this.viewport)
+      this.onStart(ev);
+  }
   public override async onTouchMove(ev: BeTouchEvent): Promise<void> {
     this.handleEvent(ev);
   }


### PR DESCRIPTION
Fixes two issues:
1. When pinch gesture is fast, view zooms, pans and sometimes jumps back to initial zoom level.
   * If only the last processed touch drag event contained zoom, inertia was not reset, causing an unnecessary animated pan after touches ended. The change removes inertia as soon as zoom is detected.
1. When multiple pinches are done by lifting only one finger, zoom level jumps when starting subsequent pinches.
    * If there was no drag events between lifting one finger and setting it down at another place, the gesture start position was not reinitialized. The change reinitializes start position as soon as any new touch happens (and therefore touches count changes) instead of waiting for a drag event.