### PR TITLE
Raplemie/status bar fields own their widget states

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3874,8 +3874,6 @@ export class MessageCenterField extends React.Component<MessageCenterFieldProps,
     componentWillUnmount(): void;
     // (undocumented)
     render(): React.ReactNode;
-    // (undocumented)
-    readonly state: Readonly<MessageCenterState>;
     }
 
 // @public
@@ -6113,7 +6111,9 @@ export abstract class StatusBarWidgetControl extends WidgetControl {
 // @public
 export interface StatusBarWidgetControlArgs {
     isInFooterMode: boolean;
+    // @deprecated
     onOpenWidget: (widget: StatusBarFieldId) => void;
+    // @deprecated
     openWidget: StatusBarFieldId;
     toastTargetRef: React_2.Ref<HTMLElement>;
 }
@@ -6147,8 +6147,10 @@ export interface StatusBarZoneProps extends CommonProps {
 // @public
 export interface StatusFieldProps extends CommonProps {
     isInFooterMode: boolean;
-    onOpenWidget: (widget: StatusBarFieldId) => void;
-    openWidget: StatusBarFieldId;
+    // @deprecated
+    onOpenWidget?: (widget: StatusBarFieldId) => void;
+    // @deprecated
+    openWidget?: StatusBarFieldId;
 }
 
 // @public

--- a/common/changes/@itwin/appui-react/raplemie-StatusBarFieldsOwnTheirWidgetStates_2022-06-21-18-33.json
+++ b/common/changes/@itwin/appui-react/raplemie-StatusBarFieldsOwnTheirWidgetStates_2022-06-21-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecate `openWidget` and `onOpenWidget` props from `StatusBarFields` interface.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/appui-react/raplemie-StatusBarFieldsOwnTheirWidgetStates_2022-06-21-18-43.json
+++ b/common/changes/@itwin/appui-react/raplemie-StatusBarFieldsOwnTheirWidgetStates_2022-06-21-18-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarWidgetControl.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarWidgetControl.tsx
@@ -20,9 +20,13 @@ export type StatusBarFieldId = string | null;
 export interface StatusBarWidgetControlArgs {
   /** Describes whether the footer is in widget or footer mode. */
   isInFooterMode: boolean;
-  /** Currently open widget or null if no widget is open. */
+  /** Currently open widget or null if no widget is open.
+   * @deprecated In upcoming versions, this will be removed. Field will be have the freedom of handling their dialog behavior however they like.
+  */
   openWidget: StatusBarFieldId;
-  /** Function called when the widget is being opened or closed. */
+  /** Function called when the widget is being opened or closed.
+   * @deprecated In upcoming versions, this will be removed. Field will be have the freedom of handling their dialog behavior however they like.
+  */
   onOpenWidget: (widget: StatusBarFieldId) => void;
   /** Element reference to which the toast will animate out to. */
   toastTargetRef: React.Ref<HTMLElement>;

--- a/ui/appui-react/src/appui-react/statusfields/MessageCenter.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/MessageCenter.tsx
@@ -31,6 +31,7 @@ interface MessageCenterState {
   activeTab: MessageCenterActiveTab;
   target: HTMLDivElement | null;
   messageCount: number;
+  openWidget: string | null;
 }
 
 /** Properties for withMessageCenterFieldProps HOC.
@@ -51,17 +52,19 @@ export class MessageCenterField extends React.Component<MessageCenterFieldProps,
   private _unloadMessagesUpdatedHandler?: () => void;
   private _removeOpenMessagesCenterHandler?: () => void;
 
-  public override readonly state: Readonly<MessageCenterState> = {
-    activeTab: MessageCenterActiveTab.AllMessages,
-    target: null,
-    messageCount: MessageManager.messages.length,
-  };
-
   constructor(p: MessageCenterFieldProps) {
     super(p);
 
     const instance = this.constructor;
     this._className = instance.name;
+
+    this.state = {
+      activeTab: MessageCenterActiveTab.AllMessages,
+      target: null,
+      messageCount: MessageManager.messages.length,
+      // eslint-disable-next-line deprecation/deprecation
+      openWidget: p.openWidget ?? null,
+    };
   }
 
   /** @internal */
@@ -115,7 +118,8 @@ export class MessageCenterField extends React.Component<MessageCenterFieldProps,
           </MessageCenter>
         </div>
         <FooterPopup
-          isOpen={this.props.openWidget === this._className}
+          // eslint-disable-next-line deprecation/deprecation
+          isOpen={(this.props.openWidget ?? this.state.openWidget) === this._className}
           onClose={this._handleClose}
           onOutsideClick={this._handleOutsideClick}
           target={this.state.target}
@@ -171,7 +175,8 @@ export class MessageCenterField extends React.Component<MessageCenterFieldProps,
   };
 
   private _handleMessageIndicatorClick = () => {
-    const isOpen = this.props.openWidget === this._className;
+    // eslint-disable-next-line deprecation/deprecation
+    const isOpen = (this.props.openWidget ?? this.state.openWidget) === this._className;
     if (isOpen)
       this.setOpenWidget(null);
     else
@@ -223,8 +228,8 @@ export class MessageCenterField extends React.Component<MessageCenterFieldProps,
   }
 
   private setOpenWidget(openWidget: StatusBarFieldId) {
-    // istanbul ignore else
-    if (this.props.onOpenWidget)
-      this.props.onOpenWidget(openWidget);
+    // eslint-disable-next-line deprecation/deprecation
+    this.props.onOpenWidget?.(openWidget);
+    this.setState({openWidget});
   }
 }

--- a/ui/appui-react/src/appui-react/statusfields/SnapMode.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SnapMode.tsx
@@ -39,7 +39,6 @@ interface SnapModeFieldState {
  * display the active snap mode that AccuSnap will use and allow the user to select a new snap mode.
  */
 class SnapModeFieldComponent extends React.Component<SnapModeFieldProps, SnapModeFieldState> {
-  private _className: string;
   private _snapModeFieldArray: SnapModeFieldEntry[] = [
     { label: UiFramework.translate("snapModeField.keypoint"), value: SnapMode.NearestKeypoint as number, iconName: "snaps" },
     { label: UiFramework.translate("snapModeField.intersection"), value: SnapMode.Intersection as number, iconName: "snaps-intersection" },
@@ -57,9 +56,6 @@ class SnapModeFieldComponent extends React.Component<SnapModeFieldProps, SnapMod
 
   constructor(props: SnapModeFieldProps) {
     super(props);
-
-    const instance = this.constructor;
-    this._className = instance.name;
   }
 
   /** Return icon class name for a specific snapMode. */

--- a/ui/appui-react/src/appui-react/statusfields/StatusFieldProps.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/StatusFieldProps.tsx
@@ -15,8 +15,12 @@ import { StatusBarFieldId } from "../statusbar/StatusBarWidgetControl";
 export interface StatusFieldProps extends CommonProps {
   /** Indicates whether the StatusBar is in footer mode */
   isInFooterMode: boolean;
-  /** Function called when the widget is opened or closed. */
-  onOpenWidget: (widget: StatusBarFieldId) => void;
-  /** Field Id for open widgets */
-  openWidget: StatusBarFieldId;
+  /** Function called when the widget is opened or closed.
+   * @deprecated In upcoming versions, this will be removed. Field will be have the freedom of handling their dialog behavior however they like.
+  */
+  onOpenWidget?: (widget: StatusBarFieldId) => void;
+  /** Field Id for open widgets
+   * @deprecated In upcoming versions, this will be removed. Field will be have the freedom of handling their dialog behavior however they like.
+  */
+  openWidget?: StatusBarFieldId;
 }

--- a/ui/appui-react/src/appui-react/statusfields/StatusFieldProps.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/StatusFieldProps.tsx
@@ -5,9 +5,10 @@
 /** @packageDocumentation
  * @module StatusBar
  */
-
 import { CommonProps } from "@itwin/core-react";
+
 import { StatusBarFieldId } from "../statusbar/StatusBarWidgetControl";
+
 
 /** Properties for a StatusBar field component
  * @public
@@ -16,11 +17,11 @@ export interface StatusFieldProps extends CommonProps {
   /** Indicates whether the StatusBar is in footer mode */
   isInFooterMode: boolean;
   /** Function called when the widget is opened or closed.
-   * @deprecated In upcoming versions, this will be removed. Field will be have the freedom of handling their dialog behavior however they like.
-  */
+   * @deprecated In upcoming versions, this will be removed. Field will have the freedom of handling their dialog behavior however they like.
+   */
   onOpenWidget?: (widget: StatusBarFieldId) => void;
   /** Field Id for open widgets
-   * @deprecated In upcoming versions, this will be removed. Field will be have the freedom of handling their dialog behavior however they like.
-  */
+   * @deprecated In upcoming versions, this will be removed. Field will have the freedom of handling their dialog behavior however they like.
+   */
   openWidget?: StatusBarFieldId;
 }

--- a/ui/appui-react/src/appui-react/statusfields/StatusFieldProps.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/StatusFieldProps.tsx
@@ -9,7 +9,6 @@ import { CommonProps } from "@itwin/core-react";
 
 import { StatusBarFieldId } from "../statusbar/StatusBarWidgetControl";
 
-
 /** Properties for a StatusBar field component
  * @public
  */

--- a/ui/appui-react/src/appui-react/statusfields/ViewAttributes.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/ViewAttributes.tsx
@@ -108,6 +108,7 @@ export class ViewAttributesStatusField extends React.Component<StatusFieldProps,
   }
 
   public override render() {
+    // eslint-disable-next-line deprecation/deprecation
     const isOpen = this.props.openWidget === this._className;
     return (
       <>

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -87,6 +87,7 @@ interface ToolAssistanceFieldState {
   showTouchInstructions: boolean;
   mouseTouchTabIndex: number;
   isPinned: boolean;
+  openWidget: string | null;
 }
 
 /** Tool Assistance Field React component.
@@ -138,6 +139,7 @@ export class ToolAssistanceField extends React.Component<ToolAssistanceFieldProp
       showTouchInstructions: false,
       mouseTouchTabIndex: 0,
       isPinned: false,
+      openWidget: null,
     };
 
     this._uiSettingsStorage = new LocalStateStorage();
@@ -397,7 +399,7 @@ export class ToolAssistanceField extends React.Component<ToolAssistanceFieldProp
           </ToolAssistance>
         </div>
         <FooterPopup
-          isOpen={this.props.openWidget === this._className}
+          isOpen={(this.props.openWidget ?? this.state.openWidget) === this._className}
           onClose={this._handleClose}
           onOutsideClick={this._handleOutsideClick}
           target={this._target}
@@ -459,7 +461,7 @@ export class ToolAssistanceField extends React.Component<ToolAssistanceFieldProp
   };
 
   private _handleToolAssistanceIndicatorClick = () => {
-    const isOpen = this.props.openWidget === this._className;
+    const isOpen = (this.props.openWidget ?? this.state.openWidget) === this._className;
     if (isOpen) {
       this.setOpenWidget(null);
     } else
@@ -477,15 +479,14 @@ export class ToolAssistanceField extends React.Component<ToolAssistanceFieldProp
   };
 
   private setOpenWidget(openWidget: StatusBarFieldId) {
-    // istanbul ignore else
-    if (this.props.onOpenWidget)
-      this.props.onOpenWidget(openWidget);
-
-    if (!openWidget && this.state.isPinned) {
-      // istanbul ignore else
-      if (this._isMounted)
-        this.setState({ isPinned: false });
+    this.props.onOpenWidget?.(openWidget);
+    let newState = {
+      openWidget,
+    };
+    if (!openWidget && this.state.isPinned && this._isMounted) {
+      newState = {...newState, ...{isPinned: false}};
     }
+    this.setState(newState);
   }
 
   /** @internal */

--- a/ui/appui-react/src/test/statusbar/StatusBar.test.tsx
+++ b/ui/appui-react/src/test/statusbar/StatusBar.test.tsx
@@ -28,10 +28,10 @@ describe("StatusBar", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
-          <MessageCenterField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} />
+          <MessageCenterField isInFooterMode={isInFooterMode} />
         </>
       );
     }

--- a/ui/appui-react/src/test/statusbar/StatusBarWidgetControl.test.tsx
+++ b/ui/appui-react/src/test/statusbar/StatusBarWidgetControl.test.tsx
@@ -17,10 +17,10 @@ describe("StatusBarWidgetControl", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
-          <MessageCenterField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} />
+          <MessageCenterField isInFooterMode={isInFooterMode} />
         </>
       );
     }

