### PR TITLE
UI: appui-test-app/standalone, Remove inner path to import

### DIFF
--- a/test-apps/appui-test-app/standalone/src/backend/electron/ElectronMain.ts
+++ b/test-apps/appui-test-app/standalone/src/backend/electron/ElectronMain.ts
@@ -9,7 +9,7 @@ import { ElectronHost } from "@itwin/core-electron/lib/cjs/ElectronBackend";
 import { getSupportedRpcs } from "../../common/rpcs";
 import { EditCommandAdmin } from "@itwin/editor-backend";
 import * as editorBuiltInCommands from "@itwin/editor-backend";
-import { IModelHostOptions } from "@itwin/core-backend/src/IModelHost";
+import { IModelHostOptions } from "@itwin/core-backend";
 
 const mainWindowName = "mainWindow";
 


### PR DESCRIPTION
One import was importing directly from src folder, which causes issues at compile time.