### PR TITLE
Remove sinon dependency from HubMock

### DIFF
--- a/common/changes/@itwin/core-backend/fix-sinon-dep_2022-06-21-13-14.json
+++ b/common/changes/@itwin/core-backend/fix-sinon-dep_2022-06-21-13-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -44,10 +44,14 @@
     "@itwin/core-bentley": "workspace:^3.3.0-dev.20",
     "@itwin/core-common": "workspace:^3.3.0-dev.20",
     "@itwin/core-geometry": "workspace:^3.3.0-dev.20",
-    "@itwin/ecschema-metadata": "workspace:^3.3.0-dev.20"
+    "@itwin/ecschema-metadata": "workspace:^3.3.0-dev.20",
+    "@opentelemetry/api": "^1.0.4"
   },
   "peerDependenciesMeta": {
     "@itwin/ecschema-metadata": {
+      "optional": true
+    },
+    "@opentelemetry/api": {
       "optional": true
     }
   },
@@ -101,14 +105,6 @@
     "multiparty": "^4.2.1",
     "semver": "^7.3.5",
     "ws": "^7.5.3"
-  },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.0.4"
-  },
-  "peerDependenciesMeta": {
-    "@opentelemetry/api": {
-      "optional": true
-    }
   },
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"

--- a/core/backend/src/HubMock.ts
+++ b/core/backend/src/HubMock.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { join } from "path";
-import * as sinon from "sinon";
 import { Guid, GuidString } from "@itwin/core-bentley";
 import {
   ChangesetFileProps, ChangesetIndex, ChangesetIndexAndId, ChangesetProps, ChangesetRange, IModelVersion, LocalDirName,
@@ -102,7 +101,6 @@ export class HubMock {
     IModelJsFs.purgeDirSync(this.mockRoot!);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     IModelJsFs.removeSync(this.mockRoot!);
-    sinon.restore();
     IModelHost.setHubAccess(this._saveHubAccess);
     this.mockRoot = undefined;
   }


### PR DESCRIPTION
The move of HubMock to the core-backend barrel file brought along a sinon dependency within our main backend code, which we do not want. The sinon dep is unused so removing it directly.

Clean up duplicate `peerDependencies` and `peerDependenciesMeta` from the `core-backend/package.json`.