### PR TITLE
Presentation: Improve seedTreeModel documentation.

### DIFF
--- a/common/api/presentation-components.api.md
+++ b/common/api/presentation-components.api.md
@@ -601,7 +601,7 @@ export interface PresentationTreeNodeLoaderProps extends PresentationTreeDataPro
     // @alpha
     enableHierarchyAutoUpdate?: boolean;
     pagingSize: number;
-    // @alpha
+    // @beta
     seedTreeModel?: TreeModel;
 }
 

--- a/common/changes/@itwin/presentation-components/presentation-tree-node-loader-props_2022-09-02-15-59.json
+++ b/common/changes/@itwin/presentation-components/presentation-tree-node-loader-props_2022-09-02-15-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-components",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-components"
+}

--- a/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
+++ b/presentation/components/src/presentation-components/tree/controlled/TreeHooks.ts
@@ -37,14 +37,15 @@ export interface PresentationTreeNodeLoaderProps extends PresentationTreeDataPro
   pagingSize: number;
 
   /**
-   * Auto-update the hierarchy when ruleset, ruleset variables or data in the iModel changes.
+   * Auto-update the hierarchy when ruleset, ruleset variables or data in the iModel changes. Cannot be used together
+   * with `seedTreeModel`.
    * @alpha
    */
   enableHierarchyAutoUpdate?: boolean;
 
   /**
    * Initialize tree data with the provided tree model.
-   * @alpha
+   * @beta
    */
   seedTreeModel?: TreeModel;
 }


### PR DESCRIPTION
We are announcing addition of `seedTreeModel` property in `NextVersion.md`, thus this property should be at least in `@beta` phase.

We also do not want users to be combining `enableHierarchyAutoUpdate` and `seedTreeModel` properties.