### PR TITLE
Presentation: Introduce nth level element selection scope support

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { ClientRequestContext } from '@bentley/bentleyjs-core';
+import { ComputeSelectionRequestOptions } from '@bentley/presentation-common';
 import { Content } from '@bentley/presentation-common';
 import { ContentDescriptorRequestOptions } from '@bentley/presentation-common';
 import { ContentRequestOptions } from '@bentley/presentation-common';
@@ -41,7 +42,6 @@ import { RegisteredRuleset } from '@bentley/presentation-common';
 import { Ruleset } from '@bentley/presentation-common';
 import { SelectionInfo } from '@bentley/presentation-common';
 import { SelectionScope } from '@bentley/presentation-common';
-import { SelectionScopeParams } from '@bentley/presentation-common';
 import { SelectionScopeRequestOptions } from '@bentley/presentation-common';
 import { UpdateInfoJSON } from '@bentley/presentation-common';
 import { VariableValue } from '@bentley/presentation-common';
@@ -163,8 +163,9 @@ export class PresentationManager {
     computeSelection(requestOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & {
         ids: Id64String[];
         scopeId: string;
-        scopeParams?: SelectionScopeParams;
     }>): Promise<KeySet>;
+    // @alpha (undocumented)
+    computeSelection(requestOptions: WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>>): Promise<KeySet>;
     dispose(): void;
     // @deprecated
     getContent(requestContext: ClientRequestContext, requestOptions: Paged<ContentRequestOptions<IModelDb>>, descriptorOrOverrides: Descriptor | DescriptorOverrides, keys: KeySet): Promise<Content | undefined>;

--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -41,6 +41,7 @@ import { RegisteredRuleset } from '@bentley/presentation-common';
 import { Ruleset } from '@bentley/presentation-common';
 import { SelectionInfo } from '@bentley/presentation-common';
 import { SelectionScope } from '@bentley/presentation-common';
+import { SelectionScopeParams } from '@bentley/presentation-common';
 import { SelectionScopeRequestOptions } from '@bentley/presentation-common';
 import { UpdateInfoJSON } from '@bentley/presentation-common';
 import { VariableValue } from '@bentley/presentation-common';
@@ -162,6 +163,7 @@ export class PresentationManager {
     computeSelection(requestOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & {
         ids: Id64String[];
         scopeId: string;
+        scopeParams?: SelectionScopeParams;
     }>): Promise<KeySet>;
     dispose(): void;
     // @deprecated

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -241,6 +241,19 @@ export type CompressedDescriptorJSON = Omit<DescriptorJSON, "selectClasses" | "f
 // @public
 export type ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise<string>;
 
+// @alpha (undocumented)
+export interface ComputeElementSelectionScopeProps {
+    // (undocumented)
+    id: "element";
+    // (undocumented)
+    params?: ElementSelectionScopeParams;
+}
+
+// @alpha (undocumented)
+export type ComputeSelectionScopeProps = ComputeElementSelectionScopeProps | {
+    id: string;
+};
+
 // @public
 export interface ConditionContainer {
     condition?: string;
@@ -835,6 +848,12 @@ export interface ElementPropertiesStructPropertyItem extends ElementPropertiesPr
         [memberLabel: string]: ElementPropertiesPropertyItem;
     };
     type: "struct";
+}
+
+// @alpha (undocumented)
+export interface ElementSelectionScopeParams {
+    // (undocumented)
+    level?: number;
 }
 
 // @public
@@ -1962,7 +1981,7 @@ export class PresentationRpcInterface extends RpcInterface {
     // (undocumented)
     compareHierarchiesPaged(_token: IModelRpcProps, _options: HierarchyCompareRpcOptions): PresentationRpcResponse<HierarchyCompareInfoJSON>;
     // (undocumented)
-    computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string): PresentationRpcResponse<KeySetJSON>;
+    computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string, _scopeParams?: any): PresentationRpcResponse<KeySetJSON>;
     // @deprecated (undocumented)
     getContent(_token: IModelRpcProps, _options: ContentRpcRequestOptions, _descriptorOrOverrides: DescriptorJSON | DescriptorOverrides, _keys: KeySetJSON): PresentationRpcResponse<ContentJSON | undefined>;
     // @deprecated (undocumented)
