### PR TITLE
Do not create a Batch with an empty FeatureTable

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-3682_2022-05-25-13-04.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-3682_2022-05-25-13-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Prevent an assertion when creating a pickable graphic with an empty FeatureTable.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/certa.json
+++ b/core/frontend/certa.json
@@ -7,7 +7,7 @@
     "frontendDebugging": 9223
   },
   "mochaOptions": {
-    "timeout": 2000, // These are unit tests; they should be quick.
+    "timeout": 10000, // These are unit tests; they should be quick. But mac build agents frequently time out on simple tests.
     "reporter": "node_modules/@itwin/build-tools/mocha-reporter",
     "reporterOptions": {
       "mochaFile": "lib/test/junit_results.xml"

--- a/core/frontend/src/render/primitives/geometry/GeometryListBuilder.ts
+++ b/core/frontend/src/render/primitives/geometry/GeometryListBuilder.ts
@@ -174,7 +174,9 @@ export class PrimitiveBuilder extends GeometryListBuilder {
       const tolerance = this.computeTolerance(accum);
       meshes = accum.saveToGraphicList(this.primitives, options, tolerance, this.pickable);
       if (undefined !== meshes) {
-        featureTable = meshes.features;
+        if (meshes.features?.anyDefined)
+          featureTable = meshes.features;
+
         range = meshes.range;
       }
     }

--- a/core/frontend/src/test/DeferredMarkerHtmlRemoval.test.ts
+++ b/core/frontend/src/test/DeferredMarkerHtmlRemoval.test.ts
@@ -78,7 +78,7 @@ describe("ScreenViewport", () => {
     }
 
     IModelApp.viewManager.dropDecorator(decorator);
-  });
+  }).timeout(20000);
 
   it("should delete markers that aren't readded by registered decorators", () => {
     const vp = openBlankViewport();

--- a/core/frontend/src/test/render/primitives/PrimitiveBuilder.test.ts
+++ b/core/frontend/src/test/render/primitives/PrimitiveBuilder.test.ts
@@ -6,23 +6,25 @@ import { expect } from "chai";
 import { Point3d } from "@itwin/core-geometry";
 import { GraphicType, IModelApp, RenderGraphic } from "../../../core-frontend";
 import { PrimitiveBuilder } from "../../../render-primitives";
-import { Branch, GraphicsArray, MeshGraphic } from "../../../webgl";
+import { Batch, Branch, GraphicsArray, MeshGraphic } from "../../../webgl";
 
 describe("PrimitiveBuilder", () => {
   before(async () => IModelApp.startup());
   after(async () => IModelApp.shutdown());
 
-  function makeShape(chordTolerance: number): RenderGraphic {
+  function makeShape(chordTolerance: number, pickableId?: string): RenderGraphic {
+    const pickable = pickableId ? { id: pickableId } : undefined;
     const builder = new PrimitiveBuilder(IModelApp.renderSystem, {
       type: GraphicType.Scene,
       computeChordTolerance: () => chordTolerance,
+      pickable,
     });
 
     builder.addShape([new Point3d(0, 0, 0), new Point3d(1, 0, 0), new Point3d(1, 1, 0), new Point3d(0, 0, 0)]);
     return builder.finish() as Branch;
   }
 
-  it.only("omits degenerate facets", () => {
+  it("omits degenerate facets", () => {
     const branch = makeShape(0.0001) as Branch;
     expect(branch).instanceof(Branch);
     expect(branch.branch.entries.length).to.equal(1);
@@ -33,6 +35,14 @@ describe("PrimitiveBuilder", () => {
     expect(array.graphics.length).to.equal(0);
   });
 
-  it.only("omits empty feature table", () => {
+  it("omits empty feature table", () => {
+    const batch = makeShape(0.0001, "0x123") as Batch;
+    expect(batch).instanceof(Batch);
+    expect(batch.featureTable.numFeatures).to.equal(1);
+
+    // Previously this would have produced a Batch with an empty FeatureTable, which induced an assertion in PackedFeatureTable.initFromMap.
+    const array = makeShape(10000.0, "0x123") as GraphicsArray;
+    expect(array).instanceof(GraphicsArray);
+    expect(array.graphics.length).to.equal(0);
   });
 });

--- a/core/frontend/src/test/render/primitives/PrimitiveBuilder.test.ts
+++ b/core/frontend/src/test/render/primitives/PrimitiveBuilder.test.ts
@@ -21,7 +21,7 @@ describe("PrimitiveBuilder", () => {
     });
 
     builder.addShape([new Point3d(0, 0, 0), new Point3d(1, 0, 0), new Point3d(1, 1, 0), new Point3d(0, 0, 0)]);
-    return builder.finish() as Branch;
+    return builder.finish();
   }
 
   it("omits degenerate facets", () => {

--- a/core/frontend/src/test/render/primitives/PrimitiveBuilder.test.ts
+++ b/core/frontend/src/test/render/primitives/PrimitiveBuilder.test.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { Point3d } from "@itwin/core-geometry";
+import { GraphicType, IModelApp, RenderGraphic } from "../../../core-frontend";
+import { PrimitiveBuilder } from "../../../render-primitives";
+import { Branch, GraphicsArray, MeshGraphic } from "../../../webgl";
+
+describe("PrimitiveBuilder", () => {
+  before(async () => IModelApp.startup());
+  after(async () => IModelApp.shutdown());
+
+  function makeShape(chordTolerance: number): RenderGraphic {
+    const builder = new PrimitiveBuilder(IModelApp.renderSystem, {
+      type: GraphicType.Scene,
+      computeChordTolerance: () => chordTolerance,
+    });
+
+    builder.addShape([new Point3d(0, 0, 0), new Point3d(1, 0, 0), new Point3d(1, 1, 0), new Point3d(0, 0, 0)]);
+    return builder.finish() as Branch;
+  }
+
+  it.only("omits degenerate facets", () => {
+    const branch = makeShape(0.0001) as Branch;
+    expect(branch).instanceof(Branch);
+    expect(branch.branch.entries.length).to.equal(1);
+    expect(branch.branch.entries[0]).instanceof(MeshGraphic);
+
+    const array = makeShape(10000.0) as GraphicsArray;
+    expect(array).instanceof(GraphicsArray);
+    expect(array.graphics.length).to.equal(0);
+  });
+
+  it.only("omits empty feature table", () => {
+  });
+});


### PR DESCRIPTION
Fixes #3682
Also bumps default timeout for core-frontend tests from 2 to 10 seconds because the mac build agents frequently time out on even very simple tests.