### PR TITLE
Free up event loop in getCustomViewState3dData RPC operation between calls to queryModelExtents

### DIFF
--- a/common/changes/@itwin/core-backend/nick-getcustomviewstate3ddata-freeup-loop_2022-08-29-16-31.json
+++ b/common/changes/@itwin/core-backend/nick-getcustomviewstate3ddata-freeup-loop_2022-08-29-16-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "await new promise in CustomViewState3dCreator getModelExtents",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CustomViewState3dCreator.ts
+++ b/core/backend/src/CustomViewState3dCreator.ts
@@ -57,6 +57,7 @@ export class CustomViewState3dCreator {
     const modelIds = new Set(modelIdsList);
     for (const id of modelIds) {
       try {
+        await new Promise((resolve) => setImmediate(resolve)); // Free up main thread temporarily. Ideally we get queryModelExtents off the main thread and do not need to do this.
         const props = this._imodel.nativeDb.queryModelExtents({ id }).modelExtents;
         modelExtents.union(Range3d.fromJSON(props), modelExtents);
       } catch (err: any) {


### PR DESCRIPTION
This is meant as a short term solution to the problem that we have been seeing where we're unable to distinguish between a long-running RPC operation and a hanging backend. The reason for the inability to distinguish is that getCustomViewState3dData does work on the main thread in the form of the native function "queryModelExtents". Since this function is called in a loop for each modelId from the typescript side we can call "await new Promise((resolve) => setImmediate(resolve));" before each call to queryModelExtents. This will allow for the backend to respond to pings which allows us to know that the backend is not hung.

Ideally, we move queryModelExtents off the main thread in the near future, in which case we will not need this call "await new Promise((resolve) => setImmediate(resolve));".