### PR TITLE
Do not produce mip-maps for reality tile textures

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3848,12 +3848,14 @@ export abstract class GltfReader {
     protected createDisplayParams(material: GltfMaterial, hasBakedLighting: boolean): DisplayParams | undefined;
     // (undocumented)
     protected readonly _deduplicateVertices: boolean;
+    defaultWrapMode: GltfWrapMode;
     // (undocumented)
     protected findTextureMapping(id: string, isTransparent: boolean): TextureMapping | undefined;
     // (undocumented)
     getBufferView(json: {
         [k: string]: any;
     }, accessorName: string): GltfBufferView | undefined;
+    getTextureType(sampler?: GltfSampler): RenderTexture.Type;
     // (undocumented)
     protected readonly _glTF: Gltf;
     // (undocumented)
@@ -3976,6 +3978,24 @@ export class GltfReaderProps {
 export interface GltfReaderResult extends TileContent {
     // (undocumented)
     readStatus: TileReadStatus;
+}
+
+// @internal
+export interface GltfSampler extends GltfChildOfRootProperty {
+    magFilter?: GltfMagFilter;
+    minFilter?: GltfMinFilter;
+    wrapS?: GltfWrapMode;
+    wrapT?: GltfWrapMode;
+}
+
+// @internal
+export enum GltfWrapMode {
+    // (undocumented)
+    ClampToEdge = 33071,
+    // (undocumented)
+    MirroredRepeat = 33648,
+    // (undocumented)
+    Repeat = 10497
 }
 
 // @internal (undocumented)

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -232,6 +232,8 @@ internal;class GltfReader
 internal;GltfReaderArgs
 internal;GltfReaderProps
 internal;GltfReaderResult 
+internal;GltfSampler 
+internal;GltfWrapMode
 internal;GLTimerResult
 internal;GLTimerResultCallback = (result: GLTimerResult) => void
 public;GpuMemoryLimit = "none" | "default" | "aggressive" | "relaxed" | number

--- a/common/changes/@itwin/core-frontend/pmc-no-mip-reality-textures_2022-04-23-16-38.json
+++ b/common/changes/@itwin/core-frontend/pmc-no-mip-reality-textures_2022-04-23-16-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Do not produce mip-maps for reality tile textures.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -308,7 +308,7 @@ describe("GltfReader", () => {
     expectCycle(3);
   });
 
-  describe.only("textures", () => {
+  describe("textures", () => {
     function expectTextureType(expected: RenderTexture.Type, sampler: GltfSampler | undefined, defaultWrap?: GltfWrapMode): void {
       const reader = createReader(makeGlb(minimalJson, minimalBin))!;
       expect(reader).not.to.be.undefined;
@@ -346,6 +346,20 @@ describe("GltfReader", () => {
       expectTextureType(RenderTexture.Type.TileSection, undefined, GltfWrapMode.ClampToEdge);
       expectTextureType(RenderTexture.Type.TileSection, { }, GltfWrapMode.ClampToEdge);
       expectTextureType(RenderTexture.Type.TileSection, { magFilter: 9728, minFilter: 9987 }, GltfWrapMode.ClampToEdge);
+
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.Repeat }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.Normal, { wrapT: GltfWrapMode.Repeat }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.Repeat, wrapT: GltfWrapMode.Repeat }, GltfWrapMode.ClampToEdge);
+
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.MirroredRepeat }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.Normal, { wrapT: GltfWrapMode.MirroredRepeat }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.MirroredRepeat, wrapT: GltfWrapMode.MirroredRepeat }, GltfWrapMode.ClampToEdge);
+
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.ClampToEdge }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.TileSection, { wrapT: GltfWrapMode.ClampToEdge }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.ClampToEdge, wrapT: GltfWrapMode.ClampToEdge }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.Repeat, wrapT: GltfWrapMode.ClampToEdge }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.ClampToEdge, wrapT: GltfWrapMode.MirroredRepeat }, GltfWrapMode.ClampToEdge);
     });
   });
 });

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -4,10 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { GltfV2ChunkTypes, GltfVersions, TileFormat } from "@itwin/core-common";
+import { GltfV2ChunkTypes, GltfVersions, RenderTexture, TileFormat } from "@itwin/core-common";
 import { IModelConnection } from "../../IModelConnection";
 import { IModelApp } from "../../IModelApp";
-import { Gltf, GltfGraphicsReader, GltfId, GltfNode, GltfReaderProps } from "../../tile/GltfReader";
+import { Gltf, GltfGraphicsReader, GltfId, GltfNode, GltfReaderProps, GltfSampler, GltfWrapMode } from "../../tile/GltfReader";
 import { createBlankConnection } from "../createBlankConnection";
 
 const minimalBin = new Uint8Array([12, 34, 0xfe, 0xdc]);
