### PR TITLE
Retry v2 checkpoint downloads in the case of "Failure when receiving data from the peer" error message

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1032,6 +1032,7 @@ export interface DownloadRequest {
     readonly checkpoint: CheckpointProps;
     localFile: LocalFileName;
     readonly onProgress?: ProgressFunction;
+    readonly retries?: number;
 }
 
 // @internal (undocumented)

--- a/common/changes/@itwin/core-backend/nick-retry-v2-checkpoint-downloads_2022-07-08-14-59.json
+++ b/common/changes/@itwin/core-backend/nick-retry-v2-checkpoint-downloads_2022-07-08-14-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "retry v2checkpoint downloads when they fail with \"Failure when receiving data from the peer\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -302,7 +302,7 @@ export class CheckpointManager {
         }
       }
     } while (!success && currentAttempts < numAttempts);
-  };
+  }
 
   private static async doDownload(request: DownloadRequest): Promise<ChangesetId> {
     try {
@@ -318,11 +318,14 @@ export class CheckpointManager {
             throw error;
         }
       });
-      if (changesetId! !== request.checkpoint.changeset.id)
-        Logger.logInfo(loggerCategory, `Downloaded previous v2 checkpoint because checkpoint for ${request.checkpoint.changeset.id} not found.  Downloaded: IModel=${request.checkpoint.iModelId}, changeset=${changesetId!}`);
+      if (changeSetId === undefined) {
+        throw Error("ChangeSetId is undefined after returning from V2CheckpointManager.downloadCheckpoint");
+      }
+      if (changesetId !== request.checkpoint.changeset.id)
+        Logger.logInfo(loggerCategory, `Downloaded previous v2 checkpoint because checkpoint for ${request.checkpoint.changeset.id} not found.  Downloaded: IModel=${request.checkpoint.iModelId}, changeset=${changesetId}`);
       else
         Logger.logInfo(loggerCategory, `Downloaded v2 checkpoint: IModel=${request.checkpoint.iModelId}, changeset=${request.checkpoint.changeset.id}`);
