### PR TITLE
Fix hypermodeling popup toolbar

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-popup-toolbar_2022-05-10-15-11.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-popup-toolbar_2022-05-10-15-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Prevent calls to readPixels from being enqueued when mousing over canvas decorations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/hypermodeling-frontend/pmc-fix-popup-toolbar_2022-05-10-15-11.json
+++ b/common/changes/@itwin/hypermodeling-frontend/pmc-fix-popup-toolbar_2022-05-10-15-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/hypermodeling-frontend",
+      "comment": "Increase delay before popup toolbar disappears.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/hypermodeling-frontend"
+}

--- a/core/hypermodeling/src/PopupToolbar.ts
+++ b/core/hypermodeling/src/PopupToolbar.ts
@@ -62,8 +62,9 @@ export class PopupToolbarManager {
     if (!this._current)
       return;
 
+    const delay = 1000;
     if (this._current.overToolbarHotspot || !IModelApp.toolAdmin.cursorView)
-      setTimeout(() => this.closeAfterTimeout(), 500); // Cursor not in view or over hotspot, check again
+      setTimeout(() => this.closeAfterTimeout(), delay); // Cursor not in view or over hotspot, check again
     else
       this.close();
   }


### PR DESCRIPTION
Regression introduced in @TitouanLeDuigou's #3504: the hypermodeling popup toolbar disappears after a short delay while trying to interact with it.
When we mouse over a canvas decoration, don't enqueue a delayed `readPixels` call.
Also, double the delay before the popup toolbar disappears to 1 second.