### PR TITLE
add keytar as an external

### DIFF
--- a/common/changes/@itwin/core-webpack-tools/webpack4-electron_2022-07-29-13-28.json
+++ b/common/changes/@itwin/core-webpack-tools/webpack4-electron_2022-07-29-13-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-webpack-tools",
+      "comment": "Add `keytar` to list of externals",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-webpack-tools"
+}

--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -43,7 +43,7 @@ steps:
       project: 2c48216e-e72f-48b4-a4eb-40ff1c04e8e4
       pipeline: 6075
       buildVersionToDownload: specific
-      buildId: 1532966
+      buildId: 1594233
       allowPartiallySucceededBuilds: true
       artifactName: Bis Docs
     condition: and(succeeded(), eq('${{ parameters.downloadCurrentBuildArtifacts }}', false))

--- a/tools/webpack-core/src/plugins/BackendDefaultsPlugin.ts
+++ b/tools/webpack-core/src/plugins/BackendDefaultsPlugin.ts
@@ -75,6 +75,7 @@ export class BackendDefaultsPlugin {
         "node-report/api",
         "applicationinsights-native-metrics",
         "@opentelemetry/tracing",
+        "keytar",
       ]),
     ];
     plugins.forEach((p) => p.apply(compiler));


### PR DESCRIPTION
To make sure you can properly webpack an electron backend with webpack@4 before we upgrade to webpack@5