@@ -306,5 +306,40 @@ describe("GltfReader", () => {
     expectCycle(1);
     expectCycle(2);
     expectCycle(3);
+  });
+
+  describe.only("textures", () => {
+    function expectTextureType(expected: RenderTexture.Type, sampler: GltfSampler | undefined): void {
+      const reader = createReader(makeGlb(minimalJson, minimalBin))!;
+      expect(reader).not.to.be.undefined;
+      expect(reader.getTextureType(sampler)).to.equal(expected);
+    }
+
+    // This test includes a current deviation from the glTF spec: we currently do not support mirrored repeat.
+    it("produces normal textures unless clamp-to-edge is specified", () => {
+      expectTextureType(RenderTexture.Type.Normal, undefined);
+      expectTextureType(RenderTexture.Type.Normal, { });
+      expectTextureType(RenderTexture.Type.Normal, { magFilter: 9728, minFilter: 9987 });
+
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.Repeat });
+      expectTextureType(RenderTexture.Type.Normal, { wrapT: GltfWrapMode.Repeat });
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.Repeat, wrapT: GltfWrapMode.Repeat });
+
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.MirroredRepeat });
+      expectTextureType(RenderTexture.Type.Normal, { wrapT: GltfWrapMode.MirroredRepeat });
+      expectTextureType(RenderTexture.Type.Normal, { wrapS: GltfWrapMode.MirroredRepeat, wrapT: GltfWrapMode.MirroredRepeat });
+    });
+
+    // This test includes a current deviation from the glTF spec: we currently do not support different wrapping behavior for S/U and T/V.
+    it("produces tile section if either S or T are clamped to edge", () => {
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.ClampToEdge });
+      expectTextureType(RenderTexture.Type.TileSection, { wrapT: GltfWrapMode.ClampToEdge });
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.ClampToEdge, wrapT: GltfWrapMode.ClampToEdge });
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.Repeat, wrapT: GltfWrapMode.ClampToEdge });
+      expectTextureType(RenderTexture.Type.TileSection, { wrapS: GltfWrapMode.ClampToEdge, wrapT: GltfWrapMode.MirroredRepeat });
+    });
+
+    it("overrides default texture type if unspecified by sampler", () => {
+    });
   });
 });

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -309,9 +309,12 @@ describe("GltfReader", () => {
   });
 
   describe.only("textures", () => {
-    function expectTextureType(expected: RenderTexture.Type, sampler: GltfSampler | undefined): void {
+    function expectTextureType(expected: RenderTexture.Type, sampler: GltfSampler | undefined, defaultWrap?: GltfWrapMode): void {
       const reader = createReader(makeGlb(minimalJson, minimalBin))!;
       expect(reader).not.to.be.undefined;
+      if (undefined !== defaultWrap)
+        reader.defaultWrapMode = defaultWrap;
+
       expect(reader.getTextureType(sampler)).to.equal(expected);
     }
 
@@ -340,6 +343,9 @@ describe("GltfReader", () => {
     });
 
     it("overrides default texture type if unspecified by sampler", () => {
+      expectTextureType(RenderTexture.Type.TileSection, undefined, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.TileSection, { }, GltfWrapMode.ClampToEdge);
+      expectTextureType(RenderTexture.Type.TileSection, { magFilter: 9728, minFilter: 9987 }, GltfWrapMode.ClampToEdge);
     });
   });
 });

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -2013,8 +2013,11 @@ export abstract class GltfReader {
   /** Exposed strictly for testing. */
   public getTextureType(sampler?: GltfSampler): RenderTexture.Type {
     // ###TODO: RenderTexture currently does not support different wrapping behavior for U vs V, nor does it support mirrored repeat.
-    const wrapS = sampler?.wrapS ?? this.defaultWrapMode;
-    const wrapT = sampler?.wrapT ?? this.defaultWrapMode;
+    let wrapS = sampler?.wrapS;
+    let wrapT = sampler?.wrapT;
+    if (undefined === wrapS && undefined === wrapT)
+      wrapS = wrapT = this.defaultWrapMode;
+
     if (GltfWrapMode.ClampToEdge === wrapS || GltfWrapMode.ClampToEdge === wrapT)
       return RenderTexture.Type.TileSection;
 


### PR DESCRIPTION
glTF spec defaults wrap mode to "repeat" if unspecified. We only produce mip-maps for repeating textures.
Some reality tiles were not specifying wrap mode, but they do not repeat and LOD is baked into the tiles so we do not want to generate mip-maps for them.
Allow GltfReader to override the default wrap mode. Make RealityTileLoader default it to ClampToEdge.
Eliminating mip-maps for these textures will reduce GPU memory usage and most likely also reduce time spent creating the textures.

This issue was reported by @TitouanLeDuigou; he discovered it in the Orlando reality model.