### PR TITLE
Viewport.readPixels returns undefined if viewport is disposed.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-read-pixels-check-target_2022-05-07-13-03.json
+++ b/common/changes/@itwin/core-frontend/pmc-read-pixels-check-target_2022-05-07-13-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Make Viewport.readPixels return undefined if the viewport has been disposed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2436,13 +2436,13 @@ export abstract class Viewport implements IDisposable, TileUser {
   /** Read selected data about each pixel within a rectangular region of this Viewport.
    * @param rect The area of the viewport's contents to read. The origin specifies the upper-left corner. Must lie entirely within the viewport's dimensions. This input viewport is specified using CSS pixels not device pixels.
    * @param selector Specifies which aspect(s) of data to read.
-   * @param receiver A function accepting a [[Pixel.Buffer]] object from which the selected data can be retrieved, or receiving undefined if the viewport is not active, the rect is out of bounds, or some other error. The pixels received will be device pixels, not CSS pixels. See [[Viewport.devicePixelRatio]] and [[Viewport.cssPixelsToDevicePixels]].
+   * @param receiver A function accepting a [[Pixel.Buffer]] object from which the selected data can be retrieved, or receiving undefined if the viewport has been disposed, the rect is out of bounds, or some other error. The pixels received will be device pixels, not CSS pixels. See [[Viewport.devicePixelRatio]] and [[Viewport.cssPixelsToDevicePixels]].
    * @param excludeNonLocatable If true, geometry with the "non-locatable" flag set will not be drawn.
    * @note The [[Pixel.Buffer]] supplied to the `receiver` function becomes invalid once that function exits. Do not store a reference to it.
    */
   public readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable = false): void {
     const viewRect = this.viewRect;
-    if (!rect.isContained(viewRect))
+    if (this.isDisposed || !rect.isContained(viewRect))
       receiver(undefined);
     else
       this.target.readPixels(rect, selector, receiver, excludeNonLocatable);

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -14,6 +14,7 @@ import { IModelApp } from "../IModelApp";
 import { openBlankViewport, testBlankViewport } from "./openBlankViewport";
 import { DecorateContext } from "../ViewContext";
 import { GraphicType } from "../render/GraphicBuilder";
+import { Pixel } from "../render/Pixel";
 
 describe("Viewport", () => {
   before(async () => IModelApp.startup());
@@ -496,6 +497,24 @@ describe("Viewport", () => {
         test(rTransp100pct, (viewport) => {
           expect(viewport.readImageBuffer()).to.be.undefined;
         });
+      });
+    });
+  });
+
+  describe("readPixels", () => {
+    it("returns undefined if viewport is disposed", async () => {
+      testBlankViewport((vp) => {
+        vp.readPixels(vp.viewRect, Pixel.Selector.All, (pixels) => expect(pixels).not.to.be.undefined);
+
+        // BlankViewport.dispose also closes the iModel and removes the viewport's div from the DOM.
+        // We don't want that until the test completes.
+        const dispose = vp.dispose; // eslint-disable-line @typescript-eslint/unbound-method
+        vp.dispose = ScreenViewport.prototype.dispose; // eslint-disable-line @typescript-eslint/unbound-method
+        vp.dispose();
+
+        vp.readPixels(vp.viewRect, Pixel.Selector.All, (pixels) => expect(pixels).to.be.undefined);
+
+        vp.dispose = dispose;
       });
     });
   });


### PR DESCRIPTION
Tools often invoke `Viewport.readPixels` from within an async callback, e.g., in response to mouse motion. It is possible for the Viewport to become disposed in between the async call and execution of the callback, in which case `this.target.readPixels` will produce an uncaught exception because `this.target` is `undefined.

This problem was made more apparent by @TitouanLeDuigou's PR #3504, which introduced a delay between mouse motion and readPixels. It was observed by @DStradley when accidentally mousing over a window running display-performance-test-app. But it can occur in "real" apps too when they close viewports due to switching front-stages etc.

The documentation for `readPixels` already falsely claimed to produce `undefined` if the viewport was not "active" (i.e., had been disposed). Now it actually does. This is easier and less error-prone than trying to track down all async callers and have them check `Viewport.isDisposed` before calling `readPixels`, though good callers should do that since they should just stop interacting with the viewport in any way after disposal.