### PR TITLE
Convert negative ViewRect coordinates to zero.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-viewrect-rounding_2022-05-20-13-07.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-viewrect-rounding_2022-05-20-13-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Convert negative ViewRect coordinates to zero.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ViewRect.ts
+++ b/core/frontend/src/ViewRect.ts
@@ -8,9 +8,10 @@
 
 import { LowAndHighXY, XAndY } from "@itwin/core-geometry";
 
-/** A rectangle in integer view coordinates with (0,0) corresponding to the top-left corner of the view.
- *
+/** A rectangle in unsigned integer view coordinates with (0,0) corresponding to the top-left corner of the view.
  * Increasing **x** moves from left to right, and increasing **y** moves from top to bottom.
+ * [[left]], [[top]], [[right]], and [[bottom]] are required to be non-negative integers; any negative inputs are treated as
+ * zero and any non-integer inputs are rounded down to the nearest integer.
  * @public
  * @extensions
  */
@@ -20,20 +21,24 @@ export class ViewRect {
   private _right!: number;
   private _bottom!: number;
 
+  private _set(key: "_left" | "_right" | "_top" | "_bottom", value: number): void {
+    this[key] = Math.max(0, Math.floor(value));
+  }
+
   /** Construct a new ViewRect. */
   public constructor(left = 0, top = 0, right = 0, bottom = 0) { this.init(left, top, right, bottom); }
-  /** The leftmost side of this ViewRect.  */
+  /** The leftmost side of this ViewRect. */
   public get left(): number { return this._left; }
-  public set left(val: number) { this._left = Math.floor(val); }
+  public set left(val: number) { this._set("_left", val); }
   /** The topmost side of this ViewRect. */
   public get top(): number { return this._top; }
-  public set top(val: number) { this._top = Math.floor(val); }
+  public set top(val: number) { this._set("_top", val); }
   /** The rightmost side of this ViewRect. */
   public get right(): number { return this._right; }
-  public set right(val: number) { this._right = Math.floor(val); }
+  public set right(val: number) { this._set("_right", val); }
   /** The bottommost side of this ViewRect. */
   public get bottom(): number { return this._bottom; }
-  public set bottom(val: number) { this._bottom = Math.floor(val); }
+  public set bottom(val: number) { this._set("_bottom", val); }
   /** True if this ViewRect has an area > 0. */
   public get isNull(): boolean { return this.right <= this.left || this.bottom <= this.top; }
   /** True if `!isNull` */

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2459,7 +2459,7 @@ export abstract class Viewport implements IDisposable, TileUser {
     return undefined === this.mapLayerFromIds(pixel.featureTable.modelId, pixel.elementId);  // Maps no selectable.
   }
 
-  /** Read the current image from this viewport from the rendering system. If a "null" rectangle is supplied (@see [[ViewRect.isNull]], the entire view is captured.
+  /** Read the current image from this viewport from the rendering system. If a "null" rectangle is supplied (@see [[ViewRect.isNull]]), the entire view is captured.
    * @param rect The area of the view to read. The origin of a viewRect must specify the upper left corner.
    * @param targetSize The size of the image to be returned. The size can be larger or smaller than the original view.
    * @param flipVertically If true, the image is flipped along the x-axis.

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2459,7 +2459,7 @@ export abstract class Viewport implements IDisposable, TileUser {
     return undefined === this.mapLayerFromIds(pixel.featureTable.modelId, pixel.elementId);  // Maps no selectable.
   }
 
-  /** Read the current image from this viewport from the rendering system. If a view rectangle outside the actual view is specified, the entire view is captured.
+  /** Read the current image from this viewport from the rendering system. If a "null" rectangle is supplied (@see [[ViewRect.isNull]], the entire view is captured.
    * @param rect The area of the view to read. The origin of a viewRect must specify the upper left corner.
    * @param targetSize The size of the image to be returned. The size can be larger or smaller than the original view.
    * @param flipVertically If true, the image is flipped along the x-axis.
@@ -2467,7 +2467,7 @@ export abstract class Viewport implements IDisposable, TileUser {
    * @note By default the image is returned with the coordinate (0,0) referring to the bottom-most pixel. Pass `true` for `flipVertically` to flip it along the x-axis.
    * @deprecated Use readImageBuffer.
    */
-  public readImage(rect: ViewRect = new ViewRect(0, 0, -1, -1), targetSize: Point2d = Point2d.createZero(), flipVertically: boolean = false): ImageBuffer | undefined {
+  public readImage(rect: ViewRect = new ViewRect(1, 1, 0, 0), targetSize: Point2d = Point2d.createZero(), flipVertically: boolean = false): ImageBuffer | undefined {
     // eslint-disable-next-line deprecation/deprecation
     return this.target.readImage(rect, targetSize, flipVertically);
   }

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -978,7 +978,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
   }
 
   /** wantRectIn is in CSS pixels. Output ImageBuffer will be in device pixels.
-   * If wantRect.right or wantRect.bottom is -1, that means "read the entire image".
+   * If wantRect is null, that means "read the entire image".
    */
   public override readImage(wantRectIn: ViewRect, targetSizeIn: Point2d, flipVertically: boolean): ImageBuffer | undefined {
     if (!this.assignDC())
@@ -986,7 +986,7 @@ export abstract class Target extends RenderTarget implements RenderTargetDebugCo
 
     // Determine capture rect and validate
     const actualViewRect = this.renderRect; // already has device pixel ratio applied
-    const wantRect = (wantRectIn.right === -1 || wantRectIn.bottom === -1) ? actualViewRect : this.cssViewRectToDeviceViewRect(wantRectIn);
+    const wantRect = wantRectIn.isNull ? actualViewRect : this.cssViewRectToDeviceViewRect(wantRectIn);
     const lowerRight = Point2d.create(wantRect.right - 1, wantRect.bottom - 1);
     if (!actualViewRect.containsPoint(Point2d.create(wantRect.left, wantRect.top)) || !actualViewRect.containsPoint(lowerRight))
       return undefined;

--- a/core/frontend/src/test/ViewRect.test.ts
+++ b/core/frontend/src/test/ViewRect.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { ViewRect } from "../ViewRect";
+import { getCenteredViewRect } from "../ImageUtil";
+
+function expectRect(rect: ViewRect, l: number, t: number, r: number, b: number): void {
+  expect(rect.left).to.equal(l);
+  expect(rect.right).to.equal(r);
+  expect(rect.top).to.equal(t);
+  expect(rect.bottom).to.equal(b);
+}
+
+describe("ViewRect", () => {
+  it("rounds negative inputs up to zero", () => {
+    expectRect(new ViewRect(-0.001, -50,  1, 2), 0, 0, 1, 2);
+  });
+
+  it("truncates inputs", () => {
+    expectRect(new ViewRect(0.1, 1.2, 3.8, 4.9), 0, 1, 3, 4);
+  });
+});
+
+describe("getCenteredViewRect", () => {
+  function center(l: number, t: number, r: number, b: number, aspect?: number): ViewRect {
+    return getCenteredViewRect(new ViewRect(l, t, r, b), aspect);
+  }
+
+  it("returns input if aspect ratio matches", () => {
+    expectRect(center(0, 0, 140, 100, 1.4), 0, 0, 140, 100);
+  });
+
+  it("eliminates floating point rounding error", () => {
+    expectRect(center(0, 0, 390, 844), 0, 282, 390, 561);
+  });
+});

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -393,7 +393,7 @@ describe("Viewport", () => {
           expectNoImage(0, 0, -1, -1);
           expectNoImage(0, 0, 100, 1);
           expectNoImage(0, 0, 1, 100);
-          expectNoImage(-1, -1, 1, 1);
+          expectNoImage(100, 100, 1, 1);
           expectNoImage(1, 1, 1, 1);
         });
       });


### PR DESCRIPTION
ViewRect coordinates are expected to be non-negative, but nothing enforces that.
They are expected to be integers, and we enforce that by flooring inputs.
`getCenteredViewRect` does some floating point arithmetic that can produce rounding error such that non-negative inputs produce results just slightly less than zero, which get floored to -1.
Ex: given left=top=0, right=390, bottom=844, the centered rect has left=-1.
If you pass such a ViewRect to `Viewport.readImage`, you get back `undefined`.

Now we enforce the non-negative constraint too. This addresses rounding error specifically when the value is negative. It does not attempt to address rounding error for non-negative values (by e.g. rounding instead of flooring, or checking for "almost equal to next highest integer").