### PR TITLE
Refactor Mobile Auth Strategy

### DIFF
--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -104,7 +104,11 @@ export class IOSApp {
 }
 
 // @beta (undocumented)
-export type IOSAppOpts = NativeAppOpts;
+export type IOSAppOpts = NativeAppOpts & {
+    iModelApp: {
+        authorizationClient?: never;
+    };
+};
 
 // @beta (undocumented)
 export class IOSHost extends MobileHost {
@@ -135,47 +139,19 @@ export class MobileApp {
 }
 
 // @beta
-export interface MobileAppAuthorizationConfiguration {
-    readonly clientId: string;
-    readonly expiryBuffer?: number;
-    issuerUrl?: string;
-    readonly redirectUri?: string;
-    readonly scope: string;
-}
-
-// @beta
 export interface MobileAppFunctions {
+    // (undocumented)
+    getAccessToken: () => Promise<AccessToken>;
     // (undocumented)
     reconnect: (connection: number) => Promise<void>;
 }
 
 // @beta
 export class MobileAuthorizationBackend implements AuthorizationClient {
-    constructor(config?: MobileAppAuthorizationConfiguration);
     // (undocumented)
-    protected _accessToken?: AccessToken;
-    // (undocumented)
-    protected _baseUrl: string;
-    // (undocumented)
-    config?: MobileAppAuthorizationConfiguration;
-    // (undocumented)
-    static defaultRedirectUri: string;
-    // (undocumented)
-    expireSafety: number;
+    protected _accessToken: AccessToken;
     // (undocumented)
     getAccessToken(): Promise<AccessToken>;
-    initialize(config?: MobileAppAuthorizationConfiguration): Promise<void>;
-    // (undocumented)
-    issuerUrl?: string;
-    // (undocumented)
-    get redirectUri(): string;
-    refreshToken(): Promise<AccessToken>;
-    // (undocumented)
-    setAccessToken(token?: AccessToken): void;
-    signIn(): Promise<void>;
-    signOut(): Promise<void>;
-    // (undocumented)
-    protected _url?: string;
 }
 
 // @beta (undocumented)
@@ -188,14 +164,6 @@ export type MobileCompletionCallback = (downloadUrl: string, downloadFileUrl: st
 export abstract class MobileDevice {
     // (undocumented)
     abstract authGetAccessToken(callback: (accessToken?: string, err?: string) => void): void;
-    // (undocumented)
-    authInit(_config: MobileAppAuthorizationConfiguration, callback: (err?: string) => void): void;
-    // (undocumented)
-    abstract authSignIn(callback: (err?: string) => void): void;
-    // (undocumented)
-    abstract authSignOut(callback: (err?: string) => void): void;
-    // (undocumented)
-    abstract authStateChanged(accessToken?: string, err?: string): void;
     // (undocumented)
     abstract cancelDownloadTask(cancelId: number): boolean;
     // (undocumented)
@@ -236,8 +204,6 @@ export class MobileFileHandler {
 
 // @beta (undocumented)
 export class MobileHost {
-    // @internal (undocumented)
-    static get authorization(): import("@itwin/core-common").AuthorizationClient | undefined;
     // (undocumented)
     static get device(): MobileDevice;
     // @internal (undocumented)
@@ -265,8 +231,6 @@ export interface MobileHostOpts extends NativeHostOpts {
     mobileHost?: {
         device?: MobileDevice;
         rpcInterfaces?: RpcInterfaceDefinition[];
-        authConfig?: MobileAppAuthorizationConfiguration;
-        noInitializeAuthClient?: boolean;
     };
 }
 

--- a/common/changes/@itwin/core-mobile/mobile-auth_2022-04-29-15-42.json
+++ b/common/changes/@itwin/core-mobile/mobile-auth_2022-04-29-15-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "Remove auth access and configuration via typescript.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/mobile/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile/src/backend/MobileAuthorizationBackend.ts
@@ -33,7 +33,7 @@ export class MobileAuthorizationBackend implements AuthorizationClient {
         resolve(this._accessToken);
       } else {
         this._fetchingToken = true;
-        MobileHost.device.authGetAccessToken((tokenString?: AccessToken, expirationDate?: String, error?: String) => {
+        MobileHost.device.authGetAccessToken((tokenString?: AccessToken, expirationDate?: string, error?: string) => {
           if (error) {
             this._accessToken = "";
             reject(error);
@@ -41,7 +41,7 @@ export class MobileAuthorizationBackend implements AuthorizationClient {
 
           this._accessToken = tokenString ?? "";
           if (expirationDate !== undefined)
-            this._expirationDate = new Date(expirationDate.toString())
+            this._expirationDate = new Date(expirationDate)
           resolve(this._accessToken);
         });
         this._fetchingToken = false;

--- a/core/mobile/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile/src/backend/MobileAuthorizationBackend.ts
@@ -48,4 +48,9 @@ export class MobileAuthorizationBackend implements AuthorizationClient {
       }
     });
   }
+
+  public setAccessToken(accessToken?: string, expirationDate?: string) {
+    this._accessToken = accessToken ?? "";
+    this._expirationDate = expirationDate ? new Date(expirationDate) : undefined;
+  }
 }

--- a/core/mobile/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile/src/backend/MobileAuthorizationBackend.ts
@@ -6,159 +6,30 @@
  * @module OIDC
  */
 
-import { AccessToken, assert, AuthStatus } from "@itwin/core-bentley";
-import { AuthorizationClient, IModelError } from "@itwin/core-common";
+import { AccessToken } from "@itwin/core-bentley";
+import { AuthorizationClient } from "@itwin/core-common";
 import { MobileHost } from "./MobileHost";
-
-/**
- * Client configuration to generate OIDC/OAuth tokens for mobile applications
- * @beta
- */
-export interface MobileAppAuthorizationConfiguration {
-  /**
-   * The OAuth token issuer URL. Defaults to Bentley's auth URL if undefined.
-   */
-  issuerUrl?: string;
-
-  /**
-   * Upon signing in, the client application receives a response from the Bentley IMS OIDC/OAuth2 provider at this URI
-   * For mobile/desktop applications, must start with `http://localhost:${redirectPort}` or `https://localhost:${redirectPort}`
-   */
-  readonly redirectUri?: string;
-
-  /** Client application's identifier as registered with the OIDC/OAuth2 provider. */
-  readonly clientId: string;
-
-  /** List of space separated scopes to request access to various resources. */
-  readonly scope: string;
-
-  /**
-   * Time in seconds that's used as a buffer to check the token for validity/expiry.
-   * The checks for authorization, and refreshing access tokens all use this buffer - i.e., the token is considered expired if the current time is within the specified
-   * time of the actual expiry.
-   * @note If unspecified this defaults to 10 minutes.
-   */
-  readonly expiryBuffer?: number;
-}
 
 /** Utility to provide OIDC/OAuth tokens from native ios app to frontend
  * @beta
  */
 export class MobileAuthorizationBackend implements AuthorizationClient {
-  protected _accessToken?: AccessToken;
-  public config?: MobileAppAuthorizationConfiguration;
-  public expireSafety = 60 * 10; // refresh token 10 minutes before real expiration time
-  public issuerUrl?: string;
-  public static defaultRedirectUri = "imodeljs://app/signin-callback";
-  public get redirectUri() { return this.config?.redirectUri ?? MobileAuthorizationBackend.defaultRedirectUri; }
-  protected _baseUrl = "https://ims.bentley.com";
-  protected _url?: string;
-
-  public constructor(config?: MobileAppAuthorizationConfiguration) {
-    this.config = config;
-  }
-
-  /** Used to initialize the client - must be awaited before any other methods are called */
-  public async initialize(config?: MobileAppAuthorizationConfiguration): Promise<void> {
-    this.config = config ?? this.config;
-    if (!this.config)
-      throw new IModelError(AuthStatus.Error, "Must specify a valid configuration when initializing authorization");
-    if (this.config.expiryBuffer)
-      this.expireSafety = this.config.expiryBuffer;
-    this.issuerUrl = this.config.issuerUrl ?? this.getUrl();
-    if (!this.issuerUrl)
-      throw new IModelError(AuthStatus.Error, "The URL of the authorization provider was not initialized");
-
-    MobileHost.device.authStateChanged = (tokenString?: AccessToken) => {
-      this.setAccessToken(tokenString);
-    };
-
-    return new Promise<void>((resolve, reject) => {
-      assert(this.config !== undefined);
-      MobileHost.device.authInit({ ...this.config, issuerUrl: this.issuerUrl }, (err?: string) => {
-        if (!err) {
-          resolve();
-        } else {
-          reject(new Error(err));
-        }
-      });
-    });
-  }
-
-  /** Start the sign-in process */
-  public async signIn(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      MobileHost.device.authSignIn((err?: string) => {
-        if (!err) {
-          resolve();
-        } else {
-          reject(new Error(err));
-        }
-      });
-    });
-  }
-
-  /** Start the sign-out process */
-  public async signOut(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      MobileHost.device.authSignOut((err?: string) => {
-        if (!err) {
-          resolve();
-        } else {
-          reject(new Error(err));
-        }
-      });
-    });
-  }
-
-  public setAccessToken(token?: AccessToken) {
-    if (token === this._accessToken)
-      return;
-    this._accessToken = token;
-  }
+  protected _accessToken: AccessToken = "";
 
   public async getAccessToken(): Promise<AccessToken> {
-    if (!this._accessToken)
-      this.setAccessToken(await this.refreshToken());
-    return this._accessToken ?? "";
-  }
-
-  /** return accessToken */
-  public async refreshToken(): Promise<AccessToken> {
     return new Promise<AccessToken>((resolve, reject) => {
-      MobileHost.device.authGetAccessToken((tokenStringJson?: AccessToken, err?: string) => {
-        if (!err && tokenStringJson) {
-          resolve(tokenStringJson);
-        } else {
-          reject(new Error(err));
-        }
-      });
+      if (this._accessToken) {
+        resolve(this._accessToken);
+      } else {
+        MobileHost.device.authGetAccessToken((tokenString?: AccessToken, error?: String) => {
+          if (error) {
+            this._accessToken = "";
+            reject(error);
+          }
+          this._accessToken = tokenString ?? "";
+          resolve(this._accessToken);
+        });
+      }
     });
-  }
-
-  /**
-   * Gets the URL of the service. Uses the default URL provided by client implementations.
-   * If defined, the value of `IMJS_URL_PREFIX` will be used as a prefix to all urls provided
-   * by the client implementations.
-   *
-   * Note that for consistency sake, the URL is stripped of any trailing "/".
-   * @returns URL for the service
-   */
-  private getUrl(): string {
-    if (this._url)
-      return this._url;
-
-    if (!this._baseUrl) {
-      throw new Error("The client is missing a default url.");
-    }
-
-    const prefix = process.env.IMJS_URL_PREFIX;
-    const authority = new URL(this.config?.issuerUrl ?? this._baseUrl);
-
-    if (prefix && !this.config?.issuerUrl)
-      authority.hostname = prefix + authority.hostname;
-    this._url = authority.href.replace(/\/$/, "");
-
-    return this._url;
   }
 }

--- a/core/mobile/src/backend/MobileAuthorizationBackend.ts
+++ b/core/mobile/src/backend/MobileAuthorizationBackend.ts
@@ -10,8 +10,8 @@ import { AccessToken } from "@itwin/core-bentley";
 import { AuthorizationClient } from "@itwin/core-common";
 import { MobileHost } from "./MobileHost";
 
-/** Utility to provide OIDC/OAuth tokens from native ios app to frontend
- * @beta
+/** Utility to provide and cache auth tokens from native mobile apps to IModelHost.
+ * @internal
  */
 export class MobileAuthorizationBackend implements AuthorizationClient {
   private _accessToken: AccessToken = "";

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { AccessToken, BeEvent, BriefcaseStatus } from "@itwin/core-bentley";
-import { IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
+import { IModelHostConfiguration, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
 import {
   IModelReadRpcInterface, IModelTileRpcInterface, RpcInterfaceDefinition,
   SnapshotIModelRpcInterface,
@@ -166,8 +166,6 @@ export class MobileHost {
   /** Start the backend of a mobile app. */
   public static async startup(opt?: MobileHostOpts): Promise<void> {
     const authorizationClient = new MobileAuthorizationBackend();
-    IModelHost.authorizationClient = authorizationClient;
-
     if (!this.isValid) {
       this._device = opt?.mobileHost?.device ?? new (MobileDevice as any)();
       // set global device interface.
@@ -195,8 +193,10 @@ export class MobileHost {
       // following will provide impl for device specific api.
       setupMobileRpc();
     }
+    const iModelHostConfiguration = opt?.iModelHost ?? new IModelHostConfiguration();
+    iModelHostConfiguration.authorizationClient = authorizationClient;
+    await NativeHost.startup({ ...opt, iModelHost: iModelHostConfiguration });
 
-    await NativeHost.startup(opt);
     if (IpcHost.isValid)
       MobileAppHandler.register();
 

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -6,7 +6,7 @@
 import { BeEvent, BriefcaseStatus } from "@itwin/core-bentley";
 import { IModelHost, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
 import {
-  IModelReadRpcInterface, IModelTileRpcInterface, InternetConnectivityStatus, RpcInterfaceDefinition,
+  IModelReadRpcInterface, IModelTileRpcInterface, RpcInterfaceDefinition,
   SnapshotIModelRpcInterface,
 } from "@itwin/core-common";
 import { CancelRequest, DownloadFailed, UserCancelledError } from "./MobileFileHandler";

--- a/core/mobile/src/common/MobileAppProps.ts
+++ b/core/mobile/src/common/MobileAppProps.ts
@@ -42,5 +42,5 @@ export type DeviceEvents = "memoryWarning" | "orientationChanged" | "enterForegr
 */
 export interface MobileAppFunctions {
   reconnect: (connection: number) => Promise<void>;
-  getAccessToken: () => Promise<AccessToken>;
+  getAccessToken: () => Promise<[AccessToken, string]>;
 }

--- a/core/mobile/src/common/MobileAppProps.ts
+++ b/core/mobile/src/common/MobileAppProps.ts
@@ -31,10 +31,11 @@ export interface MobileNotifications {
   notifyEnterForeground: () => void;
   notifyEnterBackground: () => void;
   notifyWillTerminate: () => void;
+  notifyAuthAccessTokenChanged: (accessToken: string | undefined, expirationDate: string | undefined) => void;
 }
 
 /** @beta */
-export type DeviceEvents = "memoryWarning" | "orientationChanged" | "enterForeground" | "enterBackground" | "willTerminate";
+export type DeviceEvents = "memoryWarning" | "orientationChanged" | "enterForeground" | "enterBackground" | "willTerminate" | "authAccessTokenChanged";
 
 /**
 * The methods that may be invoked via Ipc from the frontend of a Mobile App that are implemented on its backend.

--- a/core/mobile/src/common/MobileAppProps.ts
+++ b/core/mobile/src/common/MobileAppProps.ts
@@ -3,6 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import { AccessToken } from "@itwin/core-bentley";
+
 /** @beta */
 export enum Orientation {
   Unknown = 0,
@@ -40,4 +42,5 @@ export type DeviceEvents = "memoryWarning" | "orientationChanged" | "enterForegr
 */
 export interface MobileAppFunctions {
   reconnect: (connection: number) => Promise<void>;
+  getAccessToken: () => Promise<AccessToken>;
 }

--- a/core/mobile/src/frontend/IOSApp.ts
+++ b/core/mobile/src/frontend/IOSApp.ts
@@ -7,7 +7,7 @@ import { NativeAppOpts } from "@itwin/core-frontend";
 import { MobileApp } from "./MobileApp";
 
 /** @beta */
-export type IOSAppOpts = NativeAppOpts;
+export type IOSAppOpts = NativeAppOpts & { iModelApp: { authorizationClient?: never } };
 
 /** @beta */
 export class IOSApp {

--- a/core/mobile/src/frontend/MobileApp.ts
+++ b/core/mobile/src/frontend/MobileApp.ts
@@ -9,6 +9,7 @@ import { IpcApp, NativeApp, NativeAppOpts, NotificationHandler } from "@itwin/co
 import { mobileAppChannel, mobileAppNotify } from "../common/MobileAppChannel";
 import { MobileAppFunctions, MobileNotifications } from "../common/MobileAppProps";
 import { MobileRpcManager } from "../common/MobileRpcManager";
+import { MobileAuthorizationFrontend } from "./MobileAuthorizationFrontend";
 
 /** receive notifications from backend */
 class MobileAppNotifyHandler extends NotificationHandler implements MobileNotifications {
@@ -50,8 +51,14 @@ export class MobileApp {
       MobileRpcManager.initializeClient(rpcInterfaces);
       this._isValid = true;
     }
+
+    const iModelAppOpts = {
+      ...opts?.iModelApp,
+    };
+    iModelAppOpts.authorizationClient = new MobileAuthorizationFrontend();
+
     const socket = new IpcWebSocketFrontend(); // needs work
-    await NativeApp.startup(socket, opts);
+    await NativeApp.startup(socket, { ...opts, iModelApp: iModelAppOpts });
 
     MobileAppNotifyHandler.register(); // receives notifications from backend
   }

--- a/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
+++ b/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module OIDC
+ */
+
+import { AccessToken } from "@itwin/core-bentley";
+import { AuthorizationClient } from "@itwin/core-common";
+import { MobileApp } from "./MobileApp";
+
+/** Utility to request OIDC/OAuth tokens from mobile frontend to mobile backend.
+ * @beta
+ */
+export class MobileAuthorizationFrontend implements AuthorizationClient {
+  protected _accessToken: AccessToken = "";
+
+  public async getAccessToken(): Promise<AccessToken> {
+    if (!this._accessToken) {
+      this._accessToken = (await MobileApp.callBackend("getAccessToken")) ?? "";
+    }
+    return this._accessToken;
+  }
+}

--- a/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
+++ b/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
@@ -10,8 +10,8 @@ import { AccessToken } from "@itwin/core-bentley";
 import { AuthorizationClient } from "@itwin/core-common";
 import { MobileApp } from "./MobileApp";
 
-/** Utility to request OIDC/OAuth tokens from mobile frontend to mobile backend.
- * @beta
+/** Utility to provide and cache auth tokens from native mobile apps to IModelApp.
+ * @internal
  */
 export class MobileAuthorizationFrontend implements AuthorizationClient {
   private _accessToken: AccessToken = "";

--- a/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
+++ b/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
@@ -14,12 +14,30 @@ import { MobileApp } from "./MobileApp";
  * @beta
  */
 export class MobileAuthorizationFrontend implements AuthorizationClient {
-  protected _accessToken: AccessToken = "";
+  private _accessToken: AccessToken = "";
+  private _expirationDate: Date | undefined;
+  private _expiryBuffer = 60 * 10; // ten minutes
+  private _fetchingToken = false;
+
+  private get hasExpired(): boolean {
+    return this._expirationDate !== undefined && this._expirationDate.getTime() - Date.now() <= this._expiryBuffer * 1000;
+  }
 
   public async getAccessToken(): Promise<AccessToken> {
-    if (!this._accessToken) {
-      this._accessToken = (await MobileApp.callBackend("getAccessToken")) ?? "";
+    if (this._fetchingToken) {
+      return Promise.reject(); // short-circuits any recursive use of this function
     }
-    return this._accessToken;
+
+    if (this._accessToken && !this.hasExpired) {
+      return this._accessToken;
+    } else {
+      this._fetchingToken = true;
+      const result = await MobileApp.callBackend("getAccessToken");
+      this._accessToken = result[0];
+      if (result[1])
+        this._expirationDate = new Date(result[1]);
+      this._fetchingToken = false;
+      return this._accessToken;
+    }
   }
 }

--- a/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
+++ b/core/mobile/src/frontend/MobileAuthorizationFrontend.ts
@@ -40,4 +40,9 @@ export class MobileAuthorizationFrontend implements AuthorizationClient {
       return this._accessToken;
     }
   }
+
+  public setAccessToken(accessToken?: string, expirationDate?: string) {
+    this._accessToken = accessToken ?? "";
+    this._expirationDate = expirationDate ? new Date(expirationDate) : undefined;
+  }
 }

--- a/test-apps/display-test-app/src/backend/MobileMain.ts
+++ b/test-apps/display-test-app/src/backend/MobileMain.ts
@@ -3,22 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { IModelHostConfiguration } from "@itwin/core-backend";
-import { MobileAuthorizationBackend, MobileHostOpts } from "@itwin/core-mobile/lib/cjs/MobileBackend";
+import { MobileHostOpts } from "@itwin/core-mobile/lib/cjs/MobileBackend";
 import { getRpcInterfaces, initializeDtaBackend } from "./Backend";
 
 const dtaMobileMain = (async () => {
-  const authBackend = new MobileAuthorizationBackend({
-    clientId: process.env.IMJS_OIDC_MOBILE_TEST_CLIENT_ID ?? "",
-    redirectUri: process.env.IMJS_OIDC_MOBILE_TEST_REDIRECT_URI ?? "",
-    scope: process.env.IMJS_OIDC_MOBILE_TEST_SCOPES ?? "",
-  });
-
-  const config = new IModelHostConfiguration();
-  config.authorizationClient = authBackend;
-
   const opts: MobileHostOpts = {
-    iModelHost: config,
     mobileHost: {
       rpcInterfaces: getRpcInterfaces(),
     },

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -16,7 +16,7 @@ import {
   AccuDrawHintBuilder, AccuDrawShortcuts, AccuSnap, IModelApp, IpcApp, LocalhostIpcApp, LocalHostIpcAppOpts, RenderSystem, SelectionTool, SnapMode, TileAdmin, Tool,
   ToolAdmin,
 } from "@itwin/core-frontend";
-import { AndroidApp, IOSApp } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
+import { AndroidApp, IOSApp, IOSAppOpts } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
 import { RealityDataAccessClient, RealityDataClientOptions } from "@itwin/reality-data-client";
 import { DtaConfiguration } from "../common/DtaConfiguration";
 import { dtaChannel, DtaIpcInterface } from "../common/DtaIpcInterface";
@@ -251,7 +251,7 @@ export class DisplayTestApp {
     if (ProcessDetector.isElectronAppFrontend) {
       await ElectronApp.startup(opts);
     } else if (ProcessDetector.isIOSAppFrontend) {
-      await IOSApp.startup(opts);
+      await IOSApp.startup(opts as IOSAppOpts);
     } else if (ProcessDetector.isAndroidAppFrontend) {
       await AndroidApp.startup(opts);
     } else {

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -26,11 +26,11 @@ import { BentleyCloudRpcManager, BentleyCloudRpcParams, IModelVersion, RpcConfig
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { ElectronRendererAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronRenderer";
 import {
-  AccuSnap, BriefcaseConnection, IModelApp, IModelConnection, LocalUnitFormatProvider,NativeApp, NativeAppLogger,
+  AccuSnap, BriefcaseConnection, IModelApp, IModelConnection, LocalUnitFormatProvider, NativeApp, NativeAppLogger,
   NativeAppOpts, SelectionTool, SnapMode, ToolAdmin, ViewClipByPlaneTool,
 } from "@itwin/core-frontend";
 import { MarkupApp } from "@itwin/core-markup";
-import { AndroidApp, IOSApp } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
+import { AndroidApp, IOSApp, IOSAppOpts } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
 import { EditTools } from "@itwin/editor-frontend";
 import { FrontendDevTools } from "@itwin/frontend-devtools";
 import { HyperModeling } from "@itwin/hypermodeling-frontend";
@@ -199,7 +199,7 @@ export class SampleAppIModelApp {
       await ElectronApp.startup({ ...opts, iModelApp: iModelAppOpts });
       NativeAppLogger.initialize();
     } else if (ProcessDetector.isIOSAppFrontend) {
-      await IOSApp.startup(opts);
+      await IOSApp.startup(opts as IOSAppOpts);
     } else if (ProcessDetector.isAndroidAppFrontend) {
       await AndroidApp.startup(opts);
     } else {
@@ -324,7 +324,7 @@ export class SampleAppIModelApp {
 
     await FrontendDevTools.initialize();
     await HyperModeling.initialize();
-    await MapLayersUI.initialize({ featureInfoOpts: { onMapHit: DefaultMapFeatureInfoTool.onMapHit }});
+    await MapLayersUI.initialize({ featureInfoOpts: { onMapHit: DefaultMapFeatureInfoTool.onMapHit } });
 
     AppSettingsTabsProvider.initializeAppSettingProvider();
 


### PR DESCRIPTION
This PR should be in sync with the following PRs in imodel02 and mobile-sdk-ios:
[Narrow the iModelJsMobile auth API](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/244115)
[Update ITMAuthorizationClient to conform to the new protocol](https://github.com/iTwin/mobile-sdk-ios/pull/55)

Mobile auth has been refactored such that logic like sign-in, sign-out and token fetching now take place natively. Developers on iOS are expected to consume the itwin-mobile-sdk Swift package and use `ITMAuthorizationClient` if they need auth. 
The authorization interface in iModelJsMobile has been reduced to a single function: `authGetAccessToken`. The same change has been made to the AuthorizationClient protocol. From TypeScript, the mobile auth strategy becomes simpler; if auth is configured / initialized, getAccessToken will return an access token. If for any reason it is not, an empty string is returned. In TypeScript, the mobile backend will request and cache the token provided by `authGetAccessToken`, and the mobile frontend will request and cache tokens by communicating with said backend via IPC.

`authAccessTokenChanged` is used to invalidate any cached access tokens when a change in state occurs.

Developers can no longer pass `authorizationClient` in their iModelApp config on iOS. If third party auth is required, they should define their auth client in Swift / Objective-C and conform to the AuthorizationClient protocol defined in iModelJsMobile. 

Similar changes will need to take place on Android for compatibility with these updates.

[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/244115).