### PR TITLE
make openTelemetry configurable

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2623,6 +2623,8 @@ export interface IModelHostOptions {
     // @alpha
     crashReportingConfig?: CrashReportingConfig;
     // @beta
+    enableOpenTelemetry?: boolean;
+    // @beta
     hubAccess?: BackendHubAccess;
     // @internal
     logTileLoadTimeThreshold?: number;
@@ -2638,8 +2640,6 @@ export interface IModelHostOptions {
     tileContentRequestTimeout?: number;
     // @internal
     tileTreeRequestTimeout?: number;
-    // @beta
-    enableOpenTelemetry?: boolean;
     // @beta
     workspace?: WorkspaceOpts;
 }

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2639,7 +2639,7 @@ export interface IModelHostOptions {
     // @internal
     tileTreeRequestTimeout?: number;
     // @beta
-    useOpenTelemetry?: boolean;
+    enableOpenTelemetry?: boolean;
     // @beta
     workspace?: WorkspaceOpts;
 }
@@ -2764,7 +2764,7 @@ export abstract class InformationReferenceElement extends InformationContentElem
 }
 
 // @internal (undocumented)
-export function initializeRpcBackend(useOpenTelemetry?: boolean): void;
+export function initializeRpcBackend(enableOpenTelemetry?: boolean): void;
 
 // @beta
 export interface InstanceChange {

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2639,6 +2639,8 @@ export interface IModelHostOptions {
     // @internal
     tileTreeRequestTimeout?: number;
     // @beta
+    useOpenTelemetry?: boolean;
+    // @beta
     workspace?: WorkspaceOpts;
 }
 
@@ -2762,7 +2764,7 @@ export abstract class InformationReferenceElement extends InformationContentElem
 }
 
 // @internal (undocumented)
