### PR TITLE
Unpin ts-node.

### DIFF
--- a/common/changes/@itwin/appui-abstract/pmc-unpin-ts-node_2022-07-03-21-28.json
+++ b/common/changes/@itwin/appui-abstract/pmc-unpin-ts-node_2022-07-03-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-abstract",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-abstract"
+}

--- a/common/changes/@itwin/appui-layout-react/pmc-unpin-ts-node_2022-07-03-21-28.json
+++ b/common/changes/@itwin/appui-layout-react/pmc-unpin-ts-node_2022-07-03-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/appui-react/pmc-unpin-ts-node_2022-07-03-21-28.json
+++ b/common/changes/@itwin/appui-react/pmc-unpin-ts-node_2022-07-03-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/pmc-unpin-ts-node_2022-07-03-21-28.json
+++ b/common/changes/@itwin/components-react/pmc-unpin-ts-node_2022-07-03-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/pmc-unpin-ts-node_2022-07-03-21-28.json
+++ b/common/changes/@itwin/core-react/pmc-unpin-ts-node_2022-07-03-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/pmc-unpin-ts-node_2022-07-03-21-28.json
+++ b/common/changes/@itwin/imodel-components-react/pmc-unpin-ts-node_2022-07-03-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4169,7 +4169,7 @@ importers:
       rimraf: ^3.0.2
       sinon: ^9.0.2
       sinon-chai: ^3.2.0
-      ts-node: 10.8.0
+      ts-node: ^10.8.2
       typescript: ~4.4.0
       xmlhttprequest: ^1.8.0
     dependencies:
@@ -4201,7 +4201,7 @@ importers:
       rimraf: 3.0.2
       sinon: 9.2.4
       sinon-chai: 3.7.0_chai@4.3.6+sinon@9.2.4
-      ts-node: 10.8.0_ee928ac548ac44c173bf0d4654ae2c29
+      ts-node: 10.8.2_ee928ac548ac44c173bf0d4654ae2c29
       typescript: 4.4.4
       xmlhttprequest: 1.8.0
 
@@ -4251,7 +4251,7 @@ importers:
       rimraf: ^3.0.2
       sinon: ^9.0.2
       sinon-chai: ^3.2.0
-      ts-node: 10.8.0
+      ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~4.4.0
       uuid: ^7.0.3
@@ -4303,7 +4303,7 @@ importers:
       rimraf: 3.0.2
       sinon: 9.2.4
       sinon-chai: 3.7.0_chai@4.3.6+sinon@9.2.4
-      ts-node: 10.8.0_ee928ac548ac44c173bf0d4654ae2c29
+      ts-node: 10.8.2_ee928ac548ac44c173bf0d4654ae2c29
       typemoq: 2.1.0
       typescript: 4.4.4
       xmlhttprequest: 1.8.0
@@ -4381,7 +4381,7 @@ importers:
       rxjs: ^6.6.2
       sinon: ^9.0.2
       sinon-chai: ^3.2.0
-      ts-node: 10.8.0
+      ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~4.4.0
       xmlhttprequest: ^1.8.0
@@ -4458,7 +4458,7 @@ importers:
       rimraf: 3.0.2
       sinon: 9.2.4
       sinon-chai: 3.7.0_chai@4.3.6+sinon@9.2.4
-      ts-node: 10.8.0_ee928ac548ac44c173bf0d4654ae2c29
+      ts-node: 10.8.2_ee928ac548ac44c173bf0d4654ae2c29
       typemoq: 2.1.0
       typescript: 4.4.4
       xmlhttprequest: 1.8.0
@@ -4541,7 +4541,7 @@ importers:
       sinon: ^9.0.2
       sinon-chai: ^3.2.0
       ts-key-enum: ^2.0.0
-      ts-node: 10.8.0
+      ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~4.4.0
       xmlhttprequest: ^1.8.0
@@ -4623,7 +4623,7 @@ importers:
       rimraf: 3.0.2
       sinon: 9.2.4
       sinon-chai: 3.7.0_chai@4.3.6+sinon@9.2.4
