### PR TITLE
Presentation: Add navigation property target info

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1557,6 +1557,7 @@ export interface NamedFieldDescriptor extends FieldDescriptorBase {
 export interface NavigationPropertyInfo {
     classInfo: ClassInfo;
     isForwardRelationship: boolean;
+    isTargetPolymorphic: boolean;
     targetClassInfo: ClassInfo;
 }
 
@@ -1575,6 +1576,8 @@ export interface NavigationPropertyInfoJSON<TClassInfoJSON = ClassInfoJSON> {
     classInfo: TClassInfoJSON;
     // (undocumented)
     isForwardRelationship: boolean;
+    // (undocumented)
+    isTargetPolymorphic: boolean;
     // (undocumented)
     targetClassInfo: TClassInfoJSON;
 }

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1557,6 +1557,7 @@ export interface NamedFieldDescriptor extends FieldDescriptorBase {
 export interface NavigationPropertyInfo {
     classInfo: ClassInfo;
     isForwardRelationship: boolean;
+    targetClassInfo: ClassInfo;
 }
 
 // @beta (undocumented)
@@ -1574,6 +1575,8 @@ export interface NavigationPropertyInfoJSON<TClassInfoJSON = ClassInfoJSON> {
     classInfo: TClassInfoJSON;
     // (undocumented)
     isForwardRelationship: boolean;
+    // (undocumented)
+    targetClassInfo: TClassInfoJSON;
 }
 
 // @public

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1563,6 +1563,9 @@ export interface NavigationPropertyInfo {
 
 // @beta (undocumented)
 export namespace NavigationPropertyInfo {
+    export function fromCompressedJSON(compressedNavigationPropertyInfoJSON: NavigationPropertyInfoJSON<string>, classesMap: {
+        [id: string]: CompressedClassInfoJSON;
+    }): NavigationPropertyInfo;
     export function fromJSON(json: NavigationPropertyInfo): NavigationPropertyInfo;
     export function toCompressedJSON(navigationPropertyInfo: NavigationPropertyInfo, classesMap: {
         [id: string]: CompressedClassInfoJSON;

--- a/common/changes/@itwin/presentation-common/presentation-add_navigation_property_target_info_2022-07-15-13-58.json
+++ b/common/changes/@itwin/presentation-common/presentation-add_navigation_property_target_info_2022-07-15-13-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Add target info to NavigationPropertyInfo",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/full-stack-tests/presentation/src/frontend/Content.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Content.test.ts
@@ -423,6 +423,7 @@ describe("Content", () => {
       expect(field.properties[0].property.navigationPropertyInfo).is.not.null;
       expect(field.properties[0].property.navigationPropertyInfo?.isForwardRelationship).to.eq(false);
       expect(field.properties[0].property.navigationPropertyInfo?.classInfo.id).to.eq("0x40");
+      expect(field.properties[0].property.navigationPropertyInfo?.targetClassInfo.id).to.eq("0x41");
 
     });
 

--- a/presentation/common/src/presentation-common/EC.ts
+++ b/presentation/common/src/presentation-common/EC.ts
@@ -191,6 +191,15 @@ export namespace NavigationPropertyInfo {
   export function fromJSON(json: NavigationPropertyInfo): NavigationPropertyInfo {
     return { ...json, classInfo: ClassInfo.fromJSON(json.classInfo), targetClassInfo: ClassInfo.fromJSON(json.targetClassInfo) };
   }
+
+  /** Deserialize [[NavigationPropertyInfo]] from compressed JSON */
+  export function fromCompressedJSON(compressedNavigationPropertyInfoJSON: NavigationPropertyInfoJSON<string>, classesMap: { [id: string]: CompressedClassInfoJSON }): NavigationPropertyInfo {
+    return {
+      ...compressedNavigationPropertyInfoJSON,
+      classInfo: { id: compressedNavigationPropertyInfoJSON.classInfo, ...classesMap[compressedNavigationPropertyInfoJSON.classInfo] },
+      targetClassInfo: { id: compressedNavigationPropertyInfoJSON.targetClassInfo, ...classesMap[compressedNavigationPropertyInfoJSON.targetClassInfo] },
+    };
+  }
 }
 
 /**

--- a/presentation/common/src/presentation-common/EC.ts
+++ b/presentation/common/src/presentation-common/EC.ts
@@ -162,6 +162,8 @@ export interface NavigationPropertyInfo {
   isForwardRelationship: boolean;
   /** Information about ECProperty's target class */
   targetClassInfo: ClassInfo;
+  /** Is ECProperty's target class polymorphic */
+  isTargetPolymorphic: boolean;
 }
 
 /** @beta */
@@ -199,6 +201,7 @@ export interface NavigationPropertyInfoJSON<TClassInfoJSON = ClassInfoJSON> {
   classInfo: TClassInfoJSON;
   isForwardRelationship: boolean;
   targetClassInfo: TClassInfoJSON;
+  isTargetPolymorphic: boolean;
 }
 
 /**

--- a/presentation/common/src/presentation-common/EC.ts
+++ b/presentation/common/src/presentation-common/EC.ts
@@ -160,29 +160,34 @@ export interface NavigationPropertyInfo {
   classInfo: ClassInfo;
   /** Is the direction of the relationship forward */
   isForwardRelationship: boolean;
+  /** Information about ECProperty's target class */
+  targetClassInfo: ClassInfo;
 }
 
 /** @beta */
 export namespace NavigationPropertyInfo {
   /** Serialize [[NavigationPropertyInfo]] to JSON */
   export function toJSON(info: NavigationPropertyInfo): NavigationPropertyInfoJSON {
-    return { ...info, classInfo: ClassInfo.toJSON(info.classInfo) };
+    return { ...info, classInfo: ClassInfo.toJSON(info.classInfo), targetClassInfo: ClassInfo.toJSON(info.classInfo) };
   }
 
   /** Serialize [[NavigationPropertyInfo]] to compressed JSON */
   export function toCompressedJSON(navigationPropertyInfo: NavigationPropertyInfo, classesMap: { [id: string]: CompressedClassInfoJSON }): NavigationPropertyInfoJSON<string> {
-    const { id, ...leftOverInfo } = navigationPropertyInfo.classInfo;
-    classesMap[id] = leftOverInfo;
+    const { id: relationshipId, ...relationshipLeftOverInfo } = navigationPropertyInfo.classInfo;
+    const { id: targetId, ...targetLeftOverInfo} = navigationPropertyInfo.targetClassInfo;
+    classesMap[relationshipId] = relationshipLeftOverInfo;
+    classesMap[targetId] = targetLeftOverInfo;
 
     return {
       ...navigationPropertyInfo,
-      classInfo: navigationPropertyInfo.classInfo.id,
+      classInfo: relationshipId,
+      targetClassInfo: targetId,
     };
   }
 
   /** Deserialize [[NavigationPropertyInfo]] from JSON */
   export function fromJSON(json: NavigationPropertyInfo): NavigationPropertyInfo {
-    return { ...json, classInfo: ClassInfo.fromJSON(json.classInfo) };
+    return { ...json, classInfo: ClassInfo.fromJSON(json.classInfo), targetClassInfo: ClassInfo.fromJSON(json.targetClassInfo) };
   }
 }
 
@@ -193,6 +198,7 @@ export namespace NavigationPropertyInfo {
 export interface NavigationPropertyInfoJSON<TClassInfoJSON = ClassInfoJSON> {
   classInfo: TClassInfoJSON;
   isForwardRelationship: boolean;
+  targetClassInfo: TClassInfoJSON;
 }
 
 /**

--- a/presentation/common/src/presentation-common/content/Fields.ts
+++ b/presentation/common/src/presentation-common/content/Fields.ts
@@ -8,7 +8,7 @@
 
 import { assert, Id64String } from "@itwin/core-bentley";
 import {
-  ClassInfo, ClassInfoJSON, CompressedClassInfoJSON, NavigationPropertyInfo, NavigationPropertyInfoJSON, PropertyInfo, PropertyInfoJSON, RelatedClassInfo, RelationshipPath, RelationshipPathJSON,
+  ClassInfo, ClassInfoJSON, CompressedClassInfoJSON, NavigationPropertyInfo, PropertyInfo, PropertyInfoJSON, RelatedClassInfo, RelationshipPath, RelationshipPathJSON,
   StrippedRelationshipPath,
 } from "../EC";
 import { PresentationError, PresentationStatus } from "../Error";
@@ -607,14 +607,6 @@ function fromCompressedPropertyInfoJSON(compressedPropertyJSON: PropertyInfoJSON
   return {
     ...leftOverPropertyJSON,
     classInfo: { id: compressedPropertyJSON.classInfo, ...classesMap[compressedPropertyJSON.classInfo] },
-    ...(navigationPropertyInfo ? { navigationPropertyInfo: fromCompressedNavigationPropertyInfoJSON(navigationPropertyInfo, classesMap) } : undefined),
-  };
-}
-
-function fromCompressedNavigationPropertyInfoJSON(compressedNavigationPropertyInfoJSON: NavigationPropertyInfoJSON<string>, classesMap: { [id: string]: CompressedClassInfoJSON }): NavigationPropertyInfo {
-  return {
-    ...compressedNavigationPropertyInfoJSON,
-    classInfo: { id: compressedNavigationPropertyInfoJSON.classInfo, ...classesMap[compressedNavigationPropertyInfoJSON.classInfo] },
-    targetClassInfo: { id: compressedNavigationPropertyInfoJSON.targetClassInfo, ...classesMap[compressedNavigationPropertyInfoJSON.targetClassInfo] },
+    ...(navigationPropertyInfo ? { navigationPropertyInfo: NavigationPropertyInfo.fromCompressedJSON(navigationPropertyInfo, classesMap) } : undefined),
   };
 }

--- a/presentation/common/src/presentation-common/content/Fields.ts
+++ b/presentation/common/src/presentation-common/content/Fields.ts
@@ -615,5 +615,6 @@ function fromCompressedNavigationPropertyInfoJSON(compressedNavigationPropertyIn
   return {
     ...compressedNavigationPropertyInfoJSON,
     classInfo: { id: compressedNavigationPropertyInfoJSON.classInfo, ...classesMap[compressedNavigationPropertyInfoJSON.classInfo] },
+    targetClassInfo: { id: compressedNavigationPropertyInfoJSON.targetClassInfo, ...classesMap[compressedNavigationPropertyInfoJSON.targetClassInfo] },
   };
 }

--- a/presentation/common/src/test/content/Descriptor.test.snap
+++ b/presentation/common/src/test/content/Descriptor.test.snap
@@ -28,6 +28,10 @@ Object {
       "label": "label4",
       "name": "name4",
     },
+    "0x5": Object {
+      "label": "label5",
+      "name": "name5",
+    },
   },
   "connectionId": "",
   "contentFlags": 0,
@@ -145,6 +149,7 @@ Object {
             "navigationPropertyInfo": Object {
               "classInfo": "0x4",
               "isForwardRelationship": true,
+              "targetClassInfo": "0x5",
             },
             "type": "TestPropertyType",
           },

--- a/presentation/common/src/test/content/Descriptor.test.snap
+++ b/presentation/common/src/test/content/Descriptor.test.snap
@@ -149,6 +149,7 @@ Object {
             "navigationPropertyInfo": Object {
               "classInfo": "0x4",
               "isForwardRelationship": true,
+              "isTargetPolymorphic": true,
               "targetClassInfo": "0x5",
             },
             "type": "TestPropertyType",

--- a/presentation/common/src/test/content/Descriptor.test.ts
+++ b/presentation/common/src/test/content/Descriptor.test.ts
@@ -169,6 +169,7 @@ describe("Descriptor", () => {
                 classInfo: ids[3],
                 isForwardRelationship: true,
                 targetClassInfo: ids[4],
+                isTargetPolymorphic: true,
               },
             },
           }],

--- a/presentation/common/src/test/content/Descriptor.test.ts
+++ b/presentation/common/src/test/content/Descriptor.test.ts
@@ -70,7 +70,7 @@ describe("Descriptor", () => {
 
     it("creates valid Descriptor from valid JSON", () => {
       const category = createTestCategoryDescription();
-      const ids = ["0x1", "0x2", "0x3", "0x4"];
+      const ids = ["0x1", "0x2", "0x3", "0x4", "0x5"];
       const testRelatedClassInfo: RelatedClassInfoJSON<string> = {
         sourceClassInfo: ids[1],
         targetClassInfo: ids[2],
@@ -89,6 +89,7 @@ describe("Descriptor", () => {
           [ids[1]]: { name: "name2", label: "label2" },
           [ids[2]]: { name: "name3", label: "label3" },
           [ids[3]]: { name: "name4", label: "label4" },
+          [ids[4]]: { name: "name5", label: "label5" },
         },
         selectClasses: [{
           selectClassInfo: ids[0],
@@ -167,6 +168,7 @@ describe("Descriptor", () => {
               navigationPropertyInfo: {
                 classInfo: ids[3],
                 isForwardRelationship: true,
+                targetClassInfo: ids[4],
               },
             },
           }],

--- a/presentation/common/src/test/content/Fields.test.snap
+++ b/presentation/common/src/test/content/Fields.test.snap
@@ -311,6 +311,11 @@ Object {
             "name": "SchemaName:ClassName",
           },
           "isForwardRelationship": false,
+          "targetClassInfo": Object {
+            "id": "0x1",
+            "label": "Class Label",
+            "name": "SchemaName:ClassName",
+          },
         },
         "type": "string",
       },

--- a/presentation/common/src/test/content/Fields.test.snap
+++ b/presentation/common/src/test/content/Fields.test.snap
@@ -311,6 +311,7 @@ Object {
             "name": "SchemaName:ClassName",
           },
           "isForwardRelationship": false,
+          "isTargetPolymorphic": true,
           "targetClassInfo": Object {
             "id": "0x1",
             "label": "Class Label",

--- a/presentation/common/src/test/content/Fields.test.ts
+++ b/presentation/common/src/test/content/Fields.test.ts
@@ -133,7 +133,11 @@ describe("PropertiesField", () => {
       const category = createTestCategoryDescription();
       const json = createTestPropertiesContentField({
         category,
-        properties: [{ property: createTestPropertyInfo({ navigationPropertyInfo: { classInfo: createTestECClassInfo(), isForwardRelationship: false } }) }],
+        properties: [{
+          property: createTestPropertyInfo({
+            navigationPropertyInfo: { classInfo: createTestECClassInfo(), isForwardRelationship: false, targetClassInfo: createTestECClassInfo() },
+          }),
+        }],
       }).toJSON();
       const field = PropertiesField.fromJSON(json, [category]);
       expect(field).to.matchSnapshot();

--- a/presentation/common/src/test/content/Fields.test.ts
+++ b/presentation/common/src/test/content/Fields.test.ts
@@ -135,7 +135,12 @@ describe("PropertiesField", () => {
         category,
         properties: [{
           property: createTestPropertyInfo({
-            navigationPropertyInfo: { classInfo: createTestECClassInfo(), isForwardRelationship: false, targetClassInfo: createTestECClassInfo() },
+            navigationPropertyInfo: {
+              classInfo: createTestECClassInfo(),
+              isForwardRelationship: false,
+              targetClassInfo: createTestECClassInfo(),
+              isTargetPolymorphic: true,
+            },
           }),
         }],
       }).toJSON();


### PR DESCRIPTION
Added info about target class to `NavigationPropertyInfo`

Related [native changes](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/264272)