### PR TITLE
Add mergify config with backport reviewer rule

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,10 @@
+# Configuration file for mergify
+
+pull_request_rules:
+  - name: Add reviewers to backports
+    conditions:
+      - base~=release\/[0-9]+.[0-9]+.x
+    actions:
+      request_reviews:
+        teams:
+          - "@iTwin/itwinjs-core-backport-reviewers"

--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -50,6 +50,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-cfm4-qjh2-4765", // https://github.com/advisories/GHSA-cfm4-qjh2-4765.
     "GHSA-5w9c-rv96-fr7g", // https://github.com/advisories/GHSA-5w9c-rv96-fr7g.
     "GHSA-fwr7-v2mv-hh25", // https://github.com/advisories/GHSA-fwr7-v2mv-hh25.
+    "GHSA-phwq-j96m-2c2q", // https://github.com/advisories/GHSA-phwq-j96m-2c2q
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
Add mergify rule to automatically add @iTwin/itwinjs-core-backport-reviewers as reviewers to any backport PR.