### PR TITLE
UI: TypeConverter improvements

### DIFF
--- a/common/changes/@itwin/components-react/presentation-typeconverters_fix_2022-05-06-11-21.json
+++ b/common/changes/@itwin/components-react/presentation-typeconverters_fix_2022-05-06-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Add support for undefined value in TypeConverter.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/components-react/presentation-typeconverters_fix_2022-05-06-11-23.json
+++ b/common/changes/@itwin/components-react/presentation-typeconverters_fix_2022-05-06-11-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Avoid creating \"NaN\" string in numeric type converters.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/converters/NumericTypeConverter.ts
+++ b/ui/components-react/src/components-react/converters/NumericTypeConverter.ts
@@ -43,6 +43,11 @@ export abstract class NumericTypeConverterBase extends TypeConverter implements 
  * @public
  */
 export class FloatTypeConverter extends NumericTypeConverterBase {
+  private static parseString(value: string): number {
+    const parsedValue = parseFloat(value);
+    return Number.isNaN(parsedValue) ? 0 : parsedValue;
+  }
+
   public override convertToString(value?: Primitives.Float) {
     if (value === undefined)
       return "";
@@ -53,7 +58,7 @@ export class FloatTypeConverter extends NumericTypeConverterBase {
         // handle these semi-valid values as 0
         numericValue = 0;
       } else {
-        numericValue = parseFloat(value);
+        numericValue = FloatTypeConverter.parseString(value);
       }
     } else {
       numericValue = value;
@@ -68,7 +73,7 @@ export class FloatTypeConverter extends NumericTypeConverterBase {
   }
 
   public override convertFromString(value: string): number {
-    return parseFloat(value);
+    return FloatTypeConverter.parseString(value);
   }
 }
 TypeConverterManager.registerConverter(StandardTypeNames.Float, FloatTypeConverter);
@@ -80,6 +85,11 @@ TypeConverterManager.registerConverter(StandardTypeNames.Number, FloatTypeConver
  * @public
  */
 export class IntTypeConverter extends NumericTypeConverterBase {
+  private static parseString(value: string): number {
+    const parsedValue = parseInt(value, 10);
+    return Number.isNaN(parsedValue) ? 0 : parsedValue;
+  }
+
   public override convertToString(value?: Primitives.Int) {
     if (value === undefined)
       return "";
@@ -90,7 +100,7 @@ export class IntTypeConverter extends NumericTypeConverterBase {
         // handle these semi-valid values as 0
         numericValue = 0;
       } else {
-        numericValue = parseInt(value, 10);
+        numericValue = IntTypeConverter.parseString(value);
       }
     } else {
       numericValue = value;
@@ -99,7 +109,7 @@ export class IntTypeConverter extends NumericTypeConverterBase {
   }
 
   public override convertFromString(value: string): number {
-    return parseInt(value, 10);
+    return IntTypeConverter.parseString(value);
   }
 }
 

--- a/ui/components-react/src/components-react/converters/TypeConverter.ts
+++ b/ui/components-react/src/components-react/converters/TypeConverter.ts
@@ -91,7 +91,7 @@ export abstract class TypeConverter implements SortComparer, OperatorProcessor, 
     const stringValue = await this.convertFromStringWithOptions(value, converterOptions);
     const propertyValue: PrimitiveValue = {
       valueFormat: PropertyValueFormat.Primitive,
-      value: stringValue ? stringValue : "",
+      value: stringValue,
       displayValue: "",
     };
     return propertyValue;

--- a/ui/components-react/src/test/converters/NumericTypeConverter.test.ts
+++ b/ui/components-react/src/test/converters/NumericTypeConverter.test.ts
@@ -31,10 +31,20 @@ describe("IntTypeConverter", () => {
     it("returns empty string when value is undefined", () => {
       expect(converter.convertToString(undefined)).to.be.eq("");
     });
+
+    it("returns default value when value is not a number", () => {
+      expect(converter.convertToString("not a number")).to.be.eq("0");
+    });
   });
 
-  it("convertFromString", () => {
-    expect(converter.convertFromString("100")).to.equal(100);
+  describe("convertFromString", () => {
+    it("returns valid value", () => {
+      expect(converter.convertFromString("100")).to.equal(100);
+    });
+
+    it("returns undefined if string is not a number", () => {
+      expect(converter.convertFromString("not a number")).to.be.undefined;
+    });
   });
 
   it("sortCompare", () => {
@@ -105,10 +115,20 @@ describe("FloatTypeConverter", () => {
     it("returns empty string when value is undefined", () => {
       expect(converter.convertToString(undefined)).to.be.eq("");
     });
+
+    it("returns default value when value is not a number", () => {
+      expect(converter.convertToString("not a number")).to.be.eq("0.0");
+    });
   });
 
-  it("convertFromString", () => {
-    expect(converter.convertFromString("100.0")).to.equal(100.0);
+  describe("convertFromString", () => {
+    it("return valid value", () => {
+      expect(converter.convertFromString("100.0")).to.equal(100.0);
+    });
+
+    it("returns undefined if string is not a number", () => {
+      expect(converter.convertFromString("not a number")).to.be.undefined;
+    });
   });
 
   it("sortCompare", () => {

--- a/ui/components-react/src/test/converters/TypeConverter.test.ts
+++ b/ui/components-react/src/test/converters/TypeConverter.test.ts
@@ -56,13 +56,13 @@ describe("TypeConverter", () => {
   });
 
   describe("convertFromStringToPropertyValue", async () => {
-    it("returns property with empty value when convertFromString returns undefined", async () => {
+    it("returns property with undefined value when convertFromString returns undefined", async () => {
       const converterMock = moq.Mock.ofType(TestTypeConverter, moq.MockBehavior.Loose);
       converterMock.callBase = true;
       converterMock.setup(async (mock) => mock.convertFromString(moq.It.isAny())).returns(async () => undefined);
 
       const propertyValue = await converterMock.object.convertFromStringToPropertyValue("def", TestUtils.createPrimitiveStringProperty("abc", "abc"));
-      expect((propertyValue as PrimitiveValue).value).to.be.empty;
+      expect((propertyValue as PrimitiveValue).value).to.be.undefined;
     });
 
     it("returns property with correct value when convertFromString also returns a correct value", async () => {


### PR DESCRIPTION
* Changed TypeConverter to not default to empty string when converting value from string to PropertyValue. This allows setting property value to undefined when for example editor input field is cleared.
* Changed numeric type converters to avoid showing "NaN" string when value is not a number.