### PR TITLE
share cloudCache for all workspaces

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3108,6 +3108,8 @@ export class ITwinWorkspace implements Workspace {
     // (undocumented)
     readonly containerDir: LocalDirName;
     // (undocumented)
+    static finalize(): void;
+    // (undocumented)
     findContainer(containerId: WorkspaceContainer.Id): ITwinWorkspaceContainer | undefined;
     // (undocumented)
     getContainer(props: WorkspaceContainer.Props, account?: WorkspaceAccount.Props): WorkspaceContainer;
@@ -5162,9 +5164,10 @@ export interface WorkspaceDb {
 
 // @beta
 export interface WorkspaceOpts {
-    cloudCacheProps?: WorkspaceCloudCacheProps;
     containerDir?: LocalDirName;
     settingsFiles?: LocalFileName | [LocalFileName];
+    // @internal
+    testCloudCache?: SQLiteDb.CloudCache;
 }
 
 // @beta

--- a/common/api/presentation-testing.api.md
+++ b/common/api/presentation-testing.api.md
@@ -9,6 +9,7 @@ import { HierarchyCacheMode } from '@itwin/presentation-backend';
 import { IModelApp } from '@itwin/core-frontend';
 import { IModelAppOptions } from '@itwin/core-frontend';
 import { IModelConnection } from '@itwin/core-frontend';
+import { IModelHostOptions } from '@itwin/core-backend';
 import { InstanceKey } from '@itwin/presentation-common';
 import { KeySet } from '@itwin/presentation-common';
 import { Omit as Omit_2 } from '@itwin/presentation-common';
@@ -88,6 +89,7 @@ export { PresentationManagerMode }
 
 // @public (undocumented)
 export interface PresentationTestingInitProps {
+    backendHostProps?: IModelHostOptions;
     backendProps?: PresentationBackendProps;
     frontendApp?: {
         startup: (opts?: IModelAppOptions) => Promise<void>;

--- a/common/changes/@itwin/analytical-backend/workspace-cloud-cache_2022-08-16-18-38.json
+++ b/common/changes/@itwin/analytical-backend/workspace-cloud-cache_2022-08-16-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/analytical-backend"
+}

--- a/common/changes/@itwin/core-backend/workspace-cloud-cache_2022-08-16-18-38.json
+++ b/common/changes/@itwin/core-backend/workspace-cloud-cache_2022-08-16-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-tests/workspace-cloud-cache_2022-08-16-18-38.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-tests/workspace-cloud-cache_2022-08-16-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-tests"
+}

--- a/common/changes/@itwin/linear-referencing-backend/workspace-cloud-cache_2022-08-16-18-38.json
+++ b/common/changes/@itwin/linear-referencing-backend/workspace-cloud-cache_2022-08-16-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/linear-referencing-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-backend"
+}

--- a/common/changes/@itwin/physical-material-backend/workspace-cloud-cache_2022-08-16-18-38.json
+++ b/common/changes/@itwin/physical-material-backend/workspace-cloud-cache_2022-08-16-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/physical-material-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/physical-material-backend"
+}

--- a/common/changes/@itwin/presentation-backend/workspace-cloud-cache_2022-08-16-18-38.json
+++ b/common/changes/@itwin/presentation-backend/workspace-cloud-cache_2022-08-16-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-testing/workspace-cloud-cache_2022-08-17-08-35.json
+++ b/common/changes/@itwin/presentation-testing/workspace-cloud-cache_2022-08-17-08-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-testing",
+      "comment": "Allow supplying `IModelHostOptions` when initializing tests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-testing"
+}

