### PR TITLE
Close popup when the widget tab is clicked

### DIFF
--- a/common/changes/@itwin/appui-layout-react/widget-tab-tippy_2022-05-25-13-12.json
+++ b/common/changes/@itwin/appui-layout-react/widget-tab-tippy_2022-05-25-13-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Allow tippy.js to close when tab is clicked.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/base/DragHandle.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/DragHandle.tsx
@@ -66,7 +66,6 @@ export class DragHandle extends React.PureComponent<DragHandleProps, DragHandleS
 
     this.setState({ isPointerDown: true });
 
-    e.preventDefault();
     this._isDragged = false;
     this._initial = new Point(e.clientX, e.clientY);
   };

--- a/ui/appui-layout-react/src/appui-layout-react/base/PointerCaptor.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/PointerCaptor.tsx
@@ -55,7 +55,12 @@ export class PointerCaptor extends React.PureComponent<PointerCaptorProps> {
         style={this.props.style}
         role="presentation"
       >
-        <div className="nz-overlay" />
+        <div
+          className="nz-overlay"
+          onDragStart={(e)=> {
+            e.preventDefault();
+          }}
+        />
         {this.props.children}
       </div>
     );

--- a/ui/appui-layout-react/src/appui-layout-react/widget/rectangular/ResizeGrip.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/rectangular/ResizeGrip.tsx
@@ -137,7 +137,6 @@ export class ResizeGrip extends React.PureComponent<ResizeGripProps, ResizeGripS
     this._lastPosition = new Point(e.clientX, e.clientY);
 
     this._isResizing = true;
-    e.preventDefault();
 
     const bounds = Rectangle.create(grip.getBoundingClientRect());
     this.props.onResizeStart && this.props.onResizeStart({

--- a/ui/appui-layout-react/src/test/base/PointerCaptor.test.snap
+++ b/ui/appui-layout-react/src/test/base/PointerCaptor.test.snap
@@ -8,6 +8,7 @@ exports[`<PointerCaptor /> renders correctly 1`] = `
 >
   <div
     className="nz-overlay"
+    onDragStart={[Function]}
   />
 </div>
 `;
@@ -20,6 +21,7 @@ exports[`<PointerCaptor /> should respect isPointerDown prop over state 1`] = `
 >
   <div
     className="nz-overlay"
+    onDragStart={[Function]}
   />
 </div>
 `;

--- a/ui/appui-layout-react/src/test/base/PointerCaptor.test.tsx
+++ b/ui/appui-layout-react/src/test/base/PointerCaptor.test.tsx
@@ -63,6 +63,18 @@ describe("<PointerCaptor />", () => {
 
     spy.calledOnce.should.true;
   });
+
+  it("should prevent default on drag start", () => {
+    const sut = mount(<PointerCaptor isPointerDown />);
+    const overlay = sut.find("div.nz-overlay");
+
+    const preventDefault = sinon.stub();
+    overlay.simulate("dragStart", {
+      preventDefault,
+    });
+
+    preventDefault.calledOnceWithExactly().should.true;
+  });
 });
 
 describe("usePointerCaptor", () => {

--- a/ui/appui-layout-react/src/test/widget/rectangular/tab/Tab.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/rectangular/tab/Tab.test.tsx
@@ -95,22 +95,6 @@ describe("<Tab />", () => {
     result.bottom.should.eq(0);
   });
 
-  it("should prevent default on pointer down", () => {
-    const sut = mount(<Tab
-      horizontalAnchor={HorizontalAnchor.Left}
-      mode={TabMode.Open}
-      verticalAnchor={VerticalAnchor.Middle}
-    />);
-    const pointerCaptor = sut.find(PointerCaptor);
-
-    const pointerDown = new PointerEvent("pointerdown");
-    const spy = sinon.spy(pointerDown, "preventDefault");
-
-    pointerCaptor.prop("onPointerDown")!(pointerDown);
-
-    spy.calledOnceWithExactly().should.true;
-  });
-
   it("should invoke onClick handler", () => {
     const spy = sinon.spy();
     const sut = mount(<Tab


### PR DESCRIPTION
This PR fixes an issue where tippy.js popup was not being closed if the widget tab or resize handle was clicked/dragged.