### PR TITLE
ignore bulk EOL change when doing git blame on GitHub

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+
+# Ignore bulk EOL change
+
+007be59f93813bc5525b1fe2afc48f20761bca56


### PR DESCRIPTION
add git-blame-ignore-revs file which allows you to list commits to ignore. 
right now only ignoring the EOL change from a few months ago

GH should auto pick up this file and ignore the rev when doing git blame, [see](https://twitter.com/pamelafox/status/1556779165247893506?s=21&t=1cbFJzzOW4LFG_oD0XxBbA)

And if you want to configure it locally to do so, run 

```sh
git config blame.ignoreRevsFile .git-blame-ignore-revs
```