### PR TITLE
Fix assertion on valid case in IModelExporter.exportElement.

### DIFF
--- a/common/changes/@itwin/core-transformer/transformer-mapId64-assert-fix_2022-05-26-08-36.json
+++ b/common/changes/@itwin/core-transformer/transformer-mapId64-assert-fix_2022-05-26-08-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "Fix assertion on valid case in mapId64.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -195,10 +195,10 @@ function mapId64<R>(
   // is a string if compressed or singular id64, but check for singular just checks if it's a string so do this test first
   if (idContainer === undefined) {
     // nothing
-  } else if (isId64String(idContainer)) {
-    results.push(func(idContainer));
   } else if (isRelatedElem(idContainer)) {
     results.push(func(idContainer.id));
+  } else if (isId64String(idContainer)) {
+    results.push(func(idContainer));
   } else {
     throw Error([
       `Id64 container '${idContainer}' is unsupported.`,

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -186,7 +186,11 @@ function mapId64<R>(
   idContainer: Id64String | { id: Id64String } | undefined,
   func: (id: Id64String) => R
 ): R[] {
-  const isId64String = (arg: any): arg is Id64String => (typeof arg === "string" && Id64.isValidId64(arg));
+  const isId64String = (arg: any): arg is Id64String => {
+    const isString = typeof arg === "string";
+    assert(() => !isString || Id64.isValidId64(arg));
+    return isString;
+  };
   const isRelatedElem = (arg: any): arg is RelatedElement =>
     arg && typeof arg === "object" && "id" in arg;
 

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -186,7 +186,7 @@ function mapId64<R>(
   idContainer: Id64String | { id: Id64String } | undefined,
   func: (id: Id64String) => R
 ): R[] {
-  const isId64String = (arg: any): arg is Id64String => { assert(Id64.isValidId64(arg)); return typeof arg === "string"; };
+  const isId64String = (arg: any): arg is Id64String => (typeof arg === "string" && Id64.isValidId64(arg));
   const isRelatedElem = (arg: any): arg is RelatedElement =>
     arg && typeof arg === "object" && "id" in arg;
 
@@ -195,10 +195,10 @@ function mapId64<R>(
   // is a string if compressed or singular id64, but check for singular just checks if it's a string so do this test first
   if (idContainer === undefined) {
     // nothing
-  } else if (isRelatedElem(idContainer)) {
-    results.push(func(idContainer.id));
   } else if (isId64String(idContainer)) {
     results.push(func(idContainer));
+  } else if (isRelatedElem(idContainer)) {
+    results.push(func(idContainer.id));
   } else {
     throw Error([
       `Id64 container '${idContainer}' is unsupported.`,


### PR DESCRIPTION
Scenario:
Passing object containing an `id` property to `mapId64` function.

Problem:
`isId64String` is executed first and `assert(Id64.isValidId64(arg)` fires an error due to `arg` not being a string.