### PR TITLE
Lock down bis-schemas docs version

### DIFF
--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -42,7 +42,8 @@ steps:
       buildType: specific
       project: 2c48216e-e72f-48b4-a4eb-40ff1c04e8e4
       pipeline: 6075
-      buildVersionToDownload: latest
+      buildVersionToDownload: specific
+      buildId: 1532966
       allowPartiallySucceededBuilds: true
       artifactName: Bis Docs
     condition: and(succeeded(), eq('${{ parameters.downloadCurrentBuildArtifacts }}', false))


### PR DESCRIPTION
The docs build pulls in documentation artifacts from other builds, this PR locks down the version of the bis-schemas build artifact to one compatible with 3.2.x releases.