### PR TITLE
sort non-horizontal loops in polyface clipper

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -4522,6 +4522,7 @@ export class PolygonOps {
     static classifyPointInPolygon(x: number, y: number, points: XAndY[]): number | undefined;
     static classifyPointInPolygonXY(x: number, y: number, points: IndexedXYZCollection): number | undefined;
     static orientLoopsCCWForOutwardNormalInPlace(loops: IndexedReadWriteXYZCollection | IndexedReadWriteXYZCollection[], outwardNormal: Vector3d): number;
+    static sortOuterAndHoleLoops(loops: IndexedReadWriteXYZCollection[], defaultNormal: Vector3d | undefined): IndexedReadWriteXYZCollection[][];
     static sortOuterAndHoleLoopsXY(loops: IndexedReadWriteXYZCollection[]): IndexedReadWriteXYZCollection[][];
     static sumAreaXY(polygons: Point3d[][]): number;
     static sumTriangleAreas(points: Point3d[] | GrowableXYZArray): number;

--- a/core/geometry/src/polyface/PolyfaceClip.ts
+++ b/core/geometry/src/polyface/PolyfaceClip.ts
@@ -28,7 +28,6 @@ import { Transform } from "../geometry3d/Transform";
 import { SweepContour } from "../solid/SweepContour";
 import { ChainMergeContext } from "../topology/ChainMerge";
 import { RangeSearch } from "./multiclip/RangeSearch";
-// import { Point3d, Vector3d, Point2d } from "./PointVector";
 import { IndexedPolyface, Polyface, PolyfaceVisitor } from "./Polyface";
 import { PolyfaceBuilder } from "./PolyfaceBuilder";
 import { PolyfaceQuery } from "./PolyfaceQuery";
@@ -376,7 +375,7 @@ export class PolyfaceClip {
     chainContext.clusterAndMergeVerticesXYZ();
     const loops = chainContext.collectMaximalGrowableXYZArrays();
     if (loops.length > 1) {
-      const loopSets = PolygonOps.sortOuterAndHoleLoopsXY(loops);
+      const loopSets = PolygonOps.sortOuterAndHoleLoops(loops, outwardNormal);
       for (const loopSet of loopSets) {
         PolygonOps.orientLoopsCCWForOutwardNormalInPlace(loopSet, outwardNormal);
         const contour = SweepContour.createForPolygon(loopSet, outwardNormal);

--- a/core/geometry/src/test/clipping/PolyfaceClip.test.ts
+++ b/core/geometry/src/test/clipping/PolyfaceClip.test.ts
@@ -346,6 +346,70 @@ describe("PolyfaceClip", () => {
     expect(ck.getNumErrors()).equals(0);
   });
 
+  it.only("DisconnectedClips", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    let options = StrokeOptions.createForCurves();
+    options.needParams = false;
+    options.needNormals = true;
+    let builder = PolyfaceBuilder.create(options);
+
+    const targetSize = 5;
+    const targetMeshes: IndexedPolyface[] = [];
+    let x0 = 0;
+    let y0 = 0;
+
+    // create 2 disconnected boxes, separated in z direction
+    const boxRange = new Range3d(-targetSize/2, -targetSize/2, 0, targetSize/2, targetSize/2, targetSize);
+    let box = Box.createRange(boxRange, true);
+    if (ck.testDefined(box))
+      builder.addBox(box!);
+    boxRange.low.z += 2 * targetSize;
+    boxRange.high.z += 2 * targetSize;
+    box = Box.createRange(boxRange, true);
+    if (ck.testDefined(box))
+      builder.addBox(box!);
+    targetMeshes.push(builder.claimPolyface(true));
+
+    // create a star-shaped linear sweep
+    const xyStar = Sample.createStar(0, -1.4, 0, targetSize/1.5, 1, 6, true);
+    const sweep = LinearSweep.createZSweep(xyStar, 0, targetSize, true)!;
+    options = StrokeOptions.createForFacets();
+    options.maxEdgeLength = 2.0;
+    builder = PolyfaceBuilder.create(options);
+    builder.addLinearSweep(sweep);
+    targetMeshes.push(builder.claimPolyface(true));
+
+    // create two xz-planes for clipping
+    const clipPlanes: ClipPlane[] = [];
+    clipPlanes.push(ClipPlane.createPlane(Plane3dByOriginAndUnitNormal.create(Point3d.createZero(), Vector3d.unitY())!));
+    clipPlanes.push(ClipPlane.createPlane(Plane3dByOriginAndUnitNormal.create(Point3d.create(0,1,0), Vector3d.create(0,-1,0))!));
+
+    for (const targetMesh of targetMeshes) {
+      if (ck.testDefined(targetMesh) && ck.testFalse(targetMesh.isEmpty)) {
+        GeometryCoreTestIO.captureCloneGeometry(allGeometry, targetMesh, x0, y0);
+        x0 += 2 * targetSize;
+        let clippedTarget = PolyfaceClip.clipPolyfaceClipPlaneWithClosureFace(targetMesh, clipPlanes[0], true, true);
+        if (ck.testDefined(clippedTarget) && ck.testFalse(clippedTarget.isEmpty) && ck.testTrue(clippedTarget instanceof IndexedPolyface)) {
+          ck.testTrue(PolyfaceQuery.isPolyfaceClosedByEdgePairing(clippedTarget), "First clip should result in closed mesh.");
+          GeometryCoreTestIO.captureCloneGeometry(allGeometry, clippedTarget, x0, y0);
+          x0 += 2 * targetSize;
+        }
+        clippedTarget = PolyfaceClip.clipPolyfaceClipPlaneWithClosureFace(clippedTarget, clipPlanes[1], true, true);
+        if (ck.testDefined(clippedTarget) && ck.testFalse(clippedTarget.isEmpty) && ck.testTrue(clippedTarget instanceof IndexedPolyface)) {
+          ck.testTrue(PolyfaceQuery.isPolyfaceClosedByEdgePairing(clippedTarget), "Second clip should result in closed mesh.");
+          GeometryCoreTestIO.captureCloneGeometry(allGeometry, clippedTarget, x0, y0);
+          x0 += 2 * targetSize;
+        }
+      x0 = 0;
+      y0 += 3 * targetSize;
+      }
+    }
+    GeometryCoreTestIO.saveGeometry(allGeometry, "PolyfaceClip", "DisconnectedClips");
+    expect(ck.getNumErrors()).equals(0);
+  });
+
   it("TwoComponentSection", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];


### PR DESCRIPTION
Fix for #3889. Disconnected or non-convex closed polyfaces can result in open polyfaces when clipped with `PolyfaceClip.clipPolyfaceClipPlaneWithClosureFace()` because non-horizontal intersection loops were not rotated into local coordinates before the xy-sort in `addClosureFacets()`. 

Also removed an input assumption in `PolygonOps.unitNormal()` since it is currently being called with input that violates the assumption.