### PR TITLE
Material and view documentation

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2086,24 +2086,11 @@ export function createRealityTileTreeReference(props: RealityModelTileTree.Refer
 // @public
 export interface CreateRenderMaterialArgs {
     alpha?: number;
-    diffuse?: {
-        color?: ColorDef | RgbColorProps;
-        weight?: number;
-    };
+    diffuse?: MaterialDiffuseProps;
     // @internal
     source?: RenderMaterialSource;
-    specular?: {
-        color?: ColorDef | RgbColorProps;
-        weight?: number;
-        exponent?: number;
-    };
-    textureMapping?: {
-        texture: RenderTexture;
-        mode?: TextureMapping.Mode;
-        transform?: TextureMapping.Trans2x3;
-        weight?: number;
-        worldMapping?: boolean;
-    };
+    specular?: MaterialSpecularProps;
+    textureMapping?: MaterialTextureMappingProps;
 }
 
 // @internal (undocumented)
@@ -6438,6 +6425,29 @@ export type MarkerTextAlign = "left" | "right" | "center" | "start" | "end";
 
 // @public (undocumented)
 export type MarkerTextBaseline = "top" | "hanging" | "middle" | "alphabetic" | "ideographic" | "bottom";
+
+// @public
+export interface MaterialDiffuseProps {
+    color?: ColorDef | RgbColorProps;
+    weight?: number;
+}
+
+// @public
+export interface MaterialSpecularProps {
+    color?: ColorDef | RgbColorProps;
+    exponent?: number;
+    weight?: number;
+}
+
+// @public
+export interface MaterialTextureMappingProps {
+    mode?: TextureMapping.Mode;
+    texture: RenderTexture;
+    transform?: TextureMapping.Trans2x3;
+    weight?: number;
+    // @internal (undocumented)
+    worldMapping?: boolean;
+}
 
 // @public
 export class MeasureAreaByPointsTool extends PrimitiveTool {

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -382,6 +382,9 @@ public;MarkerImage = HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | I
 public;class MarkerSet
 public;MarkerTextAlign = "left" | "right" | "center" | "start" | "end"
 public;MarkerTextBaseline = "top" | "hanging" | "middle" | "alphabetic" | "ideographic" | "bottom"
+public;MaterialDiffuseProps
+public;MaterialSpecularProps
+public;MaterialTextureMappingProps
 public;MeasureAreaByPointsTool 
 public;MeasureAreaTool 
 public;MeasureDistanceTool 

--- a/common/changes/@itwin/core-frontend/pmc-render-material-docs_2022-10-04-19-20.json
+++ b/common/changes/@itwin/core-frontend/pmc-render-material-docs_2022-10-04-19-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Replace inline type definitions in CreateRenderMaterialArgs with named and documented interfaces.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/RenderMaterial.ts
+++ b/core/frontend/src/render/RenderMaterial.ts
@@ -19,6 +19,69 @@ export interface RenderMaterialSource {
   id: Id64String;
 }
 
+/** Describes the [diffuse](https://en.wikipedia.org/wiki/Diffuse_reflection) properties of a [RenderMaterial]($common).
+ * @see [[CreateRenderMaterialArgs.diffuse]].
+ * @public
+ */
+export interface MaterialDiffuseProps {
+  /** The diffuse color. If defined, this overrides the color of any surface to which the material is applied. */
+  color?: ColorDef | RgbColorProps;
+
+  /** A multiplier in [0..1] specifying how strongly the diffuse color reflects light.
+   * Default: 0.6
+   */
+  weight?: number;
+}
+
+/** Describes the [specular](https://en.wikipedia.org/wiki/Specular_highlight) properties of a material.
+ * @see [[CreateRenderMaterialArgs.specular]].
+ * @public
+ */
+export interface MaterialSpecularProps {
+  /** The color of the specular reflections.
+   * Default: white.
+   */
+  color?: ColorDef | RgbColorProps;
+
+  /** A multiplier in [0..1] specifying the strength of the specular reflections.
+   * Default: 0.4
+   */
+  weight?: number;
+
+  /** An exponent in [0..infinity] describing the shininess of the surface.
+   * Default: 13.5
+   */
+  exponent?: number;
+}
+
+/** Describes how to map a [RenderTexture]($common)'s image to the surfaces to which a [RenderMaterial]($common) is applied.
+ * @see [[CreateRenderMaterialArgs.textureMapping]].
+ * @public
+ */
+export interface MaterialTextureMappingProps {
+  /** The texture from which the image is obtained. */
+  texture: RenderTexture;
+
+  /** The mode controlling how the image is mapped onto the surface.
+   * Default: [TextureMapping.Mode.Parametric]($common).
+   */
+  mode?: TextureMapping.Mode;
+
+  /** A 2x3 matrix for computing the UV coordinates.
+   * Default: [TextureMapping.Trans2x3.identity]($common).
+   */
+  transform?: TextureMapping.Trans2x3;
+
+  /** The ratio by which the color sampled from the texture image is mixed with the surface's or material's diffuse color.
+   * A ratio of 1 selects only the texture sample; a ratio of 0 selects only the diffuse color; a ratio of 0.5 mixes them evenly.
+   * Default: 1.
+   */
+  weight?: number;
+
+  /** @internal */
+  worldMapping?: boolean;
+}
+
 /** Arguments supplied to [[RenderSystem.createRenderMaterial]].
  * @public
  */
@@ -34,45 +97,13 @@ export interface CreateRenderMaterialArgs {
    */
   alpha?: number;
 
-  /** The diffuse properties of the material. */
-  diffuse?: {
-    /** The diffuse color. If defined, this overrides the color of any surface to which the material is applied. */
-    color?: ColorDef | RgbColorProps;
-
-    /** A multiplier in [0..1] specifying how strongly the diffuse color reflects light. */
-    weight?: number;
-  };
+  /** The [diffuse](https://en.wikipedia.org/wiki/Diffuse_reflection) properties of the material. */
+  diffuse?: MaterialDiffuseProps;
 
   /** The [specular](https://en.wikipedia.org/wiki/Specular_highlight) properties of the material. */
-  specular?: {
-    /** The color of the specular reflections. Default: white. */
-    color?: ColorDef | RgbColorProps;
-
-    /** A multiplier in [0..1] specifying the strength of the specular reflections. */
-    weight?: number;
-
-    /** An exponent in [0..infinity] describing the shininess of the surface. */
-    exponent?: number;
-  };
+  specular?: MaterialSpecularProps;
 
   /** Maps a [RenderTexture]($common) image to the surfaces to which the material is applied. */
-  textureMapping?: {
-    /** The texture from which the image is obtained. */
-    texture: RenderTexture;
-
-    /** Describes how the texture image is mapped to the surface. Default: [TextureMapping.Mode.Parametric]($common). */
-    mode?: TextureMapping.Mode;
-
-    /** A 2x3 matrix for computing the UV coordinates. Default: [TextureMapping.Trans2x3.identity]($common). */
-    transform?: TextureMapping.Trans2x3;
-
-    /** The ratio by which the color sampled from the texture image is mixed with the surface's or material's diffuse color.
-     * A ratio of 1 selects only the texture sample; a ratio of 0 selects only the diffuse color; a ratio of 0.5 mixes them evenly.
-     * Default: 1.
-     */
-    weight?: number;
-
-    /** @internal */
-    worldMapping?: boolean;
+  textureMapping?: MaterialTextureMappingProps;
   };
 }

--- a/core/frontend/src/render/RenderMaterial.ts
+++ b/core/frontend/src/render/RenderMaterial.ts
@@ -105,5 +105,4 @@ export interface CreateRenderMaterialArgs {
 
   /** Maps a [RenderTexture]($common) image to the surfaces to which the material is applied. */
   textureMapping?: MaterialTextureMappingProps;
-  };
 }

--- a/docs/learning/frontend/Views.md
+++ b/docs/learning/frontend/Views.md
@@ -175,7 +175,7 @@ Every view may have a thumbnail that shows an approximation of what it contains.
 
 ## ViewState Parameters
 
- This is what the parameters to the camera methods, and the values stored by [ViewDefinition3d]($backend) mean.
+ The diagrams below illustrate what the parameters to the camera methods, and the values stored by [ViewDefinition3d]($backend) mean. You can also visualize these parameters interactively using the [camera visualization sample](https://www.itwinjs.org/sandboxes/iTwinPlatform/Camera%20Visualizer).
 
 <img src="./ViewFrustum-D1.png" width="75%">
 


### PR DESCRIPTION
Replace inline interface definitions with named, publicly documented interfaces.
Noticed the problem, illustrated below, when linking to documentation in response to a [question](https://github.com/iTwin/itwinjs-core/discussions/4423#discussioncomment-3797261).
```
interface Thing {
  prop: {
    /** This documentation is not published and therefore useless. */
    innerProp: boolean;
  };
}
```

Also add [camera visualization sample](https://www.itwinjs.org/sandboxes/iTwinPlatform/Camera%20Visualizer) to Views.md.