### PR TITLE
add `PropertyStore` interface

### DIFF
--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -280,6 +280,8 @@ public;Platform
 internal;ProcessChangesetOptions
 public;ProgressFunction = (loaded: number, total: number) => ProgressStatus
 public;ProgressStatus
+alpha;PropertyStore
+alpha;PropertyStore
 public;PullChangesArgs = ToChangesetArgs
 public;PushChangesArgs 
 beta;class RecipeDefinitionElement 
@@ -339,6 +341,7 @@ internal;CloudCache = IModelJsNative.CloudCache
 internal;CloudContainer = IModelJsNative.CloudContainer
 internal;CloudPrefetch = IModelJsNative.CloudPrefetch
 internal;LockAndOpenArgs
+internal;ObtainLockParams
 public;SqliteStatement 
 public;SqliteValue
 public;SqliteValueType

--- a/common/changes/@itwin/core-backend/property-store_2022-08-18-17-43.json
+++ b/common/changes/@itwin/core-backend/property-store_2022-08-18-17-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "add PropertyStore interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CodeService.ts
+++ b/core/backend/src/CodeService.ts
@@ -3,10 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { CloudSqlite } from "@bentley/imodeljs-native";
 import { AccessToken, BentleyError, GuidString, IModelStatus, MarkRequired, Mutable } from "@itwin/core-bentley";
 import { CodeProps } from "@itwin/core-common";
 import { BriefcaseDb } from "./IModelDb";
+import { SQLiteDb } from "./SQLiteDb";
 import { SettingObject } from "./workspace/Settings";
 
 /**
@@ -78,7 +78,7 @@ export interface CodeService {
    * Applications should set these parameters by adding a listener for `BriefcaseDb.onCodeServiceCreated`
    * that is called every time a BriefcaseDb that uses code services is opened for write access.
    */
-  readonly appParams: CodeService.ObtainLockParams & CodeService.AuthorAndOrigin;
+  readonly appParams: SQLiteDb.ObtainLockParams & CodeService.AuthorAndOrigin;
 
   /**
    * The token that grants access to the cloud container for this CodeService.
@@ -251,22 +251,6 @@ export namespace CodeService {
 
   /** An iteration function over code specs in a code index. It is called with the name and json of a each code spec. */
   export type NameAndJsonIteration = (nameAndJson: NameAndJson) => IterationReturn;
