### PR TITLE
Remove peer dependency of backend on ecschema-metadata

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -170,7 +170,6 @@ import { RenderTimelineProps } from '@itwin/core-common';
 import { RepositoryLinkProps } from '@itwin/core-common';
 import { RequestNewBriefcaseProps } from '@itwin/core-common';
 import { RpcActivity } from '@itwin/core-common';
-import type { Schema as Schema_2 } from '@itwin/ecschema-metadata';
 import { SchemaState } from '@itwin/core-common';
 import { SectionDrawingLocationProps } from '@itwin/core-common';
 import { SectionDrawingProps } from '@itwin/core-common';
@@ -1339,7 +1338,7 @@ export class EditableWorkspaceDb extends ITwinWorkspaceDb {
     updateBlob(rscName: WorkspaceResource.Name, val: Uint8Array): void;
     updateFile(rscName: WorkspaceResource.Name, localFileName: LocalFileName): void;
     updateString(rscName: WorkspaceResource.Name, val: string): void;
-    }
+}
 
 // @public
 class Element_2 extends Entity {
@@ -2427,7 +2426,7 @@ export abstract class IModelDb extends IModel {
     withStatement<T>(ecsql: string, callback: (stmt: ECSqlStatement) => T, logErrors?: boolean): T;
     // @beta
     get workspace(): Workspace;
-    }
+}
 
 // @public (undocumented)
 export namespace IModelDb {
@@ -2707,14 +2706,6 @@ export { IModelJsNative }
 export interface IModelNameArg extends TokenArg, ITwinIdArg {
     // (undocumented)
     readonly iModelName: string;
-}
-
-// @alpha
-export class IModelSchemaLoader {
-    // @internal
-    constructor(_iModel: IModelDb);
-    getSchema<T extends Schema_2>(schemaName: string): T;
-    tryGetSchema<T extends Schema_2>(schemaName: string): T | undefined;
 }
 
 // @public
@@ -4025,7 +4016,7 @@ export class SettingsSchemas {
     static reset(): void;
     // @internal (undocumented)
     static validateArrayObject<T>(val: T, schemaName: string, msg: string): T;
-    }
+}
 
 // @beta
 export type SettingType = JSONSchemaType;
