### PR TITLE
Add option to generate all edges for polyfaces

### DIFF
--- a/core/common/src/HiddenLine.ts
+++ b/core/common/src/HiddenLine.ts
@@ -14,8 +14,6 @@ import { LinePixels } from "./LinePixels";
  * @public
  */
 export namespace HiddenLine {
-  export type PolyfaceEdgeInference = "crease" | "all";
-
   /** Describes the symbology with which edges should be drawn. */
   export interface StyleProps {
     /** @internal
@@ -31,15 +29,15 @@ export namespace HiddenLine {
      *  - width is overridden if width != undefined and width != 0
      *  - pattern is overridden if pattern != undefined and pattern != LinePixels.Invalid
      */
-    readonly ovrColor?: boolean;
+    ovrColor?: boolean;
     /** If defined, the color used to draw the edges. If undefined, edges are drawn using the element's line color. */
-    readonly color?: ColorDefProps;
+    color?: ColorDefProps;
     /** If defined, the pixel pattern used to draw the edges. If undefined, edges are drawn using the element's line pattern. */
-    readonly pattern?: LinePixels;
+    pattern?: LinePixels;
     /** If defined, the width of the edges in pixels. If undefined (or 0), edges are drawn using the element's line width.
      * @note Non-integer values are truncated, and values are clamped to the range [1, 32].
      */
-    readonly width?: number;
+    width?: number;
   }
 
   /** Describes the symbology with which edges should be drawn. */
@@ -159,9 +157,9 @@ export namespace HiddenLine {
   /** Describes how visible and hidden edges and transparent surfaces should be rendered in "hidden line" and "solid fill" [[RenderMode]]s. */
   export interface SettingsProps {
     /** Describes how visible edges (those unobscured by other geometry) should be displayed. */
-    readonly visible?: StyleProps;
+    visible?: StyleProps;
     /** Describes how hidden edges (those obscured by other geometry) should be displayed. */
-    readonly hidden?: StyleProps;
+    hidden?: StyleProps;
     /** A value in the range [0.0, 1.0] specifying a threshold below which transparent surfaces should not be drawn.
      * A value of 0.0 indicates any surface that is not 100% opaque should not be drawn.
      * A value of 0.25 indicates any surface that is less than 25% opaque should not be drawn.
@@ -169,8 +167,8 @@ export namespace HiddenLine {
      * @note values will be clamped to the range [0.0, 1.0].
      * @note Defaults to 1.0.
      */
-    readonly transThreshold?: number;
-    polyfaceEdgeInference?: PolyfaceEdgeInference;
+    transThreshold?: number;
+    displaySmoothEdges?: boolean;
   }
 
   /** Describes how visible and hidden edges and transparent surfaces should be rendered in "hidden line" and "solid fill" [[RenderMode]]s. */
@@ -189,7 +187,7 @@ export namespace HiddenLine {
     public readonly transparencyThreshold: number;
     public get transThreshold(): number { return this.transparencyThreshold; }
 
-    public readonly polyfaceEdgeInference: PolyfaceEdgeInference;
+    public readonly displaySmoothEdges: boolean;
 
     /** The default display settings. */
     public static defaults = new Settings({});
@@ -211,8 +209,8 @@ export namespace HiddenLine {
         transThreshold: this.transThreshold,
       };
 
-      if ("all" === this.polyfaceEdgeInference)
-        props.polyfaceEdgeInference = "all";
+      if (this.displaySmoothEdges)
+        props.displaySmoothEdges = true;
 
       return props;
     }
@@ -226,7 +224,7 @@ export namespace HiddenLine {
         visible: undefined !== visible ? visible : this.visible.toJSON(),
         hidden: undefined !== hidden ? hidden : this.hidden.toJSON(),
         transThreshold: undefined !== transparencyThreshold ? transparencyThreshold : this.transparencyThreshold,
-        polyfaceEdgeInference: props.polyfaceEdgeInference ?? this.polyfaceEdgeInference,
+        displaySmoothEdges: props.displaySmoothEdges ?? this.displaySmoothEdges,
       });
     }
 
@@ -237,7 +235,7 @@ export namespace HiddenLine {
       return this.visible.equals(other.visible)
         && this.hidden.equals(other.hidden)
         && this.transparencyThreshold === other.transparencyThreshold
-        && this.polyfaceEdgeInference === other.polyfaceEdgeInference;
+        && this.displaySmoothEdges === other.displaySmoothEdges;
     }
 
     public get matchesDefaults(): boolean {
@@ -248,7 +246,7 @@ export namespace HiddenLine {
       this.visible = Style.fromJSON(json.visible);
       this.hidden = Style.fromJSON(json.hidden, true);
       this.transparencyThreshold = JsonUtils.asDouble(json.transThreshold, 1.0);
-      this.polyfaceEdgeInference = "all" === json.polyfaceEdgeInference ? "all" : "crease";
+      this.displaySmoothEdges = true === json.displaySmoothEdges;
     }
   }
 }

