### PR TITLE
Fix selection scope overrides

### DIFF
--- a/common/changes/@itwin/appui-react/ui-fixSelectionScopeOverrides_2022-05-31-13-09.json
+++ b/common/changes/@itwin/appui-react/ui-fixSelectionScopeOverrides_2022-05-31-13-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Ensure selection scope override labels are honored.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
@@ -41,7 +41,7 @@ class SelectionScopeFieldComponent extends React.Component<SelectionScopeFieldPr
   constructor(props: SelectionScopeFieldProps) {
     super(props);
     this._scopeOptions = this.props.availableSelectionScopes.map((scope: PresentationSelectionScope) => {
-      const label = UiFramework.translate(`selectionScopeLabels.${scope.id}`);
+      const label = !!scope.label ? scope.label : UiFramework.translate(`selectionScopeLabels.${scope.id}`);
       return { value: scope.id, label };
     });
   }

--- a/ui/appui-react/src/test/statusfields/SelectionScope.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SelectionScope.test.tsx
@@ -135,4 +135,50 @@ describe("Test that requires Presentation", () => {
     expect(UiFramework.getActiveSelectionScope()).to.be.equal("assembly");
     // expect(selectElement.selectedIndex).to.be.equal(1);
   });
+
+  it("SelectionScopeField should properly handle empty override scope labels", async () => {
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetAvailableSelectionScopes, [
+      { id: "element", label: "" } as PresentationSelectionScope,
+      { id: "assembly", label: "" } as PresentationSelectionScope,
+      { id: "top-assembly", label: "" } as PresentationSelectionScope,
+    ]);
+
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "top-assembly");
+
+    const component = render(<Provider store={TestUtils.store}>
+      <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
+    </Provider>);
+    expect(component).not.to.be.undefined;
+    const selectElement = component.getByTestId("components-selectionScope-selector") as HTMLSelectElement;
+    expect(selectElement).not.to.be.null;
+    expect(UiFramework.getActiveSelectionScope()).to.be.equal("top-assembly");
+    component.getByText("selectionScopeLabels.top-assembly");
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "assembly");
+    component.getByText("selectionScopeLabels.assembly");
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "element");
+    component.getByText("selectionScopeLabels.element");
+  });
+
+  it("SelectionScopeField should properly handle override scope labels", async () => {
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetAvailableSelectionScopes, [
+      { id: "element", label: "Functional Element" } as PresentationSelectionScope,
+      { id: "assembly", label: "Functional Assembly" } as PresentationSelectionScope,
+      { id: "top-assembly", label: "Functional TopAssembly" } as PresentationSelectionScope,
+    ]);
+
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "top-assembly");
+
+    const component = render(<Provider store={TestUtils.store}>
+      <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
+    </Provider>);
+    expect(component).not.to.be.undefined;
+    const selectElement = component.getByTestId("components-selectionScope-selector") as HTMLSelectElement;
+    expect(selectElement).not.to.be.null;
+    expect(UiFramework.getActiveSelectionScope()).to.be.equal("top-assembly");
+    component.getByText("Functional TopAssembly");
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "assembly");
+    component.getByText("Functional Assembly");
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "element");
+    component.getByText("Functional Element");
+  });
 });


### PR DESCRIPTION
Fix issue were supplied labels were being ignored and looked up from UiFramework based on scope Id. Now this only occurrs if the supplied label is empty or undefined.