@@ -4640,7 +4631,7 @@ export class V2CheckpointManager {
     static getFileName(checkpoint: CheckpointProps): LocalFileName;
     // (undocumented)
     static getFolder(): LocalDirName;
-    }
+}
 
 // @public
 export interface ValidationError {

--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -10,6 +10,7 @@ import { DecimalPrecision } from '@itwin/core-quantity';
 import { FormatTraits } from '@itwin/core-quantity';
 import { FormatType } from '@itwin/core-quantity';
 import { FractionalPrecision } from '@itwin/core-quantity';
+import { IModelDb } from '@itwin/core-backend';
 import { ScientificType } from '@itwin/core-quantity';
 import { ShowSignOption } from '@itwin/core-quantity';
 import { UnitConversion as UnitConversion_2 } from '@itwin/core-quantity';
@@ -716,6 +717,14 @@ export interface FormatProps extends SchemaItemProps {
     readonly type: string;
     // (undocumented)
     readonly uomSeparator?: string;
+}
+
+// @alpha
+export class IModelSchemaLoader {
+    // @internal
+    constructor(_iModel: IModelDb);
+    getSchema<T extends Schema>(schemaName: string): T;
+    tryGetSchema<T extends Schema>(schemaName: string): T | undefined;
 }
 
 // @beta

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -34,6 +34,7 @@ deprecated;ChangeSummaryExtractOptions
 beta;ChangeSummaryManager
 public;ChannelRootAspect 
 internal;CheckpointArg = DownloadRequest
+deprecated;CheckpointArg = DownloadRequest
 internal;CheckpointManager
 public;CheckpointProps 
 public;ClassRegistry
@@ -70,7 +71,10 @@ public;DisplayStyle3d
 public;DisplayStyleCreationOptions 
 public;DocumentListModel 
 public;DocumentPartition 
+beta;DownloadChangesetArg 
+beta;DownloadChangesetRangeArg 
 internal;DownloadJob
+beta;DownloadProgressArg
 internal;DownloadRequest
 internal;Downloads
 public;Drawing 
@@ -190,7 +194,6 @@ public;IModelIdArg
 public;IModelJsFs
 public;IModelJsFsStats
 public;IModelNameArg 
-alpha;IModelSchemaLoader
 public;class InformationContentElement 
 public;class InformationModel 
 public;class InformationPartitionElement 
@@ -262,7 +265,8 @@ public;PhysicalTypeIsOfPhysicalMaterial
 public;PlanCallout 
 public;Platform
 internal;ProcessChangesetOptions
-public;ProgressFunction = (loaded: number, total: number) => number
+public;ProgressFunction = (loaded: number, total: number) => ProgressStatus
+public;ProgressStatus
 public;PullChangesArgs = ToChangesetArgs
 public;PushChangesArgs 
 beta;class RecipeDefinitionElement 

--- a/common/api/summary/ecschema-metadata.exports.csv
+++ b/common/api/summary/ecschema-metadata.exports.csv
@@ -45,6 +45,7 @@ beta;EnumerationProps
 beta;EnumeratorProps
 beta;Format 
 beta;FormatProps 
+alpha;IModelSchemaLoader
 beta;InvertedUnit 
 beta;InvertedUnitProps 
 beta;ISchemaItemLocater

--- a/common/changes/@itwin/core-backend/ecschema-metadata_2022-07-26-14-35.json
+++ b/common/changes/@itwin/core-backend/ecschema-metadata_2022-07-26-14-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "remove peer dependency on ecschema-metadata",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-transformer/ecschema-metadata_2022-07-26-14-35.json
+++ b/common/changes/@itwin/core-transformer/ecschema-metadata_2022-07-26-14-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/common/changes/@itwin/ecschema-metadata/ecschema-metadata_2022-07-26-14-35.json
+++ b/common/changes/@itwin/ecschema-metadata/ecschema-metadata_2022-07-26-14-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "move IModelSchemaLoader here",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -96,7 +96,6 @@ importers:
       '@itwin/core-geometry': workspace:*
       '@itwin/core-telemetry': workspace:*
       '@itwin/core-webpack-tools': workspace:*
-      '@itwin/ecschema-metadata': workspace:*
       '@itwin/eslint-plugin': workspace:*
       '@opentelemetry/api': ^1.0.4
       '@types/chai': 4.3.1
@@ -147,7 +146,6 @@ importers:
       '@itwin/core-common': link:../common
       '@itwin/core-geometry': link:../geometry
       '@itwin/core-webpack-tools': link:../../tools/webpack-core
-      '@itwin/ecschema-metadata': link:../ecschema-metadata
       '@itwin/eslint-plugin': link:../../tools/eslint-plugin
       '@opentelemetry/api': 1.1.0
       '@types/chai': 4.3.1
@@ -357,7 +355,9 @@ importers:
     specifiers:
       '@bentley/units-schema': ^1.0.5
       '@itwin/build-tools': workspace:*
+      '@itwin/core-backend': workspace:*
       '@itwin/core-bentley': workspace:*
+      '@itwin/core-common': workspace:*
       '@itwin/core-quantity': workspace:*
       '@itwin/eslint-plugin': workspace:*
       '@types/almost-equal': 1.1.0
@@ -384,7 +384,9 @@ importers:
     devDependencies:
       '@bentley/units-schema': 1.0.7
       '@itwin/build-tools': link:../../tools/build
+      '@itwin/core-backend': link:../backend
       '@itwin/core-bentley': link:../bentley
+      '@itwin/core-common': link:../common
       '@itwin/core-quantity': link:../quantity
       '@itwin/eslint-plugin': link:../../tools/eslint-plugin
       '@types/almost-equal': 1.1.0

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -44,13 +44,9 @@
     "@itwin/core-bentley": "workspace:^3.3.0-dev.76",
     "@itwin/core-common": "workspace:^3.3.0-dev.76",
     "@itwin/core-geometry": "workspace:^3.3.0-dev.76",
-    "@itwin/ecschema-metadata": "workspace:^3.3.0-dev.76",
     "@opentelemetry/api": "^1.0.4"
   },
   "peerDependenciesMeta": {
-    "@itwin/ecschema-metadata": {
-      "optional": true
-    },
     "@opentelemetry/api": {
       "optional": true
     }
@@ -65,7 +61,6 @@
     "@itwin/core-common": "workspace:*",
     "@itwin/core-geometry": "workspace:*",
     "@itwin/core-webpack-tools": "workspace:*",
-    "@itwin/ecschema-metadata": "workspace:*",
     "@itwin/eslint-plugin": "workspace:*",
     "@opentelemetry/api": "^1.0.4",
     "@types/chai": "4.3.1",

--- a/core/backend/src/core-backend.ts
+++ b/core/backend/src/core-backend.ts
@@ -43,7 +43,6 @@ export * from "./domains/GenericElements";
 export { CloudSqlite, IModelJsNative, NativeLoggerCategory } from "@bentley/imodeljs-native";
 export * from "./IModelCloneContext";
 export * from "./IModelHost";
-export * from "./IModelSchemaLoader";
 export * from "./IpcHost";
 export * from "./NativeAppStorage";
 export * from "./NativeHost";

--- a/core/ecschema-metadata/package.json
+++ b/core/ecschema-metadata/package.json
@@ -37,6 +37,8 @@
     "@bentley/units-schema": "^1.0.5",
     "@itwin/build-tools": "workspace:*",
     "@itwin/core-bentley": "workspace:*",
+    "@itwin/core-backend": "workspace:*",
+    "@itwin/core-common": "workspace:*",
     "@itwin/core-quantity": "workspace:*",
     "@itwin/eslint-plugin": "workspace:*",
     "@types/almost-equal": "1.1.0",
@@ -60,6 +62,8 @@
   },
   "peerDependencies": {
     "@itwin/core-bentley": "workspace:^3.3.0-dev.76",
+    "@itwin/core-backend": "workspace:^3.3.0-dev.76",
+    "@itwin/core-common": "workspace:^3.3.0-dev.76",
     "@itwin/core-quantity": "workspace:^3.3.0-dev.76"
   },
   "dependencies": {

--- a/core/ecschema-metadata/src/ecschema-metadata.ts
+++ b/core/ecschema-metadata/src/ecschema-metadata.ts
@@ -14,6 +14,7 @@ export * from "./ECName";
 export * from "./ECObjects";
 export * from "./Exception";
 export * from "./Interfaces";
+export * from "./IModelSchemaLoader";
 export { ECClass, StructClass } from "./Metadata/Class";
 export { Constant } from "./Metadata/Constant";
 export { CustomAttributeClass } from "./Metadata/CustomAttributeClass";
@@ -43,7 +44,7 @@ export * from "./UnitConversion/UnitConverter";
 export * from "./UnitProvider/SchemaUnitProvider";
 export * from "./Validation/SchemaWalker";
 export * from "./SchemaPartVisitorDelegate";
-export { CustomAttribute, CustomAttributeContainerProps} from "./Metadata/CustomAttribute";
+export { CustomAttribute, CustomAttributeContainerProps } from "./Metadata/CustomAttribute";
 export { SchemaGraph } from "./utils/SchemaGraph";
 
 /** @docs-package-description

--- a/core/ecschema-metadata/src/test/IModelSchemaLoader.test.ts
+++ b/core/ecschema-metadata/src/test/IModelSchemaLoader.test.ts
@@ -2,18 +2,19 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 import { assert } from "chai";
 import * as path from "path";
 import { IModelError } from "@itwin/core-common";
-import { SnapshotDb } from "../../core-backend";
-import { IModelSchemaLoader } from "../../IModelSchemaLoader";
-import { IModelTestUtils } from "../IModelTestUtils";
-import { KnownTestLocations } from "../KnownTestLocations";
+import { IModelHost, SnapshotDb } from "@itwin/core-backend";
+import { IModelSchemaLoader } from "../IModelSchemaLoader";
+import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test";
 
 describe("IModelSchemaLoader", () => {
   let imodel: SnapshotDb;
 
   before(async () => {
+    await IModelHost.startup({ cacheDir: path.join(__dirname, ".cache") });
     IModelTestUtils.registerTestBimSchema();
     imodel = IModelTestUtils.createSnapshotFromSeed(IModelTestUtils.prepareOutputFile("IModel", "test.bim"), IModelTestUtils.resolveAssetFile("test.bim"));
 

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -6,15 +6,14 @@
  * @module iModels
  */
 
-import { AccessToken, assert, CompressedId64Set, DbResult, Id64, Id64String, IModelStatus, Logger, YieldManager } from "@itwin/core-bentley";
-import { ECVersion, Schema, SchemaKey } from "@itwin/ecschema-metadata";
-import { CodeSpec, FontProps, IModel, IModelError } from "@itwin/core-common";
-import { TransformerLoggerCategory } from "./TransformerLoggerCategory";
 import {
-  BisCoreSchema, BriefcaseDb, BriefcaseManager, DefinitionModel, ECSqlStatement, Element, ElementAspect,
-  ElementMultiAspect, ElementRefersToElements, ElementUniqueAspect, GeometricElement, IModelDb,
-  IModelHost, IModelJsNative, IModelSchemaLoader, Model, RecipeDefinitionElement, Relationship, RelationshipProps,
+  BisCoreSchema, BriefcaseDb, BriefcaseManager, DefinitionModel, ECSqlStatement, Element, ElementAspect, ElementMultiAspect, ElementRefersToElements,
+  ElementUniqueAspect, GeometricElement, IModelDb, IModelHost, IModelJsNative, Model, RecipeDefinitionElement, Relationship, RelationshipProps,
 } from "@itwin/core-backend";
+import { AccessToken, assert, CompressedId64Set, DbResult, Id64, Id64String, IModelStatus, Logger, YieldManager } from "@itwin/core-bentley";
+import { CodeSpec, FontProps, IModel, IModelError } from "@itwin/core-common";
+import { ECVersion, IModelSchemaLoader, Schema, SchemaKey } from "@itwin/ecschema-metadata";
+import { TransformerLoggerCategory } from "./TransformerLoggerCategory";
 
 const loggerCategory = TransformerLoggerCategory.IModelExporter;
 
@@ -72,7 +71,7 @@ export abstract class IModelExportHandler {
    *       This will become a part of onExportElement once that becomes async
    * @internal
    */
-  public async preExportElement(_element: Element): Promise<void> {}
+  public async preExportElement(_element: Element): Promise<void> { }
 
   /** Called when an element should be deleted. */
   public onDeleteElement(_elementId: Id64String): void { }
@@ -709,7 +708,7 @@ export class IModelExporter {
    * You may override this to load arbitrary json state in a transformer state dump, useful for some resumptions
    * @see [[IModelTransformer.loadStateFromFile]]
    */
-  protected loadAdditionalStateJson(_additionalState: any): void {}
+  protected loadAdditionalStateJson(_additionalState: any): void { }
 
   /**
    * Reload our state from a JSON object
@@ -727,8 +726,8 @@ export class IModelExporter {
     this.visitRelationships = state.visitRelationships;
     this._excludedCodeSpecNames = new Set(state.excludedCodeSpecNames);
     this._excludedElementIds = CompressedId64Set.decompressSet(state.excludedElementIds),
-    this._excludedElementCategoryIds = CompressedId64Set.decompressSet(state.excludedElementCategoryIds),
-    this._excludedElementClasses = new Set(state.excludedElementClassNames.map((c) => this.sourceDb.getJsClass(c)));
+      this._excludedElementCategoryIds = CompressedId64Set.decompressSet(state.excludedElementCategoryIds),
+      this._excludedElementClasses = new Set(state.excludedElementClassNames.map((c) => this.sourceDb.getJsClass(c)));
     this._excludedElementAspectClassFullNames = new Set(state.excludedElementAspectClassFullNames);
     this._excludedElementAspectClasses = new Set(state.excludedElementAspectClassFullNames.map((c) => this.sourceDb.getJsClass(c)));
     this._excludedRelationshipClasses = new Set(state.excludedRelationshipClassNames.map((c) => this.sourceDb.getJsClass(c)));

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -725,9 +725,9 @@ export class IModelExporter {
     this.visitElements = state.visitElements;
     this.visitRelationships = state.visitRelationships;
     this._excludedCodeSpecNames = new Set(state.excludedCodeSpecNames);
-    this._excludedElementIds = CompressedId64Set.decompressSet(state.excludedElementIds),
-      this._excludedElementCategoryIds = CompressedId64Set.decompressSet(state.excludedElementCategoryIds),
-      this._excludedElementClasses = new Set(state.excludedElementClassNames.map((c) => this.sourceDb.getJsClass(c)));
+    this._excludedElementIds = CompressedId64Set.decompressSet(state.excludedElementIds);
+    this._excludedElementCategoryIds = CompressedId64Set.decompressSet(state.excludedElementCategoryIds);
+    this._excludedElementClasses = new Set(state.excludedElementClassNames.map((c) => this.sourceDb.getJsClass(c)));
     this._excludedElementAspectClassFullNames = new Set(state.excludedElementAspectClassFullNames);
     this._excludedElementAspectClasses = new Set(state.excludedElementAspectClassFullNames.map((c) => this.sourceDb.getJsClass(c)));
     this._excludedRelationshipClasses = new Set(state.excludedRelationshipClassNames.map((c) => this.sourceDb.getJsClass(c)));

--- a/core/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -11,7 +11,7 @@ import {
   CategorySelector, DisplayStyle3d, DocumentListModel, Drawing, DrawingCategory, DrawingGraphic, DrawingModel, ECSqlStatement, Element,
   ElementMultiAspect, ElementOwnsChildElements, ElementOwnsExternalSourceAspects, ElementOwnsUniqueAspect, ElementRefersToElements,
   ElementUniqueAspect, ExternalSourceAspect, GenericPhysicalMaterial, GeometricElement, IModelCloneContext, IModelDb, IModelHost, IModelJsFs,
-  IModelSchemaLoader, InformationRecordModel, InformationRecordPartition, LinkElement, Model, ModelSelector, OrthographicViewDefinition,
+  InformationRecordModel, InformationRecordPartition, LinkElement, Model, ModelSelector, OrthographicViewDefinition,
   PhysicalModel, PhysicalObject, PhysicalPartition, PhysicalType, Relationship, RepositoryLink, Schema, SnapshotDb, SpatialCategory, StandaloneDb,
   SubCategory, Subject,
 } from "@itwin/core-backend";
@@ -30,6 +30,7 @@ import {
 import { KnownTestLocations } from "../KnownTestLocations";
 
 import "./TransformerTestStartup"; // calls startup/shutdown IModelHost before/after all tests
+import { IModelSchemaLoader } from "@itwin/ecschema-metadata";
 
 describe("IModelTransformer", () => {
   const outputDir = path.join(KnownTestLocations.outputDir, "IModelTransformer");


### PR DESCRIPTION
Move `IModelSchemaLoader` to ecshema-metadata package where it belongs. It is marked @alpha, so this isn't a breaking change.