### PR TITLE
Fix corrupted background map textures

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -8868,11 +8868,11 @@ export abstract class RenderSystem implements IDisposable {
     // @internal (undocumented)
     createPolylineGeometry(_params: PolylineParams, _viewIndependentOrigin?: Point3d): RenderGeometry | undefined;
     // @internal (undocumented)
-    createRealityMesh(_realityMesh: RealityMeshPrimitive, _disableTextureDisposal?: true): RenderGraphic | undefined;
+    createRealityMesh(_realityMesh: RealityMeshPrimitive, _disableTextureDisposal?: boolean): RenderGraphic | undefined;
     // @internal (undocumented)
-    createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform, _disableTextureDisposal?: true): RenderTerrainGeometry | undefined;
+    createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform, _disableTextureDisposal?: boolean): RenderTerrainGeometry | undefined;
     // @internal (undocumented)
-    createRealityMeshGraphic(_params: RealityMeshGraphicParams, _disableTextureDisposal?: true): RenderGraphic | undefined;
+    createRealityMeshGraphic(_params: RealityMeshGraphicParams, _disableTextureDisposal?: boolean): RenderGraphic | undefined;
     // @internal
     abstract createRenderGraphic(_geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic | undefined;
     createRenderMaterial(_args: CreateRenderMaterialArgs): RenderMaterial | undefined;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -8868,11 +8868,11 @@ export abstract class RenderSystem implements IDisposable {
     // @internal (undocumented)
     createPolylineGeometry(_params: PolylineParams, _viewIndependentOrigin?: Point3d): RenderGeometry | undefined;
     // @internal (undocumented)
-    createRealityMesh(_realityMesh: RealityMeshPrimitive): RenderGraphic | undefined;
+    createRealityMesh(_realityMesh: RealityMeshPrimitive, _disableTextureDisposal?: true): RenderGraphic | undefined;
     // @internal (undocumented)
-    createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform): RenderTerrainGeometry | undefined;
+    createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform, _disableTextureDisposal?: true): RenderTerrainGeometry | undefined;
     // @internal (undocumented)
-    createRealityMeshGraphic(_params: RealityMeshGraphicParams): RenderGraphic | undefined;
+    createRealityMeshGraphic(_params: RealityMeshGraphicParams, _disableTextureDisposal?: true): RenderGraphic | undefined;
     // @internal
     abstract createRenderGraphic(_geometry: RenderGeometry, instances?: InstancedGraphicParams | RenderAreaPattern): RenderGraphic | undefined;
     createRenderMaterial(_args: CreateRenderMaterialArgs): RenderMaterial | undefined;

--- a/common/changes/@itwin/core-frontend/markschlosser-fix-map-texture-disposal-bugs_2022-05-10-18-34.json
+++ b/common/changes/@itwin/core-frontend/markschlosser-fix-map-texture-disposal-bugs_2022-05-10-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Map tiles need to retain their textures longer than reality mesh geometry will if it disposes of everything when requested. These changes make reality meshes that are maps hold onto their textures.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/markschlosser-fix-map-texture-disposal-bugs_2022-05-10-18-34.json
+++ b/common/changes/@itwin/core-frontend/markschlosser-fix-map-texture-disposal-bugs_2022-05-10-18-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Map tiles need to retain their textures longer than reality mesh geometry will if it disposes of everything when requested. These changes make reality meshes that are maps hold onto their textures.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -419,11 +419,11 @@ export abstract class RenderSystem implements IDisposable {
   }
 
   /** @internal */
-  public createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform, _disableTextureDisposal?: true): RenderTerrainGeometry | undefined { return undefined; }
+  public createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform, _disableTextureDisposal = false): RenderTerrainGeometry | undefined { return undefined; }
   /** @internal */
-  public createRealityMeshGraphic(_params: RealityMeshGraphicParams, _disableTextureDisposal?: true): RenderGraphic | undefined { return undefined; }
+  public createRealityMeshGraphic(_params: RealityMeshGraphicParams, _disableTextureDisposal = false): RenderGraphic | undefined { return undefined; }
   /** @internal */
-  public createRealityMesh(_realityMesh: RealityMeshPrimitive, _disableTextureDisposal?: true): RenderGraphic | undefined { return undefined; }
+  public createRealityMesh(_realityMesh: RealityMeshPrimitive, _disableTextureDisposal = false): RenderGraphic | undefined { return undefined; }
   /** @internal */
   public get maxRealityImageryLayers() { return 0; }
   /** @internal */

--- a/core/frontend/src/render/RenderSystem.ts
+++ b/core/frontend/src/render/RenderSystem.ts
@@ -419,11 +419,11 @@ export abstract class RenderSystem implements IDisposable {
   }
 
   /** @internal */
