### PR TITLE
Expose useTransientState hook

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -7131,6 +7131,9 @@ export function useStatusBarEntry(): DockedStatusBarEntryContextArg;
 // @internal (undocumented)
 export function useToolSettingsNode(): string | number | boolean | {} | React.ReactElement<any, string | React.JSXElementConstructor<any>> | Iterable<React.ReactNode> | React.ReactPortal | null | undefined;
 
+// @beta
+export function useTransientState(onSave?: () => void, onRestore?: () => void): void;
+
 // @public
 export const useUiItemsProviderBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[];
 

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -710,6 +710,7 @@ beta;useSolarDataProvider(viewport: ScreenViewport | undefined): SolarDataProvid
 public;useSpecificWidgetDef(widgetId: string): WidgetDef | undefined
 internal;useStatusBarEntry(): DockedStatusBarEntryContextArg
 internal;useToolSettingsNode(): string | number | boolean | {} | React.ReactElement
+beta;useTransientState(onSave?: () => void, onRestore?: () => void): void
 public;useUiItemsProviderBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[]
 public;useUiItemsProviderStatusBarItems: (manager: StatusBarItemsManager_2) => readonly CommonStatusBarItem[]
 public;useUiItemsProviderToolbarItems: (manager: ToolbarItemsManager, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation) => readonly CommonToolbarItem[]

--- a/common/changes/@itwin/appui-react/transient-state_2022-06-22-12-47.json
+++ b/common/changes/@itwin/appui-react/transient-state_2022-06-22-12-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Export useTransientState hook.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -252,6 +252,7 @@ export * from "./appui-react/widget-panels/Tab";
 export * from "./appui-react/widget-panels/Toolbars";
 export * from "./appui-react/widget-panels/ToolSettings";
 export * from "./appui-react/widget-panels/useWidgetDirection";
+export * from "./appui-react/widget-panels/useTransientState";
 
 export * from "./appui-react/widgets/BackstageAppButton";
 export * from "./appui-react/widgets/BasicNavigationWidget";

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -7,7 +7,7 @@
  */
 import * as React from "react";
 import { UiItemsManager } from "@itwin/appui-abstract";
-import { ScrollableWidgetContent, TabIdContext } from "@itwin/appui-layout-react";
+import { ScrollableWidgetContent, TabIdContext, useTransientState } from "@itwin/appui-layout-react";
 import { useActiveFrontstageDef } from "../frontstage/Frontstage";
 import { WidgetDef } from "../widgets/WidgetDef";
 import { FrontstageManager } from "../frontstage/FrontstageManager";
@@ -18,6 +18,13 @@ export function WidgetContent() {
   const widget = useWidgetDef();
   // istanbul ignore next
   const itemId = widget?.id ?? widget?.label ?? "unknown";
+  const onSave = React.useCallback(() => {
+    widget?.saveTransientState();
+  }, [widget]);
+  const onRestore = React.useCallback(() => {
+    widget?.restoreTransientState();
+  }, [widget]);
+  useTransientState(onSave, onRestore);
   return (
     <ScrollableWidgetContent
       itemId={itemId}

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -7,11 +7,12 @@
  */
 import * as React from "react";
 import { UiItemsManager } from "@itwin/appui-abstract";
-import { ScrollableWidgetContent, TabIdContext, useTransientState } from "@itwin/appui-layout-react";
+import { ScrollableWidgetContent, TabIdContext } from "@itwin/appui-layout-react";
 import { useActiveFrontstageDef } from "../frontstage/Frontstage";
 import { WidgetDef } from "../widgets/WidgetDef";
 import { FrontstageManager } from "../frontstage/FrontstageManager";
 import { FrontstageNineZoneStateChangedEventArgs } from "../frontstage/FrontstageDef";
+import { useTransientState } from "./useTransientState";
 
 /** @internal */
 export function WidgetContent() {
@@ -19,9 +20,11 @@ export function WidgetContent() {
   // istanbul ignore next
   const itemId = widget?.id ?? widget?.label ?? "unknown";
   const onSave = React.useCallback(() => {
+    // istanbul ignore next
     widget?.saveTransientState();
   }, [widget]);
   const onRestore = React.useCallback(() => {
+    // istanbul ignore next
     widget?.restoreTransientState();
   }, [widget]);
   useTransientState(onSave, onRestore);

--- a/ui/appui-react/src/appui-react/widget-panels/useTransientState.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/useTransientState.tsx
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import { useTransientState as useTransientStateImpl } from "@itwin/appui-layout-react";
+
+/** Hook that allows to save and restore transient DOM state (i.e. scroll offset) of a widget.
+ * @beta
+ */
+export function useTransientState(onSave?: () => void, onRestore?: () => void): void {
+  useTransientStateImpl(onSave, onRestore);
+}


### PR DESCRIPTION
This PR exposes previously @internal `useTransientState` hook as a **@beta** API (from **appui-react** to avoid exposing new APIs from **appui-layout-react** package). Example usage of this is added to **ModelsTree** of **ui-test-app**.

This PR also ensures that previously existing handlers `AbstractWidgetProps["saveTransientState"]` and `AbstractWidgetProps["restoreTransientState"]` are fired correctly.