### PR TITLE
Fix a display issue with background color's ColorPicker where part of the dialog was missing.

### DIFF
--- a/common/changes/@itwin/map-layers/geo-widget_colorpicker_rgb_2022-05-13-20-20.json
+++ b/common/changes/@itwin/map-layers/geo-widget_colorpicker_rgb_2022-05-13-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers",
+      "comment": "Fix a display issue with background color's ColorPicker where part of the dialog was missing.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers"
+}

--- a/extensions/map-layers/src/ui/widget/BasemapPanel.tsx
+++ b/extensions/map-layers/src/ui/widget/BasemapPanel.tsx
@@ -100,7 +100,7 @@ export function BasemapPanel() {
 
   const handleBgColorClick = React.useCallback((newColor: ColorDef, e: React.MouseEvent<Element, MouseEvent>) => {
     e.preventDefault();
-    ModalDialogManager.openDialog(<ColorPickerDialog dialogTitle={colorDialogTitle} color={newColor} colorPresets={presetColors}
+    ModalDialogManager.openDialog(<ColorPickerDialog dialogTitle={colorDialogTitle} color={newColor} colorPresets={presetColors} colorInputType={"rgb"}
       onOkResult={handleBackgroundColorDialogOk} onCancelResult={handleBackgroundColorDialogCancel} />);
   }, [presetColors, handleBackgroundColorDialogOk]); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
The control letting you pick preset color was missing in the color picker:
![image](https://user-images.githubusercontent.com/8309609/168383986-bf59b815-d4a8-410b-baee-469f5fe2a7e0.png)

After the fix, It now loos like this:
![image](https://user-images.githubusercontent.com/8309609/168384022-809d249a-e6ee-4a40-a1be-9d31e7a77085.png)

