### PR TITLE
Presentation: ModelsTree might ignore some children when changing parent visbility

### DIFF
--- a/common/changes/@itwin/appui-react/presentation-models_tree_handle_all_grouped_elements_2022-07-29-06-37.json
+++ b/common/changes/@itwin/appui-react/presentation-models_tree_handle_all_grouped_elements_2022-07-29-06-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "[ModelsTree]: Make sure all child elements visibility is changed",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsVisibilityHandler.ts
+++ b/ui/appui-react/src/appui-react/imodel-components/models-tree/ModelsVisibilityHandler.ts
@@ -15,6 +15,7 @@ import { IFilteredPresentationTreeDataProvider, IPresentationTreeDataProvider } 
 import { Presentation } from "@itwin/presentation-frontend";
 import { UiFramework } from "../../UiFramework";
 import { IVisibilityHandler, VisibilityChangeListener, VisibilityStatus } from "../VisibilityTreeEventHandler";
+import { CachingElementIdsContainer } from "./Utils";
 
 /**
  * Visibility tree node types.
@@ -445,15 +446,19 @@ class SubjectModelIdsCache {
     this._subjectsHierarchy = new Map();
     const targetPartitionSubjects = new Map<Id64String, Id64String[]>();
     for await (const subject of querySubjects()) {
+      // istanbul ignore else
       if (subject.parentId)
         pushToMap(this._subjectsHierarchy, subject.parentId, subject.id);
+      // istanbul ignore if
       if (subject.targetPartitionId)
         pushToMap(targetPartitionSubjects, subject.targetPartitionId, subject.id);
     }
 
     this._subjectModels = new Map();
     for await (const model of queryModels()) {
+      // istanbul ignore next
       const subjectIds = targetPartitionSubjects.get(model.id) ?? [];
+      // istanbul ignore else
       if (!subjectIds.includes(model.parentId))
         subjectIds.push(model.parentId);
 
@@ -528,6 +533,7 @@ class ElementIdsCache {
   }
 }
 
+// istanbul ignore next
 async function* createInstanceIdsGenerator(imodel: IModelConnection, rulesetId: string, displayType: string, inputKeys: Keys) {
   const res = await Presentation.presentation.getContentInstanceKeys({
     imodel,
@@ -541,28 +547,11 @@ async function* createInstanceIdsGenerator(imodel: IModelConnection, rulesetId: 
 }
 
 // istanbul ignore next
-class CachingElementIdsContainer {
-  private _generator;
-  private _ids;
-  constructor(generator: AsyncGenerator<Id64String>) {
-    this._generator = generator;
-    this._ids = new Array<Id64String>();
-  }
-  public async* getElementIds() {
-    for (const id of this._ids) {
-      yield id;
-    }
-    for await (const id of this._generator) {
-      this._ids.push(id);
-      yield id;
-    }
-  }
-}
-
 function createAssemblyElementIdsContainer(imodel: IModelConnection, rulesetId: string, assemblyId: Id64String) {
   return new CachingElementIdsContainer(createInstanceIdsGenerator(imodel, rulesetId, "AssemblyElementsRequest", [{ className: "BisCore:Element", id: assemblyId }]));
 }
 
+// istanbul ignore next
 async function createGroupedElementsInfo(imodel: IModelConnection, rulesetId: string, groupingNodeKey: GroupingNodeKey) {
   const groupedElementIdsContainer = new CachingElementIdsContainer(createInstanceIdsGenerator(imodel, rulesetId, "AssemblyElementsRequest", [groupingNodeKey]));
   const elementId = await groupedElementIdsContainer.getElementIds().next();

--- a/ui/appui-react/src/appui-react/imodel-components/models-tree/Utils.ts
+++ b/ui/appui-react/src/appui-react/imodel-components/models-tree/Utils.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Id64String } from "@itwin/core-bentley";
+
+/** @internal */
+export class CachingElementIdsContainer {
+  private _ids = new Array<Id64String>();
+  constructor(private _generator: AsyncGenerator<Id64String>) {
+  }
+
+  private async next() {return (await this._generator.next()).value;}
+
+  public async* getElementIds() {
+    for (const id of this._ids) {
+      yield id;
+    }
+
+    let nextId;
+    while (nextId = await this.next()) {
+      this._ids.push(nextId);
+      yield nextId;
+    }
+  }
+}

--- a/ui/appui-react/src/test/imodel-components/models-tree/ModelsVisibilityHandler.test.ts
+++ b/ui/appui-react/src/test/imodel-components/models-tree/ModelsVisibilityHandler.test.ts
@@ -17,6 +17,7 @@ import { createRandomId } from "@itwin/presentation-common/lib/cjs/test";
 import { FilteredPresentationTreeDataProvider } from "@itwin/presentation-components";
 import { IModelHierarchyChangeEventArgs, Presentation, PresentationManager } from "@itwin/presentation-frontend";
 import { ModelsVisibilityHandler, ModelsVisibilityHandlerProps } from "../../../appui-react/imodel-components/models-tree/ModelsVisibilityHandler";
+import { CachingElementIdsContainer } from "../../../appui-react/imodel-components/models-tree/Utils";
 import { TestUtils } from "../../TestUtils";
 import { createCategoryNode, createElementClassGroupingNode, createElementNode, createModelNode, createSubjectNode } from "../Common";
 
@@ -1644,4 +1645,32 @@ describe("ModelsVisibilityHandler", () => {
 
   });
 
+});
+
+describe("CachingElementIdsContainer", () => {
+  const ids = ["1", "2", "3", "4", "5"];
+  const generator = async function *generator() {
+    for (const id of ids) {
+      yield id;
+    }
+  };
+
+  it("returns correct ids if previously was not fully iterated", async () => {
+    const container = new CachingElementIdsContainer(generator());
+
+    let actualIds: string[] = [];
+    // validate first id
+    for await (const id of container.getElementIds()) {
+      actualIds.push(id);
+      break;
+    }
+    expect(actualIds).to.have.lengthOf(1);
+
+    actualIds = [];
+    // validated that all ids are still returned
+    for await (const id of container.getElementIds()) {
+      actualIds.push(id);
+    }
+    expect(actualIds).to.have.lengthOf(ids.length);
+  });
 });


### PR DESCRIPTION
In some cases ModelsTree might ignore children when changing ancestor visibility because we were reusing AsyncGenerator in `for await` loop. Generator is [closed when for loop terminates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#do_not_reuse_generators). This caused some element ids to be lost in cases we didn't iterator over all children.