### PR TITLE
UI: Lock Navicube in Markup viewports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+
     {
       "name": "Attach to node process",
       "presentation": {
@@ -960,6 +961,39 @@
       ]
     },
     { /* PARTIAL */
+      "name": "[BACKEND] appui-test-app/standalone (chrome)",
+      "presentation": {
+        "hidden": true
+      },
+      "cwd": "${workspaceFolder}/test-apps/appui-test-app/standalone",
+      "type": "pwa-node",
+      "request": "launch",
+      "program": "${workspaceFolder}/test-apps/appui-test-app/standalone/lib/backend/main.js",
+      "outFiles": [
+        "${workspaceFolder}/test-apps/appui-test-app/standalone/lib/**/*.js",
+        "${workspaceFolder}/{core,clients,editor,presentation}/*/lib/**/*.js"
+      ],
+      "cascadeTerminateToConfigurations": [
+        "[FRONTEND] appui-test-app/standalone (chrome)"
+      ]
+    },
+    { /* PARTIAL */
+      "name": "[FRONTEND] appui-test-app/standalone (chrome)",
+      "presentation": {
+        "hidden": true
+      },
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3000/",
+      "outFiles": [
+        "${workspaceFolder}/test-apps/appui-test-app/standalone/lib/**/*.js",
+        "${workspaceFolder}/{core,clients,editor,ui,presentation}/*/lib/**/*.js"
+      ],
+      "cascadeTerminateToConfigurations": [
+        "[BACKEND] appui-test-app/standalone (chrome)"
+      ]
+    },
+    { /* PARTIAL */
       "name": "[BACKEND] display-test-app (chrome)",
       "presentation": {
         "hidden": true
@@ -1442,6 +1476,17 @@
       "configurations": [
         "[BACKEND] display-performance-test-app (chrome)",
         "[FRONTEND] display-performance-test-app (chrome)"
+      ]
+    },
+    {
+      "name": "appui-test-app/standalone (chrome)",
+      "presentation": {
+        "group": "1_TestApps",
+        "order": 1
+      },
+      "configurations": [
+        "[BACKEND] appui-test-app/standalone (chrome)",
+        "[FRONTEND] appui-test-app/standalone (chrome)"
       ]
     },
     {

--- a/common/changes/@itwin/imodel-components-react/raplemie-navcubeInMarkup_2022-07-29-21-15.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-navcubeInMarkup_2022-07-29-21-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Navicube is now locked when Markup is active",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.tsx
@@ -10,7 +10,7 @@ import "./CubeNavigationAid.scss";
 import classnames from "classnames";
 import * as React from "react";
 import { Angle, AxisIndex, AxisOrder, Geometry, Matrix3d, Point2d, Vector2d, Vector3d, XYAndZ } from "@itwin/core-geometry";
-import { IModelConnection, Viewport } from "@itwin/core-frontend";
+import { IModelApp, IModelConnection, Viewport } from "@itwin/core-frontend";
 import { CommonProps } from "@itwin/core-react";
 import { UiIModelComponents } from "../UiIModelComponents";
 import { ViewportComponentEvents, ViewRotationChangeEventArgs } from "../viewport/ViewportComponentEvents";
@@ -291,9 +291,21 @@ export class CubeNavigationAid extends React.Component<CubeNavigationAidProps, C
   }
 
   private _handleCellHoverChange = (vect: Vector3d, state: CubeHover) => {
+    if (this._isInteractionLocked()) {
+      this.props.onAnimationEnd?.();
+      return;
+    }
     const hoverMap = this.state.hoverMap;
     hoverMap[`${vect.x}-${vect.y}-${vect.z}`] = state;
     this.setState({ hoverMap });
+  };
+
+  private _isInteractionLocked = () => {
+    // Locked by markup
+    if(undefined !== this.props.viewport && this.props.viewport === IModelApp.toolAdmin.markupView) {
+      return true;
+    }
+    return false;
   };
 
   private static _getMatrixFace = (rotMatrix: Matrix3d): Face => {
@@ -423,6 +435,11 @@ export class CubeNavigationAid extends React.Component<CubeNavigationAidProps, C
   }
 
   private _onArrowClick = (arrow: Pointer) => {
+    if (this._isInteractionLocked()) {
+      // istanbul ignore next
+      this.props.onAnimationEnd?.();
+      return;
+    }
     const { newRotation, face } = this.getArrowRotationAndFace(arrow);
     this._animateRotation(newRotation, face);
   };
@@ -454,6 +471,10 @@ export class CubeNavigationAid extends React.Component<CubeNavigationAidProps, C
   }
 
   private _handleBoxMouseDown = (event: any) => {
+    if (this._isInteractionLocked()) {
+      this.props.onAnimationEnd?.();
+      return;
+    }
     event.preventDefault();
     // only start listening after drag is confirmed. Ie. the 3D box is clicked.
     window.addEventListener("mousemove", this._onMouseMove, false);
@@ -480,6 +501,10 @@ export class CubeNavigationAid extends React.Component<CubeNavigationAidProps, C
 
   // istanbul ignore next - unable to test touch
   private _handleBoxTouchStart = (event: any) => {
+    if (this._isInteractionLocked()) {
+      this.props.onAnimationEnd?.();
+      return;
+    }
     if (1 !== event.targetTouches.length)
       return;
     window.addEventListener("touchmove", this._onTouchMove, false);
@@ -511,6 +536,10 @@ export class CubeNavigationAid extends React.Component<CubeNavigationAidProps, C
   };
 
   private _handleFaceCellClick = (pos: Vector3d, face: Face) => {
+    if (this._isInteractionLocked()) {
+      this.props.onAnimationEnd?.();
+      return;
+    }
     const { endRotMatrix } = this.state;
     let rotMatrix = Matrix3d.createRigidViewAxesZTowardsEye(pos.x, pos.y, pos.z).inverse();
     // istanbul ignore else

--- a/ui/imodel-components-react/src/test/navigationaids/CubeNavigationAid.test.tsx
+++ b/ui/imodel-components-react/src/test/navigationaids/CubeNavigationAid.test.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { AxisIndex, Matrix3d, Transform, Vector3d } from "@itwin/core-geometry";
-import { DrawingViewState, IModelConnection, ScreenViewport } from "@itwin/core-frontend";
+import { DrawingViewState, IModelApp, IModelConnection, ScreenViewport, ToolAdmin } from "@itwin/core-frontend";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { TestUtils } from "../TestUtils";
 import { CubeHover, CubeNavigationAid, CubeNavigationHitBoxX, CubeNavigationHitBoxY, CubeNavigationHitBoxZ, FaceCell, NavCubeFace } from "../../imodel-components-react/navigationaids/CubeNavigationAid";
@@ -66,6 +66,9 @@ describe("CubeNavigationAid", () => {
   };
 
   describe("<CubeNavigationAid />", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
     it("should render", () => {
       render(<CubeNavigationAid iModelConnection={connection.object} />);
     });
@@ -74,205 +77,241 @@ describe("CubeNavigationAid", () => {
       const navAid = component.getByTestId("components-cube-navigation-aid");
       expect(navAid).to.exist;
     });
-    it("should change from top to front when arrow clicked", async () => {
-      const animationEnd = sinon.fake();
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} />);
+    [vp.object, undefined].map((lockedViewport) =>{
+      const shouldStr = !!lockedViewport ? "locked cube should not" : "should";
+      it(`${shouldStr} change from top to front when arrow clicked`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const animationEnd = sinon.fake();
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} viewport={lockedViewport} />);
 
-      const topFace = component.getByTestId("components-cube-face-top");
-      const pointerButton = component.getByTestId("cube-pointer-button-down");
+        const topFace = component.getByTestId("components-cube-face-top");
+        const pointerButton = component.getByTestId("cube-pointer-button-down");
 
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
 
-      pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+        pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
 
-      await waitForSpy(animationEnd);
+        await waitForSpy(animationEnd);
 
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(1, 0, 0, 0, 0, -1, 0, 1, 0))).is.true;
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(1, 0, 0, 0, 0, -1, 0, 1, 0);
+
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} change from top to back when arrow clicked`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const animationEnd = sinon.fake();
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const pointerButton = component.getByTestId("cube-pointer-button-up");
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+
+        pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+
+        await waitForSpy(animationEnd);
+
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(-1, 0, 0, 0, 0, -1, 0, -1, 0);
+
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} change from top to left when arrow clicked`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const animationEnd = sinon.fake();
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const pointerButton = component.getByTestId("cube-pointer-button-left");
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+
+        pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+
+        await waitForSpy(animationEnd);
+
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0, 1, 0, 0, 0, -1, -1, 0, 0);
+
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} change from top to right when arrow clicked`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const animationEnd = sinon.fake();
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const pointerButton = component.getByTestId("cube-pointer-button-right");
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+
+        pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+
+        await waitForSpy(animationEnd);
+
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0, -1, 0, 0, 0, -1, 1, 0, 0);
+
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} highlight hovered cell`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} viewport={lockedViewport} />);
+
+        const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
+
+        expect(topCenterCell.classList.contains("cube-hover")).to.be.false;
+
+        topCenterCell.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, cancelable: true, view: window }));
+
+        const expected = !lockedViewport;
+
+        expect(topCenterCell.classList.contains("cube-hover")).to.equal(expected);
+      });
+      it(`${shouldStr} click center cell`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
+
+        expect(topCenterCell.classList.contains("cube-active")).to.be.false;
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+
+        topCenterCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
+        expect(topCenterCell.classList.contains("cube-active")).to.equal(!lockedViewport);
+
+        topCenterCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
+
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createIdentity();
+
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} click corner cell`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const animationEnd = sinon.fake();
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const topCornerCell = component.getByTestId("nav-cube-face-cell-top-1-0-1");
+
+        expect(topCornerCell.classList.contains("cube-active")).to.be.false;
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+        topCornerCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
+        expect(topCornerCell.classList.contains("cube-active")).to.equal(!lockedViewport);
+        topCornerCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
+        await waitForSpy(animationEnd);
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0, -1, 0, 0.70710678, 0, -0.70710678, 0.70710678, 0, 0.70710678);
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} switch from edge to top face`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const animationEnd = sinon.fake();
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const topEdgeCell = component.getByTestId("nav-cube-face-cell-top-1-0-1");
+        const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+        topEdgeCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
+        topEdgeCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
+        await waitForSpy(animationEnd);
+
+        const expectedMatrixTemp = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0, -1, 0, 0.70710678, 0, -0.70710678, 0.70710678, 0, 0.70710678);
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrixTemp)).is.true;
+        animationEnd.resetHistory();
+        topCenterCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
+        topCenterCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
+        await waitForSpy(animationEnd);
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0, -1, 0, 1, 0, 0, 0, 0, 1);
+        const mat3 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat3.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} switch from edge to bottom face`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const animationEnd = sinon.fake();
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const bottomCornerCell = component.getByTestId("nav-cube-face-cell-bottom--1-0--1");
+        const bottomCornerCenter = component.getByTestId("nav-cube-face-cell-bottom-0-0--1");
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+        bottomCornerCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
+        bottomCornerCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
+        await waitForSpy(animationEnd);
+
+        const expectedMatrixTemp = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0, 1, 0, 0.70710678, 0, -0.70710678, -0.70710678, 0, -0.70710678);
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrixTemp)).is.true;
+
+        animationEnd.resetHistory();
+        bottomCornerCenter.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
+        bottomCornerCenter.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
+        await waitForSpy(animationEnd);
+
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0, 1, 0, 1, 0, 0, 0, 0, -1);
+        const mat3 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat3.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it(`${shouldStr} drag cube`, async () => {
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
+
+        expect(topCenterCell.classList.contains("cube-active")).to.be.false;
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+        topCenterCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window, clientX: 2, clientY: 2 }));
+        topCenterCell.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, cancelable: true, view: window, clientX: 10, clientY: 2 }));
+        topCenterCell.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, cancelable: true, view: window, clientX: 20, clientY: 2 }));
+        topCenterCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window, clientX: 20, clientY: 2 }));
+        const expectedMatrix = !!lockedViewport ? mat.matrix : Matrix3d.createRowValues(0.62160997, 0.7833269, 0, -0.7833269, 0.62160997, 0, 0, 0, 1);
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
+      });
+      it.skip(`${shouldStr} touch drag cube`, async () => { // Touch isn't currently supported so we can't test it...
+        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
+        const component = render(<CubeNavigationAid iModelConnection={connection.object} viewport={lockedViewport} />);
+
+        const topFace = component.getByTestId("components-cube-face-top");
+        const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
+
+        expect(topCenterCell.classList.contains("cube-active")).to.be.false;
+
+        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
+        const touchStart = new Touch({ identifier: 0, target: topCenterCell, clientX: 2, clientY: 2 }); // <== ReferenceError: Touch is not defined
+        const touchMove1 = new Touch({ identifier: 0, target: topCenterCell, clientX: 10, clientY: 2 });
+        const touchMove2 = new Touch({ identifier: 0, target: topCenterCell, clientX: 20, clientY: 2 });
+        const touchEnd = new Touch({ identifier: 0, target: topCenterCell, clientX: 20, clientY: 2 });
+        topCenterCell.dispatchEvent(new TouchEvent("touchstart", { bubbles: true, cancelable: true, view: window, touches: [touchStart], changedTouches: [touchStart], targetTouches: [touchStart] }));
+        topCenterCell.dispatchEvent(new TouchEvent("touchmove", { bubbles: true, cancelable: true, view: window, touches: [touchMove1], changedTouches: [touchMove1], targetTouches: [touchMove1] }));
+        topCenterCell.dispatchEvent(new TouchEvent("touchmove", { bubbles: true, cancelable: true, view: window, touches: [touchMove2], changedTouches: [touchMove2], targetTouches: [touchMove2] }));
+        topCenterCell.dispatchEvent(new TouchEvent("touchend", { bubbles: true, cancelable: true, view: window, touches: [touchEnd], changedTouches: [touchEnd] }));
+        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
+        expect(mat2.isIdentity).to.equal(!!lockedViewport);
+      });
     });
-    it("should change from top to back when arrow clicked", async () => {
-      const animationEnd = sinon.fake();
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} />);
 
-      const topFace = component.getByTestId("components-cube-face-top");
-      const pointerButton = component.getByTestId("cube-pointer-button-up");
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-
-      pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
-
-      await waitForSpy(animationEnd);
-
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(-1, 0, 0, 0, 0, -1, 0, -1, 0))).is.true;
-    });
-    it("should change from top to left when arrow clicked", async () => {
-      const animationEnd = sinon.fake();
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const pointerButton = component.getByTestId("cube-pointer-button-left");
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-
-      pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
-
-      await waitForSpy(animationEnd);
-
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(0, 1, 0, 0, 0, -1, -1, 0, 0))).is.true;
-    });
-    it("should change from top to right when arrow clicked", async () => {
-      const animationEnd = sinon.fake();
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const pointerButton = component.getByTestId("cube-pointer-button-right");
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-
-      pointerButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
-
-      await waitForSpy(animationEnd);
-
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(0, -1, 0, 0, 0, -1, 1, 0, 0))).is.true;
-    });
-    it("should highlight hovered cell", async () => {
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} />);
-
-      const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
-
-      expect(topCenterCell.classList.contains("cube-hover")).to.be.false;
-
-      topCenterCell.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, cancelable: true, view: window }));
-
-      expect(topCenterCell.classList.contains("cube-hover")).to.be.true;
-    });
-    it("should click center cell", async () => {
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
-
-      expect(topCenterCell.classList.contains("cube-active")).to.be.false;
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-      topCenterCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
-      expect(topCenterCell.classList.contains("cube-active")).to.be.true;
-      topCenterCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-    });
-    it("should click corner cell", async () => {
-      const animationEnd = sinon.fake();
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const topCornerCell = component.getByTestId("nav-cube-face-cell-top-1-0-1");
-
-      expect(topCornerCell.classList.contains("cube-active")).to.be.false;
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-      topCornerCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
-      expect(topCornerCell.classList.contains("cube-active")).to.be.true;
-      topCornerCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
-      await waitForSpy(animationEnd);
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(0, -1, 0, 0.70710678, 0, -0.70710678, 0.70710678, 0, 0.70710678))).is.true;
-    });
-    it("should switch from edge to top face", async () => {
-      const animationEnd = sinon.fake();
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const topEdgeCell = component.getByTestId("nav-cube-face-cell-top-1-0-1");
-      const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-      topEdgeCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
-      topEdgeCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
-      await waitForSpy(animationEnd);
-
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(0, -1, 0, 0.70710678, 0, -0.70710678, 0.70710678, 0, 0.70710678))).is.true;
-      animationEnd.resetHistory();
-      topCenterCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
-      topCenterCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
-      await waitForSpy(animationEnd);
-      const mat3 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat3.matrix.isAlmostEqual(Matrix3d.createRowValues(0, -1, 0, 1, 0, 0, 0, 0, 1))).is.true;
-    });
-    it("should switch from edge to bottom face", async () => {
-      const animationEnd = sinon.fake();
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} animationTime={.1} onAnimationEnd={animationEnd} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const bottomCornerCell = component.getByTestId("nav-cube-face-cell-bottom--1-0--1");
-      const bottomCornerCenter = component.getByTestId("nav-cube-face-cell-bottom-0-0--1");
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-      bottomCornerCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
-      bottomCornerCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
-      await waitForSpy(animationEnd);
-
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(0, 1, 0, 0.70710678, 0, -0.70710678, -0.70710678, 0, -0.70710678))).is.true;
-
-      animationEnd.resetHistory();
-      bottomCornerCenter.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window }));
-      bottomCornerCenter.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window }));
-      await waitForSpy(animationEnd);
-
-      const mat3 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat3.matrix.isAlmostEqual(Matrix3d.createRowValues(0, 1, 0, 1, 0, 0, 0, 0, -1))).is.true;
-    });
-    it("should drag cube", async () => {
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
-
-      expect(topCenterCell.classList.contains("cube-active")).to.be.false;
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-      topCenterCell.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true, view: window, clientX: 2, clientY: 2 }));
-      topCenterCell.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, cancelable: true, view: window, clientX: 10, clientY: 2 }));
-      topCenterCell.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, cancelable: true, view: window, clientX: 20, clientY: 2 }));
-      topCenterCell.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, view: window, clientX: 20, clientY: 2 }));
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.matrix.isAlmostEqual(Matrix3d.createRowValues(0.62160997, 0.7833269, 0, -0.7833269, 0.62160997, 0, 0, 0, 1))).is.true;
-    });
-    it.skip("should touch drag cube", async () => { // Touch isn't currently supported so we can't test it...
-      const component = render(<CubeNavigationAid iModelConnection={connection.object} />);
-
-      const topFace = component.getByTestId("components-cube-face-top");
-      const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
-
-      expect(topCenterCell.classList.contains("cube-active")).to.be.false;
-
-      const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-      const touchStart = new Touch({ identifier: 0, target: topCenterCell, clientX: 2, clientY: 2 }); // <== ReferenceError: Touch is not defined
-      const touchMove1 = new Touch({ identifier: 0, target: topCenterCell, clientX: 10, clientY: 2 });
-      const touchMove2 = new Touch({ identifier: 0, target: topCenterCell, clientX: 20, clientY: 2 });
-      const touchEnd = new Touch({ identifier: 0, target: topCenterCell, clientX: 20, clientY: 2 });
-      topCenterCell.dispatchEvent(new TouchEvent("touchstart", { bubbles: true, cancelable: true, view: window, touches: [touchStart], changedTouches: [touchStart], targetTouches: [touchStart] }));
-      topCenterCell.dispatchEvent(new TouchEvent("touchmove", { bubbles: true, cancelable: true, view: window, touches: [touchMove1], changedTouches: [touchMove1], targetTouches: [touchMove1] }));
-      topCenterCell.dispatchEvent(new TouchEvent("touchmove", { bubbles: true, cancelable: true, view: window, touches: [touchMove2], changedTouches: [touchMove2], targetTouches: [touchMove2] }));
-      topCenterCell.dispatchEvent(new TouchEvent("touchend", { bubbles: true, cancelable: true, view: window, touches: [touchEnd], changedTouches: [touchEnd] }));
-      const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-      expect(mat2.isIdentity).is.false;
-    });
     describe("onViewRotationChangeEvent", () => {
       beforeEach(() => {
         rotation = Matrix3d.createIdentity();


### PR DESCRIPTION
This uses the same technique as the ViewTools to prevent interactions with the NavCube.

fixes iTwin/itwinjs-backlog#296