--- a/ui/appui-react/src/test/statusfields/ActivityCenter.test.tsx
+++ b/ui/appui-react/src/test/statusfields/ActivityCenter.test.tsx
@@ -18,10 +18,10 @@ describe("ActivityCenter", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
-          <ActivityCenterField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} />
+          <ActivityCenterField isInFooterMode={isInFooterMode} />
         </>
       );
     }

--- a/ui/appui-react/src/test/statusfields/FooterModeField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/FooterModeField.test.tsx
@@ -18,11 +18,10 @@ describe("FooterModeField", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
-      if (openWidget) { }
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
-          <FooterModeField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget}> <FooterSeparator /> </FooterModeField>
+          <FooterModeField isInFooterMode={isInFooterMode}> <FooterSeparator /> </FooterModeField>
         </>
       );
     }

--- a/ui/appui-react/src/test/statusfields/MessageCenter.test.tsx
+++ b/ui/appui-react/src/test/statusfields/MessageCenter.test.tsx
@@ -14,133 +14,156 @@ import {
 } from "../../appui-react";
 import TestUtils, { mount } from "../TestUtils";
 
-describe("MessageCenter", () => {
+[true, false].forEach((withDeprecated) =>{
+  const testType = withDeprecated ? " (with deprecated openWidget props)" : "";
+  describe(`MessageCenter${testType}`, () => {
 
-  class AppStatusBarWidgetControl extends StatusBarWidgetControl {
-    constructor(info: ConfigurableCreateInfo, options: any) {
-      super(info, options);
+    class AppStatusBarWidgetControl extends StatusBarWidgetControl {
+      constructor(info: ConfigurableCreateInfo, options: any) {
+        super(info, options);
+      }
+
+      // eslint-disable-next-line deprecation/deprecation
+      public getReactNode({ isInFooterMode, onOpenWidget, openWidget, toastTargetRef }: StatusBarWidgetControlArgs): React.ReactNode {
+        return (
+          <>
+            <MessageCenterField isInFooterMode={isInFooterMode} {...(withDeprecated ? {onOpenWidget, openWidget} : {})} targetRef={toastTargetRef} />
+          </>
+        );
+      }
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget, toastTargetRef }: StatusBarWidgetControlArgs): React.ReactNode {
-      return (
-        <>
-          <MessageCenterField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} targetRef={toastTargetRef} />
-        </>
-      );
-    }
-  }
+    let widgetControl: StatusBarWidgetControl | undefined;
 
-  let widgetControl: StatusBarWidgetControl | undefined;
+    before(async () => {
+      await TestUtils.initializeUiFramework();
 
-  before(async () => {
-    await TestUtils.initializeUiFramework();
+      ConfigurableUiManager.unregisterControl("AppStatusBar");
+      ConfigurableUiManager.registerControl("AppStatusBar", AppStatusBarWidgetControl);
 
-    ConfigurableUiManager.unregisterControl("AppStatusBar");
-    ConfigurableUiManager.registerControl("AppStatusBar", AppStatusBarWidgetControl);
-
-    const statusBarWidgetDef = new WidgetDef({
-      classId: AppStatusBarWidgetControl,
-      defaultState: WidgetState.Open,
-      isFreeform: false,
-      isStatusBar: true,
+      const statusBarWidgetDef = new WidgetDef({
+        classId: AppStatusBarWidgetControl,
+        defaultState: WidgetState.Open,
+        isFreeform: false,
+        isStatusBar: true,
+      });
+      widgetControl = statusBarWidgetDef.getWidgetControl(ConfigurableUiControlType.StatusBarWidget) as StatusBarWidgetControl;
     });
-    widgetControl = statusBarWidgetDef.getWidgetControl(ConfigurableUiControlType.StatusBarWidget) as StatusBarWidgetControl;
+
+    after(() => {
+      TestUtils.terminateUiFramework();
+    });
+
+    it("Message Center should support all message types", () => {
+      MessageManager.clearMessages();
+      expect(MessageManager.messages.length).to.eq(0);
+
+      const infoMessage = new NotifyMessageDetails(OutputMessagePriority.Info, "Message text.");
+      MessageManager.addMessage(infoMessage);
+      const warningMessage = new NotifyMessageDetails(OutputMessagePriority.Warning, "Message text.");
+      MessageManager.addMessage(warningMessage);
+      const errorMessage = new NotifyMessageDetails(OutputMessagePriority.Error, "Message text.");
+      MessageManager.addMessage(errorMessage);
+      const fatalMessage = new NotifyMessageDetails(OutputMessagePriority.Fatal, "Message text.");
+      MessageManager.addMessage(fatalMessage);
+      expect(MessageManager.messages.length).to.eq(4);
+
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      wrapper.find("div.nz-balloon").simulate("click"); // Opens it
+      wrapper.update();
+
+      expect(wrapper.find("i.icon-info").length).to.eq(1);
+      expect(wrapper.find("i.icon-status-warning").length).to.eq(1);
+      expect(wrapper.find("i.icon-status-error").length).to.eq(1);
+      expect(wrapper.find("i.icon-status-rejected").length).to.eq(1);
+
+      wrapper.find("div.nz-balloon").simulate("click"); // Closes it
+      wrapper.update();
+    });
+
+    it("Message Center should change tabs", () => {
+      MessageManager.clearMessages();
+      expect(MessageManager.messages.length).to.eq(0);
+
+      const infoMessage = new NotifyMessageDetails(OutputMessagePriority.Info, "Brief text.", "Detail text");
+      MessageManager.addMessage(infoMessage);
+      const errorMessage = new NotifyMessageDetails(OutputMessagePriority.Error, "Message text.");
+      MessageManager.addMessage(errorMessage);
+      expect(MessageManager.messages.length).to.eq(2);
+
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      wrapper.find("div.nz-balloon").simulate("click");
+      wrapper.update();
+
+      const tabs = wrapper.find("div.nz-footer-messageCenter-tab");
+      expect(tabs.length).to.eq(2);
+
+      tabs.at(1).simulate("click"); // Change tab
+      wrapper.update();
+
+      tabs.at(0).simulate("click"); // Change tab back
+      wrapper.update();
+    });
+
+    it("Message Center should close on outside click", () => {
+      const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
+      const footerPopup = wrapper.find(FooterPopup);
+      const messageCenterField = wrapper.find(MessageCenterField);
+      const messageCenter = wrapper.find("div.nz-indicator");
+
+      const statusBarInstance = wrapper.instance();
+      messageCenter.simulate("click");
+      wrapper.update();
+
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).not.null;
+      }
+      expect(messageCenterField.state().openWidget).not.null;
+
+      const outsideClick = new MouseEvent("");
+      sinon.stub(outsideClick, "target").get(() => document.createElement("div"));
+      footerPopup.prop("onOutsideClick")!(outsideClick);
+
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).null;
+      }
+      expect(messageCenterField.state().openWidget).null;
+    });
+
+    it("Message Center should not close on outside click", () => {
+      const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
+      const footerPopup = wrapper.find(FooterPopup);
+
+      const statusBarInstance = wrapper.instance();
+      statusBarInstance.setState(() => ({ openWidget: "test-widget" }));
+
+      const outsideClick = new MouseEvent("");
+      footerPopup.prop("onOutsideClick")!(outsideClick);
+
+      expect(statusBarInstance.state.openWidget).eq("test-widget");
+    });
+
+    it("Message Center should open on OpenMessageCenterEvent", () => {
+      const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
+      const messageCenterField = wrapper.find(MessageCenterField);
+
+      const statusBarInstance = wrapper.instance();
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).null;
+      }
+      expect(messageCenterField.state().openWidget).null;
+
+      MessageManager.onOpenMessageCenterEvent.emit({});
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).not.null;
+      }
+      expect(messageCenterField.state().openWidget).not.null;
+    });
+
+    // nz-footer-messageCenter-tab
+
   });
