### PR TITLE
Bump tile format version

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -1684,8 +1684,8 @@ export const CURRENT_REQUEST: unique symbol;
 
 // @internal
 export enum CurrentImdlVersion {
-    Combined = 1835008,
-    Major = 28,
+    Combined = 1900544,
+    Major = 29,
     Minor = 0
 }
 

--- a/common/changes/@itwin/core-common/fill-range-index-from-spatial_2022-06-01-21-23.json
+++ b/common/changes/@itwin/core-common/fill-range-index-from-spatial_2022-06-01-21-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/tile/IModelTileIO.ts
+++ b/core/common/src/tile/IModelTileIO.ts
@@ -33,7 +33,7 @@ export enum CurrentImdlVersion {
    * front-end is not capable of reading the tile content. Otherwise, this front-end can read the tile content even if the header specifies a
    * greater minor version than CurrentVersion.Minor, although some data may be skipped.
    */
-  Major = 28,
+  Major = 29,
   /** The unsigned 16-bit minor version number. If the major version in the tile header is equal to CurrentVersion.Major, then this package can
    * read the tile content even if the minor version in the tile header is greater than this value, although some data may be skipped.
    */


### PR DESCRIPTION
For [corresponding native PR](https://bentleycs.visualstudio.com/iModelTechnologies/_git/imodel02/pullrequest/251307) which populates the range index from the iModel's spatial index instead of querying element ranges.