### PR TITLE
Fix reality model shadow casting.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-reality-shadow-casting_2022-08-15-19-39.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-reality-shadow-casting_2022-08-15-19-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix reality models failing to cast shadows.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/RealityMesh.ts
+++ b/core/frontend/src/render/webgl/RealityMesh.ts
@@ -369,9 +369,6 @@ export class RealityMeshGeometry extends IndexedGeometry implements IDisposable,
   public get techniqueId(): TechniqueId { return TechniqueId.RealityMesh; }
 
   public override getPass(target: Target) {
-    if (target.isDrawingShadowMap)
-      return "none";
-
     if (this._baseIsTransparent || (target.wantThematicDisplay && target.uniforms.thematic.wantIsoLines))
       return "translucent";
 

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -192,6 +192,7 @@ export class RealityTileTree extends TileTree {
     const graphicTypeBranches = new Map<TileGraphicType, GraphicBranch>();
 
     const selectedTiles = this.selectRealityTiles(args, displayedTileDescendants, preloadDebugBuilder);
+    args.processSelectedTiles(selectedTiles);
     let sortIndices;
 
     if (!this.parentsAndChildrenExclusive) {


### PR DESCRIPTION
Fixes #3946

[This commit](https://github.com/iTwin/itwinjs-core/pull/163/commits/f649df81995825e455715c6c813f5e05cc1f4212) initially broke it. SolarShadowMap relies on TileDrawArgs.processSelectedTiles being called, but it's only called by TileTree.selectTiles. That commit changed how we select tiles for shadow map, calling TileTree.draw, which for reality models goes through a totally different code path (selectRealityTiles) which does not invoke processSelectedTiles.

Subsequently Ray converted TerrainMesh into RealityMesh and started using it to draw reality models too. TerrainMesh.getPass returned "none" while drawing shadow map. Unclear why, given we should never have selected any terrain meshes for the shadow map in the first place.

@DStradley please add your test case to ImageTests runs.