@@ -2550,7 +2569,7 @@ export class RpcRequestsHandler implements IDisposable {
     // (undocumented)
     compareHierarchiesPaged(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<HierarchyCompareInfoJSON>;
     // (undocumented)
-    computeSelection(options: SelectionScopeRequestOptions<IModelRpcProps>, ids: Id64String[], scopeId: string): Promise<KeySetJSON>;
+    computeSelection(options: SelectionScopeRequestOptions<IModelRpcProps>, ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams): Promise<KeySetJSON>;
     // (undocumented)
     dispose(): void;
     // (undocumented)
@@ -2766,6 +2785,9 @@ export interface SelectionScope {
     id: string;
     label: string;
 }
+
+// @alpha (undocumented)
+export type SelectionScopeParams = ElementSelectionScopeParams;
 
 // @public
 export interface SelectionScopeRequestOptions<TIModel> extends RequestOptions<TIModel> {

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -242,9 +242,12 @@ export type CompressedDescriptorJSON = Omit<DescriptorJSON, "selectClasses" | "f
 export type ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise<string>;
 
 // @alpha
-export type ComputeSelectionRequestOptions<TIModel> = RequestOptions<TIModel> & SelectionScopeProps & {
+export interface ComputeSelectionRequestOptions<TIModel> extends RequestOptions<TIModel> {
+    // (undocumented)
     elementIds: Id64String[];
-};
+    // (undocumented)
+    scope: SelectionScopeProps;
+}
 
 // @alpha (undocumented)
 export type ComputeSelectionRpcRequestOptions = PresentationRpcRequestOptions<ComputeSelectionRequestOptions<never>>;
@@ -850,7 +853,7 @@ export interface ElementSelectionScopeProps {
     // (undocumented)
     ancestorLevel?: number;
     // (undocumented)
-    scopeId: "element";
+    id: "element";
 }
 
 // @public
@@ -2790,7 +2793,7 @@ export interface SelectionScope {
 
 // @alpha (undocumented)
 export type SelectionScopeProps = ElementSelectionScopeProps | {
-    scopeId: string;
+    id: string;
 };
 
 // @public

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -241,18 +241,13 @@ export type CompressedDescriptorJSON = Omit<DescriptorJSON, "selectClasses" | "f
 // @public
 export type ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise<string>;
 
-// @alpha (undocumented)
-export interface ComputeElementSelectionScopeProps {
-    // (undocumented)
-    id: "element";
-    // (undocumented)
-    params?: ElementSelectionScopeParams;
-}
+// @alpha
+export type ComputeSelectionRequestOptions<TIModel> = RequestOptions<TIModel> & SelectionScopeProps & {
+    elementIds: Id64String[];
+};
 
 // @alpha (undocumented)
-export type ComputeSelectionScopeProps = ComputeElementSelectionScopeProps | {
-    id: string;
-};
+export type ComputeSelectionRpcRequestOptions = PresentationRpcRequestOptions<ComputeSelectionRequestOptions<never>>;
 
 // @public
 export interface ConditionContainer {
@@ -851,9 +846,11 @@ export interface ElementPropertiesStructPropertyItem extends ElementPropertiesPr
 }
 
 // @alpha (undocumented)
-export interface ElementSelectionScopeParams {
+export interface ElementSelectionScopeProps {
     // (undocumented)
-    level?: number;
+    ancestorLevel?: number;
+    // (undocumented)
+    scopeId: "element";
 }
 
 // @public
@@ -1361,6 +1358,9 @@ export interface IntsRulesetVariableJSON extends RulesetVariableBaseJSON {
     // (undocumented)
     value: number[];
 }
+
+// @internal (undocumented)
+export function isComputeSelectionRequestOptions<TIModel>(options: ComputeSelectionRequestOptions<TIModel> | SelectionScopeRequestOptions<TIModel>): options is ComputeSelectionRequestOptions<TIModel>;
 
 // @internal (undocumented)
 export const isContentDescriptorRequestOptions: <TIModel, TKeySet, TRulesetVariable>(opts: ContentRequestOptions<TIModel, RulesetVariable> | ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable>) => opts is ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable>;
@@ -1981,7 +1981,9 @@ export class PresentationRpcInterface extends RpcInterface {
     // (undocumented)
     compareHierarchiesPaged(_token: IModelRpcProps, _options: HierarchyCompareRpcOptions): PresentationRpcResponse<HierarchyCompareInfoJSON>;
     // (undocumented)
-    computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string, _scopeParams?: any): PresentationRpcResponse<KeySetJSON>;
+    computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string): PresentationRpcResponse<KeySetJSON>;
+    // @alpha (undocumented)
+    computeSelection(_token: IModelRpcProps, _options: ComputeSelectionRpcRequestOptions): PresentationRpcResponse<KeySetJSON>;
     // @deprecated (undocumented)
     getContent(_token: IModelRpcProps, _options: ContentRpcRequestOptions, _descriptorOrOverrides: DescriptorJSON | DescriptorOverrides, _keys: KeySetJSON): PresentationRpcResponse<ContentJSON | undefined>;
     // @deprecated (undocumented)
@@ -2569,7 +2571,7 @@ export class RpcRequestsHandler implements IDisposable {
     // (undocumented)
     compareHierarchiesPaged(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<HierarchyCompareInfoJSON>;
     // (undocumented)
-    computeSelection(options: SelectionScopeRequestOptions<IModelRpcProps>, ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams): Promise<KeySetJSON>;
+    computeSelection(options: ComputeSelectionRequestOptions<IModelRpcProps>): Promise<KeySetJSON>;
     // (undocumented)
     dispose(): void;
     // (undocumented)
@@ -2787,7 +2789,9 @@ export interface SelectionScope {
 }
 
 // @alpha (undocumented)
-export type SelectionScopeParams = ElementSelectionScopeParams;
+export type SelectionScopeProps = ElementSelectionScopeProps | {
+    scopeId: string;
+};
 
 // @public
 export interface SelectionScopeRequestOptions<TIModel> extends RequestOptions<TIModel> {

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { BeEvent } from '@bentley/bentleyjs-core';
-import { ComputeSelectionScopeProps } from '@bentley/presentation-common';
 import { Content } from '@bentley/presentation-common';
 import { ContentDescriptorRequestOptions } from '@bentley/presentation-common';
 import { ContentRequestOptions } from '@bentley/presentation-common';
@@ -52,7 +51,7 @@ import { Ruleset } from '@bentley/presentation-common';
 import { RulesetVariable } from '@bentley/presentation-common';
 import { SelectionInfo } from '@bentley/presentation-common';
 import { SelectionScope } from '@bentley/presentation-common';
-import { SelectionScopeParams } from '@bentley/presentation-common';
+import { SelectionScopeProps } from '@bentley/presentation-common';
 import { SetRulesetVariableParams } from '@bentley/presentation-common';
 import { UnsetRulesetVariableParams } from '@bentley/presentation-common';
 import { UpdateHierarchyStateParams } from '@bentley/presentation-common';
@@ -69,6 +68,9 @@ export function createCombinedDiagnosticsHandler(handlers: DiagnosticsHandler[])
 
 // @internal (undocumented)
 export const createFieldOrderInfos: (field: Field) => FavoritePropertiesOrderInfo[];
+
+// @internal
+export function createSelectionScopeProps(scope: SelectionScopeProps | SelectionScope | string | undefined): SelectionScopeProps;
 
 // @public
 export class FavoritePropertiesManager implements IDisposable {
@@ -127,12 +129,6 @@ export const getFieldInfos: (field: Field) => Set<PropertyFullName>;
 
 // @public @deprecated
 export function getScopeId(scope: SelectionScope | string | undefined): string;
-
-// @internal
-export function getScopeRequestProps(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined): {
-    id: string;
-    params?: SelectionScopeParams;
-};
 
 // @internal (undocumented)
 export const HILITE_RULESET: Ruleset;
@@ -485,15 +481,15 @@ export class SelectionHelper {
 export class SelectionManager implements ISelectionProvider {
     constructor(props: SelectionManagerProps);
     addToSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;
-    addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
+    addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     clearSelection(source: string, imodel: IModelConnection, level?: number, rulesetId?: string): void;
     getHiliteSet(imodel: IModelConnection): Promise<HiliteSet>;
     getSelection(imodel: IModelConnection, level?: number): Readonly<KeySet>;
     getSelectionLevels(imodel: IModelConnection): number[];
     removeFromSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;
-    removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
+    removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     replaceSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;
-    replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
+    replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     readonly scopes: SelectionScopesManager;
     readonly selectionChange: SelectionChangeEvent;
     setSyncWithIModelToolSelection(imodel: IModelConnection, sync?: boolean): void;
@@ -509,9 +505,9 @@ export interface SelectionManagerProps {
 export class SelectionScopesManager {
     constructor(props: SelectionScopesManagerProps);
     get activeLocale(): string | undefined;
-    get activeScope(): ComputeSelectionScopeProps | SelectionScope | string | undefined;
-    set activeScope(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined);
-    computeSelection(imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string): Promise<KeySet>;
+    get activeScope(): SelectionScopeProps | SelectionScope | string | undefined;
+    set activeScope(scope: SelectionScopeProps | SelectionScope | string | undefined);
+    computeSelection(imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string): Promise<KeySet>;
     getSelectionScopes(imodel: IModelConnection, locale?: string): Promise<SelectionScope[]>;
     }
 

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { BeEvent } from '@bentley/bentleyjs-core';
+import { ComputeSelectionScopeProps } from '@bentley/presentation-common';
 import { Content } from '@bentley/presentation-common';
 import { ContentDescriptorRequestOptions } from '@bentley/presentation-common';
 import { ContentRequestOptions } from '@bentley/presentation-common';
@@ -51,6 +52,7 @@ import { Ruleset } from '@bentley/presentation-common';
 import { RulesetVariable } from '@bentley/presentation-common';
 import { SelectionInfo } from '@bentley/presentation-common';
 import { SelectionScope } from '@bentley/presentation-common';
+import { SelectionScopeParams } from '@bentley/presentation-common';
 import { SetRulesetVariableParams } from '@bentley/presentation-common';
 import { UnsetRulesetVariableParams } from '@bentley/presentation-common';
 import { UpdateHierarchyStateParams } from '@bentley/presentation-common';
@@ -123,8 +125,14 @@ export enum FavoritePropertiesScope {
 // @internal (undocumented)
 export const getFieldInfos: (field: Field) => Set<PropertyFullName>;
 
-// @public
+// @public @deprecated
 export function getScopeId(scope: SelectionScope | string | undefined): string;
+
+// @internal
+export function getScopeRequestProps(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined): {
+    id: string;
+    params?: SelectionScopeParams;
+};
 
 // @internal (undocumented)
 export const HILITE_RULESET: Ruleset;
@@ -477,15 +485,15 @@ export class SelectionHelper {
 export class SelectionManager implements ISelectionProvider {
     constructor(props: SelectionManagerProps);
     addToSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;
-    addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
+    addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     clearSelection(source: string, imodel: IModelConnection, level?: number, rulesetId?: string): void;
     getHiliteSet(imodel: IModelConnection): Promise<HiliteSet>;
     getSelection(imodel: IModelConnection, level?: number): Readonly<KeySet>;
     getSelectionLevels(imodel: IModelConnection): number[];
     removeFromSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;
-    removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
+    removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     replaceSelection(source: string, imodel: IModelConnection, keys: Keys, level?: number, rulesetId?: string): void;
-    replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
+    replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     readonly scopes: SelectionScopesManager;
     readonly selectionChange: SelectionChangeEvent;
     setSyncWithIModelToolSelection(imodel: IModelConnection, sync?: boolean): void;
@@ -501,9 +509,9 @@ export interface SelectionManagerProps {
 export class SelectionScopesManager {
     constructor(props: SelectionScopesManagerProps);
     get activeLocale(): string | undefined;
-    get activeScope(): SelectionScope | string | undefined;
-    set activeScope(scope: SelectionScope | string | undefined);
-    computeSelection(imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string): Promise<KeySet>;
+    get activeScope(): ComputeSelectionScopeProps | SelectionScope | string | undefined;
+    set activeScope(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined);
+    computeSelection(imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string): Promise<KeySet>;
     getSelectionScopes(imodel: IModelConnection, locale?: string): Promise<SelectionScope[]>;
     }
 

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -27,8 +27,8 @@ internal;CommonIpcParams
 public;CompressedClassInfoJSON
 public;CompressedDescriptorJSON = Omit
 public;ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise
-alpha;ComputeElementSelectionScopeProps
-alpha;ComputeSelectionScopeProps = ComputeElementSelectionScopeProps |
+alpha;ComputeSelectionRequestOptions
+alpha;ComputeSelectionRpcRequestOptions = PresentationRpcRequestOptions
 public;ConditionContainer
 public;Content
 public;ContentDescriptorRequestOptions
@@ -122,7 +122,7 @@ beta;ElementPropertiesRequestOptions
 beta;ElementPropertiesRpcRequestOptions = PresentationRpcRequestOptions
 beta;ElementPropertiesStructArrayPropertyItem 
 beta;ElementPropertiesStructPropertyItem 
-alpha;ElementSelectionScopeParams
+alpha;ElementSelectionScopeProps
 public;EnumerationChoice
 public;EnumerationInfo
 alpha;ExpandedNodeUpdateRecord
@@ -192,6 +192,7 @@ public;IntRulesetVariable
 public;IntRulesetVariableJSON 
 public;IntsRulesetVariable 
 public;IntsRulesetVariableJSON 
+internal;isComputeSelectionRequestOptions
 internal;isContentDescriptorRequestOptions: 
 internal;isDisplayLabelRequestOptions: 
 internal;isDisplayLabelsRequestOptions: 
@@ -369,7 +370,7 @@ public;SelectClassInfoJSON
 public;SelectedNodeInstancesSpecification 
 public;SelectionInfo
 public;SelectionScope
-alpha;SelectionScopeParams = ElementSelectionScopeParams
+alpha;SelectionScopeProps = ElementSelectionScopeProps |
 public;SelectionScopeRequestOptions
 public;SelectionScopeRpcRequestOptions = PresentationRpcRequestOptions
 internal;SetRulesetVariableParams

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -27,6 +27,8 @@ internal;CommonIpcParams
 public;CompressedClassInfoJSON
 public;CompressedDescriptorJSON = Omit
 public;ComputeDisplayValueCallback = (type: string, value: PrimitivePropertyValue, displayValue: string) => Promise
+alpha;ComputeElementSelectionScopeProps
+alpha;ComputeSelectionScopeProps = ComputeElementSelectionScopeProps |
 public;ConditionContainer
 public;Content
 public;ContentDescriptorRequestOptions
@@ -120,6 +122,7 @@ beta;ElementPropertiesRequestOptions
 beta;ElementPropertiesRpcRequestOptions = PresentationRpcRequestOptions
 beta;ElementPropertiesStructArrayPropertyItem 
 beta;ElementPropertiesStructPropertyItem 
+alpha;ElementSelectionScopeParams
 public;EnumerationChoice
 public;EnumerationInfo
 alpha;ExpandedNodeUpdateRecord
@@ -366,6 +369,7 @@ public;SelectClassInfoJSON
 public;SelectedNodeInstancesSpecification 
 public;SelectionInfo
 public;SelectionScope
+alpha;SelectionScopeParams = ElementSelectionScopeParams
 public;SelectionScopeRequestOptions
 public;SelectionScopeRpcRequestOptions = PresentationRpcRequestOptions
 internal;SetRulesetVariableParams

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -4,6 +4,7 @@ internal;buildPagedResponse:
 alpha;consoleDiagnosticsHandler(scopeLogs: DiagnosticsScopeLogs[]): void
 alpha;createCombinedDiagnosticsHandler(handlers: DiagnosticsHandler[]): (scopeLogs: DiagnosticsScopeLogs[]) => void
 internal;createFieldOrderInfos: (field: Field) => FavoritePropertiesOrderInfo[]
+internal;createSelectionScopeProps(scope: SelectionScopeProps | SelectionScope | string | undefined): SelectionScopeProps
 public;FavoritePropertiesManager 
 public;FavoritePropertiesManagerProps
 public;FavoritePropertiesOrderInfo
@@ -11,7 +12,6 @@ public;FavoritePropertiesScope
 internal;getFieldInfos: (field: Field) => Set
 public;getScopeId(scope: SelectionScope | string | undefined): string
 deprecated;getScopeId(scope: SelectionScope | string | undefined): string
-internal;getScopeRequestProps(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined):
 internal;HILITE_RULESET: Ruleset
 public;HiliteSet
 public;HiliteSetProvider

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -10,6 +10,8 @@ public;FavoritePropertiesOrderInfo
 public;FavoritePropertiesScope
 internal;getFieldInfos: (field: Field) => Set
 public;getScopeId(scope: SelectionScope | string | undefined): string
+deprecated;getScopeId(scope: SelectionScope | string | undefined): string
+internal;getScopeRequestProps(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined):
 internal;HILITE_RULESET: Ruleset
 public;HiliteSet
 public;HiliteSetProvider

--- a/common/changes/@bentley/presentation-backend/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
+++ b/common/changes/@bentley/presentation-backend/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-backend",
+      "comment": "Add support for nth level element selection scopes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-common/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
+++ b/common/changes/@bentley/presentation-common/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-common",
+      "comment": "Add support for nth level element selection scopes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-common",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-components/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
+++ b/common/changes/@bentley/presentation-components/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-components",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/common/changes/@bentley/presentation-frontend/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
+++ b/common/changes/@bentley/presentation-frontend/presentation-nth-level-element-selection-scope_2022-06-03-12-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/presentation-frontend",
+      "comment": "Add support for nth level element selection scopes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/presentation-frontend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/full-stack-tests/presentation/src/frontend/SelectionScopes.test.ts
+++ b/full-stack-tests/presentation/src/frontend/SelectionScopes.test.ts
@@ -43,7 +43,7 @@ describe("Selection Scopes", () => {
 
   it("sets correct selection with 'element' 1st parent level selection scope", async () => {
     const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
-    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { scopeId: "element", ancestorLevel: 1 });
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", ancestorLevel: 1 });
     const selection = Presentation.selection.getSelection(imodel);
     expect(selection.size).to.eq(1);
     expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(27, 0) }));
@@ -59,7 +59,7 @@ describe("Selection Scopes", () => {
 
   it("sets correct selection with 'element' 2nd parent level selection scope", async () => {
     const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
-    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { scopeId: "element", ancestorLevel: 2 });
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", ancestorLevel: 2 });
     const selection = Presentation.selection.getSelection(imodel);
     expect(selection.size).to.eq(1);
     expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(1, 0) }));
@@ -67,7 +67,7 @@ describe("Selection Scopes", () => {
 
   it("sets correct selection with 'element' exceeding parent level selection scope", async () => {
     const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
-    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { scopeId: "element", ancestorLevel: 999 });
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", ancestorLevel: 999 });
     const selection = Presentation.selection.getSelection(imodel);
     expect(selection.size).to.eq(1);
     expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(1, 0) }));

--- a/full-stack-tests/presentation/src/frontend/SelectionScopes.test.ts
+++ b/full-stack-tests/presentation/src/frontend/SelectionScopes.test.ts
@@ -41,12 +41,36 @@ describe("Selection Scopes", () => {
     expect(selection.has({ className: elementProps[0].classFullName, id: elementProps[0].id! }));
   });
 
+  it("sets correct selection with 'element' 1st parent level selection scope", async () => {
+    const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", params: { level: 1 } });
+    const selection = Presentation.selection.getSelection(imodel);
+    expect(selection.size).to.eq(1);
+    expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(27, 0) }));
+  });
+
   it("sets correct selection with 'assembly' selection scope", async () => {
     const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
     await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, "assembly");
     const selection = Presentation.selection.getSelection(imodel);
     expect(selection.size).to.eq(1);
     expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(27, 0) }));
+  });
+
+  it("sets correct selection with 'element' 2nd parent level selection scope", async () => {
+    const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", params: { level: 2 } });
+    const selection = Presentation.selection.getSelection(imodel);
+    expect(selection.size).to.eq(1);
+    expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(1, 0) }));
+  });
+
+  it("sets correct selection with 'element' exceeding parent level selection scope", async () => {
+    const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", params: { level: 999 } });
+    const selection = Presentation.selection.getSelection(imodel);
+    expect(selection.size).to.eq(1);
+    expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(1, 0) }));
   });
 
   it("sets correct selection with 'top-assembly' selection scope", async () => {

--- a/full-stack-tests/presentation/src/frontend/SelectionScopes.test.ts
+++ b/full-stack-tests/presentation/src/frontend/SelectionScopes.test.ts
@@ -43,7 +43,7 @@ describe("Selection Scopes", () => {
 
   it("sets correct selection with 'element' 1st parent level selection scope", async () => {
     const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
-    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", params: { level: 1 } });
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { scopeId: "element", ancestorLevel: 1 });
     const selection = Presentation.selection.getSelection(imodel);
     expect(selection.size).to.eq(1);
     expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(27, 0) }));
@@ -59,7 +59,7 @@ describe("Selection Scopes", () => {
 
   it("sets correct selection with 'element' 2nd parent level selection scope", async () => {
     const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
-    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", params: { level: 2 } });
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { scopeId: "element", ancestorLevel: 2 });
     const selection = Presentation.selection.getSelection(imodel);
     expect(selection.size).to.eq(1);
     expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(1, 0) }));
@@ -67,7 +67,7 @@ describe("Selection Scopes", () => {
 
   it("sets correct selection with 'element' exceeding parent level selection scope", async () => {
     const elementProps = await imodel.elements.getProps(Id64.fromUint32Pair(28, 0));
-    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { id: "element", params: { level: 999 } });
+    await Presentation.selection.addToSelectionWithScope("", imodel, elementProps[0].id!, { scopeId: "element", ancestorLevel: 999 });
     const selection = Presentation.selection.getSelection(imodel);
     expect(selection.size).to.eq(1);
     expect(selection.has({ className: "BisCore:Subject", id: Id64.fromUint32Pair(1, 0) }));

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -12,12 +12,12 @@ import { ClientRequestContext, Id64String, Logger } from "@bentley/bentleyjs-cor
 import { BriefcaseDb, IModelDb, IModelJsNative, IpcHost } from "@bentley/imodeljs-backend";
 import { FormatProps } from "@bentley/imodeljs-quantity";
 import {
-  Content, ContentDescriptorRequestOptions, ContentFlags, ContentRequestOptions, DefaultContentDisplayTypes, Descriptor, DescriptorOverrides,
-  DiagnosticsOptionsWithHandler, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DisplayValueGroup, DistinctValuesRequestOptions,
-  ElementProperties, ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, getLocalesDirectory,
-  HierarchyCompareInfo, HierarchyCompareOptions, HierarchyRequestOptions, InstanceKey, KeySet, LabelDefinition, LabelRequestOptions, Node, NodeKey,
-  NodePathElement, Paged, PagedResponse, PartialHierarchyModification, PresentationError, PresentationStatus, PresentationUnitSystem, RequestPriority,
-  Ruleset, SelectionInfo, SelectionScope, SelectionScopeParams, SelectionScopeRequestOptions,
+  ComputeSelectionRequestOptions, Content, ContentDescriptorRequestOptions, ContentFlags, ContentRequestOptions, DefaultContentDisplayTypes,
+  Descriptor, DescriptorOverrides, DiagnosticsOptionsWithHandler, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DisplayValueGroup,
+  DistinctValuesRequestOptions, ElementProperties, ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions,
+  getLocalesDirectory, HierarchyCompareInfo, HierarchyCompareOptions, HierarchyRequestOptions, InstanceKey, isComputeSelectionRequestOptions, KeySet, LabelDefinition,
+  LabelRequestOptions, Node, NodeKey, NodePathElement, Paged, PagedResponse, PartialHierarchyModification, PresentationError, PresentationStatus,
+  PresentationUnitSystem, RequestPriority, Ruleset, SelectionInfo, SelectionScope, SelectionScopeRequestOptions,
 } from "@bentley/presentation-common";
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { PRESENTATION_BACKEND_ASSETS_ROOT, PRESENTATION_COMMON_ASSETS_ROOT } from "./Constants";
@@ -901,13 +901,21 @@ export class PresentationManager {
    * Computes selection set based on provided selection scope.
    * @public
    */
-  public async computeSelection(requestOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams }>): Promise<KeySet>;
-  public async computeSelection(requestContextOrOptions: ClientRequestContext | WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams }>, deprecatedRequestOptions?: SelectionScopeRequestOptions<IModelDb>, deprecatedIds?: Id64String[], deprecatedScopeId?: string): Promise<KeySet> {
+  public async computeSelection(requestOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string }>): Promise<KeySet>;
+  /** @alpha */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  public async computeSelection(requestOptions: WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>>): Promise<KeySet>;
+  public async computeSelection(requestContextOrOptions: ClientRequestContext | WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>> | WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string }>, deprecatedRequestOptions?: SelectionScopeRequestOptions<IModelDb>, deprecatedIds?: Id64String[], deprecatedScopeId?: string): Promise<KeySet> {
     if (requestContextOrOptions instanceof ClientRequestContext) {
-      return this.computeSelection({ ...deprecatedRequestOptions!, requestContext: requestContextOrOptions, ids: deprecatedIds!, scopeId: deprecatedScopeId! });
+      return this.computeSelection({ ...deprecatedRequestOptions!, requestContext: requestContextOrOptions, elementIds: deprecatedIds!, scopeId: deprecatedScopeId! });
     }
-    const { requestContext, ids, scopeId, scopeParams, ...requestOptions } = requestContextOrOptions; // eslint-disable-line @typescript-eslint/no-unused-vars
-    return SelectionScopesHelper.computeSelection(requestOptions, ids, scopeId, scopeParams);
+    const { requestContext, ...requestOptions } = requestContextOrOptions; // eslint-disable-line @typescript-eslint/no-unused-vars
+    return SelectionScopesHelper.computeSelection(isComputeSelectionRequestOptions(requestOptions)
+      ? requestOptions
+      : (function () {
+        const { ids, ...rest } = requestOptions;
+        return { ...rest, elementIds: ids };
+      })());
   }
 
   private async request<TParams extends { requestContext: ClientRequestContext, diagnostics?: DiagnosticsOptionsWithHandler, requestId: string, imodel: IModelDb, locale?: string, unitSystem?: PresentationUnitSystem }, TResult>(params: TParams, reviver?: (key: string, value: any) => any): Promise<TResult> {

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -907,14 +907,14 @@ export class PresentationManager {
   public async computeSelection(requestOptions: WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>>): Promise<KeySet>;
   public async computeSelection(requestContextOrOptions: ClientRequestContext | WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>> | WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string }>, deprecatedRequestOptions?: SelectionScopeRequestOptions<IModelDb>, deprecatedIds?: Id64String[], deprecatedScopeId?: string): Promise<KeySet> {
     if (requestContextOrOptions instanceof ClientRequestContext) {
-      return this.computeSelection({ ...deprecatedRequestOptions!, requestContext: requestContextOrOptions, elementIds: deprecatedIds!, scopeId: deprecatedScopeId! });
+      return this.computeSelection({ ...deprecatedRequestOptions!, requestContext: requestContextOrOptions, elementIds: deprecatedIds!, scope: { id: deprecatedScopeId! } });
     }
     const { requestContext, ...requestOptions } = requestContextOrOptions; // eslint-disable-line @typescript-eslint/no-unused-vars
     return SelectionScopesHelper.computeSelection(isComputeSelectionRequestOptions(requestOptions)
       ? requestOptions
       : (function () {
-        const { ids, ...rest } = requestOptions;
-        return { ...rest, elementIds: ids };
+        const { ids, scopeId, ...rest } = requestOptions;
+        return { ...rest, elementIds: ids, scope: { id: scopeId } };
       })());
   }
 

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -17,7 +17,7 @@ import {
   ElementProperties, ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, getLocalesDirectory,
   HierarchyCompareInfo, HierarchyCompareOptions, HierarchyRequestOptions, InstanceKey, KeySet, LabelDefinition, LabelRequestOptions, Node, NodeKey,
   NodePathElement, Paged, PagedResponse, PartialHierarchyModification, PresentationError, PresentationStatus, PresentationUnitSystem, RequestPriority,
-  Ruleset, SelectionInfo, SelectionScope, SelectionScopeRequestOptions,
+  Ruleset, SelectionInfo, SelectionScope, SelectionScopeParams, SelectionScopeRequestOptions,
 } from "@bentley/presentation-common";
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { PRESENTATION_BACKEND_ASSETS_ROOT, PRESENTATION_COMMON_ASSETS_ROOT } from "./Constants";
@@ -901,13 +901,13 @@ export class PresentationManager {
    * Computes selection set based on provided selection scope.
    * @public
    */
-  public async computeSelection(requestOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string }>): Promise<KeySet>;
-  public async computeSelection(requestContextOrOptions: ClientRequestContext | WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string }>, deprecatedRequestOptions?: SelectionScopeRequestOptions<IModelDb>, deprecatedIds?: Id64String[], deprecatedScopeId?: string): Promise<KeySet> {
+  public async computeSelection(requestOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams }>): Promise<KeySet>;
+  public async computeSelection(requestContextOrOptions: ClientRequestContext | WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams }>, deprecatedRequestOptions?: SelectionScopeRequestOptions<IModelDb>, deprecatedIds?: Id64String[], deprecatedScopeId?: string): Promise<KeySet> {
     if (requestContextOrOptions instanceof ClientRequestContext) {
       return this.computeSelection({ ...deprecatedRequestOptions!, requestContext: requestContextOrOptions, ids: deprecatedIds!, scopeId: deprecatedScopeId! });
     }
-    const { requestContext, ids, scopeId, ...requestOptions } = requestContextOrOptions; // eslint-disable-line @typescript-eslint/no-unused-vars
-    return SelectionScopesHelper.computeSelection(requestOptions, ids, scopeId);
+    const { requestContext, ids, scopeId, scopeParams, ...requestOptions } = requestContextOrOptions; // eslint-disable-line @typescript-eslint/no-unused-vars
+    return SelectionScopesHelper.computeSelection(requestOptions, ids, scopeId, scopeParams);
   }
 
   private async request<TParams extends { requestContext: ClientRequestContext, diagnostics?: DiagnosticsOptionsWithHandler, requestId: string, imodel: IModelDb, locale?: string, unitSystem?: PresentationUnitSystem }, TResult>(params: TParams, reviver?: (key: string, value: any) => any): Promise<TResult> {

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -10,15 +10,15 @@ import { ClientRequestContext, Id64String, Logger } from "@bentley/bentleyjs-cor
 import { IModelDb } from "@bentley/imodeljs-backend";
 import { IModelRpcProps } from "@bentley/imodeljs-common";
 import {
-  ContentDescriptorRpcRequestOptions, ContentJSON, ContentRpcRequestOptions, Descriptor, DescriptorJSON, DescriptorOverrides, DiagnosticsOptions,
-  DiagnosticsScopeLogs, DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions, DisplayValueGroup, DisplayValueGroupJSON,
-  DistinctValuesRpcRequestOptions, ElementProperties, ElementPropertiesRpcRequestOptions, ExtendedContentRpcRequestOptions,
+  ComputeSelectionRpcRequestOptions, ContentDescriptorRpcRequestOptions, ContentJSON, ContentRpcRequestOptions, Descriptor, DescriptorJSON,
+  DescriptorOverrides, DiagnosticsOptions, DiagnosticsScopeLogs, DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions, DisplayValueGroup,
+  DisplayValueGroupJSON, DistinctValuesRpcRequestOptions, ElementProperties, ElementPropertiesRpcRequestOptions, ExtendedContentRpcRequestOptions,
   ExtendedHierarchyRpcRequestOptions, HierarchyCompareInfo, HierarchyCompareInfoJSON, HierarchyCompareRpcOptions, HierarchyRpcRequestOptions,
-  InstanceKey, InstanceKeyJSON, isContentDescriptorRequestOptions, isDisplayLabelRequestOptions, isExtendedContentRequestOptions,
-  isExtendedHierarchyRequestOptions, ItemJSON, KeySet, KeySetJSON, LabelDefinition, LabelDefinitionJSON, LabelRpcRequestOptions, Node, NodeJSON,
-  NodeKey, NodeKeyJSON, NodePathElement, NodePathElementJSON, Paged, PagedResponse, PageOptions, PartialHierarchyModification,
-  PartialHierarchyModificationJSON, PresentationError, PresentationRpcInterface, PresentationRpcResponse, PresentationStatus, Ruleset,
-  RulesetVariable, RulesetVariableJSON, SelectionInfo, SelectionScope, SelectionScopeParams, SelectionScopeRpcRequestOptions,
+  InstanceKey, InstanceKeyJSON, isComputeSelectionRequestOptions, isContentDescriptorRequestOptions, isDisplayLabelRequestOptions,
+  isExtendedContentRequestOptions, isExtendedHierarchyRequestOptions, ItemJSON, KeySet, KeySetJSON, LabelDefinition, LabelDefinitionJSON,
+  LabelRpcRequestOptions, Node, NodeJSON, NodeKey, NodeKeyJSON, NodePathElement, NodePathElementJSON, Paged, PagedResponse, PageOptions,
+  PartialHierarchyModification, PartialHierarchyModificationJSON, PresentationError, PresentationRpcInterface, PresentationRpcResponse,
+  PresentationStatus, Ruleset, RulesetVariable, RulesetVariableJSON, SelectionInfo, SelectionScope, SelectionScopeRpcRequestOptions,
 } from "@bentley/presentation-common";
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { Presentation } from "./Presentation";
@@ -369,8 +369,15 @@ export class PresentationRpcImpl extends PresentationRpcInterface {
     );
   }
 
-  public override async computeSelection(token: IModelRpcProps, requestOptions: SelectionScopeRpcRequestOptions, ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams): PresentationRpcResponse<KeySetJSON> {
-    return this.makeRequest(token, "computeSelection", { ...requestOptions, ids, scopeId, scopeParams }, async (options) => {
+  public override async computeSelection(token: IModelRpcProps, requestOptions: ComputeSelectionRpcRequestOptions | SelectionScopeRpcRequestOptions, ids?: Id64String[], scopeId?: string): PresentationRpcResponse<KeySetJSON> {
+    return this.makeRequest(token, "computeSelection", requestOptions, async (options) => {
+      if (!isComputeSelectionRequestOptions(options)) {
+        options = {
+          ...options,
+          elementIds: ids!,
+          scopeId: scopeId!,
+        };
+      }
       const keys = await this.getManager(requestOptions.clientId).computeSelection(options);
       return keys.toJSON();
     });

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -375,7 +375,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface {
         options = {
           ...options,
           elementIds: ids!,
-          scopeId: scopeId!,
+          scope: { id: scopeId! },
         };
       }
       const keys = await this.getManager(requestOptions.clientId).computeSelection(options);

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -18,7 +18,7 @@ import {
   isExtendedHierarchyRequestOptions, ItemJSON, KeySet, KeySetJSON, LabelDefinition, LabelDefinitionJSON, LabelRpcRequestOptions, Node, NodeJSON,
   NodeKey, NodeKeyJSON, NodePathElement, NodePathElementJSON, Paged, PagedResponse, PageOptions, PartialHierarchyModification,
   PartialHierarchyModificationJSON, PresentationError, PresentationRpcInterface, PresentationRpcResponse, PresentationStatus, Ruleset,
-  RulesetVariable, RulesetVariableJSON, SelectionInfo, SelectionScope, SelectionScopeRpcRequestOptions,
+  RulesetVariable, RulesetVariableJSON, SelectionInfo, SelectionScope, SelectionScopeParams, SelectionScopeRpcRequestOptions,
 } from "@bentley/presentation-common";
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory";
 import { Presentation } from "./Presentation";
@@ -369,8 +369,8 @@ export class PresentationRpcImpl extends PresentationRpcInterface {
     );
   }
 
-  public override async computeSelection(token: IModelRpcProps, requestOptions: SelectionScopeRpcRequestOptions, ids: Id64String[], scopeId: string): PresentationRpcResponse<KeySetJSON> {
-    return this.makeRequest(token, "computeSelection", { ...requestOptions, ids, scopeId }, async (options) => {
+  public override async computeSelection(token: IModelRpcProps, requestOptions: SelectionScopeRpcRequestOptions, ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams): PresentationRpcResponse<KeySetJSON> {
+    return this.makeRequest(token, "computeSelection", { ...requestOptions, ids, scopeId, scopeParams }, async (options) => {
       const keys = await this.getManager(requestOptions.clientId).computeSelection(options);
       return keys.toJSON();
     });

--- a/presentation/backend/src/presentation-backend/SelectionScopesHelper.ts
+++ b/presentation/backend/src/presentation-backend/SelectionScopesHelper.ts
@@ -223,12 +223,12 @@ export class SelectionScopesHelper {
       return this.computeSelection({
         ...requestOptions,
         elementIds: elementIds!,
-        scopeId: scopeId!,
+        scope: { id: scopeId! },
       });
     }
 
-    switch (requestOptions.scopeId) {
-      case "element": return this.computeElementSelection(requestOptions.imodel, requestOptions.elementIds, (requestOptions as ElementSelectionScopeProps).ancestorLevel ?? 0);
+    switch (requestOptions.scope.id) {
+      case "element": return this.computeElementSelection(requestOptions.imodel, requestOptions.elementIds, (requestOptions.scope as ElementSelectionScopeProps).ancestorLevel ?? 0);
       case "assembly": return this.computeElementSelection(requestOptions.imodel, requestOptions.elementIds, 1);
       case "top-assembly": return this.computeElementSelection(requestOptions.imodel, requestOptions.elementIds, Number.MAX_SAFE_INTEGER);
       case "category": return this.computeCategorySelection(requestOptions.imodel, requestOptions.elementIds);

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -2944,7 +2944,7 @@ describe("PresentationManager", () => {
       const resultKeys = new KeySet();
       const stub = sinon.stub(SelectionScopesHelper, "computeSelection").resolves(resultKeys);
       const result = await manager.computeSelection(ClientRequestContext.current, { imodel: imodel.object }, ids, "test scope");
-      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds: ids, scopeId: "test scope" });
+      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds: ids, scope: { id: "test scope" } });
       expect(result).to.eq(resultKeys);
     });
 
@@ -2953,7 +2953,7 @@ describe("PresentationManager", () => {
       const resultKeys = new KeySet();
       const stub = sinon.stub(SelectionScopesHelper, "computeSelection").resolves(resultKeys);
       const result = await manager.computeSelection({ requestContext: ClientRequestContext.current, imodel: imodel.object, ids, scopeId: "test scope" });
-      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds: ids, scopeId: "test scope" });
+      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds: ids, scope: { id: "test scope" } });
       expect(result).to.eq(resultKeys);
     });
 
@@ -2961,8 +2961,8 @@ describe("PresentationManager", () => {
       const elementIds = [createRandomId()];
       const resultKeys = new KeySet();
       const stub = sinon.stub(SelectionScopesHelper, "computeSelection").resolves(resultKeys);
-      const result = await manager.computeSelection({ requestContext: ClientRequestContext.current, imodel: imodel.object, elementIds, scopeId: "element", ancestorLevel: 123 });
-      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds, scopeId: "element", ancestorLevel: 123 });
+      const result = await manager.computeSelection({ requestContext: ClientRequestContext.current, imodel: imodel.object, elementIds, scope: { id: "element", ancestorLevel: 123 } });
+      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds, scope: { id: "element", ancestorLevel: 123 } });
       expect(result).to.eq(resultKeys);
     });
 

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -2944,7 +2944,7 @@ describe("PresentationManager", () => {
       const resultKeys = new KeySet();
       const stub = sinon.stub(SelectionScopesHelper, "computeSelection").resolves(resultKeys);
       const result = await manager.computeSelection(ClientRequestContext.current, { imodel: imodel.object }, ids, "test scope");
-      expect(stub).to.be.calledOnceWith({ imodel: imodel.object }, ids, "test scope");
+      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds: ids, scopeId: "test scope" });
       expect(result).to.eq(resultKeys);
     });
 
