### PR TITLE
Add workarounds for Mali-G72 GPU.

### DIFF
--- a/common/changes/@itwin/webgl-compatibility/pmc-mali-g72-workaround_2022-05-30-15-45.json
+++ b/common/changes/@itwin/webgl-compatibility/pmc-mali-g72-workaround_2022-05-30-15-45.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/webgl-compatibility",
-      "comment": "Apply a workaround for a transparency bug on mobile devices using Mali-G72 graphics chips.",
+      "comment": "Apply a workaround for transparency and MSAA bugs on mobile devices using Mali-G72 graphics chips.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/webgl-compatibility/pmc-mali-g72-workaround_2022-05-30-15-45.json
+++ b/common/changes/@itwin/webgl-compatibility/pmc-mali-g72-workaround_2022-05-30-15-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "Apply a workaround for a transparency bug on mobile devices using Mali-G72 graphics chips.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -314,7 +314,8 @@ export class Capabilities {
       && !ProcessDetector.isIOSBrowser
       // Samsung Galaxy Note 8 exhibits same issue as described above for iOS >= 15.
       // It uses specifically Mali-G71 MP20 but reports its renderer as follows.
-      && unmaskedRenderer !== "Mali-G71";
+      // Samsung Galaxy A50 and S9 exhibits same issue; they use Mali-G72.
+      && unmaskedRenderer !== "Mali-G71" && unmaskedRenderer !== "Mali-G72";
 
     if (allowFloatRender && undefined !== this.queryExtensionObject("EXT_float_blend") && this.isTextureRenderable(gl, gl.FLOAT)) {
       this._maxRenderType = RenderType.TextureFloat;

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -76,6 +76,7 @@ const buggyIntelMatchers = [
 // Regexes to match Mali GPUs known to suffer from GraphicsDriverBugs.msaaWillHang.
 const buggyMaliMatchers = [
   /Mali-G71/,
+  /Mali-G72/,
   /Mali-G76/,
 ];
 
@@ -267,6 +268,7 @@ export class Capabilities {
     this._driverBugs = {};
     if (unmaskedRenderer && buggyIntelMatchers.some((x) => x.test(unmaskedRenderer)))
       this._driverBugs.fragDepthDoesNotDisableEarlyZ = true;
+
     if (unmaskedRenderer && buggyMaliMatchers.some((x) => x.test(unmaskedRenderer)))
       this._driverBugs.msaaWillHang = true;
 

--- a/core/webgl-compatibility/src/test/Compatibility.test.ts
+++ b/core/webgl-compatibility/src/test/Compatibility.test.ts
@@ -244,6 +244,7 @@ describe("Render Compatibility", () => {
   it("detects MSAA hang bug", () => {
     const renderers = [
       [ "Mali-G71", true ],
+      [ "Mali-G72", true ],
       [ "Mali-G76", true ],
       [ "ANGLE (Intel HD Graphics 620 Direct3D11 vs_5_0 ps_5_0)",  false ],
       [ "Mali-G79", false ],

--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -38,6 +38,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
   // All security issues should be addressed asap.
   const excludedAdvisories = [
     "GHSA-ww39-953v-wcq6", // https://github.com/advisories/GHSA-ww39-953v-wcq6 webpack@4>watchpack>watchpack-chokidar2>chokidar>glob-parent
+    "GHSA-rp65-9cf3-cjxr", // https://github.com/advisories/GHSA-rp65-9cf3-cjxr @bentley/react-scripts>@svgr/webpack>@svgr/plugin-svgo>svgo>css-select>nth-check
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
Addresses #3700 using same workaround as #3234 for incorrect transparency.
Also applies workaround from #3499 for hang after enabling MSAA.