### PR TITLE
Support unix line endings in WorkspaceEditor

### DIFF
--- a/common/changes/@itwin/workspace-editor/workspace-editor-eol_2022-06-21-13-40.json
+++ b/common/changes/@itwin/workspace-editor/workspace-editor-eol_2022-06-21-13-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/workspace-editor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/workspace-editor"
+}

--- a/utils/workspace-editor/src/WorkspaceEditor.ts
+++ b/utils/workspace-editor/src/WorkspaceEditor.ts
@@ -722,7 +722,7 @@ Yargs.command<InitializeOpts>({
 async function runScript(arg: EditorProps & { scriptName: string }) {
   inScript = true;
   const val = fs.readFileSync(arg.scriptName, "utf-8");
-  const lines = val.split("\r");
+  const lines = val.split(/\r?\n/);
   let i = 0;
 
   for (let line of lines) {


### PR DESCRIPTION
The WorkspaceEditor CLI utility allows executing an "@ script" file listing separate WorkspaceEditor commands, but splitting by `\r` meant that files written w/ unix-style line endings (`\n`) were not parsed correctly.