--- a/core/common/src/HiddenLine.ts
+++ b/core/common/src/HiddenLine.ts
@@ -168,7 +168,7 @@ export namespace HiddenLine {
      * @note Defaults to 1.0.
      */
     transThreshold?: number;
-    displaySmoothEdges?: boolean;
+    smoothPolyfaceEdges?: boolean;
   }
 
   /** Describes how visible and hidden edges and transparent surfaces should be rendered in "hidden line" and "solid fill" [[RenderMode]]s. */
@@ -187,7 +187,7 @@ export namespace HiddenLine {
     public readonly transparencyThreshold: number;
     public get transThreshold(): number { return this.transparencyThreshold; }
 
-    public readonly displaySmoothEdges: boolean;
+    public readonly smoothPolyfaceEdges: boolean;
 
     /** The default display settings. */
     public static defaults = new Settings({});
@@ -209,8 +209,8 @@ export namespace HiddenLine {
         transThreshold: this.transThreshold,
       };
 
-      if (this.displaySmoothEdges)
-        props.displaySmoothEdges = true;
+      if (this.smoothPolyfaceEdges)
+        props.smoothPolyfaceEdges = true;
 
       return props;
     }
@@ -224,7 +224,7 @@ export namespace HiddenLine {
         visible: undefined !== visible ? visible : this.visible.toJSON(),
         hidden: undefined !== hidden ? hidden : this.hidden.toJSON(),
         transThreshold: undefined !== transparencyThreshold ? transparencyThreshold : this.transparencyThreshold,
-        displaySmoothEdges: props.displaySmoothEdges ?? this.displaySmoothEdges,
+        smoothPolyfaceEdges: props.smoothPolyfaceEdges ?? this.smoothPolyfaceEdges,
       });
     }
 
@@ -235,7 +235,7 @@ export namespace HiddenLine {
       return this.visible.equals(other.visible)
         && this.hidden.equals(other.hidden)
         && this.transparencyThreshold === other.transparencyThreshold
-        && this.displaySmoothEdges === other.displaySmoothEdges;
+        && this.smoothPolyfaceEdges === other.smoothPolyfaceEdges;
     }
 
     public get matchesDefaults(): boolean {
@@ -246,7 +246,7 @@ export namespace HiddenLine {
       this.visible = Style.fromJSON(json.visible);
       this.hidden = Style.fromJSON(json.hidden, true);
       this.transparencyThreshold = JsonUtils.asDouble(json.transThreshold, 1.0);
-      this.displaySmoothEdges = true === json.displaySmoothEdges;
+      this.smoothPolyfaceEdges = true === json.smoothPolyfaceEdges;
     }
   }
 }

--- a/core/common/src/HiddenLine.ts
+++ b/core/common/src/HiddenLine.ts
@@ -14,6 +14,8 @@ import { LinePixels } from "./LinePixels";
  * @public
  */
 export namespace HiddenLine {
+  export type PolyfaceEdgeInference = "crease" | "all";
+
   /** Describes the symbology with which edges should be drawn. */
   export interface StyleProps {
     /** @internal
@@ -168,6 +170,7 @@ export namespace HiddenLine {
      * @note Defaults to 1.0.
      */
     readonly transThreshold?: number;
+    polyfaceEdgeInference?: PolyfaceEdgeInference;
   }
 
   /** Describes how visible and hidden edges and transparent surfaces should be rendered in "hidden line" and "solid fill" [[RenderMode]]s. */
@@ -186,6 +189,8 @@ export namespace HiddenLine {
     public readonly transparencyThreshold: number;
     public get transThreshold(): number { return this.transparencyThreshold; }
 
+    public readonly polyfaceEdgeInference: PolyfaceEdgeInference;
+
     /** The default display settings. */
     public static defaults = new Settings({});
 
@@ -200,11 +205,16 @@ export namespace HiddenLine {
     }
 
     public toJSON(): SettingsProps {
-      return {
+      const props: SettingsProps = {
         visible: this.visible.toJSON(),
         hidden: this.hidden.toJSON(),
         transThreshold: this.transThreshold,
       };
+
+      if ("all" === this.polyfaceEdgeInference)
+        props.polyfaceEdgeInference = "all";
+
+      return props;
     }
 
     /** Create a Settings equivalent to this one with the exception of those properties defined in the supplied JSON. */
@@ -216,6 +226,7 @@ export namespace HiddenLine {
         visible: undefined !== visible ? visible : this.visible.toJSON(),
         hidden: undefined !== hidden ? hidden : this.hidden.toJSON(),
         transThreshold: undefined !== transparencyThreshold ? transparencyThreshold : this.transparencyThreshold,
+        polyfaceEdgeInference: props.polyfaceEdgeInference ?? this.polyfaceEdgeInference,
       });
     }
 
@@ -223,7 +234,10 @@ export namespace HiddenLine {
       if (this === other)
         return true;
 
-      return this.visible.equals(other.visible) && this.hidden.equals(other.hidden) && this.transparencyThreshold === other.transparencyThreshold;
+      return this.visible.equals(other.visible)
+        && this.hidden.equals(other.hidden)
+        && this.transparencyThreshold === other.transparencyThreshold
+        && this.polyfaceEdgeInference === other.polyfaceEdgeInference;
     }
 
     public get matchesDefaults(): boolean {
@@ -234,6 +248,7 @@ export namespace HiddenLine {
       this.visible = Style.fromJSON(json.visible);
       this.hidden = Style.fromJSON(json.hidden, true);
       this.transparencyThreshold = JsonUtils.asDouble(json.transThreshold, 1.0);
+      this.polyfaceEdgeInference = "all" === json.polyfaceEdgeInference ? "all" : "crease";
     }
   }
 }

