### PR TITLE
Return in viewState.load() if iModel associated with viewState is a blankConnection

### DIFF
--- a/common/changes/@itwin/core-frontend/nick-blank-connection-load_2022-06-22-14-37.json
+++ b/common/changes/@itwin/core-frontend/nick-blank-connection-load_2022-06-22-14-37.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "return in viewState.load() if iModel is blankConnection",
+      "comment": "Avoid attempting to load ViewState data from the backend for a BlankConnection.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-frontend/nick-blank-connection-load_2022-06-22-14-37.json
+++ b/common/changes/@itwin/core-frontend/nick-blank-connection-load_2022-06-22-14-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "return in viewState.load() if iModel is blankConnection",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -350,6 +350,11 @@ export abstract class ViewState extends ElementState {
    * @see [Views]($docs/learning/frontend/Views.md)
    */
   public async load(): Promise<void> {
+    // If the iModel associated with the viewState is a blankConnection,
+    // then no data can be retrieved from the backend.
+    if (this.iModel.isBlank)
+      return;
+
     const hydrateRequest: HydrateViewStateRequestProps = {};
     this.preload(hydrateRequest);
     const promises = [


### PR DESCRIPTION
The addition of the RPC operation "hydrateViewState" causes load() to now fail when the iModel associated with the viewState is a blankConnection. This PR returns if the iModel is a blank connection to avoid this problem. 

Before the RPC operation hydrateViewState, load() likely failed gracefully in the case of a BlankConnection.