### PR TITLE
Test shows that parent lock covers child sub-models

### DIFF
--- a/core/backend/src/test/standalone/IModelWrite.test.ts
+++ b/core/backend/src/test/standalone/IModelWrite.test.ts
@@ -7,13 +7,13 @@ import { assert, expect } from "chai";
 import * as semver from "semver";
 import { AccessToken, DbResult, GuidString, Id64, Id64String } from "@itwin/core-bentley";
 import {
-  Code, ColorDef, GeometryStreamProps, IModel, QueryRowFormat, RequestNewBriefcaseProps, SchemaState, SubCategoryAppearance,
+  Code, ColorDef, GeometricElement2dProps, GeometryStreamProps, IModel, QueryRowFormat, RequestNewBriefcaseProps, SchemaState, SubCategoryAppearance,
 } from "@itwin/core-common";
-import { Arc3d, IModelJson, Point3d } from "@itwin/core-geometry";
+import { Arc3d, IModelJson, Point2d, Point3d } from "@itwin/core-geometry";
 import { HubWrappers, KnownTestLocations } from "../";
 import { DrawingCategory } from "../../Category";
 import {
-  BriefcaseDb, BriefcaseManager, DictionaryModel, IModelHost, IModelJsFs, SpatialCategory, SqliteStatement, SqliteValue, SqliteValueType,
+  BriefcaseDb, BriefcaseManager, DefinitionModel, DictionaryModel, DocumentListModel, Drawing, DrawingGraphic, IModelHost, IModelJsFs, SpatialCategory, SqliteStatement, SqliteValue, SqliteValueType, Subject,
 } from "../../core-backend";
 import { ECSqlStatement } from "../../ECSqlStatement";
 import { HubMock } from "../../HubMock";
@@ -34,7 +34,7 @@ export async function createNewModelAndCategory(rwIModel: BriefcaseDb, parent?: 
   return { modelId, spatialCategoryId };
 }
 
