### PR TITLE
Presentation: Use promise instead of polling native addon

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-AvoidPollingNativeAddon_2022-07-12-14-35.json
+++ b/common/changes/@itwin/presentation-backend/presentation-AvoidPollingNativeAddon_2022-07-12-14-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-AvoidPollingNativeAddon_2022-07-12-14-35.json
+++ b/common/changes/@itwin/presentation-common/presentation-AvoidPollingNativeAddon_2022-07-12-14-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -148,9 +148,6 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
         throw new PresentationError(this.getStatus(response.error.status), response.error.message);
       return this.createSuccessResponse(response);
     }
-    private isPromise<T>(response: Promise<IModelJsNative.ECPresentationManagerResponse<T>> | IModelJsNative.ECPresentationManagerResponse<T>): response is Promise<IModelJsNative.ECPresentationManagerResponse<T>> {
-      return response && Object.prototype.toString.call(response) === "[object Promise]";
-    }
     public dispose() {
       this._nativeAddon.dispose();
     }
@@ -184,11 +181,7 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
       return this.handleVoidResult(this._nativeAddon.clearRulesets());
     }
     public async handleRequest(db: any, options: string) {
-      const response = this._nativeAddon.handleRequest(db, options);
-      if (!this.isPromise(response))
-        this.handleResult(response);
-
-      return (response as Promise<IModelJsNative.ECPresentationManagerResponse<string>>).then((result) => {
+      return this._nativeAddon.handleRequest(db, options).then((result) => {
         if (result.error)
           throw new PresentationError(this.getStatus(result.error.status), result.error.message);
         return this.createSuccessResponse(result);

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -181,11 +181,10 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
       return this.handleVoidResult(this._nativeAddon.clearRulesets());
     }
     public async handleRequest(db: any, options: string) {
-      return this._nativeAddon.handleRequest(db, options).then((result) => {
-        if (result.error)
-          throw new PresentationError(this.getStatus(result.error.status), result.error.message);
-        return this.createSuccessResponse(result);
-      });
+      const result = await this._nativeAddon.handleRequest(db, options);
+      if (result.error)
+        throw new PresentationError(this.getStatus(result.error.status), result.error.message);
+      return this.createSuccessResponse(result);
     }
     public getRulesetVariableValue(rulesetId: string, variableId: string, type: VariableValueTypes) {
       return this.handleResult(this._nativeAddon.getRulesetVariableValue(rulesetId, variableId, type));

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -184,7 +184,7 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
       return this.handleVoidResult(this._nativeAddon.clearRulesets());
     }
     public async handleRequest(db: any, options: string) {
-      const response = this._nativeAddon.queueRequest(db, options);
+      const response = this._nativeAddon.handleRequest(db, options);
       if (!this.isPromise(response))
         this.handleResult(response);
 

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -74,45 +74,18 @@ describe("default NativePlatform", () => {
   describe("handleRequest", () => {
 
     it("calls addon", async () => {
-      const guid = faker.random.uuid();
       addonMock
-        .setup((x) => x.queueRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: guid }))
-        .verifiable();
-      addonMock
-        .setup((x) => x.pollResponse(guid))
-        .returns(() => ({ result: "0" }))
+        .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+        .returns(async () => ({ result: "0" }))
         .verifiable();
       expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0" });
       addonMock.verifyAll();
     });
 
-    it("polls multiple times on pending response", async () => {
-      const guid = faker.random.uuid();
-      addonMock
-        .setup((x) => x.queueRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: guid }));
-      addonMock
-        .setup((x) => x.pollResponse(guid))
-        .returns(() => ({ error: { status: IModelJsNative.ECPresentationStatus.Pending, message: "" } }));
-      addonMock
-        .setup((x) => x.pollResponse(guid))
-        .returns(() => ({ error: { status: IModelJsNative.ECPresentationStatus.Pending, message: "" } }));
-      addonMock
-        .setup((x) => x.pollResponse(guid))
-        .returns(() => ({ result: "999" }));
-      expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "999" });
-      addonMock.verify((x) => x.pollResponse(guid), moq.Times.exactly(3));
-    });
-
     it("throws on cancellation response", async () => {
-      const guid = faker.random.uuid();
       addonMock
-        .setup((x) => x.queueRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: guid }));
-      addonMock
-        .setup((x) => x.pollResponse(guid))
-        .returns(() => ({ error: { status: IModelJsNative.ECPresentationStatus.Canceled, message: "test" } }));
+        .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+        .returns(async () => ({ error: { status: IModelJsNative.ECPresentationStatus.Canceled, message: "test" } }));
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
@@ -123,14 +96,10 @@ describe("default NativePlatform", () => {
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
-    it("throws on pollResponse error response", async () => {
-      const guid = faker.random.uuid();
+    it("throws on error response", async () => {
       addonMock
-        .setup((x) => x.queueRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: guid }));
-      addonMock
-        .setup((x) => x.pollResponse(guid))
-        .returns(() => ({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }));
+        .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+        .returns(async () => ({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }));
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
@@ -141,12 +110,8 @@ describe("default NativePlatform", () => {
       scope: "test",
     };
     addonMock
-      .setup((x) => x.queueRequest(moq.It.isAny(), ""))
-      .returns(() => ({ result: "" }));
-    addonMock
-      .setup((x) => x.pollResponse(moq.It.isAny()))
-      .returns(() => ({ result: "0", diagnostics }))
-      .verifiable();
+      .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+      .returns(async () => ({ result: "0", diagnostics }));
     expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0", diagnostics });
     addonMock.verifyAll();
   });

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -89,13 +89,6 @@ describe("default NativePlatform", () => {
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
-    it("throws on handleRequest error response", async () => {
-      addonMock
-        .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-        .returns(() => ({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }));
-      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
-    });
-
     it("throws on error response", async () => {
       addonMock
         .setup(async (x) => x.handleRequest(moq.It.isAny(), ""))

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -75,7 +75,7 @@ describe("default NativePlatform", () => {
 
     it("calls addon", async () => {
       addonMock
-        .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+        .setup(async (x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(async () => ({ result: "0" }))
         .verifiable();
       expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0" });
@@ -84,21 +84,21 @@ describe("default NativePlatform", () => {
 
     it("throws on cancellation response", async () => {
       addonMock
-        .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+        .setup(async (x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(async () => ({ error: { status: IModelJsNative.ECPresentationStatus.Canceled, message: "test" } }));
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
-    it("throws on queueRequest error response", async () => {
+    it("throws on handleRequest error response", async () => {
       addonMock
-        .setup((x) => x.queueRequest(moq.It.isAny(), ""))
+        .setup((x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(() => ({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }));
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
     it("throws on error response", async () => {
       addonMock
-        .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+        .setup(async (x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(async () => ({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }));
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
@@ -110,7 +110,7 @@ describe("default NativePlatform", () => {
       scope: "test",
     };
     addonMock
-      .setup(async (x) => x.queueRequest(moq.It.isAny(), ""))
+      .setup(async (x) => x.handleRequest(moq.It.isAny(), ""))
       .returns(async () => ({ result: "0", diagnostics }));
     expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0", diagnostics });
     addonMock.verifyAll();


### PR DESCRIPTION
Use promise instead of polling the result from native addon.
https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/261621
Closes iTwin/itwinjs-backlog#120