### PR TITLE
Dock tool settings if tab is removed

### DIFF
--- a/common/changes/@itwin/appui-react/master_2022-08-30-13-25.json
+++ b/common/changes/@itwin/appui-react/master_2022-08-30-13-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Dock removed widget tool settings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -757,6 +757,16 @@ export function restoreNineZoneState(frontstageDef: FrontstageDef, saved: SavedN
 
     return;
   });
+
+  // TODO: remove when isUUID check is refactored.
+  restored = produce(restored, (draft) => {
+    // Floating widget might have been removed when saving, dock tool settings if tab is not found.
+    const location = findTab(draft, toolSettingsTabId);
+    if (!location) {
+      draft.toolSettings.type = "docked";
+    }
+  });
+
   if (FrontstageManager.nineZoneSize && (0 !== FrontstageManager.nineZoneSize.height || 0 !== FrontstageManager.nineZoneSize.width)) {
     restored = FrameworkStateReducer(restored, {
       type: "RESIZE",


### PR DESCRIPTION
This PR fixes an issue where tool settings widget is removed from the UI when saving/restoring the state.