### PR TITLE
Limit shadow range for global tile trees.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-global-shadows_2022-08-16-18-56.json
+++ b/common/changes/@itwin/core-frontend/pmc-global-shadows_2022-08-16-18-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Limit the shadow-casting range for tile trees that span the entire globe, like the OpenStreetMap buildings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}


### PR DESCRIPTION
When shadows are enabled we ask each shadow-casting tile tree to disclose the volume of space containing shadow-casting geometry. For global tilesets like the OpenStreetMap buildings, that volume is the size of the Earth, making the shadow map useless. In such cases, limit the shadow-casting range to the viewed volume.

Unless you're zoomed very far in and/or looking mostly top-down, the resolution of the shadow map is still pretty lousy, but at least it produces recognizable shadows.