-export function initializeRpcBackend(): void;
+export function initializeRpcBackend(useOpenTelemetry?: boolean): void;
 
 // @beta
 export interface InstanceChange {

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -1,41 +1,41 @@
 sep=;
 Release Tag;API Item
-public;AcquireNewBriefcaseIdArg 
-beta;AliCloudStorageService 
+public;AcquireNewBriefcaseIdArg
+beta;AliCloudStorageService
 beta;AliCloudStorageServiceCredentials
-public;AnnotationElement2d 
-public;class AuxCoordSystem 
-public;AuxCoordSystem2d 
-public;AuxCoordSystem3d 
-public;AuxCoordSystemSpatial 
-beta;AzureBlobStorage 
+public;AnnotationElement2d
+public;class AuxCoordSystem
+public;AuxCoordSystem2d
+public;AuxCoordSystem3d
+public;AuxCoordSystemSpatial
+beta;AzureBlobStorage
 beta;AzureBlobStorageCredentials
 beta;BackendHubAccess
 public;BackendLoggerCategory
-internal;BaseSettings 
+internal;BaseSettings
 public;BindParameter = number | string
-public;BisCoreSchema 
-public;BriefcaseDb 
-public;BriefcaseDbArg 
-public;BriefcaseIdArg 
+public;BisCoreSchema
+public;BriefcaseDb
+public;BriefcaseDbArg
+public;BriefcaseIdArg
 internal;BriefcaseLocalValue
 public;BriefcaseManager
-public;class Callout 
-public;Category 
-public;CategoryOwnsSubCategories 
-public;CategorySelector 
-internal;ChangedElementsDb 
-public;ChangesetArg 
-internal;ChangesetIndexArg 
-public;ChangesetRangeArg 
+public;class Callout
+public;Category
+public;CategoryOwnsSubCategories
+public;CategorySelector
+internal;ChangedElementsDb
+public;ChangesetArg
+internal;ChangesetIndexArg
+public;ChangesetRangeArg
 beta;ChangeSummary
 beta;ChangeSummaryExtractOptions
 deprecated;ChangeSummaryExtractOptions
 beta;ChangeSummaryManager
-public;ChannelRootAspect 
+public;ChannelRootAspect
 internal;CheckpointArg = DownloadRequest
 internal;CheckpointManager
-public;CheckpointProps 
+public;CheckpointProps
 public;ClassRegistry
 public;CloudContainerArgs
 beta;class CloudStorageService
@@ -46,69 +46,69 @@ public;ComputedProjectExtents
 public;ComputeProjectExtentsOptions
 alpha;CrashReportingConfig
 alpha;CrashReportingConfigNameValuePair
-beta;CreateChangeSummaryArgs 
-public;CreateNewIModelProps 
-public;DefinitionContainer 
-public;class DefinitionElement 
-public;DefinitionGroup 
-public;DefinitionGroupGroupsDefinitions 
-public;DefinitionModel 
-public;DefinitionPartition 
-public;class DefinitionSet 
-public;DetailCallout 
-public;class DetailingSymbol 
+beta;CreateChangeSummaryArgs
+public;CreateNewIModelProps
+public;DefinitionContainer
+public;class DefinitionElement
+public;DefinitionGroup
+public;DefinitionGroupGroupsDefinitions
+public;DefinitionModel
+public;DefinitionPartition
+public;class DefinitionSet
+public;DetailCallout
+public;class DetailingSymbol
 internal;DevTools
 internal;DevToolsOsStats
 internal;DevToolsProcessStats
 internal;DevToolsStats
 internal;DevToolsStatsFormatter
-public;DictionaryModel 
+public;DictionaryModel
 beta;DictionaryName = string
-public;class DisplayStyle 
-public;DisplayStyle2d 
-public;DisplayStyle3d 
-public;DisplayStyleCreationOptions 
-public;class Document 
-public;DocumentListModel 
-public;DocumentPartition 
+public;class DisplayStyle
+public;DisplayStyle2d
+public;DisplayStyle3d
+public;DisplayStyleCreationOptions
+public;class Document
+public;DocumentListModel
+public;DocumentPartition
 internal;DownloadJob
 internal;DownloadRequest
 internal;Downloads
-public;Drawing 
-public;DrawingCategory 
-public;DrawingGraphic 
-public;DrawingGraphicRepresentsElement 
-public;DrawingGraphicRepresentsFunctionalElement 
-public;DrawingModel 
-public;DrawingViewDefinition 
-beta;class DriverBundleElement 
-public;ECDb 
+public;Drawing
+public;DrawingCategory
+public;DrawingGraphic
+public;DrawingGraphicRepresentsElement
+public;DrawingGraphicRepresentsFunctionalElement
+public;DrawingModel
+public;DrawingViewDefinition
+beta;class DriverBundleElement
+public;ECDb
 public;ECDbOpenMode
 public;ECEnumValue
 internal;ECSchemaXmlContext
 public;ECSqlBinder
 public;ECSqlColumnInfo
 public;ECSqlInsertResult
-public;ECSqlStatement 
+public;ECSqlStatement
 public;ECSqlValue
-public;ECSqlValueIterator 
-beta;EditableWorkspaceDb 
-public;Element 
-public;ElementAspect 
-beta;ElementDrivesElement 
-beta;ElementDrivesElementProps 
-public;ElementEncapsulatesElements 
-public;ElementGroupsMembers 
-public;ElementGroupsMembersProps 
-public;ElementMultiAspect 
-public;ElementOwnsChildElements 
-public;ElementOwnsExternalSourceAspects 
-public;ElementOwnsMultiAspects 
-public;ElementOwnsUniqueAspect 
-public;ElementRefersToElements 
-public;ElementUniqueAspect 
-public;ElevationCallout 
-public;EmbeddedFileLink 
+public;ECSqlValueIterator
+beta;EditableWorkspaceDb
+public;Element
+public;ElementAspect
+beta;ElementDrivesElement
+beta;ElementDrivesElementProps
+public;ElementEncapsulatesElements
+public;ElementGroupsMembers
+public;ElementGroupsMembersProps
+public;ElementMultiAspect
+public;ElementOwnsChildElements
+public;ElementOwnsExternalSourceAspects
+public;ElementOwnsMultiAspects
+public;ElementOwnsUniqueAspect
+public;ElementRefersToElements
+public;ElementUniqueAspect
+public;ElevationCallout
+public;EmbeddedFileLink
 public;Entity
 public;EntityClassType
 public;ExportGraphics
@@ -116,7 +116,7 @@ public;ExportGraphicsFunction = (info: ExportGraphicsInfo) => void
 public;ExportGraphicsInfo
 public;ExportGraphicsLines
 public;ExportGraphicsMesh
-public;ExportGraphicsMeshVisitor 
+public;ExportGraphicsMeshVisitor
 public;ExportGraphicsOptions
 public;ExportLinesFunction = (info: ExportLinesInfo) => void
 public;ExportLinesInfo
@@ -127,99 +127,99 @@ public;ExportPartInfo
 public;ExportPartInstanceInfo
 public;ExportPartLinesFunction = (info: ExportPartLinesInfo) => void
 public;ExportPartLinesInfo
-beta;ExternalSource 
-public;ExternalSourceAspect 
+beta;ExternalSource
 public;ExternalSourceAspect
-beta;ExternalSourceAttachment 
-beta;ExternalSourceAttachmentAttachesSource 
-beta;ExternalSourceGroup 
-beta;ExternalSourceGroupGroupsSources 
-beta;ExternalSourceIsInRepository 
-beta;ExternalSourceOwnsAttachments 
+public;ExternalSourceAspect
+beta;ExternalSourceAttachment
+beta;ExternalSourceAttachmentAttachesSource
+beta;ExternalSourceGroup
+beta;ExternalSourceGroupGroupsSources
+beta;ExternalSourceIsInRepository
+beta;ExternalSourceOwnsAttachments
 public;class FileNameResolver
-beta;FolderContainsRepositories 
-alpha;FolderLink 
-public;class FunctionalBreakdownElement 
-public;class FunctionalComponentElement 
-public;FunctionalComposite 
-public;class FunctionalElement 
-public;FunctionalElementIsOfType 
-public;FunctionalModel 
-public;FunctionalPartition 
-public;FunctionalSchema 
-public;class FunctionalType 
+beta;FolderContainsRepositories
+alpha;FolderLink
+public;class FunctionalBreakdownElement
+public;class FunctionalComponentElement
+public;FunctionalComposite
+public;class FunctionalElement
+public;FunctionalElementIsOfType
+public;FunctionalModel
+public;FunctionalPartition
+public;FunctionalSchema
+public;class FunctionalType
 internal;generateElementGraphics(request: ElementGraphicsRequestProps, iModel: IModelDb): Promise
-public;GenericDocument 
-public;GenericGraphicalModel3d 
-public;GenericGraphicalType2d 
-public;GenericPhysicalMaterial 
-public;GenericPhysicalType 
-public;GenericSchema 
-public;class GeometricElement 
-public;class GeometricElement2d 
-public;GeometricElement2dHasTypeDefinition 
-public;class GeometricElement3d 
-public;GeometricElement3dHasTypeDefinition 
-public;GeometricModel 
-public;class GeometricModel2d 
-public;class GeometricModel3d 
-public;GeometryPart 
-public;Graphic3d 
-public;class GraphicalElement2d 
-public;GraphicalElement2dIsOfType 
-public;class GraphicalElement3d 
-public;GraphicalElement3dRepresentsElement 
-public;class GraphicalModel2d 
-public;class GraphicalModel3d 
-public;GraphicalPartition3d 
-public;class GraphicalType2d 
-public;Group 
-public;GroupImpartsToMembers 
-public;class GroupInformationElement 
-public;class GroupInformationModel 
-public;GroupInformationPartition 
-public;GroupModel 
+public;GenericDocument
+public;GenericGraphicalModel3d
+public;GenericGraphicalType2d
+public;GenericPhysicalMaterial
+public;GenericPhysicalType
+public;GenericSchema
+public;class GeometricElement
+public;class GeometricElement2d
+public;GeometricElement2dHasTypeDefinition
+public;class GeometricElement3d
+public;GeometricElement3dHasTypeDefinition
+public;GeometricModel
+public;class GeometricModel2d
+public;class GeometricModel3d
+public;GeometryPart
+public;Graphic3d
+public;class GraphicalElement2d
+public;GraphicalElement2dIsOfType
+public;class GraphicalElement3d
+public;GraphicalElement3dRepresentsElement
+public;class GraphicalModel2d
+public;class GraphicalModel3d
+public;GraphicalPartition3d
+public;class GraphicalType2d
+public;Group
+public;GroupImpartsToMembers
+public;class GroupInformationElement
+public;class GroupInformationModel
+public;GroupInformationPartition
+public;GroupModel
 internal;HubMock
 beta;IModelCloneContext
-public;class IModelDb 
+public;class IModelDb
 public;IModelDb
 internal;TileContentState
 internal;Tiles
 public;IModelHost
-public;IModelHostConfiguration 
+public;IModelHostConfiguration
 public;IModelHostOptions
-public;IModelIdArg 
+public;IModelIdArg
 public;IModelJsFs
 public;IModelJsFsStats
-public;IModelNameArg 
+public;IModelNameArg
 alpha;IModelSchemaLoader
-public;class InformationContentElement 
-public;class InformationModel 
-public;class InformationPartitionElement 
-public;class InformationRecordElement 
-public;InformationRecordModel 
-public;InformationRecordPartition 
-public;class InformationReferenceElement 
-internal;initializeRpcBackend(useOpenTelemetry?: boolean): void
+public;class InformationContentElement
+public;class InformationModel
+public;class InformationPartitionElement
+public;class InformationRecordElement
+public;InformationRecordModel
+public;InformationRecordPartition
+public;class InformationReferenceElement
+internal;initializeRpcBackend(enableOpenTelemetry?: boolean): void
 beta;InstanceChange
 public;class IpcHandler
 public;IpcHost
 public;IpcHostOpts
 public;ITwinIdArg
-internal;ITwinWorkspace 
-internal;ITwinWorkspaceContainer 
-beta;ITwinWorkspaceDb 
+internal;ITwinWorkspace
+internal;ITwinWorkspaceContainer
+beta;ITwinWorkspaceDb
 public;KnownLocations
-internal;LightLocation 
-public;LineStyle 
+internal;LightLocation
+public;LineStyle
 public;LineStyleDefinition
-public;class LinkElement 
-public;LinkModel 
-public;LinkPartition 
+public;class LinkElement
+public;LinkModel
+public;LinkPartition
 internal;LocalhostIpcHost
 internal;LocalhostIpcHostOpts
 internal;LocalHub
-beta;LockConflict 
+beta;LockConflict
 beta;LockControl
 internal;LockMap = Map
 beta;LockProps
@@ -227,67 +227,67 @@ public;LockState
 internal;LockStatusExclusive
 internal;LockStatusShared
 internal;MetaDataRegistry
-public;Model 
-public;ModelSelector 
+public;Model
+public;ModelSelector
 public;NativeAppStorage
 public;NativeHost
-public;NativeHostOpts 
+public;NativeHostOpts
 beta;OnAspectArg
-beta;OnAspectIdArg 
-beta;OnAspectPropsArg 
-beta;OnChildElementArg 
-beta;OnChildElementIdArg 
-beta;OnChildElementPropsArg 
+beta;OnAspectIdArg
+beta;OnAspectPropsArg
+beta;OnChildElementArg
+beta;OnChildElementIdArg
+beta;OnChildElementPropsArg
 beta;OnElementArg
-beta;OnElementIdArg 
-beta;OnElementInModelIdArg 
-beta;OnElementInModelPropsArg 
-beta;OnElementPropsArg 
+beta;OnElementIdArg
+beta;OnElementInModelIdArg
+beta;OnElementInModelPropsArg
+beta;OnElementPropsArg
 beta;OnModelArg
-beta;OnModelIdArg 
-beta;OnModelPropsArg 
-beta;OnSubModelIdArg 
-beta;OnSubModelPropsArg 
+beta;OnModelIdArg
+beta;OnModelPropsArg
+beta;OnSubModelIdArg
+beta;OnSubModelPropsArg
 public;OpenBriefcaseArgs = OpenBriefcaseProps & CloudContainerArgs
-public;OrthographicViewDefinition 
-public;class PhysicalElement 
-public;PhysicalElementAssemblesElements 
-public;PhysicalElementFulfillsFunction 
-public;PhysicalElementIsOfPhysicalMaterial 
-public;PhysicalElementIsOfType 
-public;class PhysicalMaterial 
-public;PhysicalModel 
-public;PhysicalObject 
-public;PhysicalPartition 
-public;class PhysicalType 
-public;PhysicalTypeIsOfPhysicalMaterial 
-public;PlanCallout 
+public;OrthographicViewDefinition
+public;class PhysicalElement
+public;PhysicalElementAssemblesElements
+public;PhysicalElementFulfillsFunction
+public;PhysicalElementIsOfPhysicalMaterial
+public;PhysicalElementIsOfType
+public;class PhysicalMaterial
+public;PhysicalModel
+public;PhysicalObject
+public;PhysicalPartition
+public;class PhysicalType
+public;PhysicalTypeIsOfPhysicalMaterial
+public;PlanCallout
 public;Platform
 internal;ProcessChangesetOptions
 public;ProgressFunction = (loaded: number, total: number) => number
 public;PullChangesArgs = ToChangesetArgs
-public;PushChangesArgs 
-beta;class RecipeDefinitionElement 
-public;Relationship 
+public;PushChangesArgs
+beta;class RecipeDefinitionElement
+public;Relationship
 public;Relationships
-public;RenderMaterialElement 
 public;RenderMaterialElement
-public;RenderMaterialOwnsRenderMaterials 
-public;RenderTimeline 
-public;RepositoryLink 
-public;RepositoryModel 
-public;RequestNewBriefcaseArg 
-public;class RoleElement 
-public;RoleModel 
+public;RenderMaterialElement
+public;RenderMaterialOwnsRenderMaterials
+public;RenderTimeline
+public;RepositoryLink
+public;RepositoryModel
+public;RequestNewBriefcaseArg
+public;class RoleElement
+public;RoleModel
 public;RpcTrace
 public;Schema
 internal;SchemaKey = IModelJsNative.ECSchemaXmlContext.SchemaKey
 internal;SchemaMatchType = IModelJsNative.ECSchemaXmlContext.SchemaMatchType
 public;Schemas
-public;SectionCallout 
-public;SectionDrawing 
-public;SectionDrawingLocation 
-public;SectionDrawingModel 
+public;SectionCallout
+public;SectionDrawing
+public;SectionDrawingLocation
+public;SectionDrawingModel
 internal;setMaxEntitiesPerEvent(max: number): number
 beta;SettingDictionary = SettingObject
 beta;SettingInspector
@@ -295,73 +295,73 @@ beta;SettingName = string
 beta;SettingObject
 beta;SettingResolver
 beta;Settings
-beta;SettingSchema 
+beta;SettingSchema
 beta;SettingSchemaGroup
 beta;SettingsPriority
 beta;SettingsSchemas
 beta;SettingType = JSONSchemaType
-public;Sheet 
-public;SheetBorderTemplate 
-public;SheetModel 
-public;SheetTemplate 
-public;SheetViewDefinition 
-public;SnapshotDb 
+public;Sheet
+public;SheetBorderTemplate
+public;SheetModel
+public;SheetTemplate
+public;SheetViewDefinition
+public;SnapshotDb
 public;SnapshotDbOpenArgs = SnapshotOpenOptions & CloudContainerArgs
-public;SpatialCategory 
-public;class SpatialElement 
-public;SpatialLocation 
-public;class SpatialLocationElement 
-public;SpatialLocationIsOfType 
-public;SpatialLocationModel 
-public;SpatialLocationPartition 
-public;class SpatialLocationType 
-public;class SpatialModel 
-public;SpatialViewDefinition 
-public;SQLiteDb 
-public;SqliteStatement 
+public;SpatialCategory
+public;class SpatialElement
+public;SpatialLocation
+public;class SpatialLocationElement
+public;SpatialLocationIsOfType
+public;SpatialLocationModel
+public;SpatialLocationPartition
+public;class SpatialLocationType
+public;class SpatialModel
+public;SpatialViewDefinition
+public;SQLiteDb
+public;SqliteStatement
 public;SqliteValue
 public;SqliteValueType
-public;StandaloneDb 
+public;StandaloneDb
 internal;StatementCache
 internal;StringParam
-public;SubCategory 
-public;Subject 
-public;SubjectOwnsPartitionElements 
-public;SubjectOwnsSubjects 
-beta;SynchronizationConfigLink 
-beta;SynchronizationConfigProcessesSources 
-beta;SynchronizationConfigSpecifiesRootSources 
-beta;TemplateRecipe2d 
-beta;TemplateRecipe3d 
-internal;TemplateViewDefinition2d 
-internal;TemplateViewDefinition3d 
-public;TextAnnotation2d 
-public;TextAnnotation3d 
-public;Texture 
-internal;TextureCreateProps 
-public;TitleText 
-public;ToChangesetArgs 
+public;SubCategory
+public;Subject
+public;SubjectOwnsPartitionElements
+public;SubjectOwnsSubjects
+beta;SynchronizationConfigLink
+beta;SynchronizationConfigProcessesSources
+beta;SynchronizationConfigSpecifiesRootSources
+beta;TemplateRecipe2d
+beta;TemplateRecipe3d
+internal;TemplateViewDefinition2d
+internal;TemplateViewDefinition3d
+public;TextAnnotation2d
+public;TextAnnotation3d
+public;Texture
+internal;TextureCreateProps
+public;TitleText
+public;ToChangesetArgs
 public;TokenArg
 public;TxnChangedEntities
 public;TxnIdString = string
 public;TxnManager
-public;class TypeDefinitionElement 
-public;UpdateModelOptions 
-public;UrlLink 
+public;class TypeDefinitionElement
+public;UpdateModelOptions
+public;UrlLink
 internal;V1CheckpointManager
 internal;V2CheckpointAccessProps
 internal;V2CheckpointManager
 public;ValidationError
-public;ViewAttachment 
-public;ViewAttachmentLabel 
-public;class ViewDefinition 
-public;ViewDefinition2d 
-public;class ViewDefinition3d 
-public;VolumeElement 
-public;WebMercatorModel 
+public;ViewAttachment
+public;ViewAttachmentLabel
+public;class ViewDefinition
+public;ViewDefinition2d
+public;class ViewDefinition3d
+public;VolumeElement
+public;WebMercatorModel
 beta;Workspace
 beta;WorkspaceAccount
-beta;WorkspaceCloudCacheProps 
+beta;WorkspaceCloudCacheProps
 beta;WorkspaceContainer
 beta;WorkspaceContainer
 beta;WorkspaceDb

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -200,7 +200,7 @@ public;class InformationRecordElement
 public;InformationRecordModel 
 public;InformationRecordPartition 
 public;class InformationReferenceElement 
-internal;initializeRpcBackend(): void
+internal;initializeRpcBackend(useOpenTelemetry?: boolean): void
 beta;InstanceChange
 public;class IpcHandler
 public;IpcHost

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -1,41 +1,41 @@
 sep=;
 Release Tag;API Item
-public;AcquireNewBriefcaseIdArg
-beta;AliCloudStorageService
+public;AcquireNewBriefcaseIdArg 
+beta;AliCloudStorageService 
 beta;AliCloudStorageServiceCredentials
-public;AnnotationElement2d
-public;class AuxCoordSystem
-public;AuxCoordSystem2d
-public;AuxCoordSystem3d
-public;AuxCoordSystemSpatial
-beta;AzureBlobStorage
+public;AnnotationElement2d 
+public;class AuxCoordSystem 
+public;AuxCoordSystem2d 
+public;AuxCoordSystem3d 
+public;AuxCoordSystemSpatial 
+beta;AzureBlobStorage 
 beta;AzureBlobStorageCredentials
 beta;BackendHubAccess
 public;BackendLoggerCategory
-internal;BaseSettings
+internal;BaseSettings 
 public;BindParameter = number | string
-public;BisCoreSchema
-public;BriefcaseDb
-public;BriefcaseDbArg
-public;BriefcaseIdArg
+public;BisCoreSchema 
+public;BriefcaseDb 
+public;BriefcaseDbArg 
+public;BriefcaseIdArg 
 internal;BriefcaseLocalValue
 public;BriefcaseManager
-public;class Callout
-public;Category
-public;CategoryOwnsSubCategories
-public;CategorySelector
-internal;ChangedElementsDb
-public;ChangesetArg
-internal;ChangesetIndexArg
-public;ChangesetRangeArg
+public;class Callout 
+public;Category 
+public;CategoryOwnsSubCategories 
+public;CategorySelector 
+internal;ChangedElementsDb 
+public;ChangesetArg 
+internal;ChangesetIndexArg 
+public;ChangesetRangeArg 
 beta;ChangeSummary
 beta;ChangeSummaryExtractOptions
 deprecated;ChangeSummaryExtractOptions
 beta;ChangeSummaryManager
-public;ChannelRootAspect
+public;ChannelRootAspect 
 internal;CheckpointArg = DownloadRequest
 internal;CheckpointManager
-public;CheckpointProps
+public;CheckpointProps 
 public;ClassRegistry
 public;CloudContainerArgs
 beta;class CloudStorageService
@@ -46,69 +46,69 @@ public;ComputedProjectExtents
 public;ComputeProjectExtentsOptions
 alpha;CrashReportingConfig
 alpha;CrashReportingConfigNameValuePair
-beta;CreateChangeSummaryArgs
-public;CreateNewIModelProps
-public;DefinitionContainer
-public;class DefinitionElement
-public;DefinitionGroup
-public;DefinitionGroupGroupsDefinitions
-public;DefinitionModel
-public;DefinitionPartition
-public;class DefinitionSet
-public;DetailCallout
-public;class DetailingSymbol
+beta;CreateChangeSummaryArgs 
+public;CreateNewIModelProps 
+public;DefinitionContainer 
+public;class DefinitionElement 
+public;DefinitionGroup 
+public;DefinitionGroupGroupsDefinitions 
+public;DefinitionModel 
+public;DefinitionPartition 
+public;class DefinitionSet 
+public;DetailCallout 
+public;class DetailingSymbol 
 internal;DevTools
 internal;DevToolsOsStats
 internal;DevToolsProcessStats
 internal;DevToolsStats
 internal;DevToolsStatsFormatter
-public;DictionaryModel
+public;DictionaryModel 
 beta;DictionaryName = string
-public;class DisplayStyle
-public;DisplayStyle2d
-public;DisplayStyle3d
-public;DisplayStyleCreationOptions
-public;class Document
-public;DocumentListModel
-public;DocumentPartition
+public;class DisplayStyle 
+public;DisplayStyle2d 
+public;DisplayStyle3d 
+public;DisplayStyleCreationOptions 
+public;class Document 
+public;DocumentListModel 
+public;DocumentPartition 
 internal;DownloadJob
 internal;DownloadRequest
 internal;Downloads
-public;Drawing
-public;DrawingCategory
-public;DrawingGraphic
-public;DrawingGraphicRepresentsElement
-public;DrawingGraphicRepresentsFunctionalElement
-public;DrawingModel
-public;DrawingViewDefinition
-beta;class DriverBundleElement
-public;ECDb
+public;Drawing 
+public;DrawingCategory 
+public;DrawingGraphic 
+public;DrawingGraphicRepresentsElement 
+public;DrawingGraphicRepresentsFunctionalElement 
+public;DrawingModel 
+public;DrawingViewDefinition 
+beta;class DriverBundleElement 
+public;ECDb 
 public;ECDbOpenMode
 public;ECEnumValue
 internal;ECSchemaXmlContext
 public;ECSqlBinder
 public;ECSqlColumnInfo
 public;ECSqlInsertResult
-public;ECSqlStatement
+public;ECSqlStatement 
 public;ECSqlValue
-public;ECSqlValueIterator
-beta;EditableWorkspaceDb
-public;Element
-public;ElementAspect
-beta;ElementDrivesElement
-beta;ElementDrivesElementProps
-public;ElementEncapsulatesElements
-public;ElementGroupsMembers
-public;ElementGroupsMembersProps
-public;ElementMultiAspect
-public;ElementOwnsChildElements
-public;ElementOwnsExternalSourceAspects
-public;ElementOwnsMultiAspects
-public;ElementOwnsUniqueAspect
-public;ElementRefersToElements
-public;ElementUniqueAspect
-public;ElevationCallout
-public;EmbeddedFileLink
+public;ECSqlValueIterator 
+beta;EditableWorkspaceDb 
+public;Element 
+public;ElementAspect 
+beta;ElementDrivesElement 
+beta;ElementDrivesElementProps 
+public;ElementEncapsulatesElements 
+public;ElementGroupsMembers 
+public;ElementGroupsMembersProps 
+public;ElementMultiAspect 
+public;ElementOwnsChildElements 
+public;ElementOwnsExternalSourceAspects 
+public;ElementOwnsMultiAspects 
+public;ElementOwnsUniqueAspect 
+public;ElementRefersToElements 
+public;ElementUniqueAspect 
+public;ElevationCallout 
+public;EmbeddedFileLink 
 public;Entity
 public;EntityClassType
 public;ExportGraphics
@@ -116,7 +116,7 @@ public;ExportGraphicsFunction = (info: ExportGraphicsInfo) => void
 public;ExportGraphicsInfo
 public;ExportGraphicsLines
 public;ExportGraphicsMesh
-public;ExportGraphicsMeshVisitor
+public;ExportGraphicsMeshVisitor 
 public;ExportGraphicsOptions
 public;ExportLinesFunction = (info: ExportLinesInfo) => void
 public;ExportLinesInfo
@@ -127,99 +127,99 @@ public;ExportPartInfo
 public;ExportPartInstanceInfo
 public;ExportPartLinesFunction = (info: ExportPartLinesInfo) => void
 public;ExportPartLinesInfo
-beta;ExternalSource
+beta;ExternalSource 
+public;ExternalSourceAspect 
 public;ExternalSourceAspect
-public;ExternalSourceAspect
-beta;ExternalSourceAttachment
-beta;ExternalSourceAttachmentAttachesSource
-beta;ExternalSourceGroup
-beta;ExternalSourceGroupGroupsSources
-beta;ExternalSourceIsInRepository
-beta;ExternalSourceOwnsAttachments
+beta;ExternalSourceAttachment 
+beta;ExternalSourceAttachmentAttachesSource 
+beta;ExternalSourceGroup 
+beta;ExternalSourceGroupGroupsSources 
+beta;ExternalSourceIsInRepository 
+beta;ExternalSourceOwnsAttachments 
 public;class FileNameResolver
-beta;FolderContainsRepositories
-alpha;FolderLink
-public;class FunctionalBreakdownElement
-public;class FunctionalComponentElement
-public;FunctionalComposite
-public;class FunctionalElement
-public;FunctionalElementIsOfType
-public;FunctionalModel
-public;FunctionalPartition
-public;FunctionalSchema
-public;class FunctionalType
+beta;FolderContainsRepositories 
+alpha;FolderLink 
+public;class FunctionalBreakdownElement 
+public;class FunctionalComponentElement 
+public;FunctionalComposite 
+public;class FunctionalElement 
+public;FunctionalElementIsOfType 
+public;FunctionalModel 
+public;FunctionalPartition 
+public;FunctionalSchema 
+public;class FunctionalType 
 internal;generateElementGraphics(request: ElementGraphicsRequestProps, iModel: IModelDb): Promise
-public;GenericDocument
-public;GenericGraphicalModel3d
-public;GenericGraphicalType2d
-public;GenericPhysicalMaterial
-public;GenericPhysicalType
-public;GenericSchema
-public;class GeometricElement
-public;class GeometricElement2d
-public;GeometricElement2dHasTypeDefinition
-public;class GeometricElement3d
-public;GeometricElement3dHasTypeDefinition
-public;GeometricModel
-public;class GeometricModel2d
-public;class GeometricModel3d
-public;GeometryPart
-public;Graphic3d
-public;class GraphicalElement2d
-public;GraphicalElement2dIsOfType
-public;class GraphicalElement3d
-public;GraphicalElement3dRepresentsElement
-public;class GraphicalModel2d
-public;class GraphicalModel3d
-public;GraphicalPartition3d
-public;class GraphicalType2d
-public;Group
-public;GroupImpartsToMembers
-public;class GroupInformationElement
-public;class GroupInformationModel
-public;GroupInformationPartition
-public;GroupModel
+public;GenericDocument 
+public;GenericGraphicalModel3d 
+public;GenericGraphicalType2d 
+public;GenericPhysicalMaterial 
+public;GenericPhysicalType 
+public;GenericSchema 
+public;class GeometricElement 
+public;class GeometricElement2d 
+public;GeometricElement2dHasTypeDefinition 
+public;class GeometricElement3d 
+public;GeometricElement3dHasTypeDefinition 
+public;GeometricModel 
+public;class GeometricModel2d 
+public;class GeometricModel3d 
+public;GeometryPart 
+public;Graphic3d 
+public;class GraphicalElement2d 
+public;GraphicalElement2dIsOfType 
+public;class GraphicalElement3d 
+public;GraphicalElement3dRepresentsElement 
+public;class GraphicalModel2d 
+public;class GraphicalModel3d 
+public;GraphicalPartition3d 
+public;class GraphicalType2d 
+public;Group 
+public;GroupImpartsToMembers 
+public;class GroupInformationElement 
+public;class GroupInformationModel 
+public;GroupInformationPartition 
+public;GroupModel 
 internal;HubMock
 beta;IModelCloneContext
-public;class IModelDb
+public;class IModelDb 
 public;IModelDb
 internal;TileContentState
 internal;Tiles
 public;IModelHost
-public;IModelHostConfiguration
+public;IModelHostConfiguration 
 public;IModelHostOptions
-public;IModelIdArg
+public;IModelIdArg 
 public;IModelJsFs
 public;IModelJsFsStats
-public;IModelNameArg
+public;IModelNameArg 
 alpha;IModelSchemaLoader
-public;class InformationContentElement
-public;class InformationModel
-public;class InformationPartitionElement
-public;class InformationRecordElement
-public;InformationRecordModel
-public;InformationRecordPartition
-public;class InformationReferenceElement
+public;class InformationContentElement 
+public;class InformationModel 
+public;class InformationPartitionElement 
+public;class InformationRecordElement 
+public;InformationRecordModel 
+public;InformationRecordPartition 
+public;class InformationReferenceElement 
 internal;initializeRpcBackend(enableOpenTelemetry?: boolean): void
 beta;InstanceChange
 public;class IpcHandler
 public;IpcHost
 public;IpcHostOpts
 public;ITwinIdArg
-internal;ITwinWorkspace
-internal;ITwinWorkspaceContainer
-beta;ITwinWorkspaceDb
+internal;ITwinWorkspace 
+internal;ITwinWorkspaceContainer 
+beta;ITwinWorkspaceDb 
 public;KnownLocations
-internal;LightLocation
-public;LineStyle
+internal;LightLocation 
+public;LineStyle 
 public;LineStyleDefinition
-public;class LinkElement
-public;LinkModel
-public;LinkPartition
+public;class LinkElement 
+public;LinkModel 
+public;LinkPartition 
 internal;LocalhostIpcHost
 internal;LocalhostIpcHostOpts
 internal;LocalHub
-beta;LockConflict
+beta;LockConflict 
 beta;LockControl
 internal;LockMap = Map
 beta;LockProps
@@ -227,67 +227,67 @@ public;LockState
 internal;LockStatusExclusive
 internal;LockStatusShared
 internal;MetaDataRegistry
-public;Model
-public;ModelSelector
+public;Model 
+public;ModelSelector 
 public;NativeAppStorage
 public;NativeHost
-public;NativeHostOpts
+public;NativeHostOpts 
 beta;OnAspectArg
-beta;OnAspectIdArg
-beta;OnAspectPropsArg
-beta;OnChildElementArg
-beta;OnChildElementIdArg
-beta;OnChildElementPropsArg
+beta;OnAspectIdArg 
+beta;OnAspectPropsArg 
+beta;OnChildElementArg 
+beta;OnChildElementIdArg 
+beta;OnChildElementPropsArg 
 beta;OnElementArg
-beta;OnElementIdArg
-beta;OnElementInModelIdArg
-beta;OnElementInModelPropsArg
-beta;OnElementPropsArg
+beta;OnElementIdArg 
+beta;OnElementInModelIdArg 
+beta;OnElementInModelPropsArg 
+beta;OnElementPropsArg 
 beta;OnModelArg
-beta;OnModelIdArg
-beta;OnModelPropsArg
-beta;OnSubModelIdArg
-beta;OnSubModelPropsArg
+beta;OnModelIdArg 
+beta;OnModelPropsArg 
+beta;OnSubModelIdArg 
+beta;OnSubModelPropsArg 
 public;OpenBriefcaseArgs = OpenBriefcaseProps & CloudContainerArgs
-public;OrthographicViewDefinition
-public;class PhysicalElement
-public;PhysicalElementAssemblesElements
-public;PhysicalElementFulfillsFunction
-public;PhysicalElementIsOfPhysicalMaterial
-public;PhysicalElementIsOfType
-public;class PhysicalMaterial
-public;PhysicalModel
-public;PhysicalObject
-public;PhysicalPartition
-public;class PhysicalType
-public;PhysicalTypeIsOfPhysicalMaterial
-public;PlanCallout
+public;OrthographicViewDefinition 
+public;class PhysicalElement 
+public;PhysicalElementAssemblesElements 
+public;PhysicalElementFulfillsFunction 
+public;PhysicalElementIsOfPhysicalMaterial 
+public;PhysicalElementIsOfType 
+public;class PhysicalMaterial 
+public;PhysicalModel 
+public;PhysicalObject 
+public;PhysicalPartition 
+public;class PhysicalType 
+public;PhysicalTypeIsOfPhysicalMaterial 
+public;PlanCallout 
 public;Platform
 internal;ProcessChangesetOptions
 public;ProgressFunction = (loaded: number, total: number) => number
 public;PullChangesArgs = ToChangesetArgs
-public;PushChangesArgs
-beta;class RecipeDefinitionElement
-public;Relationship
+public;PushChangesArgs 
+beta;class RecipeDefinitionElement 
+public;Relationship 
 public;Relationships
+public;RenderMaterialElement 
 public;RenderMaterialElement
-public;RenderMaterialElement
-public;RenderMaterialOwnsRenderMaterials
-public;RenderTimeline
-public;RepositoryLink
-public;RepositoryModel
-public;RequestNewBriefcaseArg
-public;class RoleElement
-public;RoleModel
+public;RenderMaterialOwnsRenderMaterials 
+public;RenderTimeline 
+public;RepositoryLink 
+public;RepositoryModel 
+public;RequestNewBriefcaseArg 
+public;class RoleElement 
+public;RoleModel 
 public;RpcTrace
 public;Schema
 internal;SchemaKey = IModelJsNative.ECSchemaXmlContext.SchemaKey
 internal;SchemaMatchType = IModelJsNative.ECSchemaXmlContext.SchemaMatchType
 public;Schemas
-public;SectionCallout
-public;SectionDrawing
-public;SectionDrawingLocation
-public;SectionDrawingModel
+public;SectionCallout 
+public;SectionDrawing 
+public;SectionDrawingLocation 
+public;SectionDrawingModel 
 internal;setMaxEntitiesPerEvent(max: number): number
 beta;SettingDictionary = SettingObject
 beta;SettingInspector
@@ -295,73 +295,73 @@ beta;SettingName = string
 beta;SettingObject
 beta;SettingResolver
 beta;Settings
-beta;SettingSchema
+beta;SettingSchema 
 beta;SettingSchemaGroup
 beta;SettingsPriority
 beta;SettingsSchemas
 beta;SettingType = JSONSchemaType
-public;Sheet
-public;SheetBorderTemplate
-public;SheetModel
-public;SheetTemplate
-public;SheetViewDefinition
-public;SnapshotDb
+public;Sheet 
+public;SheetBorderTemplate 
+public;SheetModel 
+public;SheetTemplate 
+public;SheetViewDefinition 
+public;SnapshotDb 
 public;SnapshotDbOpenArgs = SnapshotOpenOptions & CloudContainerArgs
-public;SpatialCategory
-public;class SpatialElement
-public;SpatialLocation
-public;class SpatialLocationElement
-public;SpatialLocationIsOfType
-public;SpatialLocationModel
-public;SpatialLocationPartition
-public;class SpatialLocationType
-public;class SpatialModel
-public;SpatialViewDefinition
-public;SQLiteDb
-public;SqliteStatement
+public;SpatialCategory 
+public;class SpatialElement 
+public;SpatialLocation 
+public;class SpatialLocationElement 
+public;SpatialLocationIsOfType 
+public;SpatialLocationModel 
+public;SpatialLocationPartition 
+public;class SpatialLocationType 
+public;class SpatialModel 
+public;SpatialViewDefinition 
+public;SQLiteDb 
+public;SqliteStatement 
 public;SqliteValue
 public;SqliteValueType
-public;StandaloneDb
+public;StandaloneDb 
 internal;StatementCache
 internal;StringParam
-public;SubCategory
-public;Subject
-public;SubjectOwnsPartitionElements
-public;SubjectOwnsSubjects
-beta;SynchronizationConfigLink
-beta;SynchronizationConfigProcessesSources
-beta;SynchronizationConfigSpecifiesRootSources
-beta;TemplateRecipe2d
-beta;TemplateRecipe3d
-internal;TemplateViewDefinition2d
-internal;TemplateViewDefinition3d
-public;TextAnnotation2d
-public;TextAnnotation3d
-public;Texture
-internal;TextureCreateProps
-public;TitleText
-public;ToChangesetArgs
+public;SubCategory 
+public;Subject 
+public;SubjectOwnsPartitionElements 
+public;SubjectOwnsSubjects 
+beta;SynchronizationConfigLink 
+beta;SynchronizationConfigProcessesSources 
+beta;SynchronizationConfigSpecifiesRootSources 
+beta;TemplateRecipe2d 
+beta;TemplateRecipe3d 
+internal;TemplateViewDefinition2d 
+internal;TemplateViewDefinition3d 
+public;TextAnnotation2d 
+public;TextAnnotation3d 
+public;Texture 
+internal;TextureCreateProps 
+public;TitleText 
+public;ToChangesetArgs 
 public;TokenArg
 public;TxnChangedEntities
 public;TxnIdString = string
 public;TxnManager
-public;class TypeDefinitionElement
-public;UpdateModelOptions
-public;UrlLink
+public;class TypeDefinitionElement 
+public;UpdateModelOptions 
+public;UrlLink 
 internal;V1CheckpointManager
 internal;V2CheckpointAccessProps
 internal;V2CheckpointManager
 public;ValidationError
-public;ViewAttachment
-public;ViewAttachmentLabel
-public;class ViewDefinition
-public;ViewDefinition2d
-public;class ViewDefinition3d
-public;VolumeElement
-public;WebMercatorModel
+public;ViewAttachment 
+public;ViewAttachmentLabel 
+public;class ViewDefinition 
+public;ViewDefinition2d 
+public;class ViewDefinition3d 
+public;VolumeElement 
+public;WebMercatorModel 
 beta;Workspace
 beta;WorkspaceAccount
-beta;WorkspaceCloudCacheProps
+beta;WorkspaceCloudCacheProps 
 beta;WorkspaceContainer
 beta;WorkspaceContainer
 beta;WorkspaceDb

--- a/common/changes/@itwin/core-backend/optional-opentelemetry_2022-07-20-12-06.json
+++ b/common/changes/@itwin/core-backend/optional-opentelemetry_2022-07-20-12-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -122,6 +122,12 @@ export interface IModelHostOptions {
    */
   restrictTileUrlsByClientIp?: boolean;
 
+  /**
+   * Whether to enable OpenTelemetry tracing
+   * @beta
+   */
+  useOpenTelemetry?: boolean;
+
   /** Whether to compress cached tiles.
    * Defaults to `true`.
    */
@@ -401,7 +407,7 @@ export class IModelHost {
     this.logStartup();
 
     this.backendVersion = require("../../package.json").version; // eslint-disable-line @typescript-eslint/no-var-requires
-    initializeRpcBackend();
+    initializeRpcBackend(options.useOpenTelemetry);
 
     if (this._platform === undefined) {
       try {

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -126,7 +126,7 @@ export interface IModelHostOptions {
    * Whether to enable OpenTelemetry tracing
    * @beta
    */
-  useOpenTelemetry?: boolean;
+  enableOpenTelemetry?: boolean;
 
   /** Whether to compress cached tiles.
    * Defaults to `true`.
@@ -407,7 +407,7 @@ export class IModelHost {
     this.logStartup();
 
     this.backendVersion = require("../../package.json").version; // eslint-disable-line @typescript-eslint/no-var-requires
-    initializeRpcBackend(options.useOpenTelemetry);
+    initializeRpcBackend(options.enableOpenTelemetry);
 
     if (this._platform === undefined) {
       try {

--- a/core/backend/src/RpcBackend.ts
+++ b/core/backend/src/RpcBackend.ts
@@ -13,6 +13,7 @@ import { BentleyStatus, HttpServerRequest, IModelError, RpcActivity, RpcInvocati
 import { AsyncLocalStorage } from "async_hooks";
 import * as FormData from "form-data";
 import * as multiparty from "multiparty";
+import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { IModelHost } from "./IModelHost";
 
 /**
@@ -56,7 +57,7 @@ export class RpcTrace {
 
 let initialized = false;
 /** @internal */
-export function initializeRpcBackend() {
+export function initializeRpcBackend(useOpenTelemetry: boolean = false) {
   if (initialized)
     return;
 
@@ -64,13 +65,19 @@ export function initializeRpcBackend() {
 
   RpcInvocation.runActivity = RpcTrace.run; // redirect the invocation processing to the tracer
 
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const api = require("@opentelemetry/api");
-    const tracer = api.trace.getTracer("@itwin/core-backend", IModelHost.backendVersion);
-    Tracing.enableOpenTelemetry(tracer, api);
-    RpcInvocation.runActivity = RpcTrace.runWithSpan; // wrap invocation in an OpenTelemetry span in addition to RpcTrace
-  } catch (_e) { }
+  if (useOpenTelemetry) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const api = require("@opentelemetry/api");
+      const tracer = api.trace.getTracer("@itwin/core-backend", IModelHost.backendVersion);
+      Tracing.enableOpenTelemetry(tracer, api);
+      RpcInvocation.runActivity = RpcTrace.runWithSpan; // wrap invocation in an OpenTelemetry span in addition to RpcTrace
+    } catch (e) {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      Logger.logError(BackendLoggerCategory.IModelHost, "Failed to initialize OpenTelemetry");
+      Logger.logException(BackendLoggerCategory.IModelHost, e);
+    }
+  }
 
   // set up static logger metadata to include current RpcActivity information for logs during rpc processing
   Logger.staticMetaData.set("rpc", () => RpcInvocation.sanitizeForLog(RpcTrace.currentActivity));

--- a/core/backend/src/RpcBackend.ts
+++ b/core/backend/src/RpcBackend.ts
@@ -57,7 +57,7 @@ export class RpcTrace {
 
 let initialized = false;
 /** @internal */
-export function initializeRpcBackend(useOpenTelemetry: boolean = false) {
+export function initializeRpcBackend(enableOpenTelemetry: boolean = false) {
   if (initialized)
     return;
 
@@ -65,7 +65,7 @@ export function initializeRpcBackend(useOpenTelemetry: boolean = false) {
 
   RpcInvocation.runActivity = RpcTrace.run; // redirect the invocation processing to the tracer
 
-  if (useOpenTelemetry) {
+  if (enableOpenTelemetry) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const api = require("@opentelemetry/api");


### PR DESCRIPTION
There is a problem with dynamic loading that I didn't anticipate: if the dependency tree contains an incompatible version of `@opentelemetry/api`, it will still be resolved even though it doesn't match the version range specified in peerDependencies. To prevent such issues, I'm adding an additional step that needs to be done explicitly to enable openTelemetry.