-describe("IModelWriteTest", () => {
+describe.only("IModelWriteTest", () => {
   let managerAccessToken: AccessToken;
   let superAccessToken: AccessToken;
   let testITwinId: string;
@@ -701,4 +701,119 @@ describe("IModelWriteTest", () => {
     rwIModel.close();
     rwIModel2.close();
   });
+
+  it.only("parent lock should suffice when inserting into deeply nested sub-model", async () => {
+    const version0 = IModelTestUtils.resolveAssetFile("test.bim");
+    const iModelId = await IModelHost.hubAccess.createNewIModel({ iTwinId: testITwinId, iModelName: "subModelCoveredByParentLockTest", version0 });
+    const iModel = await HubWrappers.downloadAndOpenBriefcase({ iTwinId: testITwinId, iModelId });
+
+    /*
+      Job Subject
+        +- DefinitionPartition  --  [DefinitionModel]
+    */
+
+    await iModel.locks.acquireLocks({ shared: IModel.repositoryModelId });
+    const jobSubjectId = IModelTestUtils.createJobSubjectElement(iModel, "JobSubject").insert();
+    const definitionModelId = DefinitionModel.insert(iModel, jobSubjectId, "Definition");
+
+    iModel.saveChanges();
+    await iModel.pushChanges({ description: "create model" });
+
+    /*
+      Job Subject                                           <--- Lock this
+        +- DefinitionPartition  --  [DefinitionModel]
+                                        SpatialCategory     <=== insert this
+                                        DrawingCategory             "
+    */
+    assert.isFalse(iModel.locks.holdsExclusiveLock(jobSubjectId));
+    assert.isFalse(iModel.locks.holdsExclusiveLock(definitionModelId));
+    assert.isFalse(iModel.locks.holdsSharedLock(definitionModelId));
+    await iModel.locks.acquireLocks({ exclusive: jobSubjectId });
+    iModel.locks.checkExclusiveLock(jobSubjectId, "", "");
+    iModel.locks.checkSharedLock(jobSubjectId, "", "");
+    iModel.locks.checkSharedLock(definitionModelId, "", "");
+    iModel.locks.checkExclusiveLock(definitionModelId, "", "");
+
+    const spatialCategoryId = SpatialCategory.insert(iModel, definitionModelId, "SpatialCategory", new SubCategoryAppearance()); // throws if we get locking error
+    const drawingCategoryId = DrawingCategory.insert(iModel, definitionModelId, "DrawingCategory", new SubCategoryAppearance());
+
+    assert.isTrue(iModel.elements.getElement(spatialCategoryId).model === definitionModelId);
+    assert.isTrue(iModel.elements.getElement(drawingCategoryId).model === definitionModelId);
+
+    iModel.saveChanges();
+    await iModel.pushChanges({ description: "insert category" });
+
+    /*
+      Create some more nesting.
+
+      Job Subject                                           <--- Lock this
+        +- DefinitionPartition  --  [DefinitionModel]
+          |                             SpatialCategory
+          +- Child Subject                                                            <== Insert
+              +- DocumentList         --    [DocumentListModel]                           "
+                                              Drawing             -- [DrawingModel]       "
+    */
+    assert.isFalse(iModel.locks.holdsExclusiveLock(jobSubjectId));
+    assert.isFalse(iModel.locks.holdsExclusiveLock(definitionModelId));
+    assert.isFalse(iModel.locks.holdsSharedLock(definitionModelId));
+    await iModel.locks.acquireLocks({ exclusive: jobSubjectId });
+    iModel.locks.checkExclusiveLock(jobSubjectId, "", "");
+    iModel.locks.checkSharedLock(IModel.repositoryModelId, "", "");
+
+    const childSubjectId = Subject.insert(iModel, jobSubjectId, "Child Subject");
+
+    const documentListModelId = DocumentListModel.insert(iModel, childSubjectId, "Document"); // creates DocumentList and DocumentListModel
+    assert.isTrue(Id64.isValidId64(documentListModelId));
+    const drawingModelId = Drawing.insert(iModel, documentListModelId, "Drawing"); // creates Drawing and DrawingModel
+
+    assert.isTrue(iModel.elements.getElement(childSubjectId).parent?.id === jobSubjectId);
+    assert.isTrue(iModel.elements.getElement(childSubjectId).model === IModel.repositoryModelId);
+    assert.isTrue(iModel.elements.getElement(documentListModelId).parent?.id === childSubjectId);
+    assert.isTrue(iModel.elements.getElement(documentListModelId).model === IModel.repositoryModelId);
+    assert.isTrue(iModel.elements.getElement(drawingModelId).model === documentListModelId);
+
+    iModel.saveChanges();
+    await iModel.pushChanges({ description: "insert doc list with nested drawing model" });
+
+    /*
+      Verify that even a deeply nested insertion is covered by the exclusive lock on the top-level parent.
+
+      Job Subject                                           <--- Lock this
+        +- DefinitionPartition  --  DefinitionModel
+          |                             SpatialCategory
+          +- Child Subject
+              +- DocumentList         --    [DocumentListModel]
+                                              Drawing             -- [DrawingModel]
+                                                                        DrawingGraphic   <== Insert this
+    */
+    assert.isFalse(iModel.locks.holdsExclusiveLock(jobSubjectId));
+    assert.isFalse(iModel.locks.holdsExclusiveLock(definitionModelId));
+    assert.isFalse(iModel.locks.holdsSharedLock(definitionModelId));
+    assert.isFalse(iModel.locks.holdsSharedLock(documentListModelId));
+    assert.isFalse(iModel.locks.holdsSharedLock(drawingModelId));
+    await iModel.locks.acquireLocks({ exclusive: jobSubjectId });
+    iModel.locks.checkExclusiveLock(jobSubjectId, "", "");
+    iModel.locks.checkSharedLock(IModel.repositoryModelId, "", "");
+    iModel.locks.checkSharedLock(documentListModelId, "", "");
+    iModel.locks.checkSharedLock(drawingModelId, "", "");
+
+    const drawingGraphicProps1: GeometricElement2dProps = {
+      classFullName: DrawingGraphic.classFullName,
+      model: drawingModelId,
+      category: drawingCategoryId,
+      code: Code.createEmpty(),
+      userLabel: "DrawingGraphic1",
+      geom: IModelTestUtils.createRectangle(Point2d.create(1, 1)),
+      placement: { origin: Point2d.create(2, 2), angle: 0 },
+    };
+    const drawingGraphicId1 = iModel.elements.insertElement(drawingGraphicProps1);
+
+    assert.isTrue(iModel.elements.getElement(drawingGraphicId1).model === drawingModelId);
+
+    iModel.saveChanges();
+    await iModel.pushChanges({ description: "insert graphic into nested sub-model" });
+
+    iModel.close();
+  });
+
 });


### PR DESCRIPTION
An internal developer claimed that holding top-level parent lock was not sufficient to insert elements into nested sub-model. This test demonstrates that it is.