### PR TITLE
Support hiliting the intersection of models and subcategories

### DIFF
--- a/core/bentley/src/Id.ts
+++ b/core/bentley/src/Id.ts
@@ -551,6 +551,11 @@ export namespace Id64 {
       return undefined !== set && set.has(low);
     }
 
+    /** Returns true if the set contains the Id specified by `pair`. */
+    public hasPair(pair: Uint32Pair): boolean {
+      return this.has(pair.lower, pair.upper);
+    }
+
     /** Returns true if the set contains no Ids. */
     public get isEmpty(): boolean { return 0 === this._map.size; }
 

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -299,6 +299,7 @@ These keysins control the planar masking of reality models.
   * "children": For each tile, draw a box around the volume of each of its child tiles, color-coded such that green indicates an empty child tile and blue a non-empty child tile.
   * "sphere": Bounding sphere representing the full range of each tile.
 * `fdt time tile load` - Purges all tile trees from memory and reloads the contents of the selected viewport. Outputs to the notifications center the time elapsed once all tiles required for the view are loaded and displayed.
+* `fdt hilite mode` - Changes the ModelSubCategoryHiliteMode for the HiliteSet associated with the selected viewport. It takes a single argument: "union" or "intersection".
 * `fdt hilite settings` - Modifies the hilite settings for the selected viewport. If no arguments are specified, it resets them to the defaults. Otherwise, each argument modifies an aspect of the current settings:
   * "r", "g", or "b": An integer in [0..255] specifying the red, green, or blue component of the hilite color.
   * "v", "h": The visible or hidden ratio in [0..1].

--- a/core/frontend-devtools/public/locales/en/FrontendDevTools.json
+++ b/core/frontend-devtools/public/locales/en/FrontendDevTools.json
@@ -105,6 +105,9 @@
     "ChangeHiliteSettings": {
       "keyin": "fdt hilite settings"
     },
+    "ChangeHiliteMode": {
+      "keyin": "fdt hilite mode"
+    },
     "ChangeEmphasisSettings": {
       "keyin": "fdt emphasis settings"
     },

--- a/core/frontend-devtools/src/FrontEndDevTools.ts
+++ b/core/frontend-devtools/src/FrontEndDevTools.ts
@@ -20,9 +20,10 @@ import {
   MaskRealityModelByModelTool, MaskRealityModelBySubCategoryTool, SetHigherPriorityRealityModelMasking, SetMapHigherPriorityMasking, UnmaskMapTool, UnmaskRealityModelTool,
 } from "./tools/PlanarMaskTools";
 import {
-  ChangeCameraTool, ChangeEmphasisSettingsTool, ChangeFlashSettingsTool, ChangeHiliteSettingsTool, DefaultTileSizeModifierTool, FadeOutTool, FreezeSceneTool, SetAspectRatioSkewTool, ShowTileVolumesTool,
-  Toggle3dManipulationsTool, ToggleDrawingGraphicsTool, ToggleSectionDrawingSpatialViewTool, ToggleTileTreeReferencesTool, ToggleViewAttachmentBoundariesTool, ToggleViewAttachmentClipShapesTool,
-  ToggleViewAttachmentsTool, ViewportAddRealityModel, ViewportTileSizeModifierTool,
+  ChangeCameraTool, ChangeEmphasisSettingsTool, ChangeFlashSettingsTool, ChangeHiliteModeTool, ChangeHiliteSettingsTool, DefaultTileSizeModifierTool, FadeOutTool,
+  FreezeSceneTool, SetAspectRatioSkewTool, ShowTileVolumesTool, Toggle3dManipulationsTool, ToggleDrawingGraphicsTool, ToggleSectionDrawingSpatialViewTool,
+  ToggleTileTreeReferencesTool, ToggleViewAttachmentBoundariesTool, ToggleViewAttachmentClipShapesTool, ToggleViewAttachmentsTool, ViewportAddRealityModel,
+  ViewportTileSizeModifierTool,
 } from "./tools/ViewportTools";
 import { AnimationIntervalTool } from "./tools/AnimationIntervalTool";
 import { ChangeUnitsTool } from "./tools/ChangeUnitsTool";
@@ -109,6 +110,7 @@ export class FrontendDevTools {
       ChangeCameraTool,
       ChangeEmphasisSettingsTool,
       ChangeFlashSettingsTool,
+      ChangeHiliteModeTool,
       ChangeHiliteSettingsTool,
       ChangePlanProjectionSettingsTool,
       ChangeUnitsTool,

--- a/core/frontend-devtools/src/tools/ViewportTools.ts
+++ b/core/frontend-devtools/src/tools/ViewportTools.ts
@@ -194,6 +194,30 @@ export class SetAspectRatioSkewTool extends Tool {
   }
 }
 
