### PR TITLE
Presentation: correctly handle customizeTreeNodeItem in usePresentationTreeNodeLoader hook

### DIFF
--- a/common/changes/@itwin/presentation-components/presentation-usepresentationtreenodeloader_fix_2022-07-13-13-15.json
+++ b/common/changes/@itwin/presentation-components/presentation-usepresentationtreenodeloader_fix_2022-07-13-13-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-components",
+      "comment": "usePresentationTreeNodeLoader: pass 'customizeTreeNodeItem' callback to 'PresentationTreeDataProvider'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-components"
+}

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -76,6 +76,7 @@ export function usePresentationTreeNodeLoader(
       dataSourceOverrides: props.dataSourceOverrides,
       ruleDiagnostics: props.ruleDiagnostics,
       devDiagnostics: props.devDiagnostics,
+      customizeTreeNodeItem: props.customizeTreeNodeItem,
     }),
     [
       props.appendChildrenCountForGroupingNodes,
@@ -85,6 +86,7 @@ export function usePresentationTreeNodeLoader(
       props.pagingSize,
       props.ruleDiagnostics,
       props.ruleset,
+      props.customizeTreeNodeItem,
     ],
   );
 


### PR DESCRIPTION
When using `usePresentationTreeNodeLoader` hook `customizeTreeNodeItem` was not passed through to `PresentationTreeDataProvider` during creation. Because of this there was no way to customize tree node items when loading nodes.