-
-  after(() => {
-    TestUtils.terminateUiFramework();
-  });
-
-  it("Message Center should support all message types", () => {
-    MessageManager.clearMessages();
-    expect(MessageManager.messages.length).to.eq(0);
-
-    const infoMessage = new NotifyMessageDetails(OutputMessagePriority.Info, "Message text.");
-    MessageManager.addMessage(infoMessage);
-    const warningMessage = new NotifyMessageDetails(OutputMessagePriority.Warning, "Message text.");
-    MessageManager.addMessage(warningMessage);
-    const errorMessage = new NotifyMessageDetails(OutputMessagePriority.Error, "Message text.");
-    MessageManager.addMessage(errorMessage);
-    const fatalMessage = new NotifyMessageDetails(OutputMessagePriority.Fatal, "Message text.");
-    MessageManager.addMessage(fatalMessage);
-    expect(MessageManager.messages.length).to.eq(4);
-
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    wrapper.find("div.nz-balloon").simulate("click"); // Opens it
-    wrapper.update();
-
-    expect(wrapper.find("i.icon-info").length).to.eq(1);
-    expect(wrapper.find("i.icon-status-warning").length).to.eq(1);
-    expect(wrapper.find("i.icon-status-error").length).to.eq(1);
-    expect(wrapper.find("i.icon-status-rejected").length).to.eq(1);
-
-    wrapper.find("div.nz-balloon").simulate("click"); // Closes it
-    wrapper.update();
-  });
-
-  it("Message Center should change tabs", () => {
-    MessageManager.clearMessages();
-    expect(MessageManager.messages.length).to.eq(0);
-
-    const infoMessage = new NotifyMessageDetails(OutputMessagePriority.Info, "Brief text.", "Detail text");
-    MessageManager.addMessage(infoMessage);
-    const errorMessage = new NotifyMessageDetails(OutputMessagePriority.Error, "Message text.");
-    MessageManager.addMessage(errorMessage);
-    expect(MessageManager.messages.length).to.eq(2);
-
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    wrapper.find("div.nz-balloon").simulate("click");
-    wrapper.update();
-
-    const tabs = wrapper.find("div.nz-footer-messageCenter-tab");
-    expect(tabs.length).to.eq(2);
-
-    tabs.at(1).simulate("click"); // Change tab
-    wrapper.update();
-
-    tabs.at(0).simulate("click"); // Change tab back
-    wrapper.update();
-  });
-
-  it("Message Center should close on outside click", () => {
-    const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
-    const footerPopup = wrapper.find(FooterPopup);
-
-    const statusBarInstance = wrapper.instance();
-    statusBarInstance.setState(() => ({ openWidget: "test-widget" }));
-
-    const outsideClick = new MouseEvent("");
-    sinon.stub(outsideClick, "target").get(() => document.createElement("div"));
-    footerPopup.prop("onOutsideClick")!(outsideClick);
-
-    expect(statusBarInstance.state.openWidget).null;
-  });
-
-  it("Message Center should not close on outside click", () => {
-    const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
-    const footerPopup = wrapper.find(FooterPopup);
-
-    const statusBarInstance = wrapper.instance();
-    statusBarInstance.setState(() => ({ openWidget: "test-widget" }));
-
-    const outsideClick = new MouseEvent("");
-    footerPopup.prop("onOutsideClick")!(outsideClick);
-
-    expect(statusBarInstance.state.openWidget).eq("test-widget");
-  });
-
-  it("Message Center should open on OpenMessageCenterEvent", () => {
-    const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
-
-    const statusBarInstance = wrapper.instance();
-    expect(statusBarInstance.state.openWidget).null;
-
-    MessageManager.onOpenMessageCenterEvent.emit({});
-    expect(statusBarInstance.state.openWidget).not.null;
-  });
-
-  // nz-footer-messageCenter-tab
 
 });

--- a/ui/appui-react/src/test/statusfields/PromptField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/PromptField.test.tsx
@@ -19,8 +19,7 @@ describe("PromptField", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
-      if (openWidget) { }
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
           <PromptField isInFooterMode={isInFooterMode} openWidget={null} onOpenWidget={() => { }} />   {/* eslint-disable-line deprecation/deprecation */}

--- a/ui/appui-react/src/test/statusfields/SectionsField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SectionsField.test.tsx
@@ -20,10 +20,10 @@ describe("SectionsField", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
-          <SectionsStatusField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} />
+          <SectionsStatusField isInFooterMode={isInFooterMode} />
         </>
       );
     }

--- a/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
@@ -20,8 +20,7 @@ describe("SelectionInfoField", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
-      if (openWidget) { }
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
           <SelectionInfoField isInFooterMode={isInFooterMode} openWidget={null} onOpenWidget={() => { }} />

--- a/ui/appui-react/src/test/statusfields/SelectionScope.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SelectionScope.test.tsx
@@ -21,10 +21,10 @@ class AppStatusBarWidgetControl extends StatusBarWidgetControl {
     super(info, options);
   }
 
-  public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+  public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
     return (
       <>
-        <SelectionScopeField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} />
+        <SelectionScopeField isInFooterMode={isInFooterMode} />
       </>
     );
   }

