### PR TITLE
Replace the hyperlink of downloading iTwin Synchronizer

### DIFF
--- a/docs/learning/tutorials/create-test-imodel-itwin-sync.md
+++ b/docs/learning/tutorials/create-test-imodel-itwin-sync.md
@@ -19,7 +19,7 @@ An iTwin project containing an empty iModel will be created for you.
 
 ## Download iTwin synchronizer
 
-Download and familiarize yourself with the [iTwin Synchronizer](https://www.bentley.com/en/Products/Product-Line/Digital-Twins/iTwin-Synchronizer), a free tool for synchronizing data in CAD/BIM files on your desktop and an iModel.
+Download and familiarize yourself with the [iTwin Synchronizer](https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/47597/itwin-synchronizer-client), a free tool for synchronizing data in CAD/BIM files on your desktop and an iModel.
 
 ## Run iTwin synchronizer
 


### PR DESCRIPTION
Current link leads to a wrong page.  BE Communities is probably not the best reference but at least its topic is relevant and there is a download button to download ITSYNC.