-  public createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform): RenderTerrainGeometry | undefined { return undefined; }
+  public createRealityMeshFromTerrain(_terrainMesh: TerrainMeshPrimitive, _transform?: Transform, _disableTextureDisposal?: true): RenderTerrainGeometry | undefined { return undefined; }
   /** @internal */
-  public createRealityMeshGraphic(_params: RealityMeshGraphicParams): RenderGraphic | undefined { return undefined; }
+  public createRealityMeshGraphic(_params: RealityMeshGraphicParams, _disableTextureDisposal?: true): RenderGraphic | undefined { return undefined; }
   /** @internal */
-  public createRealityMesh(_realityMesh: RealityMeshPrimitive): RenderGraphic | undefined { return undefined; }
+  public createRealityMesh(_realityMesh: RealityMeshPrimitive, _disableTextureDisposal?: true): RenderGraphic | undefined { return undefined; }
   /** @internal */
   public get maxRealityImageryLayers() { return 0; }
   /** @internal */

--- a/core/frontend/src/render/webgl/RealityMesh.ts
+++ b/core/frontend/src/render/webgl/RealityMesh.ts
@@ -233,7 +233,7 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
   public get overrideColorMix() { return .5; }     // This could be a setting from either the mesh or the override if required.
   public get transform(): Transform | undefined { return this._transform; }
 
-  private constructor(private _realityMeshParams: RealityMeshGeometryParams, public textureParams: RealityTextureParams | undefined, private readonly _transform: Transform | undefined, public readonly baseColor: ColorDef | undefined, private _baseIsTransparent: boolean, private _isTerrain: boolean) {
+  private constructor(private _realityMeshParams: RealityMeshGeometryParams, public textureParams: RealityTextureParams | undefined, private readonly _transform: Transform | undefined, public readonly baseColor: ColorDef | undefined, private _baseIsTransparent: boolean, private _isTerrain: boolean, private _disableTextureDisposal?: true) {
     super(_realityMeshParams);
     this.hasTextures = undefined !== textureParams && textureParams.params.some((x) => undefined !== x.texture);
   }
@@ -241,28 +241,29 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
   public override dispose() {
     super.dispose();
     dispose(this._realityMeshParams);
-    dispose(this.textureParams);
+    if (true !== this._disableTextureDisposal)
+      dispose(this.textureParams);
   }
 
-  public static createFromTerrainMesh(terrainMesh: TerrainMeshPrimitive, transform: Transform | undefined) {
+  public static createFromTerrainMesh(terrainMesh: TerrainMeshPrimitive, transform: Transform | undefined, disableTextureDisposal?: true) {
     const params = RealityMeshGeometryParams.createFromRealityMesh(terrainMesh);
-    return params ? new RealityMeshGeometry(params, undefined, transform, undefined, false, true) : undefined;
+    return params ? new RealityMeshGeometry(params, undefined, transform, undefined, false, true, disableTextureDisposal) : undefined;
   }
 
-  public static createFromRealityMesh(realityMesh: RealityMeshPrimitive): RealityMeshGeometry | undefined {
+  public static createFromRealityMesh(realityMesh: RealityMeshPrimitive, disableTextureDisposal?: true): RealityMeshGeometry | undefined {
     const params = RealityMeshGeometryParams.createFromRealityMesh(realityMesh);
     if (!params)
       return undefined;
     const texture = realityMesh.texture ? new TerrainTexture(realityMesh.texture, realityMesh.featureID, Vector2d.create(1.0, -1.0), Vector2d.create(0.0, 1.0), Range2d.createXYXY(0, 0, 1, 1), 0, 0) : undefined;
 
-    return new RealityMeshGeometry(params, texture ? RealityTextureParams.create([texture]) : undefined, undefined, undefined, false, false);
+    return new RealityMeshGeometry(params, texture ? RealityTextureParams.create([texture]) : undefined, undefined, undefined, false, false, disableTextureDisposal);
   }
 
   public getRange(): Range3d {
     return Range3d.createXYZXYZ(this.qOrigin[0], this.qOrigin[1], this.qOrigin[2], this.qOrigin[0] + Quantization.rangeScale16 * this.qScale[0], this.qOrigin[1] + Quantization.rangeScale16 * this.qScale[1], this.qOrigin[2] + Quantization.rangeScale16 * this.qScale[2]);
   }
 
-  public static createGraphic(system: RenderSystem, params: RealityMeshGraphicParams): RenderGraphic | undefined {
+  public static createGraphic(system: RenderSystem, params: RealityMeshGraphicParams, disableTextureDisposal?: true): RenderGraphic | undefined {
     const meshes = [];
     const textures = params.textures ?? [];
     const realityMesh = params.realityMesh as RealityMeshGeometry;
@@ -283,7 +284,7 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
 
     if (layers.length < 2 && !layerClassifiers?.size && textures.length < texturesPerMesh) {
       // If only there is not more than one layer then we can group all of the textures into a single draw call.
-      meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(textures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain));
+      meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(textures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain, disableTextureDisposal));
     } else {
       let primaryLayer;
       while (primaryLayer === undefined)
@@ -319,10 +320,10 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
           }
         }
         while (layerTextures.length > texturesPerMesh) {
-          meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures.slice(0, texturesPerMesh)), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain));
+          meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures.slice(0, texturesPerMesh)), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain, disableTextureDisposal));
           layerTextures = layerTextures.slice(texturesPerMesh);
         }
