### PR TITLE
Lock cheerio version down (enzyme depedency)

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -475,6 +475,10 @@
       "allowedCategories": [ "tools" ]
     },
     {
+      "name": "cheerio",
+      "allowedCategories": [ "extensions", "frontend" ]
+    },
+    {
       "name": "child_process",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1486,6 +1486,7 @@ importers:
       chai-as-promised: ^7
       chai-jest-snapshot: ^2.0.0
       chai-spies: 1.0.0
+      cheerio: 1.0.0-rc.3
       classnames: ^2.3.1
       cpx2: ^3.0.0
       enzyme: ^3.4.0
@@ -1538,6 +1539,7 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-jest-snapshot: 2.0.0_chai@4.3.6
       chai-spies: 1.0.0_chai@4.3.6
+      cheerio: 1.0.0-rc.3
       cpx2: 3.0.2
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2_enzyme@3.11.0
@@ -2392,6 +2394,7 @@ importers:
       chai-as-promised: ^7
       chai-jest-snapshot: ^2.0.0
       chai-subset: 1.6.0
+      cheerio: 1.0.0-rc.3
       cpx2: ^3.0.0
       cross-env: ^5.1.4
       enzyme: ^3.4.0
@@ -2452,6 +2455,7 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-jest-snapshot: 2.0.0_chai@4.3.6
       chai-subset: 1.6.0
+      cheerio: 1.0.0-rc.3
       cpx2: 3.0.2
       cross-env: 5.2.1
       enzyme: 3.11.0
@@ -3806,6 +3810,7 @@ importers:
       chai-as-promised: ^7
       chai-jest-snapshot: ^2.0.0
       chai-spies: 1.0.0
+      cheerio: 1.0.0-rc.3
       classnames: ^2.3.1
       cpx2: ^3.0.0
       enzyme: ^3.4.0
@@ -3861,6 +3866,7 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-jest-snapshot: 2.0.0_chai@4.3.6
       chai-spies: 1.0.0_chai@4.3.6
+      cheerio: 1.0.0-rc.3
       cpx2: 3.0.2
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2_enzyme@3.11.0
@@ -3928,6 +3934,7 @@ importers:
       chai-as-promised: ^7
       chai-jest-snapshot: ^2.0.0
       chai-spies: 1.0.0
+      cheerio: 1.0.0-rc.3
       classnames: ^2.3.1
       cpx2: ^3.0.0
       enzyme: ^3.4.0
@@ -4011,6 +4018,7 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-jest-snapshot: 2.0.0_chai@4.3.6
       chai-spies: 1.0.0_chai@4.3.6
+      cheerio: 1.0.0-rc.3
       cpx2: 3.0.2
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2_enzyme@3.11.0
@@ -4079,6 +4087,7 @@ importers:
       chai-jest-snapshot: ^2.0.0
       chai-spies: 1.0.0
       chai-string: ^1.5.0
+      cheerio: 1.0.0-rc.3
       classnames: ^2.3.1
       cpx2: ^3.0.0
       enzyme: ^3.4.0
@@ -4177,6 +4186,7 @@ importers:
       chai-jest-snapshot: 2.0.0_chai@4.3.6
       chai-spies: 1.0.0_chai@4.3.6
       chai-string: 1.5.0_chai@4.3.6
+      cheerio: 1.0.0-rc.3
       cpx2: 3.0.2
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2_enzyme@3.11.0
@@ -4236,6 +4246,7 @@ importers:
       chai-as-promised: ^7
       chai-jest-snapshot: ^2.0.0
       chai-spies: 1.0.0
+      cheerio: 1.0.0-rc.3
       classnames: ^2.3.1
       cpx2: ^3.0.0
       dompurify: ^2.0.12
@@ -4304,6 +4315,7 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-jest-snapshot: 2.0.0_chai@4.3.6
       chai-spies: 1.0.0_chai@4.3.6
+      cheerio: 1.0.0-rc.3
       cpx2: 3.0.2
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2_enzyme@3.11.0
@@ -4366,6 +4378,7 @@ importers:
       chai-jest-snapshot: ^2.0.0
       chai-spies: 1.0.0
       chai-string: ^1.5.0
+      cheerio: 1.0.0-rc.3
       classnames: ^2.3.1
       cpx2: ^3.0.0
       enzyme: ^3.4.0
@@ -4437,6 +4450,7 @@ importers:
       chai-jest-snapshot: 2.0.0_chai@4.3.6
       chai-spies: 1.0.0_chai@4.3.6
       chai-string: 1.5.0_chai@4.3.6
+      cheerio: 1.0.0-rc.3
       cpx2: 3.0.2
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2_enzyme@3.11.0
@@ -9998,7 +10012,7 @@ packages:
     dev: true
 
   /boolbase/1.0.0:
-    resolution: {integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=}
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: true
 
   /boolean/3.2.0:
@@ -10480,27 +10494,16 @@ packages:
     resolution: {integrity: sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ==}
     dev: true
 
-  /cheerio-select/1.6.0:
-    resolution: {integrity: sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==}
+  /cheerio/1.0.0-rc.3:
+    resolution: {integrity: sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==}
+    engines: {node: '>= 0.6'}
     dependencies:
-      css-select: 4.3.0
-      css-what: 6.1.0
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-    dev: true
-
-  /cheerio/1.0.0-rc.10:
-    resolution: {integrity: sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==}
-    engines: {node: '>= 6'}
-    dependencies:
-      cheerio-select: 1.6.0
-      dom-serializer: 1.4.1
-      domhandler: 4.3.1
-      htmlparser2: 6.1.0
-      parse5: 6.0.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
-      tslib: 2.4.0
+      css-select: 1.2.0
+      dom-serializer: 0.1.1
+      entities: 1.1.2
+      htmlparser2: 3.10.1
+      lodash: 4.17.21
+      parse5: 3.0.3
     dev: true
 
   /child_process/1.0.2:
@@ -11257,6 +11260,15 @@ packages:
     resolution: {integrity: sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==}
     dev: true
 
+  /css-select/1.2.0:
+    resolution: {integrity: sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 2.1.3
+      domutils: 1.5.1
+      nth-check: 1.0.2
+    dev: true
+
   /css-select/2.1.0:
     resolution: {integrity: sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==}
     dependencies:
@@ -11290,6 +11302,10 @@ packages:
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
+    dev: true
+
+  /css-what/2.1.3:
+    resolution: {integrity: sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==}
     dev: true
 
   /css-what/3.4.2:
@@ -11785,6 +11801,13 @@ packages:
       '@babel/runtime': 7.17.9
       csstype: 3.0.11
 
+  /dom-serializer/0.1.1:
+    resolution: {integrity: sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==}
+    dependencies:
+      domelementtype: 1.3.1
+      entities: 1.1.2
+    dev: true
+
   /dom-serializer/0.2.2:
     resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
     dependencies:
@@ -11844,6 +11867,13 @@ packages:
 
   /domready/1.0.8:
     resolution: {integrity: sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw=}
+    dev: true
+
+  /domutils/1.5.1:
+    resolution: {integrity: sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==}
+    dependencies:
+      dom-serializer: 0.2.2
+      domelementtype: 1.3.1
     dev: true
 
   /domutils/1.7.0:
@@ -12051,7 +12081,7 @@ packages:
     resolution: {integrity: sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==}
     dependencies:
       array.prototype.flat: 1.3.0
-      cheerio: 1.0.0-rc.10
+      cheerio: 1.0.0-rc.3
       enzyme-shallow-equal: 1.0.4
       function.prototype.name: 1.1.5
       has: 1.0.3
@@ -13169,7 +13199,7 @@ packages:
     dev: true
 
   /fd-slicer/1.1.0:
-    resolution: {integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=}
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
       pend: 1.2.0
 
@@ -17539,10 +17569,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /parse5-htmlparser2-tree-adapter/6.0.1:
-    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+  /parse5/3.0.3:
+    resolution: {integrity: sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==}
     dependencies:
-      parse5: 6.0.1
+      '@types/node': 16.11.7
     dev: true
 
   /parse5/4.0.0:
@@ -17629,7 +17659,7 @@ packages:
       sha.js: 2.4.11
 
   /pend/1.2.0:
-    resolution: {integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=}
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   /performance-now/2.1.0:
     resolution: {integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=}
@@ -21071,7 +21101,7 @@ packages:
     dev: true
 
   /through/2.3.8:
-    resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   /through2/2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}

--- a/extensions/map-layers/package.json
+++ b/extensions/map-layers/package.json
@@ -68,6 +68,7 @@
     "chai-as-promised": "^7",
     "chai-jest-snapshot": "^2.0.0",
     "chai-spies": "1.0.0",
+    "cheerio": "1.0.0-rc.3",
     "cpx2": "^3.0.0",
     "enzyme": "^3.4.0",
     "enzyme-to-json": "^3.3.4",

--- a/presentation/components/package.json
+++ b/presentation/components/package.json
@@ -95,6 +95,7 @@
     "chai-as-promised": "^7",
     "chai-jest-snapshot": "^2.0.0",
     "chai-subset": "1.6.0",
+    "cheerio": "1.0.0-rc.3",
     "cpx2": "^3.0.0",
     "cross-env": "^5.1.4",
     "enzyme": "^3.4.0",

--- a/ui/appui-layout-react/package.json
+++ b/ui/appui-layout-react/package.json
@@ -70,6 +70,7 @@
     "chai-as-promised": "^7",
     "chai-jest-snapshot": "^2.0.0",
     "chai-spies": "1.0.0",
+    "cheerio": "1.0.0-rc.3",
     "cpx2": "^3.0.0",
     "enzyme": "^3.4.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -101,6 +101,7 @@
     "chai-as-promised": "^7",
     "chai-jest-snapshot": "^2.0.0",
     "chai-spies": "1.0.0",
+    "cheerio": "1.0.0-rc.3",
     "cpx2": "^3.0.0",
     "enzyme": "^3.4.0",
     "enzyme-to-json": "^3.3.4",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -83,6 +83,7 @@
     "chai-jest-snapshot": "^2.0.0",
     "chai-spies": "1.0.0",
     "chai-string": "^1.5.0",
+    "cheerio": "1.0.0-rc.3",
     "cpx2": "^3.0.0",
     "enzyme": "^3.4.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -79,6 +79,7 @@
     "chai-as-promised": "^7",
     "chai-jest-snapshot": "^2.0.0",
     "chai-spies": "1.0.0",
+    "cheerio": "1.0.0-rc.3",
     "cpx2": "^3.0.0",
     "enzyme": "^3.4.0",
     "enzyme-to-json": "^3.3.4",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -86,6 +86,7 @@
     "chai-jest-snapshot": "^2.0.0",
     "chai-spies": "1.0.0",
     "chai-string": "^1.5.0",
+    "cheerio": "1.0.0-rc.3",
     "cpx2": "^3.0.0",
     "enzyme": "^3.4.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",


### PR DESCRIPTION
Errors in one of my PR branches led me to the post below. There is aproblem with enzyme 3.11.0 which is pulling the latest cheerio RC release 1.0.0-rc.11. The next release of Enzyme will be locking down the cheerio version to 1.0.0-rc.3.  The workaround is to add this version as a dev dependency. 
https://github.com/enzymejs/enzyme/issues/2518

Errors received:
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/utils' is not defined by "exports" in D:\vsts_a\1\s\common\temp\node_modules\.pnpm\enzyme@3.11.0\node_modules\cheerio\package.json
    at new NodeError (node:internal/errors:371:5)
    at throwExportsNotFound (node:internal/modules/esm/resolve:440:9)
    at packageExportsResolve (node:internal/modules/esm/resolve:692:3)
    at resolveExports (node:internal/modules/cjs/loader:482:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (D:\vsts_a\1\s\common\temp\node_modules\.pnpm\@cspotcode+source-map-support@0.8.1\node_modules\@cspotcode\source-map-support\source-map-support.js:811:30)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
