### PR TITLE
Fix initial pending request always being treated as an error.

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -7544,6 +7544,8 @@ export abstract class RpcProtocol {
     getOperationFromPath(path: string): SerializedRpcOperation;
     getStatus(code: number): RpcRequestStatus;
     inflateToken(tokenFromBody: IModelRpcProps, _request: SerializedRpcRequest): IModelRpcProps;
+    // (undocumented)
+    initialize(_token?: IModelRpcProps): Promise<void>;
     readonly invocationType: typeof RpcInvocation;
     // (undocumented)
     onRpcClientInitialized(_definition: RpcInterfaceDefinition, _client: RpcInterface): void;
@@ -9526,7 +9528,7 @@ export abstract class WebAppRpcProtocol extends RpcProtocol {
     handleOperationPostRequest(req: HttpServerRequest, res: HttpServerResponse): Promise<void>;
     abstract info: OpenAPIInfo;
     // (undocumented)
-    initialize(): Promise<void>;
+    initialize(token?: IModelRpcProps): Promise<void>;
     isTimeout(code: number): boolean;
     get openAPIDescription(): RpcOpenAPIDescription;
     pathPrefix: string;

--- a/common/changes/@itwin/core-common/billg-integration-tests_2022-05-20-21-13.json
+++ b/common/changes/@itwin/core-common/billg-integration-tests_2022-05-20-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/rpc/core/RpcProtocol.ts
+++ b/core/common/src/rpc/core/RpcProtocol.ts
@@ -186,6 +186,9 @@ export abstract class RpcProtocol {
     return new (this.invocationType)(this, request).fulfillment;
   }
 
+  /** @internal */
+  public async initialize(_token?: IModelRpcProps): Promise<void> { }
+
   /** Serializes a request. */
   public async serialize(request: RpcRequest): Promise<SerializedRpcRequest> {
     const serializedContext = await RpcConfiguration.requestContext.serialize(request);

--- a/core/common/src/rpc/core/RpcRequest.ts
+++ b/core/common/src/rpc/core/RpcRequest.ts
@@ -323,6 +323,7 @@ export abstract class RpcRequest<TResponse = any> {
       this._connecting = true;
       RpcRequest._activeRequests.set(this.id, this);
       this.protocol.events.raiseEvent(RpcProtocolEvent.RequestCreated, this);
+      await this.protocol.initialize(this.operation.policy.token(this));
       this._sending = new Cancellable(this.setHeaders().then(async () => this.send()));
       this.operation.policy.sentCallback(this);
 

--- a/core/common/src/rpc/web/WebAppRpcRequest.ts
+++ b/core/common/src/rpc/web/WebAppRpcRequest.ts
@@ -183,10 +183,6 @@ export class WebAppRpcRequest extends RpcRequest {
 
   /** Sends the request. */
   protected async send(): Promise<number> {
-    if (this.method !== "options") {
-      await this.protocol.initialize();
-    }
-
     this._loading = true;
     await this.setupTransport();
 

--- a/full-stack-tests/rpc/src/frontend/_Setup.test.ts
+++ b/full-stack-tests/rpc/src/frontend/_Setup.test.ts
@@ -4,13 +4,17 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { executeBackendCallback } from "@itwin/certa/lib/utils/CallbackUtils";
-import { BentleyCloudRpcConfiguration, BentleyCloudRpcManager, RpcConfiguration } from "@itwin/core-common";
+import { Logger, LogLevel } from "@itwin/core-bentley";
+import { BentleyCloudRpcConfiguration, BentleyCloudRpcManager, RpcConfiguration, WebAppRpcProtocol } from "@itwin/core-common";
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { MobileRpcManager } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
 import { BackendTestCallbacks } from "../common/SideChannels";
-import { AttachedInterface, MobileTestInterface, MultipleClientsInterface, rpcInterfaces } from "../common/TestRpcInterface";
+import { AttachedInterface, MobileTestInterface, MultipleClientsInterface, rpcInterfaces, TestRpcInterface } from "../common/TestRpcInterface";
+import { assert } from "chai";
 
-RpcConfiguration.disableRoutingValidation = true;
+Logger.initializeToConsole();
+Logger.setLevelDefault(LogLevel.Warning);
+RpcConfiguration.disableRoutingValidation = false;
 
 function initializeCloud(protocol: string) {
   const port = Number(window.location.port) + 2000;
@@ -61,4 +65,19 @@ before(async () => {
     case "electron":
       return ElectronApp.startup({ iModelApp: { rpcInterfaces } });
   }
+});
+
+describe("BentleyCloudRpcManager", () => {
+  it("should initialize correctly when routing validation is enabled", async () => {
+    if (currentEnvironment === "http") {
+      const protocol = TestRpcInterface.getClient().configuration.protocol as WebAppRpcProtocol;
+      assert.equal(protocol.allowedHeaders.size, 0);
+      await TestRpcInterface.getClient().op16({ iModelId: "foo", key: "bar" }, { iModelId: "foo", key: "bar" });
+      assert.isAtLeast(protocol.allowedHeaders.size, 1);
+    }
+  });
+
+  after(() => {
+    RpcConfiguration.disableRoutingValidation = true;
+  });
 });


### PR DESCRIPTION
Our integration tests have been very flaky lately, with several test suite `before` hooks regularly [failing with cryptic errors](https://github.com/iTwin/itwinjs-core/runs/6530768910).

I believe the root cause of these failures is that the OPTIONS preflight request (made before the first RPC request to discover backend capabilities) was not being sent with a valid `IModelRpcProps` token.  This preflight is needed to set the allowed headers for future requests.  After #3395, the `X-Protocol-Version` header must be set on all requests, otherwise any HTTP 202 responses will be treated as errors, not pending. 

Our integration tests only return pending responses when downloading a checkpoint takes slightly longer than usual, hence the flakiness.