### PR TITLE
Fix MSAA hang for Mali-G71 and Mali-G76 GPUs

### DIFF
--- a/common/api/webgl-compatibility.api.md
+++ b/common/api/webgl-compatibility.api.md
@@ -105,6 +105,7 @@ export enum DepthType {
 // @public
 export interface GraphicsDriverBugs {
     fragDepthDoesNotDisableEarlyZ?: true;
+    msaaWillHang?: true;
 }
 
 // @public

--- a/common/changes/@itwin/webgl-compatibility/markschlosser-fix-msaa-hang-malig71-malig76_2022-04-08-13-29.json
+++ b/common/changes/@itwin/webgl-compatibility/markschlosser-fix-msaa-hang-malig71-malig76_2022-04-08-13-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "Do not allow buggy GPUs to render MSAA.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -73,6 +73,12 @@ const buggyIntelMatchers = [
   /ANGLE \(Intel, Intel\(R\) (U)?HD Graphics 6(2|3)0 Direct3D11/,
 ];
 
+// Regexes to match Mali GPUs known to suffer from GraphicsDriverBugs.msaaWillHang.
+const buggyMaliMatchers = [
+  /Mali-G71/,
+  /Mali-G76/,
+];
+
 // Regexes to match as many Intel integrated GPUs as possible.
 // https://en.wikipedia.org/wiki/List_of_Intel_graphics_processing_units
 const integratedIntelGpuMatchers = [
@@ -326,6 +332,8 @@ export class Capabilities {
     this._driverBugs = {};
     if (unmaskedRenderer && buggyIntelMatchers.some((x) => x.test(unmaskedRenderer)))
       this._driverBugs.fragDepthDoesNotDisableEarlyZ = true;
+    if (unmaskedRenderer && buggyMaliMatchers.some((x) => x.test(unmaskedRenderer)))
+      this._driverBugs.msaaWillHang = true;
 
     return {
       status: this._getCompatibilityStatus(missingRequiredFeatures, missingOptionalFeatures),

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -260,6 +260,16 @@ export class Capabilities {
 
     this._isMobile = ProcessDetector.isMobileBrowser;
 
+    const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
+    const unmaskedRenderer = debugInfo !== null ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) : undefined;
+    const unmaskedVendor = debugInfo !== null ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) : undefined;
+
+    this._driverBugs = {};
+    if (unmaskedRenderer && buggyIntelMatchers.some((x) => x.test(unmaskedRenderer)))
+      this._driverBugs.fragDepthDoesNotDisableEarlyZ = true;
+    if (unmaskedRenderer && buggyMaliMatchers.some((x) => x.test(unmaskedRenderer)))
+      this._driverBugs.msaaWillHang = true;
+
     this._maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
     this._supportsCreateImageBitmap = typeof createImageBitmap === "function" && ProcessDetector.isChromium && !ProcessDetector.isIOSBrowser;
     this._maxTexSizeAllow = Math.min(this._maxTextureSize, maxTexSizeAllowed);
@@ -269,7 +279,7 @@ export class Capabilities {
     this._maxVertUniformVectors = gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS);
     this._maxVaryingVectors = gl.getParameter(gl.MAX_VARYING_VECTORS);
     this._maxFragUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
-    this._maxAntialiasSamples = (this._isWebGL2 && undefined !== gl2 ? gl.getParameter(gl2.MAX_SAMPLES) : 1);
+    this._maxAntialiasSamples = this._driverBugs.msaaWillHang ? 1 : (this._isWebGL2 && undefined !== gl2 ? gl.getParameter(gl2.MAX_SAMPLES) : 1);
 
     const extensions = gl.getSupportedExtensions(); // This just retrieves a list of available extensions (not necessarily enabled).
     if (extensions) {
@@ -294,10 +304,6 @@ export class Capabilities {
       this._maxColorAttachments = dbExt !== undefined ? gl.getParameter(dbExt.MAX_COLOR_ATTACHMENTS_WEBGL) : 1;
       this._maxDrawBuffers = dbExt !== undefined ? gl.getParameter(dbExt.MAX_DRAW_BUFFERS_WEBGL) : 1;
     }
-
-    const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
-    const unmaskedRenderer = debugInfo !== null ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) : undefined;
-    const unmaskedVendor = debugInfo !== null ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) : undefined;
 
     // Determine the maximum color-renderable attachment type.
     const allowFloatRender =
@@ -328,12 +334,6 @@ export class Capabilities {
     this._presentFeatures = this._gatherFeatures();
     const missingRequiredFeatures = this._findMissingFeatures(Capabilities.requiredFeatures);
     const missingOptionalFeatures = this._findMissingFeatures(Capabilities.optionalFeatures);
-
-    this._driverBugs = {};
-    if (unmaskedRenderer && buggyIntelMatchers.some((x) => x.test(unmaskedRenderer)))
-      this._driverBugs.fragDepthDoesNotDisableEarlyZ = true;
-    if (unmaskedRenderer && buggyMaliMatchers.some((x) => x.test(unmaskedRenderer)))
-      this._driverBugs.msaaWillHang = true;
 
     return {
       status: this._getCompatibilityStatus(missingRequiredFeatures, missingOptionalFeatures),

--- a/core/webgl-compatibility/src/RenderCompatibility.ts
+++ b/core/webgl-compatibility/src/RenderCompatibility.ts
@@ -89,6 +89,13 @@ export interface GraphicsDriverBugs {
    * The workaround for this bug has minimal impact on performance and no impact on visual fidelity.
    */
   fragDepthDoesNotDisableEarlyZ?: true;
+  /** If true, the graphics driver will hang when applying MSAA to a viewport.
+   *
+   * Known to affect certain mobile Mali chipsets (G71 and G76). May affect more.
+   *
+   * The workaround for this bug means MSAA cannot be enabled on those devices.
+   */
+  msaaWillHang?: true;
 }
 
 /** Describes the level of compatibility of a client device/browser with the iTwin.js rendering system.


### PR DESCRIPTION
This PR resolves the behavior observed in [this work item](https://bentleycs.visualstudio.com/iModelTechnologies/_workitems/edit/860321).

If MSAA was applied, it could hang certain mobile GPUs.  This problem was observed to affect certain mobile Mali chipsets (G71 and G76).

The workaround for this bug means MSAA cannot be enabled on those devices.

A new entry to `GraphicsDriverBugs` titled `msaaWillHang` was added.