### PR TITLE
use NativeLibrary.isDevBuild to detect locally installed development builds of imodeljs-native

### DIFF
--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -303,7 +303,7 @@ export class IModelHost {
     const thisVersion = this.platform.version;
     if (semver.satisfies(thisVersion, requiredVersion))
       return;
-    if (IModelJsFs.existsSync(path.join(__dirname, "DevBuild.txt"))) {
+    if (NativeLibrary.isDevBuild) {
       console.log("Bypassing version checks for development build"); // eslint-disable-line no-console
       return;
     }


### PR DESCRIPTION
Corresponding [native PR](https://bentleycs.visualstudio.com/iModelTechnologies/_git/imodel02/pullrequest/259596)