### PR TITLE
Presentation: Avoid counting target instances when calling getContentDescriptor RPC operation

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -264,6 +264,8 @@ export type ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions<C
 
 // @public
 export enum ContentFlags {
+    // @internal
+    DescriptorOnly = 512,
     DistinctValues = 16,
     // @beta
     IncludeInputKeys = 256,

--- a/common/changes/@itwin/presentation-backend/presentation-content-descriptor-optimisation_2022-06-15-12-56.json
+++ b/common/changes/@itwin/presentation-backend/presentation-content-descriptor-optimisation_2022-06-15-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-content-descriptor-optimisation_2022-06-15-12-56.json
+++ b/common/changes/@itwin/presentation-common/presentation-content-descriptor-optimisation_2022-06-15-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -559,6 +559,7 @@ export class PresentationManager {
       requestId: NativePlatformRequestTypes.GetContentDescriptor,
       rulesetId,
       ...strippedOptions,
+      contentFlags: ContentFlags.DescriptorOnly,
       keys: getKeysForContentRequest(requestOptions.keys, (map) => bisElementInstanceKeysProcessor(requestOptions.imodel, map)),
     };
     const reviver = (key: string, value: any) => {

--- a/presentation/common/src/presentation-common/content/Descriptor.ts
+++ b/presentation/common/src/presentation-common/content/Descriptor.ts
@@ -125,6 +125,13 @@ export enum ContentFlags {
    * @beta
    */
   IncludeInputKeys = 1 << 8,
+
+  /**
+   * Produce content descriptor that is not intended for querying content. Allows the implementation to omit certain
+   * operations to make obtaining content descriptor faster.
+   * @internal
+   */
+  DescriptorOnly = 1 << 9,
 }
 
 /**


### PR DESCRIPTION
We only need to count target instances in order to figure out how to merge their content. Since `getContentDescriptor` returns content descriptor without any instance data, we can skip counting and achieve 10-20% performance uplift.

[Related native addon PR.](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/256796)