### PR TITLE
Fix a floating widget resize issue

### DIFF
--- a/common/changes/@itwin/appui-layout-react/fix-resize-issue_2022-09-15-13-36.json
+++ b/common/changes/@itwin/appui-layout-react/fix-resize-issue_2022-09-15-13-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Fix a floating widget resize issue.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/state/internal/NineZoneStateHelpers.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/internal/NineZoneStateHelpers.ts
@@ -10,12 +10,27 @@ import { Draft, produce } from "immer";
 import { PointProps } from "@itwin/appui-abstract";
 import { NineZoneState } from "../NineZoneState";
 import { FloatingWidgetHomeState, FloatingWidgetState } from "../WidgetState";
-import { RectangleProps, SizeProps } from "@itwin/core-react";
+import { Rectangle, RectangleProps, SizeProps } from "@itwin/core-react";
 import { toolSettingsTabId } from "../ToolSettingsState";
 import { updateFloatingWidgetState } from "./WidgetStateHelpers";
 
 /** @internal */
 export const category = "appui-layout-react:layout";
+
+/** Helper that returns a plain object. Prevents from adding an instance that is not `immerable` to the state.
+ * @internal
+ */
+export function toRectangleProps(rectangle: RectangleProps | undefined): RectangleProps {
+  if (rectangle) {
+    return {
+      bottom: rectangle.bottom,
+      left: rectangle.left,
+      right: rectangle.right,
+      top: rectangle.top,
+    };
+  }
+  return new Rectangle().toProps();
+}
 
 /** @internal */
 export function setRectangleProps(props: Draft<RectangleProps>, bounds: RectangleProps) {

--- a/ui/appui-layout-react/src/appui-layout-react/state/internal/WidgetStateHelpers.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/internal/WidgetStateHelpers.ts
@@ -13,7 +13,7 @@ import { FloatingWidgetState, PopoutWidgetState, WidgetState } from "../WidgetSt
 import { getTabLocation } from "../TabLocation";
 import { getWidgetLocation, isFloatingWidgetLocation, isPanelWidgetLocation, isPopoutWidgetLocation, PanelWidgetLocation } from "../WidgetLocation";
 import { Point, Rectangle, RectangleProps } from "@itwin/core-react";
-import { category, setRectangleProps } from "./NineZoneStateHelpers";
+import { category, setRectangleProps, toRectangleProps } from "./NineZoneStateHelpers";
 import { updatePanelState } from "./PanelStateHelpers";
 import { updateTabState } from "./TabStateHelpers";
 
@@ -84,8 +84,8 @@ export function removeWidgetState(state: NineZoneState, id: WidgetState["id"]): 
 
 /** @internal */
 export function createFloatingWidgetState(id: FloatingWidgetState["id"], args?: Partial<FloatingWidgetState>): FloatingWidgetState {
+  const bounds = toRectangleProps(args?.bounds);
   return {
-    bounds: new Rectangle().toProps(),
     home: {
       side: "left",
       widgetId: undefined,
@@ -93,20 +93,22 @@ export function createFloatingWidgetState(id: FloatingWidgetState["id"], args?: 
     },
     hidden: false,
     ...args,
+    bounds,
     id,
   };
 }
 
 /** @internal */
 export function createPopoutWidgetState(id: PopoutWidgetState["id"], args?: Partial<PopoutWidgetState>): PopoutWidgetState {
+  const bounds = toRectangleProps(args?.bounds);
   return {
-    bounds: new Rectangle().toProps(),
     home: {
       side: "left",
       widgetId: undefined,
       widgetIndex: 0,
     },
     ...args,
+    bounds,
     id,
   };
 }


### PR DESCRIPTION
This PR fixes a floating widget resize interaction.
The culprit of the problem was introduction of [non-immerable](https://immerjs.github.io/immer/complex-objects/) object - instance of `Rectangle` class was used for `bounds` property of a `FloatingWidgetState`.