### PR TITLE
Add option defaultTool prop to StandardFrontstageProps

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -5905,6 +5905,7 @@ export interface StandardFrontstageProps {
     bottomPanelProps?: WidgetPanelProps;
     contentGroupProps: ContentGroupProps | ContentGroupProvider;
     cornerButton?: React.ReactNode;
+    defaultTool?: ToolItemDef;
     hideNavigationAid?: boolean;
     hideStatusBar?: boolean;
     // (undocumented)

--- a/common/changes/@itwin/appui-react/ui-standard-frontstage-provider_2022-05-04-20-04.json
+++ b/common/changes/@itwin/appui-react/ui-standard-frontstage-provider_2022-05-04-20-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add default tool prop to StandardFrontstageProps to give apps a simple, typesafe way to specify a default tool for their frontstages.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/ui-test-app/src/frontend/appui/frontstages/FrontStageWithNoWidgets.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/frontstages/FrontStageWithNoWidgets.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import {
-  BackstageAppButton, ConfigurableUiManager, ContentGroup, ContentGroupProvider, FrontstageProps,
+  BackstageAppButton, ConfigurableUiManager, ContentGroup, ContentGroupProvider, CoreTools, FrontstageProps,
   IModelViewportControl, StandardContentToolsProvider, StandardFrontstageProps, StandardFrontstageProvider,
   StandardNavigationToolsProvider,
   StandardStatusbarItemsProvider,
@@ -61,6 +61,7 @@ export class FrontstageWithNoWidgets {
       cornerButton,
       usage: StageUsage.General,
       applicationData: undefined,
+      defaultTool: CoreTools.measureDistanceToolItemDef,
     };
 
     FrontstageWithNoWidgets.registerToolProviders();

--- a/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
@@ -19,6 +19,7 @@ import { Widget } from "../widgets/Widget";
 import { ViewToolWidgetComposer } from "../widgets/ViewToolWidgetComposer";
 import { StatusBarWidgetComposerControl } from "../widgets/StatusBarWidgetComposerControl";
 import { StagePanelState } from "../stagepanels/StagePanelDef";
+import { ToolItemDef } from "../shared/ToolItemDef";
 
 /** Properties of a [[WidgetPanelProps]] component
  * @public
@@ -71,6 +72,11 @@ export interface StandardFrontstageProps {
    * supports. See [[DefaultContentToolsAppData]] for an example.
    */
   applicationData?: any;
+  /** The defaultTool is is started when then frontstage loads and whenever any other tools exit.
+   * Most of the time, this is the Element Selection Tool (CoreTools.selectElementCommand).
+   * Your app can specify its own tool or another core tool as default with this property.
+   */
+  defaultTool?: ToolItemDef;
 }
 
 /**
@@ -94,7 +100,7 @@ export class StandardFrontstageProvider extends FrontstageProvider {
         key={this.props.id}
         id={this.props.id}
         version={this.props.version ?? 1.0}
-        defaultTool={CoreTools.selectElementCommand}
+        defaultTool={this.props.defaultTool ?? CoreTools.selectElementCommand}
         contentGroup={contentGroup}
         isInFooterMode={true}
         usage={this.props.usage}


### PR DESCRIPTION
The StandardFrontstageProvider gives apps an easy way to create a custom frontstage for their app, but overriding the default tool was more complicated. Adding an optional prop to override the default tool via StandardFrontstageProps allows the new default tool to be set up with the rest of the frontstage.