### PR TITLE
bump IModelReadRpc version to 3.3.0

### DIFF
--- a/common/changes/@itwin/core-common/imodelreadrpc-3.3_2022-09-27-16-37.json
+++ b/common/changes/@itwin/core-common/imodelreadrpc-3.3_2022-09-27-16-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/rpc/IModelReadRpcInterface.ts
+++ b/core/common/src/rpc/IModelReadRpcInterface.ts
@@ -56,7 +56,7 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
   public static readonly interfaceName = "IModelReadRpcInterface";
 
   /** The semantic version of the interface. */
-  public static interfaceVersion = "3.2.0";
+  public static interfaceVersion = "3.3.0";
 
   /*===========================================================================================
     NOTE: Any add/remove/change to the methods below requires an update of the interface version.


### PR DESCRIPTION
We're now using a new api, querySubCategories, so we should've bumped the minor previously