### PR TITLE
Fix BoxProps breaking API change

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -2750,7 +2750,7 @@ export namespace IModelJson {
         handleBagOfCurves(data: BagOfCurves): any;
         handleBezierCurve3d(curve: BezierCurve3d): any;
         handleBezierCurve3dH(curve: BezierCurve3dH): any;
-        handleBox(box: Box): SolidPrimitiveProps;
+        handleBox(box: Box): any;
         handleBSplineCurve3d(curve: BSplineCurve3d): any;
         handleBSplineCurve3dH(curve: BSplineCurve3dH): any;
         handleBSplineSurface3d(surface: BSplineSurface3d): any;

--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -655,8 +655,8 @@ export class Box extends SolidPrimitive {
     clone(): Box;
     cloneTransformed(transform: Transform): Box | undefined;
     constantVSection(zFraction: number): CurveCollection;
-    static createDgnBox(baseOrigin: Point3d, vectorX: Vector3d, vectorY: Vector3d, topOrigin: Point3d, baseX: number, baseY: number, topX: number, topY: number, capped: boolean): Box | undefined;
-    static createDgnBoxWithAxes(baseOrigin: Point3d, axes: Matrix3d, topOrigin: Point3d, baseX: number, baseY: number, topX: number, topY: number, capped: boolean): Box | undefined;
+    static createDgnBox(origin: Point3d, vectorX: Vector3d, vectorY: Vector3d, topOrigin: Point3d, baseX: number, baseY: number, topX: number, topY: number, capped: boolean): Box | undefined;
+    static createDgnBoxWithAxes(origin: Point3d, axes: Matrix3d, topOrigin: Point3d, baseX: number, baseY: number, topX: number, topY: number, capped: boolean): Box | undefined;
     static createRange(range: Range3d, capped: boolean): Box | undefined;
     dispatchToGeometryHandler(handler: GeometryHandler): any;
     extendRange(rangeToExtend: Range3d, transform?: Transform): void;
@@ -2580,13 +2580,13 @@ export namespace IModelJson {
         points: [XYZProps];
     }
     export interface BoxProps extends AxesProps {
-        baseOrigin: XYZProps;
+        // @internal @deprecated
+        baseOrigin?: XYZProps;
         baseX: number;
         baseY?: number;
         capped?: boolean;
         height?: number;
-        // @deprecated (undocumented)
-        origin?: XYZProps;
+        origin: XYZProps;
         topOrigin?: XYZProps;
         topX?: number;
         topY?: number;
@@ -2750,7 +2750,7 @@ export namespace IModelJson {
         handleBagOfCurves(data: BagOfCurves): any;
         handleBezierCurve3d(curve: BezierCurve3d): any;
         handleBezierCurve3dH(curve: BezierCurve3dH): any;
-        handleBox(box: Box): any;
+        handleBox(box: Box): SolidPrimitiveProps;
         handleBSplineCurve3d(curve: BSplineCurve3d): any;
         handleBSplineCurve3dH(curve: BSplineCurve3dH): any;
         handleBSplineSurface3d(surface: BSplineSurface3d): any;

--- a/common/changes/@itwin/core-geometry/pmc-fix-boxprops-api-change_2022-09-24-18-58.json
+++ b/common/changes/@itwin/core-geometry/pmc-fix-boxprops-api-change_2022-09-24-18-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/backend/src/GeometrySummary.ts
+++ b/core/backend/src/GeometrySummary.ts
@@ -284,7 +284,7 @@ class ResponseGenerator {
       case "box":
         const box: Box = (solid as Box);
         return `${summary}'
-        ' baseOrigin: ${JSON.stringify(box.getBaseOrigin().toJSON())}'
+        ' origin: ${JSON.stringify(box.getBaseOrigin().toJSON())}'
         ' topOrigin: ${JSON.stringify(box.getTopOrigin().toJSON())}'
         ' baseX: ${box.getBaseX()}'
         ' baseY: ${box.getBaseY()}`;

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -8,7 +8,7 @@ import {
   BriefcaseIdValue, Code, ColorDef, ElementAspectProps, ElementGeometry, GeometricElementProps, GeometryStreamProps, IModel, PhysicalElementProps,
   Placement3dProps, QueryRowFormat, SubCategoryAppearance,
 } from "@itwin/core-common";
-import { Angle, Arc3d, BoxProps, Cone, IModelJson as GeomJson, LineSegment3d, Point2d, Point3d } from "@itwin/core-geometry";
+import { Angle, Arc3d, Cone, IModelJson as GeomJson, LineSegment3d, Point2d, Point3d } from "@itwin/core-geometry";
 import { ECSqlStatement, IModelDb, IModelJsFs, PhysicalModel, PhysicalObject, SnapshotDb, SpatialCategory } from "../../core-backend";
 import { ElementRefersToElements } from "../../Relationship";
 import { IModelTestUtils } from "../IModelTestUtils";
@@ -823,29 +823,5 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
         },
       }
     );
-  });
-});
-
-describe.only("BoxProps", () => {
-  function makeBoxProps(originX: number, propertyName: "origin" | "baseOrigin"): BoxProps {
-    const origin = { x: originX, y: 1, z: 2 };
-    const props = { baseX: 10 };
-    if ("origin" === propertyName)
-      return { ...props, origin };
-
-    return { ...props, baseOrigin: origin } as BoxProps;
-  }
-
-  function expectBoxOrigin(inputProps: BoxProps, expectedOrigin: number): void {
-    const box = GeomJson.
-  }
-
-  it("outputs both origin and baseOrigin", () => {
-  });
-
-  it("accepts either origin or baseOrigin", () => {
-  });
-
-  it("prefers origin if both origin and baseOrigin are specified", () => {
   });
 });

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -803,25 +803,45 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
       }
     );
 
