### PR TITLE
Exclude advisory for async package introduced by fast-sass-loader

### DIFF
--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -49,6 +49,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-x4jg-mjrx-434g", // https://github.com/advisories/GHSA-x4jg-mjrx-434g.
     "GHSA-cfm4-qjh2-4765", // https://github.com/advisories/GHSA-cfm4-qjh2-4765.
     "GHSA-5w9c-rv96-fr7g", // https://github.com/advisories/GHSA-5w9c-rv96-fr7g.
+    "GHSA-fwr7-v2mv-hh25", // https://github.com/advisories/GHSA-fwr7-v2mv-hh25.
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
@bentley/react-scripts has a dependency on fast-sass-loader 2.0.1, which is the latest version and was released 6 months ago. Fast-sass-loader has a dependency on the async package "^2.x.x", but the async vulnerability is fixed in major version 3.

Here is the failing line from rush audit:

##[error]HIGH Security Vulnerability: Prototype Pollution in async in async (from ..__..__test-apps__display-performance-test-app>@bentley/react-scripts>fast-sass-loader>async).  See https://github.com/advisories/GHSA-fwr7-v2mv-hh25 for more info.

Here is the fast-sass-loader package (Latest release 2.0.1): https://www.npmjs.com/package/fast-sass-loader

And here is a screenshot of what fast-sass-loader requires 
![image](https://user-images.githubusercontent.com/22119573/163186284-6556473a-707a-4136-90be-b310c28a7c5e.png)