--- a/core/backend/src/GeoCoordConfig.ts
+++ b/core/backend/src/GeoCoordConfig.ts
@@ -34,7 +34,7 @@ export class GeoCoordConfig {
       const container = ws.getContainer(containerProps, account);
       const cloudContainer = container.cloudContainer;
       if (!cloudContainer?.isConnected) {
-        Logger.logInfo("GeoCoord", `could not load gcs database "${gcsDbAlias}"`);
+        Logger.logError("GeoCoord", `could not load gcs database "${gcsDbAlias}"`);
         return;
       }
 
@@ -54,12 +54,9 @@ export class GeoCoordConfig {
       if (true === dbProps.prefetch)
         SQLiteDb.startCloudPrefetch(cloudContainer, gcsDbName);
 
-    } catch (e: unknown) {
-      Logger.logError(loggerCat, `Cannot load GCS workspace: ${BentleyError.getErrorMessage(e)},
-      account="${account.accessName}"/"${containerProps.containerId}",
-      storage=${account.storageType},
-      isPublic=${containerProps.isPublic},
-      rootDir=${ws.cloudCache?.rootDir}`
+    } catch (e: any) {
+      Logger.logError(loggerCat, `Cannot load GCS workspace (${e.errorNumber}): ${BentleyError.getErrorMessage(e)},`
+        + `account="${account.accessName}"/"${containerProps.containerId}", storage=${account.storageType}, isPublic=${containerProps.isPublic}, cacheDir=${IModelHost.cacheDir}`
       );
     }
   }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -52,6 +52,8 @@ import { DrawingViewDefinition, SheetViewDefinition, ViewDefinition } from "./Vi
 import { BaseSettings, SettingDictionary, SettingName, SettingResolver, SettingsPriority, SettingType } from "./workspace/Settings";
 import { ITwinWorkspace, Workspace } from "./workspace/Workspace";
 
+// spell:ignore fontid fontmap
+
 const loggerCategory: string = BackendLoggerCategory.IModelDb;
 
 /** Options for [[IModelDb.Models.updateModel]]
@@ -238,7 +240,7 @@ export abstract class IModelDb extends IModel {
    */
   public get workspace(): Workspace {
     if (undefined === this._workspace)
-      this._workspace = new ITwinWorkspace(new IModelSettings(), IModelHost.appWorkspace);
+      this._workspace = new ITwinWorkspace(new IModelSettings());
     return this._workspace;
   }
 

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -501,8 +501,9 @@ export class IModelHost {
     IModelHost.configuration = undefined;
     IModelHost.tileCacheService = undefined;
     IModelHost.tileUploader = undefined;
-    IModelHost.appWorkspace.close();
+    IModelHost._appWorkspace?.close();
     IModelHost._appWorkspace = undefined;
+    ITwinWorkspace.finalize();
     process.removeListener("beforeExit", IModelHost.shutdown);
   }
 

--- a/core/backend/src/test/IModelHost.test.ts
+++ b/core/backend/src/test/IModelHost.test.ts
@@ -16,7 +16,7 @@ import { TestUtils } from "./TestUtils";
 import { IModelTestUtils } from "./IModelTestUtils";
 
 describe("IModelHost", () => {
-
+  const opts = { cacheDir: path.join(__dirname, ".cache") };
   beforeEach(async () => {
     await TestUtils.shutdownBackend();
   });
@@ -30,7 +30,7 @@ describe("IModelHost", () => {
   });
 
   it("valid default configuration", async () => {
-    await IModelHost.startup();
+    await IModelHost.startup(opts);
 
     // Valid registered implemented RPCs
     expect(RpcRegistry.instance.implementationClasses.size).to.equal(5);
@@ -48,7 +48,7 @@ describe("IModelHost", () => {
   it("should raise onAfterStartup events", async () => {
     const eventHandler = sinon.spy();
     IModelHost.onAfterStartup.addOnce(eventHandler);
-    await IModelHost.startup();
+    await IModelHost.startup(opts);
     expect(eventHandler.calledOnce).to.be.true;
   });
 
@@ -167,7 +167,7 @@ describe("IModelHost", () => {
       setUseTileCache: setUseTileCacheStub,
     }));
 
-    await IModelHost.startup();
+    await IModelHost.startup(opts);
 
     assert.isUndefined(IModelHost.tileCacheService);
     assert.isUndefined(IModelHost.tileUploader);
@@ -195,7 +195,7 @@ describe("IModelHost", () => {
   });
 
   it("should throw if hubAccess is undefined and getter is called", async () => {
-    await IModelHost.startup();
+    await IModelHost.startup(opts);
     expect(IModelHost.getHubAccess()).undefined;
     expect(() => IModelHost.hubAccess).throws();
   });

--- a/core/backend/src/test/standalone/ConcurrentQuery_Perf.test.ts
+++ b/core/backend/src/test/standalone/ConcurrentQuery_Perf.test.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { DbResult, QueryBinder, QueryOptionsBuilder, QueryRowFormat, QueryStats } from "@itwin/core-common";
 import { expect } from "chai";
+import * as path from "path";
 import { ECSqlStatement } from "../../ECSqlStatement";
 import { IModelDb, SnapshotDb } from "../../IModelDb";
 import { IModelHost } from "../../IModelHost";
@@ -13,7 +14,7 @@ import { IModelJsFs } from "../../IModelJsFs";
 describe.skip("Properties loading", () => {
   let imodel: SnapshotDb;
   before(async () => {
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir: path.join(__dirname, ".cache") });
   });
   after(async () => {
     await IModelHost.shutdown();

--- a/core/backend/src/workspace/Workspace.ts
+++ b/core/backend/src/workspace/Workspace.ts
@@ -190,11 +190,13 @@ export interface WorkspaceOpts {
    */
   containerDir?: LocalDirName;
 
-  /** Properties for the cloud cache for the `WorkspaceContainers` of the Workspace. */
-  cloudCacheProps?: WorkspaceCloudCacheProps;
-
   /** the local fileName(s) of one or more settings files to load after the Workspace is first created. */
   settingsFiles?: LocalFileName | [LocalFileName];
+
+  /**
+   * only for tests
+   * @internal */
+  testCloudCache?: SQLiteDb.CloudCache;
 }
 
 /**
@@ -289,29 +291,32 @@ export class ITwinWorkspace implements Workspace {
   private _containers = new Map<WorkspaceContainer.Id, ITwinWorkspaceContainer>();
   public readonly containerDir: LocalDirName;
   public readonly settings: Settings;
-
-  private _cloudCacheProps?: WorkspaceCloudCacheProps;
+  private static _sharedCloudCache?: SQLiteDb.CloudCache;
   private _cloudCache?: SQLiteDb.CloudCache;
   public get cloudCache(): SQLiteDb.CloudCache {
-    if (undefined === this._cloudCache) {
-      const cacheProps = {
-        ...this._cloudCacheProps,
-        rootDir: this._cloudCacheProps?.rootDir ?? join(this.containerDir, "cloud"),
-        cacheSize: this._cloudCacheProps?.cacheSize ?? "20G",
-        name: this._cloudCacheProps?.name ?? "workspace",
-      };
-      IModelJsFs.recursiveMkDirSync(cacheProps.rootDir);
-      if (cacheProps.clearContents)
-        fs.emptyDirSync(cacheProps.rootDir);
-      this._cloudCache = SQLiteDb.createCloudCache(cacheProps);
-    }
+    if (undefined === this._cloudCache)
+      this._cloudCache = ITwinWorkspace.getSharedCloudCache();
     return this._cloudCache;
+  }
+  private static getSharedCloudCache(): SQLiteDb.CloudCache {
+    if (undefined === this._sharedCloudCache) {
+      const rootDir = join(IModelHost.cacheDir, "Workspace", "cloud");
+      IModelJsFs.recursiveMkDirSync(rootDir);
+      this._sharedCloudCache = SQLiteDb.createCloudCache({ rootDir, cacheSize: "20G", name: "workspace" });
+    }
+    return this._sharedCloudCache;
+  }
+  public static finalize() {
+    if (this._sharedCloudCache) {
+      this._sharedCloudCache.destroy();
+      this._sharedCloudCache = undefined;
+    }
   }
 
   public constructor(settings: Settings, opts?: WorkspaceOpts) {
     this.settings = settings;
     this.containerDir = opts?.containerDir ?? join(IModelHost.cacheDir, "Workspace");
-    this._cloudCacheProps = opts?.cloudCacheProps;
+    this._cloudCache = opts?.testCloudCache;
     let settingsFiles = opts?.settingsFiles;
     if (settingsFiles) {
       if (typeof settingsFiles === "string")
@@ -362,10 +367,6 @@ export class ITwinWorkspace implements Workspace {
     for (const [_id, container] of this._containers)
       container.close();
     this._containers.clear();
-    if (this._cloudCache) {
-      this._cloudCache.destroy();
-      this._cloudCache = undefined;
-    }
   }
 
   public resolveAccount(accountName: string): WorkspaceAccount.Props {

--- a/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
+++ b/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
@@ -49,7 +49,7 @@ describe("AnalyticalSchema", () => {
   const assetsDir = path.join(__dirname, "assets");
 
   before(async () => {
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir: path.join(__dirname, ".cache") });
     AnalyticalSchema.registerSchema();
     TestAnalyticalSchema.registerSchema();
     if (!IModelJsFs.existsSync(outputDir)) {

--- a/domains/linear-referencing/backend/src/test/LinearReferencingSchema.test.ts
+++ b/domains/linear-referencing/backend/src/test/LinearReferencingSchema.test.ts
@@ -68,7 +68,7 @@ describe("LinearReferencing Domain", () => {
   const outputDir = path.join(__dirname, "output");
 
   before(async () => {
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir: path.join(__dirname, ".cache") });
     LinearReferencingSchema.registerSchema();
     TestLinearReferencingSchema.registerSchema();
     if (!IModelJsFs.existsSync(outputDir)) {

--- a/domains/physical-material/backend/src/test/PhysicalMaterialSchema.test.ts
+++ b/domains/physical-material/backend/src/test/PhysicalMaterialSchema.test.ts
@@ -14,7 +14,7 @@ describe("PhysicalMaterialSchema", () => {
   const outputDir = path.join(__dirname, "output");
 
   before(async () => {
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir: path.join(__dirname, ".cache") });
     PhysicalMaterialSchema.registerSchema();
     if (!IModelJsFs.existsSync(outputDir)) {
       IModelJsFs.mkdirSync(outputDir);

--- a/full-stack-tests/backend/src/integration/CloudWorkspace.test.ts
+++ b/full-stack-tests/backend/src/integration/CloudWorkspace.test.ts
@@ -4,8 +4,9 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
+import * as fs from "fs-extra";
 import { join } from "path";
-import { BaseSettings, CloudSqlite, EditableWorkspaceDb, IModelHost, ITwinWorkspace, SettingsPriority } from "@itwin/core-backend";
+import { BaseSettings, CloudSqlite, EditableWorkspaceDb, IModelHost, IModelJsFs, ITwinWorkspace, SettingsPriority, SQLiteDb } from "@itwin/core-backend";
 import { assert } from "@itwin/core-bentley";
 import { CloudSqliteTest } from "./CloudSqlite.test";
 
@@ -25,8 +26,19 @@ describe("Cloud workspace containers", () => {
       "cloudSqlite/containerId": containerId,
     };
 
-    const workspace1 = new ITwinWorkspace(new BaseSettings(), { containerDir: join(IModelHost.cacheDir, "TestWorkspace1"), cloudCacheProps: { name: "test1", clearContents: true } });
-    const workspace2 = new ITwinWorkspace(new BaseSettings(), { containerDir: join(IModelHost.cacheDir, "TestWorkspace2"), cloudCacheProps: { name: "test2", clearContents: true } });
+    const makeCloudCache = (name: string) => {
+      const cacheProps = {
+        rootDir: join(IModelHost.cacheDir, "cloud", name),
+        cacheSize: "20G",
+        name,
+      };
+      IModelJsFs.recursiveMkDirSync(cacheProps.rootDir);
+      fs.emptyDirSync(cacheProps.rootDir);
+      return SQLiteDb.createCloudCache(cacheProps);
+    };
+
+    const workspace1 = new ITwinWorkspace(new BaseSettings(), { containerDir: join(IModelHost.cacheDir, "TestWorkspace1"), testCloudCache: makeCloudCache("test1") });
+    const workspace2 = new ITwinWorkspace(new BaseSettings(), { containerDir: join(IModelHost.cacheDir, "TestWorkspace2"), testCloudCache: makeCloudCache("test2") });
     const settings = workspace1.settings;
     settings.addDictionary("containers", SettingsPriority.application, containerDict);
 

--- a/full-stack-tests/core/src/backend/RpcImpl.ts
+++ b/full-stack-tests/core/src/backend/RpcImpl.ts
@@ -2,7 +2,9 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 import * as nock from "nock";
+import * as path from "path";
 import { IModelDb, IModelHost, IModelJsFs, NativeHost } from "@itwin/core-backend";
 import { V1CheckpointManager } from "@itwin/core-backend/lib/cjs/CheckpointManager";
 import { IModelRpcProps, RpcInterface, RpcManager } from "@itwin/core-common";
@@ -15,7 +17,7 @@ export class TestRpcImpl extends RpcInterface implements TestRpcInterface {
 
   public async restartIModelHost(): Promise<void> {
     await IModelHost.shutdown();
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir: path.join(__dirname, ".cache") });
   }
 
   public async executeTest(tokenProps: IModelRpcProps, testName: string, params: any): Promise<any> {

--- a/full-stack-tests/ecschema-rpc-interface/src/test/backend.ts
+++ b/full-stack-tests/ecschema-rpc-interface/src/test/backend.ts
@@ -38,7 +38,7 @@ void (async () => {
   // Start the backend
   const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com/imodels` } });
   const hubAccess = new BackendIModelsAccess(iModelClient);
-  await IModelHost.startup({ hubAccess });
+  await IModelHost.startup({ hubAccess, cacheDir: path.join(__dirname, ".cache") });
 
   const rpcConfig = BentleyCloudRpcManager.initializeImpl({ info: { title: "schema-rpc-test", version: "v1.0" } }, getRpcInterfaces());
   RpcManager.registerImpl(ECSchemaRpcInterface, ECSchemaRpcImpl);

--- a/full-stack-tests/presentation/src/IntegrationTests.ts
+++ b/full-stack-tests/presentation/src/IntegrationTests.ts
@@ -116,6 +116,7 @@ const initializeCommon = async (props: { backendTimeout?: number, useClientServi
 
   const presentationTestingInitProps: PresentationTestingInitProps = {
     backendProps: backendInitProps,
+    backendHostProps: { cacheDir: path.join(__dirname, ".cache") },
     frontendProps: frontendInitProps,
     frontendApp: IntegrationTestsApp,
     frontendAppOptions,

--- a/full-stack-tests/presentation/src/performance/GetElementProperties.test.ts
+++ b/full-stack-tests/presentation/src/performance/GetElementProperties.test.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
+import { join } from "path";
 import { IModelDb, IModelHost, SnapshotDb } from "@itwin/core-backend";
 import { DbResult, QueryRowFormat } from "@itwin/core-common";
 import { Presentation } from "@itwin/presentation-backend";
@@ -11,7 +12,7 @@ describe("#performance Element properties loading", () => {
   let imodel: SnapshotDb;
 
   before(async () => {
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir: join(__dirname, ".cache") });
     Presentation.initialize({
       useMmap: true,
     });

--- a/full-stack-tests/rpc/src/backend/CommonBackendSetup.ts
+++ b/full-stack-tests/rpc/src/backend/CommonBackendSetup.ts
@@ -10,15 +10,17 @@ import { IModelReadRpcInterface, RpcConfiguration } from "@itwin/core-common";
 import { BackendTestCallbacks } from "../common/SideChannels";
 import { rpcInterfaces } from "../common/TestRpcInterface";
 import { resetOp8Initializer, TestRpcImpl2 } from "./TestRpcImpl";
+import { join } from "path";
 
 export async function commonSetup(): Promise<void> {
   RpcConfiguration.developmentMode = true;
 
+  const cacheDir = join(__dirname, ".cache");
   // Start the backend
-  if (ProcessDetector.isElectronAppBackend){
-    await ElectronHost.startup({ electronHost: { rpcInterfaces } });
+  if (ProcessDetector.isElectronAppBackend) {
+    await ElectronHost.startup({ electronHost: { rpcInterfaces }, iModelHost: { cacheDir } });
   } else
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir });
 
   registerBackendCallback(BackendTestCallbacks.registerTestRpcImpl2Class, () => {
     TestRpcImpl2.register();

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -11,6 +11,7 @@ import { createDefaultNativePlatform, NativePlatformDefinition } from "../presen
 import { PresentationManagerMode } from "../presentation-backend/PresentationManager";
 import { BeEvent } from "@itwin/core-bentley";
 import sinon from "sinon";
+import { join } from "path";
 
 describe("default NativePlatform", () => {
 
@@ -19,7 +20,7 @@ describe("default NativePlatform", () => {
 
   beforeEach(async () => {
     try {
-      await IModelHost.startup();
+      await IModelHost.startup({ cacheDir: join(__dirname, ".cache") });
     } catch (e) {
       let isLoaded = false;
       try {
@@ -78,7 +79,7 @@ describe("default NativePlatform", () => {
     it("calls addon", async () => {
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: Promise.resolve({ result: "0" }), cancel: () => {} }))
+        .returns(() => ({ result: Promise.resolve({ result: "0" }), cancel: () => { } }))
         .verifiable();
       expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0" });
       addonMock.verifyAll();
@@ -87,14 +88,14 @@ describe("default NativePlatform", () => {
     it("throws on cancellation response", async () => {
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Canceled, message: "test" } }), cancel: () => {} }));
+        .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Canceled, message: "test" } }), cancel: () => { } }));
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
     it("throws on error response", async () => {
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }), cancel: () => {} }));
+        .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }), cancel: () => { } }));
       await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
     });
 
@@ -119,7 +120,7 @@ describe("default NativePlatform", () => {
     };
     addonMock
       .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-      .returns(() => ({ result: Promise.resolve({ result: "0", diagnostics }), cancel: () => {} }));
+      .returns(() => ({ result: Promise.resolve({ result: "0", diagnostics }), cancel: () => { } }));
     expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0", diagnostics });
     addonMock.verifyAll();
   });

--- a/presentation/backend/src/test/Presentation.test.ts
+++ b/presentation/backend/src/test/Presentation.test.ts
@@ -16,6 +16,7 @@ import { PresentationManager } from "../presentation-backend/PresentationManager
 import { PresentationRpcImpl } from "../presentation-backend/PresentationRpcImpl";
 import { TemporaryStorage } from "../presentation-backend/TemporaryStorage";
 import { NativePlatformDefinition } from "../presentation-backend/NativePlatform";
+import { join } from "path";
 
 describe("Presentation", () => {
 
@@ -38,7 +39,7 @@ describe("Presentation", () => {
     });
 
     it("can be safely shutdown via IModelHost shutdown listener", async () => {
-      await IModelHost.startup();
+      await IModelHost.startup({ cacheDir: join(__dirname, ".cache") });
       Presentation.initialize();
       await IModelHost.shutdown();
       expect(() => Presentation.getManager()).to.throw(PresentationError);
@@ -51,10 +52,10 @@ describe("Presentation", () => {
     });
 
     it("subscribes for `BriefcaseDb.onOpened` event if `enableSchemasPreload` is set", () => {
-      Presentation.initialize({enableSchemasPreload: false});
+      Presentation.initialize({ enableSchemasPreload: false });
       expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(0);
       Presentation.terminate();
-      Presentation.initialize({enableSchemasPreload: true});
+      Presentation.initialize({ enableSchemasPreload: true });
       expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(1);
     });
 
@@ -128,7 +129,7 @@ describe("Presentation", () => {
     });
 
     it("unsubscribes from `BriefcaseDb.onOpened` event if `enableSchemasPreload` is set", () => {
-      Presentation.initialize({enableSchemasPreload: true});
+      Presentation.initialize({ enableSchemasPreload: true });
       expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(1);
       Presentation.terminate();
       expect(BriefcaseDb.onOpened.numberOfListeners).to.eq(0);
@@ -145,7 +146,7 @@ describe("Presentation", () => {
       managerMock.setup((x) => x.getNativePlatform).returns(() => () => nativePlatformMock.object);
       nativePlatformMock.setup((x) => x.getImodelAddon(imodelMock.object)).verifiable(moq.Times.atLeastOnce());
 
-      Presentation.initialize({enableSchemasPreload: true, clientManagerFactory: () => managerMock.object});
+      Presentation.initialize({ enableSchemasPreload: true, clientManagerFactory: () => managerMock.object });
       BriefcaseDb.onOpened.raiseEvent(imodelMock.object, {} as any);
       nativePlatformMock.verify(async (x) => x.forceLoadSchemas(moq.It.isAny()), moq.Times.once());
     });

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -45,7 +45,7 @@ describe("PresentationManager", () => {
 
   before(async () => {
     try {
-      await IModelHost.startup();
+      await IModelHost.startup({ cacheDir: path.join(__dirname, ".cache") });
     } catch (e) {
       let isLoaded = false;
       try {

--- a/presentation/backend/src/test/SelectionScopesHelper.test.ts
+++ b/presentation/backend/src/test/SelectionScopesHelper.test.ts
@@ -11,11 +11,12 @@ import { ElementProps, EntityMetaData, IModelError, ModelProps } from "@itwin/co
 import { InstanceKey } from "@itwin/presentation-common";
 import { createRandomECInstanceKey, createRandomId } from "@itwin/presentation-common/lib/cjs/test";
 import { SelectionScopesHelper } from "../presentation-backend/SelectionScopesHelper";
+import { join } from "path";
 
 describe("SelectionScopesHelper", () => {
 
   before(async () => {
-    await IModelHost.startup();
+    await IModelHost.startup({ cacheDir: join(__dirname, ".cache") });
   });
 
   after(async () => {

--- a/presentation/testing/src/presentation-testing/Helpers.ts
+++ b/presentation/testing/src/presentation-testing/Helpers.ts
@@ -5,17 +5,19 @@
 /** @packageDocumentation
  * @module Helpers
  */
+import { join } from "path";
 import * as rimraf from "rimraf";
+import { IModelHost, IModelHostOptions } from "@itwin/core-backend";
 import { Guid } from "@itwin/core-bentley";
-import { IModelHost } from "@itwin/core-backend";
 import {
   IModelReadRpcInterface, RpcConfiguration, RpcDefaultConfiguration, RpcInterfaceDefinition, SnapshotIModelRpcInterface,
 } from "@itwin/core-common";
 import { IModelApp, IModelAppOptions, NoRenderApp } from "@itwin/core-frontend";
-import { HierarchyCacheMode, Presentation as PresentationBackend, PresentationManagerProps as PresentationBackendProps, PresentationManagerMode } from "@itwin/presentation-backend";
+import {
+  HierarchyCacheMode, Presentation as PresentationBackend, PresentationManagerProps as PresentationBackendProps, PresentationManagerMode,
+} from "@itwin/presentation-backend";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { Presentation as PresentationFrontend, PresentationProps as PresentationFrontendProps } from "@itwin/presentation-frontend";
-import { join } from "path";
 
 function initializeRpcInterfaces(interfaces: RpcInterfaceDefinition[]) {
   const config = class extends RpcDefaultConfiguration {
@@ -43,11 +45,13 @@ export { HierarchyCacheMode, PresentationManagerMode, PresentationBackendProps }
 export interface PresentationTestingInitProps {
   /** Properties for backend initialization */
   backendProps?: PresentationBackendProps;
+  /** Properties for `IModelHost` */
+  backendHostProps?: IModelHostOptions;
   /** Properties for frontend initialization */
   frontendProps?: PresentationFrontendProps;
   /** IModelApp implementation */
   frontendApp?: { startup: (opts?: IModelAppOptions) => Promise<void> };
-  /** IModelApp options */
+  /** `IModelApp` options */
   frontendAppOptions?: IModelAppOptions;
 }
 
@@ -74,7 +78,7 @@ export const initialize = async (props?: PresentationTestingInitProps) => {
   props.backendProps = props.backendProps ?? {};
   if (!props.backendProps.id)
     props.backendProps.id = `test-${Guid.createValue()}`;
-  await IModelHost.startup({ cacheDir: join(__dirname, ".cache") });
+  await IModelHost.startup({ cacheDir: join(__dirname, ".cache"), ...props.backendHostProps });
   PresentationBackend.initialize(props.backendProps);
 
   // init frontend


### PR DESCRIPTION
All workspaces should use the same `cloudCache`, but previously they were each creating their own.

Also:
- clean up diagnostics for GCS workspace loading. Previous attempt could cause errors while reporting the errors
- attempt to ensure each test uses its own `cacheDir`. I think there's still a problem with `full-stack-tests\presentation`, but it is non-fatal