### PR TITLE
Use ImageBitmap in gltf reader when possible

### DIFF
--- a/core/frontend/src/ImageUtil.ts
+++ b/core/frontend/src/ImageUtil.ts
@@ -200,6 +200,19 @@ export async function imageElementFromImageSource(source: ImageSource): Promise<
   return imageElementFromUrl(URL.createObjectURL(blob));
 }
 
+/** Extract a bitmap from a binary jpeg or png.
+ * @param source The ImageSource containing the binary jpeg or png data.
+ * @returns a Promise which resolves to an ImageBitmap containing the uncompressed bitmap image in RGBA format.
+ * @public
+ */
+export async function imageBitmapFromImageSource(source: ImageSource): Promise<ImageBitmap> {
+  const blob = new Blob([source.data], { type: getImageSourceMimeType(source.format) });
+  return createImageBitmap(blob, {
+    premultiplyAlpha: "none",
+    colorSpaceConversion: "none",
+  });
+}
+
 /** Create an html Image element from a URL.
  * @param url The URL pointing to the image data.
  * @param skipCrossOriginCheck Set this to true to allow an image from a different origin than the web app to load. Default is false.

--- a/core/frontend/src/render/RenderTexture.ts
+++ b/core/frontend/src/render/RenderTexture.ts
@@ -46,7 +46,7 @@ export type TextureOwnership = TextureCacheOwnership | "external";
  * @public
  * @extensions
  */
-export type TextureImageSource = HTMLImageElement | ImageBuffer; // ###TODO | HTMLCanvasElement etc
+export type TextureImageSource = HTMLImageElement | ImageBuffer | ImageBitmap; // ###TODO | HTMLCanvasElement etc
 
 /** Describes the image from which to create a [RenderTexture]($common).
  * @see [[CreateTextureArgs.image]]

--- a/core/frontend/src/render/webgl/System.ts
+++ b/core/frontend/src/render/webgl/System.ts
@@ -739,8 +739,12 @@ export class System extends RenderSystem implements RenderSystemDebugControl, Re
     let handle;
     if (source instanceof ImageBuffer)
       handle = TextureHandle.createForImageBuffer(source, type);
-    else
+    else if (source instanceof ImageBitmap)
+      handle = TextureHandle.createForImageBitmap(source, type);
+    else if (source instanceof HTMLImageElement)
       handle = TextureHandle.createForImage(source, type);
+    else
+      assert(false);
 
     if (!handle)
       return undefined;

--- a/core/frontend/src/render/webgl/Texture.ts
+++ b/core/frontend/src/render/webgl/Texture.ts
@@ -275,8 +275,20 @@ class Texture2DCreateParams {
       }
     }
 
+    // If we have to resize, use a canvas
+    let source: TexImageSource = image;
+    if (image.width !== targetWidth || image.height !== targetHeight) {
+      const canvas = document.createElement("canvas");
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+      const context = canvas.getContext("2d")!;
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+      source = canvas;
+    }
+
     return new Texture2DCreateParams(targetWidth, targetHeight, props.format, GL.Texture.DataType.UnsignedByte, props.wrapMode,
-      (tex: TextureHandle, params: Texture2DCreateParams) => loadTexture2DImageData(tex, params, undefined, image), props.useMipMaps, props.interpolate, props.anisotropicFilter);
+      (tex: TextureHandle, params: Texture2DCreateParams) => loadTexture2DImageData(tex, params, undefined, source), props.useMipMaps, props.interpolate, props.anisotropicFilter);
   }
 
   private static getImageProperties(type: RenderTexture.Type): TextureImageProperties {

--- a/core/frontend/src/render/webgl/Texture.ts
+++ b/core/frontend/src/render/webgl/Texture.ts
@@ -20,8 +20,6 @@ import { OvrFlags, TextureUnit } from "./RenderFlags";
 import { System } from "./System";
 import { TextureOwnership } from "../RenderTexture";
 
-type CanvasOrImage = HTMLCanvasElement | HTMLImageElement;
-
 /** @internal */
 export type Texture2DData = Uint8Array | Float32Array;
 
