### PR TITLE
processChanges use new API that spans all revisions when extracting changes

### DIFF
--- a/common/changes/@itwin/core-transformer/transform-process-changes-span-all-revisions_2022-04-08-15-58.json
+++ b/common/changes/@itwin/core-transformer/transform-process-changes-span-all-revisions_2022-04-08-15-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "exportChanges now processes all changesets simultaneously since processing them individually as done is redundant and was never actually supported",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -701,11 +701,9 @@ class ChangedInstanceOps {
   public updateIds = new Set<Id64String>();
   public deleteIds = new Set<Id64String>();
   public addFromJson(val: IModelJsNative.ChangedInstanceOpsProps | undefined): void {
-    if (undefined !== val) {
-      if ((undefined !== val.insert) && (Array.isArray(val.insert))) { val.insert.forEach((id: Id64String) => this.insertIds.add(id)); }
-      if ((undefined !== val.update) && (Array.isArray(val.update))) { val.update.forEach((id: Id64String) => this.updateIds.add(id)); }
-      if ((undefined !== val.delete) && (Array.isArray(val.delete))) { val.delete.forEach((id: Id64String) => this.deleteIds.add(id)); }
-    }
+    val?.insert?.forEach?.((id) => this.insertIds.add(id));
+    val?.update?.forEach?.((id) => this.updateIds.add(id));
+    val?.delete?.forEach?.((id) => this.deleteIds.add(id));
   }
 }
 

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -723,22 +723,21 @@ class ChangedInstanceIds {
     const changesets = await IModelHost.hubAccess.downloadChangesets({ accessToken, iModelId, range: { first, end }, targetDir: BriefcaseManager.getChangeSetsPath(iModelId) });
 
     const changedInstanceIds = new ChangedInstanceIds();
-    changesets.forEach((changeset): void => {
-      const changesetPath = changeset.pathname;
-      const statusOrResult = iModel.nativeDb.extractChangedInstanceIdsFromChangeSet(changesetPath);
-      if (statusOrResult.error) {
-        throw new IModelError(statusOrResult.error.status, "Error processing changeset");
-      }
-      if (statusOrResult.result && statusOrResult?.result !== "") {
-        const result: IModelJsNative.ChangedInstanceIdsProps = JSON.parse(statusOrResult.result);
-        changedInstanceIds.codeSpec.addFromJson(result.codeSpec);
-        changedInstanceIds.model.addFromJson(result.model);
-        changedInstanceIds.element.addFromJson(result.element);
-        changedInstanceIds.aspect.addFromJson(result.aspect);
-        changedInstanceIds.relationship.addFromJson(result.relationship);
-        changedInstanceIds.font.addFromJson(result.font);
-      }
-    });
+
+    const changesetFiles = changesets.map((c) => c.pathname);
+    const statusOrResult = iModel.nativeDb.extractChangedInstanceIdsFromChangeSets(changesetFiles);
+    if (statusOrResult.error) {
+      throw new IModelError(statusOrResult.error.status, "Error processing changeset");
+    }
+    if (statusOrResult.result && statusOrResult?.result !== "") {
+      const result: IModelJsNative.ChangedInstanceIdsProps = JSON.parse(statusOrResult.result);
+      changedInstanceIds.codeSpec.addFromJson(result.codeSpec);
+      changedInstanceIds.model.addFromJson(result.model);
+      changedInstanceIds.element.addFromJson(result.element);
+      changedInstanceIds.aspect.addFromJson(result.aspect);
+      changedInstanceIds.relationship.addFromJson(result.relationship);
+      changedInstanceIds.font.addFromJson(result.font);
+    }
     return changedInstanceIds;
   }
 }


### PR DESCRIPTION
- annotate large branch synchronization test
- use new multi-changeset change extraction instead of doing it on each changeset like before which is actually not technically supported
- update tests to extract changes when it's valid, before making further changes to the database
- there is an accompanying native PR 241036