### PR TITLE
Extensions: Avoid Webpack critical dependency warning using a FunctionConstructor

### DIFF
--- a/core/frontend/src/extension/providers/ExtensionLoadScript.ts
+++ b/core/frontend/src/extension/providers/ExtensionLoadScript.ts
@@ -2,49 +2,28 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 /**
- * Executes an extension's bundled javascript module.
- * First attempts an ES6 dynamic import,
- * second attempts a dynamic import via a script element as a fallback.
+ * Imports and executes a bundled javascript (esm) module.
  * Used by remote and service Extensions.
- * Throws an error if the module does not have a default or main function to execute.
+ * Throws an error if no function is found to execute.
+ * Looks for a function in the following order:
+ * - the module itself.
+ * - the module's main export.
+ * - the module's default export.
  * @internal
  */
 export async function loadScript(jsUrl: string): Promise<any> {
-  // Warning "Critical dependency: the request of a dependency is an expression"
-  // until that is resolved, leave code commented:
   // const module = await import(/* webpackIgnore: true */jsUrl);
-  // return execute(module);
-  return new Promise((resolve, reject) => {
-    const head = document.getElementsByTagName("head")[0];
-    if (!head)
-      reject(new Error("No head element found"));
-
-    const scriptElement = document.createElement("script");
-    const tempGlobal: string = `__tempModuleLoadingVariable${Math.random().toString(32).substring(2)}`;
-
-    function cleanup() {
-      delete (window as any)[tempGlobal];
-      scriptElement.remove();
-    }
-
-    (window as any)[tempGlobal] = async function (module: any) {
-      await execute(module);
-      cleanup();
-      resolve(module);
-    };
-    scriptElement.type = "module";
-    scriptElement.textContent = `import * as m from "${jsUrl}";window.${tempGlobal}(m);`;
-
-    scriptElement.onerror = () => {
-      reject(new Error(`Failed to load extension with URL ${jsUrl}`));
-      cleanup();
-    };
-
-    head.insertBefore(scriptElement, head.lastChild);
-  });
+  // Webpack gives a warning:
+  // "Critical dependency: the request of a dependency is an expression"
+  // Because tsc transpiles "await import" to "require" (when compiled to is CommonJS).
+  // So use FunctionConstructor to avoid tsc.
+  const module = await Function("x","return import(x)")(jsUrl);
+  return execute(module);
 }
 
+/** attempts to execute an extension module */
 function execute(m: any) {
   if (typeof m === "function")
     return m();
@@ -52,5 +31,7 @@ function execute(m: any) {
     return m.main();
   if (m.default && typeof m.default === "function")
     return m.default();
-  throw new Error(`Failed to load extension. No default function was found to execute.`);
+  throw new Error(
+    `Failed to execute extension. No default function was found to execute.`
+  );
 }


### PR DESCRIPTION
To load extension bundles, ideally we want to await a dynamic import:
```ts
const module = await import(/* webpackIgnore: true */jsUrl);
```
But Webpack gives a warning: "Critical dependency: the request of a dependency is an expression" because tsc transpiles "await import" to "require" (when compiled to is CommonJS). A way around that is to use a FunctionConstructor like so:
```ts
const module = await Function("x","return import(x)")(jsUrl);
```
And in my testing I found this works no matter how the core-frontend is compiled, and without any warnings. 