### PR TITLE
fix deletion of elements in transformer during branch reverse synchronization 

### DIFF
--- a/common/api/core-transformer.api.md
+++ b/common/api/core-transformer.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AccessToken } from '@itwin/core-bentley';
-import { BriefcaseDb } from '@itwin/core-backend';
 import { CodeSpec } from '@itwin/core-common';
 import { CompressedId64Set } from '@itwin/core-bentley';
 import * as ECSchemaMetaData from '@itwin/ecschema-metadata';
@@ -20,7 +19,6 @@ import { FontProps } from '@itwin/core-common';
 import { Id64String } from '@itwin/core-bentley';
 import { IModelCloneContext } from '@itwin/core-backend';
 import { IModelDb } from '@itwin/core-backend';
-import { IModelJsNative } from '@itwin/core-backend';
 import { Model } from '@itwin/core-backend';
 import { ModelProps } from '@itwin/core-common';
 import { Placement2d } from '@itwin/core-common';
@@ -41,12 +39,7 @@ export class IModelExporter {
     excludeElementsInCategory(categoryId: Id64String): void;
     excludeRelationshipClass(classFullName: string): void;
     exportAll(): Promise<void>;
-    exportChanges(user?: AccessToken, startChangesetId?: {
-        startChangesetId?: string;
-        changedInstanceIds?: ChangedInstanceIds;
-    }): Promise<void>;
-    // @deprecated (undocumented)
-    exportChanges(user: AccessToken | undefined, startChangesetId: string): Promise<void>;
+    exportChanges(user?: AccessToken, startChangesetId?: string): Promise<void>;
     exportChildElements(elementId: Id64String): Promise<void>;
     exportCodeSpecById(codeSpecId: Id64String): Promise<void>;
     exportCodeSpecByName(codeSpecName: string): Promise<void>;

--- a/common/api/core-transformer.api.md
+++ b/common/api/core-transformer.api.md
@@ -208,7 +208,7 @@ export class IModelTransformer extends IModelExportHandler {
     readonly importer: IModelImporter;
     initFromExternalSourceAspects(args?: InitFromExternalSourceAspectsArgs): Promise<void>;
     // @deprecated (undocumented)
-    initFromExternalSourceAspects(args?: InitFromExternalSourceAspectsArgs): void;
+    initFromExternalSourceAspects(): void;
     // @internal
     static readonly jsStateTable = "TransformerJsState";
     // @internal

--- a/common/api/core-transformer.api.md
+++ b/common/api/core-transformer.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AccessToken } from '@itwin/core-bentley';
+import { BriefcaseDb } from '@itwin/core-backend';
 import { CodeSpec } from '@itwin/core-common';
 import { CompressedId64Set } from '@itwin/core-bentley';
 import * as ECSchemaMetaData from '@itwin/ecschema-metadata';
@@ -19,6 +20,7 @@ import { FontProps } from '@itwin/core-common';
 import { Id64String } from '@itwin/core-bentley';
 import { IModelCloneContext } from '@itwin/core-backend';
 import { IModelDb } from '@itwin/core-backend';
+import { IModelJsNative } from '@itwin/core-backend';
 import { Model } from '@itwin/core-backend';
 import { ModelProps } from '@itwin/core-common';
 import { Placement2d } from '@itwin/core-common';
@@ -39,7 +41,12 @@ export class IModelExporter {
     excludeElementsInCategory(categoryId: Id64String): void;
     excludeRelationshipClass(classFullName: string): void;
     exportAll(): Promise<void>;
-    exportChanges(user?: AccessToken, startChangesetId?: string): Promise<void>;
+    exportChanges(user?: AccessToken, startChangesetId?: {
+        startChangesetId?: string;
+        changedInstanceIds?: ChangedInstanceIds;
+    }): Promise<void>;
+    // @deprecated (undocumented)
+    exportChanges(user: AccessToken | undefined, startChangesetId: string): Promise<void>;
     exportChildElements(elementId: Id64String): Promise<void>;
     exportCodeSpecById(codeSpecId: Id64String): Promise<void>;
     exportCodeSpecByName(codeSpecName: string): Promise<void>;
@@ -133,6 +140,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
     set autoExtendProjectExtents(val: Required<IModelImportOptions>["autoExtendProjectExtents"]);
     computeProjectExtents(): void;
     deleteElement(elementId: Id64String): void;
+    deleteModel(modelId: Id64String): void;
     deleteRelationship(relationshipProps: RelationshipProps): void;
     readonly doNotUpdateElementIds: Set<string>;
     protected getAdditionalStateJson(): any;
@@ -146,6 +154,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
     loadStateFromJson(state: IModelImporterState): void;
     protected onDeleteElement(elementId: Id64String): void;
     protected onDeleteElementAspect(targetElementAspect: ElementAspect): void;
+    protected onDeleteModel(modelId: Id64String): void;
     protected onDeleteRelationship(relationshipProps: RelationshipProps): void;
     protected onInsertElement(elementProps: ElementProps): Id64String;
     protected onInsertElementAspect(aspectProps: ElementAspectProps): void;
@@ -204,7 +213,9 @@ export class IModelTransformer extends IModelExportHandler {
     protected getAdditionalStateJson(): any;
     protected hasElementChanged(sourceElement: Element_2, targetElementId: Id64String): boolean;
     readonly importer: IModelImporter;
-    initFromExternalSourceAspects(): void;
+    initFromExternalSourceAspects(args?: InitFromExternalSourceAspectsArgs): Promise<void>;
+    // @deprecated (undocumented)
+    initFromExternalSourceAspects(args?: InitFromExternalSourceAspectsArgs): void;
     // @internal
     static readonly jsStateTable = "TransformerJsState";
     // @internal
@@ -212,7 +223,7 @@ export class IModelTransformer extends IModelExportHandler {
     protected loadAdditionalStateJson(_additionalState: any): void;
     protected loadStateFromDb(db: SQLiteDb): void;
     onDeleteElement(sourceElementId: Id64String): void;
-    onDeleteModel(_sourceModelId: Id64String): void;
+    onDeleteModel(sourceModelId: Id64String): void;
     onDeleteRelationship(sourceRelInstanceId: Id64String): void;
     onExportCodeSpec(sourceCodeSpec: CodeSpec): void;
     onExportElement(sourceElement: Element_2): void;

--- a/common/api/core-transformer.api.md
+++ b/common/api/core-transformer.api.md
@@ -283,6 +283,14 @@ export interface IModelTransformOptions {
 }
 
 // @beta
+export interface InitFromExternalSourceAspectsArgs {
+    // (undocumented)
+    accessToken?: AccessToken;
+    // (undocumented)
+    startChangesetId?: string;
+}
+
+// @beta
 export interface OptimizeGeometryOptions {
     inlineUniqueGeometryParts?: boolean;
 }

--- a/common/api/summary/core-transformer.exports.csv
+++ b/common/api/summary/core-transformer.exports.csv
@@ -8,6 +8,7 @@ internal;IModelImporterState
 beta;IModelImportOptions
 beta;IModelTransformer 
 beta;IModelTransformOptions
+beta;InitFromExternalSourceAspectsArgs
 beta;OptimizeGeometryOptions
 beta;TemplateModelCloner 
 public;TransformerLoggerCategory

--- a/common/changes/@itwin/core-backend/transformer-reverse-sync-no-delete_2022-08-12-18-07.json
+++ b/common/changes/@itwin/core-backend/transformer-reverse-sync-no-delete_2022-08-12-18-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "generate correct date format in local hub changesets",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-transformer/transformer-reverse-sync-no-delete_2022-08-12-18-07.json
+++ b/common/changes/@itwin/core-transformer/transformer-reverse-sync-no-delete_2022-08-12-18-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "fix element deletions in reverse synchronization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/backend/src/LocalHub.ts
+++ b/core/backend/src/LocalHub.ts
@@ -236,7 +236,7 @@ export class LocalHub {
       stmt.bindString(3, changeset.description);
       stmt.bindInteger(4, stats.size);
       stmt.bindInteger(5, changeset.changesType ?? 0);
-      stmt.bindString(6, changeset.pushDate ?? new Date().toString());
+      stmt.bindString(6, changeset.pushDate ?? new Date().toISOString());
       stmt.bindString(7, changeset.userCreated ?? "");
       stmt.bindInteger(8, changeset.briefcaseId);
       const rc = stmt.step();

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -809,8 +809,6 @@ class ChangedInstanceOps {
   public insertIds = new Set<Id64String>();
   public updateIds = new Set<Id64String>();
   public deleteIds = new Set<Id64String>();
-  /** for each deleted id if applicable, the identifier in the external source */
-  public deletedExternalSources = new Map<Id64String, Id64String>();
   public addFromJson(val: IModelJsNative.ChangedInstanceOpsProps | undefined): void {
     if (undefined !== val) {
       if ((undefined !== val.insert) && (Array.isArray(val.insert))) { val.insert.forEach((id: Id64String) => this.insertIds.add(id)); }
@@ -832,11 +830,11 @@ class ChangedInstanceIds {
   public static async initialize(accessToken: AccessToken | undefined, iModel: BriefcaseDb, firstChangesetId: string): Promise<ChangedInstanceIds> {
     const iModelId = iModel.iModelId;
     const first = (await IModelHost.hubAccess.queryChangeset({ iModelId, changeset: { id: firstChangesetId }, accessToken })).index;
-    const changedInstanceIds = new ChangedInstanceIds();
     const end = (await IModelHost.hubAccess.queryChangeset({ iModelId, changeset: { id: iModel.changeset.id }, accessToken })).index;
     const changesets = await IModelHost.hubAccess.downloadChangesets({ accessToken, iModelId, range: { first, end }, targetDir: BriefcaseManager.getChangeSetsPath(iModelId) });
-    const changesetFiles = changesets.map((c) => c.pathname);
 
+    const changedInstanceIds = new ChangedInstanceIds();
+    const changesetFiles = changesets.map((c) => c.pathname);
     const statusOrResult = iModel.nativeDb.extractChangedInstanceIdsFromChangeSets(changesetFiles);
     if (statusOrResult.error) {
       throw new IModelError(statusOrResult.error.status, "Error processing changeset");
@@ -849,10 +847,6 @@ class ChangedInstanceIds {
     changedInstanceIds.aspect.addFromJson(result.aspect);
     changedInstanceIds.relationship.addFromJson(result.relationship);
     changedInstanceIds.font.addFromJson(result.font);
-
-    if (changedInstanceIds.element === undefined)
-      return changedInstanceIds;
-
     return changedInstanceIds;
   }
 }

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -821,12 +821,7 @@ class ChangedInstanceIds {
   public font = new ChangedInstanceOps();
   private constructor() { }
 
-  public static async initialize(
-    accessToken: AccessToken | undefined,
-    iModel: BriefcaseDb,
-    firstChangesetId: string,
-    targetScopeElementId: Id64String
-  ): Promise<ChangedInstanceIds> {
+  public static async initialize(accessToken: AccessToken | undefined, iModel: BriefcaseDb, firstChangesetId: string): Promise<ChangedInstanceIds> {
     const iModelId = iModel.iModelId;
     const first = (await IModelHost.hubAccess.queryChangeset({ iModelId, changeset: { id: firstChangesetId }, accessToken })).index;
     const changedInstanceIds = new ChangedInstanceIds();

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -247,16 +247,8 @@ export class IModelExporter {
    * @param startChangesetId Include changes from this changeset up through and including the current changeset.
    * If this parameter is not provided, then just the current changeset will be exported.
    * @note To form a range of versions to export, set `startChangesetId` for the start (inclusive) of the desired range and open the source iModel as of the end (inclusive) of the desired range.
-   * Passing a string for the `options` (second) argument is deprecated, pass an object containing `startChangesetId` instead.
    */
-  public async exportChanges(user?: AccessToken, startChangesetId?: { startChangesetId?: string, changedInstanceIds?: ChangedInstanceIds }): Promise<void>;
-  /** @deprecated use an options object containing a `startChangesetId` property as the second argument instead of passing a string directly */
-  public async exportChanges(user: AccessToken | undefined, startChangesetId: string): Promise<void>;
-  // eslint-disable-next-line @typescript-eslint/unified-signatures
-  public async exportChanges(user?: AccessToken, optionsOrStartChangesetId: string | {
-    startChangesetId?: string;
-    changedInstanceIds?: ChangedInstanceIds;
-  } = {}): Promise<void> {
+  public async exportChanges(user?: AccessToken, startChangesetId?: string): Promise<void> {
     if (!this.sourceDb.isBriefcaseDb()) {
       throw new IModelError(IModelStatus.BadRequest, "Must be a briefcase to export changes");
     }
@@ -264,14 +256,10 @@ export class IModelExporter {
       await this.exportAll(); // no changesets, so revert to exportAll
       return;
     }
-    const options = typeof optionsOrStartChangesetId === "string" ? { startChangesetId: optionsOrStartChangesetId } : optionsOrStartChangesetId;
-    if (options.changedInstanceIds && options.startChangesetId) {
-      throw new IModelError(IModelStatus.BadRequest, "");
+    if (undefined === startChangesetId) {
+      startChangesetId = this.sourceDb.changeset.id;
     }
-    if (undefined === options.startChangesetId) {
-      options.startChangesetId = this.sourceDb.changeset.id;
-    }
-    this._sourceDbChanges = options.changedInstanceIds ?? await ChangedInstanceIds.initialize(user, this.sourceDb, options.startChangesetId);
+    this._sourceDbChanges = await ChangedInstanceIds.initialize(user, this.sourceDb, startChangesetId);
     await this.exportCodeSpecs();
     await this.exportFonts();
     await this.exportModelContents(IModel.repositoryModelId);

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -11,7 +11,7 @@ import { ECVersion, Schema, SchemaKey } from "@itwin/ecschema-metadata";
 import { CodeSpec, FontProps, IModel, IModelError } from "@itwin/core-common";
 import { TransformerLoggerCategory } from "./TransformerLoggerCategory";
 import {
-  BisCoreSchema, BriefcaseDb, BriefcaseManager, ChangeSummaryManager, DefinitionModel, ECSqlStatement, Element, ElementAspect,
+  BisCoreSchema, BriefcaseDb, BriefcaseManager, DefinitionModel, ECSqlStatement, Element, ElementAspect,
   ElementMultiAspect, ElementRefersToElements, ElementUniqueAspect, GeometricElement, IModelDb,
   IModelHost, IModelJsNative, IModelSchemaLoader, Model, RecipeDefinitionElement, Relationship, RelationshipProps,
 } from "@itwin/core-backend";

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -277,14 +277,21 @@ export class IModelExporter {
     await this.exportModelContents(IModel.repositoryModelId);
     await this.exportSubModels(IModel.repositoryModelId);
     await this.exportRelationships(ElementRefersToElements.classFullName);
+    const deletedSubModels = new Set<Id64String>();
     // handle deletes
     if (this.visitElements) {
       for (const elementId of this._sourceDbChanges.element.deleteIds) {
+        const subModelAlsoDeleted = this._sourceDbChanges.model.deleteIds.has(elementId);
+        // must delete submodels first since they have a constraint on the element
+        if (subModelAlsoDeleted)
+          this.handler.onDeleteModel(elementId);
         this.handler.onDeleteElement(elementId);
       }
     }
     // WIP: handle ElementAspects?
     for (const modelId of this._sourceDbChanges.model.deleteIds) {
+      const alreadyDeletedSubModel = deletedSubModels.has(modelId);
+      if (alreadyDeletedSubModel) continue;
       this.handler.onDeleteModel(modelId);
     }
     if (this.visitRelationships) {

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -283,8 +283,10 @@ export class IModelExporter {
       for (const elementId of this._sourceDbChanges.element.deleteIds) {
         const subModelAlsoDeleted = this._sourceDbChanges.model.deleteIds.has(elementId);
         // must delete submodels first since they have a constraint on the element
-        if (subModelAlsoDeleted)
+        if (subModelAlsoDeleted) {
           this.handler.onDeleteModel(elementId);
+          deletedSubModels.add(elementId);
+        }
         this.handler.onDeleteElement(elementId);
       }
     }

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -257,7 +257,6 @@ export class IModelExporter {
     startChangesetId?: string;
     changedInstanceIds?: ChangedInstanceIds;
   } = {}): Promise<void> {
-    await this.exportChanges(undefined, undefined);
     if (!this.sourceDb.isBriefcaseDb()) {
       throw new IModelError(IModelStatus.BadRequest, "Must be a briefcase to export changes");
     }

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -281,7 +281,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
     this.trackProgress();
   }
 
-  /** Delete the specified Element from the target iModel. */
+  /** Delete the specified Model from the target iModel. */
   public deleteModel(modelId: Id64String): void {
     this.onDeleteModel(modelId);
   }

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -272,6 +272,20 @@ export class IModelImporter implements Required<IModelImportOptions> {
     this.onDeleteElement(elementId);
   }
 
+  /** Delete the specified Model from the target iModel.
+   * @note A subclass may override this method to customize delete behavior but should call `super.onDeleteModel`.
+   */
+  protected onDeleteModel(modelId: Id64String): void {
+    this.targetDb.models.deleteModel(modelId);
+    Logger.logInfo(loggerCategory, `Deleted model ${modelId}`);
+    this.trackProgress();
+  }
+
+  /** Delete the specified Element from the target iModel. */
+  public deleteModel(modelId: Id64String): void {
+    this.onDeleteModel(modelId);
+  }
+
   /** Format an Element for the Logger. */
   private formatElementForLogger(elementProps: ElementProps): string {
     const namePiece: string = elementProps.code.value ? `${elementProps.code.value} ` : elementProps.userLabel ? `${elementProps.userLabel} ` : "";

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -848,7 +848,7 @@ export class IModelTransformer extends IModelExportHandler {
     // - If both were deleted, [[remapDeletedSourceElements]] will find and remap the deleted element making this operation valid
     const targetModelId: Id64String = this.context.findTargetElementId(sourceModelId);
     if (Id64.isValidId64(targetModelId)) {
-      this.importer.deleteElement(targetModelId);
+      this.importer.deleteModel(targetModelId);
     }
   }
 

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -531,7 +531,7 @@ export class IModelTransformer extends IModelExportHandler {
           WHERE ic.OpCode=:opcode
             AND ic.Summary.Id=:changesetId
             AND esac.Scope.Id=:targetScopeElementId
-            AND ic.ChangedInstance.ClassId IN bisCoreExternalSourceAspectClassId
+            AND ic.ChangedInstance.ClassId IN (SELECT Id FROM bisCoreExternalSourceAspectClassId)
           `,
           (stmt) => {
             stmt.bindInteger("opcode", ChangeOpCode.Delete);

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -1412,7 +1412,7 @@ export class IModelTransformer extends IModelExportHandler {
     this.logSettings();
     this.validateScopeProvenance();
     await this.initFromExternalSourceAspects({accessToken, startChangesetId});
-    await this.exporter.exportChanges(accessToken, { startChangesetId });
+    await this.exporter.exportChanges(accessToken, startChangesetId);
     await this.processDeferredElements(); // eslint-disable-line deprecation/deprecation
 
     if (this._options.optimizeGeometry)

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -842,8 +842,14 @@ export class IModelTransformer extends IModelExportHandler {
   }
 
   /** Override of [IModelExportHandler.onDeleteModel]($transformer) that is called when [IModelExporter]($transformer) detects that a [Model]($backend) has been deleted from the source iModel. */
-  public override onDeleteModel(_sourceModelId: Id64String): void {
-    // WIP: currently ignored
+  public override onDeleteModel(sourceModelId: Id64String): void {
+    // It is possible and apparently occasionally sensical to delete a model without deleting its underlying element.
+    // - If only the model is deleted, [[initFromExternalSourceAspects]] will have already remapped the underlying element since it still exists.
+    // - If both were deleted, [[remapDeletedSourceElements]] will find and remap the deleted element making this operation valid
+    const targetModelId: Id64String = this.context.findTargetElementId(sourceModelId);
+    if (Id64.isValidId64(targetModelId)) {
+      this.importer.deleteElement(targetModelId);
+    }
   }
 
   /** Cause the model container, contents, and sub-models to be exported from the source iModel and imported into the target iModel.

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -238,7 +238,7 @@ function mapId64<R>(
 /** Arguments you can pass to [[IModelTransformer.initExternalSourceAspects]]
  * @beta
  */
-interface InitFromExternalSourceAspectsArgs {
+export interface InitFromExternalSourceAspectsArgs {
   accessToken?: AccessToken;
   startChangesetId?: string;
 }

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -515,15 +515,6 @@ export class IModelTransformer extends IModelExportHandler {
       for (const changesetId of changesetIds) {
         this.sourceDb.withPreparedStatement(
           `
-          WITH bisCoreExternalSourceAspectClassId(id) AS (
-            SELECT c.ECInstanceId
-            FROM ECDbMeta.ECClassDef c
-            JOIN ECDbMeta.ECSchemaDef s
-              ON c.Schema.Id=s.ECInstanceId
-            WHERE c.Name='ExternalSourceAspect'
-              AND s.Name='BisCore'
-            LIMIT 1
-          )
           SELECT esac.Element.Id, esac.Identifier
           FROM ecchange.change.InstanceChange ic
           JOIN BisCore.ExternalSourceAspect.Changes(:changesetId, 'BeforeDelete') esac
@@ -531,7 +522,8 @@ export class IModelTransformer extends IModelExportHandler {
           WHERE ic.OpCode=:opcode
             AND ic.Summary.Id=:changesetId
             AND esac.Scope.Id=:targetScopeElementId
-            AND ic.ChangedInstance.ClassId IN (SELECT Id FROM bisCoreExternalSourceAspectClassId)
+            -- not yet documented ecsql feature to check class id
+            AND ic.ChangedInstance.ClassId IS (ONLY BisCore.ExternalSourceAspect)
           `,
           (stmt) => {
             stmt.bindInteger("opcode", ChangeOpCode.Delete);

--- a/core/transformer/src/IModelTransformer.ts
+++ b/core/transformer/src/IModelTransformer.ts
@@ -474,11 +474,11 @@ export class IModelTransformer extends IModelExportHandler {
   /** Initialize the source to target Element mapping from ExternalSourceAspects in the target iModel.
    * @note This method is called from [[processChanges]] and [[processAll]], so it only needs to be called directly when processing a subset of an iModel.
    * @note Passing an [[InitFromExternalSourceAspectsArgs]] is required when processing changes, to remap any elements that may have been deleted.
-   *       You must await the returned promise as well in this case. The synchronous behavior is still supported but can't process everything.
+   *       You must await the returned promise as well in this case. The synchronous behavior has not changed but is deprecated and won't process everything.
    */
   public initFromExternalSourceAspects(args?: InitFromExternalSourceAspectsArgs): Promise<void>;
   /** @deprecated returning void is deprecated, return a promise, and handle returned promises appropriately */
-  public initFromExternalSourceAspects(args?: InitFromExternalSourceAspectsArgs): void;
+  public initFromExternalSourceAspects(): void;
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   public initFromExternalSourceAspects(args?: InitFromExternalSourceAspectsArgs): void | Promise<void> {
     this.forEachTrackedElement((sourceElementId: Id64String, targetElementId: Id64String) => {

--- a/core/transformer/src/test/IModelTransformerUtils.ts
+++ b/core/transformer/src/test/IModelTransformerUtils.ts
@@ -1147,7 +1147,7 @@ export class IModelToTextFileExporter extends IModelExportHandler {
   }
   public async exportChanges(requestContext: AccessToken, startChangesetId?: string): Promise<void> {
     this._shouldIndent = false;
-    return this.exporter.exportChanges(requestContext, { startChangesetId });
+    return this.exporter.exportChanges(requestContext, startChangesetId);
   }
   private writeLine(line: string, indentLevel: number = 0): void {
     if (this._shouldIndent) {

--- a/core/transformer/src/test/IModelTransformerUtils.ts
+++ b/core/transformer/src/test/IModelTransformerUtils.ts
@@ -1145,9 +1145,9 @@ export class IModelToTextFileExporter extends IModelExportHandler {
     this.writeSeparator();
     await this.exporter.exportAll();
   }
-  public async exportChanges(requestContext: AccessToken, startChangesetId?: string): Promise<void> {
+  public async exportChanges(requestContext: AccessToken, startChangeSetId?: string): Promise<void> {
     this._shouldIndent = false;
-    return this.exporter.exportChanges(requestContext, startChangesetId);
+    return this.exporter.exportChanges(requestContext, startChangeSetId);
   }
   private writeLine(line: string, indentLevel: number = 0): void {
     if (this._shouldIndent) {

--- a/core/transformer/src/test/IModelTransformerUtils.ts
+++ b/core/transformer/src/test/IModelTransformerUtils.ts
@@ -1145,9 +1145,9 @@ export class IModelToTextFileExporter extends IModelExportHandler {
     this.writeSeparator();
     await this.exporter.exportAll();
   }
-  public async exportChanges(requestContext: AccessToken, startChangeSetId?: string): Promise<void> {
+  public async exportChanges(requestContext: AccessToken, startChangesetId?: string): Promise<void> {
     this._shouldIndent = false;
-    return this.exporter.exportChanges(requestContext, startChangeSetId);
+    return this.exporter.exportChanges(requestContext, { startChangesetId });
   }
   private writeLine(line: string, indentLevel: number = 0): void {
     if (this._shouldIndent) {

--- a/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -770,6 +770,9 @@ describe("IModelTransformerHub", () => {
           return super.onExportElement(sourceElement);
         }
       }
+
+      // FIXME: add known non-equal mapping in branch
+
       const synchronizer = new IModelTransformerInjected(branchDb, new IModelImporterInjected(masterDb), {
         // NOTE: not using a targetScopeElementId because this test deals with temporary dbs, but that is a bad practice, use one
         isReverseSynchronization: true,

--- a/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -335,7 +335,7 @@ describe("IModelTransformerHub", () => {
     }
   });
 
-  it.only("should merge changes made on a branch back to master", async () => {
+  it("should merge changes made on a branch back to master", async () => {
     // create and push master IModel
     const masterIModelName = "Master";
     const masterSeedFileName = join(outputDir, `${masterIModelName}.bim`);

--- a/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -671,6 +671,136 @@ describe("IModelTransformerHub", () => {
     }
   });
 
+  it.only("reverse synchronization deletes", async () => {
+    const masterIModelName = "ReSyncDeleteMaster";
+    const masterIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: masterIModelName, noLocks: true });
+    let branchIModelId!: GuidString;
+    assert.isTrue(Guid.isGuid(masterIModelId));
+
+    try {
+      const masterDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: masterIModelId });
+
+      // populate master
+      const categId = SpatialCategory.insert(masterDb, IModel.dictionaryId, "category", new SubCategoryAppearance());
+      const physModel1Id = PhysicalModel.insert(masterDb, IModel.rootSubjectId, "phys-model-1");
+      const physObj1Id = new PhysicalObject({
+        classFullName: PhysicalObject.classFullName,
+        model: physModel1Id,
+        category: categId,
+        code: new Code({ spec: IModelDb.rootSubjectId, scope: IModelDb.rootSubjectId, value: "phys-obj1" }),
+        userLabel: "phys-obj-1",
+        geom: IModelTransformerTestUtils.createBox(Point3d.create(1, 1, 1)),
+        placement: {
+          origin: Point3d.create(0, 0, 0),
+          angles: YawPitchRollAngles.createDegrees(0, 0, 0),
+        },
+      }, masterDb).insert();
+      const physModel2Id = PhysicalModel.insert(masterDb, IModel.rootSubjectId, "phys-model-2");
+      masterDb.saveChanges();
+      await masterDb.pushChanges({ accessToken, description: "setup master" });
+
+      // create and initialize branch from master
+      const branchIModelName = "RevSyncDeleteBranch";
+      branchIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: branchIModelName, noLocks: true, version0: masterDb.pathName });
+      assert.isTrue(Guid.isGuid(branchIModelId));
+      const branchDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: branchIModelId });
+      await branchDb.importSchemas([BisCoreSchema.schemaFilePath, GenericSchema.schemaFilePath]);
+      assert.isTrue(branchDb.containsClass(ExternalSourceAspect.classFullName), "Expect BisCore to be updated and contain ExternalSourceAspect");
+      const provenanceInitializer = new IModelTransformer(masterDb, branchDb, { wasSourceIModelCopiedToTarget: true });
+      await provenanceInitializer.processSchemas();
+      await provenanceInitializer.processAll();
+      provenanceInitializer.dispose();
+      branchDb.saveChanges();
+      await branchDb.pushChanges({ accessToken, description: "setup branch" });
+
+      // delete a model and an element in branch
+      const physObj1 = branchDb.elements.getElement<PhysicalObject>(physObj1Id, PhysicalObject);
+      const physModel2 = branchDb.models.getModel<PhysicalModel>(physModel2Id, PhysicalModel);
+      const physModel2Partition = branchDb.elements.getElement<PhysicalPartition>(physModel2Id, PhysicalPartition);
+      const physObj1Aspects = branchDb.elements.getAspects(physObj1.id);
+      const physModel2PartitionAspects = branchDb.elements.getAspects(physModel2Partition.id);
+      physObj1.delete();
+      physModel2.delete();
+      // deleting the model will dangle its partition, delete that too
+      physModel2Partition.delete();
+      branchDb.saveChanges();
+      await branchDb.pushChanges({ accessToken, description: "branch delete obj1 and model2" });
+
+      // verify the branch state
+      const keptModel = branchDb.models.tryGetModel<PhysicalModel>(physModel1Id, PhysicalModel);
+      expect(keptModel).not.to.be.undefined;
+      const deletedElem = branchDb.elements.tryGetElement<PhysicalObject>(physObj1Id, PhysicalObject);
+      expect(deletedElem).to.be.undefined;
+      const deletedModelElem = branchDb.elements.tryGetElement<PhysicalPartition>(physModel2Id, PhysicalPartition);
+      expect(deletedModelElem).to.be.undefined;
+      const deletedModel = branchDb.models.tryGetModel<PhysicalModel>(physModel2Id, PhysicalModel);
+      expect(deletedModel).to.be.undefined;
+
+      // expected extracted changed ids
+      const branchDbChangesets = await IModelHost.hubAccess.downloadChangesets({ accessToken, iModelId: branchIModelId, targetDir: BriefcaseManager.getChangeSetsPath(branchIModelId) });
+      expect(branchDbChangesets).to.have.length(2);
+      const latestChangeset = branchDbChangesets[1];
+      const extractedChangedIds = branchDb.nativeDb.extractChangedInstanceIdsFromChangeSets([latestChangeset.pathname]);
+      const expectedChangedIds: IModelJsNative.ChangedInstanceIdsProps = {
+        aspect: {
+          delete: [...physModel2PartitionAspects, ...physObj1Aspects].map((a) => a.id),
+        },
+        element: { delete: [physObj1Id, physModel2Id] },
+        model: {
+          update: [IModelDb.rootSubjectId, physModel1Id], // containing model will also get last modification time updated
+          delete: [physModel2Id],
+        },
+      };
+      expect(extractedChangedIds.result).to.deep.equal(expectedChangedIds);
+
+      // reverse synchronize
+      class IModelImporterInjected extends IModelImporter {
+        public didImportDeletedElem = false;
+        public override importElement(sourceElement: ElementProps): Id64String {
+          if (sourceElement.id === physModel2Id)
+            this.didImportDeletedElem = true;
+          return super.importElement(sourceElement);
+        }
+      }
+      class IModelTransformerInjected extends IModelTransformer {
+        public didExportDeletedElem = false;
+        public override async onExportElement(sourceElement: Element) {
+          if (sourceElement.id === physModel2Id)
+            this.didExportDeletedElem = true;
+          return super.onExportElement(sourceElement);
+        }
+      }
+      const synchronizer = new IModelTransformerInjected(branchDb, new IModelImporterInjected(masterDb), {
+        // NOTE: not using a targetScopeElementId because this test deals with temporary dbs, but that is a bad practice, use one
+        isReverseSynchronization: true,
+      });
+      await synchronizer.processChanges(accessToken);
+      expect(synchronizer.didExportDeletedElem).to.be.false;
+      expect((synchronizer.importer as IModelImporterInjected).didImportDeletedElem).to.be.false;
+      branchDb.saveChanges();
+      await branchDb.pushChanges({ accessToken, description: "synchronize" });
+      synchronizer.dispose();
+
+      // check that the element was deleted in the master
+      const physModel2InMasterId = masterDb.elements.queryElementIdByCode(
+        PhysicalPartition.createCode(masterDb, IModelDb.rootSubjectId, "phys-model-2"),
+      );
+      expect(physModel2InMasterId).to.be.undefined;
+
+      // close iModel briefcases
+      await HubWrappers.closeAndDeleteBriefcaseDb(accessToken, masterDb);
+      await HubWrappers.closeAndDeleteBriefcaseDb(accessToken, branchDb);
+    } finally {
+      try {
+        // delete iModel briefcases
+        await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: masterIModelId });
+        await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: branchIModelId });
+      } catch (err) {
+        assert.fail(err, undefined, "failed to clean up");
+      }
+    }
+  });
+
   function count(iModelDb: IModelDb, classFullName: string): number {
     return iModelDb.withPreparedStatement(`SELECT COUNT(*) FROM ${classFullName}`, (statement: ECSqlStatement): number => {
       return DbResult.BE_SQLITE_ROW === statement.step() ? statement.getValue(0).getInteger() : 0;

--- a/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -671,7 +671,7 @@ describe("IModelTransformerHub", () => {
     }
   });
 
-  it.only("reverse synchronization deletes", async () => {
+  it.only("should delete branch-deleted elements in reverse synchronization", async () => {
     const masterIModelName = "ReSyncDeleteMaster";
     const masterIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: masterIModelName, noLocks: true });
     let branchIModelId!: GuidString;
@@ -782,10 +782,10 @@ describe("IModelTransformerHub", () => {
       synchronizer.dispose();
 
       // check that the element was deleted in the master
-      const physModel2InMasterId = masterDb.elements.queryElementIdByCode(
+      const physModel2InBranchId = masterDb.elements.queryElementIdByCode(
         PhysicalPartition.createCode(masterDb, IModelDb.rootSubjectId, "phys-model-2"),
       );
-      expect(physModel2InMasterId).to.be.undefined;
+      expect(physModel2InBranchId).to.be.undefined;
 
       // close iModel briefcases
       await HubWrappers.closeAndDeleteBriefcaseDb(accessToken, masterDb);

--- a/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -335,14 +335,14 @@ describe("IModelTransformerHub", () => {
     }
   });
 
-  it("should merge changes made on a branch back to master", async () => {
+  it.only("should merge changes made on a branch back to master", async () => {
     // create and push master IModel
     const masterIModelName = "Master";
     const masterSeedFileName = join(outputDir, `${masterIModelName}.bim`);
     if (IModelJsFs.existsSync(masterSeedFileName))
       IModelJsFs.removeSync(masterSeedFileName); // make sure file from last run does not exist
 
-    const state0 = [1, 2];
+    const state0 = [1, 2, 20]; // 20 will be deleted by a branch
     const masterSeedDb = SnapshotDb.createEmpty(masterSeedFileName, { rootSubject: { name: "Master" } });
     populateMaster(masterSeedDb, state0);
     assert.isTrue(IModelJsFs.existsSync(masterSeedFileName));
@@ -412,7 +412,7 @@ describe("IModelTransformerHub", () => {
 
       // push Branch1 State1
       const delta01 = [2, 3, 4]; // update 2, insert 3 and 4
-      const state1 = [1, 2, 3, 4];
+      const state1 = [1, 2, 3, 4, 20];
       maintainPhysicalObjects(branchDb1, delta01);
       assertPhysicalObjects(branchDb1, state1);
       await saveAndPushChanges(branchDb1, "State0 -> State1");
@@ -420,7 +420,7 @@ describe("IModelTransformerHub", () => {
       assert.notEqual(changesetBranch1State1, changesetBranch1State0);
 
       // push Branch1 State2
-      const delta12 = [1, -3, 5, 6]; // update 1, delete 3, insert 5 and 6
+      const delta12 = [1, -3, 5, 6, -20]; // update 1, delete 3, 20, insert 5 and 6
       const state2 = [1, 2, -3, 4, 5, 6];
       maintainPhysicalObjects(branchDb1, delta12);
       assertPhysicalObjects(branchDb1, state2);
@@ -671,7 +671,7 @@ describe("IModelTransformerHub", () => {
     }
   });
 
-  it.only("should delete branch-deleted elements in reverse synchronization", async () => {
+  it("should delete branch-deleted elements in reverse synchronization", async () => {
     const masterIModelName = "ReSyncDeleteMaster";
     const masterIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: masterIModelName, noLocks: true });
     let branchIModelId!: GuidString;

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -22,3 +22,10 @@ New effect, shown below:
 ![AO effect fades in the distance; shadows decrease in size](./assets/AONewDistance.png)
 
 For more details, see the new descriptions of the `texelStepSize` and `maxDistance` properties of [AmbientOcclusion.Props]($common).
+
+## Transformer API
+
+The synchronous `void`-returning overload of [IModelTransformer.initFromExternalSourceAspects]($transformer) has been deprecated.
+It will still perform the old behavior synchronously until it is removed. It will now however return a `Promise` (which should be
+awaited) if invoked with the an [InitFromExternalSourceAspectsArgs]($transformer) argument, which is necessary when processing
+changes instead of the full source contents.


### PR DESCRIPTION
fixes #4072

- Extract element id remaps from deleted elements and their deleted ExternalSourceAspects using change summary ECSQL queries
- modify the existing branch tests to cover this case
- add a new test specific to this case that also covers model deletion
- Handle model deletes which the transformer previously did not do

I am going to add coverage for deleting relationships while processing changes in [reverse]synchronizations in the upcoming transform-non-element-entities work.