### PR TITLE
add missing header to TileStorage.uploadTile

### DIFF
--- a/common/changes/@itwin/core-backend/fix-tilerpc_2022-09-29-16-09.json
+++ b/common/changes/@itwin/core-backend/fix-tilerpc_2022-09-29-16-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/fix-tilerpc_2022-09-29-16-09.json
+++ b/common/changes/@itwin/core-common/fix-tilerpc_2022-09-29-16-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/fix-tilerpc_2022-09-29-16-09.json
+++ b/common/changes/@itwin/core-frontend/fix-tilerpc_2022-09-29-16-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10,15 +10,15 @@ importers:
       '@azure/storage-blob': ^12.7.0
       '@bentley/imodeljs-native': 3.4.17
       '@itwin/build-tools': workspace:*
-      '@itwin/cloud-agnostic-core': 1.4.0
+      '@itwin/cloud-agnostic-core': ~1.4.0
       '@itwin/core-bentley': workspace:*
       '@itwin/core-common': workspace:*
       '@itwin/core-geometry': workspace:*
       '@itwin/core-telemetry': workspace:*
       '@itwin/core-webpack-tools': workspace:*
       '@itwin/eslint-plugin': workspace:*
-      '@itwin/object-storage-azure': 1.4.0
-      '@itwin/object-storage-core': 1.4.0
+      '@itwin/object-storage-azure': ~1.4.0
+      '@itwin/object-storage-core': ~1.4.0
       '@opentelemetry/api': 1.0.4
       '@types/chai': 4.3.1
       '@types/chai-as-promised': ^7
@@ -138,7 +138,7 @@ importers:
       '@itwin/core-bentley': workspace:*
       '@itwin/core-geometry': workspace:*
       '@itwin/eslint-plugin': workspace:*
-      '@itwin/object-storage-core': 1.4.0
+      '@itwin/object-storage-core': ~1.4.0
       '@types/chai': 4.3.1
       '@types/flatbuffers': ~1.10.0
       '@types/mocha': ^8.2.2
@@ -495,7 +495,7 @@ importers:
       '@itwin/appui-abstract': workspace:*
       '@itwin/build-tools': workspace:*
       '@itwin/certa': workspace:*
-      '@itwin/cloud-agnostic-core': 1.4.0
+      '@itwin/cloud-agnostic-core': ~1.4.0
       '@itwin/core-bentley': workspace:*
       '@itwin/core-common': workspace:*
       '@itwin/core-geometry': workspace:*
@@ -504,8 +504,8 @@ importers:
       '@itwin/core-quantity': workspace:*
       '@itwin/core-telemetry': workspace:*
       '@itwin/eslint-plugin': workspace:*
-      '@itwin/object-storage-azure': 1.4.0
-      '@itwin/object-storage-core': 1.4.0
+      '@itwin/object-storage-azure': ~1.4.0
+      '@itwin/object-storage-core': ~1.4.0
       '@itwin/webgl-compatibility': workspace:*
       '@loaders.gl/core': ^3.1.6
       '@loaders.gl/draco': ^3.1.6
@@ -1692,7 +1692,7 @@ importers:
       '@itwin/imodels-access-frontend': ^1.0.1
       '@itwin/imodels-client-authoring': ^1.0.1
       '@itwin/imodels-client-management': ^1.0.1
-      '@itwin/object-storage-core': 1.4.0
+      '@itwin/object-storage-core': ~1.4.0
       '@itwin/oidc-signin-tool': ^3.2.2
       '@itwin/projects-client': ^0.6.0
       '@itwin/reality-data-client': 0.7.0
@@ -3192,7 +3192,7 @@ importers:
       '@itwin/imodels-access-frontend': ^1.0.1
       '@itwin/imodels-client-authoring': ^1.0.1
       '@itwin/imodels-client-management': ^1.0.1
-      '@itwin/object-storage-core': 1.4.0
+      '@itwin/object-storage-core': ~1.4.0
       '@itwin/reality-data-client': 0.7.0
       '@itwin/webgl-compatibility': workspace:*
       '@types/express': ^4.16.1

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10,15 +10,15 @@ importers:
       '@azure/storage-blob': ^12.7.0
       '@bentley/imodeljs-native': 3.4.17
       '@itwin/build-tools': workspace:*
-      '@itwin/cloud-agnostic-core': 1.0.0
+      '@itwin/cloud-agnostic-core': 1.4.0
       '@itwin/core-bentley': workspace:*
       '@itwin/core-common': workspace:*
       '@itwin/core-geometry': workspace:*
       '@itwin/core-telemetry': workspace:*
       '@itwin/core-webpack-tools': workspace:*
       '@itwin/eslint-plugin': workspace:*
