### PR TITLE
Make withOpenDb internal.

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4242,6 +4242,7 @@ export class SQLiteDb implements IDisposable {
         busyHandler?: CloudSqlite.WriteLockBusyHandler;
     },
     operation: (db: SQLiteDb) => Promise<void>): Promise<void>;
+    // @internal
     static withOpenDb<T>(args: {
         dbName: string;
         openMode?: OpenMode | SQLiteDb.OpenParams;

--- a/common/changes/@itwin/core-backend/withOpenDb-internal_2022-08-11-21-03.json
+++ b/common/changes/@itwin/core-backend/withOpenDb-internal_2022-08-11-21-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/SQLiteDb.ts
+++ b/core/backend/src/SQLiteDb.ts
@@ -83,6 +83,7 @@ export class SQLiteDb implements IDisposable {
    * 1. open a database
    * 2. call a function supplying the open SQliteDb as argument. If it is async, await its return.
    * 3. close the database (even if exceptions are thrown)
+   * @internal - will be made public in 3.3.4.
    */
   public static withOpenDb<T>(args: {
     /** The name of the database to open */


### PR DESCRIPTION
@kabentley has changed its signature in #4057. Rather than backport that change to 3.3, just mark it internal until 3.4 is released.