### PR TITLE
Add setup for testing Electron frontend code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1481,6 +1481,48 @@
         "[BACKEND] Local Backend for Full Stack RPC Interface Tests"
       ]
     },
+    { /* PARTIAL */
+      "name": "[BACKEND] Electron Frontend Integration Tests",
+      "presentation": {
+        "hidden": true
+      },
+      "cwd": "${workspaceFolder}/core/electron/",
+      "type": "pwa-node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "test:integration:frontend",
+        "--",
+        "--debug"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/{core}/*/lib/**/*.js",
+        "${workspaceFolder}/tools/certa/lib/**/*.js"
+      ],
+      "outputCapture": "std",
+      "attachSimplePort": 5858, // NB: This must match ports.debugging in core/electron/src/test/frontend/utils/certa.json
+      "cascadeTerminateToConfigurations": [
+        "[FRONTEND] Electron Frontend Integration Tests"
+      ]
+    },
+    { /* PARTIAL */
+      "name": "[FRONTEND] Electron Frontend Integration Tests",
+      "presentation": {
+        "hidden": true
+      },
+      "type": "pwa-chrome",
+      "request": "attach",
+      "port": 9223, // NB: This must match ports.frontendDebugging in core/electron/src/test/frontend/utils/certa.json
+      "timeout": 60000,
+      "outFiles": [
+        "${workspaceFolder}/{core}/*/lib/**/*.js",
+        "${workspaceFolder}/tools/certa/lib/**/*.js"
+      ],
+      "cascadeTerminateToConfigurations": [
+        "[BACKEND] Electron Frontend Integration Tests"
+      ]
+    },
     {
       "name": "eslint rule test @bentley/no-internal-barrel-imports",
       "presentation": {
@@ -1508,7 +1550,7 @@
       ],
     },
     {
-      "name": "Electron Backend Tests",
+      "name": "Electron Backend Integration Tests",
       "presentation": {
         "group": "0_CoreTests"
       },
@@ -1749,6 +1791,16 @@
       "configurations": [
         "[NODE] Certa Test Runner for Clients Tests",
         "[BROWSER] Clients Tests"
+      ]
+    },
+    {
+      "name": "Electron Frontend Integration Tests",
+      "presentation": {
+        "group": "0_CoreTests"
+      },
+      "configurations": [
+        "[FRONTEND] Electron Frontend Integration Tests",
+        "[BACKEND] Electron Frontend Integration Tests"
       ]
     },
   ],

--- a/common/changes/@itwin/core-electron/gytis-setup-Electron-frontend-tests_2022-09-20-11-09.json
+++ b/common/changes/@itwin/core-electron/gytis-setup-Electron-frontend-tests_2022-09-20-11-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Add setup for frontend code testing.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -127,8 +127,8 @@ steps:
     condition: succeededOrFailed()
 
   - task: PublishTestResults@2
-    displayName: "Publish Electron Integration Test Results"
+    displayName: "Publish Electron Test Results"
     inputs:
