### PR TITLE
fix: Updated CSS variables for desktop toolbar width/height to 40px for square icons

### DIFF
--- a/common/changes/@itwin/components-react/fix-new-icon-sizes_2022-08-25-14-47.json
+++ b/common/changes/@itwin/components-react/fix-new-icon-sizes_2022-08-25-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Updated desktop toolbar width and height to 40px",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/toolbar/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/_variables.scss
@@ -14,8 +14,8 @@ $components-desktop-separator-gap-between-toolbar-items: 5px;
 $components-desktop-separator-thickness: 1px;
 $components-desktop-separator-center-offset: -3px;
 
-$components-desktop-toolbar-width: 42px;
-$components-desktop-toolbar-height: 42px;
+$components-desktop-toolbar-width: 40px;
+$components-desktop-toolbar-height: 40px;
 
 $desktop-tool-stripe-width: 2px;
 $desktop-tool-stripe-height: 30px;


### PR DESCRIPTION
Changed width and height variables for the toolbar to be 40px, which matches the toolbar items and will create 1:1 square icon sizes.