### PR TITLE
Presentation: Advanced instance filtering

### DIFF
--- a/presentation/common/src/presentation-common/InstanceFilterDefinition.ts
+++ b/presentation/common/src/presentation-common/InstanceFilterDefinition.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Core
+ */
+
+import { StrippedRelationshipPath } from "./EC";
+
+/**
+ * @alpha
+ */
+export interface InstanceFilterDefinition {
+  /**
+   * Select class filter that may be used to select only instances of specific class.
+   *
+   * If specified, the [[relatedInstances]] attribute should specify paths from this
+   * class. Also, the [[expression]] attribute's `this` symbol points to instances of this class.
+   */
+  selectClassName?: string;
+
+  /**
+   * Relationship paths pointing to related instances used in the [[expression]] attribute.
+   *
+   * Sometimes there's a need to filter on a related instance property. In that case, the relationship
+   * needs to be named by specifying the path and alias for the target (or the relationship). Then, the
+   * related instance's symbol context can be accessed through the root symbol named as specified in the
+   * [[alias]] (or [[relationshipAlias]]) attribute.
+   */
+  relatedInstances?: [{
+    /**
+     * A relationship path from select class (either specified through [[selectClassName]] or taken from context)
+     * to the target related instance containing the properties used in [[expression]].
+     */
+    pathFromSelectToPropertyClass: StrippedRelationshipPath;
+    /**
+     * An optional flag indicating that the target instance must exist. Setting this allows to filter out all
+     * select instances that don't have a related instance by following the [[pathFromSelectToPropertyClass]] path.
+     */
+    isRequired?: boolean;
+  } & ({
+    /**
+     * An alias for the target class in the [[pathFromSelectToPropertyClass]] path. This alias can be used to
+     * access related instance symbols context in the [[expression]].
+     */
+    alias: string;
+  } | {
+    /**
+     * An alias for the relationship in the last step of the [[pathFromSelectToPropertyClass]] path. This alias can be
+     * used to access the relationship instance symbols context in the [[expression]].
+     */
+    relationshipAlias: string;
+  })];
+
+  /**
+   * [ECExpression]($docs/presentation/advanced/ECExpressions.md) for filtering the select instances.
+   */
+  expression: string;
+}

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -12,6 +12,7 @@ import { SelectionInfo } from "./content/Descriptor";
 import { FieldDescriptor } from "./content/Fields";
 import { DiagnosticsOptionsWithHandler } from "./Diagnostics";
 import { InstanceKey } from "./EC";
+import { InstanceFilterDefinition } from "./InstanceFilterDefinition";
 import { Ruleset } from "./rules/Ruleset";
 import { RulesetVariable } from "./RulesetVariables";
 
@@ -57,6 +58,9 @@ export interface RequestOptionsWithRuleset<TIModel, TRulesetVariable = RulesetVa
 export interface HierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
   /** Key of the parent node to get children for */
   parentKey?: TNodeKey;
+
+  /** @alpha */
+  instanceFilter?: InstanceFilterDefinition | InstanceFilterDefinition[];
 }
 
 /**

--- a/presentation/common/src/presentation-common/content/Descriptor.ts
+++ b/presentation/common/src/presentation-common/content/Descriptor.ts
@@ -11,6 +11,7 @@ import {
   ClassInfo, ClassInfoJSON, CompressedClassInfoJSON, RelatedClassInfo, RelatedClassInfoJSON, RelatedClassInfoWithOptionalRelationship,
   RelatedClassInfoWithOptionalRelationshipJSON, RelationshipPath, RelationshipPathJSON,
 } from "../EC";
+import { InstanceFilterDefinition } from "../InstanceFilterDefinition";
 import { CategoryDescription, CategoryDescriptionJSON } from "./Category";
 import { Field, FieldDescriptor, FieldJSON, getFieldByName } from "./Fields";
 
@@ -166,7 +167,7 @@ export interface DescriptorJSON {
   sortingFieldName?: string;
   sortDirection?: SortDirection;
   contentFlags: number;
-  filterExpression?: string;
+  filterExpression?: string | InstanceFilterDefinition | InstanceFilterDefinition[];
 }
 
 /**
@@ -200,7 +201,7 @@ export interface DescriptorOverrides {
   };
 
   /** [ECExpression]($docs/presentation/advanced/ECExpressions.md) for filtering content */
-  filterExpression?: string;
+  filterExpression?: string | InstanceFilterDefinition | InstanceFilterDefinition[];
 }
 
 /**
@@ -229,7 +230,7 @@ export interface DescriptorSource {
   /** Sorting direction */
   readonly sortDirection?: SortDirection;
   /** Content filtering [ECExpression]($docs/presentation/advanced/ECExpressions) */
-  readonly filterExpression?: string;
+  readonly filterExpression?: string | InstanceFilterDefinition | InstanceFilterDefinition[];
 }
 
 /**
@@ -262,7 +263,7 @@ export class Descriptor implements DescriptorSource {
   /** Sorting direction */
   public sortDirection?: SortDirection;
   /** Content filtering [ECExpression]($docs/presentation/advanced/ECExpressions) */
-  public filterExpression?: string;
+  public filterExpression?: string | InstanceFilterDefinition | InstanceFilterDefinition[];
 
   /** Construct a new Descriptor using a [[DescriptorSource]] */
   public constructor(source: DescriptorSource) {


### PR DESCRIPTION
Need a way to pass an expression + additional information about the class and/or related instances so they could be used in the expression.

The `relatedInstances` attribute is used for describing the paths to related property instances. 

The `selectClassName` attribute is used to filter select instances based on their class. This also helps us cover the case when a single properties field is created from multiple differently named properties from different classes. In that case we'd create two instance filter definitions for each select class, each with a different expression targeting different properties. I don't like this approach too much, because in case of complex expressions, there would be a lot of duplication just to cover those special property fields..