### PR TITLE
Replace `node-report` with Node.js Diagnostic Reporting

### DIFF
--- a/common/changes/@itwin/core-backend/diagnostic-report_2022-09-20-20-37.json
+++ b/common/changes/@itwin/core-backend/diagnostic-report_2022-09-20-20-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Replace node-report crash reporting with Node.js Diagnostic Reporting",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -9,7 +9,7 @@
 import * as os from "os";
 import * as path from "path";
 import { IModelJsNative, NativeLibrary } from "@bentley/imodeljs-native";
-import { AccessToken, assert, BeDuration, BeEvent, Guid, GuidString, IModelStatus, Logger, LogLevel, Mutable, ProcessDetector, UnexpectedErrors } from "@itwin/core-bentley";
+import { AccessToken, assert, BeEvent, Guid, GuidString, IModelStatus, Logger, LogLevel, Mutable, ProcessDetector } from "@itwin/core-bentley";
 import { AuthorizationClient, BentleyStatus, IModelError, LocalDirName, SessionProps } from "@itwin/core-common";
 import { TelemetryManager } from "@itwin/core-telemetry";
 import { BackendHubAccess } from "./BackendHubAccess";
@@ -417,8 +417,7 @@ export class IModelHost {
           process.report.reportOnUncaughtException = true;
           process.report.directory = options.crashReportingConfig.crashDir;
           Logger.logTrace(loggerCategory, "Configured Node.js crash reporting");
-        }
-        else {
+        } else {
           Logger.logWarning(loggerCategory, "Unable to configure Node.js crash reporting");
         }
       }


### PR DESCRIPTION
PR for issue https://github.com/iTwin/itwinjs-core/issues/4091

We would like feedback on if we should attempt to create any tests for this? The diagnostic reports are triggered by uncaught exceptions, but such exceptions seem to be caught gracefully by mocha; i.e., in a test environment, the diagnostics reports don't get triggered.

There may be a way to get a test to work like running in a child process (messy) or maybe there are mocha options that will let the exceptions pass though. Either way, it seemed like a lot of effort to figure out, so I am bringing up the question here: Do you think we should bother figuring out tests for this?