### PR TITLE
Add `webpack:test` to `build:ci` script 

### DIFF
--- a/common/changes/@itwin/core-i18n/build-and-webpack_2022-09-27-16-12.json
+++ b/common/changes/@itwin/core-i18n/build-and-webpack_2022-09-27-16-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-i18n",
+      "comment": "Add webpack:test to build:ci",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-i18n"
+}

--- a/core/i18n/package.json
+++ b/core/i18n/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "npm run -s build:cjs",
-    "build:ci": "npm run -s build && npm run -s build:esm",
+    "build:ci": "npm run -s build && npm run -s build:esm && npm run -s webpack:test",
     "build:cjs": "tsc 1>&2 --outDir lib/cjs",
     "build:esm": "tsc 1>&2 --module ES2020 --outDir lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",


### PR DESCRIPTION
Changes made based on the following comment:

> Please make sure either the `build` or the `test` script does the webpacking. `rush build:ci` followed by `rush cover` should suffice to run all tests.

_Originally posted by @pmconne in https://github.com/iTwin/itwinjs-core/issues/4323#issuecomment-1259592991_