### PR TITLE
Restore the possibility to attach any cesium asset using getCesiumAssetUrl

### DIFF
--- a/common/changes/@itwin/core-frontend/marcbedard8-AttachCesiumAssetFromUrl_2022-06-30-16-08.json
+++ b/common/changes/@itwin/core-frontend/marcbedard8-AttachCesiumAssetFromUrl_2022-06-30-16-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Restore the possibility to attach any cesium asset using getCesiumAssetUrl",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/frontend-devtools/marcbedard8-AttachCesiumAssetFromUrl_2022-06-30-16-08.json
+++ b/common/changes/@itwin/frontend-devtools/marcbedard8-AttachCesiumAssetFromUrl_2022-06-30-16-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "Change keyin to test to attach any cesium asset using getCesiumAssetUrl",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/frontend-devtools/src/tools/RealityModelTools.ts
+++ b/core/frontend-devtools/src/tools/RealityModelTools.ts
@@ -7,8 +7,8 @@
  * @module Tools
  */
 
-import { ContextRealityModelProps, FeatureAppearance, FeatureAppearanceProps, RgbColorProps } from "@itwin/core-common";
-import { getCesiumAssetUrl, IModelApp, NotifyMessageDetails, OutputMessagePriority, RealityDataSource, Tool, Viewport } from "@itwin/core-frontend";
+import { FeatureAppearance, FeatureAppearanceProps, RgbColorProps } from "@itwin/core-common";
+import { getCesiumAssetUrl, IModelApp, NotifyMessageDetails, OutputMessagePriority, Tool, Viewport } from "@itwin/core-frontend";
 import { copyStringToClipboard } from "../ClipboardUtilities";
 import { parseBoolean } from "./parseBoolean";
 import { parseToggle } from "./parseToggle";

--- a/core/frontend-devtools/src/tools/RealityModelTools.ts
+++ b/core/frontend-devtools/src/tools/RealityModelTools.ts
@@ -276,9 +276,17 @@ export class AttachCesiumAssetTool extends Tool {
     if (vp === undefined)
       return false;
 
+    // attach using getCesiumAssetUrl
     const accessKey = requestKey ? requestKey : IModelApp.tileAdmin.cesiumIonKey ? IModelApp.tileAdmin.cesiumIonKey : "";
-    const rdSourceKey = RealityDataSource.createCesiumIonAssetKey(assetId, accessKey);
-    const props: ContextRealityModelProps = { rdSourceKey, tilesetUrl: getCesiumAssetUrl(assetId, accessKey) };
+    const props = {
+      tilesetUrl: getCesiumAssetUrl(
+        assetId,
+        accessKey
+      ),
+    };
+    // Alternative new way to attach using rdSourceKey
+    // const rdSourceKey = RealityDataSource.createCesiumIonAssetKey(assetId, accessKey);
+    // const props: ContextRealityModelProps = { rdSourceKey, tilesetUrl: getCesiumAssetUrl(assetId, accessKey) };
 
     vp.displayStyle.attachRealityModel(props);
     IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, `Cesium Asset #${assetId} attached`));

--- a/core/frontend/src/RealityDataSource.ts
+++ b/core/frontend/src/RealityDataSource.ts
@@ -116,8 +116,12 @@ export namespace RealityDataSource {
     let format = inputFormat ? inputFormat : RealityDataFormat.fromUrl(tilesetUrl);
     if (CesiumIonAssetProvider.isProviderUrl(tilesetUrl)) {
       const provider = RealityDataProvider.CesiumIonAsset;
-      // Keep url hidden and use a dummy id
-      const cesiumIonAssetKey: RealityDataSourceKey = { provider, format, id: CesiumIonAssetProvider.osmBuildingId };
+      let cesiumIonAssetKey: RealityDataSourceKey = { provider, format, id:  CesiumIonAssetProvider.osmBuildingId }; // default OSM building
+      // Parse URL to extract possible asset id and key if provided
+      const cesiumAsset = CesiumIonAssetProvider.parseCesiumUrl(tilesetUrl);
+      if (cesiumAsset) {
+        cesiumIonAssetKey = RealityDataSource.createCesiumIonAssetKey(cesiumAsset.id, cesiumAsset.key);
+      }
       return cesiumIonAssetKey;
     }
 

--- a/core/frontend/src/test/RealityDataSouce.test.ts
+++ b/core/frontend/src/test/RealityDataSouce.test.ts
@@ -39,6 +39,14 @@ describe("RealityDataSource", () => {
     expect(rdSourceKey.iTwinId).to.be.undefined;
     const rdSourceKeyStr = RealityDataSourceKey.convertToString(rdSourceKey);
     expect(rdSourceKeyStr).to.be.equal(`CesiumIonAsset:ThreeDTile:${tilesetUrl}:undefined`);
+    // Key createdFromUrl should be equal to key created from call to createCesiumIonAssetKey
+    const rdSourceKeyFromURL = RealityDataSource.createKeyFromUrl(tilesetUrl);
+    expect(rdSourceKeyFromURL.id).to.be.equal(rdSourceKey.id);
+    expect(rdSourceKeyFromURL.iTwinId).to.be.equal(rdSourceKey.iTwinId);
+    expect(rdSourceKeyFromURL.format).to.be.equal(rdSourceKey.format);
+    expect(rdSourceKeyFromURL.provider).to.be.equal(rdSourceKey.provider);
+    const rdSourceKeyFromURLStr = RealityDataSourceKey.convertToString(rdSourceKeyFromURL);
+    expect(rdSourceKeyFromURLStr).to.be.equal(`CesiumIonAsset:ThreeDTile:${tilesetUrl}:undefined`);
   });
   it("should handle creation from Context Share url", () => {
     const tilesetUrl = "https://connect-realitydataservices.bentley.com/v2.9/Repositories/S3MXECPlugin--5b4ebd22-d94b-456b-8bd8-d59563de9acd/S3MX/RealityData/994fc408-401f-4ee1-91f0-3d7bfba50136";


### PR DESCRIPTION
We should be able to attach a cesium asset from id and key using code like this:
    const cesiumProps = {
      tilesetUrl: getCesiumAssetUrl(
        cesiumAssetId,
        requestKey ? requestKey : (IModelApp.tileAdmin.cesiumIonKey ?? "")
      ),
    };
    const vp = IModelApp.viewManager.selectedView;
    if (vp)
      vp.displayStyle.attachRealityModel(cesiumProps);