### PR TITLE
set ci timeout to 1 hr

### DIFF
--- a/common/config/azure-pipelines/ci-ios.yaml
+++ b/common/config/azure-pipelines/ci-ios.yaml
@@ -22,7 +22,7 @@ variables:
 
 jobs:
   - job:
-    timeoutInMinutes: 120
+    timeoutInMinutes: 60
     pool:
       vmImage: macos-latest
     workspace:

--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -20,7 +20,7 @@ jobs:
         platform: Darwin
         name: $(mac_pool)
 
-  timeoutInMinutes: 120
+  timeoutInMinutes: 60
 
   pool: ${{ parameters.pool }}
 


### PR DESCRIPTION
set tiemout to 1 hr; 
full pipeline shouldnt take more than 25 mins on a good machine; 45 on intel macs. 
any longer then a test is hanging and dont take up time in the queue for no reason