+/** Changes the [ModelSubCategoryHiliteMode]($frontend) for the [HiliteSet]($frontend) associated with the selected Viewport.
+ * @beta
+ */
+export class ChangeHiliteModeTool extends Tool {
+  public static override get minArgs() { return 1; }
+  public static override get maxArgs() { return 1; }
+  public static override toolId = "ChangeHiliteMode";
+
+  public override async run(mode?: string) {
+    const hilites = IModelApp.viewManager.selectedView?.iModel.hilited;
+    if (!hilites)
+      return false;
+
+    if (mode === "union" || mode === "intersection")
+      hilites.modelSubCategoryMode = mode;
+
+    return true;
+  }
+
+  public override async parseAndRun(...args: string[]) {
+    return this.run(args[0]);
+  }
+}
+
 /** Changes the selected viewport's hilite or emphasis settings.
  * @beta
  */

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -215,8 +215,10 @@ export abstract class IModelConnection extends IModel {
     this.elements = new IModelConnection.Elements(this);
     this.codeSpecs = new IModelConnection.CodeSpecs(this);
     this.views = new IModelConnection.Views(this);
+
     this.selectionSet = new SelectionSet(this);
     this.hilited = new HiliteSet(this);
+
     this.tiles = new Tiles(this);
     this.subcategories = new SubCategoriesCache(this);
     this.geoServices = new GeoServices(this);
@@ -225,6 +227,10 @@ export abstract class IModelConnection extends IModel {
     this.onProjectExtentsChanged.addListener(() => {
       // Compute new displayed extents as the union of the ranges we previously expanded by with the new project extents.
       this.expandDisplayedExtents(this._extentsExpansion);
+    });
+
+    this.hilited.onModelSubCategoryModeChanged.addListener(() => {
+      IModelApp.viewManager.onSelectionSetChanged(this);
     });
   }
 

--- a/core/frontend/src/SelectionSet.ts
+++ b/core/frontend/src/SelectionSet.ts
@@ -178,10 +178,14 @@ export type ModelSubCategoryHiliteMode = "union" | "intersection";
 
 /** A set of *hilited* elements for an [[IModelConnection]], by element id.
  * Hilited elements are displayed with a customizable hilite effect within a [[Viewport]].
- * The set exposes 3 types of elements in 3 separate collections: geometric elements, subcategories, and geometric models.
+ * The set exposes 3 types of elements in 3 separate collections: [GeometricElement]($backend), [GeometricModel]($backend), and [SubCategory]($backend).
+ * The [[models]] and [[subcategories]] can be hilited independently or as an intersection of the two sets, as specified by [[modelSubCategoryMode]].
  *
  * Technically, the hilite effect is applied to [Feature]($common)s, not [Element]($backend)s. An element's geometry stream can contain multiple
  * features belonging to different subcategories.
+ *
+ * Because Javascript lacks efficient support for 64-bit integers, the Ids are stored as pairs of 32-bit integers via [Id64.Uint32Set]($bentley).
+ *
  * @note Typically, elements are hilited by virtue of their presence in the IModelConnection's [[SelectionSet]]. The HiliteSet allows additional
  * elements to be displayed with the hilite effect without adding them to the [[SelectionSet]]. If you add elements to the HiliteSet directly, you
  * are also responsible for removing them as appropriate.

--- a/core/frontend/src/SelectionSet.ts
+++ b/core/frontend/src/SelectionSet.ts
@@ -229,6 +229,7 @@ export class HiliteSet {
     this._mode = mode;
   }
 
+  /** Event raised just before changing the value of [[modelSubCategoryMode]]. */
   public readonly onModelSubCategoryModeChanged = new BeEvent<(newMode: ModelSubCategoryHiliteMode) => void>();
 
   /** Construct a HiliteSet

--- a/core/frontend/src/render/webgl/DrawCommand.ts
+++ b/core/frontend/src/render/webgl/DrawCommand.ts
@@ -297,7 +297,7 @@ export function extractHilitedVolumeClassifierCommands(hilites: Hilites, cmds: D
             continue;
 
           const feature = batch.featureTable.getPackedFeature(surface.mesh.uniformFeatureId);
-          if (undefined === feature || !isFeatureHilited(feature, hilites))
+          if (undefined === feature || !isFeatureHilited(feature, hilites, hilites.models.hasId(batch.featureTable.modelId)))
             continue;
 
           break;

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -12,7 +12,7 @@ import {
   AmbientOcclusion, AnalysisStyle, Frustum, ImageBuffer, ImageBufferFormat, Npc, RenderMode, RenderTexture, SpatialClassifier, ThematicDisplayMode, ViewFlags,
 } from "@itwin/core-common";
 import { canvasToImageBuffer, canvasToResizedCanvasWithBars, imageBufferToCanvas } from "../../ImageUtil";
-import { HiliteSet } from "../../SelectionSet";
+import { HiliteSet, ModelSubCategoryHiliteMode } from "../../SelectionSet";
 import { SceneContext } from "../../ViewContext";
 import { ReadImageBufferArgs, Viewport } from "../../Viewport";
 import { ViewRect } from "../../ViewRect";
@@ -74,6 +74,7 @@ export interface Hilites {
   readonly subcategories: Id64.Uint32Set;
   readonly models: Id64.Uint32Set;
   readonly isEmpty: boolean;
+  readonly modelSubCategoryMode: ModelSubCategoryHiliteMode;
 }
 
 class EmptyHiliteSet {
@@ -81,6 +82,7 @@ class EmptyHiliteSet {
   public readonly subcategories: Id64.Uint32Set;
   public readonly models: Id64.Uint32Set;
   public readonly isEmpty = true;
+  public readonly modelSubCategoryMode = "union";
 
   public constructor() {
     this.elements = this.subcategories = this.models = new Id64.Uint32Set();


### PR DESCRIPTION
#3829 

- [x] Promote models and subcategories support in HiliteSet to `@public`
- [x] Add new flag to HiliteSet indicating whether models and subcategories should be treated as a union (default) or intersection
- [x] Adjust logic in FeatureOverrides to respect the new flag
- [x] Add key-in to change the state of the flag
- [ ] Improve ergonomics of Uint32Set API
- [ ] Provide public frontend API to query subcategories belonging to categories
- [ ] NextVersion.md
- [ ] Unit tests
- [ ] Run ImageTests
- [ ] Add new ImageTests views exercising the new feature
- [ ] Find out from @grigasp if any adjustments are needed to HiliteSetProvider