### PR TITLE
Fix widget duplication in send back action

### DIFF
--- a/common/changes/@itwin/appui-layout-react/send-back-fix_2022-08-04-12-33.json
+++ b/common/changes/@itwin/appui-layout-react/send-back-fix_2022-08-04-12-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Fix widget duplication in send back action.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/base/NineZoneState.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/base/NineZoneState.ts
@@ -592,35 +592,36 @@ export const NineZoneStateReducer: (state: NineZoneState, action: NineZoneAction
       const widget = state.widgets[action.id];
       const home = floatingWidget.home;
       const panel = state.panels[home.side];
-      let homeWidget;
-      if (home.widgetId) {
-        homeWidget = state.widgets[home.widgetId];
-      } else if (panel.widgets.length === panel.maxWidgetCount) {
+      const destinationWidgetId = home.widgetId ?? getWidgetPanelSectionId(panel.side, home.widgetIndex);
+
+      let destinationWidget = state.widgets[destinationWidgetId];
+
+      // Use existing panel section (from widgetIndex) if new widgets can't be added to the panel.
+      if (!destinationWidget && panel.widgets.length === panel.maxWidgetCount) {
         const id = panel.widgets[home.widgetIndex];
-        homeWidget = state.widgets[id];
+        destinationWidget = state.widgets[id];
       }
 
-      if (homeWidget) {
-        // Add tabs to an existing widget.
-        homeWidget.tabs.push(...widget.tabs);
+      // Add tabs to an existing widget.
+      if (destinationWidget) {
+        destinationWidget.tabs.push(...widget.tabs);
         removeWidget(state, widget.id);
         return;
       }
 
-      const destinationWidgetContainerName = home.widgetId ?? getWidgetPanelSectionId(panel.side, home.widgetIndex);
-      // if widget container was removed because it was empty insert it
-      state.widgets[destinationWidgetContainerName] = {
+      // Add a new widget.
+      state.widgets[destinationWidgetId] = {
         activeTabId: widget.tabs[0],
-        id: destinationWidgetContainerName,
+        id: destinationWidgetId,
         minimized: false,
         tabs: [...widget.tabs],
       };
 
-      let insertIndex = destinationWidgetContainerName.endsWith("End") ? 1 : 0;
+      let insertIndex = destinationWidgetId.endsWith("End") ? 1 : 0;
       // istanbul ignore next
       if (0 === panel.widgets.length)
         insertIndex = 0;
-      panel.widgets.splice(insertIndex, 0, destinationWidgetContainerName);
+      panel.widgets.splice(insertIndex, 0, destinationWidgetId);
       widget.minimized = false;
 
       removeWidget(state, widget.id);

--- a/ui/appui-layout-react/src/test/base/NineZoneState.test.ts
+++ b/ui/appui-layout-react/src/test/base/NineZoneState.test.ts
@@ -773,6 +773,7 @@ describe("NineZoneStateReducer", () => {
       expect(newState.floatingWidgets.byId.fw1.hidden).to.be.true;
       should().not.exist(newState.widgets.fw1);
     });
+
     it("should find saved state when re-adding a floating widget", () => {
       let state = createNineZoneState();
       state = addPanelWidget(state, "left", "leftStart", ["t1"], {
@@ -803,6 +804,33 @@ describe("NineZoneStateReducer", () => {
       expect(floatedState?.floatingWidgets.byId.fw1.hidden).to.be.false;
     });
 
+    it("should send back to existing panel section", () => {
+      let state = createNineZoneState();
+      state = addFloatingWidget(state, "fw1", ["t1"], {
+        home: {
+          side: "left",
+          widgetId: undefined,
+          widgetIndex: 0,
+        },
+      });
+      state = addFloatingWidget(state, "fw2", ["t2"], {
+        home: {
+          side: "left",
+          widgetId: undefined,
+          widgetIndex: 0,
+        },
+      });
+      let newState = NineZoneStateReducer(state, {
+        type: "FLOATING_WIDGET_SEND_BACK",
+        id: "fw1",
+      });
+      newState = NineZoneStateReducer(newState, {
+        type: "FLOATING_WIDGET_SEND_BACK",
+        id: "fw2",
+      });
+      newState.panels.left.widgets.should.eql(["leftStart"]);
+      newState.widgets.leftStart.tabs.should.eql(["t1", "t2"]);
+    });
   });
 
   describe("FLOATING_WIDGET_RESIZE", () => {
@@ -1431,12 +1459,14 @@ describe("float widget tab", () => {
     });
 
     // restore widget tab "t1" back to original "rightStart" location
-    const dockedState = dockWidgetContainer(newState!, "t1");
+    const dockedState = dockWidgetContainer(newState!, "t1")!;
     // exercise code that return if already docked
     dockWidgetContainer(newState!, "t1");
     expect(dockedState).to.not.be.undefined;
-    // console.log (JSON.stringify(dockedState)); // eslint-disable-line no-console
-    dockedState!.widgets.rightStart.tabs.indexOf("t1").should.not.eq(-1);
+
+    // Should be docked to existing widget w/ index of 0 - `rightMiddle`, since `maxWidgetCount` is 2.
+    dockedState.panels.right.widgets.should.eql(["rightMiddle", "rightEnd"]);
+    dockedState.widgets.rightMiddle.tabs.should.eql(["t2", "t1"]);
   });
 
   it("should apply position and preferred size", () => {
@@ -1467,9 +1497,9 @@ describe("float widget tab", () => {
     });
 
     // restore widget tab "t1" back to original "rightStart" location
-    const dockedState = dockWidgetContainer(newState!, "t1");
+    const dockedState = dockWidgetContainer(newState!, "t1")!;
     expect(dockedState).to.not.be.undefined;
-    dockedState!.widgets.rightStart.tabs.indexOf("t1").should.not.eq(-1);
+    dockedState.widgets.rightMiddle.tabs.should.eql(["t2", "t1"]);
   });
 
   it("should apply default position {x:50, y:100} and size {height:400, width:400}", () => {
@@ -1501,12 +1531,11 @@ describe("float widget tab", () => {
     });
 
     // restore widget tab "t1" back to original "rightStart" location
-    const dockedState = dockWidgetContainer(newState!, "t1");
+    const dockedState = dockWidgetContainer(newState!, "t1")!;
     // exercise code that return if already docked
     dockWidgetContainer(newState!, "t1");
     expect(dockedState).to.not.be.undefined;
-    // console.log (JSON.stringify(dockedState)); // eslint-disable-line no-console
-    dockedState!.widgets.rightStart.tabs.indexOf("t1").should.not.eq(-1);
+    dockedState.widgets.rightMiddle.tabs.should.eql(["t2", "t1"]);
   });
 
   it("should apply position and default size of (400,400)", () => {
@@ -1537,9 +1566,9 @@ describe("float widget tab", () => {
     });
 
     // restore widget tab "t1" back to original "rightStart" location
-    const dockedState = dockWidgetContainer(newState!, "t1");
+    const dockedState = dockWidgetContainer(newState!, "t1")!;
     expect(dockedState).to.not.be.undefined;
-    dockedState!.widgets.rightStart.tabs.indexOf("t1").should.not.eq(-1);
+    dockedState.widgets.rightMiddle.tabs.should.eql(["t2", "t1"]);
   });
 
   it("should properly handle multiple widget tabs", () => {


### PR DESCRIPTION
This PR fixes an issue where widgets are duplicated in the panel when multiple `FLOATING_WIDGET_SEND_BACK` actions are fired with the same home state.