### PR TITLE
Clear drag state when button let up outside view. Don't send tools drag events if they didn't get button down event.

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-drag-state_2022-06-14-15-33.json
+++ b/common/changes/@itwin/core-frontend/fix-drag-state_2022-06-14-15-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Clear drag state when button let up outside view. Don't send tools drag events if they didn't get button down event.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}


### PR DESCRIPTION
After a canceled drag, the active tool would be restarted every time the mouse entered the view until a successful drag came along to clear the drag state. Clear both isDragging and isDown when a cancelled drag is detected.

If a tool restarted or exited on a button down event where the button is held and a drag is detected, the new tool would get the start drag event even though it didn't receive the button down. Noticed with place cylinder tool, if a drag was used to define/accept the height, the end drag location would be accepted as the base point of another cylinder.

