### PR TITLE
Promote Tool Settings APIs

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5172,10 +5172,8 @@ export abstract class InteractiveTool extends Tool {
     // @beta
     applyToolSettingPropertyChange(_updatedValue: DialogPropertySyncItem): Promise<boolean>;
     beginDynamics(): void;
-    // @beta
     bumpToolSetting(_settingIndex?: number): Promise<boolean>;
     changeLocateState(enableLocate: boolean, enableSnap?: boolean, cursor?: string, coordLockOvr?: CoordinateLockOverrides): void;
-    // @beta
     protected changeToolSettingPropertyValue(syncItem: DialogPropertySyncItem): boolean;
     decorate(_context: DecorateContext): void;
     decorateSuspended(_context: DecorateContext): void;
@@ -5187,10 +5185,8 @@ export abstract class InteractiveTool extends Tool {
     getDecorationGeometry(_hit: HitDetail): GeometryStreamProps | undefined;
     // @internal (undocumented)
     protected getToolSettingPropertyByName(propertyName: string): DialogProperty<any>;
-    // @beta
     protected getToolSettingPropertyLocked(_property: DialogProperty<any>): DialogProperty<any> | undefined;
     getToolTip(_hit: HitDetail): Promise<HTMLElement | string>;
-    // @beta
     protected initializeToolSettingPropertyValues(properties: DialogProperty<any>[]): void;
     initLocateElements(enableLocate?: boolean, enableSnap?: boolean, cursor?: string, coordLockOvr?: CoordinateLockOverrides): void;
     // (undocumented)
@@ -5227,17 +5223,14 @@ export abstract class InteractiveTool extends Tool {
     onTouchTap(_ev: BeTouchEvent): Promise<EventHandled>;
     onUnsuspend(): Promise<void>;
     receivedDownEvent: boolean;
-    // @beta
     reloadToolSettingsProperties(): void;
     // @internal (undocumented)
     protected restoreToolSettingPropertyValue(property: DialogProperty<any>): boolean;
     // @internal (undocumented)
     protected saveToolSettingPropertyValue(property: DialogProperty<any>, itemValue: DialogItemValue): boolean;
-    // @beta
     supplyToolSettingsProperties(): DialogItem[] | undefined;
     // @internal (undocumented)
     protected syncToolSettingPropertyValue(property: DialogProperty<any>, isDisabled?: boolean): void;
-    // @beta
     syncToolSettingsProperties(syncData: DialogPropertySyncItem[]): void;
     testDecorationHit(_id: string): boolean;
     // @internal (undocumented)

--- a/common/changes/@itwin/core-frontend/promote-toolsettings-apis_2022-07-22-15-32.json
+++ b/common/changes/@itwin/core-frontend/promote-toolsettings-apis_2022-07-22-15-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Promote Tool Settings APIs to public.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/Tool.ts
+++ b/core/frontend/src/tools/Tool.ts
@@ -745,7 +745,7 @@ export abstract class InteractiveTool extends Tool {
 
   /** Override to return the property that is disabled/enabled if the supplied property is a lock property.
    * @see [[changeToolSettingPropertyValue]]
-   * @beta
+   * @public
    */
   protected getToolSettingPropertyLocked(_property: DialogProperty<any>): DialogProperty<any> | undefined {
     return undefined;
@@ -754,7 +754,7 @@ export abstract class InteractiveTool extends Tool {
   /** Helper method for responding to a tool setting property value change by updating saved settings.
    * @see [[applyToolSettingPropertyChange]]
    * @see [[getToolSettingPropertyLocked]] to return the corresponding locked property, if any.
-   * @beta
+   * @public
    */
   protected changeToolSettingPropertyValue(syncItem: DialogPropertySyncItem): boolean {
     const property = this.getToolSettingPropertyByName(syncItem.propertyName);
@@ -771,7 +771,7 @@ export abstract class InteractiveTool extends Tool {
 
   /** Helper method to establish initial values for tool setting properties from saved settings.
    * @see [[supplyToolSettingsProperties]]
-   * @beta
+   * @public
    */
   protected initializeToolSettingPropertyValues(properties: DialogProperty<any>[]): void {
     if (undefined !== this.toolSettingProperties)
@@ -787,7 +787,7 @@ export abstract class InteractiveTool extends Tool {
 
   /** Used to supply list of properties that can be used to generate ToolSettings. If undefined is returned then no ToolSettings will be displayed.
    * @see [[initializeToolSettingPropertyValues]]
-   * @beta
+   * @public
    */
   public supplyToolSettingsProperties(): DialogItem[] | undefined { return undefined; }
 
@@ -799,7 +799,7 @@ export abstract class InteractiveTool extends Tool {
 
   /** Called by tool to synchronize the UI with property changes made by tool. This is typically used to provide user feedback during tool dynamics.
    * If the syncData contains a quantity value and if the displayValue is not defined, the displayValue will be generated in the UI layer before displaying the value.
-   * @beta
+   * @public
    */
   public syncToolSettingsProperties(syncData: DialogPropertySyncItem[]) {
     IModelApp.toolAdmin.syncToolSettingsProperties(this.toolId, syncData);
@@ -807,7 +807,7 @@ export abstract class InteractiveTool extends Tool {
 
   /** Called by tool to inform UI to reload ToolSettings with new set of properties. This allows properties to be added or removed from ToolSetting
    * component as tool processing progresses.
-   * @beta
+   * @public
    */
   public reloadToolSettingsProperties() {
     IModelApp.toolAdmin.reloadToolSettingsProperties();
@@ -816,7 +816,7 @@ export abstract class InteractiveTool extends Tool {
   /** Used to "bump" the value of a tool setting. To "bump" a setting means to toggle a boolean value or cycle through enum values.
    * If no `settingIndex` param is specified, the first setting is bumped.
    * Return true if the setting was successfully bumped.
-   * @beta
+   * @public
    */
   public async bumpToolSetting(_settingIndex?: number): Promise<boolean> { return false; }
 }


### PR DESCRIPTION
Tool Settings APIs that have been in use for some time were overlooked when promoting APIs to public. 