### PR TITLE
Prevent duplicate logo cards.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1133,6 +1133,8 @@ export enum ArcGisErrorCode {
 export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
     constructor(settings: ImageMapLayerSettings);
     // (undocumented)
+    addLogoCards(cards: HTMLTableElement): void;
+    // (undocumented)
     constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
     // (undocumented)
     protected get _filterByCartoRange(): boolean;
@@ -1142,8 +1144,6 @@ export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
     getFeatureInfo(featureInfos: MapLayerFeatureInfo[], quadId: QuadId, carto: Cartographic, _tree: ImageryMapTileTree): Promise<void>;
     // (undocumented)
     protected getLayerString(prefix?: string): string;
-    // (undocumented)
-    getLogo(): HTMLTableRowElement;
     // (undocumented)
     getToolTip(strings: string[], quadId: QuadId, carto: Cartographic, tree: ImageryMapTileTree): Promise<void>;
     // (undocumented)
@@ -1307,9 +1307,9 @@ export abstract class AuxCoordSystemState extends ElementState implements AuxCoo
 export class AzureMapsLayerImageryProvider extends MapLayerImageryProvider {
     constructor(settings: ImageMapLayerSettings);
     // (undocumented)
-    constructUrl(y: number, x: number, zoom: number): Promise<string>;
+    addLogoCards(cards: HTMLTableElement): void;
     // (undocumented)
-    getLogo(): HTMLTableRowElement;
+    constructUrl(y: number, x: number, zoom: number): Promise<string>;
 }
 
 // @internal
@@ -1579,9 +1579,9 @@ export class BingLocationProvider {
 export class BingMapsImageryLayerProvider extends MapLayerImageryProvider {
     constructor(settings: ImageMapLayerSettings);
     // (undocumented)
-    constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
+    addLogoCards(cards: HTMLTableElement, vp: ScreenViewport): void;
     // (undocumented)
-    getLogo(vp: ScreenViewport): HTMLTableRowElement | undefined;
+    constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
     // (undocumented)
     initialize(): Promise<void>;
     // (undocumented)
@@ -4551,11 +4551,11 @@ export class ImageryMapTile extends RealityTile {
 export class ImageryMapTileTree extends RealityTileTree {
     constructor(params: RealityTileTreeParams, _imageryLoader: ImageryTileLoader);
     // (undocumented)
+    addLogoCards(cards: HTMLTableElement, vp: ScreenViewport): void;
+    // (undocumented)
     cartoRectangleFromQuadId(quadId: QuadId): MapCartoRectangle;
     // (undocumented)
     draw(_args: TileDrawArgs): void;
-    // (undocumented)
-    getLogo(vp: ScreenViewport): HTMLTableRowElement | undefined;
     // (undocumented)
     getTileRectangle(quadId: QuadId): MapCartoRectangle;
     // (undocumented)
@@ -5547,9 +5547,9 @@ export enum ManipulatorToolEvent {
 export class MapBoxLayerImageryProvider extends MapLayerImageryProvider {
     constructor(settings: ImageMapLayerSettings);
     // (undocumented)
-    constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
+    addLogoCards(cards: HTMLTableElement): void;
     // (undocumented)
-    getLogo(): HTMLTableRowElement | undefined;
+    constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
     // (undocumented)
     initialize(): Promise<void>;
     // (undocumented)
@@ -5707,6 +5707,8 @@ export type MapLayerFormatType = typeof MapLayerFormat;
 export abstract class MapLayerImageryProvider {
     constructor(_settings: ImageMapLayerSettings, _usesCachedTiles: boolean);
     // (undocumented)
+    addLogoCards(_cards: HTMLTableElement, _viewport: ScreenViewport): void;
+    // (undocumented)
     protected _areChildrenAvailable(_tile: ImageryMapTile): Promise<boolean>;
     // (undocumented)
     cartoRange?: MapCartoRectangle;
@@ -5744,8 +5746,6 @@ export abstract class MapLayerImageryProvider {
     getFeatureInfo(featureInfos: MapLayerFeatureInfo[], _quadId: QuadId, _carto: Cartographic, _tree: ImageryMapTileTree): Promise<void>;
     // (undocumented)
     protected getImageFromTileResponse(tileResponse: Response, zoomLevel: number): ImageSource | undefined;
-    // (undocumented)
-    getLogo(_viewport: ScreenViewport): HTMLTableRowElement | undefined;
     // (undocumented)
     getPotentialChildIds(tile: ImageryMapTile): QuadId[];
     // (undocumented)
@@ -10483,13 +10483,13 @@ export class TerrainDisplayOverrides {
 export abstract class TerrainMeshProvider {
     constructor(_iModel: IModelConnection, _modelId: Id64String);
     // (undocumented)
+    addLogoCards(_cards: HTMLTableElement, _vp: ScreenViewport): void;
+    // (undocumented)
     constructUrl(_row: number, _column: number, _zoomLevel: number): string;
     // (undocumented)
     forceTileLoad(_tile: Tile): boolean;
     // (undocumented)
     abstract getChildHeightRange(_quadId: QuadId, _rectangle: MapCartoRectangle, _parent: MapTile): Range1d | undefined;
-    // (undocumented)
-    getLogo(): HTMLTableRowElement | undefined;
     // (undocumented)
     getMesh(_tile: MapTile, _data: Uint8Array): Promise<TerrainMeshPrimitive | undefined>;
     // (undocumented)

--- a/common/changes/@itwin/core-frontend/pmc-fix-duplicate-logo-cards_2022-05-19-19-45.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-duplicate-logo-cards_2022-05-19-19-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Prevent duplicate logo cards from displaying when clicking the iTwin.js logo in a viewport.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -850,7 +850,8 @@ export class RealityTreeReference extends RealityModelTileTree.Reference {
   }
 
   public override addLogoCards(cards: HTMLTableElement): void {
-    if (this._rdSourceKey.provider === RealityDataProvider.CesiumIonAsset) {
+    if (this._rdSourceKey.provider === RealityDataProvider.CesiumIonAsset && !cards.dataset.openStreetMapLogoCard) {
+      cards.dataset.openStreetMapLogoCard = "true";
       cards.appendChild(IModelApp.makeLogoCard({ heading: "OpenStreetMap", notice: `&copy;<a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> ${IModelApp.localization.getLocalizedString("iModelJs:BackgroundMap:OpenStreetMapContributors")}` }));
     }
   }

--- a/core/frontend/src/tile/map/CesiumTerrainProvider.ts
+++ b/core/frontend/src/tile/map/CesiumTerrainProvider.ts
@@ -185,8 +185,13 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     this._tokenTimeOut = BeTimePoint.now().plus(CesiumTerrainProvider._tokenTimeoutInterval);
   }
 
-  public override getLogo(): HTMLTableRowElement {
-    return IModelApp.makeLogoCard({ iconSrc: `${IModelApp.publicPath}images/cesium-ion.svg`, heading: "Cesium Ion", notice: IModelApp.localization.getLocalizedString("iModelJs:BackgroundMap.CesiumWorldTerrainAttribution") });
+  public override addLogoCards(cards: HTMLTableElement): void {
+    if (cards.dataset.cesiumIonLogoCard)
+      return;
+
+    cards.dataset.cesiumIonLogoCard = "true";
+    const card = IModelApp.makeLogoCard({ iconSrc: `${IModelApp.publicPath}images/cesium-ion.svg`, heading: "Cesium Ion", notice: IModelApp.localization.getLocalizedString("iModelJs:BackgroundMap.CesiumWorldTerrainAttribution") });
+    cards.appendChild(card);
   }
 
   public get maxDepth(): number { return this._maxDepth; }

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
@@ -190,8 +190,11 @@ export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
     }
   }
 
-  public override getLogo() {
-    return IModelApp.makeLogoCard({ heading: "ArcGIS", notice: this._copyrightText });
+  public override addLogoCards(cards: HTMLTableElement): void {
+    if (!cards.dataset.arcGisLogoCard) {
+      cards.dataset.arcGisLogoCard = "true";
+      cards.appendChild(IModelApp.makeLogoCard({ heading: "ArcGIS", notice: this._copyrightText }));
+    }
   }
 
   // Translates the provided Cartographic into a EPSG:3857 point, and retrieve information.

--- a/core/frontend/src/tile/map/ImageryProviders/AzureMapsLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/AzureMapsLayerImageryProvider.ts
@@ -21,7 +21,10 @@ export class AzureMapsLayerImageryProvider extends MapLayerImageryProvider {
     return `${this._settings.url}&${this._settings.accessKey.key}=${this._settings.accessKey.value}&api-version=2.0&zoom=${zoom}&x=${x}&y=${y}`;
   }
 
-  public override getLogo() {
-    return IModelApp.makeLogoCard({ heading: "Azure Maps", notice: IModelApp.localization.getLocalizedString("iModelJs:BackgroundMap.AzureMapsCopyright") });
+  public override addLogoCards(cards: HTMLTableElement): void {
+    if (!cards.dataset.azureMapsLogoCard) {
+      cards.dataset.azureMapsLogoCard = "true";
+      cards.appendChild(IModelApp.makeLogoCard({ heading: "Azure Maps", notice: IModelApp.localization.getLocalizedString("iModelJs:BackgroundMap.AzureMapsCopyright") }));
+    }
   }
 }

--- a/core/frontend/src/tile/map/ImageryProviders/BingImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/BingImageryProvider.ts
@@ -147,7 +147,7 @@ export class BingMapsImageryLayerProvider extends MapLayerImageryProvider {
     return matchingAttributions;
   }
 
-  public override getLogo(vp: ScreenViewport): HTMLTableRowElement | undefined {
+  public override addLogoCards(cards: HTMLTableElement, vp: ScreenViewport): void {
     const tiles = IModelApp.tileAdmin.getTilesForUser(vp)?.selected;
     const matchingAttributions = this.getMatchingAttributions(tiles);
     const copyrights: string[] = [];
@@ -160,7 +160,8 @@ export class BingMapsImageryLayerProvider extends MapLayerImageryProvider {
         copyrightMsg += "<br>";
       copyrightMsg += copyrights[i];
     }
-    return IModelApp.makeLogoCard({ iconSrc: `${IModelApp.publicPath}images/bing.svg`, heading: "Microsoft Bing", notice: copyrightMsg });
+
+    cards.appendChild(IModelApp.makeLogoCard({ iconSrc: `${IModelApp.publicPath}images/bing.svg`, heading: "Microsoft Bing", notice: copyrightMsg }));
   }
 
   // initializes the BingImageryProvider by reading the templateUrl, logo image, and attribution list.

--- a/core/frontend/src/tile/map/ImageryProviders/MapBoxLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/MapBoxLayerImageryProvider.ts
@@ -44,8 +44,11 @@ export class MapBoxLayerImageryProvider extends MapLayerImageryProvider {
     return url;
   }
 
-  public override getLogo(): HTMLTableRowElement | undefined {
-    return IModelApp.makeLogoCard({ heading: "Mapbox", notice: IModelApp.localization.getLocalizedString("iModelJs:BackgroundMap.MapBoxCopyright") });
+  public override addLogoCards(cards: HTMLTableElement): void {
+    if (!cards.dataset.mapboxLogoCard) {
+      cards.dataset.mapboxLogoCard = "true";
+      cards.appendChild(IModelApp.makeLogoCard({ heading: "Mapbox", notice: IModelApp.localization.getLocalizedString("iModelJs:BackgroundMap.MapBoxCopyright") }));
+    }
   }
 
   // no initialization needed for MapBoxImageryProvider.

--- a/core/frontend/src/tile/map/ImageryTileTree.ts
+++ b/core/frontend/src/tile/map/ImageryTileTree.ts
@@ -143,7 +143,10 @@ export class ImageryMapTileTree extends RealityTileTree {
     this._rootTile = new ImageryMapTile(params.rootTile, this, rootQuadId, this.getTileRectangle(rootQuadId));
   }
   public get tilingScheme(): MapTilingScheme { return this._imageryLoader.imageryProvider.tilingScheme; }
-  public getLogo(vp: ScreenViewport): HTMLTableRowElement | undefined { return this._imageryLoader.getLogo(vp); }
+  public addLogoCards(cards: HTMLTableElement, vp: ScreenViewport): void {
+    this._imageryLoader.addLogoCards(cards, vp);
+  }
+
   public getTileRectangle(quadId: QuadId): MapCartoRectangle {
     return this.tilingScheme.tileXYToRectangle(quadId.column, quadId.row, quadId.level);
   }
@@ -178,7 +181,10 @@ class ImageryTileLoader extends RealityTileLoader {
   public get maxDepth(): number { return this._imageryProvider.maximumZoomLevel; }
   public get minDepth(): number { return this._imageryProvider.minimumZoomLevel; }
   public get priority(): TileLoadPriority { return TileLoadPriority.Map; }
-  public getLogo(vp: ScreenViewport): HTMLTableRowElement | undefined { return this._imageryProvider.getLogo(vp); }
+  public addLogoCards(cards: HTMLTableElement, vp: ScreenViewport): void {
+    this._imageryProvider.addLogoCards(cards, vp);
+  }
+
   public get maximumScreenSize(): number { return this._imageryProvider.maximumScreenSize; }
   public get imageryProvider(): MapLayerImageryProvider { return this._imageryProvider; }
   public async getToolTip(strings: string[], quadId: QuadId, carto: Cartographic, tree: ImageryMapTileTree): Promise<void> { await this._imageryProvider.getToolTip(strings, quadId, carto, tree); }

--- a/core/frontend/src/tile/map/MapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryProvider.ts
@@ -55,7 +55,7 @@ export abstract class MapLayerImageryProvider {
   }
   public abstract constructUrl(row: number, column: number, zoomLevel: number): Promise<string>;
   public get tilingScheme(): MapTilingScheme { return this.useGeographicTilingScheme ? this._geographicTilingScheme : this._mercatorTilingScheme;  }
-  public getLogo(_viewport: ScreenViewport): HTMLTableRowElement | undefined { return undefined; }
+  public addLogoCards(_cards: HTMLTableElement, _viewport: ScreenViewport): void { }
   protected _missingTileData?: Uint8Array;
   public get transparentBackgroundString(): string { return this._settings.transparentBackground ? "true" : "false"; }
 

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -911,15 +911,13 @@ export class MapTileTreeReference extends TileTreeReference {
   /** Add logo cards to logo div. */
   public override addLogoCards(cards: HTMLTableElement, vp: ScreenViewport): void {
     const tree = this.treeOwner.tileTree as MapTileTree;
-    let logo;
     if (tree) {
-      if (undefined !== (logo = tree.mapLoader.terrainProvider.getLogo()))
-        cards.appendChild(logo);
+      tree.mapLoader.terrainProvider.addLogoCards(cards, vp);
       for (const imageryTreeRef of this._layerTrees) {
         if (imageryTreeRef.layerSettings.visible) {
-          const imageryTree = imageryTreeRef.treeOwner.tileTree as ImageryMapTileTree;
-          if (imageryTree && (undefined !== (logo = imageryTree.getLogo(vp))))
-            cards.appendChild(logo);
+          const imageryTree = imageryTreeRef.treeOwner.tileTree;
+          if (imageryTree instanceof ImageryMapTileTree)
+            imageryTree.addLogoCards(cards, vp);
         }
       }
     }

--- a/core/frontend/src/tile/map/TerrainMeshProvider.ts
+++ b/core/frontend/src/tile/map/TerrainMeshProvider.ts
@@ -10,6 +10,7 @@ import { assert, Id64String } from "@itwin/core-bentley";
 import { Range1d } from "@itwin/core-geometry";
 import { RequestOptions } from "../../request/Request";
 import { IModelConnection } from "../../IModelConnection";
+import { ScreenViewport } from "../../Viewport";
 import { TerrainMeshPrimitive } from "../../render/primitives/mesh/TerrainMeshPrimitive";
 import { MapCartoRectangle, MapTile, MapTilingScheme, QuadId, Tile } from "../internal";
 
@@ -21,7 +22,7 @@ import { MapCartoRectangle, MapTile, MapTilingScheme, QuadId, Tile } from "../in
 export abstract class TerrainMeshProvider {
   constructor(protected _iModel: IModelConnection, protected _modelId: Id64String) { }
   public constructUrl(_row: number, _column: number, _zoomLevel: number): string { assert(false); return ""; }
-  public getLogo(): HTMLTableRowElement | undefined { return undefined; }
+  public addLogoCards(_cards: HTMLTableElement, _vp: ScreenViewport): void { }
   public abstract isTileAvailable(quadId: QuadId): boolean;
   public get requestOptions(): RequestOptions { return { method: "GET", responseType: "arraybuffer" }; }
   public abstract get maxDepth(): number;


### PR DESCRIPTION
Turn on background map with terrain.
Click the iTwin.js logo in the bottom-left corner of the viewport.
Observe 2 identical Cesium ION copyright notices.

A viewport has two map tile tree references: one for background map, the other for overlay map. Each has its own terrain provider. Each produces the same attribution.
Similar issues could arise with other types of tile trees.
Use [HTMLElement.dataset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) to keep track of which attribution has already been provided to avoid duplicates.
The required function signature changes also now enable providers to add multiple logo cards, and/or to customize the logo card based on the contents of the viewport (like the bing imagery provider does).

https://github.com/iTwin/itwinjs-backlog/issues/68
