### PR TITLE
clean up last dead collectPredecessorIds references

### DIFF
--- a/common/changes/@itwin/core-common/fix-remaining-predecessor-vocab_2022-06-24-14-07.json
+++ b/common/changes/@itwin/core-common/fix-remaining-predecessor-vocab_2022-06-24-14-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "move reference of collectPredecessorIds from deprecated to new API getReferenceIds",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/RenderSchedule.ts
+++ b/core/common/src/RenderSchedule.ts
@@ -880,7 +880,7 @@ export namespace RenderSchedule {
         timeline.addSymbologyOverrides(overrides, time);
     }
 
-    /** Used by collectPredecessorIds methods of RenderTimeline and DisplayStyle.
+    /** Used by the [Element.collectReferenceIds]($backend) method overrides in RenderTimeline and DisplayStyle.
      * @internal
      */
     public discloseIds(ids: Id64Set): void {


### PR DESCRIPTION
#3858 left this reference to the deprecated `collectPredecessorIds`