### PR TITLE
Define secondary radius and angle in separate phases.

### DIFF
--- a/common/api/editor-frontend.api.md
+++ b/common/api/editor-frontend.api.md
@@ -995,9 +995,10 @@ export class CreateSphereTool extends SolidPrimitiveTool {
 
 // @alpha
 export enum CreateTorusPhase {
-    AcceptAngle = 2,
+    AcceptAngle = 3,
     AcceptCenter = 1,
-    AcceptResult = 3,
+    AcceptResult = 4,
+    AcceptSecondaryRadius = 2,
     AcceptStart = 0
 }
 

--- a/common/changes/@itwin/editor-frontend/torus-tool_2022-06-30-16-43.json
+++ b/common/changes/@itwin/editor-frontend/torus-tool_2022-06-30-16-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "Define secondary radius and angle in separate phases.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/editor/frontend/src/public/locales/en/Editor.json
+++ b/editor/frontend/src/public/locales/en/Editor.json
@@ -183,7 +183,8 @@
       "Prompts": {
         "StartPoint": "Define start",
         "CenterPoint": "Define center",
-        "AnglePoint": "Define angle and secondary radius"
+        "SecondaryRadiusPoint": "Define secondary radius",
+        "AnglePoint": "Define angle"
       }
     },
     "OffsetCurve": {


### PR DESCRIPTION
Change in behavior from the MicroStation torus tool to better support AccuDraw. Requiring an additional step to define the secondary radius allows AccuDraw to be positioned such that it's distance input can specify the radius value.