--- a/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
@@ -21,10 +21,10 @@ describe("SnapModeField", () => {
       super(info, options);
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+    public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
-          <SnapModeField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} />
+          <SnapModeField isInFooterMode={isInFooterMode} />
         </>
       );
     }

--- a/ui/appui-react/src/test/statusfields/ViewAttributes.test.tsx
+++ b/ui/appui-react/src/test/statusfields/ViewAttributes.test.tsx
@@ -15,86 +15,90 @@ import { ViewAttributesStatusField } from "../../appui-react/statusfields/ViewAt
 import { WidgetDef } from "../../appui-react/widgets/WidgetDef";
 import TestUtils, { mount } from "../TestUtils";
 
-describe("ViewAttributes", () => {
-  class AppStatusBarWidgetControl extends StatusBarWidgetControl {
-    constructor(info: ConfigurableCreateInfo, options: any) {
-      super(info, options);
+[true, false].forEach((withDeprecated) =>{
+  const testType = withDeprecated ? " (with deprecated openWidget props)" : "";
+
+  describe(`ViewAttributes${testType}`, () => {
+    class AppStatusBarWidgetControl extends StatusBarWidgetControl {
+      constructor(info: ConfigurableCreateInfo, options: any) {
+        super(info, options);
+      }
+
+      // eslint-disable-next-line deprecation/deprecation
+      public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+        return (
+          <>
+            <ViewAttributesStatusField isInFooterMode={isInFooterMode} {...(withDeprecated ? {onOpenWidget, openWidget} : {})} />
+          </>
+        );
+      }
     }
 
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
-      return (
-        <>
-          <ViewAttributesStatusField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget} />
-        </>
-      );
-    }
-  }
+    let widgetControl: StatusBarWidgetControl | undefined;
 
-  let widgetControl: StatusBarWidgetControl | undefined;
+    before(async () => {
+      await TestUtils.initializeUiFramework();
+      await MockRender.App.startup();
 
-  before(async () => {
-    await TestUtils.initializeUiFramework();
-    await MockRender.App.startup();
-
-    const statusBarWidgetDef = new WidgetDef({
-      classId: AppStatusBarWidgetControl,
-      defaultState: WidgetState.Open,
-      isFreeform: false,
-      isStatusBar: true,
+      const statusBarWidgetDef = new WidgetDef({
+        classId: AppStatusBarWidgetControl,
+        defaultState: WidgetState.Open,
+        isFreeform: false,
+        isStatusBar: true,
+      });
+      widgetControl = statusBarWidgetDef.getWidgetControl(ConfigurableUiControlType.StatusBarWidget) as StatusBarWidgetControl;
     });
-    widgetControl = statusBarWidgetDef.getWidgetControl(ConfigurableUiControlType.StatusBarWidget) as StatusBarWidgetControl;
+
+    after(async () => {
+      await MockRender.App.shutdown();
+      TestUtils.terminateUiFramework();
+    });
+
+    it("should render", () => {
+      mount(<Provider store={TestUtils.store}>
+        <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
+      </Provider>);
+    });
+
+    it("should open/close on click", () => {
+      const wrapper = mount(<Provider store={TestUtils.store}>
+        <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
+      </Provider>);
+
+      // Simulate a click to open the pop-up dialog
+      wrapper.find("div.uifw-indicator-icon").simulate("click"); // Opens it
+      wrapper.update();
+
+      expect(wrapper.find("div.uifw-view-attributes-contents").length).to.eq(1);
+
+      wrapper.find("div.uifw-indicator-icon").simulate("click"); // Closes it
+      wrapper.update();
+    });
+
+    it("should process Checkbox clicks", () => {
+      const wrapper = mount(<Provider store={TestUtils.store}>
+        <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
+      </Provider>);
+
+      // Simulate a click to open the pop-up dialog
+      wrapper.find("div.uifw-indicator-icon").simulate("click"); // Opens it
+      wrapper.update();
+
+      expect(wrapper.find("div.uifw-view-attributes-contents").length).to.eq(1);
+
+      const checkBoxes = wrapper.find(Checkbox);
+      expect(checkBoxes.length).to.be.greaterThan(0);
+
+      const acs = checkBoxes.find({ label: "listTools.acs" });
+      expect(acs.length).to.be.greaterThan(0);
+      acs.at(0).prop("onClick")!();
+
+      const camera = checkBoxes.find({ label: "listTools.camera" });
+      expect(camera.length).to.be.greaterThan(0);
+      camera.at(0).prop("onClick")!();
+
+      wrapper.find("div.uifw-indicator-icon").simulate("click"); // Closes it
+      wrapper.update();
+    });
   });
-
-  after(async () => {
-    await MockRender.App.shutdown();
-    TestUtils.terminateUiFramework();
-  });
-
-  it("should render", () => {
-    mount(<Provider store={TestUtils.store}>
-      <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
-    </Provider>);
-  });
-
-  it("should open/close on click", () => {
-    const wrapper = mount(<Provider store={TestUtils.store}>
-      <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
-    </Provider>);
-
-    // Simulate a click to open the pop-up dialog
-    wrapper.find("div.uifw-indicator-icon").simulate("click"); // Opens it
-    wrapper.update();
-
-    expect(wrapper.find("div.uifw-view-attributes-contents").length).to.eq(1);
-
-    wrapper.find("div.uifw-indicator-icon").simulate("click"); // Closes it
-    wrapper.update();
-  });
-
-  it("should process Checkbox clicks", () => {
-    const wrapper = mount(<Provider store={TestUtils.store}>
-      <StatusBar widgetControl={widgetControl} isInFooterMode={true} />
-    </Provider>);
-
-    // Simulate a click to open the pop-up dialog
-    wrapper.find("div.uifw-indicator-icon").simulate("click"); // Opens it
-    wrapper.update();
-
-    expect(wrapper.find("div.uifw-view-attributes-contents").length).to.eq(1);
-
-    const checkBoxes = wrapper.find(Checkbox);
-    expect(checkBoxes.length).to.be.greaterThan(0);
-
-    const acs = checkBoxes.find({ label: "listTools.acs" });
-    expect(acs.length).to.be.greaterThan(0);
-    acs.at(0).prop("onClick")!();
-
-    const camera = checkBoxes.find({ label: "listTools.camera" });
-    expect(camera.length).to.be.greaterThan(0);
-    camera.at(0).prop("onClick")!();
-
-    wrapper.find("div.uifw-indicator-icon").simulate("click"); // Closes it
-    wrapper.update();
-  });
-
 });

--- a/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
@@ -18,511 +18,532 @@ import {
 } from "../../../appui-react";
 import TestUtils, { mount, storageMock } from "../../TestUtils";
 
-describe("ToolAssistanceField", () => {
-  const uiSettingsStorage = new LocalStateStorage({ localStorage: storageMock() } as Window);
+[true, false].forEach((withDeprecated) =>{
+  const testType = withDeprecated ? " (with deprecated (on)openWidget props)" : "";
+  describe(`ToolAssistanceField${testType}`, () => {
 
-  before(async () => {
-    await uiSettingsStorage.saveSetting("ToolAssistance", "showPromptAtCursor", true);
-    await uiSettingsStorage.saveSetting("ToolAssistance", "mouseTouchTabIndex", 0);
-  });
+    const uiSettingsStorage = new LocalStateStorage({ localStorage: storageMock() } as Window);
 
-  class AppStatusBarWidgetControl extends StatusBarWidgetControl {
-    constructor(info: ConfigurableCreateInfo, options: any) {
-      super(info, options);
-    }
-
-    public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
-      return (
-        <>
-          <ToolAssistanceField isInFooterMode={isInFooterMode} onOpenWidget={onOpenWidget} openWidget={openWidget}
-            includePromptAtCursor={true}
-            uiStateStorage={uiSettingsStorage} />
-        </>
-      );
-    }
-  }
-
-  let widgetControl: StatusBarWidgetControl | undefined;
-
-  const clickIndicator = (wrapper: ReactWrapper) => {
-    wrapper.update();
-    const indicator = wrapper.find("div.nz-indicator");
-    expect(indicator.length).to.eq(1);
-    indicator.simulate("click");
-    wrapper.update();
-  };
-
-  before(async () => {
-    await TestUtils.initializeUiFramework();
-    await MockRender.App.startup();
-
-    const statusBarWidgetDef = new WidgetDef({
-      classId: AppStatusBarWidgetControl,
-      defaultState: WidgetState.Open,
-      isFreeform: false,
-      isStatusBar: true,
+    before(async () => {
+      await uiSettingsStorage.saveSetting("ToolAssistance", "showPromptAtCursor", true);
+      await uiSettingsStorage.saveSetting("ToolAssistance", "mouseTouchTabIndex", 0);
     });
-    widgetControl = statusBarWidgetDef.getWidgetControl(ConfigurableUiControlType.StatusBarWidget) as StatusBarWidgetControl;
+
+    class AppStatusBarWidgetControl extends StatusBarWidgetControl {
+      constructor(info: ConfigurableCreateInfo, options: any) {
+        super(info, options);
+      }
+
+      // eslint-disable-next-line deprecation/deprecation
+      public getReactNode({ isInFooterMode, onOpenWidget, openWidget }: StatusBarWidgetControlArgs): React.ReactNode {
+        return (
+          <>
+            <ToolAssistanceField isInFooterMode={isInFooterMode} {...(withDeprecated ? {onOpenWidget, openWidget} : {})}
+              includePromptAtCursor={true}
+              uiStateStorage={uiSettingsStorage} />
+          </>
+        );
+      }
+    }
+
+    let widgetControl: StatusBarWidgetControl | undefined;
+
+    const clickIndicator = (wrapper: ReactWrapper) => {
+      wrapper.update();
+      const indicator = wrapper.find("div.nz-indicator");
+      expect(indicator.length).to.eq(1);
+      indicator.simulate("click");
+      wrapper.update();
+    };
+
+    before(async () => {
+      await TestUtils.initializeUiFramework();
+      await MockRender.App.startup();
+
+      const statusBarWidgetDef = new WidgetDef({
+        classId: AppStatusBarWidgetControl,
+        defaultState: WidgetState.Open,
+        isFreeform: false,
+        isStatusBar: true,
+      });
+      widgetControl = statusBarWidgetDef.getWidgetControl(ConfigurableUiControlType.StatusBarWidget) as StatusBarWidgetControl;
+    });
+
+    after(async () => {
+      TestUtils.terminateUiFramework();
+      await MockRender.App.shutdown();
+    });
+
+    // cSpell:Ignore TOOLPROMPT
+
+    it("Status Bar with ToolAssistanceField should mount", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const helloWorld = "Hello World!";
+      const notifications = new AppNotificationManager();
+      notifications.outputPrompt(helloWorld);
+      wrapper.update();
+    });
+
+    it("dialog should open and close on click", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const helloWorld = "Hello World!";
+      const notifications = new AppNotificationManager();
+      notifications.outputPrompt(helloWorld);
+      wrapper.update();
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(0);
+    });
+
+    it("passing isNew:true should use newDot", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
+
+      const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true);
+      const instruction2 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["A"]), "Press a key", true);
+      const section1 = ToolAssistance.createSection([instruction1, instruction2], "Inputs");
+
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+
+      notifications.setToolAssistance(instructions);
+      wrapper.update();
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find(".nz-footer-toolAssistance-newDot").length).to.eq(3);
+      expect(wrapper.find(".nz-text-new").length).to.eq(3);
+    });
+
+    it("ToolAssistanceImage.Keyboard with a single key should generate key image", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
+      const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["A"]), "Press a key");
+      const section1 = ToolAssistance.createSection([instruction1], "Inputs");
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+      notifications.setToolAssistance(instructions);
+
+      wrapper.update();
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key").length).to.eq(1);
+    });
+
+    it("should support known icons and multiple sections", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction("icon-clock", "This is the prompt that is fairly long 1234567890");
+
+      const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
+      const instruction2 = ToolAssistance.createInstruction(ToolAssistanceImage.MouseWheel, "xyz");
+      const section1 = ToolAssistance.createSection([instruction1, instruction2], "Inputs");
+
+      const instruction21 = ToolAssistance.createInstruction(ToolAssistanceImage.LeftClick, "xyz");
+      const instruction22 = ToolAssistance.createInstruction(ToolAssistanceImage.RightClick, "xyz");
+      const instruction23 = ToolAssistance.createInstruction(ToolAssistanceImage.LeftClickDrag, "xyz");
+      const instruction24 = ToolAssistance.createInstruction(ToolAssistanceImage.RightClickDrag, "xyz");
+      const instruction25 = ToolAssistance.createInstruction(ToolAssistanceImage.MouseWheelClickDrag, "xyz");
+      const section2 = ToolAssistance.createSection([instruction21, instruction22, instruction23, instruction24, instruction25], "More Inputs");
+
+      const instruction31 = ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchTap, "xyz");
+      const instruction32 = ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchDoubleTap, "xyz");
+      const instruction33 = ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchDrag, "xyz");
+      const instruction34 = ToolAssistance.createInstruction(ToolAssistanceImage.TwoTouchTap, "xyz");
+      const instruction35 = ToolAssistance.createInstruction(ToolAssistanceImage.TwoTouchDrag, "xyz");
+      const instruction36 = ToolAssistance.createInstruction(ToolAssistanceImage.TwoTouchPinch, "xyz");
+      const instruction37 = ToolAssistance.createInstruction(ToolAssistanceImage.TouchCursorTap, "xyz");
+      const instruction38 = ToolAssistance.createInstruction(ToolAssistanceImage.TouchCursorDrag, "xyz");
+      const section3 = ToolAssistance.createSection([instruction31, instruction32, instruction33, instruction34, instruction35, instruction36, instruction37, instruction38], "Touch Inputs");
+
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1, section2, section3]);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
+      expect(wrapper.find("div.nz-footer-toolAssistance-separator").length).to.eq(4);
+      expect(wrapper.find("div.nz-footer-toolAssistance-instruction").length).to.eq(16);
+    });
+
+    it("ToolAssistanceImage.Keyboard with a key containing multiple chars should use large key", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
+      const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.shiftKeyboardInfo, "Press the Shift key");
+      const section1 = ToolAssistance.createSection([instruction1], "Inputs");
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-large").length).to.eq(1);
+    });
+
+    it("ToolAssistanceImage.Keyboard with 2 keys should use medium keys", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
+      const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["A", "B"]), "Press one of two keys");
+      const section1 = ToolAssistance.createSection([instruction1], "Inputs");
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-medium").length).to.eq(2);
+    });
+
+    it("ToolAssistanceImage.Keyboard with a modifier key should a medium modifier key & medium key", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
+      const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo([ToolAssistance.ctrlKey, "Z"]), "Press Ctrl+Z", true);
+      const section1 = ToolAssistance.createSection([instruction1], "Inputs");
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-modifier").length).to.eq(1);
+      expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-medium").length).to.eq(1);
+    });
+
+    it("ToolAssistanceImage.Keyboard with bottomRow should use small keys", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
+      const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["W"], ["A", "S", "D"]), "Press one of four keys");
+      const section1 = ToolAssistance.createSection([instruction1], "Inputs");
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-small").length).to.eq(4);
+    });
+
+    it("ToolAssistanceImage.Keyboard but keyboardInfo should log error", () => {
+      const spyMethod = sinon.spy(Logger, "logError");
+      mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.Keyboard, "Press a key" /* No keyboardInfo */);
+      const instructions = ToolAssistance.createInstructions(mainInstruction);
+
+      notifications.setToolAssistance(instructions);
+
+      spyMethod.called.should.true;
+    });
+
+    it("ToolAssistanceImage.Keyboard with invalid keyboardInfo should log error", () => {
+      const spyMethod = sinon.spy(Logger, "logError");
+      mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo([]), "Press key");
+      const instructions = ToolAssistance.createInstructions(mainInstruction);
+
+      notifications.setToolAssistance(instructions);
+
+      spyMethod.called.should.true;
+    });
+
+    it("createModifierKeyInstruction should generate valid instruction", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true, ToolAssistanceInputMethod.Both, ToolAssistance.createKeyboardInfo([]));
+
+      const instruction1 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.LeftClick, "Shift + something else");
+      const instruction2 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.ctrlKey, "icon-cursor-click", "Ctrl + something else");
+      const instruction3 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.LeftClickDrag, "shiftKey + drag something");
+      const instruction4 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.RightClickDrag, "shiftKey + drag something");
+      const instruction5 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.MouseWheelClickDrag, "shiftKey + drag something");
+      const section1 = ToolAssistance.createSection([instruction1, instruction2, instruction3, instruction4, instruction5], "Inputs");
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.uifw-toolassistance-key-modifier").length).to.eq(5);
+      expect(wrapper.find("div.uifw-toolassistance-svg-medium").length).to.eq(1);
+      expect(wrapper.find("div.uifw-toolassistance-icon-medium").length).to.eq(1);
+      expect(wrapper.find("div.uifw-toolassistance-svg-medium-wide").length).to.eq(3);
+    });
+
+    it("should support svg icons in string-based instruction.image", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction("svg:test", "This is the prompt");
+
+      const instructions = ToolAssistance.createInstructions(mainInstruction);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.uifw-toolassistance-svg").length).to.eq(1);
+      expect(wrapper.find("div.uifw-toolassistance-icon-large").length).to.eq(0);
+    });
+
+    it("invalid modifier key info along with image should log error", () => {
+      const spyMethod = sinon.spy(Logger, "logError");
+      mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true, ToolAssistanceInputMethod.Both, ToolAssistance.createKeyboardInfo([]));
+      const instructions = ToolAssistance.createInstructions(mainInstruction);
+      notifications.setToolAssistance(instructions);
+
+      spyMethod.called.should.true;
+    });
+
+    it("should close on outside click", () => {
+      const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
+      const footerPopup = wrapper.find(FooterPopup);
+      const toolAssistanceField = wrapper.find(ToolAssistanceField);
+      const toolAssistance = wrapper.find("div.nz-indicator");
+
+      const statusBarInstance = wrapper.instance();
+      toolAssistance.simulate("click");
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).not.null;
+      }
+      expect(toolAssistanceField.state().openWidget).not.null;
+
+      const outsideClick = new MouseEvent("");
+      sinon.stub(outsideClick, "target").get(() => document.createElement("div"));
+      footerPopup.prop("onOutsideClick")!(outsideClick);
+
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).null;
+      }
+      expect(toolAssistanceField.state().openWidget).null;
+    });
+
+    it("should not close on outside click if pinned", () => {
+      const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
+      const footerPopup = wrapper.find(FooterPopup);
+      const toolAssistance = wrapper.find("div.nz-indicator");
+      const toolAssistanceField = wrapper.find(ToolAssistanceField);
+
+      const statusBarInstance = wrapper.instance();
+      toolAssistance.simulate("click");
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).not.null;
+      }
+      expect(toolAssistanceField.state().openWidget).not.null;
+
+      expect(toolAssistanceField.length).to.eq(1);
+      expect(toolAssistanceField.state("isPinned")).to.be.false;
+      toolAssistanceField.setState({ isPinned: true });
+      expect(toolAssistanceField.state("isPinned")).to.be.true;
+
+      const outsideClick = new MouseEvent("");
+      sinon.stub(outsideClick, "target").get(() => document.createElement("div"));
+      footerPopup.prop("onOutsideClick")!(outsideClick);
+
+      if(withDeprecated) {
+        expect(statusBarInstance.state.openWidget).not.null;
+      }
+      expect(toolAssistanceField.state().openWidget).not.null;
+    });
+
+    it("dialog should open and close on click, even if pinned", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const helloWorld = "Hello World!";
+      const notifications = new AppNotificationManager();
+      notifications.outputPrompt(helloWorld);
+      wrapper.update();
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
+
+      const toolAssistanceField = wrapper.find(ToolAssistanceField);
+      expect(toolAssistanceField.length).to.eq(1);
+      expect(toolAssistanceField.state("isPinned")).to.be.false;
+      toolAssistanceField.setState({ isPinned: true });
+      expect(toolAssistanceField.state("isPinned")).to.be.true;
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(0);
+      expect(toolAssistanceField.state("isPinned")).to.be.false;
+    });
+
+    it("should set showPromptAtCursor on toggle click", async () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={false} />);
+      await TestUtils.flushAsyncOperations();
+      const toolAssistanceField = wrapper.find(ToolAssistanceField);
+      expect(toolAssistanceField.length).to.eq(1);
+      expect(toolAssistanceField.state("showPromptAtCursor")).to.be.true;
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
+      const instructions = ToolAssistance.createInstructions(mainInstruction);
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      const toggle = wrapper.find(ToggleSwitch);
+      expect(toggle.length).to.eq(1);
+      toggle.find("input").simulate("change", { target: { checked: false } });
+
+      expect(toolAssistanceField.state("showPromptAtCursor")).to.be.false;
+    });
+
+    it("cursorPrompt should open when tool assistance set", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={false} />);
+
+      const toolAssistanceField = wrapper.find(ToolAssistanceField);
+      expect(toolAssistanceField.length).to.eq(1);
+      toolAssistanceField.setState({ showPromptAtCursor: true });
+
+      const spyMethod = sinon.spy();
+      CursorPopupManager.onCursorPopupUpdatePositionEvent.addListener(spyMethod);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
+      const instructions = ToolAssistance.createInstructions(mainInstruction);
+      notifications.setToolAssistance(instructions);
+      wrapper.update();
+
+      spyMethod.called.should.true;
+
+      CursorPopupManager.onCursorPopupUpdatePositionEvent.removeListener(spyMethod);
+    });
+
+    it("cursorPrompt should open when tool icon changes", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={false} />);
+
+      FrontstageManager.onToolIconChangedEvent.emit({ iconSpec: "icon-placeholder" });
+
+      const toolAssistanceField = wrapper.find(ToolAssistanceField);
+      expect(toolAssistanceField.length).to.eq(1);
+      toolAssistanceField.setState({ showPromptAtCursor: true });
+
+      // emit before instructions set
+      FrontstageManager.onToolIconChangedEvent.emit({ iconSpec: "icon-placeholder" });
+
+      const spyMethod = sinon.spy();
+      CursorPopupManager.onCursorPopupUpdatePositionEvent.addListener(spyMethod);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
+      const instructions = ToolAssistance.createInstructions(mainInstruction);
+      notifications.setToolAssistance(instructions);
+
+      // emit after instructions set
+      FrontstageManager.onToolIconChangedEvent.emit({ iconSpec: "icon-placeholder" });
+
+      wrapper.update();
+
+      spyMethod.called.should.true;
+
+      CursorPopupManager.onCursorPopupUpdatePositionEvent.removeListener(spyMethod);
+    });
+
+    it("mouse & touch instructions should generate tabs", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
+
+      const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true, ToolAssistanceInputMethod.Mouse);
+      const instruction2 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true, ToolAssistanceInputMethod.Touch);
+      const section1 = ToolAssistance.createSection([instruction1, instruction2], "Inputs");
+
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      const tabList = wrapper.find("ul.uifw-toolAssistance-tabs");
+      expect(tabList.length).to.eq(1);
+
+      const tabIndex = wrapper.find(ToolAssistanceField).state("mouseTouchTabIndex");
+      expect(tabIndex).to.satisfy((index: number) => index === 0 || index === 1);
+      const nonActive = tabList.find(".iui-tab:not(.iui-active)");
+      expect(nonActive.length).to.eq(1);
+
+      nonActive.simulate("click");
+
+      const newTabIndex = wrapper.find(ToolAssistanceField).state("mouseTouchTabIndex");
+      expect(tabIndex !== newTabIndex).to.be.true;
+    });
+
+    it("touch instructions should show", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const notifications = new AppNotificationManager();
+      const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
+
+      const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true, ToolAssistanceInputMethod.Touch);
+      const section1 = ToolAssistance.createSection([instruction1], "Inputs");
+
+      const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
+
+      notifications.setToolAssistance(instructions);
+
+      clickIndicator(wrapper);
+
+      const showTouchInstructions = wrapper.find(ToolAssistanceField).state("showTouchInstructions");
+      expect(showTouchInstructions).to.be.true;
+    });
+
+    it("dialog should open, pin and close on click", () => {
+      const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
+
+      const helloWorld = "Hello World!";
+      const notifications = new AppNotificationManager();
+      notifications.outputPrompt(helloWorld);
+
+      clickIndicator(wrapper);
+
+      expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
+
+      const toolAssistanceField = wrapper.find(ToolAssistanceField);
+      expect(toolAssistanceField.length).to.eq(1);
+      expect(toolAssistanceField.state("isPinned")).to.be.false;
+
+      let buttons = wrapper.find(TitleBarButton); // Pin button
+      expect(buttons.length).to.eq(1);
+      buttons.simulate("click");
+      wrapper.update();
+      expect(toolAssistanceField.state("isPinned")).to.be.true;
+
+      buttons = wrapper.find(TitleBarButton);   // Close button
+      expect(buttons.length).to.eq(1);
+      buttons.simulate("click");
+      wrapper.update();
+      expect(toolAssistanceField.state("isPinned")).to.be.false;
+
+      expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(0);
+    });
   });
