### PR TITLE
Process IPC invokes sequentially

### DIFF
--- a/common/changes/@itwin/core-common/ipc-test-fix_2022-08-10-16-47.json
+++ b/common/changes/@itwin/core-common/ipc-test-fix_2022-08-10-16-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Test fix",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-common/ipc-test-fix_2022-08-10-16-47.json
+++ b/common/changes/@itwin/core-common/ipc-test-fix_2022-08-10-16-47.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-common",
-      "comment": "Test fix",
+      "comment": "Ensure IPC messages are processed sequentially on the backend",
       "type": "none"
     }
   ],

--- a/core/common/src/ipc/IpcWebSocket.ts
+++ b/core/common/src/ipc/IpcWebSocket.ts
@@ -131,6 +131,8 @@ export class IpcWebSocketFrontend extends IpcWebSocket implements IpcSocketFront
 /** @internal */
 export class IpcWebSocketBackend extends IpcWebSocket implements IpcSocketBackend {
   private _handlers = new Map<string, (event: Event, methodName: string, ...args: any[]) => Promise<any>>();
+  private _processingQueue: IpcWebSocketMessage[] = [];
+  private _processing: IpcWebSocketMessage | undefined;
 
   public constructor() {
     super();
@@ -151,25 +153,42 @@ export class IpcWebSocketBackend extends IpcWebSocket implements IpcSocketBacken
   }
 
   private async dispatch(_evt: Event, message: IpcWebSocketMessage) {
-    if (message.type !== IpcWebSocketMessageType.Invoke || !message.method)
+    if (message.type !== IpcWebSocketMessageType.Invoke)
       return;
 
-    const handler = this._handlers.get(message.channel);
-    if (!handler)
+    this._processingQueue.push(message);
+    this.processMessages();
+  }
+
+  private async processMessages() {
+    if (this._processing || !this._processingQueue.length) {
       return;
+    }
 
-    let args = message.data;
-    if (typeof (args) === "undefined")
-      args = [];
+    const message = this._processingQueue.shift();
+    if (message && message.method) {
+      const handler = this._handlers.get(message.channel);
+      if (handler) {
+        this._processing = message;
 
-    const response = await handler({} as any, message.method, ...args);
+        let args = message.data;
+        if (typeof (args) === "undefined")
+          args = [];
 
-    IpcWebSocket.transport.send({
-      type: IpcWebSocketMessageType.Response,
-      channel: message.channel,
-      response: message.request,
-      data: response,
-      sequence: -1,
-    });
+        const response = await handler({} as any, message.method, ...args);
+
+        IpcWebSocket.transport.send({
+          type: IpcWebSocketMessageType.Response,
+          channel: message.channel,
+          response: message.request,
+          data: response,
+          sequence: -1,
+        });
+
+        this._processing = undefined;
+      }
+    }
+
+    this.processMessages();
   }
 }

--- a/core/common/src/ipc/IpcWebSocket.ts
+++ b/core/common/src/ipc/IpcWebSocket.ts
@@ -157,7 +157,7 @@ export class IpcWebSocketBackend extends IpcWebSocket implements IpcSocketBacken
       return;
 
     this._processingQueue.push(message);
-    this.processMessages();
+    await this.processMessages();
   }
 
   private async processMessages() {
@@ -189,6 +189,6 @@ export class IpcWebSocketBackend extends IpcWebSocket implements IpcSocketBacken
       }
     }
 
-    this.processMessages();
+    await this.processMessages();
   }
 }


### PR DESCRIPTION
During the BriefcaseTxns tests, the frontend sends a purgeTileTrees RPC request and then a closeIModel IPC message.

When RPC is transported over IPC, this crashes occasionally on web.
The crash happens when the impl function for the first message (purgeTileTrees) awaits. This yields to the impl function for the second mesage (closeIModel). When control returns to purgeTileTrees, the imodel is gone.

When RPC is implemented using HTTP requests, there are two separate network connections. So, I think the purgeTileTrees request is able to complete fully (including any awaits, which only go out to the v8 microtask queue and do not spin the outer node/uv loop again, which would allow closeIModel IPC message to sneak in).

The fix here is to process IPC messages (including RPC ones) sequentially on the backend.

The frontend is correctly assuming here that everything is safe as long as the send order is correct.
I'm assuming that electron IPC must honor the send order (I didn't check how exactly) or we would see the same crash on that platform. Now, we do the same on web.