### PR TITLE
move core deps in editor-frontend to peerDeps

### DIFF
--- a/common/changes/@itwin/editor-frontend/editor-deps_2022-07-27-17-37.json
+++ b/common/changes/@itwin/editor-frontend/editor-deps_2022-07-27-17-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "Move dependencies to peerDependencies",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1319,15 +1319,15 @@ importers:
       rimraf: ^3.0.2
       typescript: ~4.4.0
     dependencies:
-      '@itwin/appui-abstract': link:../../ui/appui-abstract
-      '@itwin/core-frontend': link:../../core/frontend
-      '@itwin/core-geometry': link:../../core/geometry
       '@itwin/editor-common': link:../common
     devDependencies:
+      '@itwin/appui-abstract': link:../../ui/appui-abstract
       '@itwin/build-tools': link:../../tools/build
       '@itwin/certa': link:../../tools/certa
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
+      '@itwin/core-frontend': link:../../core/frontend
+      '@itwin/core-geometry': link:../../core/geometry
       '@itwin/eslint-plugin': link:../../tools/eslint-plugin
       cpx2: 3.0.2
       eslint: 7.32.0
@@ -8406,7 +8406,7 @@ packages:
   /@types/cpx/1.5.0:
     resolution: {integrity: sha512-kuGK3lZqEvHTSDbJcaA6tcPoEXV4/e88YrltZMcQUewZhzYQwNSTMGIiPBqeeFd4LCBo1CX5U6CV6LaHG3wXSg==}
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 14.14.31
     dev: false
 
   /@types/debug/4.1.7:
@@ -8657,6 +8657,10 @@ packages:
 
   /@types/node/12.20.24:
     resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
+    dev: false
+
+  /@types/node/14.14.31:
+    resolution: {integrity: sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==}
     dev: false
 
   /@types/node/14.18.22:

--- a/editor/frontend/package.json
+++ b/editor/frontend/package.json
@@ -36,18 +36,24 @@
     "url": "http://www.bentley.com"
   },
   "peerDependencies": {
+    "@itwin/appui-abstract": "workspace:^3.3.0-dev.77",
     "@itwin/core-bentley": "workspace:^3.3.0-dev.77",
-    "@itwin/core-common": "workspace:^3.3.0-dev.77"
+    "@itwin/core-common": "workspace:^3.3.0-dev.77",
+    "@itwin/core-frontend": "workspace:^3.3.0-dev.77",
+    "@itwin/core-geometry": "workspace:^3.3.0-dev.77"
   },
   "//devDependencies": [
     "NOTE: All peerDependencies should also be listed as devDependencies since peerDependencies are not considered by npm install",
     "NOTE: All tools used by scripts in this package must be listed as devDependencies"
   ],
   "devDependencies": {
+    "@itwin/appui-abstract": "workspace:*",
     "@itwin/build-tools": "workspace:*",
     "@itwin/certa": "workspace:*",
     "@itwin/core-bentley": "workspace:*",
     "@itwin/core-common": "workspace:*",
+    "@itwin/core-frontend": "workspace:*",
+    "@itwin/core-geometry": "workspace:*",
     "@itwin/eslint-plugin": "workspace:*",
     "cpx2": "^3.0.0",
     "eslint": "^7.11.0",
@@ -59,10 +65,7 @@
     "NOTE: editor-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
   ],
   "dependencies": {
-    "@itwin/core-frontend": "workspace:*",
-    "@itwin/core-geometry": "workspace:*",
-    "@itwin/editor-common": "workspace:*",
-    "@itwin/appui-abstract": "workspace:*"
+    "@itwin/editor-common": "workspace:*"
   },
   "eslintConfig": {
     "plugins": [


### PR DESCRIPTION
In its current state, an application that imports both core-frontend and editor-frontend will fail when the extension runtime attempts to hoist:

<img width="403" alt="image" src="https://user-images.githubusercontent.com/6283674/181313441-e881916f-e5ce-4e39-9a93-7214f43dec2e.png">

This is technically a breaking change for any consumers of editor-frontend that are not currently importing core-frontend, appui-abstract, and core-geometry, if any exist. 