### PR TITLE
Convert getModelProps RPC operation to a GET request from POST

### DIFF
--- a/common/changes/@itwin/core-common/nick-cache-getModelProps_2022-06-20-13-16.json
+++ b/common/changes/@itwin/core-common/nick-cache-getModelProps_2022-06-20-13-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "make getModelProps a GET request instead of a POST",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/rpc/IModelReadRpcInterface.ts
+++ b/core/common/src/rpc/IModelReadRpcInterface.ts
@@ -66,6 +66,7 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
   public async getConnectionProps(_iModelToken: IModelRpcOpenProps): Promise<IModelConnectionProps> { return this.forward(arguments); }
   public async queryRows(_iModelToken: IModelRpcProps, _request: DbQueryRequest): Promise<DbQueryResponse> { return this.forward(arguments); }
   public async queryBlob(_iModelToken: IModelRpcProps, _request: DbBlobRequest): Promise<DbBlobResponse> { return this.forward(arguments); }
+  @RpcOperation.allowResponseCaching(RpcResponseCacheControl.Immutable)
   public async getModelProps(_iModelToken: IModelRpcProps, _modelIds: Id64String[]): Promise<ModelProps[]> { return this.forward(arguments); }
   @RpcOperation.allowResponseCaching(RpcResponseCacheControl.Immutable)
   public async queryModelRanges(_iModelToken: IModelRpcProps, _modelIds: Id64String[]): Promise<Range3dProps[]> { return this.forward(arguments); }


### PR DESCRIPTION
Some types of tile trees (ClassifierTileTree, RealityModelTileTree, MapTileTree) need to load models which results in a call to GetModelProps. We want to cache getModelProps so that initial View creation (and tile generation) is speedy and requires little assistance from a backend while these RPC requests are cached.