### PR TITLE
Fix display issue with ArcGIS server of 'Geologic Map of North America'

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1201,8 +1201,6 @@ export class ArcGisUtilities {
     // (undocumented)
     static getEndpoint(url: string): Promise<any | undefined>;
     // (undocumented)
-    static getFootprintJson(url: string, credentials?: RequestBasicCredentials): Promise<any>;
-    // (undocumented)
     static getNationalMapSources(): Promise<MapLayerSource[]>;
     // (undocumented)
     static getServiceDirectorySources(url: string, baseUrl?: string): Promise<MapLayerSource[]>;

--- a/common/changes/@itwin/core-frontend/geo-fix_ArcGisFilterByRange_2022-08-16-19-56.json
+++ b/common/changes/@itwin/core-frontend/geo-fix_ArcGisFilterByRange_2022-08-16-19-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix display issue with ArcGIS server of 'Geologic Map of North America'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/map/ArcGisUtilities.ts
+++ b/core/frontend/src/tile/map/ArcGisUtilities.ts
@@ -198,31 +198,6 @@ export class ArcGisUtilities {
     }
   }
 
-  private static _footprintCache = new Map<string, any>();
-  public static async getFootprintJson(url: string, credentials?: RequestBasicCredentials): Promise<any> {
-    const cached = ArcGisUtilities._footprintCache.get(url);
-    if (cached !== undefined)
-      return cached;
-
-    try {
-      const tmpUrl = new URL(url);
-      tmpUrl.searchParams.append("f", "json");
-      tmpUrl.searchParams.append("option", "footprints");
-      tmpUrl.searchParams.append("outSR", "4326");
-      const accessClient = IModelApp.mapLayerFormatRegistry.getAccessClient("ArcGIS");
-      if (accessClient) {
-        await ArcGisUtilities.appendSecurityToken(tmpUrl, accessClient, {mapLayerUrl: new URL(url), userName: credentials?.user, password: credentials?.password });
-      }
-
-      const json = await getJson(tmpUrl.toString());
-      ArcGisUtilities._footprintCache.set(url, json);
-      return json;
-    } catch (_error) {
-      ArcGisUtilities._footprintCache.set(url, undefined);
-      return undefined;
-    }
-  }
-
   // return the appended access token if available.
   public static async appendSecurityToken(url: URL, accessClient: MapLayerAccessClient, accessTokenParams: MapLayerAccessTokenParams): Promise<MapLayerAccessToken|undefined> {
 

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
@@ -188,19 +188,9 @@ export class ArcGISMapLayerImageryProvider extends MapLayerImageryProvider {
         this._tileMap = new ArcGISTileMap(this._settings.url, json.tileInfo?.lods?.length);
       }
 
-      const footprintJson = await ArcGisUtilities.getFootprintJson(this._settings.url, this.getRequestAuthorization());
-      if (undefined !== footprintJson && undefined !== footprintJson.featureCollection && Array.isArray(footprintJson.featureCollection.layers)) {
-        for (const layer of footprintJson.featureCollection.layers) {
-          if (layer.layerDefinition && layer.layerDefinition.extent) {
-            this.cartoRange = MapCartoRectangle.createFromDegrees(layer.layerDefinition.extent.xmin, layer.layerDefinition.extent.ymin, layer.layerDefinition.extent.xmax, layer.layerDefinition.extent.ymax);
-            break;
-          }
-        }
-      }
-
-      // Sometimes footprint request doesnt work, fallback to dataset fullextent
-      if (this.cartoRange === undefined && json.fullExtent) {
-        if (json.fullExtent.spatialReference.latestWkid === 3857) {
+      // Read range using fullextent from service metadata
+      if (json.fullExtent) {
+        if (json.fullExtent.spatialReference.latestWkid === 3857 || json.fullExtent.spatialReference.wkid === 102100) {
           const range3857 = Range2d.createFrom({
             low: {x: json.fullExtent.xmin, y: json.fullExtent.ymin},
             high: {x: json.fullExtent.xmax, y: json.fullExtent.ymax} });


### PR DESCRIPTION
When publishing from [Geologic Map of North America](https://certmapper.cr.usgs.gov/server/rest/services/geology/northamerica_gmna/MapServer), only northen tiles would be displayed.  This occurs because the data range is read from a 'footprints' request, which turns out to be unreliable for some servers.  We now rely on 'fullextent' of the service metadata, which appears to be more reliable (at least it works for several USGS servers tested)