### PR TITLE
Work around Mali G-76 transparency issues

### DIFF
--- a/common/changes/@itwin/webgl-compatibility/markschlosser-workaround-mali-g76-transparency-issues_2022-07-25-13-51.json
+++ b/common/changes/@itwin/webgl-compatibility/markschlosser-workaround-mali-g76-transparency-issues_2022-07-25-13-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -317,7 +317,8 @@ export class Capabilities {
       // Samsung Galaxy Note 8 exhibits same issue as described above for iOS >= 15.
       // It uses specifically Mali-G71 MP20 but reports its renderer as follows.
       // Samsung Galaxy A50 and S9 exhibits same issue; they use Mali-G72.
-      && unmaskedRenderer !== "Mali-G71" && unmaskedRenderer !== "Mali-G72";
+      // HUAWEI P30 exhibits same issue; they use Mali-G76.
+      && unmaskedRenderer !== "Mali-G71" && unmaskedRenderer !== "Mali-G72" && unmaskedRenderer !== "Mali-G76";
 
     if (allowFloatRender && undefined !== this.queryExtensionObject("EXT_float_blend") && this.isTextureRenderable(gl, gl.FLOAT)) {
       this._maxRenderType = RenderType.TextureFloat;

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -317,7 +317,7 @@ export class Capabilities {
       // Samsung Galaxy Note 8 exhibits same issue as described above for iOS >= 15.
       // It uses specifically Mali-G71 MP20 but reports its renderer as follows.
       // Samsung Galaxy A50 and S9 exhibits same issue; they use Mali-G72.
-      // HUAWEI P30 exhibits same issue; they use Mali-G76.
+      // HUAWEI P30 exhibits same issue; it uses Mali-G76.
       && unmaskedRenderer !== "Mali-G71" && unmaskedRenderer !== "Mali-G72" && unmaskedRenderer !== "Mali-G76";
 
     if (allowFloatRender && undefined !== this.queryExtensionObject("EXT_float_blend") && this.isTextureRenderable(gl, gl.FLOAT)) {


### PR DESCRIPTION
Mali G-76 is unable to render transparency when using full floating point textures.  Fall back to non-full floating textures when that chipset is detected (like we do for other similar chipsets).