### PR TITLE
Improve handling of invalid/malformed web RPC requests.

### DIFF
--- a/common/changes/@itwin/core-common/send-400s-for-junk-reqs_2022-08-17-20-06.json
+++ b/common/changes/@itwin/core-common/send-400s-for-junk-reqs_2022-08-17-20-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/rpc/web/BentleyCloudRpcProtocol.ts
+++ b/core/common/src/rpc/web/BentleyCloudRpcProtocol.ts
@@ -56,6 +56,10 @@ export abstract class BentleyCloudRpcProtocol extends WebAppRpcProtocol {
     const operationComponent = components.slice(-1)[0];
     const encodedRequest = url.searchParams.get("parameters") || "";
 
+    // The encodedRequest should be base64 - fail now if any other characters detected.
+    if (/[^A-z0-9=+\/]/.test(encodedRequest))
+      throw new IModelError(BentleyStatus.ERROR, `Invalid request: Malformed URL parameters detected.`);
+
     const firstHyphen = operationComponent.indexOf("-");
     const lastHyphen = operationComponent.lastIndexOf("-");
     const interfaceDefinition = operationComponent.slice(0, firstHyphen);

--- a/core/common/src/rpc/web/WebAppRpcRequest.ts
+++ b/core/common/src/rpc/web/WebAppRpcRequest.ts
@@ -91,7 +91,7 @@ export class WebAppRpcRequest extends RpcRequest {
     }
 
     if (!request.id) {
-      throw new IModelError(BentleyStatus.ERROR, `Invalid request.`);
+      throw new IModelError(BentleyStatus.ERROR, `Invalid request: Missing required activity ID.`);
     }
 
     return request;

--- a/full-stack-tests/rpc/src/frontend/Routing.test.ts
+++ b/full-stack-tests/rpc/src/frontend/Routing.test.ts
@@ -5,14 +5,11 @@ import { assert } from "chai";
 *--------------------------------------------------------------------------------------------*/
 import { ProcessDetector } from "@itwin/core-bentley";
 import { TestRpcInterface, WebRoutingInterface } from "../common/TestRpcInterface";
-import { RpcProtocol, WebAppRpcProtocol, WebAppRpcRequest } from "@itwin/core-common";
+import { BentleyCloudRpcProtocol, RpcProtocol, RpcProtocolVersion, WebAppRpcProtocol, WebAppRpcRequest } from "@itwin/core-common";
 import { currentEnvironment } from "./_Setup.test";
 
 if (!ProcessDetector.isElectronAppFrontend) {
   describe("Web Routing", () => {
-    if (currentEnvironment === "websocket") {
-      return;
-    }
 
     it("should always send and recieve protocolVersion without prefectch", async () => {
       if (currentEnvironment === "websocket") {
@@ -47,6 +44,55 @@ if (!ProcessDetector.isElectronAppFrontend) {
         client.ping503(sent),
         client.ping504(sent),
       ]).then((results) => results.forEach((result) => assert.isTrue(result)));
+    });
+
+    it("should return 400 response for requests with invalid URL parameters", async () => {
+      if (currentEnvironment === "websocket")
+        return;
+
+      const protocol = TestRpcInterface.getClient().configuration.protocol as BentleyCloudRpcProtocol;
+
+      const testParamsWithSuffix = async (suffix: string) => {
+        const realParams = btoa(JSON.stringify([1, 10])); // eslint-disable-line deprecation/deprecation
+        assert.equal(realParams.indexOf("="), -1);  // we don't want any padding in the real base64 value
+
+        const response = await fetch(`${protocol.pathPrefix}/${protocol.info.title}/${protocol.info.version}/mode/1/context/undefined/imodel/undefined/changeset/0/${TestRpcInterface.interfaceName}-${TestRpcInterface.interfaceVersion}-op1?parameters=${encodeURIComponent(realParams)}${suffix}`, {
+          method: "GET",
+          headers: {
+            "accept": "*/*",
+            "content-type": "text/plain",
+            [protocol.protocolVersionHeaderName]: String(RpcProtocolVersion.IntroducedStatusCategory),
+            [protocol.serializedClientRequestContextHeaderNames.id]: "foo",
+          },
+        });
+        assert.equal(response.status, 400);
+        const result = (await (response.json()));
+        assert.isTrue(result.isError);
+        assert.equal(result.message, "Error: Invalid request: Malformed URL parameters detected.");
+      };
+      await testParamsWithSuffix("%3D%27%27");
+      await testParamsWithSuffix("%27%27BAD");
+      await testParamsWithSuffix("%27%27%2BAD");
+    });
+
+    it("should return 400 response for requests with missing id", async () => {
+      if (currentEnvironment === "websocket")
+        return;
+
+      const protocol = TestRpcInterface.getClient().configuration.protocol as BentleyCloudRpcProtocol;
+      const realParams = btoa(JSON.stringify([1, 10])); // eslint-disable-line deprecation/deprecation
+      const response = await fetch(`${protocol.pathPrefix}/${protocol.info.title}/${protocol.info.version}/mode/1/context/undefined/imodel/undefined/changeset/0/${TestRpcInterface.interfaceName}-${TestRpcInterface.interfaceVersion}-op1?parameters=${encodeURIComponent(realParams)}`, {
+        method: "GET",
+        headers: {
+          "accept": "*/*",
+          "content-type": "text/plain",
+          [protocol.protocolVersionHeaderName]: String(RpcProtocolVersion.IntroducedStatusCategory),
+        },
+      });
+      assert.equal(response.status, 400);
+      const result = (await (response.json()));
+      assert.isTrue(result.isError);
+      assert.equal(result.message, "Error: Invalid request: Missing required activity ID.");
     });
   });
 }


### PR DESCRIPTION
Now that more RPC requests are sent as GET requests, our dynamic fuzzing scans have started (incorrectly) flagging those endpoints as potentially vulnerable to SQL injection, due to the fact that appending junk to the request URL query string results in inconsistent behavior (depending on what's appended this can either be ignored when the value is base64 decoded or result in invalid JSON).

While we can safely ignore the SQL injection concern (again, that is a false positive), this inconsistent behavior itself should probably be fixed for its own sake.  I think the easiest thing to do here is to simply scan the query params for any characters that don't belong in a base64-encoded value and fail the request handling early if any are detected.  Also, these invalid requests should result in an HTTP 400 response.