-      '@itwin/object-storage-azure': 1.0.0
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-azure': 1.4.0
+      '@itwin/object-storage-core': 1.4.0
       '@opentelemetry/api': 1.0.4
       '@types/chai': 4.3.1
       '@types/chai-as-promised': ^7
@@ -55,10 +55,10 @@ importers:
     dependencies:
       '@azure/storage-blob': 12.11.0
       '@bentley/imodeljs-native': 3.4.17
-      '@itwin/cloud-agnostic-core': 1.0.0
+      '@itwin/cloud-agnostic-core': 1.4.0
       '@itwin/core-telemetry': link:../telemetry
-      '@itwin/object-storage-azure': 1.0.0
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-azure': 1.4.0
+      '@itwin/object-storage-core': 1.4.0
       form-data: 2.5.1
       fs-extra: 8.1.0
       inversify: 5.0.5
@@ -138,7 +138,7 @@ importers:
       '@itwin/core-bentley': workspace:*
       '@itwin/core-geometry': workspace:*
       '@itwin/eslint-plugin': workspace:*
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-core': 1.4.0
       '@types/chai': 4.3.1
       '@types/flatbuffers': ~1.10.0
       '@types/mocha': ^8.2.2
@@ -156,7 +156,7 @@ importers:
       string_decoder: ^1.3.0
       typescript: ~4.4.0
     dependencies:
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-core': 1.4.0
       buffer: 6.0.3
       flatbuffers: 1.12.0
       js-base64: 3.7.2
@@ -495,7 +495,7 @@ importers:
       '@itwin/appui-abstract': workspace:*
       '@itwin/build-tools': workspace:*
       '@itwin/certa': workspace:*
-      '@itwin/cloud-agnostic-core': 1.0.0
+      '@itwin/cloud-agnostic-core': 1.4.0
       '@itwin/core-bentley': workspace:*
       '@itwin/core-common': workspace:*
       '@itwin/core-geometry': workspace:*
@@ -504,8 +504,8 @@ importers:
       '@itwin/core-quantity': workspace:*
       '@itwin/core-telemetry': workspace:*
       '@itwin/eslint-plugin': workspace:*
-      '@itwin/object-storage-azure': 1.0.0
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-azure': 1.4.0
+      '@itwin/object-storage-core': 1.4.0
       '@itwin/webgl-compatibility': workspace:*
       '@loaders.gl/core': ^3.1.6
       '@loaders.gl/draco': ^3.1.6
@@ -541,11 +541,11 @@ importers:
       wms-capabilities: 0.4.0
       xml-js: ~1.6.11
     dependencies:
-      '@itwin/cloud-agnostic-core': 1.0.0
+      '@itwin/cloud-agnostic-core': 1.4.0
       '@itwin/core-i18n': link:../i18n
       '@itwin/core-telemetry': link:../telemetry
-      '@itwin/object-storage-azure': 1.0.0
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-azure': 1.4.0
+      '@itwin/object-storage-core': 1.4.0
       '@loaders.gl/core': 3.2.9
       '@loaders.gl/draco': 3.2.9
       deep-assign: 2.0.0
@@ -1692,7 +1692,7 @@ importers:
       '@itwin/imodels-access-frontend': ^1.0.1
       '@itwin/imodels-client-authoring': ^1.0.1
       '@itwin/imodels-client-management': ^1.0.1
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-core': 1.4.0
       '@itwin/oidc-signin-tool': ^3.2.2
       '@itwin/projects-client': ^0.6.0
       '@itwin/reality-data-client': 0.7.0
@@ -1751,7 +1751,7 @@ importers:
       '@itwin/imodels-access-frontend': 1.0.2
       '@itwin/imodels-client-authoring': 1.1.0
       '@itwin/imodels-client-management': 1.1.0
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-core': 1.4.0
       '@itwin/reality-data-client': 0.7.0
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -3192,7 +3192,7 @@ importers:
       '@itwin/imodels-access-frontend': ^1.0.1
       '@itwin/imodels-client-authoring': ^1.0.1
       '@itwin/imodels-client-management': ^1.0.1
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-core': 1.4.0
       '@itwin/reality-data-client': 0.7.0
       '@itwin/webgl-compatibility': workspace:*
       '@types/express': ^4.16.1
@@ -3248,7 +3248,7 @@ importers:
       '@itwin/imodels-access-frontend': 1.0.2
       '@itwin/imodels-client-authoring': 1.1.0
       '@itwin/imodels-client-management': 1.1.0
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/object-storage-core': 1.4.0
       '@itwin/reality-data-client': 0.7.0
       '@itwin/webgl-compatibility': link:../../core/webgl-compatibility
       body-parser: 1.20.0
