### PR TITLE
Add appui-4.0 branch to CI job

### DIFF
--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -3,6 +3,7 @@
 trigger:
   - master
   - release/*
+  - appui-4.0
 
 variables:
   - group: Rush Build Cache SAS Token


### PR DESCRIPTION
Add the protected branch appui-4.0 to the list of branches that run the ci job.