@@ -2953,7 +2953,16 @@ describe("PresentationManager", () => {
       const resultKeys = new KeySet();
       const stub = sinon.stub(SelectionScopesHelper, "computeSelection").resolves(resultKeys);
       const result = await manager.computeSelection({ requestContext: ClientRequestContext.current, imodel: imodel.object, ids, scopeId: "test scope" });
-      expect(stub).to.be.calledOnceWith({ imodel: imodel.object }, ids, "test scope");
+      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds: ids, scopeId: "test scope" });
+      expect(result).to.eq(resultKeys);
+    });
+
+    it("computes element selection using `SelectionScopesHelper`", async () => {
+      const elementIds = [createRandomId()];
+      const resultKeys = new KeySet();
+      const stub = sinon.stub(SelectionScopesHelper, "computeSelection").resolves(resultKeys);
+      const result = await manager.computeSelection({ requestContext: ClientRequestContext.current, imodel: imodel.object, elementIds, scopeId: "element", ancestorLevel: 123 });
+      expect(stub).to.be.calledOnceWith({ imodel: imodel.object, elementIds, scopeId: "element", ancestorLevel: 123 });
       expect(result).to.eq(resultKeys);
     });
 

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -1628,7 +1628,7 @@ describe("PresentationRpcImpl", () => {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
           elementIds: ids,
-          scopeId: scope.id,
+          scope: { id: scope.id },
         };
         const result = new KeySet();
         presentationManagerMock.setup(async (x) => x.computeSelection(managerOptions))
@@ -1646,15 +1646,19 @@ describe("PresentationRpcImpl", () => {
         const rpcOptions: ComputeSelectionRpcRequestOptions = {
           ...defaultRpcParams,
           elementIds,
-          scopeId,
-          ancestorLevel,
-        } as any;
+          scope: {
+            id: scopeId,
+            ancestorLevel,
+          },
+        };
         const managerOptions: WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
           elementIds,
-          scopeId,
-          ancestorLevel,
+          scope: {
+            id: scopeId,
+            ancestorLevel,
+          },
         };
         const result = new KeySet();
         presentationManagerMock.setup(async (x) => x.computeSelection(managerOptions))

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -16,8 +16,8 @@ import {
   ElementPropertiesRpcRequestOptions, ExtendedContentRequestOptions, ExtendedContentRpcRequestOptions, ExtendedHierarchyRequestOptions,
   ExtendedHierarchyRpcRequestOptions, FieldDescriptor, FieldDescriptorType, HierarchyCompareInfo, HierarchyCompareOptions, HierarchyCompareRpcOptions,
   HierarchyRequestOptions, HierarchyRpcRequestOptions, InstanceKey, Item, KeySet, KeySetJSON, Node, NodeKey, NodePathElement, Paged, PageOptions,
-  PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable, RulesetVariableJSON, SelectionScopeRequestOptions,
-  VariableValueTypes,
+  PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable, RulesetVariableJSON, SelectionScopeParams,
+  SelectionScopeRequestOptions, VariableValueTypes,
 } from "@bentley/presentation-common";
 import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { ResolvablePromise } from "@bentley/presentation-common/lib/test/_helpers/Promises";
@@ -1620,21 +1620,23 @@ describe("PresentationRpcImpl", () => {
 
       it("calls manager", async () => {
         const scope = createRandomSelectionScope();
+        const scopeParams = { level: 123 };
         const ids = [createRandomId()];
         const rpcOptions: PresentationRpcRequestOptions<SelectionScopeRequestOptions<never>> = {
           ...defaultRpcParams,
         };
-        const managerOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string }> = {
+        const managerOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams }> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
           ids,
           scopeId: scope.id,
+          scopeParams,
         };
         const result = new KeySet();
         presentationManagerMock.setup(async (x) => x.computeSelection(managerOptions))
           .returns(async () => result)
           .verifiable();
-        const actualResult = await impl.computeSelection(testData.imodelToken, rpcOptions, ids, scope.id);
+        const actualResult = await impl.computeSelection(testData.imodelToken, rpcOptions, ids, scope.id, scopeParams);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(result.toJSON());
       });

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -6,18 +6,18 @@
 import { expect } from "chai";
 import * as faker from "faker";
 import * as sinon from "sinon";
-import { ClientRequestContext, CompressedId64Set, Id64String } from "@bentley/bentleyjs-core";
+import { ClientRequestContext, CompressedId64Set } from "@bentley/bentleyjs-core";
 import { IModelDb } from "@bentley/imodeljs-backend";
 import { IModelNotFoundResponse, IModelRpcProps } from "@bentley/imodeljs-common";
 import {
-  ContentDescriptorRequestOptions, ContentDescriptorRpcRequestOptions, ContentRequestOptions, ContentRpcRequestOptions, Descriptor, DescriptorJSON,
-  DescriptorOverrides, DiagnosticsScopeLogs, DisplayLabelRequestOptions, DisplayLabelRpcRequestOptions, DisplayLabelsRequestOptions,
-  DisplayLabelsRpcRequestOptions, DistinctValuesRequestOptions, ElementProperties, ElementPropertiesRequestOptions,
-  ElementPropertiesRpcRequestOptions, ExtendedContentRequestOptions, ExtendedContentRpcRequestOptions, ExtendedHierarchyRequestOptions,
-  ExtendedHierarchyRpcRequestOptions, FieldDescriptor, FieldDescriptorType, HierarchyCompareInfo, HierarchyCompareOptions, HierarchyCompareRpcOptions,
-  HierarchyRequestOptions, HierarchyRpcRequestOptions, InstanceKey, Item, KeySet, KeySetJSON, Node, NodeKey, NodePathElement, Paged, PageOptions,
-  PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable, RulesetVariableJSON, SelectionScopeParams,
-  SelectionScopeRequestOptions, VariableValueTypes,
+  ComputeSelectionRequestOptions, ComputeSelectionRpcRequestOptions, ContentDescriptorRequestOptions, ContentDescriptorRpcRequestOptions,
+  ContentRequestOptions, ContentRpcRequestOptions, Descriptor, DescriptorJSON, DescriptorOverrides, DiagnosticsScopeLogs, DisplayLabelRequestOptions,
+  DisplayLabelRpcRequestOptions, DisplayLabelsRequestOptions, DisplayLabelsRpcRequestOptions, DistinctValuesRequestOptions, ElementProperties,
+  ElementPropertiesRequestOptions, ElementPropertiesRpcRequestOptions, ExtendedContentRequestOptions, ExtendedContentRpcRequestOptions,
+  ExtendedHierarchyRequestOptions, ExtendedHierarchyRpcRequestOptions, FieldDescriptor, FieldDescriptorType, HierarchyCompareInfo,
+  HierarchyCompareOptions, HierarchyCompareRpcOptions, HierarchyRequestOptions, HierarchyRpcRequestOptions, InstanceKey, Item, KeySet, KeySetJSON,
+  Node, NodeKey, NodePathElement, Paged, PageOptions, PresentationError, PresentationRpcRequestOptions, PresentationStatus, RulesetVariable,
+  RulesetVariableJSON, SelectionScopeRequestOptions, VariableValueTypes,
 } from "@bentley/presentation-common";
 import * as moq from "@bentley/presentation-common/lib/test/_helpers/Mocks";
 import { ResolvablePromise } from "@bentley/presentation-common/lib/test/_helpers/Promises";
@@ -1618,25 +1618,49 @@ describe("PresentationRpcImpl", () => {
 
     describe("computeSelection", () => {
 
-      it("calls manager", async () => {
+      it("[deprecated] calls manager", async () => {
         const scope = createRandomSelectionScope();
-        const scopeParams = { level: 123 };
         const ids = [createRandomId()];
         const rpcOptions: PresentationRpcRequestOptions<SelectionScopeRequestOptions<never>> = {
           ...defaultRpcParams,
         };
-        const managerOptions: WithClientRequestContext<SelectionScopeRequestOptions<IModelDb> & { ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams }> = {
+        const managerOptions: WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>> = {
           requestContext: ClientRequestContext.current,
           imodel: testData.imodelMock.object,
-          ids,
+          elementIds: ids,
           scopeId: scope.id,
-          scopeParams,
         };
         const result = new KeySet();
         presentationManagerMock.setup(async (x) => x.computeSelection(managerOptions))
           .returns(async () => result)
           .verifiable();
-        const actualResult = await impl.computeSelection(testData.imodelToken, rpcOptions, ids, scope.id, scopeParams);
+        const actualResult = await impl.computeSelection(testData.imodelToken, rpcOptions, ids, scope.id);
+        presentationManagerMock.verifyAll();
+        expect(actualResult.result).to.deep.eq(result.toJSON());
+      });
+
+      it("calls manager", async () => {
+        const scopeId = "element";
+        const ancestorLevel = 123;
+        const elementIds = [createRandomId()];
+        const rpcOptions: ComputeSelectionRpcRequestOptions = {
+          ...defaultRpcParams,
+          elementIds,
+          scopeId,
+          ancestorLevel,
+        } as any;
+        const managerOptions: WithClientRequestContext<ComputeSelectionRequestOptions<IModelDb>> = {
+          requestContext: ClientRequestContext.current,
+          imodel: testData.imodelMock.object,
+          elementIds,
+          scopeId,
+          ancestorLevel,
+        };
+        const result = new KeySet();
+        presentationManagerMock.setup(async (x) => x.computeSelection(managerOptions))
+          .returns(async () => result)
+          .verifiable();
+        const actualResult = await impl.computeSelection(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(result.toJSON());
       });

--- a/presentation/backend/src/test/SelectionScopesHelper.test.ts
+++ b/presentation/backend/src/test/SelectionScopesHelper.test.ts
@@ -194,7 +194,7 @@ describe("SelectionScopesHelper", () => {
         const element = setupIModelForElementProps({ key: createRandomECInstanceKey(), parentKey: parent1.key });
         setupIModelForElementKey(parent2.key);
 
-        const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object, elementIds: [element.key.id], scopeId: "element", ancestorLevel: 2 });
+        const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object, elementIds: [element.key.id], scope: { id: "element", ancestorLevel: 2 } });
         expect(result.size).to.eq(1);
         expect(result.has(parent2.key)).to.be.true;
       });

--- a/presentation/backend/src/test/SelectionScopesHelper.test.ts
+++ b/presentation/backend/src/test/SelectionScopesHelper.test.ts
@@ -38,7 +38,8 @@ describe("SelectionScopesHelper", () => {
     const modelsMock = moq.Mock.ofType<IModelDb.Models>();
 
     const setupIModelForElementKey = (key: InstanceKey) => {
-      imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).callback((_q, cb) => {
+      // this mock simulates the element key query returning a single row with results for the given key (`getElementKey` in Utils.ts)
+      imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((q) => (typeof q === "string" && q.includes("SELECT ECClassId FROM"))), moq.It.isAny())).callback((_q, cb) => {
         const valueMock = moq.Mock.ofType<ECSqlValue>();
         valueMock.setup((x) => x.getClassNameForClassId()).returns(() => key.className);
         const stmtMock = moq.Mock.ofType<ECSqlStatement>();
@@ -49,8 +50,8 @@ describe("SelectionScopesHelper", () => {
     };
 
     const setupIModelForInvalidId = () => {
-      // this mock simulates trying to bind an invalid id
-      imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).callback((_q, cb) => {
+      // this mock simulates trying to bind an invalid id to the element key query (`getElementKey` in Utils.ts)
+      imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((q) => (typeof q === "string" && q.includes("SELECT ECClassId FROM"))), moq.It.isAny())).callback((_q, cb) => {
         const stmtMock = moq.Mock.ofType<ECSqlStatement>();
         stmtMock.setup((x) => x.bindId(moq.It.isAnyNumber(), moq.It.isAny())).throws(new IModelError(DbResult.BE_SQLITE_ERROR, "Error binding Id"));
         stmtMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_ERROR);
@@ -59,6 +60,7 @@ describe("SelectionScopesHelper", () => {
     };
 
     const setupIModelForNoResultStatement = () => {
+      // this mock simulates any kind of query returning no results
       imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).callback((_q, cb) => {
         const stmtMock = moq.Mock.ofType<ECSqlStatement>();
         stmtMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
@@ -101,7 +103,8 @@ describe("SelectionScopesHelper", () => {
     const createTransientElementId = () => Id64.fromLocalAndBriefcaseIds(faker.random.number(), 0xffffff);
 
     const setupIModelForFunctionalKeyQuery = (props: { graphicalElementKey: InstanceKey, stepResult?: DbResult, functionalElementKey?: InstanceKey }) => {
-      imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns((_q, cb) => {
+      const functionalKeyQueryIdentifier = "SELECT funcSchemaDef.Name || '.' || funcClassDef.Name funcElClassName, fe.ECInstanceId funcElId";
+      imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((q) => (typeof q === "string" && q.includes(functionalKeyQueryIdentifier))), moq.It.isAny())).returns((_q, cb) => {
         const stmtMock = moq.Mock.ofType<ECSqlStatement>();
         stmtMock.setup((x) => x.step()).returns(() => props.stepResult ?? DbResult.BE_SQLITE_ROW);
         stmtMock.setup((x) => x.getRow()).returns(() => ({
@@ -112,17 +115,16 @@ describe("SelectionScopesHelper", () => {
       });
     };
 
-    const setupIModelForElementProps = (props?: { key?: InstanceKey, parentKey?: InstanceKey }) => {
+    const setupIModelForElementProps = (props?: { key?: InstanceKey, parentKey?: InstanceKey, isRemoved?: boolean }) => {
       const key = props?.key ?? createRandomECInstanceKey();
-      const elementProps = props?.parentKey ? createRandomElementProps(props.parentKey.id) : createRandomTopmostElementProps();
+      const elementProps = props?.isRemoved ? undefined : props?.parentKey ? createRandomElementProps(props.parentKey.id) : createRandomTopmostElementProps();
       elementsMock.setup((x) => x.tryGetElementProps(key.id)).returns(() => elementProps);
-      if (props?.parentKey)
-        setupIModelForElementKey(props.parentKey);
       return { key, props: elementProps };
     };
 
     const setupIModelDerivesFromClassQuery = (doesDeriveFromSuppliedClass: boolean) => {
-      imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns((_q, cb) => {
+      const classDerivesFromQueryIdentifier = "SELECT 1";
+      imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((q) => (typeof q === "string" && q.includes(classDerivesFromQueryIdentifier))), moq.It.isAny())).returns((_q, cb) => {
         const stmtMock = moq.Mock.ofType<ECSqlStatement>();
         stmtMock.setup((x) => x.step()).returns(() => doesDeriveFromSuppliedClass ? DbResult.BE_SQLITE_ROW : DbResult.BE_SQLITE_DONE);
         return cb(stmtMock.object);
@@ -183,6 +185,18 @@ describe("SelectionScopesHelper", () => {
         const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [validKeys[0].id, "not an id", validKeys[1].id], "element");
         expect(result.size).to.eq(2);
         validKeys.forEach((key) => expect(result.has(key)));
+      });
+
+      it("returns nth parent key", async () => {
+        const parent3 = setupIModelForElementProps({ key: createRandomECInstanceKey() });
+        const parent2 = setupIModelForElementProps({ key: createRandomECInstanceKey(), parentKey: parent3.key });
+        const parent1 = setupIModelForElementProps({ key: createRandomECInstanceKey(), parentKey: parent2.key });
+        const element = setupIModelForElementProps({ key: createRandomECInstanceKey(), parentKey: parent1.key });
+        setupIModelForElementKey(parent2.key);
+
+        const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [element.key.id], "element", { level: 2 });
+        expect(result.size).to.eq(1);
+        expect(result.has(parent2.key)).to.be.true;
       });
 
     });
@@ -546,6 +560,29 @@ describe("SelectionScopesHelper", () => {
         expect(result.has(graphicalElementKey)).to.be.true;
       });
 
+      it("skips removed GeometricElement2d parents when looking for closest functional element", async () => {
+        setupIModelDerivesFromClassQuery(false);
+
+        // set up one element with existing parent that has a related functional element
+        const functionalElement = setupIModelForElementProps({ key: createRandomECInstanceKey() });
+        const existingParent = setupIModelForElementProps({ key: createRandomECInstanceKey() });
+        const existingElement = setupIModelForElementProps({ key: createRandomECInstanceKey(), parentKey: existingParent.key });
+        setupIModelForFunctionalKeyQuery({ graphicalElementKey: existingElement.key });
+        setupIModelForFunctionalKeyQuery({ graphicalElementKey: existingParent.key, functionalElementKey: functionalElement.key });
+
+        // set up one element with removed parent
+        const removedParent = setupIModelForElementProps({ key: createRandomECInstanceKey(), isRemoved: true });
+        const elementWithRemovedParent = setupIModelForElementProps({ key: createRandomECInstanceKey(), parentKey: removedParent.key });
+        setupIModelForFunctionalKeyQuery({ graphicalElementKey: elementWithRemovedParent.key });
+        setupIModelForElementKey(elementWithRemovedParent.key);
+
+        // request
+        const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [existingElement.key.id, elementWithRemovedParent.key.id], "functional-element");
+        expect(result.size).to.eq(2);
+        expect(result.has(functionalElement.key)).to.be.true;
+        expect(result.has(elementWithRemovedParent.key)).to.be.true;
+      });
+
     });
 
     describe("scope: 'functional-assembly'", () => {
@@ -566,6 +603,7 @@ describe("SelectionScopesHelper", () => {
         const graphicalElementKey = createRandomECInstanceKey();
         setupIModelDerivesFromClassQuery(true);
         setupIModelForElementProps({ key: graphicalElementKey, parentKey: graphicalParentElementKey });
+        setupIModelForElementKey(graphicalParentElementKey);
         setupIModelForFunctionalKeyQuery({ graphicalElementKey: graphicalParentElementKey });
 
         const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [graphicalElementKey.id], "functional-assembly");
@@ -580,6 +618,7 @@ describe("SelectionScopesHelper", () => {
         const graphicalElementKey = createRandomECInstanceKey();
         setupIModelDerivesFromClassQuery(true);
         setupIModelForElementProps({ key: graphicalElementKey, parentKey: graphicalParentElementKey });
+        setupIModelForElementKey(graphicalParentElementKey);
         setupIModelForFunctionalKeyQuery({ graphicalElementKey: graphicalGrandParentElementKey, functionalElementKey });
 
         const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [graphicalElementKey.id], "functional-assembly");
@@ -647,6 +686,7 @@ describe("SelectionScopesHelper", () => {
         setupIModelForElementProps({ key: graphicalElementKey, parentKey: graphicalParentElementKey });
         setupIModelForFunctionalKeyQuery({ graphicalElementKey: graphicalParentElementKey, functionalElementKey });
         setupIModelForElementProps({ key: functionalElementKey, parentKey: functionalParentElementKey });
+        setupIModelForElementKey(functionalParentElementKey);
 
         const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [graphicalElementKey.id], "functional-assembly");
         expect(result.size).to.eq(1);
@@ -676,6 +716,7 @@ describe("SelectionScopesHelper", () => {
         setupIModelForElementProps({ key: graphicalElementKey, parentKey: graphicalParentElementKey });
         setupIModelForElementProps({ key: graphicalParentElementKey, parentKey: graphicalGrandParentElementKey });
         setupIModelForElementProps({ key: graphicalGrandParentElementKey });
+        setupIModelForElementKey(graphicalGrandParentElementKey);
         setupIModelForFunctionalKeyQuery({ graphicalElementKey: graphicalGrandParentElementKey });
 
         const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [graphicalElementKey.id], "functional-top-assembly");
@@ -692,6 +733,7 @@ describe("SelectionScopesHelper", () => {
         setupIModelForElementProps({ key: graphicalElementKey, parentKey: graphicalParentElementKey });
         setupIModelForElementProps({ key: graphicalParentElementKey, parentKey: graphicalGrandParentElementKey });
         setupIModelForElementProps({ key: graphicalGrandParentElementKey });
+        setupIModelForElementKey(graphicalGrandParentElementKey);
         setupIModelForFunctionalKeyQuery({ graphicalElementKey: graphicalGrandParentElementKey, functionalElementKey });
 
         const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [graphicalElementKey.id], "functional-top-assembly");

--- a/presentation/backend/src/test/SelectionScopesHelper.test.ts
+++ b/presentation/backend/src/test/SelectionScopesHelper.test.ts
@@ -194,7 +194,7 @@ describe("SelectionScopesHelper", () => {
         const element = setupIModelForElementProps({ key: createRandomECInstanceKey(), parentKey: parent1.key });
         setupIModelForElementKey(parent2.key);
 
-        const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object }, [element.key.id], "element", { level: 2 });
+        const result = await SelectionScopesHelper.computeSelection({ imodel: imodelMock.object, elementIds: [element.key.id], scopeId: "element", ancestorLevel: 2 });
         expect(result.size).to.eq(1);
         expect(result.has(parent2.key)).to.be.true;
       });

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -218,9 +218,10 @@ export interface SelectionScopeRequestOptions<TIModel> extends RequestOptions<TI
  * Request options used for calculating selection based on picked instance ksy and selection scope
  * @alpha
  */
-export type ComputeSelectionRequestOptions<TIModel> = RequestOptions<TIModel> & SelectionScopeProps & {
+export interface ComputeSelectionRequestOptions<TIModel> extends RequestOptions<TIModel> {
   elementIds: Id64String[];
-};
+  scope: SelectionScopeProps;
+}
 /** @internal */
 export function isComputeSelectionRequestOptions<TIModel>(options: ComputeSelectionRequestOptions<TIModel> | SelectionScopeRequestOptions<TIModel>): options is ComputeSelectionRequestOptions<TIModel> {
   return !!(options as ComputeSelectionRequestOptions<TIModel>).elementIds;

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -12,6 +12,7 @@ import { FieldDescriptor } from "./content/Fields";
 import { DiagnosticsOptionsWithHandler } from "./Diagnostics";
 import { Ruleset } from "./rules/Ruleset";
 import { RulesetVariable } from "./RulesetVariables";
+import { SelectionScopeProps } from "./selection/SelectionScope";
 
 /**
  * Enumeration of standard request priorities.
@@ -212,6 +213,18 @@ export const isDisplayLabelsRequestOptions = <TIModel, TInstanceKey>(opts: Label
  * @public
  */
 export interface SelectionScopeRequestOptions<TIModel> extends RequestOptions<TIModel> { } // eslint-disable-line @typescript-eslint/no-empty-interface
+
+/**
+ * Request options used for calculating selection based on picked instance ksy and selection scope
+ * @alpha
+ */
+export type ComputeSelectionRequestOptions<TIModel> = RequestOptions<TIModel> & SelectionScopeProps & {
+  elementIds: Id64String[];
+};
+/** @internal */
+export function isComputeSelectionRequestOptions<TIModel>(options: ComputeSelectionRequestOptions<TIModel> | SelectionScopeRequestOptions<TIModel>): options is ComputeSelectionRequestOptions<TIModel> {
+  return !!(options as ComputeSelectionRequestOptions<TIModel>).elementIds;
+}
 
 /**
  * Data structure for comparing presentation data after ruleset or ruleset variable changes.

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -141,7 +141,7 @@ export class PresentationRpcInterface extends RpcInterface {
   public static readonly interfaceName = "PresentationRpcInterface"; // eslint-disable-line @typescript-eslint/naming-convention
 
   /** The semantic version of the interface. */
-  public static interfaceVersion = "2.10.0";
+  public static interfaceVersion = "2.11.0";
 
   /*===========================================================================================
     NOTE: Any add/remove/change to the methods below requires an update of the interface version.
@@ -218,7 +218,7 @@ export class PresentationRpcInterface extends RpcInterface {
 
   public async getSelectionScopes(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions): PresentationRpcResponse<SelectionScope[]> { return this.forward(arguments); }
   // TODO: need to enforce paging on this
-  public async computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string): PresentationRpcResponse<KeySetJSON> { return this.forward(arguments); }
+  public async computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string, _scopeParams?: any): PresentationRpcResponse<KeySetJSON> { return this.forward(arguments); }
 
   /** @alpha @deprecated Use [[compareHierarchiesPaged]] */
   public async compareHierarchies(_token: IModelRpcProps, _options: HierarchyCompareRpcOptions): PresentationRpcResponse<PartialHierarchyModificationJSON[]> { return this.forward(arguments); }

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -22,9 +22,9 @@ import { NodePathElementJSON } from "./hierarchy/NodePathElement";
 import { KeySetJSON } from "./KeySet";
 import { LabelDefinitionJSON } from "./LabelDefinition";
 import {
-  ContentDescriptorRequestOptions, ContentRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DistinctValuesRequestOptions,
-  ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, HierarchyCompareOptions, HierarchyRequestOptions,
-  LabelRequestOptions, Paged, SelectionScopeRequestOptions,
+  ComputeSelectionRequestOptions, ContentDescriptorRequestOptions, ContentRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
+  DistinctValuesRequestOptions, ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions,
+  HierarchyCompareOptions, HierarchyRequestOptions, LabelRequestOptions, Paged, SelectionScopeRequestOptions,
 } from "./PresentationManagerOptions";
 import { RulesetVariableJSON } from "./RulesetVariables";
 import { SelectionScope } from "./selection/SelectionScope";
@@ -127,6 +127,11 @@ export type DisplayLabelsRpcRequestOptions = PresentationRpcRequestOptions<Displ
 export type SelectionScopeRpcRequestOptions = PresentationRpcRequestOptions<SelectionScopeRequestOptions<never>>;
 
 /**
+ * @alpha
+ */
+export type ComputeSelectionRpcRequestOptions = PresentationRpcRequestOptions<ComputeSelectionRequestOptions<never>>;
+
+/**
  * Data structure for comparing presentation data after ruleset or ruleset variable changes.
  * @public
  */
@@ -218,7 +223,10 @@ export class PresentationRpcInterface extends RpcInterface {
 
   public async getSelectionScopes(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions): PresentationRpcResponse<SelectionScope[]> { return this.forward(arguments); }
   // TODO: need to enforce paging on this
-  public async computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string, _scopeParams?: any): PresentationRpcResponse<KeySetJSON> { return this.forward(arguments); }
+  public async computeSelection(_token: IModelRpcProps, _options: SelectionScopeRpcRequestOptions, _ids: Id64String[], _scopeId: string): PresentationRpcResponse<KeySetJSON>;
+  /** @alpha */
+  public async computeSelection(_token: IModelRpcProps, _options: ComputeSelectionRpcRequestOptions): PresentationRpcResponse<KeySetJSON>;
+  public async computeSelection(_token: IModelRpcProps, _options: ComputeSelectionRpcRequestOptions | SelectionScopeRpcRequestOptions, _ids?: Id64String[], _scopeId?: string): PresentationRpcResponse<KeySetJSON> { return this.forward(arguments); }
 
   /** @alpha @deprecated Use [[compareHierarchiesPaged]] */
   public async compareHierarchies(_token: IModelRpcProps, _options: HierarchyCompareRpcOptions): PresentationRpcResponse<PartialHierarchyModificationJSON[]> { return this.forward(arguments); }

--- a/presentation/common/src/presentation-common/RpcRequestsHandler.ts
+++ b/presentation/common/src/presentation-common/RpcRequestsHandler.ts
@@ -6,7 +6,7 @@
  * @module RPC
  */
 
-import { Guid, Id64String, IDisposable } from "@bentley/bentleyjs-core";
+import { Guid, IDisposable } from "@bentley/bentleyjs-core";
 import { IModelRpcProps, RpcManager } from "@bentley/imodeljs-common";
 import { DescriptorJSON } from "./content/Descriptor";
 import { ItemJSON } from "./content/Item";
@@ -21,13 +21,13 @@ import { NodePathElementJSON } from "./hierarchy/NodePathElement";
 import { KeySetJSON } from "./KeySet";
 import { LabelDefinitionJSON } from "./LabelDefinition";
 import {
-  ContentDescriptorRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DistinctValuesRequestOptions,
-  ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, HierarchyCompareOptions, Paged, RequestOptions,
-  SelectionScopeRequestOptions,
+  ComputeSelectionRequestOptions, ContentDescriptorRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
+  DistinctValuesRequestOptions, ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions,
+  HierarchyCompareOptions, Paged, RequestOptions, SelectionScopeRequestOptions,
 } from "./PresentationManagerOptions";
 import { PresentationRpcInterface, PresentationRpcRequestOptions, PresentationRpcResponse } from "./PresentationRpcInterface";
 import { RulesetVariableJSON } from "./RulesetVariables";
-import { SelectionScope, SelectionScopeParams } from "./selection/SelectionScope";
+import { SelectionScope } from "./selection/SelectionScope";
 import { HierarchyCompareInfoJSON, PartialHierarchyModificationJSON } from "./Update";
 import { PagedResponse } from "./Utils";
 
@@ -185,9 +185,9 @@ export class RpcRequestsHandler implements IDisposable {
     return this.request<SelectionScope[], SelectionScopeRequestOptions<IModelRpcProps>>(
       this.rpcClient.getSelectionScopes.bind(this.rpcClient), options);
   }
-  public async computeSelection(options: SelectionScopeRequestOptions<IModelRpcProps>, ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams): Promise<KeySetJSON> {
-    return this.request<KeySetJSON, SelectionScopeRequestOptions<IModelRpcProps>>(
-      this.rpcClient.computeSelection.bind(this.rpcClient), options, ids, scopeId, scopeParams);
+  public async computeSelection(options: ComputeSelectionRequestOptions<IModelRpcProps>): Promise<KeySetJSON> {
+    return this.request<KeySetJSON, ComputeSelectionRequestOptions<IModelRpcProps>>(
+      this.rpcClient.computeSelection.bind(this.rpcClient), options);
   }
   public async compareHierarchies(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<PartialHierarchyModificationJSON[]> {
     return this.request<PartialHierarchyModificationJSON[], HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>(

--- a/presentation/common/src/presentation-common/RpcRequestsHandler.ts
+++ b/presentation/common/src/presentation-common/RpcRequestsHandler.ts
@@ -27,7 +27,7 @@ import {
 } from "./PresentationManagerOptions";
 import { PresentationRpcInterface, PresentationRpcRequestOptions, PresentationRpcResponse } from "./PresentationRpcInterface";
 import { RulesetVariableJSON } from "./RulesetVariables";
-import { SelectionScope } from "./selection/SelectionScope";
+import { SelectionScope, SelectionScopeParams } from "./selection/SelectionScope";
 import { HierarchyCompareInfoJSON, PartialHierarchyModificationJSON } from "./Update";
 import { PagedResponse } from "./Utils";
 
@@ -185,9 +185,9 @@ export class RpcRequestsHandler implements IDisposable {
     return this.request<SelectionScope[], SelectionScopeRequestOptions<IModelRpcProps>>(
       this.rpcClient.getSelectionScopes.bind(this.rpcClient), options);
   }
-  public async computeSelection(options: SelectionScopeRequestOptions<IModelRpcProps>, ids: Id64String[], scopeId: string): Promise<KeySetJSON> {
+  public async computeSelection(options: SelectionScopeRequestOptions<IModelRpcProps>, ids: Id64String[], scopeId: string, scopeParams?: SelectionScopeParams): Promise<KeySetJSON> {
     return this.request<KeySetJSON, SelectionScopeRequestOptions<IModelRpcProps>>(
-      this.rpcClient.computeSelection.bind(this.rpcClient), options, ids, scopeId);
+      this.rpcClient.computeSelection.bind(this.rpcClient), options, ids, scopeId, scopeParams);
   }
   public async compareHierarchies(options: HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>): Promise<PartialHierarchyModificationJSON[]> {
     return this.request<PartialHierarchyModificationJSON[], HierarchyCompareOptions<IModelRpcProps, NodeKeyJSON, RulesetVariableJSON>>(

--- a/presentation/common/src/presentation-common/selection/SelectionScope.ts
+++ b/presentation/common/src/presentation-common/selection/SelectionScope.ts
@@ -22,9 +22,9 @@ export interface SelectionScope {
 
 /** @alpha */
 export interface ElementSelectionScopeProps {
-  scopeId: "element";
+  id: "element";
   ancestorLevel?: number;
 }
 
 /** @alpha */
-export type SelectionScopeProps = ElementSelectionScopeProps | { scopeId: string };
+export type SelectionScopeProps = ElementSelectionScopeProps | { id: string };

--- a/presentation/common/src/presentation-common/selection/SelectionScope.ts
+++ b/presentation/common/src/presentation-common/selection/SelectionScope.ts
@@ -19,3 +19,20 @@ export interface SelectionScope {
   /** Description */
   description?: string;
 }
+
+/** @alpha */
+export interface ElementSelectionScopeParams {
+  level?: number;
+}
+
+/** @alpha */
+export type SelectionScopeParams = ElementSelectionScopeParams;
+
+/** @alpha */
+export interface ComputeElementSelectionScopeProps {
+  id: "element";
+  params?: ElementSelectionScopeParams;
+}
+
+/** @alpha */
+export type ComputeSelectionScopeProps = ComputeElementSelectionScopeProps | { id: string };

--- a/presentation/common/src/presentation-common/selection/SelectionScope.ts
+++ b/presentation/common/src/presentation-common/selection/SelectionScope.ts
@@ -21,18 +21,10 @@ export interface SelectionScope {
 }
 
 /** @alpha */
-export interface ElementSelectionScopeParams {
-  level?: number;
+export interface ElementSelectionScopeProps {
+  scopeId: "element";
+  ancestorLevel?: number;
 }
 
 /** @alpha */
-export type SelectionScopeParams = ElementSelectionScopeParams;
-
-/** @alpha */
-export interface ComputeElementSelectionScopeProps {
-  id: "element";
-  params?: ElementSelectionScopeParams;
-}
-
-/** @alpha */
-export type ComputeSelectionScopeProps = ComputeElementSelectionScopeProps | { id: string };
+export type SelectionScopeProps = ElementSelectionScopeProps | { scopeId: string };

--- a/presentation/common/src/test/PresentationManagerOptions.test.ts
+++ b/presentation/common/src/test/PresentationManagerOptions.test.ts
@@ -9,11 +9,12 @@ import { InstanceKey } from "../presentation-common/EC";
 import { NodeKey } from "../presentation-common/hierarchy/Key";
 import { KeySet } from "../presentation-common/KeySet";
 import {
-  ContentDescriptorRequestOptions, ContentRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, ExtendedContentRequestOptions,
-  ExtendedHierarchyRequestOptions, HierarchyRequestOptions, isContentDescriptorRequestOptions, isDisplayLabelRequestOptions,
-  isDisplayLabelsRequestOptions, isExtendedContentRequestOptions, isExtendedHierarchyRequestOptions, LabelRequestOptions,
+  ComputeSelectionRequestOptions, ContentDescriptorRequestOptions, ContentRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
+  ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, HierarchyRequestOptions, isComputeSelectionRequestOptions,
+  isContentDescriptorRequestOptions, isDisplayLabelRequestOptions, isDisplayLabelsRequestOptions, isExtendedContentRequestOptions,
+  isExtendedHierarchyRequestOptions, LabelRequestOptions, SelectionScopeRequestOptions,
 } from "../presentation-common/PresentationManagerOptions";
-import { createRandomBaseNodeKey, createRandomECInstanceKey } from "./_helpers/random";
+import { createRandomBaseNodeKey, createRandomECInstanceKey, createRandomId } from "./_helpers/random";
 
 describe("isContentDescriptorRequestOptions", () => {
 
@@ -114,6 +115,26 @@ describe("isDisplayLabelsRequestOptions ", () => {
       keys: [createRandomECInstanceKey(), createRandomECInstanceKey()],
     };
     expect(isDisplayLabelsRequestOptions(opts)).to.be.true;
+  });
+
+});
+
+describe("isComputeSelectionRequestOptions ", () => {
+
+  it("returns `false` for `SelectionScopeRequestOptions`", () => {
+    const opts: SelectionScopeRequestOptions<any> = {
+      imodel: undefined,
+    };
+    expect(isComputeSelectionRequestOptions(opts)).to.be.false;
+  });
+
+  it("returns `true` for `ComputeSelectionRequestOptions`", () => {
+    const opts: ComputeSelectionRequestOptions<any> = {
+      imodel: undefined,
+      elementIds: [createRandomId(), createRandomId()],
+      scopeId: "test",
+    };
+    expect(isComputeSelectionRequestOptions(opts)).to.be.true;
   });
 
 });

--- a/presentation/common/src/test/PresentationManagerOptions.test.ts
+++ b/presentation/common/src/test/PresentationManagerOptions.test.ts
@@ -132,7 +132,7 @@ describe("isComputeSelectionRequestOptions ", () => {
     const opts: ComputeSelectionRequestOptions<any> = {
       imodel: undefined,
       elementIds: [createRandomId(), createRandomId()],
-      scopeId: "test",
+      scope: { id: "test" },
     };
     expect(isComputeSelectionRequestOptions(opts)).to.be.true;
   });

--- a/presentation/common/src/test/PresentationRpcInterface.test.ts
+++ b/presentation/common/src/test/PresentationRpcInterface.test.ts
@@ -311,7 +311,7 @@ describe("PresentationRpcInterface", () => {
     it("forwards computeSelection call", async () => {
       const options: ComputeSelectionRpcRequestOptions = {
         elementIds: new Array<Id64String>(),
-        scopeId: faker.random.uuid(),
+        scope: { id: faker.random.uuid() },
       };
       await rpcInterface.computeSelection(token, options);
       expect(spy).to.be.calledOnceWith(toArguments(token, options));

--- a/presentation/common/src/test/PresentationRpcInterface.test.ts
+++ b/presentation/common/src/test/PresentationRpcInterface.test.ts
@@ -9,10 +9,10 @@ import * as sinon from "sinon";
 import { Id64String, using } from "@bentley/bentleyjs-core";
 import { IModelRpcProps, RpcOperation, RpcRegistry, RpcRequest, RpcSerializedValue } from "@bentley/imodeljs-common";
 import {
-  ContentDescriptorRpcRequestOptions, ContentRpcRequestOptions, DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions,
-  DistinctValuesRpcRequestOptions, ElementPropertiesRpcRequestOptions, ExtendedContentRpcRequestOptions, ExtendedHierarchyRpcRequestOptions,
-  HierarchyCompareRpcOptions, HierarchyRpcRequestOptions, KeySet, LabelRpcRequestOptions, Paged, PresentationRpcInterface,
-  SelectionScopeRpcRequestOptions,
+  ComputeSelectionRpcRequestOptions, ContentDescriptorRpcRequestOptions, ContentRpcRequestOptions, DisplayLabelRpcRequestOptions,
+  DisplayLabelsRpcRequestOptions, DistinctValuesRpcRequestOptions, ElementPropertiesRpcRequestOptions, ExtendedContentRpcRequestOptions,
+  ExtendedHierarchyRpcRequestOptions, HierarchyCompareRpcOptions, HierarchyRpcRequestOptions, KeySet, LabelRpcRequestOptions, Paged,
+  PresentationRpcInterface, SelectionScopeRpcRequestOptions,
 } from "../presentation-common";
 import { FieldDescriptorType } from "../presentation-common/content/Fields";
 import {
@@ -299,13 +299,22 @@ describe("PresentationRpcInterface", () => {
       expect(spy).to.be.calledOnceWith(toArguments(token, options));
     });
 
-    it("forwards computeSelection call", async () => {
+    it("[deprecated] forwards computeSelection call", async () => {
       const options: SelectionScopeRpcRequestOptions = {
       };
       const ids = new Array<Id64String>();
       const scopeId = faker.random.uuid();
       await rpcInterface.computeSelection(token, options, ids, scopeId);
       expect(spy).to.be.calledOnceWith(toArguments(token, options, ids, scopeId));
+    });
+
+    it("forwards computeSelection call", async () => {
+      const options: ComputeSelectionRpcRequestOptions = {
+        elementIds: new Array<Id64String>(),
+        scopeId: faker.random.uuid(),
+      };
+      await rpcInterface.computeSelection(token, options);
+      expect(spy).to.be.calledOnceWith(toArguments(token, options));
     });
 
     it("[deprecated] forwards compareHierarchies call", async () => {

--- a/presentation/common/src/test/RpcRequestsHandler.test.ts
+++ b/presentation/common/src/test/RpcRequestsHandler.test.ts
@@ -497,12 +497,12 @@ describe("RpcRequestsHandler", () => {
       const handlerOptions: ComputeSelectionRequestOptions<IModelRpcProps> = {
         imodel: token,
         elementIds: [Id64.invalid],
-        scopeId: "test scope",
+        scope: { id: "test scope" },
       };
       const rpcOptions: PresentationRpcRequestOptions<ComputeSelectionRequestOptions<any>> = {
         clientId,
         elementIds: [Id64.invalid],
-        scopeId: "test scope",
+        scope: { id: "test scope" },
       };
       const result = new KeySet().toJSON();
       rpcInterfaceMock.setup(async (x) => x.computeSelection(token, rpcOptions)).returns(async () => successResponse(result)).verifiable();

--- a/presentation/common/src/test/RpcRequestsHandler.test.ts
+++ b/presentation/common/src/test/RpcRequestsHandler.test.ts
@@ -501,9 +501,10 @@ describe("RpcRequestsHandler", () => {
       };
       const ids = new Array<Id64String>();
       const scopeId = faker.random.uuid();
+      const scopeParams = { level: 123 };
       const result = new KeySet().toJSON();
-      rpcInterfaceMock.setup(async (x) => x.computeSelection(token, rpcOptions, ids, scopeId)).returns(async () => successResponse(result)).verifiable();
-      expect(await handler.computeSelection(handlerOptions, ids, scopeId)).to.eq(result);
+      rpcInterfaceMock.setup(async (x) => x.computeSelection(token, rpcOptions, ids, scopeId, scopeParams)).returns(async () => successResponse(result)).verifiable();
+      expect(await handler.computeSelection(handlerOptions, ids, scopeId, scopeParams)).to.eq(result);
       rpcInterfaceMock.verifyAll();
     });
 

--- a/presentation/common/src/test/RpcRequestsHandler.test.ts
+++ b/presentation/common/src/test/RpcRequestsHandler.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import * as faker from "faker";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
-import { Id64String } from "@bentley/bentleyjs-core";
+import { Id64 } from "@bentley/bentleyjs-core";
 import { IModelRpcProps, RpcInterface, RpcInterfaceDefinition, RpcManager } from "@bentley/imodeljs-common";
 import {
   DescriptorJSON, DistinctValuesRpcRequestOptions, KeySet, KeySetJSON, Paged, PresentationError, PresentationRpcInterface,
@@ -20,8 +20,9 @@ import { InstanceKeyJSON } from "../presentation-common/EC";
 import { ElementProperties } from "../presentation-common/ElementProperties";
 import { NodeKey, NodeKeyJSON } from "../presentation-common/hierarchy/Key";
 import {
-  ContentDescriptorRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DistinctValuesRequestOptions,
-  ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions, HierarchyCompareOptions,
+  ComputeSelectionRequestOptions, ContentDescriptorRequestOptions, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
+  DistinctValuesRequestOptions, ElementPropertiesRequestOptions, ExtendedContentRequestOptions, ExtendedHierarchyRequestOptions,
+  HierarchyCompareOptions,
 } from "../presentation-common/PresentationManagerOptions";
 import {
   ContentDescriptorRpcRequestOptions, DisplayLabelRpcRequestOptions, DisplayLabelsRpcRequestOptions, ElementPropertiesRpcRequestOptions,
@@ -493,18 +494,19 @@ describe("RpcRequestsHandler", () => {
     });
 
     it("forwards computeSelection call", async () => {
-      const handlerOptions: SelectionScopeRequestOptions<IModelRpcProps> = {
+      const handlerOptions: ComputeSelectionRequestOptions<IModelRpcProps> = {
         imodel: token,
+        elementIds: [Id64.invalid],
+        scopeId: "test scope",
       };
-      const rpcOptions: PresentationRpcRequestOptions<SelectionScopeRequestOptions<any>> = {
+      const rpcOptions: PresentationRpcRequestOptions<ComputeSelectionRequestOptions<any>> = {
         clientId,
+        elementIds: [Id64.invalid],
+        scopeId: "test scope",
       };
-      const ids = new Array<Id64String>();
-      const scopeId = faker.random.uuid();
-      const scopeParams = { level: 123 };
       const result = new KeySet().toJSON();
-      rpcInterfaceMock.setup(async (x) => x.computeSelection(token, rpcOptions, ids, scopeId, scopeParams)).returns(async () => successResponse(result)).verifiable();
-      expect(await handler.computeSelection(handlerOptions, ids, scopeId, scopeParams)).to.eq(result);
+      rpcInterfaceMock.setup(async (x) => x.computeSelection(token, rpcOptions)).returns(async () => successResponse(result)).verifiable();
+      expect(await handler.computeSelection(handlerOptions)).to.eq(result);
       rpcInterfaceMock.verifyAll();
     });
 

--- a/presentation/components/src/presentation-components/favorite-properties/DataProvider.ts
+++ b/presentation/components/src/presentation-components/favorite-properties/DataProvider.ts
@@ -9,7 +9,7 @@
 import { Id64Arg, using } from "@bentley/bentleyjs-core";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
 import { CategoryDescription, KeySet, Ruleset } from "@bentley/presentation-common";
-import { getScopeRequestProps, Presentation } from "@bentley/presentation-frontend";
+import { createSelectionScopeProps, Presentation } from "@bentley/presentation-frontend";
 import { PropertyData } from "@bentley/ui-components";
 import { translate } from "../common/Utils";
 import { PresentationPropertyDataProvider } from "../propertygrid/DataProvider";
@@ -108,7 +108,7 @@ export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataPr
       });
     }
 
-    const keys = await Presentation.selection.scopes.computeSelection(imodel, elementIds, getScopeRequestProps(Presentation.selection.scopes.activeScope));
+    const keys = await Presentation.selection.scopes.computeSelection(imodel, elementIds, createSelectionScopeProps(Presentation.selection.scopes.activeScope));
     return this.getData(imodel, keys);
   }
 }

--- a/presentation/components/src/presentation-components/favorite-properties/DataProvider.ts
+++ b/presentation/components/src/presentation-components/favorite-properties/DataProvider.ts
@@ -9,7 +9,7 @@
 import { Id64Arg, using } from "@bentley/bentleyjs-core";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
 import { CategoryDescription, KeySet, Ruleset } from "@bentley/presentation-common";
-import { getScopeId, Presentation } from "@bentley/presentation-frontend";
+import { getScopeRequestProps, Presentation } from "@bentley/presentation-frontend";
 import { PropertyData } from "@bentley/ui-components";
 import { translate } from "../common/Utils";
 import { PresentationPropertyDataProvider } from "../propertygrid/DataProvider";
@@ -108,7 +108,7 @@ export class FavoritePropertiesDataProvider implements IFavoritePropertiesDataPr
       });
     }
 
-    const keys = await Presentation.selection.scopes.computeSelection(imodel, elementIds, getScopeId(Presentation.selection.scopes.activeScope));
+    const keys = await Presentation.selection.scopes.computeSelection(imodel, elementIds, getScopeRequestProps(Presentation.selection.scopes.activeScope));
     return this.getData(imodel, keys);
   }
 }

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -8,11 +8,11 @@
 
 import { Id64, Id64Arg, Id64Array, IDisposable, using } from "@bentley/bentleyjs-core";
 import { IModelConnection, SelectionSetEvent, SelectionSetEventType } from "@bentley/imodeljs-frontend";
-import { AsyncTasksTracker, Keys, KeySet, SelectionScope } from "@bentley/presentation-common";
+import { AsyncTasksTracker, ComputeSelectionScopeProps, Keys, KeySet, SelectionScope } from "@bentley/presentation-common";
 import { HiliteSet, HiliteSetProvider } from "./HiliteSetProvider";
 import { ISelectionProvider } from "./ISelectionProvider";
 import { SelectionChangeEvent, SelectionChangeEventArgs, SelectionChangeType } from "./SelectionChangeEvent";
-import { getScopeId, SelectionScopesManager } from "./SelectionScopesManager";
+import { getScopeRequestProps, SelectionScopesManager } from "./SelectionScopesManager";
 
 /**
  * Properties for creating [[SelectionManager]].
@@ -234,7 +234,7 @@ export class SelectionManager implements ISelectionProvider {
    * @param level Selection level (see [Selection levels]($docs/learning/presentation/Unified-Selection/Terminology#selection-level))
    * @param rulesetId ID of the ruleset in case the selection was changed from a rules-driven control
    */
-  public async addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
+  public async addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
     const scopedKeys = await this.scopes.computeSelection(imodel, ids, scope);
     this.addToSelection(source, imodel, scopedKeys, level, rulesetId);
   }
@@ -248,7 +248,7 @@ export class SelectionManager implements ISelectionProvider {
    * @param level Selection level (see [Selection levels]($docs/learning/presentation/Unified-Selection/Terminology#selection-level))
    * @param rulesetId ID of the ruleset in case the selection was changed from a rules-driven control
    */
-  public async removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
+  public async removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
     const scopedKeys = await this.scopes.computeSelection(imodel, ids, scope);
     this.removeFromSelection(source, imodel, scopedKeys, level, rulesetId);
   }
@@ -262,7 +262,7 @@ export class SelectionManager implements ISelectionProvider {
    * @param level Selection level (see [Selection levels]($docs/learning/presentation/Unified-Selection/Terminology#selection-level))
    * @param rulesetId ID of the ruleset in case the selection was changed from a rules-driven control
    */
-  public async replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
+  public async replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
     const scopedKeys = await this.scopes.computeSelection(imodel, ids, scope);
     this.replaceSelection(source, imodel, scopedKeys, level, rulesetId);
   }
@@ -372,13 +372,11 @@ export class ToolSelectionSyncHandler implements IDisposable {
         break;
     }
 
-    const scopeId = getScopeId(this._logicalSelection.scopes.activeScope);
-
     // we're always using scoped selection changer even if the scope is set to "element" - that
     // makes sure we're adding to selection keys with concrete classes and not "BisCore:Element", which
     // we can't because otherwise our keys compare fails (presentation components load data with
     // concrete classes)
-    const changer = new ScopedSelectionChanger(this._selectionSourceName, this._imodel, this._logicalSelection, scopeId);
+    const changer = new ScopedSelectionChanger(this._selectionSourceName, this._imodel, this._logicalSelection, getScopeRequestProps(this._logicalSelection.scopes.activeScope));
 
     // we know what to do immediately on `clear` events
     if (SelectionSetEventType.Clear === ev.type) {
@@ -447,8 +445,8 @@ class ScopedSelectionChanger {
   public readonly name: string;
   public readonly imodel: IModelConnection;
   public readonly manager: SelectionManager;
-  public readonly scope: SelectionScope | string;
-  public constructor(name: string, imodel: IModelConnection, manager: SelectionManager, scope: SelectionScope | string) {
+  public readonly scope: ComputeSelectionScopeProps | SelectionScope | string;
+  public constructor(name: string, imodel: IModelConnection, manager: SelectionManager, scope: ComputeSelectionScopeProps | SelectionScope | string) {
     this.name = name;
     this.imodel = imodel;
     this.manager = manager;

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -8,11 +8,11 @@
 
 import { Id64, Id64Arg, Id64Array, IDisposable, using } from "@bentley/bentleyjs-core";
 import { IModelConnection, SelectionSetEvent, SelectionSetEventType } from "@bentley/imodeljs-frontend";
-import { AsyncTasksTracker, ComputeSelectionScopeProps, Keys, KeySet, SelectionScope } from "@bentley/presentation-common";
+import { AsyncTasksTracker, Keys, KeySet, SelectionScope, SelectionScopeProps } from "@bentley/presentation-common";
 import { HiliteSet, HiliteSetProvider } from "./HiliteSetProvider";
 import { ISelectionProvider } from "./ISelectionProvider";
 import { SelectionChangeEvent, SelectionChangeEventArgs, SelectionChangeType } from "./SelectionChangeEvent";
-import { getScopeRequestProps, SelectionScopesManager } from "./SelectionScopesManager";
+import { createSelectionScopeProps, SelectionScopesManager } from "./SelectionScopesManager";
 
 /**
  * Properties for creating [[SelectionManager]].
@@ -234,7 +234,7 @@ export class SelectionManager implements ISelectionProvider {
    * @param level Selection level (see [Selection levels]($docs/learning/presentation/Unified-Selection/Terminology#selection-level))
    * @param rulesetId ID of the ruleset in case the selection was changed from a rules-driven control
    */
-  public async addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
+  public async addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
     const scopedKeys = await this.scopes.computeSelection(imodel, ids, scope);
     this.addToSelection(source, imodel, scopedKeys, level, rulesetId);
   }
@@ -248,7 +248,7 @@ export class SelectionManager implements ISelectionProvider {
    * @param level Selection level (see [Selection levels]($docs/learning/presentation/Unified-Selection/Terminology#selection-level))
    * @param rulesetId ID of the ruleset in case the selection was changed from a rules-driven control
    */
-  public async removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
+  public async removeFromSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
     const scopedKeys = await this.scopes.computeSelection(imodel, ids, scope);
     this.removeFromSelection(source, imodel, scopedKeys, level, rulesetId);
   }
@@ -262,7 +262,7 @@ export class SelectionManager implements ISelectionProvider {
    * @param level Selection level (see [Selection levels]($docs/learning/presentation/Unified-Selection/Terminology#selection-level))
    * @param rulesetId ID of the ruleset in case the selection was changed from a rules-driven control
    */
-  public async replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
+  public async replaceSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string, level: number = 0, rulesetId?: string): Promise<void> {
     const scopedKeys = await this.scopes.computeSelection(imodel, ids, scope);
     this.replaceSelection(source, imodel, scopedKeys, level, rulesetId);
   }
@@ -376,7 +376,7 @@ export class ToolSelectionSyncHandler implements IDisposable {
     // makes sure we're adding to selection keys with concrete classes and not "BisCore:Element", which
     // we can't because otherwise our keys compare fails (presentation components load data with
     // concrete classes)
-    const changer = new ScopedSelectionChanger(this._selectionSourceName, this._imodel, this._logicalSelection, getScopeRequestProps(this._logicalSelection.scopes.activeScope));
+    const changer = new ScopedSelectionChanger(this._selectionSourceName, this._imodel, this._logicalSelection, createSelectionScopeProps(this._logicalSelection.scopes.activeScope));
 
     // we know what to do immediately on `clear` events
     if (SelectionSetEventType.Clear === ev.type) {
@@ -445,8 +445,8 @@ class ScopedSelectionChanger {
   public readonly name: string;
   public readonly imodel: IModelConnection;
   public readonly manager: SelectionManager;
-  public readonly scope: ComputeSelectionScopeProps | SelectionScope | string;
-  public constructor(name: string, imodel: IModelConnection, manager: SelectionManager, scope: ComputeSelectionScopeProps | SelectionScope | string) {
+  public readonly scope: SelectionScopeProps | SelectionScope | string;
+  public constructor(name: string, imodel: IModelConnection, manager: SelectionManager, scope: SelectionScopeProps | SelectionScope | string) {
     this.name = name;
     this.imodel = imodel;
     this.manager = manager;

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionScopesManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionScopesManager.ts
@@ -78,7 +78,7 @@ export class SelectionScopesManager {
       const batchStart = batchSize * batchIndex;
       const batchEnd = (batchStart + batchSize > ids.length) ? ids.length : (batchStart + batchSize);
       const batchIds = (0 === batchIndex && ids.length <= batchEnd) ? ids : ids.slice(batchStart, batchEnd);
-      batchKeyPromises.push(this._rpcRequestsHandler.computeSelection({ imodel: imodel.getRpcProps(), elementIds: batchIds, ...createSelectionScopeProps(scope) }));
+      batchKeyPromises.push(this._rpcRequestsHandler.computeSelection({ imodel: imodel.getRpcProps(), elementIds: batchIds, scope: createSelectionScopeProps(scope) }));
     }
     const batchKeys = (await Promise.all(batchKeyPromises)).map(KeySet.fromJSON);
     batchKeys.forEach((bk) => keys.add(bk));
@@ -94,17 +94,10 @@ export class SelectionScopesManager {
  */
 export function createSelectionScopeProps(scope: SelectionScopeProps | SelectionScope | string | undefined): SelectionScopeProps {
   if (!scope)
-    return { scopeId: "element" };
+    return { id: "element" };
   if (typeof scope === "string")
-    return { scopeId: scope };
-  if (isSelectionScope(scope)) {
-    return { scopeId: scope.id };
-  }
+    return { id: scope };
   return scope;
-}
-
-function isSelectionScope(param: SelectionScopeProps | SelectionScope): param is SelectionScope {
-  return !!(param as SelectionScope).id;
 }
 
 /**
@@ -115,5 +108,5 @@ function isSelectionScope(param: SelectionScopeProps | SelectionScope): param is
  */
 // istanbul ignore next
 export function getScopeId(scope: SelectionScope | string | undefined): string {
-  return createSelectionScopeProps(scope).scopeId;
+  return createSelectionScopeProps(scope).id;
 }

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionScopesManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionScopesManager.ts
@@ -8,7 +8,9 @@
 
 import { Id64Arg } from "@bentley/bentleyjs-core";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
-import { DEFAULT_KEYS_BATCH_SIZE, KeySet, RpcRequestsHandler, SelectionScope } from "@bentley/presentation-common";
+import {
+  ComputeSelectionScopeProps, DEFAULT_KEYS_BATCH_SIZE, KeySet, RpcRequestsHandler, SelectionScope, SelectionScopeParams,
+} from "@bentley/presentation-common";
 
 /**
  * Properties for creating [[SelectionScopesManager]].
@@ -32,7 +34,7 @@ export class SelectionScopesManager {
 
   private _rpcRequestsHandler: RpcRequestsHandler;
   private _getLocale: () => string | undefined;
-  private _activeScope: SelectionScope | string | undefined;
+  private _activeScope: ComputeSelectionScopeProps | SelectionScope | string | undefined;
 
   public constructor(props: SelectionScopesManagerProps) {
     this._rpcRequestsHandler = props.rpcRequestsHandler;
@@ -44,7 +46,7 @@ export class SelectionScopesManager {
 
   /** The active selection scope or its id */
   public get activeScope() { return this._activeScope; }
-  public set activeScope(scope: SelectionScope | string | undefined) { this._activeScope = scope; }
+  public set activeScope(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined) { this._activeScope = scope; }
 
   /**
    * Get available selection scopes.
@@ -62,8 +64,8 @@ export class SelectionScopesManager {
    * @param ids Element IDs to compute selection for
    * @param scope Selection scope to apply
    */
-  public async computeSelection(imodel: IModelConnection, ids: Id64Arg, scope: SelectionScope | string): Promise<KeySet> {
-    const scopeId = getScopeId(scope);
+  public async computeSelection(imodel: IModelConnection, ids: Id64Arg, scope: ComputeSelectionScopeProps | SelectionScope | string): Promise<KeySet> {
+    const { id: scopeId, params: scopeParams } = getScopeRequestProps(scope);
 
     // convert ids input to array
     if (typeof ids === "string")
@@ -80,7 +82,7 @@ export class SelectionScopesManager {
       const batchStart = batchSize * batchIndex;
       const batchEnd = (batchStart + batchSize > ids.length) ? ids.length : (batchStart + batchSize);
       const batchIds = (0 === batchIndex && ids.length <= batchEnd) ? ids : ids.slice(batchStart, batchEnd);
-      batchKeyPromises.push(this._rpcRequestsHandler.computeSelection({ imodel: imodel.getRpcProps() }, batchIds, scopeId));
+      batchKeyPromises.push(this._rpcRequestsHandler.computeSelection({ imodel: imodel.getRpcProps() }, batchIds, scopeId, scopeParams));
     }
     const batchKeys = (await Promise.all(batchKeyPromises)).map(KeySet.fromJSON);
     batchKeys.forEach((bk) => keys.add(bk));
@@ -89,14 +91,28 @@ export class SelectionScopesManager {
 }
 
 /**
+ * Normalizes given scope options and returns [[ComputeSelectionScopeProps]] that can be used for
+ * calculating selection with scope.
+ *
+ * @internal
+ */
+export function getScopeRequestProps(scope: ComputeSelectionScopeProps | SelectionScope | string | undefined): { id: string, params?: SelectionScopeParams } {
+  if (!scope)
+    return { id: "element" };
+  if (typeof scope === "string")
+    return { id: scope };
+  return {
+    ...scope,
+  };
+}
+
+/**
  * Determines the scope id
  * @param scope Selection scope
  * @public
+ * @deprecated This is an internal utility that should've never become public.
  */
+// istanbul ignore next
 export function getScopeId(scope: SelectionScope | string | undefined): string {
-  if (!scope)
-    return "element";
-  if (typeof scope === "string")
-    return scope;
-  return scope.id;
+  return getScopeRequestProps(scope).id;
 }

--- a/presentation/frontend/src/test/selection/SelectionManager.test.ts
+++ b/presentation/frontend/src/test/selection/SelectionManager.test.ts
@@ -511,7 +511,7 @@ describe("SelectionManager", () => {
 
         it("uses \"element\" scope when `activeScope = undefined`", async () => {
           scopesMock.setup((x) => x.activeScope).returns(() => undefined);
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { scopeId: "element" }))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { id: "element" }))
             .returns(async () => new KeySet([createRandomECInstanceKey()]))
             .verifiable();
           ss.add(createRandomId());
@@ -522,7 +522,7 @@ describe("SelectionManager", () => {
 
         it("uses \"element\" scope when `activeScope = \"element\"`", async () => {
           scopesMock.setup((x) => x.activeScope).returns(() => "element");
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { scopeId: "element" }))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { id: "element" }))
             .returns(async () => new KeySet([createRandomECInstanceKey()]))
             .verifiable();
           ss.add(createRandomId());

--- a/presentation/frontend/src/test/selection/SelectionManager.test.ts
+++ b/presentation/frontend/src/test/selection/SelectionManager.test.ts
@@ -511,7 +511,7 @@ describe("SelectionManager", () => {
 
         it("uses \"element\" scope when `activeScope = undefined`", async () => {
           scopesMock.setup((x) => x.activeScope).returns(() => undefined);
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { id: "element" }))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { scopeId: "element" }))
             .returns(async () => new KeySet([createRandomECInstanceKey()]))
             .verifiable();
           ss.add(createRandomId());
@@ -522,7 +522,7 @@ describe("SelectionManager", () => {
 
         it("uses \"element\" scope when `activeScope = \"element\"`", async () => {
           scopesMock.setup((x) => x.activeScope).returns(() => "element");
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { id: "element" }))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { scopeId: "element" }))
             .returns(async () => new KeySet([createRandomECInstanceKey()]))
             .verifiable();
           ss.add(createRandomId());

--- a/presentation/frontend/src/test/selection/SelectionManager.test.ts
+++ b/presentation/frontend/src/test/selection/SelectionManager.test.ts
@@ -511,7 +511,7 @@ describe("SelectionManager", () => {
 
         it("uses \"element\" scope when `activeScope = undefined`", async () => {
           scopesMock.setup((x) => x.activeScope).returns(() => undefined);
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), "element"))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { id: "element" }))
             .returns(async () => new KeySet([createRandomECInstanceKey()]))
             .verifiable();
           ss.add(createRandomId());
@@ -522,7 +522,7 @@ describe("SelectionManager", () => {
 
         it("uses \"element\" scope when `activeScope = \"element\"`", async () => {
           scopesMock.setup((x) => x.activeScope).returns(() => "element");
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), "element"))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.isAny(), { id: "element" }))
             .returns(async () => new KeySet([createRandomECInstanceKey()]))
             .verifiable();
           ss.add(createRandomId());
@@ -555,9 +555,9 @@ describe("SelectionManager", () => {
           selectionManager.selectionChange.addListener(logicalSelectionChangesListener);
 
           scopesMock.setup((x) => x.activeScope).returns(() => scope);
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, [], moq.It.isAnyString()))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, [], moq.It.isAny()))
             .returns(async () => new KeySet());
-          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.is((v) => equalId64Arg(v, [persistentElementId])), moq.It.isAnyString()))
+          scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, moq.It.is((v) => equalId64Arg(v, [persistentElementId])), moq.It.isAny()))
             .returns(async () => new KeySet([scopedKey]));
         });
 
@@ -740,7 +740,7 @@ describe("SelectionManager", () => {
       imodelMock.setup((x) => x.selectionSet).returns(() => ss);
 
       scopesMock.setup((x) => x.activeScope).returns(() => undefined);
-      scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, [], moq.It.isAnyString())).returns(async () => new KeySet());
+      scopesMock.setup(async (x) => x.computeSelection(imodelMock.object, [], moq.It.isAny())).returns(async () => new KeySet());
 
       selectionManager.setSyncWithIModelToolSelection(imodelMock.object, true);
     });

--- a/presentation/frontend/src/test/selection/SelectionScopesManager.test.ts
+++ b/presentation/frontend/src/test/selection/SelectionScopesManager.test.ts
@@ -8,7 +8,7 @@ import * as moq from "typemoq";
 import { Id64String } from "@bentley/bentleyjs-core";
 import { IModelRpcProps } from "@bentley/imodeljs-common";
 import { IModelConnection } from "@bentley/imodeljs-frontend";
-import { DEFAULT_KEYS_BATCH_SIZE, KeySet, RpcRequestsHandler, SelectionScopeProps } from "@bentley/presentation-common";
+import { DEFAULT_KEYS_BATCH_SIZE, ElementSelectionScopeProps, KeySet, RpcRequestsHandler } from "@bentley/presentation-common";
 import { createRandomECInstanceKey, createRandomId, createRandomSelectionScope } from "@bentley/presentation-common/lib/test/_helpers/random";
 import { SelectionScopesManager, SelectionScopesManagerProps } from "../../presentation-frontend/selection/SelectionScopesManager";
 
@@ -102,7 +102,11 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken, elementIds: ids, scopeId: scope.id })))
+        .setup(async (x) => x.computeSelection(moq.It.is((options) => {
+          return options.imodel === imodelToken
+            && options.elementIds.length === 1 && options.elementIds[0] === ids[0]
+            && options.scope.id === scope.id;
+        })))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, ids, scope);
@@ -116,7 +120,11 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken, elementIds: ids, scopeId: scope.id })))
+        .setup(async (x) => x.computeSelection(moq.It.is((options) => {
+          return options.imodel === imodelToken
+            && options.elementIds.length === 1 && options.elementIds[0] === ids[0]
+            && options.scope.id === scope.id;
+        })))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, ids, scope.id);
@@ -127,16 +135,21 @@ describe("SelectionScopesManager", () => {
 
     it("forwards request to RpcRequestsHandler with element scope and params", async () => {
       const elementIds = [createRandomId()];
-      const selectionScopeProps: SelectionScopeProps = {
-        scopeId: "element",
+      const scope: ElementSelectionScopeProps = {
+        id: "element",
         ancestorLevel: 123,
       };
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken, elementIds, ...selectionScopeProps })))
+        .setup(async (x) => x.computeSelection(moq.It.is((options) => {
+          return options.imodel === imodelToken
+            && options.elementIds.length === 1 && options.elementIds[0] === elementIds[0]
+            && options.scope.id === scope.id
+            && (options.scope as ElementSelectionScopeProps).ancestorLevel === scope.ancestorLevel;
+        })))
         .returns(async () => result.toJSON())
         .verifiable();
-      const computedResult = await getManager().computeSelection(imodelMock.object, elementIds, selectionScopeProps);
+      const computedResult = await getManager().computeSelection(imodelMock.object, elementIds, scope);
       rpcRequestsHandlerMock.verifyAll();
       expect(computedResult.size).to.eq(result.size);
       expect(computedResult.hasAll(result)).to.be.true;
@@ -153,7 +166,7 @@ describe("SelectionScopesManager", () => {
         .setup(async (x) => x.computeSelection(moq.It.is((options) => {
           return options.imodel === imodelToken
             && options.elementIds.length === DEFAULT_KEYS_BATCH_SIZE
-            && options.scopeId === scope.id;
+            && options.scope.id === scope.id;
         })))
         .returns(async () => result1.toJSON())
         .verifiable();
@@ -161,7 +174,7 @@ describe("SelectionScopesManager", () => {
         .setup(async (x) => x.computeSelection(moq.It.is((options) => {
           return options.imodel === imodelToken
             && options.elementIds.length === 1
-            && options.scopeId === scope.id;
+            && options.scope.id === scope.id;
         })))
         .returns(async () => result2.toJSON())
         .verifiable();
@@ -177,7 +190,11 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken, elementIds: [id], scopeId: scope.id })))
+        .setup(async (x) => x.computeSelection(moq.It.is((options) => {
+          return options.imodel === imodelToken
+            && options.elementIds.length === 1 && options.elementIds[0] === id
+            && options.scope.id === scope.id;
+        })))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, id, scope);
@@ -191,7 +208,11 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken, elementIds: [id], scopeId: scope.id })))
+        .setup(async (x) => x.computeSelection(moq.It.is((options) => {
+          return options.imodel === imodelToken
+            && options.elementIds.length === 1 && options.elementIds[0] === id
+            && options.scope.id === scope.id;
+        })))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, new Set([id]), scope);

--- a/presentation/frontend/src/test/selection/SelectionScopesManager.test.ts
+++ b/presentation/frontend/src/test/selection/SelectionScopesManager.test.ts
@@ -102,7 +102,7 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), ids, scope.id))
+        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), ids, scope.id, undefined))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, ids, scope);
@@ -116,10 +116,24 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), ids, scope.id))
+        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), ids, scope.id, undefined))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, ids, scope.id);
+      rpcRequestsHandlerMock.verifyAll();
+      expect(computedResult.size).to.eq(result.size);
+      expect(computedResult.hasAll(result)).to.be.true;
+    });
+
+    it("forwards request to RpcRequestsHandler with scope and params", async () => {
+      const ids = [createRandomId()];
+      const scope = { id: "element", params: { level: 123 } };
+      const result = new KeySet();
+      rpcRequestsHandlerMock
+        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), ids, scope.id, scope.params))
+        .returns(async () => result.toJSON())
+        .verifiable();
+      const computedResult = await getManager().computeSelection(imodelMock.object, ids, scope);
       rpcRequestsHandlerMock.verifyAll();
       expect(computedResult.size).to.eq(result.size);
       expect(computedResult.hasAll(result)).to.be.true;
@@ -133,11 +147,11 @@ describe("SelectionScopesManager", () => {
       const result1 = new KeySet([createRandomECInstanceKey()]);
       const result2 = new KeySet([createRandomECInstanceKey()]);
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((inIds: string[]): boolean => (inIds.length === DEFAULT_KEYS_BATCH_SIZE)), scope.id))
+        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((inIds: string[]): boolean => (inIds.length === DEFAULT_KEYS_BATCH_SIZE)), scope.id, undefined))
         .returns(async () => result1.toJSON())
         .verifiable();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((inIds: string[]): boolean => (inIds.length === 1)), scope.id))
+        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((inIds: string[]): boolean => (inIds.length === 1)), scope.id, undefined))
         .returns(async () => result2.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, ids, scope.id);
@@ -152,7 +166,7 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((a) => a.length === 1 && a[0] === id), scope.id))
+        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((a) => a.length === 1 && a[0] === id), scope.id, undefined))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, id, scope);
@@ -166,7 +180,7 @@ describe("SelectionScopesManager", () => {
       const scope = createRandomSelectionScope();
       const result = new KeySet();
       rpcRequestsHandlerMock
-        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((a) => a.length === 1 && a[0] === id), scope.id))
+        .setup(async (x) => x.computeSelection(moq.It.isObjectWith({ imodel: imodelToken }), moq.It.is((a) => a.length === 1 && a[0] === id), scope.id, undefined))
         .returns(async () => result.toJSON())
         .verifiable();
       const computedResult = await getManager().computeSelection(imodelMock.object, new Set([id]), scope);


### PR DESCRIPTION
Resolves itwin/itwinjs-backlog#164.

Introduced a new type `ComputeSelectionScopeProps` that has an `id` attribute for available scopes and also has a `params: { level: number }` attribute for the scope with `id: "element"`. On the frontend objects of this new type can now be set on `Presentation.selection.scopes.activeScope` or passed to `Presentation.selection.scopes.activeScope.computeSelection`. This allows passing the level of requested ancestor when using "element" scope.

The PR also increases minor version of `PresentationRpcInterface` to make sure new frontends don't request old backends to compute selection in the new way and assume the backends handles the added params. Old frontends can still safely use updated backends.