### PR TITLE
Remove RPC preflight and InitializeInterface

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -7551,8 +7551,6 @@ export abstract class RpcProtocol {
     getOperationFromPath(path: string): SerializedRpcOperation;
     getStatus(code: number): RpcRequestStatus;
     inflateToken(tokenFromBody: IModelRpcProps, _request: SerializedRpcRequest): IModelRpcProps;
-    // (undocumented)
-    initialize(_token?: IModelRpcProps): Promise<void>;
     readonly invocationType: typeof RpcInvocation;
     // (undocumented)
     onRpcClientInitialized(_definition: RpcInterfaceDefinition, _client: RpcInterface): void;
@@ -7744,7 +7742,6 @@ export abstract class RpcRequest<TResponse = any> {
     // (undocumented)
     protected handleUnknownResponse(code: number): void;
     readonly id: string;
-    protected isHeaderAvailable(_name: string): boolean;
     get lastSubmitted(): number;
     get lastUpdated(): number;
     protected abstract load(): Promise<RpcSerializedValue>;
@@ -7770,7 +7767,7 @@ export abstract class RpcRequest<TResponse = any> {
     // (undocumented)
     protected _response: Response | undefined;
     // (undocumented)
-    protected responseProtocolVersion: number;
+    responseProtocolVersion: RpcProtocolVersion;
     get retryAfter(): number | null;
     retryInterval: number;
     protected abstract send(): Promise<number>;
@@ -9525,8 +9522,6 @@ export const WEB_RPC_CONSTANTS: {
 // @internal
 export abstract class WebAppRpcProtocol extends RpcProtocol {
     constructor(configuration: RpcConfiguration);
-    // (undocumented)
-    allowedHeaders: Set<string>;
     static computeContentType(httpType: string | null | undefined): RpcContentType;
     getCode(status: RpcRequestStatus): number;
     getStatus(code: number): RpcRequestStatus;
@@ -9534,8 +9529,6 @@ export abstract class WebAppRpcProtocol extends RpcProtocol {
     handleOperationGetRequest(req: HttpServerRequest, res: HttpServerResponse): Promise<void>;
     handleOperationPostRequest(req: HttpServerRequest, res: HttpServerResponse): Promise<void>;
     abstract info: OpenAPIInfo;
-    // (undocumented)
-    initialize(token?: IModelRpcProps): Promise<void>;
     isTimeout(code: number): boolean;
     get openAPIDescription(): RpcOpenAPIDescription;
     pathPrefix: string;
@@ -9556,8 +9549,6 @@ export class WebAppRpcRequest extends RpcRequest {
     // (undocumented)
     protected handleUnknownResponse(code: number): void;
     // (undocumented)
-    protected isHeaderAvailable(name: string): boolean;
-    // (undocumented)
     protected load(): Promise<RpcSerializedValue>;
     static maxUrlComponentSize: number;
     metadata: {
@@ -9566,8 +9557,6 @@ export class WebAppRpcRequest extends RpcRequest {
     };
     method: HttpMethod_T;
     static parseRequest(protocol: WebAppRpcProtocol, req: HttpServerRequest): Promise<SerializedRpcRequest>;
-    // (undocumented)
-    preflight(): Promise<Response | undefined>;
     readonly protocol: WebAppRpcProtocol;
     protected send(): Promise<number>;
     static sendResponse(protocol: WebAppRpcProtocol, request: SerializedRpcRequest, fulfillment: RpcRequestFulfillment, req: HttpServerRequest, res: HttpServerResponse): Promise<void>;

--- a/common/changes/@itwin/core-common/remove-preflight_2022-06-17-14-57.json
+++ b/common/changes/@itwin/core-common/remove-preflight_2022-06-17-14-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/rpc/core/RpcProtocol.ts
+++ b/core/common/src/rpc/core/RpcProtocol.ts
@@ -186,9 +186,6 @@ export abstract class RpcProtocol {
     return new (this.invocationType)(this, request).fulfillment;
   }
 
-  /** @internal */
-  public async initialize(_token?: IModelRpcProps): Promise<void> { }
-
   /** Serializes a request. */
   public async serialize(request: RpcRequest): Promise<SerializedRpcRequest> {
     const serializedContext = await RpcConfiguration.requestContext.serialize(request);

--- a/core/common/src/rpc/web/WebAppRpcRequest.ts
+++ b/core/common/src/rpc/web/WebAppRpcRequest.ts
@@ -164,20 +164,6 @@ export class WebAppRpcRequest extends RpcRequest {
     this._request.headers = {};
   }
 
-  /** @internal */
-  public async preflight(): Promise<Response | undefined> {
-    this.method = "options";
-    this._request.method = "options";
-    await this.setHeaders();
-    await this.send();
-    return this._response;
-  }
-
-  protected override isHeaderAvailable(name: string): boolean {
-    const allowed = this.protocol.allowedHeaders;
-    return allowed.has("*") || allowed.has(name);
-  }
-
   /** Sets request header values. */
   protected setHeader(name: string, value: string): void {
     this._headers[name] = value;
@@ -390,10 +376,6 @@ export class WebAppRpcRequest extends RpcRequest {
   }
 
   private async setupTransport(): Promise<void> {
-    if (this.method === "options") {
-      return;
-    }
-
     const parameters = (await this.protocol.serialize(this)).parameters;
     const transportType = WebAppRpcRequest.computeTransportType(parameters, this.parameters);
 

--- a/full-stack-tests/rpc/src/backend/TestRpcImpl.ts
+++ b/full-stack-tests/rpc/src/backend/TestRpcImpl.ts
@@ -153,6 +153,10 @@ export class TestRpcImpl extends RpcInterface implements TestRpcInterface {
   public async noContent() {
     throw new NoContentError();
   }
+
+  public async getRequestedProtocolVersion() {
+    return RpcInvocation.current(this).request.protocolVersion;
+  }
 }
 
 export class TestRpcImpl2 extends RpcInterface implements TestRpcInterface2 {

--- a/full-stack-tests/rpc/src/common/TestRpcInterface.ts
+++ b/full-stack-tests/rpc/src/common/TestRpcInterface.ts
@@ -142,6 +142,10 @@ export abstract class TestRpcInterface extends RpcInterface {
   public async noContent() {
     return this.forward(arguments);
   }
+
+  public async getRequestedProtocolVersion() {
+    return this.forward(arguments);
+  }
 }
 
 export abstract class TestRpcInterface2 extends RpcInterface {

--- a/full-stack-tests/rpc/src/frontend/_Setup.test.ts
+++ b/full-stack-tests/rpc/src/frontend/_Setup.test.ts
@@ -9,7 +9,7 @@ import { BentleyCloudRpcConfiguration, BentleyCloudRpcManager, RpcConfiguration 
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { MobileRpcManager } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
 import { BackendTestCallbacks } from "../common/SideChannels";
-import { AttachedInterface, MobileTestInterface, MultipleClientsInterface, rpcInterfaces } from "../common/TestRpcInterface";;
+import { AttachedInterface, MobileTestInterface, MultipleClientsInterface, rpcInterfaces } from "../common/TestRpcInterface";
 
 Logger.initializeToConsole();
 Logger.setLevelDefault(LogLevel.Warning);

--- a/full-stack-tests/rpc/src/frontend/_Setup.test.ts
+++ b/full-stack-tests/rpc/src/frontend/_Setup.test.ts
@@ -5,16 +5,15 @@
 
 import { executeBackendCallback } from "@itwin/certa/lib/utils/CallbackUtils";
 import { Logger, LogLevel } from "@itwin/core-bentley";
-import { BentleyCloudRpcConfiguration, BentleyCloudRpcManager, RpcConfiguration, WebAppRpcProtocol } from "@itwin/core-common";
+import { BentleyCloudRpcConfiguration, BentleyCloudRpcManager, RpcConfiguration } from "@itwin/core-common";
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { MobileRpcManager } from "@itwin/core-mobile/lib/cjs/MobileFrontend";
 import { BackendTestCallbacks } from "../common/SideChannels";
-import { AttachedInterface, MobileTestInterface, MultipleClientsInterface, rpcInterfaces, TestRpcInterface } from "../common/TestRpcInterface";
-import { assert } from "chai";
+import { AttachedInterface, MobileTestInterface, MultipleClientsInterface, rpcInterfaces } from "../common/TestRpcInterface";;
 
 Logger.initializeToConsole();
 Logger.setLevelDefault(LogLevel.Warning);
-RpcConfiguration.disableRoutingValidation = false;
+RpcConfiguration.disableRoutingValidation = true;
 
 function initializeCloud(protocol: string) {
   const port = Number(window.location.port) + 2000;
@@ -65,19 +64,4 @@ before(async () => {
     case "electron":
       return ElectronApp.startup({ iModelApp: { rpcInterfaces } });
   }
-});
-
-describe("BentleyCloudRpcManager", () => {
-  it("should initialize correctly when routing validation is enabled", async () => {
-    if (currentEnvironment === "http") {
-      const protocol = TestRpcInterface.getClient().configuration.protocol as WebAppRpcProtocol;
-      assert.equal(protocol.allowedHeaders.size, 0);
-      await TestRpcInterface.getClient().op16({ iModelId: "foo", key: "bar" }, { iModelId: "foo", key: "bar" });
-      assert.isAtLeast(protocol.allowedHeaders.size, 1);
-    }
-  });
-
-  after(() => {
-    RpcConfiguration.disableRoutingValidation = true;
-  });
 });


### PR DESCRIPTION
In commit d415d8c34a672aa03b52f47053d6e966304acd34, a new HTTP header (`X-Protocol-Version`) was added to all RPC requests (and responses) sent via the `BentleyCloudRpcProtocol`.  This exchange of protocol versions allows us to detect backend capabilities and gracefully roll out new capabilities while maintaining backwards compatibility.

However, that change _itself_ presented its own backwards compatibility problem: When the frontend and backed are served from separate [origins](https://developer.mozilla.org/en-US/docs/Glossary/Origin) (this is usually the case), [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requires browsers to automatically send a [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) before each HTTP request[^1] and use the preflight response to determine whether to block or allow that request.  So any requests sent with the new `X-Protocol-Version` header would thus be blocked by CORS unless the backend had _also_ been configured to respond to that preceding preflight with `X-Protocol-Version` included in the [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) response[^2].

In that same commit, @swbsi came up with the clever idea of making _our own preflight_ - explicitly sending an `OPTIONS` request once (ahead of the first RPC request) and using the value of the `Access-Control-Allow-Headers` response header to determine which headers were safe to send.  Thus, RPC calls made by newer frontends would never be blocked by CORS because we would never send the new header unless the backend already supported it. 

Unfortunately, after #3660, we realized that this "RPC preflight" mechanism presented a problem for RPC caching, since `OPTIONS` requests are not meant to be cacheable[^3] (per the [HTTP spec](https://httpwg.org/specs/rfc7231.html#cacheable.methods)).  Normally this is not a problem for typical CORS preflight requests, as most API gateways and proxies support directly responding to CORS preflights (without needing the actual backend to handle/respond to the `OPTIONS` request).  However, after some experimentation we discovered that the `OPTIONS` request sent as our "RPC preflight" is ***not*** treated/handled by said gateways the same way a CORS preflight would be because it does not include the [`Access-Control-Request-Method`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method) header.  Of course, `Access-Control-Request-Method` is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name), so there is no way for us to programmatically add it to this "RPC preflight" request.

The good news is that backends using `BentleyCloudRpcConfiguration` have included `X-Protocol-Version` in their `Access-Control-Allow-Headers` response since version 2.7.0, so we can now remove this entire "RPC preflight" mechanism without fear of breaking any 3.x frontends!  In the future, if we ever need to add another request header, we can simply rely on the value of `X-Protocol-Version` from earlier responses to determine whether it's safe to include.

[^1]: Technically not _every_ HTTP request must be preflighted - some ["simple requests"](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) don't trigger CORS preflights.  This is because the whole rationale for CORS has to do with the web's [long history](https://www.youtube.com/watch?v=vfAHa5GBLio) of supporting _some_ limited cross-origin requests (via elements like `img`, `form`, `script`, etc.) - so with the introduction of more powerful APIs like `XMLHttpRequest` and `fetch`, steps had to be taken to allow servers to opt-in and confirm that they did not rely on those cross-origin limitations for security purposes.

    In practice, however, our RPC requests will _always_ be preflighted (for using the `Authorization` header, among other things).   

[^2]: This would be true for any new header other than the handful of [CORS-safelisted request headers](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header).

[^3]: CORS preflight responses are still _effectively_ cached by browsers via the [`Access-Control-Max-Age
`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) header, but strictly speaking this does not mean the OPTIONS response is going into the usual HTTP cache, rather the browser is caching just the info from the `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers` response headers for the purpose of skipping CORS preflights.  Also, unlike normal HTTP caching, this max age is capped by the browser (chrome caps at 2hrs but this varies by browser).