-    const geom = [
-      { header: { flags: 0 } },
-      { box: { origin: Point3d.create(0, 1, 2), baseX: 10, baseY: 20 } },
-    ];
+    interface TestBoxProps {
+      originX?: number;
+      baseOriginX?: number;
+    }
 
-    insertAndVerifyPlacement(
-      "geom-through-json",
-      {
-        geom,
-        elementGeometryBuilderParams: undefined,
-      },
-      {
-        expectedPlacementOverrides: {
-          bbox: {
-            low: { x: 0, y: 1, z: 2 },
-            high: { x: 10, y: 21, z: 12 },
-          },
+    // Previously, TypeScript BoxProps defined "origin" but native code only understood "baseOrigin".
+    // Now, native code accepts either, preferring "origin" if both are specified.
+    const testBox = (props: TestBoxProps, expectedXOffset: number) => {
+      const box: any = { };
+      if (undefined !== props.originX)
+        box.origin = [ props.originX, 1, 2 ];
+
+      if (undefined !== props.baseOriginX)
+        box.baseOrigin = [ props.baseOriginX, 1, 2 ];
+
+      const geom = [
+        { header: { flags: 0 } },
+        { box: { ...box, baseX: 10, baseY: 20 } },
+      ];
+
+      insertAndVerifyPlacement(
+        "geom-through-json",
+        {
+          geom,
+          elementGeometryBuilderParams: undefined,
         },
-      }
-    );
+        {
+          expectedPlacementOverrides: {
+            bbox: {
+              low: { x: expectedXOffset, y: 1, z: 2 },
+              high: { x: expectedXOffset + 10, y: 21, z: 12 },
+            },
+          },
+        }
+      );
+    };
+
+    testBox({ originX: 0 }, 0);
+    testBox({ baseOriginX: 5 }, 5);
+    testBox({ originX: 2, baseOriginX: 4 }, 2);
   });
 });

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -805,7 +805,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
 
     const geom = [
       { header: { flags: 0 } },
-      { box: { baseOrigin: Point3d.create(0, 1, 2), baseX: 10, baseY: 20 } },
+      { box: { origin: Point3d.create(0, 1, 2), baseX: 10, baseY: 20 } },
     ];
 
     insertAndVerifyPlacement(

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -8,7 +8,7 @@ import {
   BriefcaseIdValue, Code, ColorDef, ElementAspectProps, ElementGeometry, GeometricElementProps, GeometryStreamProps, IModel, PhysicalElementProps,
   Placement3dProps, QueryRowFormat, SubCategoryAppearance,
 } from "@itwin/core-common";
-import { Angle, Arc3d, Cone, IModelJson as GeomJson, LineSegment3d, Point2d, Point3d } from "@itwin/core-geometry";
+import { Angle, Arc3d, BoxProps, Cone, IModelJson as GeomJson, LineSegment3d, Point2d, Point3d } from "@itwin/core-geometry";
 import { ECSqlStatement, IModelDb, IModelJsFs, PhysicalModel, PhysicalObject, SnapshotDb, SpatialCategory } from "../../core-backend";
 import { ElementRefersToElements } from "../../Relationship";
 import { IModelTestUtils } from "../IModelTestUtils";
@@ -823,5 +823,29 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
         },
       }
     );
