### PR TITLE
UI: Optimize creating subjects hierarchy in Models Tree

### DIFF
--- a/common/changes/@itwin/appui-react/ui-models-tree-optimize-creating-subjects-hierarchy_2022-05-24-12-58.json
+++ b/common/changes/@itwin/appui-react/ui-models-tree-optimize-creating-subjects-hierarchy_2022-05-24-12-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Models Tree: Optimize creating subjects hierarchy",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-GroupedByClass.PresentationRuleSet.json
+++ b/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree-GroupedByClass.PresentationRuleSet.json
@@ -121,6 +121,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -152,6 +153,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false

--- a/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree.PresentationRuleSet.json
+++ b/test-apps/presentation-test-app/assets/presentation_rules/VisibilityWidget.ModelsTree.PresentationRuleSet.json
@@ -121,6 +121,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -152,6 +153,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false

--- a/ui/appui-react/src/appui-react/imodel-components/models-tree/Hierarchy.GroupedByClass.json
+++ b/ui/appui-react/src/appui-react/imodel-components/models-tree/Hierarchy.GroupedByClass.json
@@ -121,6 +121,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -152,6 +153,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false

--- a/ui/appui-react/src/appui-react/imodel-components/models-tree/Hierarchy.json
+++ b/ui/appui-react/src/appui-react/imodel-components/models-tree/Hierarchy.json
@@ -121,6 +121,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideIfNoChildren": true,
           "groupByClass": false,
           "groupByLabel": false
@@ -152,6 +153,7 @@
             }
           ],
           "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL) AND this.HasRelatedInstance(\"BisCore:ModelContainsElements\", \"Forward\", \"BisCore:GeometricElement3d\")",
+          "hasChildren": "Always",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false


### PR DESCRIPTION
We create nodes for Models only if they have elements. If a GeometricModel has an element, it means it definitely has a child node of a Category instance. Put a hint for this so we don't have to run a query to check what we already know.

This makes a huge difference for the initial Models Tree load performance, because we don't need to run the slow Models-to-Categories queries. Local run on the performance test suite:

Before (s) | After (s)
-- | --
5.217 | 0.774
4.037 | 0.263
2.3635 | 0.421
3.016 | 0.355
6.0315 | 0.414
2.0585 | 0.374
0.726 | 0.393
0.7 | 0.432
0.2775 | 0.171
0.302 | 0.226
1.819 | 0.391
1.756 | 0.607
0.21 | 0.215
5.7805 | 1.545
0.2285 | 0.165
0.167 | 0.167
0.585 | 0.23
0.352 | 0.226
0.578 | 0.243
0.261 | 0.225
0.6225 | 0.376
0.251 | 0.187
0.228 | 0.143
0.181 | 0.163
0.203 | 0.186
0.2 | 0.183
0.2335 | 0.19
0.201 | 0.175
0.201 | 0.165
0.191 | 0.171
18.0665 | 0.997
10.8725 | 0.558
7.9495 | 2.021
461.814 | 26.862
8.979 | 1.458
8.8035 | 1.045
2.2795 | 0.279
0.398 | 0.367

A change in the addon is also required for this to have effect: https://bentleycs.visualstudio.com/iModelTechnologies/_git/imodel02/pullrequest/251290