-        meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain));
+        meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain, disableTextureDisposal));
       }
     }
 

--- a/core/frontend/src/render/webgl/RealityMesh.ts
+++ b/core/frontend/src/render/webgl/RealityMesh.ts
@@ -233,9 +233,32 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
   public get overrideColorMix() { return .5; }     // This could be a setting from either the mesh or the override if required.
   public get transform(): Transform | undefined { return this._transform; }
 
-  private constructor(private _realityMeshParams: RealityMeshGeometryParams, public textureParams: RealityTextureParams | undefined, private readonly _transform: Transform | undefined, public readonly baseColor: ColorDef | undefined, private _baseIsTransparent: boolean, private _isTerrain: boolean, private _disableTextureDisposal?: true) {
-    super(_realityMeshParams);
-    this.hasTextures = undefined !== textureParams && textureParams.params.some((x) => undefined !== x.texture);
+  private _realityMeshParams: RealityMeshGeometryParams;
+  public textureParams: RealityTextureParams | undefined;
+  private readonly _transform: Transform | undefined;
+  public readonly baseColor: ColorDef | undefined;
+  private _baseIsTransparent: boolean;
+  private _isTerrain: boolean;
+  private _disableTextureDisposal: boolean;
+
+  private constructor(props: {
+    realityMeshParams: RealityMeshGeometryParams;
+    textureParams?: RealityTextureParams;
+    transform?: Transform;
+    baseColor?: ColorDef;
+    baseIsTransparent: boolean;
+    isTerrain: boolean;
+    disableTextureDisposal: boolean;
+  }) {
+    super(props.realityMeshParams);
+    this._realityMeshParams = props.realityMeshParams;
+    this.textureParams = props.textureParams;
+    this._transform = props.transform;
+    this.baseColor = props.baseColor;
+    this._baseIsTransparent = props.baseIsTransparent;
+    this._isTerrain = props.isTerrain;
+    this._disableTextureDisposal = props.disableTextureDisposal;
+    this.hasTextures = undefined !== this.textureParams && this.textureParams.params.some((x) => undefined !== x.texture);
   }
 
   public override dispose() {
@@ -245,25 +268,25 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
       dispose(this.textureParams);
   }
 
-  public static createFromTerrainMesh(terrainMesh: TerrainMeshPrimitive, transform: Transform | undefined, disableTextureDisposal?: true) {
+  public static createFromTerrainMesh(terrainMesh: TerrainMeshPrimitive, transform: Transform | undefined, disableTextureDisposal = false) {
     const params = RealityMeshGeometryParams.createFromRealityMesh(terrainMesh);
-    return params ? new RealityMeshGeometry(params, undefined, transform, undefined, false, true, disableTextureDisposal) : undefined;
+    return params ? new RealityMeshGeometry({realityMeshParams: params, transform, baseIsTransparent: false, isTerrain: true, disableTextureDisposal}) : undefined;
   }
 
-  public static createFromRealityMesh(realityMesh: RealityMeshPrimitive, disableTextureDisposal?: true): RealityMeshGeometry | undefined {
+  public static createFromRealityMesh(realityMesh: RealityMeshPrimitive, disableTextureDisposal = false): RealityMeshGeometry | undefined {
     const params = RealityMeshGeometryParams.createFromRealityMesh(realityMesh);
     if (!params)
       return undefined;
     const texture = realityMesh.texture ? new TerrainTexture(realityMesh.texture, realityMesh.featureID, Vector2d.create(1.0, -1.0), Vector2d.create(0.0, 1.0), Range2d.createXYXY(0, 0, 1, 1), 0, 0) : undefined;
 
-    return new RealityMeshGeometry(params, texture ? RealityTextureParams.create([texture]) : undefined, undefined, undefined, false, false, disableTextureDisposal);
+    return new RealityMeshGeometry({realityMeshParams: params, textureParams: texture ? RealityTextureParams.create([texture]) : undefined, baseIsTransparent: false, isTerrain: false, disableTextureDisposal});
   }
 
   public getRange(): Range3d {
     return Range3d.createXYZXYZ(this.qOrigin[0], this.qOrigin[1], this.qOrigin[2], this.qOrigin[0] + Quantization.rangeScale16 * this.qScale[0], this.qOrigin[1] + Quantization.rangeScale16 * this.qScale[1], this.qOrigin[2] + Quantization.rangeScale16 * this.qScale[2]);
   }
 
-  public static createGraphic(system: RenderSystem, params: RealityMeshGraphicParams, disableTextureDisposal?: true): RenderGraphic | undefined {
+  public static createGraphic(system: RenderSystem, params: RealityMeshGraphicParams, disableTextureDisposal = false): RenderGraphic | undefined {
     const meshes = [];
     const textures = params.textures ?? [];
     const realityMesh = params.realityMesh as RealityMeshGeometry;
@@ -284,7 +307,7 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
 
     if (layers.length < 2 && !layerClassifiers?.size && textures.length < texturesPerMesh) {
       // If only there is not more than one layer then we can group all of the textures into a single draw call.
-      meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(textures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain, disableTextureDisposal));
+      meshes.push(new RealityMeshGeometry({realityMeshParams: realityMesh._realityMeshParams, textureParams: RealityTextureParams.create(textures), transform: realityMesh._transform, baseColor, baseIsTransparent: baseTransparent, isTerrain: realityMesh._isTerrain, disableTextureDisposal}));
     } else {
       let primaryLayer;
       while (primaryLayer === undefined)
@@ -320,10 +343,10 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
           }
         }
         while (layerTextures.length > texturesPerMesh) {
-          meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures.slice(0, texturesPerMesh)), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain, disableTextureDisposal));
+          meshes.push(new RealityMeshGeometry({realityMeshParams: realityMesh._realityMeshParams, textureParams: RealityTextureParams.create(layerTextures.slice(0, texturesPerMesh)), transform: realityMesh._transform, baseColor, baseIsTransparent: baseTransparent, isTerrain: realityMesh._isTerrain, disableTextureDisposal}));
           layerTextures = layerTextures.slice(texturesPerMesh);
         }
