### PR TITLE
Increase visibility of widget targets

### DIFF
--- a/common/changes/@itwin/appui-layout-react/widget-target-visibility_2022-09-08-15-37.json
+++ b/common/changes/@itwin/appui-layout-react/widget-target-visibility_2022-09-08-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Increase visibility of widget targets.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/target/_variables.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/target/_variables.scss
@@ -24,7 +24,7 @@ $nz-widget-target-border-size: 2px;
   transition: transform $iui-speed-fast ease-in;
   pointer-events: all;
   display: flex;
-  box-shadow: $iui-elevation-2;
+  box-shadow: $iui-elevation-8;
 
   @include uicore-z-index(drop-target);
 }
@@ -32,5 +32,5 @@ $nz-widget-target-border-size: 2px;
 @mixin nz-targeted-widget-target {
   transform: scale(1.2);
   background-color: $nz-opaque-outline-color;
-  box-shadow: $iui-elevation-4;
+  box-shadow: $iui-elevation-16;
 }


### PR DESCRIPTION
Use higher elevation box-shadow to increase widget target visibility.

Before:
![old](https://user-images.githubusercontent.com/10091419/189166654-2f11ea28-6fb0-4682-a803-52c9c25466b7.png)

After:
![new2](https://user-images.githubusercontent.com/10091419/189166685-4b288953-ab50-4b77-8dcf-640785b77c03.png)