-
-  after(async () => {
-    TestUtils.terminateUiFramework();
-    await MockRender.App.shutdown();
-  });
-
-  // cSpell:Ignore TOOLPROMPT
-
-  it("Status Bar with ToolAssistanceField should mount", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const helloWorld = "Hello World!";
-    const notifications = new AppNotificationManager();
-    notifications.outputPrompt(helloWorld);
-    wrapper.update();
-  });
-
-  it("dialog should open and close on click", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const helloWorld = "Hello World!";
-    const notifications = new AppNotificationManager();
-    notifications.outputPrompt(helloWorld);
-    wrapper.update();
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(0);
-  });
-
-  it("passing isNew:true should use newDot", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
-
-    const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true);
-    const instruction2 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["A"]), "Press a key", true);
-    const section1 = ToolAssistance.createSection([instruction1, instruction2], "Inputs");
-
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-
-    notifications.setToolAssistance(instructions);
-    wrapper.update();
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find(".nz-footer-toolAssistance-newDot").length).to.eq(3);
-    expect(wrapper.find(".nz-text-new").length).to.eq(3);
-  });
-
-  it("ToolAssistanceImage.Keyboard with a single key should generate key image", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
-    const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["A"]), "Press a key");
-    const section1 = ToolAssistance.createSection([instruction1], "Inputs");
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-    notifications.setToolAssistance(instructions);
-
-    wrapper.update();
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key").length).to.eq(1);
-  });
-
-  it("should support known icons and multiple sections", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction("icon-clock", "This is the prompt that is fairly long 1234567890");
-
-    const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
-    const instruction2 = ToolAssistance.createInstruction(ToolAssistanceImage.MouseWheel, "xyz");
-    const section1 = ToolAssistance.createSection([instruction1, instruction2], "Inputs");
-
-    const instruction21 = ToolAssistance.createInstruction(ToolAssistanceImage.LeftClick, "xyz");
-    const instruction22 = ToolAssistance.createInstruction(ToolAssistanceImage.RightClick, "xyz");
-    const instruction23 = ToolAssistance.createInstruction(ToolAssistanceImage.LeftClickDrag, "xyz");
-    const instruction24 = ToolAssistance.createInstruction(ToolAssistanceImage.RightClickDrag, "xyz");
-    const instruction25 = ToolAssistance.createInstruction(ToolAssistanceImage.MouseWheelClickDrag, "xyz");
-    const section2 = ToolAssistance.createSection([instruction21, instruction22, instruction23, instruction24, instruction25], "More Inputs");
-
-    const instruction31 = ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchTap, "xyz");
-    const instruction32 = ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchDoubleTap, "xyz");
-    const instruction33 = ToolAssistance.createInstruction(ToolAssistanceImage.OneTouchDrag, "xyz");
-    const instruction34 = ToolAssistance.createInstruction(ToolAssistanceImage.TwoTouchTap, "xyz");
-    const instruction35 = ToolAssistance.createInstruction(ToolAssistanceImage.TwoTouchDrag, "xyz");
-    const instruction36 = ToolAssistance.createInstruction(ToolAssistanceImage.TwoTouchPinch, "xyz");
-    const instruction37 = ToolAssistance.createInstruction(ToolAssistanceImage.TouchCursorTap, "xyz");
-    const instruction38 = ToolAssistance.createInstruction(ToolAssistanceImage.TouchCursorDrag, "xyz");
-    const section3 = ToolAssistance.createSection([instruction31, instruction32, instruction33, instruction34, instruction35, instruction36, instruction37, instruction38], "Touch Inputs");
-
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1, section2, section3]);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
-    expect(wrapper.find("div.nz-footer-toolAssistance-separator").length).to.eq(4);
-    expect(wrapper.find("div.nz-footer-toolAssistance-instruction").length).to.eq(16);
-  });
-
-  it("ToolAssistanceImage.Keyboard with a key containing multiple chars should use large key", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
-    const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.shiftKeyboardInfo, "Press the Shift key");
-    const section1 = ToolAssistance.createSection([instruction1], "Inputs");
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-large").length).to.eq(1);
-  });
-
-  it("ToolAssistanceImage.Keyboard with 2 keys should use medium keys", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
-    const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["A", "B"]), "Press one of two keys");
-    const section1 = ToolAssistance.createSection([instruction1], "Inputs");
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-medium").length).to.eq(2);
-  });
-
-  it("ToolAssistanceImage.Keyboard with a modifier key should a medium modifier key & medium key", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
-    const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo([ToolAssistance.ctrlKey, "Z"]), "Press Ctrl+Z", true);
-    const section1 = ToolAssistance.createSection([instruction1], "Inputs");
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-modifier").length).to.eq(1);
-    expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-medium").length).to.eq(1);
-  });
-
-  it("ToolAssistanceImage.Keyboard with bottomRow should use small keys", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz");
-    const instruction1 = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo(["W"], ["A", "S", "D"]), "Press one of four keys");
-    const section1 = ToolAssistance.createSection([instruction1], "Inputs");
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find(".nz-content-dialog .uifw-toolassistance-key-small").length).to.eq(4);
-  });
-
-  it("ToolAssistanceImage.Keyboard but keyboardInfo should log error", () => {
-    const spyMethod = sinon.spy(Logger, "logError");
-    mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.Keyboard, "Press a key" /* No keyboardInfo */);
-    const instructions = ToolAssistance.createInstructions(mainInstruction);
-
-    notifications.setToolAssistance(instructions);
-
-    spyMethod.called.should.true;
-  });
-
-  it("ToolAssistanceImage.Keyboard with invalid keyboardInfo should log error", () => {
-    const spyMethod = sinon.spy(Logger, "logError");
-    mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createKeyboardInstruction(ToolAssistance.createKeyboardInfo([]), "Press key");
-    const instructions = ToolAssistance.createInstructions(mainInstruction);
-
-    notifications.setToolAssistance(instructions);
-
-    spyMethod.called.should.true;
-  });
-
-  it("createModifierKeyInstruction should generate valid instruction", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true, ToolAssistanceInputMethod.Both, ToolAssistance.createKeyboardInfo([]));
-
-    const instruction1 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.LeftClick, "Shift + something else");
-    const instruction2 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.ctrlKey, "icon-cursor-click", "Ctrl + something else");
-    const instruction3 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.LeftClickDrag, "shiftKey + drag something");
-    const instruction4 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.RightClickDrag, "shiftKey + drag something");
-    const instruction5 = ToolAssistance.createModifierKeyInstruction(ToolAssistance.shiftKey, ToolAssistanceImage.MouseWheelClickDrag, "shiftKey + drag something");
-    const section1 = ToolAssistance.createSection([instruction1, instruction2, instruction3, instruction4, instruction5], "Inputs");
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.uifw-toolassistance-key-modifier").length).to.eq(5);
-    expect(wrapper.find("div.uifw-toolassistance-svg-medium").length).to.eq(1);
-    expect(wrapper.find("div.uifw-toolassistance-icon-medium").length).to.eq(1);
-    expect(wrapper.find("div.uifw-toolassistance-svg-medium-wide").length).to.eq(3);
-  });
-
-  it("should support svg icons in string-based instruction.image", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction("svg:test", "This is the prompt");
-
-    const instructions = ToolAssistance.createInstructions(mainInstruction);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.uifw-toolassistance-svg").length).to.eq(1);
-    expect(wrapper.find("div.uifw-toolassistance-icon-large").length).to.eq(0);
-  });
-
-  it("invalid modifier key info along with image should log error", () => {
-    const spyMethod = sinon.spy(Logger, "logError");
-    mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true, ToolAssistanceInputMethod.Both, ToolAssistance.createKeyboardInfo([]));
-    const instructions = ToolAssistance.createInstructions(mainInstruction);
-    notifications.setToolAssistance(instructions);
-
-    spyMethod.called.should.true;
-  });
-
-  it("should close on outside click", () => {
-    const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
-    const footerPopup = wrapper.find(FooterPopup);
-
-    const statusBarInstance = wrapper.instance();
-    statusBarInstance.setState(() => ({ openWidget: "test-widget" }));
-
-    const outsideClick = new MouseEvent("");
-    sinon.stub(outsideClick, "target").get(() => document.createElement("div"));
-    footerPopup.prop("onOutsideClick")!(outsideClick);
-
-    expect(statusBarInstance.state.openWidget).null;
-  });
-
-  it("should not close on outside click if pinned", () => {
-    const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} isInFooterMode />);
-    const footerPopup = wrapper.find(FooterPopup);
-
-    const statusBarInstance = wrapper.instance();
-    statusBarInstance.setState(() => ({ openWidget: "test-widget" }));
-
-    const toolAssistanceField = wrapper.find(ToolAssistanceField);
-    expect(toolAssistanceField.length).to.eq(1);
-    expect(toolAssistanceField.state("isPinned")).to.be.false;
-    toolAssistanceField.setState({ isPinned: true });
-    expect(toolAssistanceField.state("isPinned")).to.be.true;
-
-    const outsideClick = new MouseEvent("");
-    sinon.stub(outsideClick, "target").get(() => document.createElement("div"));
-    footerPopup.prop("onOutsideClick")!(outsideClick);
-
-    expect(statusBarInstance.state.openWidget).not.null;
-  });
-
-  it("dialog should open and close on click, even if pinned", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const helloWorld = "Hello World!";
-    const notifications = new AppNotificationManager();
-    notifications.outputPrompt(helloWorld);
-    wrapper.update();
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
-
-    const toolAssistanceField = wrapper.find(ToolAssistanceField);
-    expect(toolAssistanceField.length).to.eq(1);
-    expect(toolAssistanceField.state("isPinned")).to.be.false;
-    toolAssistanceField.setState({ isPinned: true });
-    expect(toolAssistanceField.state("isPinned")).to.be.true;
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(0);
-    expect(toolAssistanceField.state("isPinned")).to.be.false;
-  });
-
-  it("should set showPromptAtCursor on toggle click", async () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={false} />);
-    await TestUtils.flushAsyncOperations();
-    const toolAssistanceField = wrapper.find(ToolAssistanceField);
-    expect(toolAssistanceField.length).to.eq(1);
-    expect(toolAssistanceField.state("showPromptAtCursor")).to.be.true;
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
-    const instructions = ToolAssistance.createInstructions(mainInstruction);
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    const toggle = wrapper.find(ToggleSwitch);
-    expect(toggle.length).to.eq(1);
-    toggle.find("input").simulate("change", { target: { checked: false } });
-
-    expect(toolAssistanceField.state("showPromptAtCursor")).to.be.false;
-  });
-
-  it("cursorPrompt should open when tool assistance set", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={false} />);
-
-    const toolAssistanceField = wrapper.find(ToolAssistanceField);
-    expect(toolAssistanceField.length).to.eq(1);
-    toolAssistanceField.setState({ showPromptAtCursor: true });
-
-    const spyMethod = sinon.spy();
-    CursorPopupManager.onCursorPopupUpdatePositionEvent.addListener(spyMethod);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
-    const instructions = ToolAssistance.createInstructions(mainInstruction);
-    notifications.setToolAssistance(instructions);
-    wrapper.update();
-
-    spyMethod.called.should.true;
-
-    CursorPopupManager.onCursorPopupUpdatePositionEvent.removeListener(spyMethod);
-  });
-
-  it("cursorPrompt should open when tool icon changes", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={false} />);
-
-    FrontstageManager.onToolIconChangedEvent.emit({ iconSpec: "icon-placeholder" });
-
-    const toolAssistanceField = wrapper.find(ToolAssistanceField);
-    expect(toolAssistanceField.length).to.eq(1);
-    toolAssistanceField.setState({ showPromptAtCursor: true });
-
-    // emit before instructions set
-    FrontstageManager.onToolIconChangedEvent.emit({ iconSpec: "icon-placeholder" });
-
-    const spyMethod = sinon.spy();
-    CursorPopupManager.onCursorPopupUpdatePositionEvent.addListener(spyMethod);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
-    const instructions = ToolAssistance.createInstructions(mainInstruction);
-    notifications.setToolAssistance(instructions);
-
-    // emit after instructions set
-    FrontstageManager.onToolIconChangedEvent.emit({ iconSpec: "icon-placeholder" });
-
-    wrapper.update();
-
-    spyMethod.called.should.true;
-
-    CursorPopupManager.onCursorPopupUpdatePositionEvent.removeListener(spyMethod);
-  });
-
-  it("mouse & touch instructions should generate tabs", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
-
-    const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true, ToolAssistanceInputMethod.Mouse);
-    const instruction2 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true, ToolAssistanceInputMethod.Touch);
-    const section1 = ToolAssistance.createSection([instruction1, instruction2], "Inputs");
-
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    const tabList = wrapper.find("ul.uifw-toolAssistance-tabs");
-    expect(tabList.length).to.eq(1);
-
-    const tabIndex = wrapper.find(ToolAssistanceField).state("mouseTouchTabIndex");
-    expect(tabIndex).to.satisfy((index: number) => index === 0 || index === 1);
-    const nonActive = tabList.find(".iui-tab:not(.iui-active)");
-    expect(nonActive.length).to.eq(1);
-
-    nonActive.simulate("click");
-
-    const newTabIndex = wrapper.find(ToolAssistanceField).state("mouseTouchTabIndex");
-    expect(tabIndex !== newTabIndex).to.be.true;
-  });
-
-  it("touch instructions should show", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const notifications = new AppNotificationManager();
-    const mainInstruction = ToolAssistance.createInstruction(ToolAssistanceImage.CursorClick, "Click on something", true);
-
-    const instruction1 = ToolAssistance.createInstruction(ToolAssistanceImage.AcceptPoint, "xyz", true, ToolAssistanceInputMethod.Touch);
-    const section1 = ToolAssistance.createSection([instruction1], "Inputs");
-
-    const instructions = ToolAssistance.createInstructions(mainInstruction, [section1]);
-
-    notifications.setToolAssistance(instructions);
-
-    clickIndicator(wrapper);
-
-    const showTouchInstructions = wrapper.find(ToolAssistanceField).state("showTouchInstructions");
-    expect(showTouchInstructions).to.be.true;
-  });
-
-  it("dialog should open, pin and close on click", () => {
-    const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-
-    const helloWorld = "Hello World!";
-    const notifications = new AppNotificationManager();
-    notifications.outputPrompt(helloWorld);
-
-    clickIndicator(wrapper);
-
-    expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(1);
-
-    const toolAssistanceField = wrapper.find(ToolAssistanceField);
-    expect(toolAssistanceField.length).to.eq(1);
-    expect(toolAssistanceField.state("isPinned")).to.be.false;
-
-    let buttons = wrapper.find(TitleBarButton); // Pin button
-    expect(buttons.length).to.eq(1);
-    buttons.simulate("click");
-    wrapper.update();
-    expect(toolAssistanceField.state("isPinned")).to.be.true;
-
-    buttons = wrapper.find(TitleBarButton);   // Close button
-    expect(buttons.length).to.eq(1);
-    buttons.simulate("click");
-    wrapper.update();
-    expect(toolAssistanceField.state("isPinned")).to.be.false;
-
-    expect(wrapper.find("div.nz-footer-toolAssistance-dialog").length).to.eq(0);
-  });
-
 });


### PR DESCRIPTION
# StatusBarFields `openWidget` and `onOpenWidget` deprectation

Part of itwin/itwinjs-backlog#190

The 2 props provided by the HOC were used only by 3 components, the other newer one were handling the state of their popups internally, so this handling by the StatusBar was really only working in a few specific scenario and not in most other. In this PR, I deprecated the props from the `StatusFiledProps` interface, and the different places where these were used. (`StatusBarWidgetControlArgs`) from the `getReactNode` calls.

The component that were actually using those properties were updated to handle their open state themselves, but will still take the received props into account so we dont break existing behavior.

In 4.0 we would only have to remove the handling of the props, and the code could be refactored to simply use `true` or `false` on an `isOpen` state, rather than sticking with the `state.openWidget`. (I used the same structure to easily use either the prop or the state version.)

A byproduct of this is that it fixes an issue where if the "ToolAssistance" was pinned open, it would require 2 clicks to open then "MessageCenter". However, it still closes the ToolAssistance even if it is pinned when clicking on the "MessageCenter", which feels like a bug (but willl be "fixed" when we completely remove the link between that state and the status bar, as the SnapMode widget does)