-      testResultsFiles: core/electron/lib/test/junit_results.xml
-      testRunTitle: "Electron - Integration Tests - ${{ parameters.Node_Version }}"
+      testResultsFiles: core/electron/lib/test/*_junit_results.xml
+      testRunTitle: "Core - Electron Tests - ${{ parameters.Node_Version }}"
     condition: succeededOrFailed()

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -78,7 +78,8 @@ steps:
     displayName: "Run Presentation Full Stack Tests"
     condition: succeededOrFailed()
 
-  - script: npm run test:integration
+  # By default linux agents do not have a real display so use the virtual framebuffer
+  - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run test:integration
     workingDirectory: "core/electron"
     displayName: "Run Electron Tests"
     condition: succeededOrFailed()

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -128,7 +128,7 @@
     },
     {
       "name": "@itwin/certa",
-      "allowedCategories": [ "common", "edit", "frontend", "integration-testing", "internal" ]
+      "allowedCategories": [ "backend", "common", "edit", "frontend", "integration-testing", "internal" ]
     },
     {
       "name": "@itwin/components-react",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -374,6 +374,7 @@ importers:
   ../../core/electron:
     specifiers:
       '@itwin/build-tools': workspace:*
+      '@itwin/certa': workspace:*
       '@itwin/core-backend': workspace:*
       '@itwin/core-bentley': workspace:*
       '@itwin/core-common': workspace:*
@@ -390,14 +391,17 @@ importers:
       mocha: ^10.0.0
       open: ^7.0.0
       rimraf: ^3.0.2
+      source-map-loader: ^4.0.0
       typescript: ~4.4.0
       username: ^5.1.0
+      webpack: ^5.64.4
     dependencies:
       '@openid/appauth': 1.3.1
       open: 7.4.2
       username: 5.1.0
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
+      '@itwin/certa': link:../../tools/certa
       '@itwin/core-backend': link:../backend
       '@itwin/core-bentley': link:../bentley
       '@itwin/core-common': link:../common
@@ -412,7 +416,9 @@ importers:
       eslint: 7.32.0
       mocha: 10.0.0
       rimraf: 3.0.2
+      source-map-loader: 4.0.0_webpack@5.74.0
       typescript: 4.4.4
+      webpack: 5.74.0
 
   ../../core/express-server:
     specifiers:
@@ -12781,7 +12787,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.36.2_77f94d9de7bd70955131db5256eb6d24
       '@typescript-eslint/experimental-utils': 5.36.2_eslint@8.23.0+typescript@4.4.4
       eslint: 8.23.0
-      jest: 27.5.1
+      jest: 27.5.1_ts-node@10.9.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15562,7 +15568,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 27.5.1
+      jest: 27.5.1_ts-node@10.9.1
       jest-regex-util: 28.0.2
       jest-watcher: 28.1.3
       slash: 4.0.0
@@ -20915,7 +20921,7 @@ packages:
       babel-jest: 27.5.1_@babel+core@7.19.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1
+      jest: 27.5.1_ts-node@10.9.1
       jest-util: 27.5.1
       json5: 2.2.1
       lodash.memoize: 4.1.2

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -15,7 +15,10 @@
     "extract-api": "betools extract-api --entry=__DOC_ONLY__",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "",
-    "test:integration": "mocha lib/cjs/test/backend/RunElectronBackendTests.js",
+    "test:integration": "npm run -s webpack:frontend-test && npm run test:integration:backend && npm run test:integration:frontend",
+    "test:integration:frontend": "certa -r electron --config src/test/frontend/utils/certa.json",
+    "test:integration:backend": "mocha --config src/test/backend/.mocharc.json",
+    "webpack:frontend-test": "webpack --config ./src/test/frontend/utils/webpack.config.js 1>&2",
     "cover": ""
   },
   "repository": {
@@ -41,6 +44,7 @@
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",
+    "@itwin/certa": "workspace:*",
     "@itwin/core-backend": "workspace:*",
     "@itwin/core-bentley": "workspace:*",
     "@itwin/core-common": "workspace:*",
@@ -55,7 +59,9 @@
     "eslint": "^7.11.0",
     "mocha": "^10.0.0",
     "rimraf": "^3.0.2",
-    "typescript": "~4.4.0"
+    "source-map-loader": "^4.0.0",
+    "typescript": "~4.4.0",
+    "webpack": "^5.64.4"
   },
   "dependencies": {
     "@openid/appauth": "^1.2.6",

--- a/core/electron/src/test/backend/.mocharc.json
+++ b/core/electron/src/test/backend/.mocharc.json
@@ -1,0 +1,13 @@
+{
+  "checkLeaks": true,
+  "timeout": 60000,
+  "spec": [
+    "lib/cjs/test/backend/RunElectronBackendTests.js"
+  ],
+  "reporter": [
+    "node_modules/@itwin/build-tools/mocha-reporter"
+  ],
+  "reporterOptions": [
+    "mochaFile=lib/test/backend_junit_results.xml"
+  ]
+}

--- a/core/electron/src/test/frontend/ElectronApp.test.ts
+++ b/core/electron/src/test/frontend/ElectronApp.test.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { assert } from "chai";
+import { IModelReadRpcInterface, IModelTileRpcInterface, RpcInterface, RpcRegistry, SnapshotIModelRpcInterface } from "@itwin/core-common";
+import { PresentationRpcInterface } from "@itwin/presentation-common";
+import { IModelApp, NativeApp } from "@itwin/core-frontend";
+import { ElectronApp } from "../../ElectronFrontend";
+
+describe("ElectronApp tests.", () => {
+  it("Should start and shutdown.", async () => {
+    assert(!ElectronApp.isValid);
+    assert(!NativeApp.isValid);
+    assert(!IModelApp.initialized);
+
+    await ElectronApp.startup();
+
+    assert(ElectronApp.isValid);
+    assert(NativeApp.isValid);
+    assert(IModelApp.initialized);
+
+    await ElectronApp.shutdown();
+
+    assert(!ElectronApp.isValid);
+    assert(!NativeApp.isValid);
+    assert(!IModelApp.initialized);
+  });
+
+  it("Should initialize and terminate provided RPC interfaces.", async () => {
+    abstract class TestRpcInterface extends RpcInterface {
+      public static readonly interfaceName = "TestRpcInterface";
+      public static interfaceVersion = "0.0.0";
+    }
+
+    await ElectronApp.startup({
+      iModelApp: {
+        rpcInterfaces: [TestRpcInterface],
+      },
+    });
+    assert(RpcRegistry.instance.definitionClasses.has(TestRpcInterface.interfaceName));
+
+    await ElectronApp.shutdown();
+    assert(!RpcRegistry.instance.definitionClasses.has(TestRpcInterface.interfaceName));
+  });
+
+  it("Should initialize and terminate default RPC interfaces.", async () => {
+    const defaultInterfaces = [
+      IModelReadRpcInterface,
+      IModelTileRpcInterface,
+      SnapshotIModelRpcInterface,
+      PresentationRpcInterface,
+    ];
+
+    await ElectronApp.startup();
+    for (const interfaceDef of defaultInterfaces)
+      assert(RpcRegistry.instance.definitionClasses.has(interfaceDef.interfaceName));
+
+    await ElectronApp.shutdown();
+    for (const interfaceDef of defaultInterfaces)
+      assert(!RpcRegistry.instance.definitionClasses.has(interfaceDef.interfaceName));
+  });
+});

--- a/core/electron/src/test/frontend/utils/backend.ts
+++ b/core/electron/src/test/frontend/utils/backend.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { ElectronHost } from "../../../ElectronBackend";
+
+async function init() {
+  await ElectronHost.startup();
+}
+
+module.exports = init();

--- a/core/electron/src/test/frontend/utils/certa.json
+++ b/core/electron/src/test/frontend/utils/certa.json
@@ -1,0 +1,17 @@
+{
+  // Comments are allowed here!
+  "testBundle": "../../../../lib/cjs/test/frontend/webpack/bundled-tests.js",
+  "backendInitModule": "../../../../lib/cjs/test/frontend/utils/backend.js",
+  "ports": {
+    "debugging": 5858,
+    "frontend": 3000,
+    "frontendDebugging": 9223
+  },
+  "mochaOptions": {
+    "timeout": 10000,
+    "reporter": "node_modules/@itwin/build-tools/mocha-reporter",
+    "reporterOptions": {
+      "mochaFile": "lib/test/frontend_junit_results.xml"
+    }
+  }
+}

--- a/core/electron/src/test/frontend/utils/webpack.config.js
+++ b/core/electron/src/test/frontend/utils/webpack.config.js
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+const path = require("path");
+const webpack = require("webpack");
+const glob = require("glob");
+
+const frontendLib = path.resolve(__dirname, "../../../../lib/cjs");
+
+function createConfig() {
+  const config = {
+    mode: "development",
+    entry: glob.sync(path.resolve(frontendLib, "test/frontend/**/*.test.js")),
+    output: {
+      path: path.resolve(frontendLib, "test/frontend/webpack/"),
+      filename: "bundled-tests.js",
+      devtoolModuleFilenameTemplate: "file:///[absolute-resource-path]"
+    },
+    devtool: "nosources-source-map",
+    module: {
+      noParse: [
+        // Don't parse draco_*_nodejs.js modules for `require` calls.  There are
+        // requires for fs that cause it to fail even though the fs dependency
+        // is not used.
+        /draco_decoder_nodejs.js$/,
+        /draco_encoder_nodejs.js$/
+      ],
+      rules: [
+        {
+          test: /\.js$/,
+          use: "source-map-loader",
+          enforce: "pre"
+        },
+      ]
+    },
+    stats: "errors-only",
+    optimization: {
+      nodeEnv: "production"
+    },
+    externals: {
+      electron: "commonjs electron",
+    },
+    plugins: [
+      // Makes some environment variables available to the JS code, for example:
+      // if (process.env.NODE_ENV === "development") { ... }. See `./env.js`.
+      new webpack.DefinePlugin({
+        "process.env": Object.keys(process.env)
+          .reduce((env, key) => {
+            env[key] = JSON.stringify(process.env[key]);
+            return env;
+          }, {}),
+      })
+    ]
+  };
+
+  return config;
+}
+
+module.exports = [
+  createConfig()
+]


### PR DESCRIPTION
PR adds setup for testing _core-electron_ frontend code (at this point, it's just `ElectronApp` class).

Related:
[PR #4155: Add setup for testing Electron backend code](https://github.com/iTwin/itwinjs-core/pull/4155)