### PR TITLE
IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2526,7 +2526,7 @@ export class IModelHost {
         exactMatch?: boolean;
     }): string;
     // (undocumented)
-    static configuration?: IModelHostConfiguration;
+    static configuration?: IModelHostOptions;
     // @internal (undocumented)
     static flushLog(): void;
     static getAccessToken(): Promise<AccessToken>;
@@ -2560,7 +2560,7 @@ export class IModelHost {
     static setHubAccess(hubAccess: BackendHubAccess | undefined): void;
     static shutdown(): Promise<void>;
     static snapshotFileNameResolver?: FileNameResolver;
-    static startup(configuration?: IModelHostConfiguration): Promise<void>;
+    static startup(options?: IModelHostOptions): Promise<void>;
     // @alpha (undocumented)
     static readonly telemetry: TelemetryManager;
     // @internal
@@ -2576,7 +2576,43 @@ export class IModelHost {
     }
 
 // @public
-export class IModelHostConfiguration {
+export class IModelHostConfiguration implements IModelHostOptions {
+    // (undocumented)
+    appAssetsDir?: LocalDirName;
+    // (undocumented)
+    authorizationClient?: AuthorizationClient;
+    // (undocumented)
+    cacheDir?: LocalDirName;
+    // (undocumented)
+    compressCachedTiles?: boolean;
+    // (undocumented)
+    static defaultLogTileLoadTimeThreshold: number;
+    // (undocumented)
+    static defaultLogTileSizeThreshold: number;
+    // (undocumented)
+    static defaultTileRequestTimeout: number;
+    // @beta (undocumented)
+    hubAccess?: BackendHubAccess;
+    // (undocumented)
+    logTileLoadTimeThreshold: number;
+    // (undocumented)
+    logTileSizeThreshold: number;
+    // (undocumented)
+    restrictTileUrlsByClientIp?: boolean;
+    // @beta (undocumented)
+    tileCacheAzureCredentials?: AzureBlobStorageCredentials;
+    // @beta (undocumented)
+    tileCacheService?: CloudStorageService;
+    // (undocumented)
+    tileContentRequestTimeout: number;
+    // (undocumented)
+    tileTreeRequestTimeout: number;
+    // @beta (undocumented)
+    workspace?: WorkspaceOpts;
+}
+
+// @public
+export interface IModelHostOptions {
     appAssetsDir?: LocalDirName;
     // @beta
     authorizationClient?: AuthorizationClient;
@@ -2584,18 +2620,12 @@ export class IModelHostConfiguration {
     compressCachedTiles?: boolean;
     // @alpha
     crashReportingConfig?: CrashReportingConfig;
-    // @internal
-    static defaultLogTileLoadTimeThreshold: number;
-    // @internal
-    static defaultLogTileSizeThreshold: number;
-    // @internal
-    static defaultTileRequestTimeout: number;
     // @beta
     hubAccess?: BackendHubAccess;
     // @internal
-    logTileLoadTimeThreshold: number;
+    logTileLoadTimeThreshold?: number;
     // @internal
-    logTileSizeThreshold: number;
+    logTileSizeThreshold?: number;
     // @beta
     restrictTileUrlsByClientIp?: boolean;
     // @beta
@@ -2603,9 +2633,9 @@ export class IModelHostConfiguration {
     // @beta
     tileCacheService?: CloudStorageService;
     // @internal
-    tileContentRequestTimeout: number;
+    tileContentRequestTimeout?: number;
     // @internal
-    tileTreeRequestTimeout: number;
+    tileTreeRequestTimeout?: number;
     // @beta
     workspace?: WorkspaceOpts;
 }
@@ -2777,7 +2807,7 @@ export class IpcHost {
 // @public
 export interface IpcHostOpts {
     // (undocumented)
-    iModelHost?: IModelHostConfiguration;
+    iModelHost?: IModelHostOptions;
     // (undocumented)
     ipcHost?: {
         socket?: IpcSocketBackend;
@@ -3103,7 +3133,7 @@ export class LocalhostIpcHost {
     // (undocumented)
     static startup(opts?: {
         localhostIpcHost?: LocalhostIpcHostOpts;
-        iModelHost?: IModelHostConfiguration;
+        iModelHost?: IModelHostOptions;
     }): Promise<void>;
 }
 

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -186,7 +186,8 @@ public;IModelDb
 internal;TileContentState
 internal;Tiles
 public;IModelHost
-public;IModelHostConfiguration
+public;IModelHostConfiguration 
+public;IModelHostOptions
 public;IModelIdArg 
 public;IModelJsFs
 public;IModelJsFsStats

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -4,6 +4,7 @@ public;AdditionalTransform
 public;AdditionalTransformProps
 public;AffineTransform 
 public;AffineTransformProps
+internal;aggregateLoad:
 public;AmbientLight
 public;AmbientLightProps
 public;AmbientOcclusion
@@ -375,6 +376,7 @@ public;IModelVersionProps =
 public;InformationPartitionElementProps 
 internal;initializeRpcRequest: () => void
 internal;INSTANCE: unique symbol
+internal;InterceptedRpcRequest
 beta;InternetConnectivityStatus
 public;Interpolation:
 public;InterpolationFunction = (v: any, k: number) => number
@@ -383,6 +385,7 @@ internal;IpcAppFunctions
 internal;IpcAppNotifications
 internal;IpcInvokeReturn =
 public;IpcListener = (evt: Event, ...args: any[]) => void
+internal;class IpcSession
 public;IpcSocket
 public;IpcSocketBackend 
 public;IpcSocketFrontend 
@@ -641,6 +644,7 @@ internal;RpcRoutingMap
 internal;RpcRoutingToken
 internal;RpcSerializedValue
 internal;RpcSerializedValue
+internal;RpcSessionInvocation 
 beta;SchemaState
 public;SectionDrawingLocationProps 
 public;SectionDrawingProps 

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -555,8 +555,6 @@ public;SelectionTool
 internal;SelectParent
 public;SelectRemoveEvent
 public;SelectReplaceEvent
-alpha;ServiceExtensionProvider 
-alpha;ServiceExtensionProviderProps
 public;SetupCameraTool 
 public;SetupWalkCameraTool 
 public;SheetModelState 

--- a/common/changes/@itwin/core-backend/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/core-backend/imodelhost-options_2022-07-16-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/core-backend/imodelhost-options_2022-07-16-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-mobile/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/core-mobile/imodelhost-options_2022-07-16-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-mobile",
-      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-mobile/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/core-mobile/imodelhost-options_2022-07-16-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/common/changes/@itwin/core-transformer/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/core-transformer/imodelhost-options_2022-07-16-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-transformer",
-      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-transformer/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/core-transformer/imodelhost-options_2022-07-16-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-tests/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-tests/imodelhost-options_2022-07-16-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-tests",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-tests"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-tests/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-tests/imodelhost-options_2022-07-16-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/ecschema-rpcinterface-tests",
-      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/presentation-testing/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/presentation-testing/imodelhost-options_2022-07-16-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/presentation-testing",
-      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/presentation-testing/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/presentation-testing/imodelhost-options_2022-07-16-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-testing",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-testing"
+}

--- a/common/changes/@itwin/rpcinterface-full-stack-tests/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/rpcinterface-full-stack-tests/imodelhost-options_2022-07-16-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/rpcinterface-full-stack-tests",
-      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/rpcinterface-full-stack-tests/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/rpcinterface-full-stack-tests/imodelhost-options_2022-07-16-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/rpcinterface-full-stack-tests",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/rpcinterface-full-stack-tests"
+}

--- a/common/changes/@itwin/workspace-editor/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/workspace-editor/imodelhost-options_2022-07-16-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/workspace-editor",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/workspace-editor"
+}

--- a/common/changes/@itwin/workspace-editor/imodelhost-options_2022-07-16-17-57.json
+++ b/common/changes/@itwin/workspace-editor/imodelhost-options_2022-07-16-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/workspace-editor",
-      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration intance",
+      "comment": "IModelHost.startup now accepts IModelHostOptions interface rather than IModelHostConfiguration instance",
       "type": "none"
     }
   ],

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -69,6 +69,10 @@ export interface CrashReportingConfig {
   uploadToBentley?: boolean;
 }
 
+/**
+ * Options for [[IModelHost.startup]]
+ * @public
+ */
 export interface IModelHostOptions {
   /**
    * Root of the directory holding all the files that iTwin.js caches
@@ -86,68 +90,70 @@ export interface IModelHostOptions {
    */
   cacheDir?: LocalDirName;
 
-  /** Options for creating the [[Workspace]]
-    * @beta
-    */
+  /**
+   * Options for creating the [[Workspace]]
+   * @beta
+   */
   workspace?: WorkspaceOpts;
 
   /** The directory where the app's assets are found. */
   appAssetsDir?: LocalDirName;
 
-  /** The kind of iModel hub server to use.
-    * @beta
-    */
+  /**
+   * The kind of iModel hub server to use.
+   * @beta
+   */
   hubAccess?: BackendHubAccess;
 
   /** The Azure blob storage credentials to use for the tile cache service. If omitted and no external service implementation is provided, a local cache will be used.
-    * @beta
-    */
+   * @beta
+   */
   tileCacheAzureCredentials?: AzureBlobStorageCredentials;
 
   /**
-    * @beta
-    * @note A reference implementation is set for [[AzureBlobStorage]] if [[tileCacheAzureCredentials]] property is set. To supply a different implementation for any service provider (such as AWS),
-    *       set this property with a custom [[CloudStorageService]].
-    */
+   * @beta
+   * @note A reference implementation is set for [[AzureBlobStorage]] if [[tileCacheAzureCredentials]] property is set. To supply a different implementation for any service provider (such as AWS),
+   *       set this property with a custom [[CloudStorageService]].
+   */
   tileCacheService?: CloudStorageService;
 
   /** Whether to restrict tile cache URLs by client IP address (if available).
-    * @beta
-    */
+   * @beta
+   */
   restrictTileUrlsByClientIp?: boolean;
 
   /** Whether to compress cached tiles.
-    * Defaults to `true`.
-    */
+   * Defaults to `true`.
+   */
   compressCachedTiles?: boolean;
 
   /** The time, in milliseconds, for which [IModelTileRpcInterface.requestTileTreeProps]($common) should wait before returning a "pending" status.
-    * @internal
-    */
+   * @internal
+   */
   tileTreeRequestTimeout?: number;
   /** The time, in milliseconds, for which [IModelTileRpcInterface.requestTileContent]($common) should wait before returning a "pending" status.
-    * @internal
-    */
+   * @internal
+   */
   tileContentRequestTimeout?: number;
 
   /** The backend will log when a tile took longer to load than this threshold in seconds.
-    * @internal
-    */
+   * @internal
+   */
   logTileLoadTimeThreshold?: number;
 
   /** The backend will log when a tile is loaded with a size in bytes above this threshold.
-    * @internal
-    */
+   * @internal
+   */
   logTileSizeThreshold?: number;
 
   /** Crash-reporting configuration
-    * @alpha
-    */
+   * @alpha
+   */
   crashReportingConfig?: CrashReportingConfig;
 
   /** The AuthorizationClient used to get accessTokens
-    * @beta
-    */
+   * @beta
+   */
   authorizationClient?: AuthorizationClient;
 }
 
@@ -160,13 +166,17 @@ export class IModelHostConfiguration implements IModelHostOptions {
   public static defaultLogTileSizeThreshold = 20 * 1000000;
 
   public cacheDir?: LocalDirName;
+  /** @beta */
   public workspace?: WorkspaceOpts;
   public appAssetsDir?: LocalDirName;
+  /** @beta */
   public hubAccess?: BackendHubAccess;
   public authorizationClient?: AuthorizationClient;
+  /** @beta */
   public tileCacheService?: CloudStorageService;
   public restrictTileUrlsByClientIp?: boolean;
   public compressCachedTiles?: boolean;
+  /** @beta */
   public tileCacheAzureCredentials?: AzureBlobStorageCredentials;
   public tileTreeRequestTimeout = IModelHostConfiguration.defaultTileRequestTimeout;
   public tileContentRequestTimeout = IModelHostConfiguration.defaultTileRequestTimeout;

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -69,11 +69,7 @@ export interface CrashReportingConfig {
   uploadToBentley?: boolean;
 }
 
-/** Configuration of core-backend.
- * @public
- */
-export class IModelHostConfiguration {
-
+export interface IModelHostOptions {
   /**
    * Root of the directory holding all the files that iTwin.js caches
    * - If not specified at startup a platform specific default is used -
@@ -88,83 +84,94 @@ export class IModelHostConfiguration {
    *   - etc.
    * @see [[IModelHost.cacheDir]] for the value it's set to after startup
    */
-  public cacheDir?: LocalDirName;
+  cacheDir?: LocalDirName;
 
   /** Options for creating the [[Workspace]]
-   * @beta
-   */
-  public workspace?: WorkspaceOpts;
+    * @beta
+    */
+  workspace?: WorkspaceOpts;
 
   /** The directory where the app's assets are found. */
-  public appAssetsDir?: LocalDirName;
+  appAssetsDir?: LocalDirName;
 
   /** The kind of iModel hub server to use.
-   * @beta
-   */
-  public hubAccess?: BackendHubAccess;
+    * @beta
+    */
+  hubAccess?: BackendHubAccess;
 
   /** The Azure blob storage credentials to use for the tile cache service. If omitted and no external service implementation is provided, a local cache will be used.
-   * @beta
-   */
-  public tileCacheAzureCredentials?: AzureBlobStorageCredentials;
+    * @beta
+    */
+  tileCacheAzureCredentials?: AzureBlobStorageCredentials;
 
   /**
-   * @beta
-   * @note A reference implementation is set for [[AzureBlobStorage]] if [[tileCacheAzureCredentials]] property is set. To supply a different implementation for any service provider (such as AWS),
-   *       set this property with a custom [[CloudStorageService]].
-   */
-  public tileCacheService?: CloudStorageService;
+    * @beta
+    * @note A reference implementation is set for [[AzureBlobStorage]] if [[tileCacheAzureCredentials]] property is set. To supply a different implementation for any service provider (such as AWS),
+    *       set this property with a custom [[CloudStorageService]].
+    */
+  tileCacheService?: CloudStorageService;
 
   /** Whether to restrict tile cache URLs by client IP address (if available).
-   * @beta
-   */
-  public restrictTileUrlsByClientIp?: boolean;
+    * @beta
+    */
+  restrictTileUrlsByClientIp?: boolean;
 
   /** Whether to compress cached tiles.
-   * Defaults to `true`.
-   */
-  public compressCachedTiles?: boolean;
+    * Defaults to `true`.
+    */
+  compressCachedTiles?: boolean;
 
   /** The time, in milliseconds, for which [IModelTileRpcInterface.requestTileTreeProps]($common) should wait before returning a "pending" status.
-   * @internal
-   */
-  public tileTreeRequestTimeout = IModelHostConfiguration.defaultTileRequestTimeout;
+    * @internal
+    */
+  tileTreeRequestTimeout?: number;
   /** The time, in milliseconds, for which [IModelTileRpcInterface.requestTileContent]($common) should wait before returning a "pending" status.
-   * @internal
-   */
-  public tileContentRequestTimeout = IModelHostConfiguration.defaultTileRequestTimeout;
-  /** The default time, in milliseconds, used for [[tileTreeRequestTimeout]] and [[tileContentRequestTimeout]]. To change this, override one or both of those properties.
-   * @internal
-   */
-  public static defaultTileRequestTimeout = 20 * 1000;
+    * @internal
+    */
+  tileContentRequestTimeout?: number;
 
-  /** The default time, in seconds, used for [[logTileLoadTimeThreshold]]. To change this, override that property.
-   * @internal
-   */
-  public static defaultLogTileLoadTimeThreshold = 40;
   /** The backend will log when a tile took longer to load than this threshold in seconds.
-   * @internal
-   */
-  public logTileLoadTimeThreshold: number = IModelHostConfiguration.defaultLogTileLoadTimeThreshold;
+    * @internal
+    */
+  logTileLoadTimeThreshold?: number;
 
-  /** The default size, in bytes, used for [[logTileSizeThreshold]]. To change this, override that property.
-   * @internal
-   */
-  public static defaultLogTileSizeThreshold = 20 * 1000000;
   /** The backend will log when a tile is loaded with a size in bytes above this threshold.
-   * @internal
-   */
-  public logTileSizeThreshold: number = IModelHostConfiguration.defaultLogTileSizeThreshold;
+    * @internal
+    */
+  logTileSizeThreshold?: number;
 
   /** Crash-reporting configuration
-   * @alpha
-   */
-  public crashReportingConfig?: CrashReportingConfig;
+    * @alpha
+    */
+  crashReportingConfig?: CrashReportingConfig;
 
   /** The AuthorizationClient used to get accessTokens
-   * @beta
-   */
+    * @beta
+    */
+  authorizationClient?: AuthorizationClient;
+}
+
+/** Configuration of core-backend.
+ * @public
+ */
+export class IModelHostConfiguration implements IModelHostOptions {
+  public static defaultTileRequestTimeout = 20 * 1000;
+  public static defaultLogTileLoadTimeThreshold = 40;
+  public static defaultLogTileSizeThreshold = 20 * 1000000;
+
+  public cacheDir?: LocalDirName;
+  public workspace?: WorkspaceOpts;
+  public appAssetsDir?: LocalDirName;
+  public hubAccess?: BackendHubAccess;
   public authorizationClient?: AuthorizationClient;
+  public tileCacheService?: CloudStorageService;
+  public restrictTileUrlsByClientIp?: boolean;
+  public compressCachedTiles?: boolean;
+  public tileCacheAzureCredentials?: AzureBlobStorageCredentials;
+  public tileTreeRequestTimeout = IModelHostConfiguration.defaultTileRequestTimeout;
+  public tileContentRequestTimeout = IModelHostConfiguration.defaultTileRequestTimeout;
+  public logTileLoadTimeThreshold = IModelHostConfiguration.defaultLogTileLoadTimeThreshold;
+  public logTileSizeThreshold = IModelHostConfiguration.defaultLogTileSizeThreshold;
 }
 
 /**
@@ -223,7 +230,7 @@ export class IModelHost {
     return this._platform;
   }
 
-  public static configuration?: IModelHostConfiguration;
+  public static configuration?: IModelHostOptions;
 
   /** Event raised during startup to allow loading settings data */
   public static readonly onWorkspaceStartup = new BeEvent<() => void>();
@@ -314,7 +321,7 @@ export class IModelHost {
 
   /**
    * @internal
-   * @note Use [[IModelHostConfiguration.tileCacheService]] to set the service provider.
+   * @note Use [[IModelHostOptions.tileCacheService]] to set the service provider.
    */
   public static tileCacheService?: CloudStorageService;
 
@@ -332,16 +339,16 @@ export class IModelHost {
 
   /** Provides access to the IModelHub for this IModelHost
    * @beta
-   * @note If [[IModelHostConfiguration.hubAccess]] was undefined when initializing this class, accessing this property will throw an error.
+   * @note If [[IModelHostOptions.hubAccess]] was undefined when initializing this class, accessing this property will throw an error.
    * To determine whether one is present, use [[getHubAccess]].
    */
   public static get hubAccess(): BackendHubAccess {
     if (this._hubAccess === undefined)
-      throw new IModelError(IModelStatus.BadRequest, "No BackendHubAccess supplied in IModelHostConfiguration");
+      throw new IModelError(IModelStatus.BadRequest, "No BackendHubAccess supplied in IModelHostOptions");
     return this._hubAccess;
   }
 
-  private static initializeWorkspace(configuration: IModelHostConfiguration) {
+  private static initializeWorkspace(configuration: IModelHostOptions) {
     const settingAssets = path.join(KnownLocations.packageAssetsDir, "Settings");
     SettingsSchemas.addDirectory(path.join(settingAssets, "Schemas"));
     this._appWorkspace = new ITwinWorkspace(new ApplicationSettings(), configuration.workspace);
@@ -356,19 +363,20 @@ export class IModelHost {
   /** Returns true if IModelHost is started.  */
   public static get isValid() { return this._isValid; }
   /** This method must be called before any iTwin.js services are used.
-   * @param configuration Host configuration data.
+   * @param options Host configuration data.
    * Raises [[onAfterStartup]].
    * @see [[shutdown]].
    */
-  public static async startup(configuration: IModelHostConfiguration = new IModelHostConfiguration()): Promise<void> {
+  public static async startup(options?: IModelHostOptions): Promise<void> {
     if (this._isValid)
       return; // we're already initialized
     this._isValid = true;
 
+    options = options ?? {};
     if (IModelHost.sessionId === "")
       IModelHost.sessionId = Guid.createValue();
 
-    this.authorizationClient = configuration.authorizationClient;
+    this.authorizationClient = options.authorizationClient;
 
     this.logStartup();
 
@@ -379,27 +387,27 @@ export class IModelHost {
       try {
         this.loadNative();
       } catch (error) {
-        Logger.logError(loggerCategory, "Error registering/loading the native platform API", () => (configuration));
+        Logger.logError(loggerCategory, "Error registering/loading the native platform API", () => (options));
         throw error;
       }
     }
 
-    if (configuration.crashReportingConfig && configuration.crashReportingConfig.crashDir && !ProcessDetector.isElectronAppBackend && !ProcessDetector.isMobileAppBackend) {
-      this.platform.setCrashReporting(configuration.crashReportingConfig);
+    if (options.crashReportingConfig && options.crashReportingConfig.crashDir && !ProcessDetector.isElectronAppBackend && !ProcessDetector.isMobileAppBackend) {
+      this.platform.setCrashReporting(options.crashReportingConfig);
 
-      Logger.logTrace(loggerCategory, "Configured crash reporting", () => ({
-        enableCrashDumps: configuration.crashReportingConfig?.enableCrashDumps,
-        wantFullMemoryDumps: configuration.crashReportingConfig?.wantFullMemoryDumps,
-        enableNodeReport: configuration.crashReportingConfig?.enableNodeReport,
-        uploadToBentley: configuration.crashReportingConfig?.uploadToBentley,
-      }));
+      Logger.logTrace(loggerCategory, "Configured crash reporting", {
+        enableCrashDumps: options.crashReportingConfig?.enableCrashDumps,
+        wantFullMemoryDumps: options.crashReportingConfig?.wantFullMemoryDumps,
+        enableNodeReport: options.crashReportingConfig?.enableNodeReport,
+        uploadToBentley: options.crashReportingConfig?.uploadToBentley,
+      });
 
-      if (configuration.crashReportingConfig.enableNodeReport) {
+      if (options.crashReportingConfig.enableNodeReport) {
         try {
           // node-report reports on V8 fatal errors and unhandled exceptions/Promise rejections.
           const nodereport = require("node-report/api"); // eslint-disable-line @typescript-eslint/no-var-requires
           nodereport.setEvents("exception+fatalerror+apicall");
-          nodereport.setDirectory(configuration.crashReportingConfig.crashDir);
+          nodereport.setDirectory(options.crashReportingConfig.crashDir);
           nodereport.setVerbose("yes");
           Logger.logTrace(loggerCategory, "Configured native crash reporting (node-report)");
         } catch (err) {
@@ -408,8 +416,8 @@ export class IModelHost {
       }
     }
 
-    this.setupHostDirs(configuration);
-    this.initializeWorkspace(configuration);
+    this.setupHostDirs(options);
+    this.initializeWorkspace(options);
 
     BriefcaseManager.initialize(this._briefcaseCacheDir);
 
@@ -427,9 +435,10 @@ export class IModelHost {
       FunctionalSchema,
     ].forEach((schema) => schema.registerSchema()); // register all of the schemas
 
-    if (undefined !== configuration.hubAccess)
-      this._hubAccess = configuration.hubAccess;
-    this.configuration = configuration;
+    if (undefined !== options.hubAccess)
+      this._hubAccess = options.hubAccess;
+
+    this.configuration = options;
     this.setupTileCache();
 
     this.platform.setUseTileCache(IModelHost.tileCacheService ? false : true);
@@ -462,7 +471,7 @@ export class IModelHost {
     Logger.logTrace(loggerCategory, "IModelHost.startup", () => startupInfo);
   }
 
-  private static setupHostDirs(configuration: IModelHostConfiguration) {
+  private static setupHostDirs(configuration: IModelHostOptions) {
     const setupDir = (dir: LocalDirName) => {
       dir = path.normalize(dir);
       IModelJsFs.recursiveMkDirSync(dir);
@@ -525,19 +534,19 @@ export class IModelHost {
    * @internal
    */
   public static get tileTreeRequestTimeout(): number {
-    return undefined !== IModelHost.configuration ? IModelHost.configuration.tileTreeRequestTimeout : IModelHostConfiguration.defaultTileRequestTimeout;
+    return IModelHost.configuration?.tileTreeRequestTimeout ?? IModelHostConfiguration.defaultTileRequestTimeout;
   }
   /** The time, in milliseconds, for which [IModelTileRpcInterface.requestTileContent]($common) should wait before returning a "pending" status.
    * @internal
    */
   public static get tileContentRequestTimeout(): number {
-    return undefined !== IModelHost.configuration ? IModelHost.configuration.tileContentRequestTimeout : IModelHostConfiguration.defaultTileRequestTimeout;
+    return IModelHost.configuration?.tileContentRequestTimeout ?? IModelHostConfiguration.defaultTileRequestTimeout;
   }
 
   /** The backend will log when a tile took longer to load than this threshold in seconds. */
-  public static get logTileLoadTimeThreshold(): number { return undefined !== IModelHost.configuration ? IModelHost.configuration.logTileLoadTimeThreshold : IModelHostConfiguration.defaultLogTileLoadTimeThreshold; }
+  public static get logTileLoadTimeThreshold(): number { return IModelHost.configuration?.logTileLoadTimeThreshold ?? IModelHostConfiguration.defaultLogTileLoadTimeThreshold; }
   /** The backend will log when a tile is loaded with a size in bytes above this threshold. */
-  public static get logTileSizeThreshold(): number { return undefined !== IModelHost.configuration ? IModelHost.configuration.logTileSizeThreshold : IModelHostConfiguration.defaultLogTileSizeThreshold; }
+  public static get logTileSizeThreshold(): number { return IModelHost.configuration?.logTileSizeThreshold ?? IModelHostConfiguration.defaultLogTileSizeThreshold; }
 
   /** Whether external tile caching is active.
    * @internal

--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -14,7 +14,7 @@ import {
 } from "@itwin/core-common";
 import { IModelJsNative } from "@bentley/imodeljs-native";
 import { BriefcaseDb, IModelDb, StandaloneDb } from "./IModelDb";
-import { IModelHost, IModelHostConfiguration } from "./IModelHost";
+import { IModelHost, IModelHostOptions } from "./IModelHost";
 import { cancelTileContentRequests } from "./rpc-impl/IModelTileRpcImpl";
 
 /**
@@ -22,7 +22,7 @@ import { cancelTileContentRequests } from "./rpc-impl/IModelTileRpcImpl";
   * @public
   */
 export interface IpcHostOpts {
-  iModelHost?: IModelHostConfiguration;
+  iModelHost?: IModelHostOptions;
   ipcHost?: {
     /** The Ipc socket to use for communications with frontend. Allows undefined only for headless tests. */
     socket?: IpcSocketBackend;
@@ -158,12 +158,12 @@ export abstract class IpcHandler {
           throw new IModelError(IModelStatus.FunctionNotFound, `Method "${impl.constructor.name}.${funcName}" not found on IpcHandler registered for channel: ${impl.channelName}`);
 
         return { result: await func.call(impl, ...args) };
-      } catch (err) {
+      } catch (err: any) {
         const ret: IpcInvokeReturn = {
           error: {
-            name: (err && typeof (err) === "object") ? err.constructor.name : "Unknown Error",
+            name: (err && typeof err === "object") ? err.constructor.name : "Unknown Error",
             message: BentleyError.getErrorMessage(err),
-            errorNumber: (err as any).errorNumber ?? 0,
+            errorNumber: err.errorNumber ?? 0,
           },
         };
         if (!IpcHost.noStack)

--- a/core/backend/src/LocalhostIpcHost.ts
+++ b/core/backend/src/LocalhostIpcHost.ts
@@ -9,7 +9,7 @@
 import * as ws from "ws";
 import { InterceptedRpcRequest, IpcWebSocket, IpcWebSocketBackend, IpcWebSocketMessage, IpcWebSocketTransport, RpcSessionInvocation } from "@itwin/core-common";
 import { IpcHandler, IpcHost } from "./IpcHost";
-import { IModelHostConfiguration } from "./IModelHost";
+import { IModelHostOptions } from "./IModelHost";
 
 /** @internal */
 export interface LocalhostIpcHostOpts {
@@ -79,7 +79,7 @@ export class LocalhostIpcHost {
     (IpcWebSocket.transport as LocalTransport).connect(connection);
   }
 
-  public static async startup(opts?: { localhostIpcHost?: LocalhostIpcHostOpts, iModelHost?: IModelHostConfiguration }) {
+  public static async startup(opts?: { localhostIpcHost?: LocalhostIpcHostOpts, iModelHost?: IModelHostOptions }) {
     let registerHandler = false;
 
     if (!this._initialized) {

--- a/core/backend/src/test/IModelHost.test.ts
+++ b/core/backend/src/test/IModelHost.test.ts
@@ -8,7 +8,7 @@ import * as sinon from "sinon";
 import { RpcRegistry } from "@itwin/core-common";
 import { BriefcaseManager } from "../BriefcaseManager";
 import { SnapshotDb } from "../IModelDb";
-import { IModelHost, IModelHostConfiguration, KnownLocations } from "../IModelHost";
+import { IModelHost, IModelHostOptions, KnownLocations } from "../IModelHost";
 import { Schemas } from "../Schema";
 import { AzureBlobStorage } from "../CloudStorageBackend";
 import { KnownTestLocations } from "./KnownTestLocations";
@@ -98,7 +98,7 @@ describe("IModelHost", () => {
   });
 
   it("should set the briefcase cache directory to expected locations", async () => {
-    const config = new IModelHostConfiguration();
+    const config: IModelHostOptions = {};
     const cacheSubDir = "imodels";
 
     // Test cache default location
@@ -116,7 +116,7 @@ describe("IModelHost", () => {
   });
 
   it("should set Azure cloud storage provider for tile cache", async () => {
-    const config = new IModelHostConfiguration();
+    const config: IModelHostOptions = {};
     config.tileCacheAzureCredentials = {
       account: "testAccount",
       accessKey: "testAccessKey",
@@ -136,7 +136,7 @@ describe("IModelHost", () => {
   });
 
   it("should set custom cloud storage provider for tile cache", async () => {
-    const config = new IModelHostConfiguration();
+    const config: IModelHostOptions = {};
     config.tileCacheService = {} as AzureBlobStorage;
 
     const setUseTileCacheStub = sinon.stub();
@@ -151,7 +151,7 @@ describe("IModelHost", () => {
   });
 
   it("should throw if both tileCacheService and tileCacheAzureCredentials are set", async () => {
-    const config = new IModelHostConfiguration();
+    const config: IModelHostOptions = {};
     config.tileCacheAzureCredentials = {
       account: "testAccount",
       accessKey: "testAccessKey",
@@ -175,7 +175,7 @@ describe("IModelHost", () => {
   });
 
   it("should cleanup tileCacheService and tileUploader on shutdown", async () => {
-    const config = new IModelHostConfiguration();
+    const config: IModelHostOptions = {};
     config.tileCacheService = {} as AzureBlobStorage;
 
     await IModelHost.startup(config);

--- a/core/backend/src/test/TestUtils.ts
+++ b/core/backend/src/test/TestUtils.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import { IModelJsNative, NativeLoggerCategory } from "@bentley/imodeljs-native";
 import { BentleyLoggerCategory, IDisposable, Logger, LogLevel, ProcessDetector } from "@itwin/core-bentley";
 import { BackendLoggerCategory } from "../BackendLoggerCategory";
-import { IModelHost, IModelHostConfiguration } from "../IModelHost";
+import { IModelHost, IModelHostOptions } from "../IModelHost";
 
 /** Class for simple test timing */
 export class Timer {
@@ -56,8 +56,8 @@ export class TestUtils {
    * - concurrentQuery.current === 4
    * - cacheDir === path.join(__dirname, ".cache")
    */
-  public static async startBackend(config?: IModelHostConfiguration): Promise<void> {
-    const cfg = config ?? new IModelHostConfiguration();
+  public static async startBackend(config?: IModelHostOptions): Promise<void> {
+    const cfg = config ?? {};
     if (ProcessDetector.isIOSAppBackend) {
       cfg.cacheDir = undefined; // Let the native side handle the cache.
     } else {

--- a/core/backend/src/test/standalone/TileCache.test.ts
+++ b/core/backend/src/test/standalone/TileCache.test.ts
@@ -10,7 +10,7 @@ import {
   BatchType, ContentIdProvider, defaultTileOptions, IModelTileRpcInterface, iModelTileTreeIdToString, RpcActivity, RpcManager, RpcRegistry,
 } from "@itwin/core-common";
 import { IModelDb, SnapshotDb } from "../../IModelDb";
-import { IModelHost, IModelHostConfiguration } from "../../IModelHost";
+import { IModelHost } from "../../IModelHost";
 import { IModelJsFs } from "../../IModelJsFs";
 import { GeometricModel3d } from "../../Model";
 import { RpcTrace } from "../../RpcBackend";
@@ -91,8 +91,7 @@ describe("TileCache open v1", () => {
   it("should create .tiles file next to .bim with default cacheDir", async () => {
     // Shutdown IModelHost to allow this test to use it.
     await TestUtils.shutdownBackend();
-    const config = new IModelHostConfiguration();
-    await TestUtils.startBackend(config);
+    await TestUtils.startBackend();
 
     const dbPath = IModelTestUtils.prepareOutputFile("IModel", "mirukuru.ibim");
     const snapshot = IModelTestUtils.createSnapshotFromSeed(dbPath, IModelTestUtils.resolveAssetFile("mirukuru.ibim"));
@@ -103,8 +102,9 @@ describe("TileCache open v1", () => {
   it("should create .tiles file next to .bim with set cacheDir", async () => {
     // Shutdown IModelHost to allow this test to use it.
     await TestUtils.shutdownBackend();
-    const config = new IModelHostConfiguration();
-    config.cacheDir = path.join(__dirname, ".cache");
+    const config = {
+      cacheDir: path.join(__dirname, ".cache"),
+    };
     await TestUtils.startBackend(config);
 
     const dbPath = IModelTestUtils.prepareOutputFile("IModel", "mirukuru.ibim");

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { AccessToken, BeEvent, BriefcaseStatus } from "@itwin/core-bentley";
-import { IModelHostConfiguration, IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
+import { IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
 import {
   IModelReadRpcInterface, IModelTileRpcInterface, IpcWebSocketBackend, RpcInterfaceDefinition,
   SnapshotIModelRpcInterface,
@@ -197,9 +197,9 @@ export class MobileHost {
     const socket = opt?.ipcHost?.socket ?? new IpcWebSocketBackend();
     opt = { ...opt, mobileHost: { ...opt?.mobileHost }, ipcHost: { ...opt?.ipcHost, socket } };
 
-    const iModelHostConfiguration = opt?.iModelHost ?? new IModelHostConfiguration();
-    iModelHostConfiguration.authorizationClient = authorizationClient;
-    await NativeHost.startup({ ...opt, iModelHost: iModelHostConfiguration });
+    const iModelHost = opt?.iModelHost ?? {};
+    iModelHost.authorizationClient = authorizationClient;
+    await NativeHost.startup({ ...opt, iModelHost });
 
     if (IpcHost.isValid)
       MobileAppHandler.register();

--- a/core/transformer/src/test/standalone/TransformerTestStartup.ts
+++ b/core/transformer/src/test/standalone/TransformerTestStartup.ts
@@ -3,14 +3,14 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost, IModelHostOptions } from "@itwin/core-backend";
 import { Logger, LogLevel, ProcessDetector } from "@itwin/core-bentley";
 import * as path from "path";
 
 export async function transformerTestStartup() {
   Logger.initializeToConsole();
   Logger.setLevelDefault(LogLevel.Error);
-  const cfg = new IModelHostConfiguration();
+  const cfg: IModelHostOptions = {};
   if (ProcessDetector.isIOSAppBackend) {
     cfg.cacheDir = undefined; // Let the native side handle the cache.
   } else {

--- a/example-code/app/src/backend/RobotWorldEngine.ts
+++ b/example-code/app/src/backend/RobotWorldEngine.ts
@@ -5,7 +5,7 @@
 import * as path from "path";
 import { DbResult, Id64String } from "@itwin/core-bentley";
 import { Angle, Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
-import { BriefcaseDb, ECSqlStatement, Element, IModelDb, IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { BriefcaseDb, ECSqlStatement, Element, IModelDb, IModelHost } from "@itwin/core-backend";
 import {
   Code, FeatureGates, IModelReadRpcInterface, RpcInterfaceDefinition, RpcManager, TestRpcManager,
 } from "@itwin/core-common";
@@ -117,9 +117,7 @@ export class RobotWorldEngine {
   }
 
   public static async initialize(): Promise<void> {
-    const config = new IModelHostConfiguration();
-    config.appAssetsDir = path.join(__dirname, "assets");
-    await IModelHost.startup(config);
+    await IModelHost.startup({ appAssetsDir: path.join(__dirname, "assets") });
 
     RpcManager.registerImpl(RobotWorldWriteRpcInterface, RobotWorldWriteRpcImpl); // register impls that we don't want in the doc example
     this.registerImpls();

--- a/example-code/snippets/src/backend/IModelTestUtils.ts
+++ b/example-code/snippets/src/backend/IModelTestUtils.ts
@@ -6,7 +6,7 @@ import { assert } from "chai";
 import * as path from "path";
 import { OpenMode } from "@itwin/core-bentley";
 import { ProjectsAccessClient } from "@itwin/projects-client";
-import { IModelHost, IModelHostConfiguration, IModelJsFs, IModelJsFsStats, KnownLocations, SnapshotDb, StandaloneDb } from "@itwin/core-backend";
+import { IModelHost, IModelJsFs, IModelJsFsStats, KnownLocations, SnapshotDb, StandaloneDb } from "@itwin/core-backend";
 import { IModelReadRpcInterface, RpcManager } from "@itwin/core-common";
 
 RpcManager.initializeInterface(IModelReadRpcInterface);
@@ -91,11 +91,8 @@ export class IModelTestUtils {
       cacheDir = path.join(tempDir, "iModelJs_cache");
     }
 
-    const imHostConfig = new IModelHostConfiguration();
-    imHostConfig.cacheDir = cacheDir;
-
     // Start up IModelHost, supplying the configuration.
-    await IModelHost.startup(imHostConfig);
+    await IModelHost.startup({ cacheDir });
   }
   // __PUBLISH_EXTRACT_END__
 

--- a/full-stack-tests/backend/src/integration/StartupShutdown.ts
+++ b/full-stack-tests/backend/src/integration/StartupShutdown.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost, IModelHostOptions } from "@itwin/core-backend";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { IModelsClient } from "@itwin/imodels-client-authoring";
 import * as fs from "fs";
@@ -26,14 +26,15 @@ function loadEnv(envFile: string) {
 
 loadEnv(path.join(__dirname, "..", "..", "..", ".env"));
 
-export async function startupForIntegration(cfg: IModelHostConfiguration) {
+export async function startupForIntegration(cfg?: IModelHostOptions) {
+  cfg = cfg ?? {};
   cfg.cacheDir = path.join(__dirname, ".cache");  // Set the cache dir to be under the lib directory.
   const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels` } });
   cfg.hubAccess = new BackendIModelsAccess(iModelClient);
   return IModelHost.startup(cfg);
 }
 before(async () => {
-  return startupForIntegration(new IModelHostConfiguration());
+  return startupForIntegration();
 });
 
 after(async () => {

--- a/full-stack-tests/backend/src/integration/TileUpload.test.ts
+++ b/full-stack-tests/backend/src/integration/TileUpload.test.ts
@@ -10,7 +10,7 @@ import {
   BatchType, CloudStorageTileCache, ContentIdProvider, defaultTileOptions, IModelRpcProps, IModelTileRpcInterface, iModelTileTreeIdToString,
   RpcManager, RpcRegistry, TileContentSource,
 } from "@itwin/core-common";
-import { GeometricModel3d, IModelDb, IModelHost, IModelHostConfiguration, RpcTrace } from "@itwin/core-backend";
+import { GeometricModel3d, IModelDb, IModelHost, IModelHostOptions, RpcTrace } from "@itwin/core-backend";
 import { HubWrappers } from "@itwin/core-backend/lib/cjs/test";
 import { HubUtility } from "../HubUtility";
 import { TestUsers, TestUtility } from "@itwin/oidc-signin-tool";
@@ -70,12 +70,12 @@ describe("TileUpload", () => {
     // Shutdown IModelHost to allow this test to use it.
     await IModelHost.shutdown();
 
-    const config = new IModelHostConfiguration();
-
     // Default account and key for azurite
-    config.tileCacheAzureCredentials = {
-      account: "devstoreaccount1",
-      accessKey: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+    const config: IModelHostOptions = {
+      tileCacheAzureCredentials: {
+        account: "devstoreaccount1",
+        accessKey: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+      },
     };
 
     await startupForIntegration(config);
@@ -91,7 +91,7 @@ describe("TileUpload", () => {
     testIModelId = await HubUtility.getTestIModelId(accessToken, HubUtility.testIModelNames.stadium);
 
     // Get URL for cached tile
-    const credentials = new Azure.StorageSharedKeyCredential(config.tileCacheAzureCredentials.account, config.tileCacheAzureCredentials.accessKey);
+    const credentials = new Azure.StorageSharedKeyCredential(config.tileCacheAzureCredentials!.account, config.tileCacheAzureCredentials!.accessKey);
     const pipeline = Azure.newPipeline(credentials);
     blobService = new Azure.BlobServiceClient(`http://127.0.0.1:10000/${credentials.accountName}`, pipeline);
 
@@ -107,7 +107,7 @@ describe("TileUpload", () => {
   after(async () => {
     // Re-start backend with default config
     await IModelHost.shutdown();
-    await startupForIntegration(new IModelHostConfiguration());
+    await startupForIntegration();
   });
 
   it("should upload tile to external cache with metadata", async () => {

--- a/full-stack-tests/core/src/backend/backend.ts
+++ b/full-stack-tests/core/src/backend/backend.ts
@@ -12,7 +12,7 @@ import { WebEditServer } from "@itwin/express-server";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { IModelsClient } from "@itwin/imodels-client-authoring";
 import {
-  FileNameResolver, IModelDb, IModelHost, IModelHostConfiguration, IpcHandler, IpcHost, LocalhostIpcHost, PhysicalModel, PhysicalPartition, SpatialCategory,
+  FileNameResolver, IModelDb, IModelHost, IModelHostOptions, IpcHandler, IpcHost, LocalhostIpcHost, PhysicalModel, PhysicalPartition, SpatialCategory,
   SubjectOwnsPartitionElements,
 } from "@itwin/core-backend";
 import { Id64String, Logger, LogLevel, ProcessDetector } from "@itwin/core-bentley";
@@ -78,7 +78,7 @@ async function init() {
   loadEnv(path.join(__dirname, "..", "..", ".env"));
   RpcConfiguration.developmentMode = true;
 
-  const iModelHost = new IModelHostConfiguration();
+  const iModelHost: IModelHostOptions = {};
 
   // Bootstrap the cloud environment
   const enableIModelBank: boolean = process.env.IMJS_TEST_IMODEL_BANK !== undefined && !!JSON.parse(process.env.IMJS_TEST_IMODEL_BANK);

--- a/full-stack-tests/ecschema-rpc-interface/src/test/backend.ts
+++ b/full-stack-tests/ecschema-rpc-interface/src/test/backend.ts
@@ -7,7 +7,7 @@
 
 import * as path from "path";
 import { IModelJsExpressServer } from "@itwin/express-server";
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost } from "@itwin/core-backend";
 import { BentleyCloudRpcManager, RpcConfiguration, RpcManager } from "@itwin/core-common";
 import { getRpcInterfaces } from "../common/Settings";
 import * as fs from "fs";
@@ -36,10 +36,9 @@ void (async () => {
   RpcConfiguration.developmentMode = true;
 
   // Start the backend
-  const hostConfig = new IModelHostConfiguration();
-  const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels`}});
-  hostConfig.hubAccess = new BackendIModelsAccess(iModelClient);
-  await IModelHost.startup(hostConfig);
+  const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels` } });
+  const hubAccess = new BackendIModelsAccess(iModelClient);
+  await IModelHost.startup({ hubAccess });
 
   const rpcConfig = BentleyCloudRpcManager.initializeImpl({ info: { title: "schema-rpc-test", version: "v1.0" } }, getRpcInterfaces());
   RpcManager.registerImpl(ECSchemaRpcInterface, ECSchemaRpcImpl);

--- a/full-stack-tests/rpc-interface/src/test/backend.ts
+++ b/full-stack-tests/rpc-interface/src/test/backend.ts
@@ -7,7 +7,7 @@
 
 import * as path from "path";
 import { IModelJsExpressServer } from "@itwin/express-server";
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost } from "@itwin/core-backend";
 import { BentleyCloudRpcManager, RpcConfiguration } from "@itwin/core-common";
 import { Presentation as PresentationBackend } from "@itwin/presentation-backend";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
@@ -38,10 +38,9 @@ const settings = new Settings(process.env);
   RpcConfiguration.developmentMode = true;
 
   // Start the backend
-  const hostConfig = new IModelHostConfiguration();
-  const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels`}});
-  hostConfig.hubAccess = new BackendIModelsAccess(iModelClient);
-  await IModelHost.startup(hostConfig);
+  const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels` } });
+  const hubAccess = new BackendIModelsAccess(iModelClient);
+  await IModelHost.startup({ hubAccess });
 
   PresentationBackend.initialize();
 

--- a/presentation/testing/src/presentation-testing/Helpers.ts
+++ b/presentation/testing/src/presentation-testing/Helpers.ts
@@ -6,11 +6,8 @@
  * @module Helpers
  */
 import * as rimraf from "rimraf";
-// common includes
 import { Guid } from "@itwin/core-bentley";
-// backend includes
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
-// frontend includes
+import { IModelHost } from "@itwin/core-backend";
 import {
   IModelReadRpcInterface, RpcConfiguration, RpcDefaultConfiguration, RpcInterfaceDefinition, SnapshotIModelRpcInterface,
 } from "@itwin/core-common";
@@ -77,9 +74,7 @@ export const initialize = async (props?: PresentationTestingInitProps) => {
   props.backendProps = props.backendProps ?? {};
   if (!props.backendProps.id)
     props.backendProps.id = `test-${Guid.createValue()}`;
-  const cfg = new IModelHostConfiguration();
-  cfg.cacheDir = join(__dirname, ".cache");
-  await IModelHost.startup(cfg);
+  await IModelHost.startup({ cacheDir: join(__dirname, ".cache") });
   PresentationBackend.initialize(props.backendProps);
 
   // init frontend

--- a/test-apps/appui-test-app/connected/src/backend/electron/ElectronMain.ts
+++ b/test-apps/appui-test-app/connected/src/backend/electron/ElectronMain.ts
@@ -8,14 +8,14 @@ import { assert } from "@itwin/core-bentley";
 import { ElectronMainAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronMain";
 import { ElectronHost } from "@itwin/core-electron/lib/cjs/ElectronBackend";
 import { getSupportedRpcs } from "../../common/rpcs";
-import { IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHostOptions } from "@itwin/core-backend";
 import { EditCommandAdmin } from "@itwin/editor-backend";
 import * as editorBuiltInCommands from "@itwin/editor-backend";
 
 const mainWindowName = "mainWindow";
 
 /** Initializes Electron backend */
-export async function initializeElectron(opts?: IModelHostConfiguration) {
+export async function initializeElectron(opts?: IModelHostOptions) {
   const opt = {
     electronHost: {
       webResourcesPath: join(__dirname, "..", "..", "..", "build"),

--- a/test-apps/appui-test-app/connected/src/backend/main.ts
+++ b/test-apps/appui-test-app/connected/src/backend/main.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 import * as fs from "fs";
 import * as path from "path";
-import { IModelHostConfiguration } from "@itwin/core-backend";
 import { Logger, ProcessDetector } from "@itwin/core-bentley";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { IModelsClient } from "@itwin/imodels-client-authoring";
@@ -28,9 +27,10 @@ import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 
     initializeLogging();
 
-    const iModelHost = new IModelHostConfiguration();
-    const iModelClient = new  IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels`}});
-    iModelHost.hubAccess = new BackendIModelsAccess(iModelClient);
+    const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels` } });
+    const iModelHost = {
+      hubAccess: new BackendIModelsAccess(iModelClient),
+    };
 
     // ECSchemaRpcInterface allows schema retrieval for the UnitProvider implementation.
     RpcManager.registerImpl(ECSchemaRpcInterface, ECSchemaRpcImpl);

--- a/test-apps/appui-test-app/connected/src/backend/web/BackendServer.ts
+++ b/test-apps/appui-test-app/connected/src/backend/web/BackendServer.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { Logger } from "@itwin/core-bentley";
 import { IModelJsExpressServer } from "@itwin/express-server";
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost, IModelHostOptions } from "@itwin/core-backend";
 import { BentleyCloudRpcManager } from "@itwin/core-common";
 import { getSupportedRpcs } from "../../common/rpcs";
 import { loggerCategory } from "../../common/TestAppConfiguration";
@@ -12,7 +12,7 @@ import { loggerCategory } from "../../common/TestAppConfiguration";
 /**
  * Initializes Web Server backend
  */
-export async function initializeWeb(opts?: IModelHostConfiguration) {
+export async function initializeWeb(opts?: IModelHostOptions) {
   // tell BentleyCloudRpcManager which RPC interfaces to handle
   const rpcConfig = BentleyCloudRpcManager.initializeImpl({ info: { title: "appui-test-app", version: "v1.0" } }, getSupportedRpcs());
 

--- a/test-apps/appui-test-app/standalone/src/backend/electron/ElectronMain.ts
+++ b/test-apps/appui-test-app/standalone/src/backend/electron/ElectronMain.ts
@@ -5,17 +5,16 @@
 
 import { join } from "path";
 import { assert } from "@itwin/core-bentley";
-// import { ElectronMainAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronMain";
 import { ElectronHost } from "@itwin/core-electron/lib/cjs/ElectronBackend";
 import { getSupportedRpcs } from "../../common/rpcs";
-import { IModelHostConfiguration } from "@itwin/core-backend";
 import { EditCommandAdmin } from "@itwin/editor-backend";
 import * as editorBuiltInCommands from "@itwin/editor-backend";
+import { IModelHostOptions } from "@itwin/core-backend/src/IModelHost";
 
 const mainWindowName = "mainWindow";
 
 /** Initializes Electron backend */
-export async function initializeElectron(opts?: IModelHostConfiguration) {
+export async function initializeElectron(opts?: IModelHostOptions) {
   const opt = {
     electronHost: {
       webResourcesPath: join(__dirname, "..", "..", "..", "build"),

--- a/test-apps/appui-test-app/standalone/src/backend/main.ts
+++ b/test-apps/appui-test-app/standalone/src/backend/main.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 import * as fs from "fs";
 import * as path from "path";
-import { IModelHostConfiguration } from "@itwin/core-backend";
 import { Logger, ProcessDetector } from "@itwin/core-bentley";
 import { MobileHost } from "@itwin/core-mobile/lib/cjs/MobileBackend";
 import { Presentation } from "@itwin/presentation-backend";
@@ -28,18 +27,16 @@ import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 
     initializeLogging();
 
-    const iModelHost = new IModelHostConfiguration();
-
     // ECSchemaRpcInterface allows schema retrieval for the UnitProvider implementation.
     RpcManager.registerImpl(ECSchemaRpcInterface, ECSchemaRpcImpl);
 
     // invoke platform-specific initialization
     if (ProcessDetector.isElectronAppBackend) {
-      await initializeElectron(iModelHost);
+      await initializeElectron();
     } else if (ProcessDetector.isMobileAppBackend) {
       await MobileHost.startup({ mobileHost: { rpcInterfaces: getSupportedRpcs() } });
     } else {
-      await initializeWeb(iModelHost);
+      await initializeWeb();
     }
 
     // initialize presentation-backend

--- a/test-apps/appui-test-app/standalone/src/backend/web/BackendServer.ts
+++ b/test-apps/appui-test-app/standalone/src/backend/web/BackendServer.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { Logger } from "@itwin/core-bentley";
 import { IModelJsExpressServer } from "@itwin/express-server";
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost, IModelHostOptions } from "@itwin/core-backend";
 import { BentleyCloudRpcManager } from "@itwin/core-common";
 import { getSupportedRpcs } from "../../common/rpcs";
 import { loggerCategory } from "../../common/TestAppConfiguration";
@@ -12,7 +12,7 @@ import { loggerCategory } from "../../common/TestAppConfiguration";
 /**
  * Initializes Web Server backend
  */
-export async function initializeWeb(opts?: IModelHostConfiguration) {
+export async function initializeWeb(opts?: IModelHostOptions) {
   // tell BentleyCloudRpcManager which RPC interfaces to handle
   const rpcConfig = BentleyCloudRpcManager.initializeImpl({ info: { title: "appui-test-app", version: "v1.0" } }, getSupportedRpcs());
 

--- a/test-apps/display-performance-test-app/src/backend/backend.ts
+++ b/test-apps/display-performance-test-app/src/backend/backend.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import { ProcessDetector } from "@itwin/core-bentley";
 import { ElectronHost } from "@itwin/core-electron/lib/cjs/ElectronBackend";
 import { ElectronMainAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronMain";
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost, IModelHostOptions } from "@itwin/core-backend";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { IModelsClient } from "@itwin/imodels-client-authoring";
 import { AuthorizationClient, IModelReadRpcInterface, IModelTileRpcInterface, SnapshotIModelRpcInterface } from "@itwin/core-common";
@@ -33,8 +33,8 @@ function loadEnv(envFile: string) {
 export async function initializeBackend() {
   loadEnv(path.join(__dirname, "..", "..", ".env"));
 
-  const iModelHost = new IModelHostConfiguration();
-  const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels`}});
+  const iModelHost: IModelHostOptions = {};
+  const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels` } });
   iModelHost.hubAccess = new BackendIModelsAccess(iModelClient);
   iModelHost.cacheDir = process.env.BRIEFCASE_CACHE_LOCATION;
   iModelHost.authorizationClient = await initializeAuthorizationClient();
@@ -48,15 +48,15 @@ export async function initializeBackend() {
       },
       iModelHost,
     });
-    if(iModelHost.authorizationClient)
+    if (iModelHost.authorizationClient)
       await (iModelHost.authorizationClient as ElectronMainAuthorization).signInSilent();
   } else
     await IModelHost.startup(iModelHost);
 }
 
 async function initializeAuthorizationClient(): Promise<AuthorizationClient | undefined> {
-  if(process.env.IMJS_OIDC_HEADLESS) {
-    if(!checkEnvVars(
+  if (process.env.IMJS_OIDC_HEADLESS) {
+    if (!checkEnvVars(
       "IMJS_OIDC_CLIENT_ID",
       "IMJS_OIDC_REDIRECT_URI",
       "IMJS_OIDC_SCOPE",
@@ -74,9 +74,9 @@ async function initializeAuthorizationClient(): Promise<AuthorizationClient | un
       password: process.env.IMJS_OIDC_PASSWORD!,
     });
   } else {
-    if(!checkEnvVars("IMJS_OIDC_CLIENT_ID", "IMJS_OIDC_SCOPE"))
+    if (!checkEnvVars("IMJS_OIDC_CLIENT_ID", "IMJS_OIDC_SCOPE"))
       return undefined;
-    if(ProcessDetector.isElectronAppBackend) {
+    if (ProcessDetector.isElectronAppBackend) {
       return new ElectronMainAuthorization({
         clientId: process.env.IMJS_OIDC_CLIENT_ID!,
         scope: process.env.IMJS_OIDC_SCOPE!,
@@ -92,11 +92,11 @@ async function initializeAuthorizationClient(): Promise<AuthorizationClient | un
  */
 function checkEnvVars(...keys: Array<string>): boolean {
   const missing = keys.filter((name) => process.env[name] === undefined);
-  if(missing.length === 0)
+  if (missing.length === 0)
     return true;
-  if(missing.length < keys.length) { // Some missing, warn
+  if (missing.length < keys.length) { // Some missing, warn
     // eslint-disable-next-line no-console
-    console.log(`Skipping auth setup due to missing: ${ missing.join(", ") }`);
+    console.log(`Skipping auth setup due to missing: ${missing.join(", ")}`);
   }
   return false;
 }

--- a/test-apps/display-test-app/src/backend/Backend.ts
+++ b/test-apps/display-test-app/src/backend/Backend.ts
@@ -11,7 +11,7 @@ import { IModelBankClient } from "@bentley/imodelbank-client";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
 import { IModelsClient } from "@itwin/imodels-client-authoring";
 import { IModelHubBackend, UrlFileHandler } from "@bentley/imodelbank-client/lib/cjs/imodelhub-node";
-import { IModelHost, IModelHostConfiguration, LocalhostIpcHost } from "@itwin/core-backend";
+import { IModelHost, IModelHostOptions, LocalhostIpcHost } from "@itwin/core-backend";
 import {
   IModelReadRpcInterface, IModelTileRpcInterface, RpcInterfaceDefinition, RpcManager,
   SnapshotIModelRpcInterface,
@@ -199,7 +199,7 @@ export const loadBackendConfig = (): DtaConfiguration => {
 export const initializeDtaBackend = async (hostOpts?: ElectronHostOptions & MobileHostOpts) => {
   const dtaConfig = loadBackendConfig();
 
-  const iModelHost = new IModelHostConfiguration();
+  const iModelHost: IModelHostOptions = {};
   iModelHost.logTileLoadTimeThreshold = 3;
   iModelHost.logTileSizeThreshold = 500000;
 

--- a/test-apps/presentation-test-app/src/backend/electron/ElectronMain.ts
+++ b/test-apps/presentation-test-app/src/backend/electron/ElectronMain.ts
@@ -7,7 +7,7 @@ import { ElectronMainAuthorization } from "@itwin/electron-authorization/lib/cjs
 import { ElectronHost, ElectronHostOptions } from "@itwin/core-electron/lib/cjs/ElectronBackend";
 import { RpcInterfaceDefinition } from "@itwin/core-common";
 import { SampleIpcHandler } from "../SampleIpcHandler";
-import { IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHostOptions } from "@itwin/core-backend";
 
 /**
  * Initializes Electron backend
@@ -21,7 +21,7 @@ export default async function initialize(rpcInterfaces: RpcInterfaceDefinition[]
     developmentServer: process.env.NODE_ENV === "development",
     ipcHandlers: [SampleIpcHandler],
   };
-  const iModelHost = new IModelHostConfiguration();
+  const iModelHost: IModelHostOptions = {};
 
   let authClient;
   if (process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID && process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI && process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES) {

--- a/test-apps/ui-test-app/src/backend/electron/ElectronMain.ts
+++ b/test-apps/ui-test-app/src/backend/electron/ElectronMain.ts
@@ -8,14 +8,14 @@ import { assert } from "@itwin/core-bentley";
 import { ElectronMainAuthorization } from "@itwin/electron-authorization/lib/cjs/ElectronMain";
 import { ElectronHost } from "@itwin/core-electron/lib/cjs/ElectronBackend";
 import { getSupportedRpcs } from "../../common/rpcs";
-import { IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHostOptions } from "@itwin/core-backend";
 import { EditCommandAdmin } from "@itwin/editor-backend";
 import * as editorBuiltInCommands from "@itwin/editor-backend";
 
 const mainWindowName = "mainWindow";
 
 /** Initializes Electron backend */
-export async function initializeElectron(opts?: IModelHostConfiguration) {
+export async function initializeElectron(opts?: IModelHostOptions) {
   const opt = {
     electronHost: {
       webResourcesPath: join(__dirname, "..", "..", "..", "build"),

--- a/test-apps/ui-test-app/src/backend/main.ts
+++ b/test-apps/ui-test-app/src/backend/main.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 import * as fs from "fs";
 import * as path from "path";
-import { IModelHostConfiguration } from "@itwin/core-backend";
 import { Logger, ProcessDetector } from "@itwin/core-bentley";
 import { MobileHost } from "@itwin/core-mobile/lib/cjs/MobileBackend";
 import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
@@ -30,9 +29,10 @@ import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 
     initializeLogging();
 
-    const iModelHost = new IModelHostConfiguration();
     const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels` } });
-    iModelHost.hubAccess = new BackendIModelsAccess(iModelClient);
+    const iModelHost = {
+      hubAccess: new BackendIModelsAccess(iModelClient),
+    };
 
     // ECSchemaRpcInterface allows schema retrieval for the UnitProvider implementation.
     RpcManager.registerImpl(ECSchemaRpcInterface, ECSchemaRpcImpl);

--- a/test-apps/ui-test-app/src/backend/web/BackendServer.ts
+++ b/test-apps/ui-test-app/src/backend/web/BackendServer.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { Logger } from "@itwin/core-bentley";
 import { IModelJsExpressServer } from "@itwin/express-server";
-import { IModelHost, IModelHostConfiguration } from "@itwin/core-backend";
+import { IModelHost, IModelHostOptions } from "@itwin/core-backend";
 import { BentleyCloudRpcManager } from "@itwin/core-common";
 import { getSupportedRpcs } from "../../common/rpcs";
 import { loggerCategory } from "../../common/TestAppConfiguration";
@@ -12,7 +12,7 @@ import { loggerCategory } from "../../common/TestAppConfiguration";
 /**
  * Initializes Web Server backend
  */
-export async function initializeWeb(opts?: IModelHostConfiguration) {
+export async function initializeWeb(opts?: IModelHostOptions) {
   // tell BentleyCloudRpcManager which RPC interfaces to handle
   const rpcConfig = BentleyCloudRpcManager.initializeImpl({ info: { title: "ui-test-app", version: "v1.0" } }, getSupportedRpcs());
 

--- a/utils/workspace-editor/src/WorkspaceEditor.ts
+++ b/utils/workspace-editor/src/WorkspaceEditor.ts
@@ -11,7 +11,7 @@ import { extname, join } from "path";
 import * as readline from "readline";
 import * as Yargs from "yargs";
 import {
-  CloudSqlite, EditableWorkspaceDb, IModelHost, IModelHostConfiguration, IModelJsFs, IModelJsNative, ITwinWorkspaceContainer, ITwinWorkspaceDb,
+  CloudSqlite, EditableWorkspaceDb, IModelHost, IModelJsFs, IModelJsNative, ITwinWorkspaceContainer, ITwinWorkspaceDb,
   SqliteStatement, WorkspaceAccount, WorkspaceContainer, WorkspaceDb, WorkspaceResource,
 } from "@itwin/core-backend";
 import { BentleyError, DbResult, Logger, LogLevel, StopWatch } from "@itwin/core-bentley";
@@ -543,15 +543,14 @@ function runCommand<T extends EditorProps>(cmd: (args: T) => Promise<void>) {
       return cmd(args);
 
     try {
-      const config = new IModelHostConfiguration();
-      config.workspace = {
+      const workspace = {
         containerDir: args.directory,
         cloudCacheProps: {
           nRequests: args.nRequests,
           curlDiagnostics: args.curlDiagnostics,
         },
       };
-      await IModelHost.startup(config);
+      await IModelHost.startup({ workspace });
       if (true === args.logging) {
         Logger.initializeToConsole();
         Logger.setLevel("CloudSqlite", LogLevel.Trace);


### PR DESCRIPTION
This makes `IModelHost` match `IModelApp` and makes supplying options easier. 