--- a/core/common/src/test/TileMetadata.test.ts
+++ b/core/common/src/test/TileMetadata.test.ts
@@ -8,7 +8,7 @@ import { Point3d, Range3d } from "@itwin/core-geometry";
 import { expect } from "chai";
 import { BatchType } from "../FeatureTable";
 import {
-  ClassifierTileTreeId, computeTileChordTolerance, ContentIdProvider, defaultTileOptions, EdgeType, IModelTileTreeId, iModelTileTreeIdToString,
+  ClassifierTileTreeId, computeTileChordTolerance, ContentIdProvider, defaultTileOptions, IModelTileTreeId, iModelTileTreeIdToString,
   parseTileTreeIdAndContentId, PrimaryTileTreeId, TileMetadata, TileOptions, TreeFlags,
 } from "../tile/TileMetadata";
 
@@ -64,7 +64,7 @@ describe("TileMetadata", () => {
     const primaryId = (edgesRequired = true, enforceDisplayPriority = false, sectionCut?: string, animationId?: string): IModelTileTreeId => {
       return {
         type: BatchType.Primary,
-        edges: edgesRequired ? EdgeType.NonIndexed : EdgeType.None,
+        edges: edgesRequired ? { indexed: false, smooth: false } : false,
         animationId,
         enforceDisplayPriority,
         sectionCut,
@@ -335,26 +335,26 @@ describe("TileMetadata", () => {
       expect(ContentIdProvider.create(true, parsed.options).idFromSpec(parsed.contentId)).to.equal(contentIdStr);
     }
 
-    test("0x1c", { type: BatchType.Primary, edges: EdgeType.None } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, defaultTileOptions);
-    test("0x1c", { type: BatchType.Primary, edges: EdgeType.None } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableInstancing: false });
-    test("0x1c", { type: BatchType.Primary, edges: EdgeType.None } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableImprovedElision: false });
-    test("0x1c", { type: BatchType.Primary, edges: EdgeType.None } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, ignoreAreaPatterns: true });
-    test("0x1c", { type: BatchType.Primary, edges: EdgeType.None } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableExternalTextures: false });
-    test("0x1c", { type: BatchType.Primary, edges: EdgeType.None } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, useProjectExtents: false });
+    test("0x1c", { type: BatchType.Primary, edges: false } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, defaultTileOptions);
+    test("0x1c", { type: BatchType.Primary, edges: false } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableInstancing: false });
+    test("0x1c", { type: BatchType.Primary, edges: false } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableImprovedElision: false });
+    test("0x1c", { type: BatchType.Primary, edges: false } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, ignoreAreaPatterns: true });
+    test("0x1c", { type: BatchType.Primary, edges: false } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableExternalTextures: false });
+    test("0x1c", { type: BatchType.Primary, edges: false } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, useProjectExtents: false });
     // disableMagnification and alwaysSubdivideIncompleteTiles intentionally left out - they're not included in tileTreeId and contentId strings
