### PR TITLE
Refactor Mobile Auth

### DIFF
--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -104,7 +104,11 @@ export class IOSApp {
 }
 
 // @beta (undocumented)
-export type IOSAppOpts = NativeAppOpts;
+export type IOSAppOpts = NativeAppOpts & {
+    iModelApp: {
+        authorizationClient?: never;
+    };
+};
 
 // @beta (undocumented)
 export class IOSHost extends MobileHost {

--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -135,47 +135,19 @@ export class MobileApp {
 }
 
 // @beta
-export interface MobileAppAuthorizationConfiguration {
-    readonly clientId: string;
-    readonly expiryBuffer?: number;
-    issuerUrl?: string;
-    readonly redirectUri?: string;
-    readonly scope: string;
-}
-
-// @beta
 export interface MobileAppFunctions {
+    // (undocumented)
+    getAccessToken: () => Promise<AccessToken>;
     // (undocumented)
     reconnect: (connection: number) => Promise<void>;
 }
 
 // @beta
 export class MobileAuthorizationBackend implements AuthorizationClient {
-    constructor(config?: MobileAppAuthorizationConfiguration);
     // (undocumented)
-    protected _accessToken?: AccessToken;
-    // (undocumented)
-    protected _baseUrl: string;
-    // (undocumented)
-    config?: MobileAppAuthorizationConfiguration;
-    // (undocumented)
-    static defaultRedirectUri: string;
-    // (undocumented)
-    expireSafety: number;
+    protected _accessToken: AccessToken;
     // (undocumented)
     getAccessToken(): Promise<AccessToken>;
-    initialize(config?: MobileAppAuthorizationConfiguration): Promise<void>;
-    // (undocumented)
-    issuerUrl?: string;
-    // (undocumented)
-    get redirectUri(): string;
-    refreshToken(): Promise<AccessToken>;
-    // (undocumented)
-    setAccessToken(token?: AccessToken): void;
-    signIn(): Promise<void>;
-    signOut(): Promise<void>;
-    // (undocumented)
-    protected _url?: string;
 }
 
 // @beta (undocumented)
@@ -188,14 +160,6 @@ export type MobileCompletionCallback = (downloadUrl: string, downloadFileUrl: st
 export abstract class MobileDevice {
     // (undocumented)
     abstract authGetAccessToken(callback: (accessToken?: string, err?: string) => void): void;
-    // (undocumented)
-    authInit(_config: MobileAppAuthorizationConfiguration, callback: (err?: string) => void): void;
-    // (undocumented)
-    abstract authSignIn(callback: (err?: string) => void): void;
-    // (undocumented)
-    abstract authSignOut(callback: (err?: string) => void): void;
-    // (undocumented)
-    abstract authStateChanged(accessToken?: string, err?: string): void;
     // (undocumented)
     abstract cancelDownloadTask(cancelId: number): boolean;
     // (undocumented)
@@ -236,8 +200,6 @@ export class MobileFileHandler {
 
 // @beta (undocumented)
 export class MobileHost {
-    // @internal (undocumented)
-    static get authorization(): import("@itwin/core-common").AuthorizationClient | undefined;
     // (undocumented)
     static get device(): MobileDevice;
     // @internal (undocumented)
@@ -265,8 +227,6 @@ export interface MobileHostOpts extends NativeHostOpts {
     mobileHost?: {
         device?: MobileDevice;
         rpcInterfaces?: RpcInterfaceDefinition[];
-        authConfig?: MobileAppAuthorizationConfiguration;
-        noInitializeAuthClient?: boolean;
     };
 }
 

--- a/common/changes/@itwin/core-mobile/refactor-mobile-auth_2022-04-28-17-26.json
+++ b/common/changes/@itwin/core-mobile/refactor-mobile-auth_2022-04-28-17-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "Remove auth configuration in favor of native auth handling.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/mobile/src/common/MobileAppProps.ts
+++ b/core/mobile/src/common/MobileAppProps.ts
@@ -3,6 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import { AccessToken } from "@itwin/core-bentley";
+
 /** @beta */
 export enum Orientation {
   Unknown = 0,
@@ -40,4 +42,5 @@ export type DeviceEvents = "memoryWarning" | "orientationChanged" | "enterForegr
 */
 export interface MobileAppFunctions {
   reconnect: (connection: number) => Promise<void>;
+  getAccessToken: () => Promise<AccessToken>;
 }

--- a/core/mobile/src/frontend/IOSApp.ts
+++ b/core/mobile/src/frontend/IOSApp.ts
@@ -7,7 +7,7 @@ import { NativeAppOpts } from "@itwin/core-frontend";
 import { MobileApp } from "./MobileApp";
 
 /** @beta */
-export type IOSAppOpts = NativeAppOpts;
+export type IOSAppOpts = NativeAppOpts & { iModelApp: { authorizationClient?: never } };
 
 /** @beta */
 export class IOSApp {

--- a/core/mobile/src/frontend/MobileApp.ts
+++ b/core/mobile/src/frontend/MobileApp.ts
@@ -9,6 +9,7 @@ import { IpcApp, NativeApp, NativeAppOpts, NotificationHandler } from "@itwin/co
 import { mobileAppChannel, mobileAppNotify } from "../common/MobileAppChannel";
 import { MobileAppFunctions, MobileNotifications } from "../common/MobileAppProps";
 import { MobileRpcManager } from "../common/MobileRpcManager";
+import { MobileAuthorizationFrontend } from "./MobileAuthorizationFrontend";
 
 /** receive notifications from backend */
 class MobileAppNotifyHandler extends NotificationHandler implements MobileNotifications {
@@ -50,8 +51,14 @@ export class MobileApp {
       MobileRpcManager.initializeClient(rpcInterfaces);
       this._isValid = true;
     }
+
+    const iModelAppOpts = {
+      ...opts?.iModelApp,
+    };
+    iModelAppOpts.authorizationClient = new MobileAuthorizationFrontend();
+
     const socket = new IpcWebSocketFrontend(); // needs work
-    await NativeApp.startup(socket, opts);
+    await NativeApp.startup(socket, { ...opts, iModelApp: iModelAppOpts });
 
     MobileAppNotifyHandler.register(); // receives notifications from backend
   }

--- a/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
+++ b/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
@@ -10,7 +10,7 @@ import { AccessToken } from "@itwin/core-bentley";
 import { AuthorizationClient } from "@itwin/core-common";
 import { MobileApp } from "./MobileApp";
 
-/** Utility to provide OIDC/OAuth tokens from native ios app to frontend
+/** Utility to request OIDC/OAuth tokens from mobile frontend to mobile backend.
  * @beta
  */
 export class MobileAuthorizationFrontend implements AuthorizationClient {

--- a/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
+++ b/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
@@ -8,28 +8,18 @@
 
 import { AccessToken } from "@itwin/core-bentley";
 import { AuthorizationClient } from "@itwin/core-common";
-import { MobileHost } from "./MobileHost";
+import { MobileApp } from "./MobileApp";
 
 /** Utility to provide OIDC/OAuth tokens from native ios app to frontend
  * @beta
  */
-export class MobileAuthorizationBackend implements AuthorizationClient {
+export class MobileAuthorizationFrontend implements AuthorizationClient {
   protected _accessToken: AccessToken = "";
 
   public async getAccessToken(): Promise<AccessToken> {
-    return new Promise<AccessToken>((resolve, reject) => {
-      if (this._accessToken) {
-        resolve(this._accessToken);
-      } else {
-        MobileHost.device.authGetAccessToken((tokenString?: AccessToken, error?: String) => {
-          if (error) {
-            this._accessToken = "";
-            reject(error);
-          }
-          this._accessToken = tokenString ?? "";
-          resolve(this._accessToken);
-        });
-      }
-    });
+    if (!this._accessToken) {
+      this._accessToken = (await MobileApp.callBackend("getAccessToken")) ?? "";
+    }
+    return this._accessToken;
   }
 }

--- a/test-apps/display-test-app/src/backend/MobileMain.ts
+++ b/test-apps/display-test-app/src/backend/MobileMain.ts
@@ -3,22 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { IModelHostConfiguration } from "@itwin/core-backend";
-import { MobileAuthorizationBackend, MobileHostOpts } from "@itwin/core-mobile/lib/cjs/MobileBackend";
+import { MobileHostOpts } from "@itwin/core-mobile/lib/cjs/MobileBackend";
 import { getRpcInterfaces, initializeDtaBackend } from "./Backend";
 
 const dtaMobileMain = (async () => {
-  const authBackend = new MobileAuthorizationBackend({
-    clientId: process.env.IMJS_OIDC_MOBILE_TEST_CLIENT_ID ?? "",
-    redirectUri: process.env.IMJS_OIDC_MOBILE_TEST_REDIRECT_URI ?? "",
-    scope: process.env.IMJS_OIDC_MOBILE_TEST_SCOPES ?? "",
-  });
-
-  const config = new IModelHostConfiguration();
-  config.authorizationClient = authBackend;
-
   const opts: MobileHostOpts = {
-    iModelHost: config,
     mobileHost: {
       rpcInterfaces: getRpcInterfaces(),
     },

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -16,7 +16,7 @@ import {
   AccuDrawHintBuilder, AccuDrawShortcuts, AccuSnap, IModelApp, IpcApp, LocalhostIpcApp, LocalHostIpcAppOpts, RenderSystem, SelectionTool, SnapMode, TileAdmin, Tool,
   ToolAdmin,
 } from "@itwin/core-frontend";
-import { AndroidApp, IOSApp } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
+import { AndroidApp, IOSApp, IOSAppOpts } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
 import { RealityDataAccessClient, RealityDataClientOptions } from "@itwin/reality-data-client";
 import { DtaConfiguration } from "../common/DtaConfiguration";
 import { dtaChannel, DtaIpcInterface } from "../common/DtaIpcInterface";
@@ -251,7 +251,7 @@ export class DisplayTestApp {
     if (ProcessDetector.isElectronAppFrontend) {
       await ElectronApp.startup(opts);
     } else if (ProcessDetector.isIOSAppFrontend) {
-      await IOSApp.startup(opts);
+      await IOSApp.startup(opts as IOSAppOpts);
     } else if (ProcessDetector.isAndroidAppFrontend) {
       await AndroidApp.startup(opts);
     } else {

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -26,11 +26,11 @@ import { BentleyCloudRpcManager, BentleyCloudRpcParams, IModelVersion, RpcConfig
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { ElectronRendererAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronRenderer";
 import {
-  AccuSnap, BriefcaseConnection, IModelApp, IModelConnection, LocalUnitFormatProvider,NativeApp, NativeAppLogger,
+  AccuSnap, BriefcaseConnection, IModelApp, IModelConnection, LocalUnitFormatProvider, NativeApp, NativeAppLogger,
   NativeAppOpts, SelectionTool, SnapMode, ToolAdmin, ViewClipByPlaneTool,
 } from "@itwin/core-frontend";
 import { MarkupApp } from "@itwin/core-markup";
-import { AndroidApp, IOSApp } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
+import { AndroidApp, IOSApp, IOSAppOpts } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
 import { EditTools } from "@itwin/editor-frontend";
 import { FrontendDevTools } from "@itwin/frontend-devtools";
 import { HyperModeling } from "@itwin/hypermodeling-frontend";
@@ -199,7 +199,7 @@ export class SampleAppIModelApp {
       await ElectronApp.startup({ ...opts, iModelApp: iModelAppOpts });
       NativeAppLogger.initialize();
     } else if (ProcessDetector.isIOSAppFrontend) {
-      await IOSApp.startup(opts);
+      await IOSApp.startup(opts as IOSAppOpts);
     } else if (ProcessDetector.isAndroidAppFrontend) {
       await AndroidApp.startup(opts);
     } else {
@@ -324,7 +324,7 @@ export class SampleAppIModelApp {
 
     await FrontendDevTools.initialize();
     await HyperModeling.initialize();
-    await MapLayersUI.initialize({ featureInfoOpts: { onMapHit: DefaultMapFeatureInfoTool.onMapHit }});
+    await MapLayersUI.initialize({ featureInfoOpts: { onMapHit: DefaultMapFeatureInfoTool.onMapHit } });
 
     AppSettingsTabsProvider.initializeAppSettingProvider();
 


### PR DESCRIPTION
This PR should be in sync with the following PRs in imodel02 and mobile-sdk-ios:
[Narrow the iModelJsMobile auth API](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/244115)
[Update ITMAuthorizationClient to conform to the new protocol](https://github.com/iTwin/mobile-sdk-ios/pull/55)

Mobile auth has been refactored such that logic like sign-in, sign-out and token fetching now take place natively. Developers on iOS are expected to consume the itwin-mobile-sdk Swift package and use `ITMAuthorizationClient` if they need auth. 
The authorization interface in iModelJsMobile has been reduced to a single function: `authGetAccessToken`. The same change has been made to the AuthorizationClient protocol. From TypeScript, the mobile auth strategy becomes simpler; if auth is configured / initialized, getAccessToken will return an access token. If for any reason it is not, an empty string is returned. In TypeScript, the mobile backend will request and cache the token provided by `authGetAccessToken`, and the mobile frontend will request and cache tokens by communicating with said backend via IPC.

Developers can no longer pass `authorizationClient` in their iModelApp config on iOS. If third party auth is required, they should define their auth client in Swift / Objective-C and conform to the AuthorizationClient protocol defined in iModelJsMobile. 

Similar changes will need to take place on Android for compatibility with these updates.