### PR TITLE
Read pixel improvements

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -11731,6 +11731,7 @@ export class ToolSettings {
     static doubleTapTimeout: BeDuration;
     // @beta
     static enableVirtualCursorForLocate: boolean;
+    static maxOnMotionSnapCallPerSecond: number;
     static preserveWorldUp: boolean;
     static scrollSpeed: number;
     static startDragDelay: BeDuration;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -24,7 +24,7 @@ public;AccuSnap
 public;AccuSnap
 public;ACSDisplayOptions
 public;ACSType
-alpha;ActivationEvent
+alpha;ActivationEvent = "onStartup"
 public;ActivityMessageDetails
 public;ActivityMessageEndReason
 internal;addRangeGraphic(builder: GraphicBuilder, range: Range3d, is2d: boolean): void
@@ -160,9 +160,6 @@ public;EntityState
 internal;EnvironmentDecorations
 public;EventController
 public;EventHandled
-alpha;ExtensionAdmin
-alpha;ExtensionHost
-alpha;ExtensionImpl
 alpha;ExtensionLoader
 alpha;ExtensionLoaderProps
 alpha;ExtensionManifest
@@ -651,7 +648,6 @@ public;ToolAssistanceInstructions
 public;ToolAssistanceKeyboardInfo
 public;ToolAssistanceSection
 public;ToolList = ToolType[]
-alpha;ToolProvider 
 public;ToolRegistry
 public;ToolSettings
 internal;ToolSettingsState

--- a/common/changes/@itwin/core-frontend/read-pixel-improvements_2022-04-14-08-40.json
+++ b/common/changes/@itwin/core-frontend/read-pixel-improvements_2022-04-14-08-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Reduce number of OnMotionSnap call",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -7,7 +7,7 @@
  */
 
 import { BeDuration } from "@itwin/core-bentley";
-import { CurveCurve, CurvePrimitive, GeometryQuery, IModelJson as GeomJson, Point2d, Point3d, Transform, /* Vector2d,*/ Vector3d, XAndY } from "@itwin/core-geometry";
+import { CurveCurve, CurvePrimitive, GeometryQuery, IModelJson as GeomJson, Point2d, Point3d, Transform, Vector3d, XAndY } from "@itwin/core-geometry";
 import { SnapRequestProps } from "@itwin/core-common";
 import { ElementLocateManager, HitListHolder, LocateAction, LocateFilterStatus, LocateResponse, SnapStatus } from "./ElementLocateManager";
 import { HitDetail, HitDetailType, HitGeomType, HitList, HitPriority, HitSource, IntersectDetail, SnapDetail, SnapHeat, SnapMode } from "./HitDetail";
@@ -19,9 +19,6 @@ import { ToolSettings } from "./tools/ToolSettings";
 import { DecorateContext } from "./ViewContext";
 import { Decorator } from "./ViewManager";
 import { ScreenViewport, Viewport } from "./Viewport";
-
-let rpCount = 0;
-let rpTimerHandle: any;
 
 // cspell:ignore dont primitivetools
 
@@ -928,22 +925,6 @@ export class AccuSnap implements Decorator {
    * @internal
    */
   public async onMotion(ev: BeButtonEvent): Promise<void> {
-    //    const screenPoint = new Vector2d(ev.viewPoint.x / ev.viewport.viewRect.width, ev.viewPoint.y / ev.viewport.viewRect.height);
-    //    const lastScreenPoint = new Vector2d(this._lastCursorPos.x / ev.viewport.viewRect.width, this._lastCursorPos.y / ev.viewport.viewRect.height);
-    //    const normalizedMovement = screenPoint.distance(lastScreenPoint);
-
-    if (rpTimerHandle === undefined) {
-      rpTimerHandle = setInterval(() => {
-        if (rpCount > 0) {
-          // eslint-disable-next-line no-console
-          console.log(`${rpCount} read pixel instruction the last second.`);
-        }
-        rpCount = 0;
-
-      }, 1000);
-    }
-    rpCount ++;
-
     this.clearToolTip(ev);
     const out = new LocateResponse();
     out.snapStatus = SnapStatus.Disabled;

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -7,7 +7,7 @@
  */
 
 import { BeDuration } from "@itwin/core-bentley";
-import { CurveCurve, CurvePrimitive, GeometryQuery, IModelJson as GeomJson, Point2d, Point3d, Transform, Vector3d, XAndY } from "@itwin/core-geometry";
+import { CurveCurve, CurvePrimitive, GeometryQuery, IModelJson as GeomJson, Point2d, Point3d, Transform, /* Vector2d,*/ Vector3d, XAndY } from "@itwin/core-geometry";
 import { SnapRequestProps } from "@itwin/core-common";
 import { ElementLocateManager, HitListHolder, LocateAction, LocateFilterStatus, LocateResponse, SnapStatus } from "./ElementLocateManager";
 import { HitDetail, HitDetailType, HitGeomType, HitList, HitPriority, HitSource, IntersectDetail, SnapDetail, SnapHeat, SnapMode } from "./HitDetail";
@@ -19,6 +19,9 @@ import { ToolSettings } from "./tools/ToolSettings";
 import { DecorateContext } from "./ViewContext";
 import { Decorator } from "./ViewManager";
 import { ScreenViewport, Viewport } from "./Viewport";
+
+let rpCount = 0;
+let rpTimerHandle: any;
 
 // cspell:ignore dont primitivetools
 
@@ -925,6 +928,22 @@ export class AccuSnap implements Decorator {
    * @internal
    */
   public async onMotion(ev: BeButtonEvent): Promise<void> {
+    //    const screenPoint = new Vector2d(ev.viewPoint.x / ev.viewport.viewRect.width, ev.viewPoint.y / ev.viewport.viewRect.height);
+    //    const lastScreenPoint = new Vector2d(this._lastCursorPos.x / ev.viewport.viewRect.width, this._lastCursorPos.y / ev.viewport.viewRect.height);
+    //    const normalizedMovement = screenPoint.distance(lastScreenPoint);
+
+    if (rpTimerHandle === undefined) {
+      rpTimerHandle = setInterval(() => {
+        if (rpCount > 0) {
+          // eslint-disable-next-line no-console
+          console.log(`${rpCount} read pixel instruction the last second.`);
+        }
+        rpCount = 0;
+
+      }, 1000);
+    }
+    rpCount ++;
+
     this.clearToolTip(ev);
     const out = new LocateResponse();
     out.snapStatus = SnapStatus.Disabled;

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -55,7 +55,7 @@ import { System } from "./System";
 import { TargetUniforms } from "./TargetUniforms";
 import { Techniques } from "./Technique";
 import { TechniqueId } from "./TechniqueId";
-import { TextureHandle } from "./Texture";
+import { Texture2DHandle, TextureHandle } from "./Texture";
 import { TextureDrape } from "./TextureDrape";
 import { EdgeSettings } from "./EdgeSettings";
 import { TargetGraphics } from "./TargetGraphics";
@@ -87,6 +87,11 @@ class EmptyHiliteSet {
   }
 }
 
+interface ReadPixelResources {
+  readonly texture: Texture2DHandle;
+  readonly fbo: FrameBuffer;
+}
+
 /** @internal */
 export abstract class Target extends RenderTarget implements RenderTargetDebugControl, WebGLDisposable {
   public readonly graphics = new TargetGraphics();
@@ -116,6 +121,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   private _animationBranches?: AnimationBranchStates;
   private _isReadPixelsInProgress = false;
   private _readPixelsSelector = Pixel.Selector.None;
+  private _readPixelReusableResources?: ReadPixelResources;
   private _drawNonLocatable = true;
   private _currentlyDrawingClassifier?: PlanarClassifier;
   private _analysisFraction: number = 0;
@@ -739,30 +745,68 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
     // We can't reuse the previous frame's data for a variety of reasons, chief among them that some types of geometry (surfaces, translucent stuff) don't write
     // to the pick buffers and others we don't want - such as non-pickable decorations - do.
     // Render to an offscreen buffer so that we don't destroy the current color buffer.
-    const texture = TextureHandle.createForAttachment(rect.width, rect.height, GL.Texture.Format.Rgba, GL.Texture.DataType.UnsignedByte);
-    if (undefined === texture) {
+    const resources = this.createOrReuseReadPixelResources(rect);
+    if (resources === undefined) {
       receiver(undefined);
       return;
     }
 
     let result: Pixel.Buffer | undefined;
-    const fbo = FrameBuffer.create([texture]);
-    if (undefined !== fbo) {
-      this.renderSystem.frameBufferStack.execute(fbo, true, false, () => {
-        this._drawNonLocatable = !excludeNonLocatable;
-        result = this.readPixelsFromFbo(rect, selector);
-        this._drawNonLocatable = true;
-      });
 
-      dispose(fbo);
-    }
+    this.renderSystem.frameBufferStack.execute(resources.fbo, true, false, () => {
+      this._drawNonLocatable = !excludeNonLocatable;
+      result = this.readPixelsFromFbo(rect, selector);
+      this._drawNonLocatable = true;
+    });
 
-    dispose(texture);
+    this.disposeOrReuseReadPixelResources(resources);
 
     receiver(result);
 
     // Reset the batch IDs in all batches drawn for this call.
     this.uniforms.batch.resetBatchState();
+  }
+
+  private createOrReuseReadPixelResources(rect: ViewRect): ReadPixelResources | undefined {
+    if (this._readPixelReusableResources !== undefined) {
+
+      // To reuse a texture, we need it to be the same size or smaller than what we need
+      if (this._readPixelReusableResources.texture.width >= rect.width && this._readPixelReusableResources.texture.height >= rect.height) {
+        const resources = this._readPixelReusableResources;
+        this._readPixelReusableResources = undefined;
+
+        return resources;
+      }
+    }
+
+    // Create a new texture/fbo
+    const texture = TextureHandle.createForAttachment(rect.width, rect.height, GL.Texture.Format.Rgba, GL.Texture.DataType.UnsignedByte);
+    if (texture === undefined)
+      return undefined;
+
+    const fbo = FrameBuffer.create([texture]);
+    if (fbo === undefined) {
+      dispose(texture);
+      return undefined;
+    }
+
+    return { texture, fbo };
+  }
+
+  private disposeOrReuseReadPixelResources({texture, fbo}: ReadPixelResources) {
+    if (this._readPixelReusableResources !== undefined) {
+      // Keep the biggest texture
+      if (this._readPixelReusableResources.texture.width > texture.width && this._readPixelReusableResources.texture.height > texture.height) {
+        dispose(fbo);
+        dispose(texture);
+        return;
+      } else {
+        dispose(this._readPixelReusableResources.fbo);
+        dispose(this._readPixelReusableResources.texture);
+      }
+    }
+
+    this._readPixelReusableResources = {texture, fbo};
   }
 
   private beginReadPixels(selector: Pixel.Selector, cullingFrustum?: Frustum): void {

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -770,7 +770,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   private createOrReuseReadPixelResources(rect: ViewRect): ReadPixelResources | undefined {
     if (this._readPixelReusableResources !== undefined) {
 
-      // To reuse a texture, we need it to be the same size or smaller than what we need
+      // To reuse a texture, we need it to be the same size or bigger than what we need
       if (this._readPixelReusableResources.texture.width >= rect.width && this._readPixelReusableResources.texture.height >= rect.height) {
         const resources = this._readPixelReusableResources;
         this._readPixelReusableResources = undefined;

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -6,8 +6,8 @@
  * @module Tools
  */
 
-import { AbandonedError, assert, BeEvent, IModelStatus, Logger } from "@itwin/core-bentley";
-import { Matrix3d, Point2d, Point3d, Transform, Vector3d, XAndY } from "@itwin/core-geometry";
+import { AbandonedError, assert, BeEvent, BeTimePoint, IModelStatus, Logger } from "@itwin/core-bentley";
+import { Matrix3d, Point2d, Point3d, Transform, Vector2d, Vector3d, XAndY } from "@itwin/core-geometry";
 import { Easing, GeometryStreamProps, NpcCenter } from "@itwin/core-common";
 import { DialogItemValue, DialogPropertyItem, DialogPropertySyncItem } from "@itwin/appui-abstract";
 import { AccuSnap, TentativeOrAccuSnap } from "../AccuSnap";
@@ -322,6 +322,9 @@ export class ToolAdmin {
   private _saveLocateCircle = false;
   private _defaultToolId = "Select";
   private _defaultToolArgs?: any[];
+  private _lastHandledMotionTime?: BeTimePoint;
+  private _lastHandledMotionPoint?: Vector2d;
+  private _mouseMoveOverTimeout?: NodeJS.Timeout;
 
   /** The name of the [[PrimitiveTool]] to use as the default tool. Defaults to "Select", referring to [[SelectionTool]].
    * @see [[startDefaultTool]] to activate the default tool.
@@ -952,13 +955,51 @@ export class ToolAdmin {
 
   private async onMotionSnap(ev: BeButtonEvent): Promise<boolean> {
     try {
-      await IModelApp.accuSnap.onMotion(ev);
+      await this.onMotionSnapOrSkip(ev);
       return true;
     } catch (error) {
       if (error instanceof AbandonedError)
         return false; // expected, not a problem. Just ignore this motion and return.
       throw error; // unknown error
     }
+  }
+
+  // Call accuSnap.onMotion
+  private async onMotionSnapOrSkip(ev: BeButtonEvent): Promise<void> {
+    if (this.shouldSkipOnMotionSnap(ev))
+      return;
+
+    await IModelApp.accuSnap.onMotion(ev);
+
+    this._lastHandledMotionTime = BeTimePoint.now();
+    this._lastHandledMotionPoint = Vector2d.fromJSON(ev.viewPoint);
+  }
+
+  // Should the current onMotionSnap event be skipped to avoid unnecessary ReadPixel calls?
+  private shouldSkipOnMotionSnap(ev: BeButtonEvent ): boolean {
+    if (this._lastHandledMotionTime === undefined)
+      return false;
+
+    const now = BeTimePoint.now();
+    const msSinceLastCall = now.milliseconds - this._lastHandledMotionTime.milliseconds;
+
+    const maxOnMotionCallPerSecond = 15; // TODO: Make it configurable?
+    const delay = 1000 / maxOnMotionCallPerSecond;
+
+    if (msSinceLastCall < delay) // Call too close to the previous one, skip it
+      return true;
+    if (msSinceLastCall > 2 * delay) // Call too long after last one, keep it
+      return false;
+
+    const movement = this._lastHandledMotionPoint?.vectorTo(ev.viewPoint);
+
+    if (movement !== undefined) {
+      const distance = new Vector2d(movement.x / ev.viewport!.viewRect.width, movement.y / ev.viewport!.viewRect.height).magnitude();
+
+      return distance < 0.1 || distance > 0.6; // TODO: Make it configurable?
+    }
+
+    return false;
   }
 
   private async onStartDrag(ev: BeButtonEvent, tool?: InteractiveTool): Promise<EventHandled> {
@@ -1047,7 +1088,27 @@ export class ToolAdmin {
     if (!(buttonMask & 1))
       this.currentInputState.button[BeButton.Data].isDown = false;
 
+    if (this._mouseMoveOverTimeout !== undefined)
+      clearTimeout(this._mouseMoveOverTimeout);
+    this._mouseMoveOverTimeout = setTimeout(async () => {await this.onMouseMoveOver(event);}, 100);
+
     return this.onMotion(vp, pos, InputSource.Mouse, false, mov);
+  }
+
+  // Called with the last MouseMove event if the user stopped moving the mouse
+  private async onMouseMoveOver(event: ToolEvent): Promise<any> {
+    // Make sure that we fire the motion snap event correctly
+    this._lastHandledMotionTime = this._lastHandledMotionPoint = undefined;
+
+    const vp = event.vp!;
+    const pos = this.getMousePosition(event);
+    const current = this.currentInputState;
+
+    const ev = new BeButtonEvent();
+    current.fromPoint(vp, pos, InputSource.Mouse);
+    current.toEvent(ev, false);
+
+    await this.onMotionSnap(ev);
   }
 
   public adjustPointToACS(pointActive: Point3d, vp: Viewport, perpendicular: boolean): void {
@@ -1229,6 +1290,8 @@ export class ToolAdmin {
     current.onButtonDown(button);
     current.toEvent(ev, true);
     current.updateDownPoint(ev);
+
+    await this.onMotionSnap(ev);
 
     return this.sendButtonEvent(ev);
   }

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -981,8 +981,7 @@ export class ToolAdmin {
     const now = BeTimePoint.now();
     const msSinceLastCall = now.milliseconds - this._lastHandledMotionTime.milliseconds;
 
-    const maxOnMotionCallPerSecond = 15; // TODO: Make it configurable?
-    const delay = 1000 / maxOnMotionCallPerSecond;
+    const delay = 1000 / ToolSettings.maxOnMotionSnapCallPerSecond;
 
     return msSinceLastCall < delay;
   }

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -952,6 +952,13 @@ export class ToolAdmin {
     this._snapMotionPromise = this._toolMotionPromise = undefined;
   }
 
+  private async forceOnMotionSnap(ev: BeButtonEvent): Promise<boolean> {
+    // Make sure that we fire the motion snap event correctly
+    this._lastHandledMotionTime = undefined;
+
+    return this.onMotionSnap(ev);
+  }
+
   private async onMotionSnap(ev: BeButtonEvent): Promise<boolean> {
     try {
       await this.onMotionSnapOrSkip(ev);
@@ -1081,9 +1088,6 @@ export class ToolAdmin {
 
   // Called with the last MouseMove event if the user stopped moving the mouse
   private async onMouseMoveOver(event: ToolEvent): Promise<any> {
-    // Make sure that we fire the motion snap event correctly
-    this._lastHandledMotionTime = undefined;
-
     const vp = event.vp!;
     const pos = this.getMousePosition(event);
     const current = this.currentInputState;
@@ -1092,7 +1096,7 @@ export class ToolAdmin {
     current.fromPoint(vp, pos, InputSource.Mouse);
     current.toEvent(ev, false);
 
-    await this.onMotionSnap(ev);
+    await this.forceOnMotionSnap(ev);
   }
 
   public adjustPointToACS(pointActive: Point3d, vp: Viewport, perpendicular: boolean): void {
@@ -1275,7 +1279,7 @@ export class ToolAdmin {
     current.toEvent(ev, true);
     current.updateDownPoint(ev);
 
-    await this.onMotionSnap(ev);
+    await this.forceOnMotionSnap(ev);
 
     return this.sendButtonEvent(ev);
   }

--- a/core/frontend/src/tools/ToolSettings.ts
+++ b/core/frontend/src/tools/ToolSettings.ts
@@ -75,4 +75,6 @@ export class ToolSettings {
     /** Maximum duration of the inertia operation. Important when frame rates are low. */
     duration: BeDuration.fromMilliseconds(500),
   };
+  /** Maximum number of times in a second the accuSnap tool's onMotion function is called. */
+  public static maxOnMotionSnapCallPerSecond = 15;
 }


### PR DESCRIPTION
This PR aims to reduce the footprint of ReadPixel calls triggered by accuSnap tool. ReadPixel is an expensive call forcing synchronization and currently it is being called each time the mouse is moved. Most of the time this is not necessary.

It tries to reuse the textures and fbo generated in the call when possible.

It imposes a delay between each to avoid unnecessary calls. To avoid using invalid data at the end of a movement, a callback is created to detect when the mouse stops moving and to trigger a last readPixel call.

When the use press a mouse button, ReadPixel is also called to make sure the clicked point is accurate.