### PR TITLE
Fix UI 1.0 bug were widgets defined by providers did not honor the Center Zone position

### DIFF
--- a/common/changes/@itwin/appui-react/ui-exampleOfHidingWidgetsInUi1and2_2022-04-19-12-24.json
+++ b/common/changes/@itwin/appui-react/ui-exampleOfHidingWidgetsInUi1and2_2022-04-19-12-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix bug where widgets from UiItemProviders were not honoring Center Zonelocation in UI 1.0 mode.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/ui-items-providers-test/src/ui/widgets/SelectedElementDataWidget.tsx
+++ b/test-apps/ui-items-providers-test/src/ui/widgets/SelectedElementDataWidget.tsx
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { useSpecificWidgetDef } from "@itwin/appui-react";
+import { UiFramework, useSpecificWidgetDef } from "@itwin/appui-react";
 import { WidgetState } from "@itwin/appui-abstract";
 import { Centered } from "@itwin/core-react";
 import { ISelectionProvider, Presentation, SelectionChangeEventArgs } from "@itwin/presentation-frontend";
@@ -40,6 +40,9 @@ export function SelectedElementDataWidgetComponent() {
   const widgetDef = useSpecificWidgetDef("ui-item-provider-test:elementDataListWidget");
 
   React.useEffect(() => {
+    if (UiFramework.uiVersion === "1")
+      return;
+
     // using setImmediate to give time for frontstage to load before calling setWidgetState
     if (idList.length === 0) {
       setImmediate(() => widgetDef?.setWidgetState(WidgetState.Hidden));

--- a/ui/appui-react/src/appui-react/widgets/WidgetHost.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetHost.tsx
@@ -77,40 +77,89 @@ export class WidgetHost {
 
     let dynamicWidgetDefs: readonly WidgetDef[] | undefined;
 
-    if (location in ZoneLocation) {
-      switch (location) {
-        case ZoneLocation.CenterLeft:
-          break; // added to BottomLeft
-        case ZoneLocation.BottomLeft:
-          {
-            const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.CenterLeft, section, frontstageApplicationData) ?? [];
-            const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.BottomLeft, section, frontstageApplicationData) ?? [];
-            dynamicWidgetDefs = [...middleDynamicWidgetDefs, ...bottomDynamicWidgetDefs];
-          }
-          break;
-        case ZoneLocation.CenterRight:
-          break; // added to BottomRight
-        case ZoneLocation.BottomRight:
-          {
-            const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.CenterRight, section, frontstageApplicationData) ?? [];
-            const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.BottomRight, section, frontstageApplicationData) ?? [];
-            dynamicWidgetDefs = [...middleDynamicWidgetDefs, ...bottomDynamicWidgetDefs];
-          }
-          break;
-      }
-    } else if ((location in StagePanelLocation) && undefined !== section) {
-      switch (section) {
-        case StagePanelSection.Start: {
-          dynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.Start, frontstageApplicationData) ?? [];
-          break;
+    if (UiFramework.uiVersion === "1") {
+      // istanbul ignore next
+      if (location in ZoneLocation) {
+        switch (location) {
+          case ZoneLocation.CenterLeft:
+            {
+              const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.CenterLeft, section, frontstageApplicationData) ?? [];
+              dynamicWidgetDefs = [...middleDynamicWidgetDefs];
+            }
+            break;
+          case ZoneLocation.BottomLeft:
+            {
+              const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.BottomLeft, section, frontstageApplicationData) ?? [];
+              dynamicWidgetDefs = [...bottomDynamicWidgetDefs];
+            }
+            break;
+          case ZoneLocation.CenterRight:
+            {
+              const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.CenterRight, section, frontstageApplicationData) ?? [];
+              dynamicWidgetDefs = [...middleDynamicWidgetDefs];
+            }
+            break; // added to BottomRight
+          case ZoneLocation.BottomRight:
+            {
+              const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.BottomRight, section, frontstageApplicationData) ?? [];
+              dynamicWidgetDefs = [...bottomDynamicWidgetDefs];
+            }
+            break;
         }
-        case StagePanelSection.Middle:
-          break; // added to BottomLeft
-        case StagePanelSection.End: {
-          const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.Middle, frontstageApplicationData) ?? [];
-          const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.End, frontstageApplicationData) ?? [];
-          dynamicWidgetDefs = [...middleDynamicWidgetDefs, ...bottomDynamicWidgetDefs];
-          break;
+      } else if ((location in StagePanelLocation) && undefined !== section) {
+        switch (section) {
+          case StagePanelSection.Start: {
+            dynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.Start, frontstageApplicationData) ?? [];
+            break;
+          }
+          case StagePanelSection.Middle:
+            const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.Middle, frontstageApplicationData) ?? [];
+            dynamicWidgetDefs = [...middleDynamicWidgetDefs];
+            break; // added to BottomLeft
+          case StagePanelSection.End: {
+            const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.End, frontstageApplicationData) ?? [];
+            dynamicWidgetDefs = [...bottomDynamicWidgetDefs];
+            break;
+          }
+        }
+      }
+
+    } else {
+      if (location in ZoneLocation) {
+        switch (location) {
+          case ZoneLocation.CenterLeft:
+            break; // added to BottomLeft
+          case ZoneLocation.BottomLeft:
+            {
+              const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.CenterLeft, section, frontstageApplicationData) ?? [];
+              const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.BottomLeft, section, frontstageApplicationData) ?? [];
+              dynamicWidgetDefs = [...middleDynamicWidgetDefs, ...bottomDynamicWidgetDefs];
+            }
+            break;
+          case ZoneLocation.CenterRight:
+            break; // added to BottomRight
+          case ZoneLocation.BottomRight:
+            {
+              const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.CenterRight, section, frontstageApplicationData) ?? [];
+              const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, ZoneLocation.BottomRight, section, frontstageApplicationData) ?? [];
+              dynamicWidgetDefs = [...middleDynamicWidgetDefs, ...bottomDynamicWidgetDefs];
+            }
+            break;
+        }
+      } else if ((location in StagePanelLocation) && undefined !== section) {
+        switch (section) {
+          case StagePanelSection.Start: {
+            dynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.Start, frontstageApplicationData) ?? [];
+            break;
+          }
+          case StagePanelSection.Middle:
+            break; // added to BottomLeft
+          case StagePanelSection.End: {
+            const middleDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.Middle, frontstageApplicationData) ?? [];
+            const bottomDynamicWidgetDefs = UiFramework.widgetManager.getWidgetDefs(stageId, stageUsage, location, StagePanelSection.End, frontstageApplicationData) ?? [];
+            dynamicWidgetDefs = [...middleDynamicWidgetDefs, ...bottomDynamicWidgetDefs];
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
Fix UI 1.0 bug were widgets defined by providers did not honor the Center Zone position. Since UI 2.0 now only supports two panel sections the widgets in 1.0 were being moved for center to bottom, but for UI 1 the center zone should be supported.