### PR TITLE
Temporarily bypass moment vulnerability

### DIFF
--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -39,6 +39,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
   const excludedAdvisories = [
     "GHSA-ww39-953v-wcq6", // https://github.com/advisories/GHSA-ww39-953v-wcq6 webpack@4>watchpack>watchpack-chokidar2>chokidar>glob-parent
     "GHSA-rp65-9cf3-cjxr", // https://github.com/advisories/GHSA-rp65-9cf3-cjxr @bentley/react-scripts>@svgr/webpack>@svgr/plugin-svgo>svgo>css-select>nth-check
+    "GHSA-wc69-rhjr-hc9g", // https://github.com/advisories/GHSA-wc69-rhjr-hc9g backend-integration-tests>azurite>sequelize>moment
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
https://github.com/advisories/GHSA-wc69-rhjr-hc9g
backend-integration-tests uses azurite which uses sequelize which uses moment.
Latest version of azurite (3.18.0) wants sequelize ^6.3.0. It gets 6.20.1_mysql2@2.3.3+tedious@14.5.0 (ok...?) which gets moment 2.29.3.
As far as I can tell sequelize has since removed its dependency on moment.