-
-  /** Parameters used to obtain the write lock on a cloud container */
-  export interface ObtainLockParams {
-    /** The name of the user attempting to acquire the write lock. This name will be shown to other users while the lock is held. */
-    user?: string;
-    /** number of times to retry in the event the lock currently held by someone else.
-     * After this number of attempts, `onFailure` is called. Default is 20.
-     */
-    nRetries: number;
-    /** Delay between retries, in milliseconds. Default is 100. */
-    retryDelayMs: number;
-    /** function called if lock cannot be obtained after all retries. It is called with the name of the user currently holding the lock and
-     * generally is expected that the user will be consulted whether to wait further.
-     * If this function returns "stop", an exception will be thrown. Otherwise the retry cycle is restarted. */
-    onFailure?: CloudSqlite.WriteLockBusyHandler;
-  }
 
   /** Argument for reserving an array of new codes. */
   export interface ReserveCodesArgs {

--- a/core/backend/src/PropertyStore.ts
+++ b/core/backend/src/PropertyStore.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { CloudSqlite } from "@bentley/imodeljs-native";
+import { AccessToken } from "@itwin/core-bentley";
+import { SQLiteDb } from "./SQLiteDb";
+import { SettingObject } from "./workspace/Settings";
+
+/**
+ * A persistent storage for a set of values of type `PropertyType`, each with a unique `PropertyName`.
+ * `PropertyStore`s are stored in cloud containers, and require an access token that grants permission to read and/or write them.
+ * All write operations will fail without an access token that grants write permission.
+ * A `PropertyStore` is cached on a local drive so reads are fast and inexpensive, and may even be done offline after a prefetch.
+ * However, that means that callers are responsible for synchronizing the local cache to ensure it includes changes
+ * made by others, as appropriate (see [[synchronizeWithCloud]]).
+ * @alpha */
+export interface PropertyStore {
+
+  /** The collection of property values in the PropertyStore as of the last time it was synchronized. */
+  readonly values: PropertyStore.Values;
+
+  /** Application-supplied parameters for obtaining the write lock on the container for a PropertyStore.*/
+  readonly appParams: SQLiteDb.ObtainLockParams;
+
+  /**
+   * The token that grants access to the cloud container for this PropertyStore. If it does not grant write permissions, all
+   * write operations will fail. It should be refreshed (via a timer) before it expires.
+   */
+  sasToken: AccessToken;
+
+  /**
+   * Synchronize the local values in this PropertyStore with any changes by made by others.
+   * @note This is called automatically whenever any write operation is performed on the PropertyStore. It is only necessary to
+   * call this directly if you have not changed the PropertyStore recently, but wish to perform a readonly operation and want to
+   * ensure it is up-to-date as of now.
+   * @note There is no guarantee that the Values are up-to-date even immediately after calling this method, since others
+   * may be modifying them at any time.
+   */
+  synchronizeWithCloud: () => void;
+
+  /** initiate a prefetch operation on this PropertyStore
+   * @internal
+   */
+  startPrefetch(): SQLiteDb.CloudPrefetch;
+
+  /** Save a single property in this PropertyStore. If the property already exists, its value is overwritten.
+   * @note This will obtain the write lock, save the value, and then release the write lock.
+   */
+  saveProperty(name: PropertyStore.PropertyName, value: PropertyStore.PropertyType): Promise<void>;
+  /** Save an array of properties in this PropertyStore. If a property already exists, its value is overwritten.
+   * @note This will obtain the write lock, save the values, and then release the write lock.
+   */
+  saveProperties(props: PropertyStore.PropertyArray): Promise<void>;
+  /** Delete a single property from this PropertyStore. If the value does not exist, this method does nothing.
+   * @note This will obtain the write lock, delete the value, and then release the write lock.
+   */
+  deleteProperty(propName: PropertyStore.PropertyName): Promise<void>;
+  /** Delete an array of properties from this PropertyStore. Any value that does not exist is ignored.
+   * @note This will obtain the write lock, delete the values, and then release the write lock.
+   */
+  deleteProperties(propNames: PropertyStore.PropertyName[]): Promise<void>;
+}
+
+/** @alpha */
+export namespace PropertyStore {
+  /** @internal */
+  export let openPropertyStore: undefined | ((props: CloudSqlite.ContainerAccessProps) => PropertyStore);
+
+  /** The set of valid types for properties in a PropertyStore. */
+  export type PropertyType = string | number | boolean | Uint8Array | SettingObject;
+  /** The name of a Property. May not have leading or trailing spaces, and must be between 3 and 2048 characters long. */
+  export type PropertyName = string;
+  /** An array of PropertyName/PropertyType pairs to be stored in a PropertyStore. */
+  export type PropertyArray = { name: PropertyName, value: PropertyType }[];
+  /** The return status of an iteration function. The value "stop" causes the iteration to terminate. */
+  export type IterationReturn = void | "stop";
+  /** An iteration function over Properties in a PropertyStore. It is called with the name of a each Property. */
+  export type PropertyIteration = (name: string) => IterationReturn;
+
+  /** A filter used to limit and/or sort the values returned by an iteration. */
+  export interface PropertyFilter {
+    /** A value filter. May include wild cards when used with `GLOB` or `LIKE` */
+    readonly value?: string;
+    /** The comparison operator for `value`. Default is `=` */
+    readonly valueCompare?: "GLOB" | "LIKE" | "NOT GLOB" | "NOT LIKE" | "=" | "<" | ">";
+    /** Order results ascending or descending. If not supplied, the results are unordered (random). */
+    readonly orderBy?: "ASC" | "DESC";
+    /** An SQL expression to further filter results. This string is appended to the `WHERE` clause with an `AND` (that should not be part of the sqlExpression) */
+    readonly sqlExpression?: string;
+  }
+
+  /**
+   * A readonly set of Property values in a PropertyStore.
+   * @alpha
+   */
+  export interface Values {
+    /** get the value of a Property by name.
+     * @returns the property's value if it exists, `undefined` otherwise.
+     */
+    getProperty(name: PropertyName): PropertyType | undefined;
+    /** Get the value of a string property by name.
+    * @returns the property's value if it exists and is a string, `undefined` otherwise.
+    */
+    getString(name: PropertyName): string | undefined;
+    /** Get the value of a string property by name.
+    * @returns the property's value if it exists and is a string, otherwise the supplied default value.
+    */
+    getString(name: PropertyName, defaultValue: string): string;
+    /** Get the value of a boolean property by name.
+    * @returns the property's value if it exists and is a boolean, `undefined` otherwise.
+    */
+    getBoolean(name: PropertyName): boolean | undefined;
+    /** Get the value of a boolean property by name.
+    * @returns the property's value if it exists and is a boolean, otherwise the supplied default value.
+    */
+    getBoolean(name: PropertyName, defaultValue: boolean): boolean;
+    /** Get the value of a number property by name.
+    * @returns the property's value if it exists and is a number, `undefined` otherwise.
+    */
+    getNumber(name: PropertyName): number | undefined;
+    /** Get the value of a number property by name.
+    * @returns the property's value if it exists and is a number, otherwise the supplied default value.
+    */
+    getNumber(name: PropertyName, defaultValue: number): number;
+    /** Get the value of a blob property by name.
+    * @returns the property's value if it exists and is a blob, `undefined` otherwise.
+    */
+    getBlob(name: PropertyName): Uint8Array | undefined;
+    /** Get the value of a blob property by name.
+    * @returns the property's value if it exists and is a blob, otherwise the supplied default value.
+    */
+    getBlob(name: PropertyName, defaultValue: Uint8Array): Uint8Array;
+    /** Get the value of an object property by name.
+    * @returns the property's value if it exists and is an object, `undefined` otherwise.
+    */
+    getObject<T extends SettingObject>(name: PropertyName): T | undefined;
+    /** Get the value of an object property by name.
+    * @returns the property's value if it exists and is an object, otherwise the supplied default value.
+    */
+    getObject<T extends SettingObject>(name: PropertyName, defaultValue: T): T;
+    /** call an iteration function for each property, optionally applying a filter */
+    forAllProperties(iter: PropertyIteration, filter?: PropertyFilter): void;
+  }
+}

--- a/core/backend/src/SQLiteDb.ts
+++ b/core/backend/src/SQLiteDb.ts
@@ -290,6 +290,24 @@ export namespace SQLiteDb {
   /** Parameters for creating a new SQLiteDb */
   export type CreateParams = OpenOrCreateParams & PageSize;
 
+  /** Parameters used to obtain the write lock on a cloud container
+   * @internal
+   */
+  export interface ObtainLockParams {
+    /** The name of the user attempting to acquire the write lock. This name will be shown to other users while the lock is held. */
+    user?: string;
+    /** number of times to retry in the event the lock currently held by someone else.
+   * After this number of attempts, `onFailure` is called. Default is 20.
+   */
+    nRetries: number;
+    /** Delay between retries, in milliseconds. Default is 100. */
+    retryDelayMs: number;
+    /** function called if lock cannot be obtained after all retries. It is called with the name of the user currently holding the lock and
+   * generally is expected that the user will be consulted whether to wait further.
+   * If this function returns "stop", an exception will be thrown. Otherwise the retry cycle is restarted. */
+    onFailure?: CloudSqlite.WriteLockBusyHandler;
+  }
+
   /** @internal */
   export interface LockAndOpenArgs {
     /** the name to be displayed in the event of lock collisions */

--- a/core/backend/src/core-backend.ts
+++ b/core/backend/src/core-backend.ts
@@ -50,6 +50,7 @@ export * from "./IModelSchemaLoader";
 export * from "./IpcHost";
 export * from "./NativeAppStorage";
 export * from "./NativeHost";
+export * from "./PropertyStore";
 export * from "./CloudStorageBackend";
 export * from "./AliCloudStorageService";
 export * from "./DevTools";


### PR DESCRIPTION
For use by applications for storing user/team/app properties that are cloud-backed but cached locally.