### PR TITLE
Prefer `Set` in `sortChildrenBeforeParents`

### DIFF
--- a/common/changes/@itwin/core-backend/use-set-for-definitions_2022-08-19-19-36.json
+++ b/common/changes/@itwin/core-backend/use-set-for-definitions_2022-08-19-19-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Use `Set` in `sortChildrenBeforeParents`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/imodel/ElementTreeWalker.test.ts
+++ b/core/backend/src/test/imodel/ElementTreeWalker.test.ts
@@ -406,6 +406,11 @@ describe("ElementTreeWalker", () => {
       imodel = SnapshotDb.createEmpty(iModelFileName, { rootSubject: { name: "ElementTreeWalker Test" } });
     });
 
+    afterEach(() => {
+      sinon.restore();
+      imodel.close();
+    });
+
     it("definition model models definition container", (): void => {
       //                         o - subject
       //                         |

--- a/core/backend/src/test/imodel/ElementTreeWalker.test.ts
+++ b/core/backend/src/test/imodel/ElementTreeWalker.test.ts
@@ -3,12 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Id64, Id64Array, Id64String } from "@itwin/core-bentley";
-import { Code, GeometricElement2dProps, GeometricElementProps, IModel, SubCategoryAppearance } from "@itwin/core-common";
+import { CategoryProps, Code, CodeScopeSpec, CodeSpec, DefinitionElementProps, GeometricElement2dProps, GeometricElementProps, IModel, InformationPartitionElementProps, ModelProps, SubCategoryAppearance, SubjectProps } from "@itwin/core-common";
 import { Point2d } from "@itwin/core-geometry";
 import { assert } from "chai";
 import * as path from "path";
 import * as sinon from "sinon";
-import { DefinitionModel, DocumentListModel, Drawing, DrawingCategory, DrawingGraphic, ElementGroupsMembers, ElementOwnsChildElements, ExternalSource, ExternalSourceGroup, IModelDb, Model, PhysicalPartition, SnapshotDb, SpatialCategory, SubCategory, Subject } from "../../core-backend";
+import { DefinitionContainer, DefinitionModel, DefinitionPartition, DocumentListModel, Drawing, DrawingCategory, DrawingGraphic, ElementGroupsMembers, ElementOwnsChildElements, ExternalSource, ExternalSourceGroup, IModelDb, Model, PhysicalPartition, SnapshotDb, SpatialCategory, SubCategory, Subject, SubjectOwnsPartitionElements, SubjectOwnsSubjects } from "../../core-backend";
 import { deleteElementSubTrees, deleteElementTree, ElementTreeBottomUp, ElementTreeWalkerScope } from "../../ElementTreeWalker";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
@@ -66,320 +66,442 @@ function doesGroupRelationshipExist(iModel: IModelDb, source: Id64String, target
 }
 
 describe("ElementTreeWalker", () => {
-  let iModel: SnapshotDb;
-  let originalEnv: any;
+  describe("flat model with partitions", () => {
+    let iModel: SnapshotDb;
+    let originalEnv: any;
 
-  let repositoryLinkId: Id64String;
-  let jobSubjectId: Id64String;
-  let childSubject: Id64String;
-  let definitionModelId: Id64String;
-  let drawingDefinitionModelId: Id64String;
-  let spatialCategoryId: Id64String;
-  let drawingCategoryId: Id64String;
-  let drawingSubCategory1Id: Id64String;
-  let drawingSubCategory2Id: Id64String;
-  let xsGroup: Id64String;
-  let xsElement: Id64String;
-  let documentListModelId: Id64String;
-  let drawingModelId: Id64String;
-  let drawingGraphicId1: Id64String;
-  let physicalModelId: Id64String;
-  let physicalObjectId1: Id64String;
-  let physicalObjectId2: Id64String;
-  let physicalObjectId3: Id64String;
+    let repositoryLinkId: Id64String;
+    let jobSubjectId: Id64String;
+    let childSubject: Id64String;
+    let definitionModelId: Id64String;
+    let drawingDefinitionModelId: Id64String;
+    let spatialCategoryId: Id64String;
+    let drawingCategoryId: Id64String;
+    let drawingSubCategory1Id: Id64String;
+    let drawingSubCategory2Id: Id64String;
+    let xsGroup: Id64String;
+    let xsElement: Id64String;
+    let documentListModelId: Id64String;
+    let drawingModelId: Id64String;
+    let drawingGraphicId1: Id64String;
+    let physicalModelId: Id64String;
+    let physicalObjectId1: Id64String;
+    let physicalObjectId2: Id64String;
+    let physicalObjectId3: Id64String;
 
-  before(async () => {
-    originalEnv = { ...process.env };
+    before(async () => {
+      originalEnv = { ...process.env };
 
-    IModelTestUtils.registerTestBimSchema();
+      IModelTestUtils.registerTestBimSchema();
+    });
+
+    after(() => {
+      process.env = originalEnv;
+    });
+
+    beforeEach(async () => {
+      // Uncomment the following two lines to debug test failures
+      // Logger.initializeToConsole();
+      // Logger.setLevel("core-backend.IModelDb.ElementTreeWalker", LogLevel.Trace);
+
+      const iModelFileName = IModelTestUtils.prepareOutputFile("ElementTreeWalker", "Test.bim");
+      iModel = SnapshotDb.createEmpty(iModelFileName, { rootSubject: { name: "ElementTreeWalker Test" } });
+      const schemaPathname = path.join(KnownTestLocations.assetsDir, "TestBim.ecschema.xml");
+      await iModel.importSchemas([schemaPathname]); // will throw an exception if import fails
+
+      /*
+        [RepositoryModel]
+          RepositoryLink
+          Job Subject
+            +- DefinitionParitition  --   [DefinitionModel]
+            |                               DrawingCategory
+            |                                 default SubCategory + 2 non-default SubCategories
+            |                               ExternalSourceGroup
+            |                                 ExternalSource child1
+            +- DefinitionParitition  --   [DefinitionModel]
+            |                               SpatialCategory
+            |
+            +- DocumentList         --    [DocumentListModel]
+            |                               Drawing             -- [DrawingModel]
+            |                                                       DrawingGraphic
+            +- Child Subject
+                |
+                +- PhysicalPartition --   [PhysicalModel]
+                                            PhysicalObject, PhysicalObject, PhysicalObject (grouped)
+      */
+
+      repositoryLinkId = IModelTestUtils.insertRepositoryLink(iModel, "test link", "foo", "bar");
+      jobSubjectId = IModelTestUtils.createJobSubjectElement(iModel, "Job").insert();
+
+      childSubject = Subject.insert(iModel, jobSubjectId, "Child Subject");
+
+      definitionModelId = DefinitionModel.insert(iModel, jobSubjectId, "Definition");
+      spatialCategoryId = SpatialCategory.insert(iModel, definitionModelId, "SpatialCategory", new SubCategoryAppearance());
+      drawingDefinitionModelId = DefinitionModel.insert(iModel, jobSubjectId, "DrawingDefinition");
+      drawingCategoryId = DrawingCategory.insert(iModel, drawingDefinitionModelId, "DrawingCategory", new SubCategoryAppearance());
+      drawingSubCategory1Id = SubCategory.insert(iModel, drawingCategoryId, "SubCategory1", new SubCategoryAppearance());
+      drawingSubCategory2Id = SubCategory.insert(iModel, drawingCategoryId, "SubCategory2", new SubCategoryAppearance());
+
+      xsGroup = iModel.elements.insertElement({ classFullName: ExternalSourceGroup.classFullName, model: drawingDefinitionModelId, code: Code.createEmpty() });
+      xsElement = iModel.elements.insertElement({ classFullName: ExternalSource.classFullName, model: drawingDefinitionModelId, parent: new ElementOwnsChildElements(xsGroup), code: Code.createEmpty() });
+
+      documentListModelId = DocumentListModel.insert(iModel, jobSubjectId, "Document");
+      assert.isTrue(Id64.isValidId64(documentListModelId));
+      drawingModelId = Drawing.insert(iModel, documentListModelId, "Drawing");
+      const drawingGraphicProps1: GeometricElement2dProps = {
+        classFullName: DrawingGraphic.classFullName,
+        model: drawingModelId,
+        category: drawingCategoryId,
+        code: Code.createEmpty(),
+        userLabel: "DrawingGraphic1",
+        geom: IModelTestUtils.createRectangle(Point2d.create(1, 1)),
+        placement: { origin: Point2d.create(2, 2), angle: 0 },
+      };
+      drawingGraphicId1 = iModel.elements.insertElement(drawingGraphicProps1);
+
+      [, physicalModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(iModel, PhysicalPartition.createCode(iModel, childSubject, "Physical"), false, childSubject);
+      const elementProps: GeometricElementProps = {
+        classFullName: "TestBim:TestPhysicalObject",
+        model: physicalModelId,
+        category: spatialCategoryId,
+        code: Code.createEmpty(),
+      };
+
+      physicalObjectId1 = iModel.elements.insertElement(iModel.elements.createElement(elementProps).toJSON());
+      physicalObjectId2 = iModel.elements.insertElement(iModel.elements.createElement(elementProps).toJSON());
+      physicalObjectId3 = iModel.elements.insertElement(iModel.elements.createElement(elementProps).toJSON());
+      ElementGroupsMembers.create(iModel, physicalObjectId1, physicalObjectId2).insert();
+      ElementGroupsMembers.create(iModel, physicalObjectId1, physicalObjectId3).insert();
+
+      assert.isTrue(doesElementExist(iModel, repositoryLinkId));
+      assert.equal(iModel.elements.getElement(jobSubjectId).parent?.id, IModel.rootSubjectId);
+      assert.equal(iModel.elements.getElement(definitionModelId).parent?.id, jobSubjectId);
+      assert.equal(iModel.elements.getElement(spatialCategoryId).model, definitionModelId);
+      assert.equal(iModel.elements.getElement(drawingDefinitionModelId).parent?.id, jobSubjectId);
+      assert.equal(iModel.elements.getElement(drawingCategoryId).model, drawingDefinitionModelId);
+      assert.equal(iModel.elements.getElement(drawingSubCategory1Id).parent?.id, drawingCategoryId);
+      assert.equal(iModel.elements.getElement(drawingSubCategory2Id).parent?.id, drawingCategoryId);
+      assert.equal(iModel.elements.getElement(xsGroup).model, drawingDefinitionModelId);
+      assert.equal(iModel.elements.getElement(xsElement).parent?.id, xsGroup);
+      assert.equal(iModel.elements.getElement(documentListModelId).parent?.id, jobSubjectId);
+      assert.equal(iModel.elements.getElement(drawingModelId).model, documentListModelId);
+      assert.equal(iModel.elements.getElement(drawingGraphicId1).model, drawingModelId);
+      assert.equal(iModel.elements.getElement(physicalModelId).parent?.id, childSubject);
+      assert.equal(iModel.elements.getElement(physicalObjectId1).model, physicalModelId);
+      assert.equal(iModel.elements.getElement(physicalObjectId2).model, physicalModelId);
+      assert.equal(iModel.elements.getElement(physicalObjectId3).model, physicalModelId);
+      assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
+      assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
+      assert.isTrue(doesModelExist(iModel, definitionModelId));
+      assert.isTrue(doesModelExist(iModel, drawingDefinitionModelId));
+      assert.isTrue(doesModelExist(iModel, drawingModelId));
+      assert.isTrue(doesModelExist(iModel, physicalModelId));
+    });
+
+    afterEach(() => {
+      sinon.restore();
+      iModel.close();
+    });
+
+    it("DFS search and deleteElementTree", () => {
+      // First, check that DFS search visits elements and models in expected bottom-up order
+      {
+        const collector1 = new ElementTreeCollector(iModel);
+        collector1.collect(jobSubjectId);
+        assert.isTrue(collector1.subModels.includes(physicalModelId));
+        assert.isTrue(collector1.subModels.includes(drawingModelId));
+        assert.isTrue(collector1.subModels.includes(documentListModelId));
+        assert.isTrue(collector1.subModels.indexOf(drawingModelId) < collector1.subModels.indexOf(documentListModelId), "in bottom-up search, a child model should be visited before its parent model");
+        assert.isFalse(collector1.subModels.includes(definitionModelId));
+        assert.isTrue(collector1.definitionModels.includes(definitionModelId));
+        assert.isFalse(collector1.subModels.includes(drawingDefinitionModelId));
+        assert.isTrue(collector1.definitionModels.includes(drawingDefinitionModelId));
+        assert.isTrue(collector1.definitions.includes(drawingCategoryId));
+        assert.isTrue(collector1.definitions.includes(spatialCategoryId));
+        assert.isFalse(collector1.elements.includes(drawingCategoryId));
+        assert.isFalse(collector1.elements.includes(spatialCategoryId));
+        assert.isTrue(collector1.elements.indexOf(physicalObjectId1) < collector1.elements.indexOf(physicalModelId), "in bottom-up search, an element in a model should be visited before its model's element");
+        assert.isTrue(collector1.elements.indexOf(drawingGraphicId1) < collector1.elements.indexOf(drawingModelId), "in bottom-up search, an element in a model should be visited before its model's element");
+        assert.isTrue(collector1.elements.indexOf(drawingModelId) < collector1.elements.indexOf(documentListModelId), "in bottom-up search, an element in a model should be visited before its model's element");
+        assert.isTrue(collector1.elements.indexOf(documentListModelId) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
+        assert.isTrue(collector1.elements.indexOf(definitionModelId) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
+        assert.isTrue(collector1.elements.indexOf(drawingDefinitionModelId) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
+        assert.isTrue(collector1.elements.indexOf(childSubject) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
+        assert.isTrue(collector1.elements.indexOf(physicalModelId) < collector1.elements.indexOf(childSubject), "in bottom-up search, a child element should be visited before its parent element");
+      }
+
+      // Exercise the search filters
+      {
+        const collector2 = new SelectedElementCollector(iModel, [drawingGraphicId1, spatialCategoryId, physicalObjectId3]);
+        collector2.collect(jobSubjectId);
+        assert.isTrue(collector2.definitions.length === 1);
+        assert.isTrue(collector2.definitions.includes(spatialCategoryId));
+        assert.isTrue(collector2.elements.length === 2);
+        assert.isTrue(collector2.elements.includes(drawingGraphicId1));
+        assert.isTrue(collector2.elements.includes(physicalObjectId3));
+      }
+
+      // Test the deleteElementTree function
+      deleteElementTree(iModel, jobSubjectId);
+
+      assert.isTrue(doesModelExist(iModel, IModel.repositoryModelId));
+      assert.isTrue(doesModelExist(iModel, IModel.dictionaryId));
+      assert.isTrue(doesElementExist(iModel, repositoryLinkId), "RepositoryLink should not have been deleted, since it is not under Job Subject");
+      assert.isFalse(doesElementExist(iModel, definitionModelId));
+      assert.isFalse(doesElementExist(iModel, drawingDefinitionModelId));
+      assert.isFalse(doesElementExist(iModel, spatialCategoryId));
+      assert.isFalse(doesElementExist(iModel, drawingCategoryId));
+      assert.isFalse(doesElementExist(iModel, xsGroup));
+      assert.isFalse(doesElementExist(iModel, xsElement));
+      assert.isFalse(doesElementExist(iModel, documentListModelId));
+      assert.isFalse(doesElementExist(iModel, drawingModelId));
+      assert.isFalse(doesElementExist(iModel, drawingGraphicId1));
+      assert.isFalse(doesElementExist(iModel, physicalModelId));
+      assert.isFalse(doesElementExist(iModel, physicalObjectId1));
+      assert.isFalse(doesElementExist(iModel, physicalObjectId2));
+      assert.isFalse(doesElementExist(iModel, physicalObjectId3));
+      assert.isFalse(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
+      assert.isFalse(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
+      assert.isFalse(doesElementExist(iModel, jobSubjectId));
+      assert.isFalse(doesModelExist(iModel, definitionModelId));
+      assert.isFalse(doesModelExist(iModel, drawingDefinitionModelId));
+      assert.isFalse(doesModelExist(iModel, drawingModelId));
+      assert.isFalse(doesModelExist(iModel, physicalModelId));
+    });
+
+    it("deleteElementSubTrees", () => {
+      /*
+        [RepositoryModel]
+          RepositoryLink
+          Job Subject
+            +- DefinitionParitition  --   [DefinitionModel]
+            |                               DrawingCategory                         <-- PRUNE
+            |                                 default SubCategory + 2 non-default SubCategories
+            |                               ExternalSourceGroup
+            |                                 ExternalSource child1
+            +- DefinitionParitition  --   [DefinitionModel]
+            |                               SpatialCategory
+            |
+            +- DocumentList         --    [DocumentListModel]
+            |                               Drawing             -- [DrawingModel]   <-- PRUNE
+            |                                                       DrawingGraphic       "
+            +- Child Subject
+                |
+                +- PhysicalPartition --   [PhysicalModel]
+                                            PhysicalObject, PhysicalObject, PhysicalObject (grouped)
+                                                                                    ^-- PRUNE
+      */
+
+      const toPrune = new Set<string>();
+      toPrune.add(drawingModelId);
+      toPrune.add(drawingCategoryId);
+      toPrune.add(physicalObjectId3);
+
+      deleteElementSubTrees(iModel, jobSubjectId, (elementId) => toPrune.has(elementId));
+
+      assert.isFalse(doesElementExist(iModel, drawingCategoryId));
+      assert.isFalse(doesElementExist(iModel, drawingSubCategory1Id));
+      assert.isFalse(doesElementExist(iModel, drawingSubCategory2Id));
+      assert.isFalse(doesElementExist(iModel, drawingModelId));
+      assert.isFalse(doesModelExist(iModel, drawingModelId));
+      assert.isFalse(doesElementExist(iModel, drawingGraphicId1)); // contents of drawing model should be gone
+      assert.isFalse(doesElementExist(iModel, physicalObjectId3));
+      assert.isFalse(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
+
+      assert.isTrue(doesElementExist(iModel, repositoryLinkId));
+      assert.isTrue(doesElementExist(iModel, definitionModelId));
+      assert.isTrue(doesElementExist(iModel, drawingDefinitionModelId));
+      assert.equal(iModel.elements.getElement(xsGroup).model, drawingDefinitionModelId);
+      assert.equal(iModel.elements.getElement(xsElement).parent?.id, xsGroup);
+      assert.isTrue(doesElementExist(iModel, spatialCategoryId));
+      assert.isTrue(doesElementExist(iModel, documentListModelId));
+      assert.isTrue(doesElementExist(iModel, physicalModelId));
+      assert.isTrue(doesElementExist(iModel, physicalObjectId1));
+      assert.isTrue(doesElementExist(iModel, physicalObjectId2));
+      assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
+      assert.isTrue(doesElementExist(iModel, jobSubjectId));
+      assert.isTrue(doesModelExist(iModel, definitionModelId));
+      assert.isTrue(doesModelExist(iModel, drawingDefinitionModelId));
+      assert.isTrue(doesModelExist(iModel, physicalModelId));
+      assert.isTrue(doesModelExist(iModel, IModel.repositoryModelId));
+      assert.isTrue(doesModelExist(iModel, IModel.dictionaryId));
+    });
+
+    it("deleteDefinitionPartition", () => {
+      /*
+        [RepositoryModel]
+          RepositoryLink
+          Job Subject
+            +- DefinitionParitition  --   [DefinitionModel]                         <-- PRUNE
+            |                               DrawingCategory
+            |                                 default SubCategory + 2 non-default SubCategories
+            |                               ExternalSourceGroup
+            |                                 ExternalSource child1
+            +- DefinitionParitition  --   [DefinitionModel]
+            |                               SpatialCategory
+            |
+            +- DocumentList         --    [DocumentListModel]
+            |                               Drawing             -- [DrawingModel]
+            |                                                       DrawingGraphic
+            +- Child Subject
+                |
+                +- PhysicalPartition --   [PhysicalModel]
+                                            PhysicalObject, PhysicalObject, PhysicalObject (grouped)
+      */
+
+      const toPrune = new Set<string>();
+      toPrune.add(drawingDefinitionModelId);
+      toPrune.add(documentListModelId); // (also get rid of the elements that use the definitions)
+
+      deleteElementSubTrees(iModel, jobSubjectId, (elementId) => toPrune.has(elementId));
+
+      assert.isFalse(doesElementExist(iModel, drawingDefinitionModelId));
+      assert.isFalse(doesModelExist(iModel, drawingDefinitionModelId));
+      assert.isFalse(doesElementExist(iModel, drawingCategoryId));
+      assert.isFalse(doesElementExist(iModel, drawingSubCategory1Id));
+      assert.isFalse(doesElementExist(iModel, drawingSubCategory2Id));
+      assert.isFalse(doesElementExist(iModel, xsGroup));
+      assert.isFalse(doesElementExist(iModel, xsElement));
+      assert.isFalse(doesElementExist(iModel, documentListModelId));
+      assert.isFalse(doesModelExist(iModel, documentListModelId));
+      assert.isFalse(doesElementExist(iModel, drawingModelId));
+      assert.isFalse(doesModelExist(iModel, drawingModelId));
+      assert.isFalse(doesElementExist(iModel, drawingGraphicId1));
+
+      assert.isTrue(doesElementExist(iModel, repositoryLinkId));
+      assert.isTrue(doesElementExist(iModel, definitionModelId));
+      assert.isTrue(doesElementExist(iModel, spatialCategoryId));
+      assert.isTrue(doesElementExist(iModel, physicalModelId));
+      assert.isTrue(doesElementExist(iModel, physicalObjectId1));
+      assert.isTrue(doesElementExist(iModel, physicalObjectId2));
+      assert.isTrue(doesElementExist(iModel, physicalObjectId3));
+      assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
+      assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
+      assert.isTrue(doesElementExist(iModel, jobSubjectId));
+      assert.isTrue(doesModelExist(iModel, definitionModelId));
+      assert.isTrue(doesModelExist(iModel, physicalModelId));
+      assert.isTrue(doesModelExist(iModel, IModel.repositoryModelId));
+      assert.isTrue(doesModelExist(iModel, IModel.dictionaryId));
+    });
   });
 
-  after(() => {
-    process.env = originalEnv;
-  });
+  describe("nested definition models", () => {
+    let imodel: SnapshotDb;
+    let originalEnv: any;
 
-  beforeEach(async () => {
-    // Uncomment the following two lines to debug test failures
-    // Logger.initializeToConsole();
-    // Logger.setLevel("core-backend.IModelDb.ElementTreeWalker", LogLevel.Trace);
+    before(async () => {
+      originalEnv = { ...process.env }; // ???
+    });
 
-    const iModelFileName = IModelTestUtils.prepareOutputFile("ElementTreeWalker", "Test.bim");
-    iModel = SnapshotDb.createEmpty(iModelFileName, { rootSubject: { name: "ElementTreeWalker Test" } });
-    const schemaPathname = path.join(KnownTestLocations.assetsDir, "TestBim.ecschema.xml");
-    await iModel.importSchemas([schemaPathname]); // will throw an exception if import fails
+    after(() => {
+      process.env = originalEnv;
+    });
 
-    /*
-      [RepositoryModel]
-        RepositoryLink
-        Job Subject
-          +- DefinitionParitition  --   [DefinitionModel]
-          |                               DrawingCategory
-          |                                 default SubCategory + 2 non-default SubCategories
-          |                               ExternalSourceGroup
-          |                                 ExternalSource child1
-          +- DefinitionParitition  --   [DefinitionModel]
-          |                               SpatialCategory
-          |
-          +- DocumentList         --    [DocumentListModel]
-          |                               Drawing             -- [DrawingModel]
-          |                                                       DrawingGraphic
-          +- Child Subject
-              |
-              +- PhysicalPartition --   [PhysicalModel]
-                                          PhysicalObject, PhysicalObject, PhysicalObject (grouped)
-    */
+    beforeEach(async () => {
+      // Uncomment the following two lines to debug test failures
+      // Logger.initializeToConsole();
+      // Logger.setLevel("core-backend.IModelDb.ElementTreeWalker", LogLevel.Trace);
 
-    repositoryLinkId = IModelTestUtils.insertRepositoryLink(iModel, "test link", "foo", "bar");
-    jobSubjectId = IModelTestUtils.createJobSubjectElement(iModel, "Job").insert();
+      const iModelFileName = IModelTestUtils.prepareOutputFile("ElementTreeWalker", "Test.bim");
+      imodel = SnapshotDb.createEmpty(iModelFileName, { rootSubject: { name: "ElementTreeWalker Test" } });
+    });
 
-    childSubject = Subject.insert(iModel, jobSubjectId, "Child Subject");
+    it("definition model models definition container", (): void => {
+      //                         o - subject
+      //                         |
+      //                         o - partition
+      //                         |
+      //                         o - model
+      //                         |
+      //                         o - definition container
+      //                        / \
+      //            category - o   o - definition container
+      //                       |   |
+      // default subcategory - o   o - nested definition model
+      //                           |
+      //                           o - category
+      //                           |
+      //                           o - default subcategory
 
-    definitionModelId = DefinitionModel.insert(iModel, jobSubjectId, "Definition");
-    spatialCategoryId = SpatialCategory.insert(iModel, definitionModelId, "SpatialCategory", new SubCategoryAppearance());
-    drawingDefinitionModelId = DefinitionModel.insert(iModel, jobSubjectId, "DrawingDefinition");
-    drawingCategoryId = DrawingCategory.insert(iModel, drawingDefinitionModelId, "DrawingCategory", new SubCategoryAppearance());
-    drawingSubCategory1Id = SubCategory.insert(iModel, drawingCategoryId, "SubCategory1", new SubCategoryAppearance());
-    drawingSubCategory2Id = SubCategory.insert(iModel, drawingCategoryId, "SubCategory2", new SubCategoryAppearance());
+      const subject: SubjectProps = {
+        classFullName: Subject.classFullName,
+        code: Code.createEmpty(),
+        model: SnapshotDb.repositoryModelId,
+        parent: new SubjectOwnsSubjects(SnapshotDb.rootSubjectId),
+      };
 
-    xsGroup = iModel.elements.insertElement({ classFullName: ExternalSourceGroup.classFullName, model: drawingDefinitionModelId, code: Code.createEmpty() });
-    xsElement = iModel.elements.insertElement({ classFullName: ExternalSource.classFullName, model: drawingDefinitionModelId, parent: new ElementOwnsChildElements(xsGroup), code: Code.createEmpty() });
+      const subjectId = imodel.elements.insertElement(subject);
 
-    documentListModelId = DocumentListModel.insert(iModel, jobSubjectId, "Document");
-    assert.isTrue(Id64.isValidId64(documentListModelId));
-    drawingModelId = Drawing.insert(iModel, documentListModelId, "Drawing");
-    const drawingGraphicProps1: GeometricElement2dProps = {
-      classFullName: DrawingGraphic.classFullName,
-      model: drawingModelId,
-      category: drawingCategoryId,
-      code: Code.createEmpty(),
-      userLabel: "DrawingGraphic1",
-      geom: IModelTestUtils.createRectangle(Point2d.create(1, 1)),
-      placement: { origin: Point2d.create(2, 2), angle: 0 },
-    };
-    drawingGraphicId1 = iModel.elements.insertElement(drawingGraphicProps1);
+      const partition: InformationPartitionElementProps = {
+        classFullName: DefinitionPartition.classFullName,
+        code: Code.createEmpty(),
+        model: SnapshotDb.repositoryModelId,
+        parent: new SubjectOwnsPartitionElements(subjectId),
+      };
 
-    [, physicalModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(iModel, PhysicalPartition.createCode(iModel, childSubject, "Physical"), false, childSubject);
-    const elementProps: GeometricElementProps = {
-      classFullName: "TestBim:TestPhysicalObject",
-      model: physicalModelId,
-      category: spatialCategoryId,
-      code: Code.createEmpty(),
-    };
+      const partitionId = imodel.elements.insertElement(partition);
 
-    physicalObjectId1 = iModel.elements.insertElement(iModel.elements.createElement(elementProps).toJSON());
-    physicalObjectId2 = iModel.elements.insertElement(iModel.elements.createElement(elementProps).toJSON());
-    physicalObjectId3 = iModel.elements.insertElement(iModel.elements.createElement(elementProps).toJSON());
-    ElementGroupsMembers.create(iModel, physicalObjectId1, physicalObjectId2).insert();
-    ElementGroupsMembers.create(iModel, physicalObjectId1, physicalObjectId3).insert();
+      const model: ModelProps = {
+        classFullName: DefinitionModel.classFullName,
+        modeledElement: { id: partitionId },
+        parentModel: IModel.repositoryModelId,
+      };
 
-    assert.isTrue(doesElementExist(iModel, repositoryLinkId));
-    assert.equal(iModel.elements.getElement(jobSubjectId).parent?.id, IModel.rootSubjectId);
-    assert.equal(iModel.elements.getElement(definitionModelId).parent?.id, jobSubjectId);
-    assert.equal(iModel.elements.getElement(spatialCategoryId).model, definitionModelId);
-    assert.equal(iModel.elements.getElement(drawingDefinitionModelId).parent?.id, jobSubjectId);
-    assert.equal(iModel.elements.getElement(drawingCategoryId).model, drawingDefinitionModelId);
-    assert.equal(iModel.elements.getElement(drawingSubCategory1Id).parent?.id, drawingCategoryId);
-    assert.equal(iModel.elements.getElement(drawingSubCategory2Id).parent?.id, drawingCategoryId);
-    assert.equal(iModel.elements.getElement(xsGroup).model, drawingDefinitionModelId);
-    assert.equal(iModel.elements.getElement(xsElement).parent?.id, xsGroup);
-    assert.equal(iModel.elements.getElement(documentListModelId).parent?.id, jobSubjectId);
-    assert.equal(iModel.elements.getElement(drawingModelId).model, documentListModelId);
-    assert.equal(iModel.elements.getElement(drawingGraphicId1).model, drawingModelId);
-    assert.equal(iModel.elements.getElement(physicalModelId).parent?.id, childSubject);
-    assert.equal(iModel.elements.getElement(physicalObjectId1).model, physicalModelId);
-    assert.equal(iModel.elements.getElement(physicalObjectId2).model, physicalModelId);
-    assert.equal(iModel.elements.getElement(physicalObjectId3).model, physicalModelId);
-    assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
-    assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
-    assert.isTrue(doesModelExist(iModel, definitionModelId));
-    assert.isTrue(doesModelExist(iModel, drawingDefinitionModelId));
-    assert.isTrue(doesModelExist(iModel, drawingModelId));
-    assert.isTrue(doesModelExist(iModel, physicalModelId));
-  });
+      const modelId = imodel.models.insertModel(model);
 
-  afterEach(() => {
-    sinon.restore();
-    iModel.close();
-  });
+      // Surely this isn't the right way to create a code for a definition container?
+      const containerSpec = CodeSpec.create(imodel, "bis:DefinitionContainer", CodeScopeSpec.Type.Model);
 
-  it("DFS search and deleteElementTree", () => {
-    // First, check that DFS search visits elements and models in expected bottom-up order
-    {
-      const collector1 = new ElementTreeCollector(iModel);
-      collector1.collect(jobSubjectId);
-      assert.isTrue(collector1.subModels.includes(physicalModelId));
-      assert.isTrue(collector1.subModels.includes(drawingModelId));
-      assert.isTrue(collector1.subModels.includes(documentListModelId));
-      assert.isTrue(collector1.subModels.indexOf(drawingModelId) < collector1.subModels.indexOf(documentListModelId), "in bottom-up search, a child model should be visited before its parent model");
-      assert.isFalse(collector1.subModels.includes(definitionModelId));
-      assert.isTrue(collector1.definitionModels.includes(definitionModelId));
-      assert.isFalse(collector1.subModels.includes(drawingDefinitionModelId));
-      assert.isTrue(collector1.definitionModels.includes(drawingDefinitionModelId));
-      assert.isTrue(collector1.definitions.includes(drawingCategoryId));
-      assert.isTrue(collector1.definitions.includes(spatialCategoryId));
-      assert.isFalse(collector1.elements.includes(drawingCategoryId));
-      assert.isFalse(collector1.elements.includes(spatialCategoryId));
-      assert.isTrue(collector1.elements.indexOf(physicalObjectId1) < collector1.elements.indexOf(physicalModelId), "in bottom-up search, an element in a model should be visited before its model's element");
-      assert.isTrue(collector1.elements.indexOf(drawingGraphicId1) < collector1.elements.indexOf(drawingModelId), "in bottom-up search, an element in a model should be visited before its model's element");
-      assert.isTrue(collector1.elements.indexOf(drawingModelId) < collector1.elements.indexOf(documentListModelId), "in bottom-up search, an element in a model should be visited before its model's element");
-      assert.isTrue(collector1.elements.indexOf(documentListModelId) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
-      assert.isTrue(collector1.elements.indexOf(definitionModelId) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
-      assert.isTrue(collector1.elements.indexOf(drawingDefinitionModelId) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
-      assert.isTrue(collector1.elements.indexOf(childSubject) < collector1.elements.indexOf(jobSubjectId), "in bottom-up search, a child element should be visited before its parent element");
-      assert.isTrue(collector1.elements.indexOf(physicalModelId) < collector1.elements.indexOf(childSubject), "in bottom-up search, a child element should be visited before its parent element");
-    }
+      const rootContainer: DefinitionElementProps = {
+        ...DefinitionContainer.create(
+          imodel,
+          modelId,
+          new Code({scope: modelId, spec: containerSpec.id, value: "root container"}),
+        ).toJSON(),
+      };
 
-    // Exercise the search filters
-    {
-      const collector2 = new SelectedElementCollector(iModel, [drawingGraphicId1, spatialCategoryId, physicalObjectId3]);
-      collector2.collect(jobSubjectId);
-      assert.isTrue(collector2.definitions.length === 1);
-      assert.isTrue(collector2.definitions.includes(spatialCategoryId));
-      assert.isTrue(collector2.elements.length === 2);
-      assert.isTrue(collector2.elements.includes(drawingGraphicId1));
-      assert.isTrue(collector2.elements.includes(physicalObjectId3));
-    }
+      const rootContainerId = imodel.elements.insertElement(rootContainer);
 
-    // Test the deleteElementTree function
-    deleteElementTree(iModel, jobSubjectId);
+      const firstCategory: CategoryProps = {
+        classFullName: SpatialCategory.classFullName,
+        code: SpatialCategory.createCode(imodel, modelId, "first category"),
+        model: modelId,
+        parent: new ElementOwnsChildElements(rootContainerId),
+      };
 
-    assert.isTrue(doesModelExist(iModel, IModel.repositoryModelId));
-    assert.isTrue(doesModelExist(iModel, IModel.dictionaryId));
-    assert.isTrue(doesElementExist(iModel, repositoryLinkId), "RepositoryLink should not have been deleted, since it is not under Job Subject");
-    assert.isFalse(doesElementExist(iModel, definitionModelId));
-    assert.isFalse(doesElementExist(iModel, drawingDefinitionModelId));
-    assert.isFalse(doesElementExist(iModel, spatialCategoryId));
-    assert.isFalse(doesElementExist(iModel, drawingCategoryId));
-    assert.isFalse(doesElementExist(iModel, xsGroup));
-    assert.isFalse(doesElementExist(iModel, xsElement));
-    assert.isFalse(doesElementExist(iModel, documentListModelId));
-    assert.isFalse(doesElementExist(iModel, drawingModelId));
-    assert.isFalse(doesElementExist(iModel, drawingGraphicId1));
-    assert.isFalse(doesElementExist(iModel, physicalModelId));
-    assert.isFalse(doesElementExist(iModel, physicalObjectId1));
-    assert.isFalse(doesElementExist(iModel, physicalObjectId2));
-    assert.isFalse(doesElementExist(iModel, physicalObjectId3));
-    assert.isFalse(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
-    assert.isFalse(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
-    assert.isFalse(doesElementExist(iModel, jobSubjectId));
-    assert.isFalse(doesModelExist(iModel, definitionModelId));
-    assert.isFalse(doesModelExist(iModel, drawingDefinitionModelId));
-    assert.isFalse(doesModelExist(iModel, drawingModelId));
-    assert.isFalse(doesModelExist(iModel, physicalModelId));
-  });
+      imodel.elements.insertElement(firstCategory);
 
-  it("deleteElementSubTrees", () => {
-    /*
-      [RepositoryModel]
-        RepositoryLink
-        Job Subject
-          +- DefinitionParitition  --   [DefinitionModel]
-          |                               DrawingCategory                         <-- PRUNE
-          |                                 default SubCategory + 2 non-default SubCategories
-          |                               ExternalSourceGroup
-          |                                 ExternalSource child1
-          +- DefinitionParitition  --   [DefinitionModel]
-          |                               SpatialCategory
-          |
-          +- DocumentList         --    [DocumentListModel]
-          |                               Drawing             -- [DrawingModel]   <-- PRUNE
-          |                                                       DrawingGraphic       "
-          +- Child Subject
-              |
-              +- PhysicalPartition --   [PhysicalModel]
-                                          PhysicalObject, PhysicalObject, PhysicalObject (grouped)
-                                                                                  ^-- PRUNE
-    */
+      const childContainer: DefinitionElementProps = {
+        ...DefinitionContainer.create(
+          imodel,
+          modelId,
+          new Code({scope: modelId, spec: containerSpec.id, value: "child container"}),
+        ).toJSON(),
+      };
 
-    const toPrune = new Set<string>();
-    toPrune.add(drawingModelId);
-    toPrune.add(drawingCategoryId);
-    toPrune.add(physicalObjectId3);
+      const childContainerId = imodel.elements.insertElement(childContainer);
 
-    deleteElementSubTrees(iModel, jobSubjectId, (elementId) => toPrune.has(elementId));
+      const nestedModel: ModelProps = {
+        classFullName: DefinitionModel.classFullName,
+        modeledElement: { id: childContainerId },
+        parentModel: modelId,
+      };
 
-    assert.isFalse(doesElementExist(iModel, drawingCategoryId));
-    assert.isFalse(doesElementExist(iModel, drawingSubCategory1Id));
-    assert.isFalse(doesElementExist(iModel, drawingSubCategory2Id));
-    assert.isFalse(doesElementExist(iModel, drawingModelId));
-    assert.isFalse(doesModelExist(iModel, drawingModelId));
-    assert.isFalse(doesElementExist(iModel, drawingGraphicId1)); // contents of drawing model should be gone
-    assert.isFalse(doesElementExist(iModel, physicalObjectId3));
-    assert.isFalse(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
+      const nestedModelId = imodel.models.insertModel(nestedModel);
 
-    assert.isTrue(doesElementExist(iModel, repositoryLinkId));
-    assert.isTrue(doesElementExist(iModel, definitionModelId));
-    assert.isTrue(doesElementExist(iModel, drawingDefinitionModelId));
-    assert.equal(iModel.elements.getElement(xsGroup).model, drawingDefinitionModelId);
-    assert.equal(iModel.elements.getElement(xsElement).parent?.id, xsGroup);
-    assert.isTrue(doesElementExist(iModel, spatialCategoryId));
-    assert.isTrue(doesElementExist(iModel, documentListModelId));
-    assert.isTrue(doesElementExist(iModel, physicalModelId));
-    assert.isTrue(doesElementExist(iModel, physicalObjectId1));
-    assert.isTrue(doesElementExist(iModel, physicalObjectId2));
-    assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
-    assert.isTrue(doesElementExist(iModel, jobSubjectId));
-    assert.isTrue(doesModelExist(iModel, definitionModelId));
-    assert.isTrue(doesModelExist(iModel, drawingDefinitionModelId));
-    assert.isTrue(doesModelExist(iModel, physicalModelId));
-    assert.isTrue(doesModelExist(iModel, IModel.repositoryModelId));
-    assert.isTrue(doesModelExist(iModel, IModel.dictionaryId));
-  });
+      const childCategory: CategoryProps = {
+        classFullName: SpatialCategory.classFullName,
+        code: SpatialCategory.createCode(imodel, modelId, "second category"),
+        model: nestedModelId,
+      };
 
-  it("deleteDefinitionPartition", () => {
-    /*
-      [RepositoryModel]
-        RepositoryLink
-        Job Subject
-          +- DefinitionParitition  --   [DefinitionModel]                         <-- PRUNE
-          |                               DrawingCategory
-          |                                 default SubCategory + 2 non-default SubCategories
-          |                               ExternalSourceGroup
-          |                                 ExternalSource child1
-          +- DefinitionParitition  --   [DefinitionModel]
-          |                               SpatialCategory
-          |
-          +- DocumentList         --    [DocumentListModel]
-          |                               Drawing             -- [DrawingModel]
-          |                                                       DrawingGraphic
-          +- Child Subject
-              |
-              +- PhysicalPartition --   [PhysicalModel]
-                                          PhysicalObject, PhysicalObject, PhysicalObject (grouped)
-    */
+      imodel.elements.insertElement(childCategory);
 
-    const toPrune = new Set<string>();
-    toPrune.add(drawingDefinitionModelId);
-    toPrune.add(documentListModelId); // (also get rid of the elements that use the definitions)
-
-    deleteElementSubTrees(iModel, jobSubjectId, (elementId) => toPrune.has(elementId));
-
-    assert.isFalse(doesElementExist(iModel, drawingDefinitionModelId));
-    assert.isFalse(doesModelExist(iModel, drawingDefinitionModelId));
-    assert.isFalse(doesElementExist(iModel, drawingCategoryId));
-    assert.isFalse(doesElementExist(iModel, drawingSubCategory1Id));
-    assert.isFalse(doesElementExist(iModel, drawingSubCategory2Id));
-    assert.isFalse(doesElementExist(iModel, xsGroup));
-    assert.isFalse(doesElementExist(iModel, xsElement));
-    assert.isFalse(doesElementExist(iModel, documentListModelId));
-    assert.isFalse(doesModelExist(iModel, documentListModelId));
-    assert.isFalse(doesElementExist(iModel, drawingModelId));
-    assert.isFalse(doesModelExist(iModel, drawingModelId));
-    assert.isFalse(doesElementExist(iModel, drawingGraphicId1));
-
-    assert.isTrue(doesElementExist(iModel, repositoryLinkId));
-    assert.isTrue(doesElementExist(iModel, definitionModelId));
-    assert.isTrue(doesElementExist(iModel, spatialCategoryId));
-    assert.isTrue(doesElementExist(iModel, physicalModelId));
-    assert.isTrue(doesElementExist(iModel, physicalObjectId1));
-    assert.isTrue(doesElementExist(iModel, physicalObjectId2));
-    assert.isTrue(doesElementExist(iModel, physicalObjectId3));
-    assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId2));
-    assert.isTrue(doesGroupRelationshipExist(iModel, physicalObjectId1, physicalObjectId3));
-    assert.isTrue(doesElementExist(iModel, jobSubjectId));
-    assert.isTrue(doesModelExist(iModel, definitionModelId));
-    assert.isTrue(doesModelExist(iModel, physicalModelId));
-    assert.isTrue(doesModelExist(iModel, IModel.repositoryModelId));
-    assert.isTrue(doesModelExist(iModel, IModel.dictionaryId));
+      // Eat the whole tree, starting from the subject.
+      assert.throws(
+        () => deleteElementTree(imodel, subjectId),
+        /error deleting element/i
+      );
+    });
   });
 });


### PR DESCRIPTION
Assuming `ECInstanceId`'s are unique among definition elements, I think we should be using a set to sort a bag of definition elements into their breadth-first ordering. In the worst-case scenario your iModel contains definition elements arranged in a linked list, and so this reduces the time complexity of `sortChildrenBeforeParents` from $O(n^3)$ to $O(n^2) $, `n === ids.length`.

I've also added a failing test for nested definition models. If we attempt to delete all deferred definition elements first, and any of those definition elements are modeled, the backend gets upset because the model's `ModeledElement` navigation property is still pointing to its modeled element.