### PR TITLE
test native fixes for roundtripping placement when no geometry is present

### DIFF
--- a/common/changes/@itwin/core-backend/origin-no-geom-bug_2022-05-18-17-58.json
+++ b/common/changes/@itwin/core-backend/origin-no-geom-bug_2022-05-18-17-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-transformer/origin-no-geom-bug_2022-05-18-17-58.json
+++ b/common/changes/@itwin/core-transformer/origin-no-geom-bug_2022-05-18-17-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1459,7 +1459,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     }
 
     /** Read element data from the iModel as JSON
-     * @param elementIdArg a json string with the identity of the element to load. Must have one of "id", "federationGuid", or "code".
+     * @param loadProps - a json string with the identity of the element to load. Must have one of "id", "federationGuid", or "code".
      * @returns The JSON properties of the element or `undefined` if the element is not found.
      * @throws [[IModelError]] if the element exists, but cannot be loaded.
      * @see getElementJson

--- a/core/backend/src/test/DeepEqualWithFpTolerance.ts
+++ b/core/backend/src/test/DeepEqualWithFpTolerance.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { Assertion, util } from "chai";
+import { Geometry } from "@itwin/core-geometry";
+
+interface DeepEqualWithFpToleranceOpts {
+  /**
+   * Tolerance for fields, if not defined will be 1e-10
+   * If you don't want a tolerance, either supply 0 or use regular .deep.equal
+   */
+  tolerance?: number;
+  /** e.g. consider {x: undefined} and {} as deeply equal */
+  considerNonExistingAndUndefinedEqual?: boolean;
+}
+
+export const defaultOpts = {
+  tolerance: 1e-10,
+  considerNonExistingAndUndefinedEqual: false,
+};
+
+declare global {
+  namespace Chai {
+    interface Deep {
+      // might be more consistent to implement .approximately.deep.equal, but this is much simpler
+      equalWithFpTolerance(actual: any, options?: DeepEqualWithFpToleranceOpts): Assertion;
+    }
+  }
+}
+
+/** get whether two numbers are almost equal within a tolerance  */
+const isAlmostEqualNumber: (a: number, b: number, tol: number) => boolean = Geometry.isSameCoordinate;
+
+/**
+ * The diff shown on failure will show undefined fields as part of the diff even if
+ * consideringNonExistingAndUndefinedEqual is true. You can ignore that.
+ * We would have to mutate the object to clean the diff, although it is worth considering.
+ */
+export function deepEqualWithFpTolerance(
+  a: any,
+  b: any,
+  options: DeepEqualWithFpToleranceOpts = {},
+): boolean {
+  if (options.tolerance === undefined) options.tolerance = defaultOpts.tolerance;
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  switch (typeof a) {
+    case "number":
+      return isAlmostEqualNumber(a, b, options.tolerance);
+    case "string":
+    case "boolean":
+    case "function":
+    case "symbol":
+    case "undefined":
+      return false; // these objects can only be strict equal which was already tested
+    case "object":
+      if ((a === null) !== (b === null)) return false;
+      const aSize = Object.keys(a).filter((k) => options.considerNonExistingAndUndefinedEqual && a[k] !== undefined).length;
+      const bSize = Object.keys(b).filter((k) => options.considerNonExistingAndUndefinedEqual && b[k] !== undefined).length;
+      return aSize === bSize && Object.keys(a).every(
+        (key) =>
+          (key in b || options.considerNonExistingAndUndefinedEqual) &&
+          deepEqualWithFpTolerance(a[key], b[key], options)
+      );
+    default: // bigint unhandled
+      throw Error("unhandled deep compare type");
+  }
+}
+
+Assertion.addMethod(
+  "equalWithFpTolerance",
+  function equalWithFpTolerance(
+    expected: any,
+    options: DeepEqualWithFpToleranceOpts = {}
+  ) {
+    if (options.tolerance === undefined) options.tolerance = 1e-10;
+    const actual = this._obj;
+    const isDeep = util.flag(this, "deep");
+    this.assert(
+      isDeep
+        ? deepEqualWithFpTolerance(expected, actual, options)
+        : isAlmostEqualNumber(expected, actual, options.tolerance),
+      `expected ${
+        isDeep ? "deep equality of " : " "
+      }#{exp} and #{act} with a tolerance of ${options.tolerance}`,
+      `expected ${
+        isDeep ? "deep inequality of " : " "
+      }#{exp} and #{act} with a tolerance of ${options.tolerance}`,
+      expected,
+      actual
+    );
+  }
+);

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -737,8 +737,8 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
       extraProps: Partial<PhysicalElementProps> = {},
       {
         /**
-         * setting geometry will override the passed placement with a calculated one,
-         * so we can expect a different bounding box than that which is passed in
+         * setting some geometry will override the passed bounding box with a calculated one,
+         * so we need to be able to override parts of the expected placement based on the geometry used
          */
         expectedPlacementOverrides = {},
       }: {

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -5,10 +5,10 @@
 import { assert, expect } from "chai";
 import { DbResult, Id64, Id64String } from "@itwin/core-bentley";
 import {
-  BriefcaseIdValue, Code, ColorDef, ElementAspectProps, GeometricElementProps, GeometryStreamProps, IModel, QueryRowFormat, SubCategoryAppearance,
+  BriefcaseIdValue, Code, ColorDef, ElementAspectProps, ElementGeometry, GeometricElement3dProps, GeometricElementProps, GeometryStreamProps, IModel, PhysicalElementProps, Placement3d, Placement3dProps, QueryBinder, QueryRowFormat, SubCategoryAppearance,
 } from "@itwin/core-common";
-import { Arc3d, Cone, IModelJson as GeomJson, Point2d, Point3d } from "@itwin/core-geometry";
-import { ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "../../core-backend";
+import { Angle, Arc3d, Cone, IModelJson as GeomJson, LineSegment3d, LowAndHighXYZ, Point2d, Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
+import { ECSqlStatement, IModelDb, IModelJsFs, PhysicalModel, PhysicalObject, SnapshotDb, SpatialCategory } from "../../core-backend";
 import { ElementRefersToElements } from "../../Relationship";
 import { IModelTestUtils } from "../IModelTestUtils";
 
@@ -716,5 +716,111 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     });
 
     imodel.close();
+  });
+
+  it("Roundtrip placement when geom is undefined", async () => {
+    const placement = {
+      origin: { x: 10, y: 20, z: 30 },
+      angles: {
+        yaw: Angle.createDegrees(90),
+        pitch: Angle.createDegrees(180),
+        roll: Angle.createDegrees(270),
+      },
+      bbox: {
+        low: { x: -1, y: -2, z: -3 },
+        high: { x: 1, y: 2, z: 3 },
+      },
+    } as const;
+
+    const insertAndVerifyPlacement = (
+      name: string,
+      extraProps: Partial<PhysicalElementProps> = {},
+      {
+        /**
+         * setting geometry will override the passed placement with a calculated one,
+         * so we can expect a different bounding box than that which is passed in
+         */
+        expectedPlacementOverrides = {},
+      }: {
+        expectedPlacementOverrides?: Partial<Placement3dProps>;
+      } = {}
+    ) => {
+      const imodelPath = IModelTestUtils.prepareOutputFile(subDirName, `roundtrip_placement-${name}.bim`);
+      let imodel = IModelTestUtils.createSnapshotFromSeed(imodelPath, iModelPath);
+      const modelId = PhysicalModel.insert(imodel, IModelDb.rootSubjectId, "model");
+      const categoryId = SpatialCategory.insert(imodel, IModelDb.dictionaryId, "model", {});
+
+      const expectedPlacement = { ...placement, ...expectedPlacementOverrides };
+
+      const objId = imodel.elements.insertElement({
+        classFullName: PhysicalObject.classFullName,
+        code: Code.createEmpty(),
+        model: modelId,
+        placement,
+        category: categoryId,
+        ...extraProps,
+      });
+
+      imodel.saveChanges();
+
+      const inMemoryCopy = imodel.elements.getElement<PhysicalObject>({id: objId, wantGeometry: true}, PhysicalObject);
+      expect(inMemoryCopy.placement).to.deep.equalWithFpTolerance(expectedPlacement);
+
+      // reload db since there is a different path for loading properties not in memory that we want to force
+      imodel.close();
+      imodel = SnapshotDb.openFile(imodelPath);
+
+      const readFromDbCopy = imodel.elements.getElement<PhysicalObject>({id: objId, wantGeometry: true}, PhysicalObject);
+      expect(readFromDbCopy.placement).to.deep.equalWithFpTolerance(expectedPlacement);
+
+      imodel.close();
+    };
+
+    insertAndVerifyPlacement("no-geom", {
+      geom: undefined,
+      elementGeometryBuilderParams: undefined,
+    });
+
+    const pts = [Point3d.create(5, 10, 0), Point3d.create(10, 10, 0)];
+    const geomEntry = ElementGeometry.fromGeometryQuery(LineSegment3d.create(pts[0], pts[1]));
+    assert(geomEntry !== undefined);
+
+    const elementGeometryBuilderParams = { entryArray: [geomEntry] };
+    insertAndVerifyPlacement(
+      "geom-through-elementGeometryBuilderParams",
+      {
+        geom: undefined,
+        elementGeometryBuilderParams,
+      },
+      {
+        expectedPlacementOverrides: {
+          bbox: {
+            low: { x: 5, y: 10, z: 0 },
+            high: { x: 10, y: 10, z: 0 },
+          },
+        },
+      }
+    );
+
+    const geom = [
+      { header: { flags: 0 } },
+      { box: { origin: Point3d.create(0, 1, 2), baseX: 10, baseY: 20 } },
+    ];
+
+    insertAndVerifyPlacement(
+      "geom-through-json",
+      {
+        geom,
+        elementGeometryBuilderParams: undefined,
+      },
+      {
+        expectedPlacementOverrides: {
+          bbox: {
+            low: { x: 0, y: 0, z: 0 },
+            high: { x: 10, y: 20, z: 0 },
+          },
+        },
+      }
+    );
   });
 });

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -5,9 +5,9 @@
 import { assert, expect } from "chai";
 import { DbResult, Id64, Id64String } from "@itwin/core-bentley";
 import {
-  BriefcaseIdValue, Code, ColorDef, ElementAspectProps, ElementGeometry, GeometricElement3dProps, GeometricElementProps, GeometryStreamProps, IModel, PhysicalElementProps, Placement3d, Placement3dProps, QueryBinder, QueryRowFormat, SubCategoryAppearance,
+  BriefcaseIdValue, Code, ColorDef, ElementAspectProps, ElementGeometry, GeometricElementProps, GeometryStreamProps, IModel, PhysicalElementProps, Placement3dProps, QueryRowFormat, SubCategoryAppearance,
 } from "@itwin/core-common";
