### PR TITLE
Add test for attaching aspect to a different element

### DIFF
--- a/common/changes/@itwin/core-backend/master_2022-09-02-20-09.json
+++ b/common/changes/@itwin/core-backend/master_2022-09-02-20-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add test for attaching aspect to a different element",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/master_2022-09-02-20-09.json
+++ b/common/changes/@itwin/core-backend/master_2022-09-02-20-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Add test for attaching aspect to a different element",
+      "comment": "",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Hey `core` team. I'm working on aspect support in the declarative connector framework [`@itwin/pcf`](https://github.com/iTwin/pcf). The aspect API gave me a hard time with my declarative synchronizer [`fir`](https://github.com/jackson-at-bentley/fir) and I suspect [`@itwin/connector-framework`](https://github.com/iTwin/connector-framework) is going to run into the same problems when it eventually supports aspects.

This may be the same problem as #3969: currently the aspect API doesn't give you a handle on the aspect you insert, and it's just gone forever in the iModel, because aspects don't have codes or provenance.

It seems like `updateAspect` fails when you change the `Element` navigation property of its argument, which has type `RelatedElementProps`. In the attached test, the backend seems to consider its updated argument a different aspect even though it has the same `ECInstanceId`.

I'm confused and will appreciate any insight. My workaround to this in `pcf` is just to delete and reinsert the aspect.