-        meshes.push(new RealityMeshGeometry(realityMesh._realityMeshParams, RealityTextureParams.create(layerTextures), realityMesh._transform, baseColor, baseTransparent, realityMesh._isTerrain, disableTextureDisposal));
+        meshes.push(new RealityMeshGeometry({realityMeshParams: realityMesh._realityMeshParams, textureParams: RealityTextureParams.create(layerTextures), transform: realityMesh._transform, baseColor, baseIsTransparent: baseTransparent, isTerrain: realityMesh._isTerrain, disableTextureDisposal}));
       }
     }
 

--- a/core/frontend/src/render/webgl/System.ts
+++ b/core/frontend/src/render/webgl/System.ts
@@ -528,15 +528,15 @@ export class System extends RenderSystem implements RenderSystemDebugControl, Re
     return PlanarGridGeometry.create(frustum, grid, this);
   }
 
-  public override createRealityMeshFromTerrain(terrainMesh: TerrainMeshPrimitive, transform?: Transform): RealityMeshGeometry | undefined {
-    return RealityMeshGeometry.createFromTerrainMesh(terrainMesh, transform);
+  public override createRealityMeshFromTerrain(terrainMesh: TerrainMeshPrimitive, transform?: Transform, disableTextureDisposal?: true): RealityMeshGeometry | undefined {
+    return RealityMeshGeometry.createFromTerrainMesh(terrainMesh, transform, disableTextureDisposal);
   }
 
-  public override createRealityMeshGraphic(params: RealityMeshGraphicParams): RenderGraphic | undefined {
-    return RealityMeshGeometry.createGraphic(this, params);
+  public override createRealityMeshGraphic(params: RealityMeshGraphicParams, disableTextureDisposal?: true): RenderGraphic | undefined {
+    return RealityMeshGeometry.createGraphic(this, params, disableTextureDisposal);
   }
-  public override createRealityMesh(realityMesh: RealityMeshPrimitive): RenderGraphic | undefined {
-    const geom = RealityMeshGeometry.createFromRealityMesh(realityMesh);
+  public override createRealityMesh(realityMesh: RealityMeshPrimitive, disableTextureDisposal?: true): RenderGraphic | undefined {
+    const geom = RealityMeshGeometry.createFromRealityMesh(realityMesh, disableTextureDisposal);
     return geom ? Primitive.create(geom) : undefined;
   }
 

--- a/core/frontend/src/render/webgl/System.ts
+++ b/core/frontend/src/render/webgl/System.ts
@@ -528,14 +528,14 @@ export class System extends RenderSystem implements RenderSystemDebugControl, Re
     return PlanarGridGeometry.create(frustum, grid, this);
   }
 
-  public override createRealityMeshFromTerrain(terrainMesh: TerrainMeshPrimitive, transform?: Transform, disableTextureDisposal?: true): RealityMeshGeometry | undefined {
+  public override createRealityMeshFromTerrain(terrainMesh: TerrainMeshPrimitive, transform?: Transform, disableTextureDisposal = false): RealityMeshGeometry | undefined {
     return RealityMeshGeometry.createFromTerrainMesh(terrainMesh, transform, disableTextureDisposal);
   }
 
-  public override createRealityMeshGraphic(params: RealityMeshGraphicParams, disableTextureDisposal?: true): RenderGraphic | undefined {
+  public override createRealityMeshGraphic(params: RealityMeshGraphicParams, disableTextureDisposal = false): RenderGraphic | undefined {
     return RealityMeshGeometry.createGraphic(this, params, disableTextureDisposal);
   }
-  public override createRealityMesh(realityMesh: RealityMeshPrimitive, disableTextureDisposal?: true): RenderGraphic | undefined {
+  public override createRealityMesh(realityMesh: RealityMeshPrimitive, disableTextureDisposal = false): RenderGraphic | undefined {
     const geom = RealityMeshGeometry.createFromRealityMesh(realityMesh, disableTextureDisposal);
     return geom ? Primitive.create(geom) : undefined;
   }

--- a/core/frontend/src/tile/map/MapTile.ts
+++ b/core/frontend/src/tile/map/MapTile.ts
@@ -430,7 +430,7 @@ export class MapTile extends RealityTile {
 
     const textures = this.getDrapeTextures();
     const { baseColor, baseTransparent, layerClassifiers } = this.mapTree;
-    const graphic = IModelApp.renderSystem.createRealityMeshGraphic({ realityMesh: geometry, projection: this.getProjection(), tileRectangle: this.rectangle, featureTable: PackedFeatureTable.pack(this.mapLoader.featureTable), tileId: this.contentId, baseColor, baseTransparent, textures, layerClassifiers });
+    const graphic = IModelApp.renderSystem.createRealityMeshGraphic({ realityMesh: geometry, projection: this.getProjection(), tileRectangle: this.rectangle, featureTable: PackedFeatureTable.pack(this.mapLoader.featureTable), tileId: this.contentId, baseColor, baseTransparent, textures, layerClassifiers }, true);
 
     // If there are no layer classifiers then we can save this graphic for re-use.  If layer classifiers exist they are regenerated based on view and we must collate them with the imagery.
     if (this.imageryIsReady && 0 === this.mapTree.layerClassifiers.size)
@@ -677,7 +677,7 @@ export class UpsampledMapTile extends MapTile {
       const upsample = this.upsampleFromParent();
       const projection = this.loadableTerrainTile.getProjection(this.heightRange);
       if (upsample)
-        this._renderGeometry = IModelApp.renderSystem.createRealityMeshFromTerrain(upsample.mesh, projection.transformFromLocal);
+        this._renderGeometry = IModelApp.renderSystem.createRealityMeshFromTerrain(upsample.mesh, projection.transformFromLocal, true);
     }
     return this._renderGeometry;
   }

--- a/core/frontend/src/tile/map/MapTileLoader.ts
+++ b/core/frontend/src/tile/map/MapTileLoader.ts
@@ -81,7 +81,7 @@ export class MapTileLoader extends RealityTileLoader {
       return {};
 
     const projection = tile.getProjection(tile.heightRange);
-    const terrainGeometry = system.createRealityMeshFromTerrain(mesh, projection.transformFromLocal);
+    const terrainGeometry = system.createRealityMeshFromTerrain(mesh, projection.transformFromLocal, true);
 
     let unavailableChild = false;
     if (quadId.level < this.maxDepth) {


### PR DESCRIPTION
This PR resolves a regression introduced in @TitouanLeDuigou's #3536: background map textures will get corrupted after a period of time, especially triggered after opening a second viewport.
Map tiles (a type of reality mesh) currently need to retain their textures longer than the dispose introduced in the previous PR allows.
This PR makes map tiles retain their textures (like they previously would) by allowing them to skip the dispose.  Other reality meshes will still make use of the dispose introduced in the previous PR.