-    test("0x1c", { type: BatchType.Primary, edges: EdgeType.None } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableInstancing: false, enableImprovedElision: false, ignoreAreaPatterns: true, enableExternalTextures: false, useProjectExtents: false });
+    test("0x1c", { type: BatchType.Primary, edges: false } as PrimaryTileTreeId, { depth: 2, i: 5, j: 400, k: 16, multiplier: 8 }, { ...defaultTileOptions, enableInstancing: false, enableImprovedElision: false, ignoreAreaPatterns: true, enableExternalTextures: false, useProjectExtents: false });
 
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.NonIndexed } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.NonIndexed, enforceDisplayPriority: true } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.NonIndexed, animationId: "0x105" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
-    test("0x1000000d", { type: BatchType.Primary, edges: EdgeType.None, animationId: "0x105", animationTransformNodeId: 50 } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: false } } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: false }, enforceDisplayPriority: true } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: false }, animationId: "0x105" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1000000d", { type: BatchType.Primary, edges: false, animationId: "0x105", animationTransformNodeId: 50 } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
 
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.NonIndexed, sectionCut: "010_1_0_-5_30_0_-1_5e-11____" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: false }, sectionCut: "010_1_0_-5_30_0_-1_5e-11____" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
 
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.Indexed } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.Indexed, enforceDisplayPriority: true } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.Indexed, animationId: "0x105" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
-    test("0x1d", { type: BatchType.Primary, edges: EdgeType.Indexed, sectionCut: "010_1_0_-5_30_0_-1_5e-11____" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: false } } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: false }, enforceDisplayPriority: true } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: false }, animationId: "0x105" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: false }, sectionCut: "010_1_0_-5_30_0_-1_5e-11____" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
 
     test("0x1d", { type: BatchType.VolumeClassifier, expansion: 50 } as ClassifierTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
     test("0x1000000d", { type: BatchType.VolumeClassifier, expansion: 50, animationId: "0x50000001" } as ClassifierTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
@@ -434,7 +434,7 @@ describe("TileMetadata", () => {
       modelId: "0x1d",
       treeId: {
         type: BatchType.Primary,
-        edges: EdgeType.NonIndexed,
+        edges: { indexed: false, smooth: false },
         sectionCut: "010_1_0_-5_30_0_-1_5e-11____",
         animationId: undefined,
         enforceDisplayPriority: undefined,

--- a/core/common/src/test/TileMetadata.test.ts
+++ b/core/common/src/test/TileMetadata.test.ts
@@ -454,6 +454,50 @@ describe("TileMetadata", () => {
       contentId: { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 },
     });
 
+    test("19_d-E:3_S010_1_0_-5_30_0_-1_5e-11____s0x1d", "-b-14-32-4-1-1", {
+      tileOptions: {
+        elision: true,
+        instancing: true,
+        noPatterns: false,
+        version: 25,
+        projectExtents: true,
+        externalTextures: true,
+        optimizeBReps: true,
+        largerTiles: true,
+      },
+      modelId: "0x1d",
+      treeId: {
+        type: BatchType.Primary,
+        edges: { indexed: false, smooth: true },
+        sectionCut: "010_1_0_-5_30_0_-1_5e-11____",
+        animationId: undefined,
+        enforceDisplayPriority: undefined,
+      },
+      contentId: { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 },
+    });
+
+    test("19_d-E:4_S010_1_0_-5_30_0_-1_5e-11____s0x1d", "-b-14-32-4-1-1", {
+      tileOptions: {
+        elision: true,
+        instancing: true,
+        noPatterns: false,
+        version: 25,
+        projectExtents: true,
+        externalTextures: true,
+        optimizeBReps: true,
+        largerTiles: true,
+      },
+      modelId: "0x1d",
+      treeId: {
+        type: BatchType.Primary,
+        edges: { indexed: true, smooth: true },
+        sectionCut: "010_1_0_-5_30_0_-1_5e-11____",
+        animationId: undefined,
+        enforceDisplayPriority: undefined,
+      },
+      contentId: { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 },
+    });
+
     test("19_1-S010_1_0_-5_30_0_-1_5e-11____0x1d", "-b-14-32-4-1-1", "tree"); // removed 's' after sectionCut
     test("19_1-C50.000000_A:0x50000001_#1f4_0x1000000d", "-b-14-32-4-1-1", "tree"); // removed ':' after C (VolumeClassifier)
     test("19_1-C:50.000000-A:0x50000001_#1f4_0x1000000d", "-b-14-32-4-1-1", "tree"); // replaced '_' with '-'

--- a/core/common/src/test/TileMetadata.test.ts
+++ b/core/common/src/test/TileMetadata.test.ts
@@ -356,6 +356,18 @@ describe("TileMetadata", () => {
     test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: false }, animationId: "0x105" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
     test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: false }, sectionCut: "010_1_0_-5_30_0_-1_5e-11____" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
 
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: true } } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: true }, enforceDisplayPriority: true } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: true }, animationId: "0x105" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1000000d", { type: BatchType.Primary, edges: false, animationId: "0x105", animationTransformNodeId: 50 } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: false, smooth: true }, sectionCut: "010_1_0_-5_30_0_-1_5e-11____" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: true } } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: true }, enforceDisplayPriority: true } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: true }, animationId: "0x105" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+    test("0x1d", { type: BatchType.Primary, edges: { indexed: true, smooth: true }, sectionCut: "010_1_0_-5_30_0_-1_5e-11____" } as PrimaryTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
+
     test("0x1d", { type: BatchType.VolumeClassifier, expansion: 50 } as ClassifierTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
     test("0x1000000d", { type: BatchType.VolumeClassifier, expansion: 50, animationId: "0x50000001" } as ClassifierTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);
     test("0x1000000d", { type: BatchType.VolumeClassifier, expansion: 50, animationId: "0x50000001", animationTransformNodeId: 500 } as ClassifierTileTreeId, { depth: 20, i: 50, j: 4, k: 1, multiplier: 1 }, defaultTileOptions);

--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -37,9 +37,15 @@ export interface GraphicsRequestProps {
   /** If true, surface edges will be omitted from the graphics. */
   readonly omitEdges?: boolean;
   /** If omitEdges is false, specifies the type of edges to produce. Generally determined by TileAdmin.requestElementGraphics.
+   * @note This uses the deleted EdgeType enum where 1 indicates non-indexed edges and 2 indicates indexed edges, to avoid breaking the RPC API.
    * @internal
    */
-  readonly edges?: EdgeOptions;
+  readonly edgeType?: 1 | 2;
+  /** If true, and omitEdges is false, a polyface with no edge visibility info will display edges for all faces;
+   * if false, edges will be inferred from the polyface's topology.
+   * @internal
+   */
+  readonly smoothPolyfaceEdges?: boolean;
   /** If true, the element's graphics will be clipped against the iModel's project extents. */
   readonly clipToProjectExtents?: boolean;
   /** If defined, the compact string representation of a [ClipVector]($core-geometry) to be applied to the geometry to produce section-cut

--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -11,7 +11,7 @@ import { TransformProps } from "@itwin/core-geometry";
 import { Placement2dProps, Placement3dProps } from "../ElementProps";
 import { ElementGeometryDataEntry } from "../geometry/ElementGeometry";
 import { GeometryStreamProps } from "../geometry/GeometryStream";
-import { ContentFlags, EdgeType, TreeFlags } from "../tile/TileMetadata";
+import { ContentFlags, EdgeOptions, TreeFlags } from "../tile/TileMetadata";
 
 /** Wire format describing properties common to [[PersistentGraphicsRequestProps]] and [[DynamicGraphicsRequestProps]].
  * @see [[ElementGraphicsRequestProps]] for more details.
@@ -39,7 +39,7 @@ export interface GraphicsRequestProps {
   /** If omitEdges is false, specifies the type of edges to produce. Generally determined by TileAdmin.requestElementGraphics.
    * @internal
    */
-  readonly edgeType?: EdgeType;
+  readonly edges?: EdgeOptions;
   /** If true, the element's graphics will be clipped against the iModel's project extents. */
   readonly clipToProjectExtents?: boolean;
   /** If defined, the compact string representation of a [ClipVector]($core-geometry) to be applied to the geometry to produce section-cut

--- a/core/frontend/src/tile/ClassifierTileTree.ts
+++ b/core/frontend/src/tile/ClassifierTileTree.ts
@@ -52,14 +52,13 @@ class ClassifierTreeSupplier implements TileTreeSupplier {
     const idStr = iModelTileTreeIdToString(id.modelId, id, IModelApp.tileAdmin);
     const props = await IModelApp.tileAdmin.requestTileTreeProps(iModel, idStr);
 
-    const options = {
-      edgesRequired: false,
+    const params = iModelTileTreeParamsFromJSON(props, iModel, id.modelId, {
+      edges: false,
       allowInstancing: false,
       is3d: true,
       batchType: id.type,
-    };
+    });
 
-    const params = iModelTileTreeParamsFromJSON(props, iModel, id.modelId, options);
     return new IModelTileTree(params, id);
   }
 

--- a/core/frontend/src/tile/DynamicIModelTile.ts
+++ b/core/frontend/src/tile/DynamicIModelTile.ts
@@ -359,7 +359,8 @@ class GraphicsTile extends Tile {
       formatVersion: idProvider.majorFormatVersion,
       location: this.tree.iModelTransform.toJSON(),
       contentFlags: idProvider.contentFlags,
-      omitEdges: !this.tree.hasEdges,
+      omitEdges: !this.tree.edgeOptions,
+      edges: this.tree.edgeOptions ? this.tree.edgeOptions : undefined,
       clipToProjectExtents: true,
       sectionCut: this.tree.stringifiedSectionClip,
     };
@@ -387,7 +388,7 @@ class GraphicsTile extends Tile {
     const reader = ImdlReader.create({
       stream, iModel, modelId, is3d, system, isCanceled, containsTransformNodes,
       type: tree.batchType,
-      loadEdges: tree.hasEdges,
+      loadEdges: false !== tree.edgeOptions,
       options: { tileId: this.contentId },
     });
 

--- a/core/frontend/src/tile/DynamicIModelTile.ts
+++ b/core/frontend/src/tile/DynamicIModelTile.ts
@@ -360,7 +360,8 @@ class GraphicsTile extends Tile {
       location: this.tree.iModelTransform.toJSON(),
       contentFlags: idProvider.contentFlags,
       omitEdges: !this.tree.edgeOptions,
-      edges: this.tree.edgeOptions ? this.tree.edgeOptions : undefined,
+      edgeType: this.tree.edgeOptions && this.tree.edgeOptions.indexed ? 2 : 1,
+      smoothPolyfaceEdges: this.tree.edgeOptions && this.tree.edgeOptions.smooth,
       clipToProjectExtents: true,
       sectionCut: this.tree.stringifiedSectionClip,
     };

--- a/core/frontend/src/tile/IModelTile.ts
+++ b/core/frontend/src/tile/IModelTile.ts
@@ -118,7 +118,7 @@ export class IModelTile extends Tile {
     const reader = ImdlReader.create({
       stream: streamBuffer,
       type: tree.batchType,
-      loadEdges: tree.hasEdges,
+      loadEdges: false !== tree.edgeOptions,
       options: { tileId: this.contentId },
       iModel, modelId, is3d, system, isCanceled, sizeMultiplier, containsTransformNodes,
     });

--- a/core/frontend/src/tile/IModelTileTree.ts
+++ b/core/frontend/src/tile/IModelTileTree.ts
@@ -9,7 +9,7 @@
 import { assert, BeTimePoint, GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
 import { Range3d, Transform } from "@itwin/core-geometry";
 import {
-  BatchType, ContentIdProvider, ElementAlignedBox3d, ElementGeometryChange, FeatureAppearanceProvider,
+  BatchType, ContentIdProvider, EdgeOptions, ElementAlignedBox3d, ElementGeometryChange, FeatureAppearanceProvider,
   IModelTileTreeId, IModelTileTreeProps, ModelGeometryChanges, TileProps,
 } from "@itwin/core-common";
 import { IModelApp } from "../IModelApp";
@@ -25,7 +25,7 @@ import {
 /** @internal */
 export interface IModelTileTreeOptions {
   readonly allowInstancing: boolean;
-  readonly edgesRequired: boolean;
+  readonly edges: EdgeOptions | false;
   readonly batchType: BatchType;
   readonly is3d: boolean;
 }
@@ -386,7 +386,7 @@ export class IModelTileTree extends TileTree {
   public get viewFlagOverrides() { return viewFlagOverrides; }
 
   public get batchType(): BatchType { return this._options.batchType; }
-  public get hasEdges(): boolean { return this._options.edgesRequired; }
+  public get edgeOptions(): EdgeOptions | false { return this._options.edges; }
 
   public override get loadPriority(): TileLoadPriority {
     // If the model has been modified, we want to prioritize keeping its graphics up to date.

--- a/core/frontend/src/tile/PrimaryTileTree.ts
+++ b/core/frontend/src/tile/PrimaryTileTree.ts
@@ -267,7 +267,7 @@ class PrimaryTreeReference extends TileTreeReference {
     if (edgesRequired) {
       edges = {
         indexed: IModelApp.tileAdmin.enableIndexedEdges,
-        smooth: view.is3d() && view.displayStyle.settings.hiddenLineSettings.displaySmoothEdges,
+        smooth: view.is3d() && view.displayStyle.settings.hiddenLineSettings.smoothPolyfaceEdges,
       };
     }
 

--- a/core/frontend/src/tile/PrimaryTileTree.ts
+++ b/core/frontend/src/tile/PrimaryTileTree.ts
@@ -8,7 +8,7 @@
 
 import { assert, compareBooleans, compareStrings, Id64String } from "@itwin/core-bentley";
 import {
-  BatchType, compareIModelTileTreeIds, EdgeType, FeatureAppearance, FeatureAppearanceProvider, HiddenLine, iModelTileTreeIdToString, MapLayerSettings, ModelMapLayerSettings, PrimaryTileTreeId, RenderMode, SpatialClassifier, ViewFlagOverrides, ViewFlagsProperties,
+  BatchType, compareIModelTileTreeIds, EdgeOptions, FeatureAppearance, FeatureAppearanceProvider, HiddenLine, iModelTileTreeIdToString, MapLayerSettings, ModelMapLayerSettings, PrimaryTileTreeId, RenderMode, SpatialClassifier, ViewFlagOverrides, ViewFlagsProperties,
 } from "@itwin/core-common";
 import { Geometry, Range3d, StringifiedClipVector, Transform } from "@itwin/core-geometry";
 import { DisplayStyleState } from "../DisplayStyleState";
@@ -65,7 +65,7 @@ class PrimaryTreeSupplier implements TileTreeSupplier {
     const props = await IModelApp.tileAdmin.requestTileTreeProps(iModel, idStr);
 
     const options = {
-      edgesRequired: EdgeType.None !== treeId.edges,
+      edges: treeId.edges,
       allowInstancing: undefined === treeId.animationId && !treeId.enforceDisplayPriority && !treeId.sectionCut && !id.forceNoInstancing,
       is3d: id.is3d,
       batchType: BatchType.Primary,
@@ -263,7 +263,14 @@ class PrimaryTreeReference extends TileTreeReference {
     const renderMode = this._viewFlagOverrides.renderMode ?? view.viewFlags.renderMode;
     const visibleEdges = this._viewFlagOverrides.visibleEdges ?? view.viewFlags.visibleEdges;
     const edgesRequired = visibleEdges || RenderMode.SmoothShade !== renderMode || IModelApp.tileAdmin.alwaysRequestEdges;
-    const edges = edgesRequired ? (IModelApp.tileAdmin.enableIndexedEdges ? EdgeType.Indexed : EdgeType.NonIndexed) : EdgeType.None;
+    let edges: EdgeOptions | false = false;
+    if (edgesRequired) {
+      edges = {
+        indexed: IModelApp.tileAdmin.enableIndexedEdges,
+        smooth: view.is3d() && view.displayStyle.settings.hiddenLineSettings.displaySmoothEdges,
+      };
+    }
+
     const sectionCut = this._sectionClip?.clipString;
     return { type: BatchType.Primary, edges, animationId, sectionCut };
   }
@@ -442,7 +449,7 @@ class MaskTreeReference extends TileTreeReference {
     return this._owner;
   }
   protected createTreeId(): PrimaryTileTreeId {
-    return { type: BatchType.Primary, edges: EdgeType.None };
+    return { type: BatchType.Primary, edges: false };
   }
 }
 
@@ -471,7 +478,7 @@ export class ModelMapLayerTileTreeReference extends MapLayerTileTreeReference {
   }
 
   protected createTreeId(): PrimaryTileTreeId {
-    return { type: BatchType.Primary, edges: EdgeType.None };
+    return { type: BatchType.Primary, edges: false };
   }
 
   public get treeOwner(): TileTreeOwner {

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -10,7 +10,7 @@ import {
   assert, BeDuration, BeEvent, BentleyStatus, BeTimePoint, Id64Array, IModelStatus, ProcessDetector,
 } from "@itwin/core-bentley";
 import {
-  BackendError, CloudStorageTileCache, defaultTileOptions, EdgeType, ElementGraphicsRequestProps, getMaximumMajorTileFormatVersion, IModelError, IModelTileRpcInterface,
+  BackendError, CloudStorageTileCache, defaultTileOptions, ElementGraphicsRequestProps, getMaximumMajorTileFormatVersion, IModelError, IModelTileRpcInterface,
   IModelTileTreeProps, RpcOperation, RpcResponseCacheControl, ServerTimeoutError, TileContentSource, TileVersionInfo,
 } from "@itwin/core-common";
 import { IModelApp } from "../IModelApp";
@@ -642,8 +642,15 @@ export class TileAdmin {
    * @public
    */
   public async requestElementGraphics(iModel: IModelConnection, requestProps: ElementGraphicsRequestProps): Promise<Uint8Array | undefined> {
-    if (true !== requestProps.omitEdges && undefined === requestProps.edgeType)
-      requestProps = { ...requestProps, edgeType: this.enableIndexedEdges ? EdgeType.Indexed : EdgeType.NonIndexed };
+    if (true !== requestProps.omitEdges && undefined === requestProps.edges) {
+      requestProps = {
+        ...requestProps,
+        edges: {
+          indexed: this.enableIndexedEdges,
+          smooth: false,
+        },
+      };
+    }
 
     this.initializeRpc();
     const intfc = IModelTileRpcInterface.getClient();

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -642,15 +642,8 @@ export class TileAdmin {
    * @public
    */
   public async requestElementGraphics(iModel: IModelConnection, requestProps: ElementGraphicsRequestProps): Promise<Uint8Array | undefined> {
-    if (true !== requestProps.omitEdges && undefined === requestProps.edges) {
-      requestProps = {
-        ...requestProps,
-        edges: {
-          indexed: this.enableIndexedEdges,
-          smooth: false,
-        },
-      };
-    }
+    if (true !== requestProps.omitEdges && undefined === requestProps.edgeType)
+      requestProps = { ...requestProps, edgeType: this.enableIndexedEdges ? 2 : 1 };
 
     this.initializeRpc();
     const intfc = IModelTileRpcInterface.getClient();

--- a/test-apps/display-test-app/src/frontend/TileContentTool.ts
+++ b/test-apps/display-test-app/src/frontend/TileContentTool.ts
@@ -28,7 +28,7 @@ export class GenerateTileContentTool extends Tool {
         stream, iModel, modelId, is3d, containsTransformNodes,
         system: IModelApp.renderSystem,
         type: tree.batchType,
-        loadEdges: tree.hasEdges,
+        loadEdges: false !== tree.edgeOptions,
         options: { tileId: contentId },
       });
 

--- a/test-apps/display-test-app/src/frontend/ViewAttributes.ts
+++ b/test-apps/display-test-app/src/frontend/ViewAttributes.ts
@@ -752,6 +752,11 @@ export class ViewAttributes {
       this.sync();
     }, edgeDisplayDiv);
 
+    const smoothEdgesCb = this.addCheckbox("Smooth Edges", (enabled: boolean) => {
+      this.overrideEdgeSettings({ displaySmoothEdges: enabled });
+      this.sync();
+    }, edgeDisplayDiv);
+
     const hidEditor = this.addHiddenLineEditor(true);
     edgeDisplayDiv.appendChild(hidEditor);
 
@@ -770,6 +775,8 @@ export class ViewAttributes {
       visEdgesCb.checkbox.checked = vf.visibleEdges;
       visEditor.hidden = !vf.visibleEdges;
       hidEdgesCb.checkbox.checked = vf.visibleEdges && vf.hiddenEdges;
+      smoothEdgesCb.checkbox.checked = settings.displaySmoothEdges;
+      smoothEdgesCb.div.hidden = !vf.visibleEdges;
       hidEditor.hidden = !vf.hiddenEdges;
     });
     const hr = document.createElement("hr");

--- a/test-apps/display-test-app/src/frontend/ViewAttributes.ts
+++ b/test-apps/display-test-app/src/frontend/ViewAttributes.ts
@@ -735,6 +735,11 @@ export class ViewAttributes {
     });
     slider.div.style.textAlign = "left";
 
+    const smoothEdgesCb = this.addCheckbox("Smooth Polyface Edges", (enabled: boolean) => {
+      this.overrideEdgeSettings({ smoothPolyfaceEdges: enabled });
+      this.sync();
+    }, edgeDisplayDiv);
+
     const visEdgesCb = this.addCheckbox("Visible Edges", (enabled: boolean) => {
       this._vp.viewFlags = this._vp.viewFlags.with("visibleEdges", enabled);
       hidEdgesCb.checkbox.disabled = !enabled;
@@ -749,11 +754,6 @@ export class ViewAttributes {
     const hidEdgesCb = this.addCheckbox("Hidden Edges", (enabled: boolean) => {
       this._vp.viewFlags = this._vp.viewFlags.with("hiddenEdges", enabled);
       hidEditor.hidden = !enabled;
-      this.sync();
-    }, edgeDisplayDiv);
-
-    const smoothEdgesCb = this.addCheckbox("Smooth Edges", (enabled: boolean) => {
-      this.overrideEdgeSettings({ smoothPolyfaceEdges: enabled });
       this.sync();
     }, edgeDisplayDiv);
 
@@ -776,7 +776,6 @@ export class ViewAttributes {
       visEditor.hidden = !vf.visibleEdges;
       hidEdgesCb.checkbox.checked = vf.visibleEdges && vf.hiddenEdges;
       smoothEdgesCb.checkbox.checked = settings.smoothPolyfaceEdges;
-      smoothEdgesCb.div.hidden = !vf.visibleEdges;
       hidEditor.hidden = !vf.hiddenEdges;
     });
     const hr = document.createElement("hr");

--- a/test-apps/display-test-app/src/frontend/ViewAttributes.ts
+++ b/test-apps/display-test-app/src/frontend/ViewAttributes.ts
@@ -753,7 +753,7 @@ export class ViewAttributes {
     }, edgeDisplayDiv);
 
     const smoothEdgesCb = this.addCheckbox("Smooth Edges", (enabled: boolean) => {
-      this.overrideEdgeSettings({ displaySmoothEdges: enabled });
+      this.overrideEdgeSettings({ smoothPolyfaceEdges: enabled });
       this.sync();
     }, edgeDisplayDiv);
 
@@ -775,7 +775,7 @@ export class ViewAttributes {
       visEdgesCb.checkbox.checked = vf.visibleEdges;
       visEditor.hidden = !vf.visibleEdges;
       hidEdgesCb.checkbox.checked = vf.visibleEdges && vf.hiddenEdges;
-      smoothEdgesCb.checkbox.checked = settings.displaySmoothEdges;
+      smoothEdgesCb.checkbox.checked = settings.smoothPolyfaceEdges;
       smoothEdgesCb.div.hidden = !vf.visibleEdges;
       hidEditor.hidden = !vf.hiddenEdges;
     });


### PR DESCRIPTION
For a polyface with no explicit edge visibility:
- MicroStation displays the edges of all faces.
- iTwin.js attempts to infer the edge visibility from the topology

A user has filed a critical defect, wanting the MicroStation behavior.
Added a new flag to the hidden line settings of a display style to enable it.

[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/246961).

TODO
- [ ] Documentation
- [ ] Fix up tests