-      ts-node: 10.8.0_ee928ac548ac44c173bf0d4654ae2c29
+      ts-node: 10.8.2_ee928ac548ac44c173bf0d4654ae2c29
       typemoq: 2.1.0
       typescript: 4.4.4
       xmlhttprequest: 1.8.0
@@ -4686,7 +4686,7 @@ importers:
       rimraf: ^3.0.2
       sinon: ^9.0.2
       sinon-chai: ^3.2.0
-      ts-node: 10.8.0
+      ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~4.4.0
       xmlhttprequest: ^1.8.0
@@ -4748,7 +4748,7 @@ importers:
       rimraf: 3.0.2
       sinon: 9.2.4
       sinon-chai: 3.7.0_chai@4.3.6+sinon@9.2.4
-      ts-node: 10.8.0_ee928ac548ac44c173bf0d4654ae2c29
+      ts-node: 10.8.2_ee928ac548ac44c173bf0d4654ae2c29
       typemoq: 2.1.0
       typescript: 4.4.4
       xmlhttprequest: 1.8.0
@@ -4815,7 +4815,7 @@ importers:
       sinon: ^9.0.2
       sinon-chai: ^3.2.0
       ts-key-enum: ^2.0.0
-      ts-node: 10.8.0
+      ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~4.4.0
       xmlhttprequest: ^1.8.0
@@ -4881,7 +4881,7 @@ importers:
       rimraf: 3.0.2
       sinon: 9.2.4
       sinon-chai: 3.7.0_chai@4.3.6+sinon@9.2.4
-      ts-node: 10.8.0_ee928ac548ac44c173bf0d4654ae2c29
+      ts-node: 10.8.2_ee928ac548ac44c173bf0d4654ae2c29
       typemoq: 2.1.0
       typescript: 4.4.4
       xmlhttprequest: 1.8.0
@@ -21956,8 +21956,8 @@ packages:
     resolution: {integrity: sha512-ZYcdy6/RdwryMm2hcRT3KJanGSQREd5SDkMirdFjhWINe12wht2A26tzBqi3pxPau9Pf3Bq1C7iwzFCOfdm5yQ==}
     dev: false
 
-  /ts-node/10.8.0_ee928ac548ac44c173bf0d4654ae2c29:
-    resolution: {integrity: sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==}
+  /ts-node/10.8.2_ee928ac548ac44c173bf0d4654ae2c29:
+    resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}
     hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'

--- a/ui/appui-abstract/package.json
+++ b/ui/appui-abstract/package.json
@@ -69,7 +69,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.2.0",
-    "ts-node": "10.8.0",
+    "ts-node": "^10.8.2",
     "typescript": "~4.4.0",
     "xmlhttprequest": "^1.8.0"
   },

--- a/ui/appui-layout-react/package.json
+++ b/ui/appui-layout-react/package.json
@@ -86,7 +86,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.2.0",
-    "ts-node": "10.8.0",
+    "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
     "typescript": "~4.4.0",
     "xmlhttprequest": "^1.8.0"

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -121,7 +121,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.2.0",
-    "ts-node": "10.8.0",
+    "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
     "typescript": "~4.4.0",
     "xmlhttprequest": "^1.8.0"

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -103,7 +103,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.2.0",
-    "ts-node": "10.8.0",
+    "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
     "typescript": "~4.4.0",
     "xmlhttprequest": "^1.8.0"

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -96,7 +96,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.2.0",
-    "ts-node": "10.8.0",
+    "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
     "typescript": "~4.4.0",
     "xmlhttprequest": "^1.8.0"

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -104,7 +104,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.2.0",
-    "ts-node": "10.8.0",
+    "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
     "typescript": "~4.4.0",
     "xmlhttprequest": "^1.8.0"


### PR DESCRIPTION
#3832 pinned ts-node to 10.8.0 because a bug in 10.8.1 [broke nyc](https://github.com/istanbuljs/nyc/issues/1473).
It is [fixed in 10.8.2](https://github.com/TypeStrong/ts-node/pull/1771).