### PR TITLE
UI: Remove skipped tests

### DIFF
--- a/common/changes/@itwin/components-react/raplemie-removeSkippedUITests_2022-09-26-20-55.json
+++ b/common/changes/@itwin/components-react/raplemie-removeSkippedUITests_2022-09-26-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fix/Remove skipped tests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/imodel-components-react/raplemie-removeSkippedUITests_2022-09-26-20-55.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-removeSkippedUITests_2022-09-26-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Fix/Remove skipped tests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/ui/components-react/src/test/editors/EnumEditor.test.tsx
+++ b/ui/components-react/src/test/editors/EnumEditor.test.tsx
@@ -89,21 +89,6 @@ describe("<EnumEditor />", () => {
     expect(spyOnCommit.called).to.be.false;
   });
 
-  it.skip("onCommit should be called for blur", async () => {
-    const propertyRecord = TestUtils.createEnumProperty("Test", 0);
-    const spyOnCommit = sinon.spy();
-    function handleCommit(_commit: PropertyUpdatedArgs): void {
-      spyOnCommit();
-    }
-    const wrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={handleCommit} onCancel={() => { }} />);
-    const selectNode = wrapper.getByTestId("components-select-editor");
-    expect(selectNode).not.to.be.null;
-
-    fireEvent.blur(selectNode);
-    await TestUtils.flushAsyncOperations();
-    expect(spyOnCommit.calledOnce).to.be.true;
-  });
-
   it("componentDidUpdate updates the value", async () => {
     const record = TestUtils.createEnumProperty("Test", 0);
     const wrapper = mount(<EnumEditor propertyRecord={record} />);

--- a/ui/components-react/src/test/table/columnfiltering/TableFilterDescriptor.test.ts
+++ b/ui/components-react/src/test/table/columnfiltering/TableFilterDescriptor.test.ts
@@ -552,12 +552,6 @@ describe("TableFilterDescriptor", () => {
       const expression = filterDescriptor.getFilterExpression();
       expect(expression).to.eq("(col3 <2458797.5)");
     });
-
-    it("IsLessThan - number", () => {
-      const filterDescriptor = new TableFilterDescriptor(testTable, columns[3].key, columnTypes[3], FilterOperator.IsLessThan, 2458797.5);
-      const expression = filterDescriptor.getFilterExpression();
-      expect(expression).to.eq("(col3 <2440587.320115741)");
-    });
   });
 
   describe("getFilterExpression - boolean", () => {

--- a/ui/components-react/src/test/table/columnfiltering/TableFilterDescriptor.test.ts
+++ b/ui/components-react/src/test/table/columnfiltering/TableFilterDescriptor.test.ts
@@ -553,7 +553,7 @@ describe("TableFilterDescriptor", () => {
       expect(expression).to.eq("(col3 <2458797.5)");
     });
 
-    it.skip("IsLessThan - number", () => {
+    it("IsLessThan - number", () => {
       const filterDescriptor = new TableFilterDescriptor(testTable, columns[3].key, columnTypes[3], FilterOperator.IsLessThan, 2458797.5);
       const expression = filterDescriptor.getFilterExpression();
       expect(expression).to.eq("(col3 <2440587.320115741)");

--- a/ui/components-react/src/test/table/component/Table.test.tsx
+++ b/ui/components-react/src/test/table/component/Table.test.tsx
@@ -623,16 +623,16 @@ describe("Table", () => {
           expect(onPropertyEditing.calledOnce).to.be.true;
         });
 
-        it.skip("deselects other rows when selects a row", async () => {
-          const isRowSelected = () => true;
-          table.setProps({ isRowSelected });
-          table.update();
-          expect(table.find(selectedRowClassName).length).to.be.greaterThan(1);
+        it("deselects other rows when selects a row", async () => {
+          const lastRow = table.find(rowClassName).last();
+          lastRow.simulate("click");
+          await verifyRowIterator(["9"], selectedRowsIterator);
+
           const row = table.find(rowClassName).first();
           row.simulate("click");
-
           await verifyRowIterator(["0"], selectedRowsIterator);
-          onRowsSelectedCallbackMock.verify(async (x) => x(moq.It.isAny(), true), moq.Times.once());
+
+          onRowsSelectedCallbackMock.verify(async (x) => x(moq.It.isAny(), true), moq.Times.exactly(2));
           onRowsDeselectedCallbackMock.verify(async (x) => x(moq.It.isAny()), moq.Times.never());
           expect(table.find(selectedRowClassName).length).to.be.equal(1);
         });

--- a/ui/components-react/src/test/table/component/TableCell.test.tsx
+++ b/ui/components-react/src/test/table/component/TableCell.test.tsx
@@ -99,29 +99,6 @@ describe("TableCellContent", () => {
     expect((content.container.firstChild! as HTMLElement).innerHTML).to.be.empty;
   });
 
-  // Fails sporadically after React 17 upgrade
-  it.skip("rerenders when props update", async () => {
-    let record = TestUtils.createPrimitiveStringProperty("Label", "Test property");
-    let cellItem: CellItem = { key, record };
-
-    const content = render(
-      <TableCellContent
-        cellItem={cellItem}
-        isSelected={false}
-        propertyValueRendererManager={PropertyValueRendererManager.defaultManager}
-      />);
-
-    record = TestUtils.createPrimitiveStringProperty("Label", "Changed property");
-    cellItem = { key, record };
-    content.rerender(
-      <TableCellContent
-        cellItem={cellItem}
-        isSelected={false}
-        propertyValueRendererManager={PropertyValueRendererManager.defaultManager}
-      />);
-
-    await waitFor(() => content.getByText("Changed property"));
-  });
 });
 
 describe("TableIconCellContent", () => {

--- a/ui/imodel-components-react/src/test/navigationaids/CubeNavigationAid.test.tsx
+++ b/ui/imodel-components-react/src/test/navigationaids/CubeNavigationAid.test.tsx
@@ -288,28 +288,6 @@ describe("CubeNavigationAid", () => {
         const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
         expect(mat2.matrix.isAlmostEqual(expectedMatrix)).is.true;
       });
-      it.skip(`${shouldStr} touch drag cube`, async () => { // Touch isn't currently supported so we can't test it...
-        sinon.replaceGetter(IModelApp, "toolAdmin", () => ({markupView: lockedViewport}) as ToolAdmin);
-        const component = render(<CubeNavigationAid iModelConnection={connection.object} viewport={lockedViewport} />);
-
-        const topFace = component.getByTestId("components-cube-face-top");
-        const topCenterCell = component.getByTestId("nav-cube-face-cell-top-0-0-1");
-
-        expect(topCenterCell.classList.contains("cube-active")).to.be.false;
-
-        const mat = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-        expect(mat.matrix.isAlmostEqual(Matrix3d.createIdentity())).is.true;
-        const touchStart = new Touch({ identifier: 0, target: topCenterCell, clientX: 2, clientY: 2 }); // <== ReferenceError: Touch is not defined
-        const touchMove1 = new Touch({ identifier: 0, target: topCenterCell, clientX: 10, clientY: 2 });
-        const touchMove2 = new Touch({ identifier: 0, target: topCenterCell, clientX: 20, clientY: 2 });
-        const touchEnd = new Touch({ identifier: 0, target: topCenterCell, clientX: 20, clientY: 2 });
-        topCenterCell.dispatchEvent(new TouchEvent("touchstart", { bubbles: true, cancelable: true, view: window, touches: [touchStart], changedTouches: [touchStart], targetTouches: [touchStart] }));
-        topCenterCell.dispatchEvent(new TouchEvent("touchmove", { bubbles: true, cancelable: true, view: window, touches: [touchMove1], changedTouches: [touchMove1], targetTouches: [touchMove1] }));
-        topCenterCell.dispatchEvent(new TouchEvent("touchmove", { bubbles: true, cancelable: true, view: window, touches: [touchMove2], changedTouches: [touchMove2], targetTouches: [touchMove2] }));
-        topCenterCell.dispatchEvent(new TouchEvent("touchend", { bubbles: true, cancelable: true, view: window, touches: [touchEnd], changedTouches: [touchEnd] }));
-        const mat2 = cssMatrix3dToBentleyTransform(topFace.style.transform)!;
-        expect(mat2.isIdentity).to.equal(!!lockedViewport);
-      });
     });
 
     describe("onViewRotationChangeEvent", () => {


### PR DESCRIPTION
When this was done for other packages, I asked UI to be left away because of the ongoing Enzyme stuff, however these packages will not be touched by the enzyme removal short term, so I remove /fix the tests.

I'll try to run the CI a couple of times to see if the remaining tests are flaky.

Follow up of  iTwin/itwinjs-backlog#386