### PR TITLE
Presentation: Fix NativePlatform coverage

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-FixNativePlatformCoverage_2022-07-13-15-35.json
+++ b/common/changes/@itwin/presentation-backend/presentation-FixNativePlatformCoverage_2022-07-13-15-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -182,9 +182,7 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
     }
     public async handleRequest(db: any, options: string) {
       const result = await this._nativeAddon.handleRequest(db, options);
-      if (result.error)
-        throw new PresentationError(this.getStatus(result.error.status), result.error.message);
-      return this.createSuccessResponse(result);
+      return this.handleResult(result);
     }
     public getRulesetVariableValue(rulesetId: string, variableId: string, type: VariableValueTypes) {
       return this.handleResult(this._nativeAddon.getRulesetVariableValue(rulesetId, variableId, type));


### PR DESCRIPTION
Line `throw new PresentationError(this.getStatus(response.error.status), response.error.message);` in `handleResult<T>` was not covered.