-import { Angle, Arc3d, Cone, IModelJson as GeomJson, LineSegment3d, LowAndHighXYZ, Point2d, Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
+import { Angle, Arc3d, Cone, IModelJson as GeomJson, LineSegment3d, Point2d, Point3d } from "@itwin/core-geometry";
 import { ECSqlStatement, IModelDb, IModelJsFs, PhysicalModel, PhysicalObject, SnapshotDb, SpatialCategory } from "../../core-backend";
 import { ElementRefersToElements } from "../../Relationship";
 import { IModelTestUtils } from "../IModelTestUtils";

--- a/core/backend/src/test/index.ts
+++ b/core/backend/src/test/index.ts
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+export * from "./DeepEqualWithFpTolerance";
 export * from "./HubMock";
 export * from "./IModelTestUtils";
 export * from "./KnownTestLocations";

--- a/core/transformer/src/test/IModelTransformerUtils.ts
+++ b/core/transformer/src/test/IModelTransformerUtils.ts
@@ -3,11 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { assert, Assertion, expect, util } from "chai";
+import { assert, expect } from "chai";
 import * as path from "path";
 import { AccessToken, CompressedId64Set, DbResult, Guid, Id64, Id64Set, Id64String, Mutable } from "@itwin/core-bentley";
 import { Schema } from "@itwin/ecschema-metadata";
-import { Geometry, Point3d, Transform, YawPitchRollAngles } from "@itwin/core-geometry";
+import { Point3d, Transform, YawPitchRollAngles } from "@itwin/core-geometry";
 import {
   AuxCoordSystem, AuxCoordSystem2d, CategorySelector, DefinitionModel, DisplayStyle3d, DrawingCategory, DrawingGraphicRepresentsElement,
   ECSqlStatement, Element, ElementAspect, ElementMultiAspect, ElementRefersToElements, ElementUniqueAspect, Entity, ExternalSourceAspect, FunctionalSchema,
@@ -23,78 +23,6 @@ import {
 } from "@itwin/core-common";
 import { IModelExporter, IModelExportHandler, IModelImporter, IModelTransformer } from "../core-transformer";
 
-interface DeepEqualWithFpToleranceOpts {
-  tolerance?: number;
-  /** e.g. consider {x: undefined} and {} as deeply equal */
-  considerNonExistingAndUndefinedEqual?: boolean;
-}
-
-declare global {
-  namespace Chai {
-    interface Deep {
-      // might be better to implement .approximately.deep.equal, but this is simpler
-      equalWithFpTolerance(actual: any, options?: DeepEqualWithFpToleranceOpts): Assertion;
-    }
-  }
-}
-
-const isAlmostEqualNumber: (a: number, b: number, tol: number) => boolean = Geometry.isSameCoordinate;
-
-export function deepEqualWithFpTolerance(
-  a: any,
-  b: any,
-  options: DeepEqualWithFpToleranceOpts = {},
-): boolean {
-  if (options.tolerance === undefined) options.tolerance = 1e-10;
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  switch (typeof a) {
-    case "number":
-      return isAlmostEqualNumber(a, b, options.tolerance);
-    case "string":
-    case "boolean":
-    case "function":
-    case "symbol":
-    case "undefined":
-      return false; // these objects can only be strict equal which was already tested
-    case "object":
-      if ((a === null) !== (b === null)) return false;
-      const aSize = Object.keys(a).filter((k) => options.considerNonExistingAndUndefinedEqual && a[k] !== undefined).length;
-      const bSize = Object.keys(b).filter((k) => options.considerNonExistingAndUndefinedEqual && b[k] !== undefined).length;
-      return aSize === bSize && Object.keys(a).every(
-        (key) =>
-          (key in b || options.considerNonExistingAndUndefinedEqual) &&
-          deepEqualWithFpTolerance(a[key], b[key], options)
-      );
-    default: // bigint unhandled
-      throw Error("unhandled deep compare type");
-  }
-}
-
-Assertion.addMethod(
-  "equalWithFpTolerance",
-  function equalWithFpTolerance(
-    expected: any,
-    options: DeepEqualWithFpToleranceOpts = {}
-  ) {
-    if (options.tolerance === undefined) options.tolerance = 1e-10;
-    const actual = this._obj;
-    const isDeep = util.flag(this, "deep");
-    this.assert(
-      isDeep
-        ? deepEqualWithFpTolerance(expected, actual, options)
-        : isAlmostEqualNumber(expected, actual, options.tolerance),
-      `expected ${
-        isDeep ? "deep equality of " : " "
-      }#{exp} and #{act} with a tolerance of ${options.tolerance}`,
-      `expected ${
-        isDeep ? "deep inequality of " : " "
-      }#{exp} and #{act} with a tolerance of ${options.tolerance}`,
-      expected,
-      actual
-    );
-  }
-);
 
 export class IModelTransformerTestUtils {
   public static createTeamIModel(outputDir: string, teamName: string, teamOrigin: Point3d, teamColor: ColorDef): SnapshotDb {
@@ -354,7 +282,7 @@ export async function assertIdentityTransformation(
           );
         } else if (!propChangesAllowed) {
           // kept for conditional breakpoints
-          const _propEq = deepEqualWithFpTolerance(targetElem.asAny[propName], sourceElem.asAny[propName]);
+          const _propEq = BackendTestUtils.deepEqualWithFpTolerance(targetElem.asAny[propName], sourceElem.asAny[propName]);
           expect(targetElem.asAny[propName]).to.deep.equalWithFpTolerance(
             sourceElem.asAny[propName]
           );
@@ -404,7 +332,7 @@ export async function assertIdentityTransformation(
       }
       // END jsonProperties TRANSFORMATION EXCEPTIONS
       // kept for conditional breakpoints
-      const _eq = deepEqualWithFpTolerance(
+      const _eq = BackendTestUtils.deepEqualWithFpTolerance(
         expectedSourceElemJsonProps,
         targetElem.jsonProperties,
         { considerNonExistingAndUndefinedEqual: true }
@@ -473,7 +401,7 @@ export async function assertIdentityTransformation(
       targetModelIds.add(targetModelId);
       targetToSourceModelsMap.set(targetModel, sourceModel);
       const expectedSourceModelJsonProps = { ...sourceModel.jsonProperties };
-      const _eq = deepEqualWithFpTolerance(
+      const _eq = BackendTestUtils.deepEqualWithFpTolerance(
         expectedSourceModelJsonProps,
         targetModel.jsonProperties,
       );


### PR DESCRIPTION
- hoist `deepEqualWithFpTolerance` to the backend tests so it can be used there and in transformer tests
- minor jsdoc fix in iModelDb I noticed
- tests for this [native pr](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/248644)