+  });
+});
+
+describe.only("BoxProps", () => {
+  function makeBoxProps(originX: number, propertyName: "origin" | "baseOrigin"): BoxProps {
+    const origin = { x: originX, y: 1, z: 2 };
+    const props = { baseX: 10 };
+    if ("origin" === propertyName)
+      return { ...props, origin };
+
+    return { ...props, baseOrigin: origin } as BoxProps;
+  }
+
+  function expectBoxOrigin(inputProps: BoxProps, expectedOrigin: number): void {
+    const box = GeomJson.
+  }
+
+  it("outputs both origin and baseOrigin", () => {
+  });
+
+  it("accepts either origin or baseOrigin", () => {
+  });
+
+  it("prefers origin if both origin and baseOrigin are specified", () => {
   });
 });

--- a/core/geometry/src/serialization/IModelJsonSchema.ts
+++ b/core/geometry/src/serialization/IModelJsonSchema.ts
@@ -1693,8 +1693,8 @@ export namespace IModelJson {
     }
 
     /** Convert strongly typed instance to tagged json */
-    public handleBox(box: Box): any {
-      const out: any = {
+    public handleBox(box: Box): SolidPrimitiveProps {
+      const out: SolidPrimitiveProps = {
         box: {
           origin: box.getBaseOrigin().toJSON(),
           baseOrigin: box.getBaseOrigin().toJSON(),
@@ -1704,11 +1704,13 @@ export namespace IModelJson {
           topOrigin: box.getTopOrigin().toJSON(),
         },
       };
-      Writer.insertXYOrientation(out.box, box.getVectorX(), box.getVectorY(), true);
+
+      const outBox = out.box!;
+      Writer.insertXYOrientation(outBox, box.getVectorX(), box.getVectorY(), true);
       if (!Geometry.isSameCoordinate(box.getTopX(), box.getBaseX()))
-        out.box.topX = box.getTopX();
+        outBox.topX = box.getTopX();
       if (!Geometry.isSameCoordinate(box.getTopY(), box.getBaseY()))
-        out.box.topY = box.getTopY();
+        outBox.topY = box.getTopY();
 
       return out;
     }

--- a/core/geometry/src/serialization/IModelJsonSchema.ts
+++ b/core/geometry/src/serialization/IModelJsonSchema.ts
@@ -1693,7 +1693,7 @@ export namespace IModelJson {
     }
 
     /** Convert strongly typed instance to tagged json */
-    public handleBox(box: Box): SolidPrimitiveProps {
+    public handleBox(box: Box): any {
       const out: SolidPrimitiveProps = {
         box: {
           origin: box.getBaseOrigin().toJSON(),

--- a/core/geometry/src/serialization/IModelJsonSchema.ts
+++ b/core/geometry/src/serialization/IModelJsonSchema.ts
@@ -388,8 +388,8 @@ export namespace IModelJson {
     /** Origin of the box coordinate system  (required) */
     origin: XYZProps;
     /** A previous mismatch existed between native and TypeScript code: TypeScript used "origin" where native used "baseOrigin".
-     * Now both native and TypeScript accept either, preferring "origin", but "baseOrigin" is undocumented in TypeScript.
-     * It's also "deprecated" so that linter will warn to use the documented property instead.
+     * Now both native and TypeScript will output both and accept either, preferring "origin".
+     * "baseOrigin" is undocumented in TypeScript; it's also "deprecated" so that the linter will warn to use the documented property instead.
      * @internal
      * @deprecated use origin
      */

--- a/core/geometry/src/serialization/IModelJsonSchema.ts
+++ b/core/geometry/src/serialization/IModelJsonSchema.ts
@@ -1175,7 +1175,7 @@ export namespace IModelJson {
 
       // A mismatch between native and TypeScript code: TypeScript used "origin" where native used "baseOrigin".
       // Native now outputs and accepts either, preferring "origin"; TypeScript continues to expose only "origin".
-      let origin = Reader.parsePoint3dProperty(json, "origin") ?? Reader.parsePoint3dProperty(json, "baseOrigin");
+      const origin = Reader.parsePoint3dProperty(json, "origin") ?? Reader.parsePoint3dProperty(json, "baseOrigin");
       const baseX = Reader.parseNumberProperty(json, "baseX");
       const baseY = Reader.parseNumberProperty(json, "baseY", baseX);
       let topOrigin = Reader.parsePoint3dProperty(json, "topOrigin");

--- a/core/geometry/src/solid/Box.ts
+++ b/core/geometry/src/solid/Box.ts
@@ -80,7 +80,7 @@ export class Box extends SolidPrimitive {
 
   /**
    * Create a new box from vector and size daa.
-   * @param baseOrigin Origin of base rectangle
+   * @param origin Origin of base rectangle
    * @param vectorX  Direction for base rectangle
    * @param vectorY Direction for base rectangle
    * @param topOrigin origin of top rectangle
@@ -90,18 +90,18 @@ export class Box extends SolidPrimitive {
    * @param topY size factor for top rectangle (multiplies vectorY)
    * @param capped true to define top and bottom closure caps
    */
-  public static createDgnBox(baseOrigin: Point3d, vectorX: Vector3d, vectorY: Vector3d,
+  public static createDgnBox(origin: Point3d, vectorX: Vector3d, vectorY: Vector3d,
     topOrigin: Point3d,
     baseX: number, baseY: number, topX: number, topY: number,
     capped: boolean): Box | undefined {
-    const vectorZ = baseOrigin.vectorTo(topOrigin);
-    const localToWorld = Transform.createOriginAndMatrixColumns(baseOrigin, vectorX, vectorY, vectorZ);
+    const vectorZ = origin.vectorTo(topOrigin);
+    const localToWorld = Transform.createOriginAndMatrixColumns(origin, vectorX, vectorY, vectorZ);
     return new Box(localToWorld, baseX, baseY, topX, topY, capped);
   }
 
   /**
    * Create a new box with xy directions taken from columns of the `axes` matrix.
-   * @param baseOrigin Origin of base rectangle
+   * @param origin Origin of base rectangle
    * @param axes  Direction for base rectangle
    * @param topOrigin origin of top rectangle
    * @param baseX size factor for base rectangle (multiplies vectorX)
@@ -110,11 +110,11 @@ export class Box extends SolidPrimitive {
    * @param topY size factor for top rectangle (multiplies vectorY)
    * @param capped true to define top and bottom closure caps
    */
-  public static createDgnBoxWithAxes(baseOrigin: Point3d, axes: Matrix3d,
+  public static createDgnBoxWithAxes(origin: Point3d, axes: Matrix3d,
     topOrigin: Point3d,
     baseX: number, baseY: number, topX: number, topY: number,
     capped: boolean): Box | undefined {
-    return Box.createDgnBox(baseOrigin, axes.columnX(), axes.columnY(), topOrigin,
+    return Box.createDgnBox(origin, axes.columnX(), axes.columnY(), topOrigin,
       baseX, baseY, topX, topY, capped);
   }
 

--- a/core/geometry/src/test/serialization/IModelJson.test.ts
+++ b/core/geometry/src/test/serialization/IModelJson.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 // Requires for grabbing json object from external file
 import * as fs from "fs";
 import { Arc3d } from "../../curve/Arc3d";
+import { Box } from "../../solid/Box";
 import { CoordinateXYZ } from "../../curve/CoordinateXYZ";
 import { GeometryQuery } from "../../curve/GeometryQuery";
 import { Point3d, Vector3d } from "../../geometry3d/Point3dVector3d";
@@ -319,5 +320,45 @@ describe("CreateIModelJsonSamples", () => {
     ck.checkpoint("BSIJSON.ParseIMJS");
     expect(ck.getNumErrors()).equals(0);
   });
+});
 
+describe.only("BoxProps", () => {
+  type BoxProps = IModelJson.BoxProps;
+
+  function makeBoxProps(originX: number, propertyName: "origin" | "baseOrigin"): BoxProps {
+    const origin = { x: originX, y: 1, z: 2 };
+    const props = { baseX: 10 };
+    if ("origin" === propertyName)
+      return { ...props, origin };
+
+    return { ...props, baseOrigin: origin } as BoxProps;
+  }
+
+  function parseBox(props: BoxProps): Box | undefined {
+    return IModelJson.Reader.parseBox(props);
+  }
+
+  function writeBox(box: Box): BoxProps {
+    const solidProps = new IModelJson.Writer().handleBox(box);
+    expect(solidProps.box).not.to.be.undefined;
+    return solidProps.box!;
+  }
+
+  function expectBoxOrigin(inputProps: BoxProps, expectedOrigin: number): void {
+    const box = parseBox(inputProps)!;
+    expect(box).not.to.be.undefined;
+    expect(box.getBaseOrigin().x).to.equal(expectedOrigin);
+  }
+
+  it("outputs both origin and baseOrigin", () => {
+  });
+
+  it("accepts either origin or baseOrigin", () => {
+  });
+
+  it("prefers origin if both origin and baseOrigin are specified", () => {
+  });
+
+  it("requires either origin or baseOrigin", () => {
+  });
 });

--- a/core/geometry/src/test/serialization/IModelJson.test.ts
+++ b/core/geometry/src/test/serialization/IModelJson.test.ts
@@ -322,26 +322,11 @@ describe("CreateIModelJsonSamples", () => {
   });
 });
 
-describe.only("BoxProps", () => {
+describe("BoxProps", () => {
   type BoxProps = IModelJson.BoxProps;
-
-  function makeBoxProps(originX: number, propertyName: "origin" | "baseOrigin"): BoxProps {
-    const origin = { x: originX, y: 1, z: 2 };
-    const props = { baseX: 10 };
-    if ("origin" === propertyName)
-      return { ...props, origin };
-
-    return { ...props, baseOrigin: origin } as BoxProps;
-  }
 
   function parseBox(props: BoxProps): Box | undefined {
     return IModelJson.Reader.parseBox(props);
-  }
-
-  function writeBox(box: Box): BoxProps {
-    const solidProps = new IModelJson.Writer().handleBox(box);
-    expect(solidProps.box).not.to.be.undefined;
-    return solidProps.box!;
   }
 
   function expectBoxOrigin(inputProps: BoxProps, expectedOrigin: number): void {
@@ -350,15 +335,41 @@ describe.only("BoxProps", () => {
     expect(box.getBaseOrigin().x).to.equal(expectedOrigin);
   }
 
-  it("outputs both origin and baseOrigin", () => {
-  });
-
   it("accepts either origin or baseOrigin", () => {
+    expectBoxOrigin({ origin: [3, 2, 1], baseX: 10 }, 3);
+    expectBoxOrigin({ baseOrigin: [4, 5, 6], baseX: 5 } as BoxProps, 4);
   });
 
   it("prefers origin if both origin and baseOrigin are specified", () => {
+    expectBoxOrigin({
+      origin: [5, 5, 5],
+      baseOrigin: [6, 6, 6],
+      baseX: 7,
+    }, 5);
   });
 
   it("requires either origin or baseOrigin", () => {
+    expect(parseBox({ baseX: 123 } as BoxProps)).to.be.undefined;
+  });
+
+  it("outputs both origin and baseOrigin", () => {
+    const box = parseBox({ origin: [1, 2, 3], baseX: 4 })!;
+    expect(box).not.to.be.undefined;
+
+    const solidProps = new IModelJson.Writer().handleBox(box);
+    const props = solidProps.box!;
+    expect(props).not.to.be.undefined;
+
+    expect(props.origin).not.to.be.undefined;
+    const origin = Point3d.fromJSON(props.origin);
+    expect(origin.x).to.equal(1);
+    expect(origin.y).to.equal(2);
+    expect(origin.z).to.equal(3);
+
+    expect(props.baseOrigin).not.to.be.undefined;
+    const baseOrigin = Point3d.fromJSON(props.baseOrigin);
+    expect(baseOrigin?.x).to.equal(1);
+    expect(baseOrigin?.y).to.equal(2);
+    expect(baseOrigin?.z).to.equal(3);
   });
 });

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -23,7 +23,6 @@ Table of contents:
   - [Coplanar facet consolidation](#coplanar-facet-consolidation)
   - [Filling mesh holes](#filling-mesh-holes)
 - [Deprecations](#deprecations)
-  - [@itwin/core-geometry](#itwincore-geometry)
   - [@itwin/core-transformer](#itwincore-transformer)
 
 ## Electron 17 support
@@ -168,10 +167,6 @@ A new method, [PolyfaceQuery.fillSimpleHoles]($core-geometry), can identify hole
 The [IModelCloneContext]($backend) in `@itwin/core-backend` is now deprecated, and renamed to [IModelElementCloneContext]($backend), since it
 can only clone elements. If you want to clone entities other than elements, as the transformer now does, you must use the transformer's derived
 class, [IModelCloneContext]($transformer).
-
-### @itwin/core-geometry
-
-`BoxProps.origin` has been replaced with `BoxProps.baseOrigin` to align with the "box" JSON format.
 
 ### @itwin/core-transformer
 

--- a/docs/learning/geometry/IModelJsonGeometrySchema.md
+++ b/docs/learning/geometry/IModelJsonGeometrySchema.md
@@ -24,7 +24,7 @@
 |----|----|---|
 | Sphere.createCenterRadius(center, radius) | full sphere | `{"sphere":{"center":[1,1,0],"radius":3}}`|
 | Cone.createAxisPoints(centerA, centerB, radiusA, radiusB, capped) | full sphere | `{"cone":{"capped":true,"start":[-1,1,0],"end":[3,2,0],"startRadius":1.5,"endRadius":2,"xyVectors":[[-0.24253562503633297,0.9701425001453319,0],[0,0,1]]}}`|
-| Box.createDgnBox(cornerA, xVector, yVector, baseX, baseY, topX, topY, capped) | box with sides slanting inward | `{"box":{"baseOrigin":[-1,1,0],"baseX":4,"baseY":3,"capped":true,"topOrigin":[-1,2,4],"topY":2}}`|
+| Box.createDgnBox(cornerA, xVector, yVector, baseX, baseY, topX, topY, capped) | box with sides slanting inward | `{"box":{"origin":[-1,1,0],"baseX":4,"baseY":3,"capped":true,"topOrigin":[-1,2,4],"topY":2}}`|
 | TorusPipe.createInFrame(frame, majorRadius, minorRadius, sweep, capped) | 90 degree elbos | `{"torusPipe":{"center":[1,1,1],"majorRadius":3,"minorRadius":1,"xyVectors":[[0,1,0],[-0.8320502943378437,0,0.5547001962252291]],"sweepAngle":90,"capped":true}}`|
 | LinearSweep.create(contour, sweepVector, capped) | swept hexagon | `{"linearSweep":{"contour":{"loop":[{"lineString":[[2,0,0],[1.5,0.8660254037844386,0],[0.5,0.8660254037844387,0],[0,0,0],[0.5,-0.8660254037844385,0],[1.5,-0.866025403784439,0],[2,0,0]]}]},"capped":true,"vector":[0,0,4]}}`|
 | RotationalSweep.create(contour, axisOfRotation, sweepAngle, capped) | hexagon rotated | `{"rotationalSweep":{"axis":[0,1,0],"contour":{"loop":[{"lineString":[[2,0,0],[1.5,0.8660254037844386,0],[0.5,0.8660254037844387,0],[0,0,0],[0.5,-0.8660254037844385,0],[1.5,-0.866025403784439,0],[2,0,0]]}]},"capped":true,"center":[-1,0,0],"sweepAngle":135}}`|


### PR DESCRIPTION
Fixes #4350

Retain `origin` as  the documented, required way to specify the origin of the box's base rectangle.
Add `baseOrigin` as an optional, deprecated, undocumented property with the same meaning as `origin`.
Output both when serializing.
When deserializing, if `origin` is not present, try to use `baseOrigin` instead.
[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/281508).

TODO: test, lint, extract-api, etc.