@@ -5068,6 +5068,14 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/logger': 1.0.3
+      tslib: 2.4.0
+    dev: false
+
+  /@azure/core-paging/1.2.1:
+    resolution: {integrity: sha512-UtH5iMlYsvg+nQYIl4UHlvvSrsBjOlRF4fs0j7mxd3rWdAStrKYrh2durOpHs5C9yZbVhsVDaisoyaf/lL1EVA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@azure/core-asynciterator-polyfill': 1.0.2
       tslib: 2.4.0
     dev: false
 
@@ -7417,8 +7425,8 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/cloud-agnostic-core/1.0.0:
-    resolution: {integrity: sha512-9lSvBXWknuDqOcSqZ5sDLngdVsUZtKDBsEJxvnQa8fi+e4Rm64Mc/NGf+495k5rYYKpi8dSxt1oxgRrSjAbmfQ==}
+  /@itwin/cloud-agnostic-core/1.4.0:
+    resolution: {integrity: sha512-KxoIrK6kQRcuc2lzA0MsxURZ6/+EeoegrzXgmngx3D0PTUz2K9TYuLlOeQu8e5VLYf3ppv000s1MZDifIwXLNA==}
     engines: {node: '>=12.20 <17.0.0'}
     dependencies:
       inversify: 5.0.5
@@ -7570,13 +7578,14 @@ packages:
       - debug
     dev: false
 
-  /@itwin/object-storage-azure/1.0.0:
-    resolution: {integrity: sha512-HVXLiIHCPJcgnz4sXWj2dPY7hqdQKhmCAoUlFRkg6C/TWjTtvNeCp+EkfyJsiqVI2NwM4HHG5qoW8BfLFDqdTQ==}
+  /@itwin/object-storage-azure/1.4.0:
+    resolution: {integrity: sha512-/vREtCo/h+Np5RlmLP8AHZ2Yb7rc77ywKj8jNCwoV/uyg9ea3r+OaoBJX/0w9epQwjGRsLEXwFFywXB5IUQJ7A==}
     engines: {node: '>=12.20 <17.0.0'}
     dependencies:
+      '@azure/core-paging': 1.2.1
       '@azure/storage-blob': 12.2.1
-      '@itwin/cloud-agnostic-core': 1.0.0
-      '@itwin/object-storage-core': 1.0.0
+      '@itwin/cloud-agnostic-core': 1.4.0
+      '@itwin/object-storage-core': 1.4.0
       inversify: 5.0.5
       reflect-metadata: 0.1.13
     transitivePeerDependencies:
@@ -7584,11 +7593,11 @@ packages:
       - encoding
     dev: false
 
-  /@itwin/object-storage-core/1.0.0:
-    resolution: {integrity: sha512-eiOPTNQ5hLrQ8aL7T9P+IjL0aoxgqbxQ2L9Kt0wsC8ukpyuvVUD9UjAhS0SclxCa4bgulO8nEF5CZBeFA4+RkA==}
+  /@itwin/object-storage-core/1.4.0:
+    resolution: {integrity: sha512-ixAgmeLuz3y34SyIDZbNNAfJBgfyqLjQZP0g8maLMd5TGcpU7ZNykA9Gtx1chSJcxUM+J3U7uaLBjULPkTtr7g==}
     engines: {node: '>=12.20 <17.0.0'}
     dependencies:
-      '@itwin/cloud-agnostic-core': 1.0.0
+      '@itwin/cloud-agnostic-core': 1.4.0
       axios: 0.27.2
       inversify: 5.0.5
       reflect-metadata: 0.1.13

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -92,9 +92,9 @@
   "dependencies": {
     "@azure/storage-blob": "^12.7.0",
     "@bentley/imodeljs-native": "3.4.17",
-    "@itwin/object-storage-azure": "1.0.0",
-    "@itwin/cloud-agnostic-core": "1.0.0",
-    "@itwin/object-storage-core": "1.0.0",
+    "@itwin/object-storage-azure": "1.4.0",
+    "@itwin/cloud-agnostic-core": "1.4.0",
+    "@itwin/object-storage-core": "1.4.0",
     "@itwin/core-telemetry": "workspace:*",
     "form-data": "^2.3.2",
     "fs-extra": "^8.1.0",

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -92,9 +92,9 @@
   "dependencies": {
     "@azure/storage-blob": "^12.7.0",
     "@bentley/imodeljs-native": "3.4.17",
-    "@itwin/object-storage-azure": "1.4.0",
-    "@itwin/cloud-agnostic-core": "1.4.0",
-    "@itwin/object-storage-core": "1.4.0",
+    "@itwin/object-storage-azure": "~1.4.0",
+    "@itwin/cloud-agnostic-core": "~1.4.0",
+    "@itwin/object-storage-core": "~1.4.0",
     "@itwin/core-telemetry": "workspace:*",
     "form-data": "^2.3.2",
     "fs-extra": "^8.1.0",

--- a/core/backend/src/TileStorage.ts
+++ b/core/backend/src/TileStorage.ts
@@ -62,7 +62,7 @@ export class TileStorage {
   }
 
   public async getCachedTiles(iModelId: string, _prefix: string): Promise<{ treeId: string, contentId: string, guid?: string }[]> {
-    return (await this.storage.list({ baseDirectory: iModelId }))
+    return (await this.storage.listObjects({ baseDirectory: iModelId }))
       .map((objectReference) => ({
         parts: objectReference.relativeDirectory?.split("/") ?? [""],
         objectName: objectReference.objectName,

--- a/core/backend/src/TileStorage.ts
+++ b/core/backend/src/TileStorage.ts
@@ -39,7 +39,8 @@ export class TileStorage {
       await this.storage.upload(
         getTileObjectReference(iModelId, changesetId, treeId, contentId, guid),
         Buffer.from(IModelHost.compressCachedTiles ? await promisify(gzip)(content.buffer) : content.buffer),
-        metadata
+        metadata,
+        IModelHost.compressCachedTiles ? { contentEncoding: "gzip" } : undefined,
       );
     } catch (err) {
       this.logException("Failed to upload tile", err);

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -35,7 +35,7 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
-    "@itwin/object-storage-core": "1.4.0",
+    "@itwin/object-storage-core": "~1.4.0",
     "buffer": "^6.0.3",
     "flatbuffers": "~1.12.0",
     "semver": "^7.3.5",

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -35,7 +35,7 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
-    "@itwin/object-storage-core": "1.0.0",
+    "@itwin/object-storage-core": "1.4.0",
     "buffer": "^6.0.3",
     "flatbuffers": "~1.12.0",
     "semver": "^7.3.5",

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -92,9 +92,9 @@
     "NOTE: core-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
   ],
   "dependencies": {
-    "@itwin/object-storage-azure": "1.4.0",
-    "@itwin/cloud-agnostic-core": "1.4.0",
-    "@itwin/object-storage-core": "1.4.0",
+    "@itwin/object-storage-azure": "~1.4.0",
+    "@itwin/cloud-agnostic-core": "~1.4.0",
+    "@itwin/object-storage-core": "~1.4.0",
     "@itwin/core-i18n": "workspace:*",
     "@itwin/core-telemetry": "workspace:*",
     "@loaders.gl/core": "^3.1.6",

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -92,9 +92,9 @@
     "NOTE: core-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
   ],
   "dependencies": {
-    "@itwin/object-storage-azure": "1.0.0",
-    "@itwin/cloud-agnostic-core": "1.0.0",
-    "@itwin/object-storage-core": "1.0.0",
+    "@itwin/object-storage-azure": "1.4.0",
+    "@itwin/cloud-agnostic-core": "1.4.0",
+    "@itwin/object-storage-core": "1.4.0",
     "@itwin/core-i18n": "workspace:*",
     "@itwin/core-telemetry": "workspace:*",
     "@loaders.gl/core": "^3.1.6",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -43,7 +43,7 @@
     "@itwin/imodels-access-frontend": "^1.0.1",
     "@itwin/imodels-client-authoring": "^1.0.1",
     "@itwin/imodels-client-management": "^1.0.1",
-    "@itwin/object-storage-core": "1.0.0",
+    "@itwin/object-storage-core": "1.4.0",
     "@itwin/reality-data-client": "0.7.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -43,7 +43,7 @@
     "@itwin/imodels-access-frontend": "^1.0.1",
     "@itwin/imodels-client-authoring": "^1.0.1",
     "@itwin/imodels-client-management": "^1.0.1",
-    "@itwin/object-storage-core": "1.4.0",
+    "@itwin/object-storage-core": "~1.4.0",
     "@itwin/reality-data-client": "0.7.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -68,7 +68,7 @@
     "@itwin/reality-data-client": "0.7.0",
     "@itwin/browser-authorization": "^0.5.1",
     "@itwin/electron-authorization": "^0.8.3",
-    "@itwin/object-storage-core": "1.0.0",
+    "@itwin/object-storage-core": "1.4.0",
     "body-parser": "^1.18.2"
   },
   "devDependencies": {

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -68,7 +68,7 @@
     "@itwin/reality-data-client": "0.7.0",
     "@itwin/browser-authorization": "^0.5.1",
     "@itwin/electron-authorization": "^0.8.3",
-    "@itwin/object-storage-core": "1.4.0",
+    "@itwin/object-storage-core": "~1.4.0",
     "body-parser": "^1.18.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The object-storage packages were missing a header that was needed for requesting tiles. That fix was in this PR, https://github.com/iTwin/object-storage/pull/65, and is pulled in via the 1.4.0 release of those packages.