### PR TITLE
Fix repeated requesting of backport reviewers team

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,9 @@
 pull_request_rules:
   - name: Add reviewers to backports
     conditions:
-      - base~=release\/[0-9]+.[0-9]+.x
+      - and:
+        - base~=release\/[0-9]+.[0-9]+.x
+        - approved-reviews-by!=@iTwin/itwinjs-core-backport-reviewers
     actions:
       request_reviews:
         teams:


### PR DESCRIPTION
Mergify would re request a review from the @iTwin/itwinjs-core-backport-reviewers team each time a review was submitted on that teams behalf. Update the "Add reviewers to backports" conditions so that it will not add the team if the PR was already approved by a team member.