### PR TITLE
Work around Mali G-76 transparency issues (bp #3963)

### DIFF
--- a/common/changes/@bentley/webgl-compatibility/markschlosser-bp-workaround-mali-g76-transparency-issues_2022-07-25-19-38.json
+++ b/common/changes/@bentley/webgl-compatibility/markschlosser-bp-workaround-mali-g76-transparency-issues_2022-07-25-19-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/webgl-compatibility",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/webgl-compatibility",
+  "email": "47000437+markschlosseratbentley@users.noreply.github.com"
+}

--- a/core/webgl-compatibility/src/Capabilities.ts
+++ b/core/webgl-compatibility/src/Capabilities.ts
@@ -297,7 +297,8 @@ export class Capabilities {
       // Samsung Galaxy Note 8 exhibits same issue as described above for iOS >= 15.
       // It uses specifically Mali-G71 MP20 but reports its renderer as follows.
       // Samsung Galaxy A50 and S9 exhibits same issue; they use Mali-G72.
-      && unmaskedRenderer !== "Mali-G71" && unmaskedRenderer !== "Mali-G72";
+      // HUAWEI P30 exhibits same issue; it uses Mali-G76.
+      && unmaskedRenderer !== "Mali-G71" && unmaskedRenderer !== "Mali-G72" && unmaskedRenderer !== "Mali-G76";
 
     if (allowFloatRender && undefined !== this.queryExtensionObject("EXT_float_blend") && this.isTextureRenderable(gl, gl.FLOAT)) {
       this._maxRenderType = RenderType.TextureFloat;


### PR DESCRIPTION
Backport of: https://github.com/iTwin/itwinjs-core/pull/3963