@@ -41,7 +39,7 @@ function computeBytesUsed(width: number, height: number, format: GL.Texture.Form
 }
 
 /** Associate texture data with a WebGLTexture from a canvas, image, OR a bitmap. */
-function loadTexture2DImageData(handle: TextureHandle, params: Texture2DCreateParams, bytes?: Texture2DData, element?: CanvasOrImage): void {
+function loadTexture2DImageData(handle: TextureHandle, params: Texture2DCreateParams, bytes?: Texture2DData, source?: TexImageSource): void {
   handle.bytesUsed = undefined !== bytes ? bytes.byteLength : computeBytesUsed(params.width, params.height, params.format, params.dataType);
 
   const tex = handle.getHandle()!;
@@ -68,8 +66,8 @@ function loadTexture2DImageData(handle: TextureHandle, params: Texture2DCreatePa
   }
 
   // send the texture data
-  if (undefined !== element) {
-    gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, params.format, params.dataType, element);
+  if (undefined !== source) {
+    gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, params.format, params.dataType, source);
   } else {
     const pixelData = undefined !== bytes ? bytes : null;
     gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, params.width, params.height, 0, params.format, params.dataType, pixelData);
@@ -96,7 +94,7 @@ function loadTexture2DImageData(handle: TextureHandle, params: Texture2DCreatePa
 function loadTextureFromBytes(handle: TextureHandle, params: Texture2DCreateParams, bytes?: Texture2DData): void { loadTexture2DImageData(handle, params, bytes); }
 
 /** Associate cube texture data with a WebGLTexture from an image. */
-function loadTextureCubeImageData(handle: TextureHandle, params: TextureCubeCreateParams, images: CanvasOrImage[]): void {
+function loadTextureCubeImageData(handle: TextureHandle, params: TextureCubeCreateParams, images: TexImageSource[]): void {
   handle.bytesUsed = computeBytesUsed(params.dim * 6, params.dim, params.format, params.dataType);
 
   const tex = handle.getHandle()!;
@@ -238,7 +236,7 @@ class Texture2DCreateParams {
     targetWidth = Math.min(targetWidth, maxTexSize);
     targetHeight = Math.min(targetHeight, maxTexSize);
 
-    let element: CanvasOrImage = image;
+    let element: TexImageSource = image;
     if (targetWidth !== image.naturalWidth || targetHeight !== image.naturalHeight) {
       // Resize so dimensions are powers-of-two
       const canvas = document.createElement("canvas");
@@ -277,15 +275,8 @@ class Texture2DCreateParams {
       }
     }
 
-    // Always draw to canvas for ImageBitmap
-    const canvas = document.createElement("canvas");
-    canvas.width = targetWidth;
-    canvas.height = targetHeight;
-    const context = canvas.getContext("2d")!;
-    context.drawImage(image, 0, 0, canvas.width, canvas.height);
-
     return new Texture2DCreateParams(targetWidth, targetHeight, props.format, GL.Texture.DataType.UnsignedByte, props.wrapMode,
-      (tex: TextureHandle, params: Texture2DCreateParams) => loadTexture2DImageData(tex, params, undefined, canvas), props.useMipMaps, props.interpolate, props.anisotropicFilter);
+      (tex: TextureHandle, params: Texture2DCreateParams) => loadTexture2DImageData(tex, params, undefined, image), props.useMipMaps, props.interpolate, props.anisotropicFilter);
   }
 
   private static getImageProperties(type: RenderTexture.Type): TextureImageProperties {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -18,7 +18,7 @@ import {
   QPoint3dList, Quantization, RenderTexture, TextureMapping, TextureTransparency, TileFormat, TileReadStatus,
 } from "@itwin/core-common";
 import { FrontendLoggerCategory } from "../FrontendLoggerCategory";
-import { getImageSourceFormatForMimeType, imageElementFromImageSource, tryImageElementFromUrl } from "../ImageUtil";
+import { getImageSourceFormatForMimeType, imageBitmapFromImageSource, imageElementFromImageSource, tryImageElementFromUrl } from "../ImageUtil";
 import { IModelConnection } from "../IModelConnection";
 import { IModelApp } from "../IModelApp";
 import { GraphicBranch } from "../render/GraphicBranch";
@@ -32,6 +32,8 @@ import { RenderGraphic } from "../render/RenderGraphic";
 import { RenderSystem } from "../render/RenderSystem";
 import { RealityTileGeometry, TileContent } from "./internal";
 import type { DracoLoader, DracoMesh } from "@loaders.gl/draco";
+import { System } from "../render/webgl/System";
+import { TextureImageSource } from "../render/RenderTexture";
 
 /* eslint-disable no-restricted-syntax */
 
@@ -911,7 +913,7 @@ export abstract class GltfReader {
   protected get _samplers(): GltfDictionary<GltfSampler> { return this._glTF.samplers ?? emptyDict; }
   protected get _textures(): GltfDictionary<GltfTexture> { return this._glTF.textures ?? emptyDict; }
 
-  protected get _images(): GltfDictionary<GltfImage & { resolvedImage?: HTMLImageElement }> { return this._glTF.images ?? emptyDict; }
+  protected get _images(): GltfDictionary<GltfImage & { resolvedImage?: TextureImageSource }> { return this._glTF.images ?? emptyDict; }
   protected get _buffers(): GltfDictionary<GltfBuffer & { resolvedBuffer?: Uint8Array }> { return this._glTF.buffers ?? emptyDict; }
 
   /* -----------------------------------
@@ -1966,7 +1968,7 @@ export abstract class GltfReader {
     }
   }
 
-  private async resolveImage(image: GltfImage & { resolvedImage?: HTMLImageElement }): Promise<void> {
+  private async resolveImage(image: GltfImage & { resolvedImage?: TextureImageSource }): Promise<void> {
     if (image.resolvedImage)
       return;
 
@@ -1985,7 +1987,13 @@ export abstract class GltfReader {
       const offset = bufferView.byteOffset ?? 0;
       const bytes = bufferData.subarray(offset, offset + bufferView.byteLength);
       try {
-        image.resolvedImage = await imageElementFromImageSource(new ImageSource(bytes, format));
+        const imageSource = new ImageSource(bytes, format);
+
+        if (System.instance.capabilities.supportsCreateImageBitmap) {
+          image.resolvedImage = await imageBitmapFromImageSource(imageSource);
+        } else {
+          image.resolvedImage = await imageElementFromImageSource(imageSource);
+        }
       } catch (_) {
         //
       }

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -271,7 +271,7 @@ export class Capabilities {
       this._driverBugs.msaaWillHang = true;
 
     this._maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-    this._supportsCreateImageBitmap = typeof createImageBitmap === "function" && ProcessDetector.isChromium && !ProcessDetector.isIOSBrowser;
+    this._supportsCreateImageBitmap = typeof createImageBitmap === "function" && !ProcessDetector.isIOSBrowser;
     this._maxTexSizeAllow = Math.min(this._maxTextureSize, maxTexSizeAllowed);
     this._maxFragTextureUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
     this._maxVertTextureUnits = gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS);


### PR DESCRIPTION
This PR allows the GLTF reader to load textures using ImageBitmaps instead of HTMLImageElements when possible (ie. when createImageBitmap is available).

This should improve slightly the time spend in the glTexImage2D call in Firefox, and DecodeImage in Chromium based browser.

This PR changes several functions to allow the use of ImageBitmaps, including the TextureImageSource type and functions previously using CanvasOrImage type.