### PR TITLE
Remove trailing slash from geocoord workspace URL.

### DIFF
--- a/common/changes/@itwin/core-backend/fix-workspace-slash_2022-08-15-21-37.json
+++ b/common/changes/@itwin/core-backend/fix-workspace-slash_2022-08-15-21-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/assets/Settings/backend.setting.json5
+++ b/core/backend/src/assets/Settings/backend.setting.json5
@@ -2,7 +2,7 @@
   "cloud/accounts": [
     {
       "name": "gcs/account",
-      "accessName": "https://geocoord-workspace.itwinjs.org/",
+      "accessName": "https://geocoord-workspace.itwinjs.org",
       "storageType": "azure?customuri=1&sas=1"
     }
   ],


### PR DESCRIPTION
This should resolve the transient "attach error: HTTP/1.1 400" errors we've been seeing periodically.