### PR TITLE
Fix scaled monochrome for instanced geometry.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-instanced-monochrome-fix_2022-04-23-16-53.json
+++ b/common/changes/@itwin/core-frontend/pmc-instanced-monochrome-fix_2022-04-23-16-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix scaled monochrome mode not applying to instanced geometry.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/InstancedGeometry.ts
+++ b/core/frontend/src/render/webgl/InstancedGeometry.ts
@@ -298,6 +298,7 @@ export class InstancedGeometry extends CachedGeometry {
   public override getLineCode(params: ShaderProgramParams) { return this._repr.getLineCode(params); }
   public override getLineWeight(params: ShaderProgramParams) { return this._repr.getLineWeight(params); }
   public override wantMonochrome(target: Target) { return this._repr.wantMonochrome(target); }
+  public override wantMixMonochromeColor(target: Target): boolean { return this._repr.wantMixMonochromeColor(target); }
 
   public static create(repr: LUTGeometry, ownsBuffers: boolean, buffers: InstanceBuffers): InstancedGeometry {
     const techId = repr.techniqueId;


### PR DESCRIPTION
Instanced geometry was always using flat (not scaled) monochrome color.