-      return changesetId!;
+      return changesetId;
     } catch (error: any) {
       if (error.errorNumber === IModelStatus.NotFound) // No V2 checkpoint available, try a v1 checkpoint
         return V1CheckpointManager.downloadCheckpoint(request);

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -307,7 +307,7 @@ export class CheckpointManager {
   private static async doDownload(request: DownloadRequest): Promise<ChangesetId> {
     try {
       // first see if there's a V2 checkpoint available.
-      let changesetId: string;
+      let changesetId: string | undefined;
       await this.withAttempts(5, async () => {
         try {
           changesetId = await V2CheckpointManager.downloadCheckpoint(request);
@@ -318,7 +318,7 @@ export class CheckpointManager {
             throw error;
         }
       });
-      if (changeSetId === undefined) {
+      if (changesetId === undefined) {
         throw Error("ChangeSetId is undefined after returning from V2CheckpointManager.downloadCheckpoint");
       }
       if (changesetId !== request.checkpoint.changeset.id)

--- a/core/backend/src/test/hubaccess/CheckpointManager.test.ts
+++ b/core/backend/src/test/hubaccess/CheckpointManager.test.ts
@@ -131,7 +131,7 @@ describe("Checkpoint Manager", () => {
     assert.isUndefined(db);
   });
 
-  it.only("should fail when downloadCheckpoint does not throw a transient error", async () => {
+  it("should fail when downloadCheckpoint does not throw a transient error", async () => {
     // Mock iModelHub
     const mockCheckpointV2: V2CheckpointAccessProps = {
       accountName: "testAccount",
@@ -159,7 +159,7 @@ describe("Checkpoint Manager", () => {
     assert.isTrue(v2Spy.callCount === 2, `Expected call count of 2, but got ${v2Spy.callCount}`);
   });
 
-  it.only("should fail when downloadCheckpoint throws transient error too many times", async () => {
+  it("should fail when downloadCheckpoint throws transient error too many times", async () => {
     // Mock iModelHub
     const mockCheckpointV2: V2CheckpointAccessProps = {
       accountName: "testAccount",

--- a/core/backend/src/test/hubaccess/CheckpointManager.test.ts
+++ b/core/backend/src/test/hubaccess/CheckpointManager.test.ts
@@ -3,10 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import * as path from "path";
 import * as sinon from "sinon";
 import { Guid } from "@itwin/core-bentley";
+import { V2CheckpointAccessProps } from "../../core-backend";
 import { CheckpointManager, V1CheckpointManager, V2CheckpointManager } from "../../CheckpointManager";
 import { IModelHost } from "../../core-backend";
 import { SnapshotDb } from "../../IModelDb";
@@ -129,6 +130,46 @@ describe("Checkpoint Manager", () => {
     };
     const db = CheckpointManager.tryOpenLocalFile(request);
     assert.isUndefined(db);
+  });
+
+  it.only("should only retry v2 checkpoint download number of times (5) passed to 'withAttempts' function", async () => {
+    // Mock iModelHub
+    const mockCheckpointV2: V2CheckpointAccessProps = {
+      accountName: "testAccount",
+      containerId: "imodelblocks-123",
+      sasToken: "testSAS",
+      dbName: "testDb",
+      storageType: "azure?sas=1",
+    };
+
+    sinon.stub(IModelHost, "hubAccess").get(() => HubMock);
+    sinon.stub(IModelHost.hubAccess, "queryV2Checkpoint").callsFake(async () => mockCheckpointV2);
+
+    // Should break out of the loop to try downloadCheckpoint, we'll hit the max number of attempts here in this scenario and then throw in doDownload in CheckpointManager
+    const v2Spy = sinon.stub(V2CheckpointManager, "downloadCheckpoint").onCall(0).callsFake(async () => {
+      throw Error("Failure when receiving data from the peer");
+    }).onCall(1).callsFake(async () => {
+      throw Error("Failure when receiving data from the peer");
+    }).onCall(2).callsFake(async () => {
+      throw Error("Failure when receiving data from the peer");
+    }).onCall(3).callsFake(async () => {
+      throw Error("Failure when receiving data from the peer");
+    }).onCall(4).callsFake(async () => {
+      throw Error("Failure when receiving data from the peer");
+    }).onCall(5).callsFake(async () => {
+      throw Error("Failure when receiving data from the peer");
+    }).onCall(6).callsFake(async () => {
+      throw Error("Failure when receiving data from the peer")
+    }).callThrough();
+
+    const iModelId = Guid.createValue();
+    const iTwinId = Guid.createValue();
+    const changeset = IModelTestUtils.generateChangeSetId();
+    const localFile = IModelTestUtils.prepareOutputFile("IModel", "TestCheckpoint2.bim");
+    const request = { localFile, checkpoint: { accessToken: "dummy", iTwinId, iModelId, changeset } };
+    // expect(await CheckpointManager.downloadCheckpoint(request);
+    await expect(CheckpointManager.downloadCheckpoint(request)).to.eventually.be.rejectedWith("Failure when receiving data from the peer");
+    assert.isTrue(v2Spy.callCount === 5, `Expected call count of 5, but got ${v2Spy.callCount}`);
   });
 
   it("downloadCheckpoint should fall back to use v1 checkpoints if v2 checkpoints are not enabled", async () => {

--- a/core/backend/src/test/hubaccess/CheckpointManager.test.ts
+++ b/core/backend/src/test/hubaccess/CheckpointManager.test.ts
@@ -7,9 +7,8 @@ import { assert, expect } from "chai";
 import * as path from "path";
 import * as sinon from "sinon";
 import { Guid } from "@itwin/core-bentley";
-import { V2CheckpointAccessProps } from "../../core-backend";
 import { CheckpointManager, V1CheckpointManager, V2CheckpointManager } from "../../CheckpointManager";
-import { IModelHost } from "../../core-backend";
+import { IModelHost, V2CheckpointAccessProps } from "../../core-backend";
 import { SnapshotDb } from "../../IModelDb";
 import { IModelJsFs } from "../../IModelJsFs";
 import { IModelTestUtils } from "../IModelTestUtils";
@@ -132,7 +131,7 @@ describe("Checkpoint Manager", () => {
     assert.isUndefined(db);
   });
 
-  it.only("should only retry v2 checkpoint download number of times (5) passed to 'withAttempts' function", async () => {
+  it("should only retry v2 checkpoint download number of times (5) passed to 'withAttempts' function", async () => {
     // Mock iModelHub
     const mockCheckpointV2: V2CheckpointAccessProps = {
       accountName: "testAccount",
@@ -159,7 +158,7 @@ describe("Checkpoint Manager", () => {
     }).onCall(5).callsFake(async () => {
       throw Error("Failure when receiving data from the peer");
     }).onCall(6).callsFake(async () => {
-      throw Error("Failure when receiving data from the peer")
+      throw Error("Failure when receiving data from the peer");
     }).callThrough();
 
     const iModelId = Guid.createValue();
@@ -167,7 +166,6 @@ describe("Checkpoint Manager", () => {
     const changeset = IModelTestUtils.generateChangeSetId();
     const localFile = IModelTestUtils.prepareOutputFile("IModel", "TestCheckpoint2.bim");
     const request = { localFile, checkpoint: { accessToken: "dummy", iTwinId, iModelId, changeset } };
-    // expect(await CheckpointManager.downloadCheckpoint(request);
     await expect(CheckpointManager.downloadCheckpoint(request)).to.eventually.be.rejectedWith("Failure when receiving data from the peer");
     assert.isTrue(v2Spy.callCount === 5, `Expected call count of 5, but got ${v2Spy.callCount}`);
   });


### PR DESCRIPTION
This is a short term solution to a problem surrounding Transient Fault handling with v2 checkpoints. In the long term, we expect to work with SQLite and hopefully have them provide a way for us to better control what we do in the event of an error when downloading blocks. 

Resumable downloads are supported by blockcachevfs, meaning that we will not be repeating the same block downloads when retrying these v2 checkpoint downloads.