### PR TITLE
White-list dialog module methods in Electron IPC handler

### DIFF
--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -518,6 +518,9 @@ export abstract class ErrorCategory extends StatusCategory {
     error: boolean;
 }
 
+// @beta
+export type ExtractLiterals<T, U extends T> = Extract<T, U>;
+
 // @public
 export enum GeoServiceStatus {
     // (undocumented)

--- a/common/api/core-electron.api.md
+++ b/common/api/core-electron.api.md
@@ -7,6 +7,7 @@
 import { AsyncMethodsOf } from '@itwin/core-bentley';
 import { BrowserWindow } from 'electron';
 import { BrowserWindowConstructorOptions } from 'electron';
+import { ExtractLiterals } from '@itwin/core-bentley';
 import { IpcHandler } from '@itwin/core-backend';
 import { NativeAppOpts } from '@itwin/core-frontend';
 import { NativeHostOpts } from '@itwin/core-backend';
@@ -15,10 +16,11 @@ import { RpcConfiguration } from '@itwin/core-common';
 import { RpcInterfaceDefinition } from '@itwin/core-common';
 
 // @beta
+export type DialogModuleMethod = ExtractLiterals<AsyncMethodsOf<Electron.Dialog>, "showMessageBox" | "showOpenDialog" | "showSaveDialog">;
+
+// @beta
 export class ElectronApp {
-    static callApp<T extends AsyncMethodsOf<Electron.App>>(methodName: T, ...args: Parameters<Electron.App[T]>): Promise<PromiseReturnType<Electron.App[T]>>;
-    static callDialog<T extends AsyncMethodsOf<Electron.Dialog>>(methodName: T, ...args: Parameters<Electron.Dialog[T]>): Promise<PromiseReturnType<Electron.Dialog[T]>>;
-    static callShell<T extends AsyncMethodsOf<Electron.Shell>>(methodName: T, ...args: Parameters<Electron.Shell[T]>): Promise<PromiseReturnType<Electron.Shell[T]>>;
+    static callDialog<T extends DialogModuleMethod>(methodName: T, ...args: Parameters<Electron.Dialog[T]>): Promise<PromiseReturnType<Electron.Dialog[T]>>;
     // (undocumented)
     static get isValid(): boolean;
     // (undocumented)

--- a/common/api/summary/core-bentley.exports.csv
+++ b/common/api/summary/core-bentley.exports.csv
@@ -46,6 +46,7 @@ public;DuplicatePolicy
 public;Entry
 public;EntryContainer
 alpha;class ErrorCategory 
+beta;ExtractLiterals
 public;GeoServiceStatus
 public;GetMetaDataFunction = () => object | undefined
 public;Guid

--- a/common/changes/@itwin/core-bentley/electron-ipc_2022-05-11-13-46.json
+++ b/common/changes/@itwin/core-bentley/electron-ipc_2022-05-11-13-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Add ExtractLiterals type.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-electron/electron-ipc_2022-05-11-13-46.json
+++ b/common/changes/@itwin/core-electron/electron-ipc_2022-05-11-13-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "White-list APIs from dialog module.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/core/bentley/src/UtilityTypes.ts
+++ b/core/bentley/src/UtilityTypes.ts
@@ -98,3 +98,7 @@ export type AsyncMethodsOf<T> = { [P in keyof T]: T[P] extends AsyncFunction ? P
  */
 export type PromiseReturnType<T extends AsyncFunction> = T extends (...args: any) => Promise<infer R> ? R : any;
 
+/** Extracts a subset of literals `U` from a union of literals `T` in a type-safe way.
+ * @beta
+ */
+export type ExtractLiterals<T, U extends T> = Extract<T, U>;

--- a/core/electron/src/__DOC_ONLY__.ts
+++ b/core/electron/src/__DOC_ONLY__.ts
@@ -8,4 +8,5 @@
 // Do not import it in real code!
 
 export * from "./backend/ElectronHost";
+export * from "./common/ElectronIpcInterface";
 export * from "./frontend/ElectronApp";

--- a/core/electron/src/backend/ElectronHost.ts
+++ b/core/electron/src/backend/ElectronHost.ts
@@ -16,6 +16,7 @@ import { BeDuration, IModelStatus, ProcessDetector } from "@itwin/core-bentley";
 import { IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
 import { IModelError, IpcListener, IpcSocketBackend, RemoveFunction, RpcConfiguration, RpcInterfaceDefinition } from "@itwin/core-common";
 import { ElectronRpcConfiguration, ElectronRpcManager } from "../common/ElectronRpcManager";
+import { DialogModuleMethod } from "../common/ElectronIpcInterface";
 
 // cSpell:ignore signin devserver webcontents copyfile unmaximize eopt
 
@@ -280,7 +281,7 @@ class ElectronAppHandler extends IpcHandler {
   public async callElectron(member: string, method: string, ...args: any) {
     let allowedMethods: readonly string[] = [];
     if (member === "dialog") {
-      const methods: readonly (keyof Electron.Dialog)[] = ["showMessageBox", "showOpenDialog", "showSaveDialog"];
+      const methods: DialogModuleMethod[] = ["showMessageBox", "showOpenDialog", "showSaveDialog"];
       allowedMethods = methods;
     }
 

--- a/core/electron/src/common/ElectronIpcInterface.ts
+++ b/core/electron/src/common/ElectronIpcInterface.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { AsyncMethodsOf, ExtractLiterals } from "@itwin/core-bentley";
+
+/** Exposed main process methods of dialog module in an Electron app.
+ * @beta
+ */
+export type DialogModuleMethod = ExtractLiterals<AsyncMethodsOf<Electron.Dialog>, "showMessageBox" | "showOpenDialog" | "showSaveDialog">;

--- a/core/electron/src/frontend/ElectronApp.ts
+++ b/core/electron/src/frontend/ElectronApp.ts
@@ -2,11 +2,16 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { AsyncMethodsOf, ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
+import { AsyncMethodsOf, ExtractLiterals, ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
 import { IpcListener, IpcSocketFrontend } from "@itwin/core-common";
 import { IpcApp, NativeApp, NativeAppOpts } from "@itwin/core-frontend";
 import { ITwinElectronApi } from "../backend/ElectronPreload";
 import { ElectronRpcManager } from "../common/ElectronRpcManager";
+
+/** Exposed main process methods of dialog module in an Electron app.
+ * @beta
+ */
+export type DialogModuleMethods = ExtractLiterals<AsyncMethodsOf<Electron.Dialog>, "showMessageBox" | "showOpenDialog" | "showSaveDialog">;
 
 /**
  * Frontend Ipc support for Electron apps.
@@ -69,23 +74,7 @@ export class ElectronApp {
    * @param methodName the name of the method to call
    * @param args arguments to method
    */
-  public static async callDialog<T extends AsyncMethodsOf<Electron.Dialog>>(methodName: T, ...args: Parameters<Electron.Dialog[T]>) {
+  public static async callDialog<T extends DialogModuleMethods>(methodName: T, ...args: Parameters<Electron.Dialog[T]>) {
     return IpcApp.callIpcChannel("electron-safe", "callElectron", "dialog", methodName, ...args) as PromiseReturnType<Electron.Dialog[T]>;
-  }
-  /**
-   * Call an asynchronous method in the [Electron.shell](https://www.electronjs.org/docs/api/shell) interface from a previously initialized ElectronFrontend.
-   * @param methodName the name of the method to call
-   * @param args arguments to method
-   */
-  public static async callShell<T extends AsyncMethodsOf<Electron.Shell>>(methodName: T, ...args: Parameters<Electron.Shell[T]>) {
-    return IpcApp.callIpcChannel("electron-safe", "callElectron", "shell", methodName, ...args) as PromiseReturnType<Electron.Shell[T]>;
-  }
-  /**
-   * Call an asynchronous method in the [Electron.app](https://www.electronjs.org/docs/api/app) interface from a previously initialized ElectronFrontend.
-   * @param methodName the name of the method to call
-   * @param args arguments to method
-   */
-  public static async callApp<T extends AsyncMethodsOf<Electron.App>>(methodName: T, ...args: Parameters<Electron.App[T]>) {
-    return IpcApp.callIpcChannel("electron-safe", "callElectron", "app", methodName, ...args) as PromiseReturnType<Electron.App[T]>;
   }
 }

--- a/core/electron/src/frontend/ElectronApp.ts
+++ b/core/electron/src/frontend/ElectronApp.ts
@@ -2,16 +2,12 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { AsyncMethodsOf, ExtractLiterals, ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
+import { ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
 import { IpcListener, IpcSocketFrontend } from "@itwin/core-common";
 import { IpcApp, NativeApp, NativeAppOpts } from "@itwin/core-frontend";
 import { ITwinElectronApi } from "../backend/ElectronPreload";
+import { DialogModuleMethod } from "../common/ElectronIpcInterface";
 import { ElectronRpcManager } from "../common/ElectronRpcManager";
-
-/** Exposed main process methods of dialog module in an Electron app.
- * @beta
- */
-export type DialogModuleMethods = ExtractLiterals<AsyncMethodsOf<Electron.Dialog>, "showMessageBox" | "showOpenDialog" | "showSaveDialog">;
 
 /**
  * Frontend Ipc support for Electron apps.
@@ -74,7 +70,7 @@ export class ElectronApp {
    * @param methodName the name of the method to call
    * @param args arguments to method
    */
-  public static async callDialog<T extends DialogModuleMethods>(methodName: T, ...args: Parameters<Electron.Dialog[T]>) {
+  public static async callDialog<T extends DialogModuleMethod>(methodName: T, ...args: Parameters<Electron.Dialog[T]>) {
     return IpcApp.callIpcChannel("electron-safe", "callElectron", "dialog", methodName, ...args) as PromiseReturnType<Electron.Dialog[T]>;
   }
 }

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -9,6 +9,7 @@ Table of contents:
   - [Dynamic schedule scripts](#dynamic-schedule-scripts)
   - [Hiliting models and subcategories](#hiliting-models-and-subcategories)
 - [Frontend category APIs](#frontend-category-apis)
+- [ElectronApp changes](#electronapp-changes)
 - [Deprecations](#deprecations)
 
 ## Display system
@@ -50,6 +51,10 @@ A [Category]($backend) provides a way to organize groups of [GeometricElement]($
 [IModelConnection.categories]($frontend) now provides access to APIs for querying this information. The information is cached upon retrieval so that repeated requests need not query the backend.
 - [IModelConnection.Categories.getCategoryInfo]($frontend) provides the Ids and appearance properties of all subcategories belonging to one or more categories.
 - [IModelConnection.Categories.getSubCategoryInfo]($frontend) provides the appearance properties of one or more subcategories belonging to a specific category.
+
+## ElectronApp changes
+
+Reduced API surface of an `ElectronApp` class to only allow white-listed APIs from `electron` modules to be called. `ElectronApp` is updated to reflect the change: `callShell` and `callApp` methods are removed, `callDialog` is updated to only show dialogs and a message box.
 
 ## Deprecations
 


### PR DESCRIPTION
This PR fixes an issue where Electron IPC handler allows the frontend part of the application to invoke any electron main process module API (bypassing `sandbox`/`nodeIntegration` configuration).

The issue is fixed by specifying a **white-list of allowed modules/methods** in the handler for **`dialog` module**. `ElectronApp.callDialog` types are updated to reflect that (breaking change, `ElectronApp` is marked as @beta).
This PR also suggests to remove `ElectronApp.callShell` and `ElectronApp.callApp` methods until a real use case  for such APIs emerges (breaking change, `ElectronApp` is marked as `@beta`, also couldn't find any usage of these APIs in iTwin/internal repositories).