### PR TITLE
Jchick/connector framework docs

### DIFF
--- a/docs/learning/WriteAConnector.md
+++ b/docs/learning/WriteAConnector.md
@@ -434,16 +434,28 @@ Constructor
 
 The ConnectorRunner has a constructor which takes JobArgs and HubArgs as parameters.
 
+```ts
+  public static fromJSON(json: AllArgsProps): ConnectorRunner {
+    const supportedVersion = "0.0.1";
+    if (!json.version || json.version !== supportedVersion)
+      throw new Error(`Arg file has invalid version ${json.version}. Supported version is ${supportedVersion}.`);
+    if (!(json.jobArgs))
+      throw new Error("jobArgs is not defined");
+    const jobArgs = new JobArgs(json.jobArgs);
+
+    let hubArgs: HubArgs | undefined;
+    if (json.hubArgs)
+      hubArgs = new HubArgs(json.hubArgs);
+
+    const runner = new ConnectorRunner(jobArgs, hubArgs);
+    return runner;
+```
+
 Methods
 
 The ConnectorRunner has a Run method that runs your connector module.
 
 ```ts
-    const jobArgs = new JobArgs({"c:\tmp\mynativefile.txt" : source, "c:\tmp\out\" : stagingDir, "snapshot" : dbType});
-
-    const hubArgs = new HubArgs();
-
-    const runner = new ConnectorRunner(jobArgs, hubArgs);
 
     const status = await runner.run("./HelloWorldConnector.js");
 
@@ -509,11 +521,7 @@ Your source data may have non-graphical data best represented as definitions. Ty
     if (this._sourceDataState === ItemState.Unchanged) {
       return;
     }
-    if (this.synchronizer.imodel.codeSpecs.hasName(CodeSpecs.Group)) {
-      return;
-    }
-    const spec = CodeSpec.create(this.synchronizer.imodel, CodeSpecs.Group, CodeScopeSpec.Type.Model);
-    this.synchronizer.imodel.codeSpecs.insert(spec);
+    this.insertCodeSpecs();
   }
 
 ```
@@ -523,6 +531,7 @@ Your source data may have non-graphical data best represented as definitions. Ty
 Use this method to import any domain schema that is required to publish your data.
 
 ```ts
+
   public async importDomainSchema(_requestContext: AccessToken): Promise<any> {
 
     if (this._sourceDataState === ItemState.Unchanged) {

--- a/example-code/snippets/src/connector-framework/ConnectorRunner.test.ts
+++ b/example-code/snippets/src/connector-framework/ConnectorRunner.test.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import type { AccessToken, Id64String} from "@itwin/core-bentley";
+import { BentleyStatus } from "@itwin/core-bentley";
+import { BriefcaseDb, BriefcaseManager, IModelHost, IModelJsFs } from "@itwin/core-backend";
+import type { TestBrowserAuthorizationClientConfiguration} from "@itwin/oidc-signin-tool";
+import { TestUtility} from "@itwin/oidc-signin-tool";
+import { expect } from "chai";
+import { ConnectorRunner } from "../../src/ConnectorRunner";
+import type { HubArgsProps} from "../../src/Args";
+import { HubArgs, JobArgs } from "../../src/Args";
+import { KnownTestLocations } from "../KnownTestLocations";
+import { IModelsClient } from "@itwin/imodels-client-authoring";
+import { BackendIModelsAccess } from "@itwin/imodels-access-backend";
+import * as utils from "../ConnectorTestUtils";
+import * as path from "path";
+
+describe("iTwin Connector Fwk (#integration)", () => {
+
+  let testProjectId: Id64String;
+  let testIModelId: Id64String| undefined;
+  let updateIModelId: Id64String | undefined;
+  let testClientConfig: TestBrowserAuthorizationClientConfiguration;
+  let token: AccessToken| undefined;
+
+  const testConnector = path.join("..", "lib", "test", "TestConnector", "TestConnector.js");
+
+  before(async () => {
+    await utils.startBackend();
+    utils.setupLogging();
+    const iModelClient = new IModelsClient({ api: { baseUrl: `https://${process.env.imjs_url_prefix ?? ""}api.bentley.com/imodels`}});
+    IModelHost.setHubAccess(new BackendIModelsAccess(iModelClient));
+
+    if (!IModelJsFs.existsSync(KnownTestLocations.outputDir))
+      IModelJsFs.mkdirSync(KnownTestLocations.outputDir);
+
+    testClientConfig = {
+      clientId: process.env.test_client_id!,
+      redirectUri: process.env.test_redirect_uri!,
+      scope: process.env.test_scopes!,
+    };
+
+    const userCred = {
+      email: process.env.test_user_name!,
+      password: process.env.test_user_password!,
+    };
+    const client = TestUtility.getAuthorizationClient(userCred, testClientConfig);
+    token = await client.getAccessToken();
+
+    if (!token) {
+      throw new Error("Token not defined");
+    }
+    IModelHost.authorizationClient = client;
+    testProjectId = process.env.test_project_id!;
+    const updateImodelName = process.env.test_existing_imodel_name!;
+    const newImodelName = process.env.test_new_imodel_name!;
+
+    updateIModelId = await IModelHost.hubAccess.queryIModelByName({ accessToken: token, iTwinId: testProjectId, iModelName: updateImodelName });
+    if (!updateIModelId) {
+      updateIModelId = await IModelHost.hubAccess.createNewIModel({ iTwinId: testProjectId, iModelName: updateImodelName, accessToken: token });
+    }
+    testIModelId = await IModelHost.hubAccess.queryIModelByName({ accessToken: token, iTwinId: testProjectId, iModelName: newImodelName});
+    if (!testIModelId) {
+      testIModelId = await IModelHost.hubAccess.createNewIModel({ accessToken: token, iTwinId: testProjectId, iModelName: newImodelName });
+    }
+  });
+
+  after(async () => {
+    // updated method to clear briefcases for an imodel
+    // let briefcases = await IModelHost.hubAccess.getMyBriefcaseIds({accessToken: token!, iModelId: testIModelId!});
+    // briefcases.forEach(async b => {
+    // await IModelHost.hubAccess.releaseBriefcase({briefcaseId: b, accessToken: token!, iModelId: testIModelId!});
+    // });
+    // const briefcases = await IModelHost.hubAccess.getMyBriefcaseIds({accessToken: token!, iModelId: updateIModelId!});
+    // briefcases.forEach(async b => {
+    //   await IModelHost.hubAccess.releaseBriefcase({briefcaseId: b, accessToken: token!, iModelId: updateIModelId!});
+    // });
+    await utils.shutdownBackend();
+    IModelJsFs.purgeDirSync(KnownTestLocations.outputDir);
+  });
+
+  async function runConnector(jobArgs: JobArgs, hubArgs: HubArgs) {
+    const runner = new ConnectorRunner(jobArgs, hubArgs);
+    // __PUBLISH_EXTRACT_START__ ConnectorRunnerTest.run.example-code
+    const status = await runner.run(testConnector);
+    // __PUBLISH_EXTRACT_END_
+
+    if (status !== BentleyStatus.SUCCESS)
+      throw new Error();
+
+    const briefcases = BriefcaseManager.getCachedBriefcases(hubArgs.iModelGuid);
+    const briefcaseEntry = briefcases[0];
+    expect(briefcaseEntry !== undefined);
+    const db = await BriefcaseDb.open({ fileName: briefcases[0].fileName, readonly: true });
+    try {
+      utils.verifyIModel(db, jobArgs, false);
+    } finally {
+      db.close();
+    }
+  }
+
+  it("should download and perform updates on a new imodel", async () => {
+    const assetPath = path.join(KnownTestLocations.assetsDir, "TestConnector.json");
+    const jobArgs = new JobArgs({
+      source: assetPath,
+    });
+
+    const hubArgs = new HubArgs({
+      projectGuid: testProjectId,
+      iModelGuid: testIModelId,
+    } as HubArgsProps);
+
+    hubArgs.clientConfig = testClientConfig;
+    hubArgs.tokenCallback = async (): Promise<AccessToken> => {
+      return token!;
+    };
+
+    await runConnector(jobArgs, hubArgs);
+
+    // cleanup
+    await IModelHost.hubAccess.deleteIModel({accessToken: token, iTwinId: testProjectId, iModelId: testIModelId! });
+  });
+
+  it("should download and perform updates on an existing imodel", async () => {
+    // TODO: This test does not seem to operate on a fresh iModel; see before().
+
+    const assetPath = path.join(KnownTestLocations.assetsDir, "TestConnector.json");
+    const jobArgs = new JobArgs({
+      source: assetPath,
+    });
+
+    const hubArgs = new HubArgs({
+      projectGuid: testProjectId,
+      iModelGuid: updateIModelId,
+    } as HubArgsProps);
+
+    hubArgs.clientConfig = testClientConfig;
+    hubArgs.tokenCallback = async (): Promise<AccessToken> => {
+      return token!;
+    };
+
+    await runConnector(jobArgs, hubArgs);
+
+    // run sync again to test update
+
+    await runConnector(jobArgs, hubArgs);
+
+    // cleanup
+    await IModelHost.hubAccess.deleteIModel({accessToken: token, iTwinId: testProjectId, iModelId: updateIModelId!});
+  });
+});

--- a/example-code/snippets/src/connector-framework/ConnectorRunner.ts
+++ b/example-code/snippets/src/connector-framework/ConnectorRunner.ts
@@ -1,0 +1,582 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import type { LocalBriefcaseProps, OpenBriefcaseProps, SubjectProps } from "@itwin/core-common";
+import { IModel } from "@itwin/core-common";
+import type { AccessToken, Id64Arg, Id64String } from "@itwin/core-bentley";
+import { BentleyError, IModelHubStatus } from "@itwin/core-bentley";
+import { assert, BentleyStatus, Logger, LogLevel } from "@itwin/core-bentley";
+import type { IModelDb, RequestNewBriefcaseArg } from "@itwin/core-backend";
+import { BriefcaseDb, BriefcaseManager, LinkElement, SnapshotDb, StandaloneDb, Subject, SubjectOwnsSubjects, SynchronizationConfigLink } from "@itwin/core-backend";
+import { NodeCliAuthorizationClient } from "@itwin/node-cli-authorization";
+import type { BaseConnector } from "./BaseConnector";
+import { LoggerCategories } from "./LoggerCategory";
+import type { AllArgsProps } from "./Args";
+import { HubArgs, JobArgs } from "./Args";
+import { Synchronizer } from "./Synchronizer";
+import type { ConnectorIssueReporter } from "./ConnectorIssueReporter";
+import * as fs from "fs";
+import * as path from "path";
+
+type Path = string;
+
+enum BeforeRetry { Nothing = 0, PullMergePush = 1 }
+
+export class ConnectorRunner {
+
+  private _jobArgs: JobArgs;
+  private _hubArgs?: HubArgs;
+
+  private _db?: IModelDb;
+  private _connector?: BaseConnector;
+  private _issueReporter?: ConnectorIssueReporter;
+  private _reqContext?: AccessToken;
+
+  /**
+   * @throws Error when jobArgs or/and hubArgs are malformated or contain invalid arguments
+   */
+  constructor(jobArgs: JobArgs, hubArgs?: HubArgs) {
+    if (!jobArgs.isValid)
+      throw new Error("Invalid jobArgs");
+    this._jobArgs = jobArgs;
+
+    if (hubArgs) {
+      if (!hubArgs.isValid)
+        throw new Error("Invalid hubArgs");
+      this._hubArgs = hubArgs;
+    }
+
+    Logger.initializeToConsole();
+    const { loggerConfigJSONFile } = jobArgs;
+    if (loggerConfigJSONFile && path.extname(loggerConfigJSONFile) === ".json" && fs.existsSync(loggerConfigJSONFile))
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      Logger.configureLevels(require(loggerConfigJSONFile));
+    else
+      Logger.setLevelDefault(LogLevel.Info);
+  }
+
+  /**
+   * Generates a ConnectorRunner instance from a .json argument file
+   * @param file absolute path to a .json file that stores arguments
+   * @returns ConnectorRunner
+   * @throws Error when file does not exist
+   */
+  public static fromFile(file: string): ConnectorRunner {
+    if (!fs.existsSync(file))
+      throw new Error(`${file} does not exist`);
+    const json = JSON.parse(fs.readFileSync(file, "utf8"));
+    const runner = ConnectorRunner.fromJSON(json);
+    return runner;
+  }
+
+  /**
+   * Generates a ConnectorRunner instance from json body
+   * @param json
+   * @returns ConnectorRunner
+   * @throws Error when content does not include "jobArgs" as key
+   */
+  public static fromJSON(json: AllArgsProps): ConnectorRunner {
+    const supportedVersion = "0.0.1";
+    if (!json.version || json.version !== supportedVersion)
+      throw new Error(`Arg file has invalid version ${json.version}. Supported version is ${supportedVersion}.`);
+
+    // __PUBLISH_EXTRACT_START__ ConnectorRunner-constructor.example-code
+    if (!(json.jobArgs))
+      throw new Error("jobArgs is not defined");
+    const jobArgs = new JobArgs(json.jobArgs);
+
+    let hubArgs: HubArgs | undefined;
+    if (json.hubArgs)
+      hubArgs = new HubArgs(json.hubArgs);
+
+    const runner = new ConnectorRunner(jobArgs, hubArgs);
+    // __PUBLISH_EXTRACT_END__
+
+    return runner;
+  }
+
+  // NEEDSWORK - How to check if string version od Access Token is expired
+  private get _isAccessTokenExpired(): boolean {
+    //  return this._reqContext.isExpired(5);
+    return true;
+  }
+
+  public async getAuthReqContext(): Promise<AccessToken> {
+    if (!this._reqContext)
+      throw new Error("AuthorizedClientRequestContext has not been loaded.");
+    if (this._isAccessTokenExpired) {
+      this._reqContext = await this.getToken();
+      Logger.logInfo(LoggerCategories.Framework, "AccessToken Refreshed");
+    }
+    return this._reqContext;
+  }
+
+  public async getReqContext(): Promise<AccessToken> {
+    if (!this._reqContext)
+      throw new Error("ConnectorRunner.reqContext has not been loaded. Must sign in first.");
+
+    let reqContext: AccessToken;
+    if (this.db.isBriefcaseDb())
+      reqContext = await this.getAuthReqContext();
+    else
+      reqContext = this._reqContext;
+
+    return reqContext;
+  }
+
+  public get jobArgs(): JobArgs {
+    return this._jobArgs;
+  }
+
+  public get hubArgs(): HubArgs {
+    if (!this._hubArgs)
+      throw new Error(`ConnectorRunner.hubArgs is not defined for current iModel with type = ${this.jobArgs.dbType}.`);
+    return this._hubArgs;
+  }
+
+  public set issueReporter(reporter: ConnectorIssueReporter) {
+    this._issueReporter = reporter;
+  }
+
+  public get jobSubjectName(): string {
+    let name = this.jobArgs.source;
+
+    const moreArgs = this.jobArgs.moreArgs;
+    if (moreArgs && moreArgs.pcf && moreArgs.pcf.subjectNode)
+      name = moreArgs.pcf.subjectNode;
+
+    return name;
+  }
+
+  public get db(): IModelDb {
+    if (!this._db)
+      throw new Error("IModelDb has not been loaded.");
+    return this._db;
+  }
+
+  public get connector(): BaseConnector {
+    if (!this._connector)
+      throw new Error("Connector has not been loaded.");
+    return this._connector;
+  }
+
+  /**
+   * Safely executes a connector job
+   * This method does not throw any errors
+   * @returns BentleyStatus
+   */
+  public async run(connector: Path): Promise<BentleyStatus> {
+    let runStatus = BentleyStatus.SUCCESS;
+    try {
+      await this.runUnsafe(connector);
+    } catch (err) {
+      const msg = (err as any).message;
+      Logger.logError(LoggerCategories.Framework, msg);
+      Logger.logError(LoggerCategories.Framework, `Failed to execute connector module - ${connector}`);
+      this.connector.reportError(this.jobArgs.stagingDir, msg, "ConnectorRunner", "Run", LoggerCategories.Framework);
+      runStatus = BentleyStatus.ERROR;
+      await this.onFailure(err);
+    } finally {
+      await this.onFinish();
+    }
+    return runStatus;
+  }
+
+  private async runUnsafe(connector: Path) {
+    Logger.logInfo(LoggerCategories.Framework, "Connector job has started");
+
+    // load
+
+    Logger.logInfo(LoggerCategories.Framework, "Loading connector...");
+    await this.loadConnector(connector);
+
+    Logger.logInfo(LoggerCategories.Framework, "Authenticating...");
+    await this.loadReqContext();
+
+    Logger.logInfo(LoggerCategories.Framework, "Retrieving iModel...");
+    await this.loadDb();
+
+    Logger.logInfo(LoggerCategories.Framework, "Loading synchronizer...");
+    await this.loadSynchronizer();
+
+    Logger.logInfo(LoggerCategories.Framework, "Writing configuration and opening source data...");
+    const synchConfig = await this.doInRepositoryChannel(
+      async () => {
+        const config = this.insertSynchronizationConfigLink();
+        await this.connector.openSourceData(this.jobArgs.source);
+        await this.connector.onOpenIModel();
+        return config;
+      },
+      "Write configuration and open source data."
+    );
+
+    // ***
+    // *** NEEDS WORK - this API should be changed - The connector should return
+    // *** schema *strings* from both importDomainSchema and importDynamicSchema. The connector should not import them.
+    // *** (Or, these two connector methods should be combined into a single method that returns an array of strings.)
+    // *** Then ConnectorRunner should get the schema lock and import all schemas in one shot.
+    // ***
+    Logger.logInfo(LoggerCategories.Framework, "Importing domain schema...");
+    await this.doInRepositoryChannel(
+      async () => {
+        return this.connector.importDomainSchema(await this.getReqContext());
+      },
+      "Write domain schema."
+    );
+
+    Logger.logInfo(LoggerCategories.Framework, "Importing dynamic schema...");
+    await this.doInRepositoryChannel(
+      async () => {
+        return this.connector.importDynamicSchema(await this.getReqContext());
+      },
+      "Write dynamic schema."
+    );
+
+    Logger.logInfo(LoggerCategories.Framework, "Writing job subject and definitions...");
+    const jobSubject = await this.doInRepositoryChannel(
+      async () => {
+        const job = await this.updateJobSubject();
+        await this.connector.initializeJob();
+        await this.connector.importDefinitions();
+        return job;
+      },
+      "Write job subject and definitions."
+    );
+
+    Logger.logInfo(LoggerCategories.Framework, "Synchronizing...");
+    await this.doInConnectorChannel(jobSubject.id,
+      async () => {
+        await this.connector.updateExistingData();
+        this.updateDeletedElements();
+      },
+      "Synchronize."
+    );
+
+    Logger.logInfo(LoggerCategories.Framework, "Writing job finish time and extent...");
+    await this.doInRepositoryChannel(
+      async () => {
+        this.updateProjectExtent();
+        this.connector.synchronizer.updateRepositoryLinks();
+        this.updateSynchronizationConfigLink(synchConfig);
+      },
+      "Write synchronization finish time and extent."
+    );
+
+    Logger.logInfo(LoggerCategories.Framework, "Connector job complete!");
+  }
+
+  private async onFailure(err: any) {
+    try {
+      if (this._db && this._db.isBriefcaseDb()) {
+        this._db.abandonChanges();
+        await this.db.locks.releaseAllLocks();
+      }
+    } catch (err1) {
+      // don't allow a further exception to prevent onFailure from reporting and returning. We need to finish the abend sequence.
+      // eslint-disable-next-line no-console
+      console.error(err1);
+    } finally {
+      try {
+        this.recordError(err);
+      } catch (err2) {
+        // eslint-disable-next-line no-console
+        console.error(err2);
+      }
+    }
+  }
+
+  public recordError(err: any) {
+    const errorFile = this.jobArgs.errorFile;
+    const errorStr = JSON.stringify({
+      id: this._connector?.getConnectorName() ?? "",
+      message: "Failure",
+      description: err.message,
+      extendedData: err,
+    });
+    fs.writeFileSync(errorFile, errorStr);
+    Logger.logInfo(LoggerCategories.Framework, `Error recorded at ${errorFile}`);
+  }
+
+  private async onFinish() {
+    if (this._db) {
+      this._db.abandonChanges();
+
+      this.connector?.onClosingIModel?.();
+
+      this._db.close();
+    }
+
+    if (this._connector && this.connector.issueReporter)
+      await this.connector.issueReporter.publishReport();
+  }
+
+  private updateDeletedElements() {
+    if (this.connector.shouldDeleteElements())
+      this.connector.synchronizer.detectDeletedElements();
+  }
+
+  private updateProjectExtent() {
+    const res = this.db.computeProjectExtents({
+      reportExtentsWithOutliers: false,
+      reportOutliers: false,
+    });
+    this.db.updateProjectExtents(res.extents);
+  }
+  private async updateJobSubject(): Promise<Subject> {
+    const code = Subject.createCode(this.db, IModel.rootSubjectId, this.jobSubjectName);
+    const existingSubjectId = this.db.elements.queryElementIdByCode(code);
+
+    let subject: Subject;
+
+    if (existingSubjectId) {
+      subject = this.db.elements.getElement<Subject>(existingSubjectId);
+    } else {
+      /* eslint-disable @typescript-eslint/naming-convention */
+      const jsonProperties: any = {
+        Subject: {
+          Job: {
+            Properties: {
+              ConnectorVersion: this.connector.getApplicationVersion(),
+              ConnectorType: "JSConnector",
+            },
+            Connector: this.connector.getConnectorName(),
+          },
+        },
+      };
+      /* eslint-disable @typescript-eslint/naming-convention */
+
+      const root = this.db.elements.getRootSubject();
+      const subjectProps: SubjectProps = {
+        classFullName: Subject.classFullName,
+        model: root.model,
+        code,
+        jsonProperties,
+        parent: new SubjectOwnsSubjects(root.id),
+      };
+      const newSubjectId = this.db.elements.insertElement(subjectProps);
+      subject = this.db.elements.getElement<Subject>(newSubjectId);
+      // await this.db.locks.releaseAllLocks();
+    }
+
+    this.connector.jobSubject = subject;
+    this.connector.synchronizer.jobSubjectId = subject.id;
+    return subject;
+  }
+
+  private async loadConnector(connector: Path) {
+    // TODO: Using `require` in a library isn't ergonomic. See
+    // https://github.com/iTwin/connector-framework/issues/40.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    this._connector = await require(connector).default.create();
+  }
+
+  private insertSynchronizationConfigLink() {
+    let synchConfigData = {
+      classFullName: SynchronizationConfigLink.classFullName,
+      model: IModel.repositoryModelId,
+      code: LinkElement.createCode(this.db, IModel.repositoryModelId, "SynchConfig"),
+    };
+    if (this.jobArgs.synchConfigFile) {
+      synchConfigData = require(this.jobArgs.synchConfigFile);
+    }
+    const prevSynchConfigId = this.db.elements.queryElementIdByCode(
+      LinkElement.createCode(this.db, IModel.repositoryModelId, "SynchConfig")
+    );
+    let idToReturn: string;
+    if (prevSynchConfigId === undefined) {
+      idToReturn = this.db.elements.insertElement(synchConfigData);
+    } else {
+      this.updateSynchronizationConfigLink(prevSynchConfigId);
+      idToReturn = prevSynchConfigId;
+    }
+    return idToReturn;
+  }
+  private updateSynchronizationConfigLink(synchConfigId: string) {
+    const synchConfigData = {
+      id: synchConfigId,
+      classFullName: SynchronizationConfigLink.classFullName,
+      model: IModel.repositoryModelId,
+      code: LinkElement.createCode(this.db, IModel.repositoryModelId, "SynchConfig"),
+      lastSuccessfulRun: Date.now().toString(),
+    };
+    this.db.elements.updateElement(synchConfigData);
+  }
+
+  private async loadReqContext() {
+    const token = await this.getToken();
+    this._reqContext = token;
+  }
+
+  private async getToken() {
+    let token: string;
+    const kind = this._jobArgs.dbType;
+    if (kind === "snapshot" || kind === "standalone")
+      return "notoken";
+
+    if (this.hubArgs.doInteractiveSignIn)
+      token = await this.getTokenInteractive();
+    else
+      token = await this.getTokenSilent();
+    return token;
+  }
+
+  private async getTokenSilent() {
+    let token: string;
+    if (this.hubArgs && this.hubArgs.tokenCallbackUrl) {
+      const response = await fetch(this.hubArgs.tokenCallbackUrl);
+      const tokenStr = await response.json();
+      token = tokenStr;
+    } else if (this.hubArgs && this.hubArgs.tokenCallback) {
+      token = await this.hubArgs.tokenCallback();
+    } else {
+      throw new Error("Define either HubArgs.acccessTokenCallbackUrl or HubArgs.accessTokenCallback to retrieve accessToken");
+    }
+    return token;
+  }
+
+  private async getTokenInteractive() {
+    const client = new NodeCliAuthorizationClient(this.hubArgs.clientConfig!);
+    Logger.logInfo(LoggerCategories.Framework, "token signin");
+    await client.signIn();
+    return client.getAccessToken();
+  }
+
+  private async loadDb() {
+    if (this.jobArgs.dbType === "briefcase") {
+      await this.loadBriefcaseDb();
+    } else if (this.jobArgs.dbType === "standalone") {
+      await this.loadStandaloneDb();
+    } else if (this.jobArgs.dbType === "snapshot") {
+      await this.loadSnapshotDb();
+    } else {
+      throw new Error("Invalid JobArgs.dbType");
+    }
+  }
+
+  private async loadSnapshotDb() {
+    const cname = this.connector.getConnectorName();
+    const fname = `${cname}.bim`;
+    const fpath = path.join(this.jobArgs.stagingDir, fname);
+    if (fs.existsSync(fpath))
+      fs.unlinkSync(fpath);
+    this._db = SnapshotDb.createEmpty(fpath, { rootSubject: { name: cname } });
+  }
+
+  private async loadStandaloneDb() {
+    const cname = this.connector.getConnectorName();
+    const fname = `${cname}.bim`;
+    const fpath = path.join(this.jobArgs.stagingDir, fname);
+    if (fs.existsSync(fpath))
+      this._db = StandaloneDb.openFile(fpath);
+    else
+      this._db = StandaloneDb.createEmpty(fpath, { rootSubject: { name: cname } });
+  }
+
+  private async loadBriefcaseDb() {
+
+    let bcFile: string | undefined;
+    if (this.hubArgs.briefcaseFile) {
+      bcFile = this.hubArgs.briefcaseFile;
+    } else {
+      const briefcases = BriefcaseManager.getCachedBriefcases(this.hubArgs.iModelGuid);
+      for (const bc of briefcases) {
+        assert(bc.iModelId === this.hubArgs.iModelGuid);
+        if (this.hubArgs.briefcaseId && bc.briefcaseId !== this.hubArgs.briefcaseId)
+          continue;
+        bcFile = bc.fileName;
+        break;
+      }
+    }
+
+    let openProps: OpenBriefcaseProps;
+    if (bcFile) {
+      openProps = { fileName: bcFile };
+    } else {
+      const reqArg: RequestNewBriefcaseArg = { iTwinId: this.hubArgs.projectGuid, iModelId: this.hubArgs.iModelGuid };
+      if (this.hubArgs.briefcaseId)
+        reqArg.briefcaseId = this.hubArgs.briefcaseId;
+
+      const bcProps: LocalBriefcaseProps = await BriefcaseManager.downloadBriefcase(reqArg);
+      if (this.jobArgs.updateDbProfile || this.jobArgs.updateDomainSchemas) {
+        await this.doWithRetries(async () => BriefcaseDb.upgradeSchemas(bcProps), BeforeRetry.Nothing);
+      }
+
+      openProps = { fileName: bcProps.fileName };
+    }
+
+    this._db = await BriefcaseDb.open(openProps);
+    // (this._db as BriefcaseDb).concurrencyControl.startBulkMode(); // not sure what/if anything is the new "startBulkMode"
+  }
+
+  private async loadSynchronizer() {
+    const synchronizer = new Synchronizer(this.db, false, this._reqContext);
+    this.connector.synchronizer = synchronizer;
+  }
+
+  private async persistChanges(changeDesc: string) {
+    const { revisionHeader } = this.jobArgs;
+    const comment = `${revisionHeader} - ${changeDesc}`;
+    const isStandalone = this.jobArgs.dbType === "standalone";
+    if (!isStandalone && this.db.isBriefcaseDb()) {
+      this._db = this.db;
+      await this.db.pullChanges();
+      this.db.saveChanges(comment);
+      await this.db.pushChanges({ description: comment });
+      await this.db.locks.releaseAllLocks(); // in case there were no changes
+    } else {
+      this.db.saveChanges(comment);
+    }
+  }
+
+  private async acquireLocks(arg: { shared?: Id64Arg, exclusive?: Id64Arg }): Promise<void> {
+    const isStandalone = this.jobArgs.dbType === "standalone";
+    if (isStandalone || !this.db.isBriefcaseDb())
+      return;
+
+    return this.doWithRetries(async () => this.db.locks.acquireLocks(arg), BeforeRetry.PullMergePush);
+  }
+
+  private shouldRetryAfterError(err: unknown): boolean {
+    if (!(err instanceof BentleyError))
+      return false;
+    return err.errorNumber === IModelHubStatus.LockOwnedByAnotherBriefcase;
+  }
+
+  private async doWithRetries(task: () => Promise<void>, beforeRetry: BeforeRetry): Promise<void> {
+    let count = 0;
+    do {
+      try {
+        await task();
+        return;
+      } catch (err) {
+        if (!this.shouldRetryAfterError(err))
+          throw err;
+        if (++count > this.hubArgs.maxLockRetries)
+          throw err;
+        const sleepms = Math.random() * this.hubArgs.maxLockRetryWaitSeconds * 1000;
+        await new Promise((resolve) => setTimeout(resolve, sleepms));
+
+        if (beforeRetry === BeforeRetry.PullMergePush) {
+          assert(this.db.isBriefcaseDb());
+          await this.db.pullChanges(); // do not catch!
+          await this.db.pushChanges({ description: "" }); // "
+        }
+      }
+    } while (true);
+  }
+
+  private async doInRepositoryChannel<R>(task: () => Promise<R>, message: string): Promise<R> {
+    await this.acquireLocks({ exclusive: IModel.rootSubjectId });
+    const result = await task();
+    await this.persistChanges(message);
+    return result;
+  }
+
+  private async doInConnectorChannel<R>(jobSubject: Id64String, task: () => Promise<R>, message: string): Promise<R> {
+    await this.acquireLocks({ exclusive: jobSubject });  // automatically acquires shared lock on root subject (the parent/model)
+    const result = await task();
+    await this.persistChanges(message);
+    return result;
+  }
+}

--- a/example-code/snippets/src/connector-framework/Synchronizer.ts
+++ b/example-code/snippets/src/connector-framework/Synchronizer.ts
@@ -1,0 +1,786 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Framework
+ */
+
+import { ElementUniqueAspect } from "@itwin/core-backend";
+import type { ECSqlStatement, IModelDb } from "@itwin/core-backend";
+import type { Element } from "@itwin/core-backend";
+import { DefinitionElement, ElementOwnsChildElements, ExternalSource, ExternalSourceAspect, RepositoryLink } from "@itwin/core-backend";
+import type { AccessToken, GuidString, Id64String } from "@itwin/core-bentley";
+import { assert, DbResult, Guid, Id64, IModelStatus, Logger } from "@itwin/core-bentley";
+import type { ElementProps, ExternalSourceAspectProps, ExternalSourceProps, RepositoryLinkProps } from "@itwin/core-common";
+import { Code, IModel, IModelError, RelatedElement } from "@itwin/core-common";
+import { LoggerCategories } from "./LoggerCategory";
+import { deleteElementSubTrees } from "./ElementTreeWalker";
+
+/** The state of the given SourceItem against the iModelDb
+ * @beta
+ */
+export enum ItemState {
+  /** The SourceItem is unchanged */
+  Unchanged,
+  /** The SourceItem is not currently in the iModelDb */
+  New,
+  /** The SourceItem has been changed */
+  Changed,
+}
+
+/** @beta */
+export interface ChangeResults {
+  /** Id of the item, if it currently exists in the iModel */
+  id?: Id64String;
+  /** State of the item */
+  state: ItemState;
+  /** The ExternalSourceAspect, if any, that was found in the iModel. This contains the state of the item from the last time it was synchronized. */
+  existingExternalSourceAspect?: ExternalSourceAspectProps;
+}
+
+type RemoveNullable<T, TKey extends keyof T> = T & {
+  [K in TKey]-?: NonNullable<T[K]>
+};
+
+/** A `SourceItem` identifies an entity in an external source and the state of the content of the entity.
+ * The data provided by the SourceItem is stored in the iModel as the "provenance" of the entity.
+ * This provenance data enables users and applications to trace an element in an iModel back to its native, external source.
+ * Provenance also enables a connector to track and synchronize changes to the entity.
+ * ## Document, external source, and scope
+ *  The "document" is the data source that is being read by the connector. This could be a file, a managed document, or a database connection. A document is represented in the iModel by a RepositoryLink element.
+ *  The "external source" represents either the document as a whole or an area within the document. (Also see ExternalSourceGroup.) The external source is represented by an ExternalSource element. See https://www.itwinjs.org/learning/provenence-in-imodels/.
+ *  The "scope" identifies either the ExternalSource or an area within in.
+ * ## Kind
+ *  A value that the connector uses to classify the entity.
+ * ## Id
+ *  The ID that was assigned to the entity by the external system that creates and manages it. This ID must be stable -- a given entity must have the same ID each time it is synchronized.
+ * ## Entity identification
+ *  The (kind, scope, id) triple must uniquely identify the entity in the outside world.
+ *  This triple is what allows the iModel to track the entity.
+ * ## Entity change detection
+ *  The version and/or checksum values capture the state of the content of the entity.
+ *  These values are stored in the iModel.
+ *  They allow the Synchronizer to detect if the entity has changed since the last synchronization.
+ *  See below for details on change-detection.
+ * ## Persistence
+ *  The properties of a SourceItem are stored in the ExternalSourceAspect of the Element in the iModel that represents the entity.
+ *  The ExternalSourceAspect tracks the external source of the element.
+ *  https://www.itwinjs.org/bis/domains/biscore.ecschema/#externalsourceaspect
+ *
+ * ## Change-detection using version and checksum
+ * The connector must call Synchronizer.detectChanges on each entity to determine if there are changes that must be written to the iModel or not.
+ *
+ * The SourceItem's version and/or checksum values must capture the entity's *current* state in the external source.
+ * The ExternalSourceAspect records the state of the entity as of the last synchronization.
+ *
+ * Synchronizer.detectChanges compares the SourceItem's current state with the stored state recorded by the aspect.
+ * If they match, the entity is unchanged and should be skipped.
+ * If they do not match, the entity has changed, and the connector should convert the entity and then call Synchronizer.updateIModel.
+ *
+ * Change-detection is based on version and/or checksum values that capture the state of the content of each entity in a summary form.
+ * In principle, Synchronizer could detect changes by letting the connector convert an entity to BIS format and then comparing the results with the Elements
+ * and Aspects currently in the iModel. That would be a waste of time in the common case where most entities are unchanged. To avoid this, Synchronizer
+ * uses version and/or checksum values instead. This approach minimizes the cost of up-front change-detection. The connector can compute these summary values directly
+ * from the raw source data, without using its conversion logic. One or both of these values may even be directly available in the source data.
+ *
+ * A SourceItem must have a version or a checksum, and it can have both.
+ * 1. If a SourceItem defines *both* version and checksum, then the entity is considered to be unchanged if the version is unchanged. If the version has changed, then the checksum is checked.
+ * 2. If a SourceItem defines version only, the entity is considered to have changed if the item's version has changed.
+ * 3. If a SourceItem defines checksum only, the entity is considered to have changed if the item's checksum has changed.
+ *
+ * @beta
+ */
+export interface SourceItem {
+  /** The unique identity of the entity (relative to its scope and kind) in the external source. */
+  id: string;
+  /** Identifies an element in the iModel that represents an area of the external source. Defaults to the Job Subject element. */
+  scope?: string;
+  /** Indicates what kind of thing this is in the external source. The value and purpose of this string is known only to the connector. Defaults to "". */
+  kind?: string;
+  /** An optional value that is typically a version number or a pseudo version number like last modified time.
+   * It will be used by the synchronization process to detect that a source entity is unchanged so that computing a cryptographic hash can be avoided.
+   * If present, this value must be guaranteed to change when any of the source entity's content changes. If not defined, checksum must be defined
+   */
+  version?: string;
+  /** The optional cryptographic hash (any algorithm) of the source entity's content. If defined, it must be guaranteed to change when the source entity's content changes.
+   * If defined, this function should cache its return value the first time that it is called, because it may be called multiple times.
+   */
+  checksum?(): string | undefined;
+  /* Identifies the ExternalSource of the entity. See https://www.itwinjs.org/learning/provenence-in-imodels/.
+  * If not specified or empty, then the ExternalSource of the RepositoryLink will be used by default, provided that only
+  * one RepositoryLink has been recorded. That is the common case.
+  */
+  source?: string;
+}
+
+/** Properties that may be assigned to a document by its home document control system
+ * @beta
+ */
+export interface DocumentProperties {
+  /** The GUID assigned to the document */
+  docGuid?: string;
+  /** The URN to use when referring to this document over the Internet */
+  webURN?: string;
+  /** The URN to use when referring to this document from a desktop program */
+  desktopURN?: string;
+  /** Document attributes, in JSON format. These are additional attributes that may be assigned to the document by the external document management system. */
+  attributesJson?: string;
+}
+
+/** Identifies an external document and its state.
+ * This data is stored in the ExternalSourceAspect of the RepositoryLink Element that represents the document.
+ * The ExternalSourceAspect tracks the source document.
+*/
+export interface SourceDocument {
+  /** The stable unique ID of the source document. This must never change. Preferably this should be a GUID that is assigned once and for all to the document
+   * by an external document management system. If the document is an unmanaged file, then a lower-cased, relative filename should be used.
+   */
+  docid: string;
+  /** Additional properties that may be assigned to the document by the document management system. */
+  docProps?: DocumentProperties;
+  /** A human-readable description of the source document. */
+  description?: string;
+  /** An optional value that is typically the last modified time of the document.
+  * It will be used by the synchronization process to detect that the document is unchanged so that computing a cryptographic hash can be avoided.
+  * If present, this value must be guaranteed to change when any of the document's content changes. If not defined, checksum must be defined
+  */
+  lastModifiedTime?: string;
+  /** The cryptographic hash (any algorithm) of the document's content. If defined, it must be guaranteed to change when the document's content changes.
+  * The method of computing this value is known only to the connector or source repository.  If not defined, version must be defined.
+  * This function will not be called if `lastModifiedTime` is defined and is not equal to the version property of the stored aspect.
+  */
+  checksum?(): string | undefined;
+}
+
+/** @beta */
+export interface SynchronizationResults {
+  /** The props of the element being synchronized */
+  elementProps: ElementProps;
+  /**  Children of element that have been synchronized */
+  childElements?: SynchronizationResults[];
+  /** The state of the element */
+  itemState: ItemState;
+}
+
+export interface RecordDocumentResults extends SynchronizationResults {
+  /** Identifies the ExternalSource element that corresponds to to the RepositoryLink. This may be empty or invalid. */
+  source: Id64String;
+  /** The RepositoryLink's previously stored state, if any. Will be undefined if the document is new. */
+  preChangeAspect?: ExternalSourceAspectProps;
+  /** The RepositoryLink's current state. Note that this state has not yet been written to the iModel. This is used by updateRepositoryLinks to update the iModel when synchronization is finished. */
+  postChangeAspect: ExternalSourceAspectProps;
+}
+
+type ItemWithScopeAndKind = RemoveNullable<SourceItem, "scope" | "kind">;
+
+function sourceItemHasScopeAndKind(item: SourceItem): item is ItemWithScopeAndKind {
+  return item.scope !== undefined && item.kind !== undefined;
+}
+
+/** Helper class for interacting with the iModelDb during synchronization.
+ * @beta
+ */
+export class Synchronizer {
+  private _seenElements: Set<Id64String> = new Set<Id64String>();
+  private _seenAspects: Set<Id64String> = new Set<Id64String>();
+  private _unchangedSources: Id64String[] = new Array<Id64String>();
+  private _links = new Map<string, RecordDocumentResults>();
+  private _jobSubjectId: string | undefined;
+
+  public constructor(
+    public readonly imodel: IModelDb,
+    private _supportsMultipleFilesPerChannel: boolean,
+    protected _requestContext?: AccessToken) {
+    if (imodel.isBriefcaseDb() && undefined === _requestContext)
+      throw new IModelError(IModelStatus.BadArg, "RequestContext must be set when working with a BriefcaseDb");
+  }
+
+  /** @internal */
+  public get linkCount() { return this._links.size; }
+  public get unchangedSources() { return this._unchangedSources; }
+
+  public set jobSubjectId(id: Id64String) { this._jobSubjectId = id; }
+  public get jobSubjectId(): string {
+    if (this._jobSubjectId === undefined)
+      throw new IModelError(IModelStatus.MissingId, "No Job Subject");
+    return this._jobSubjectId;
+  }
+
+  // __PUBLISH_EXTRACT_START__ Sychronizer-getOrCreateExternalSource.example-code
+  private getOrCreateExternalSource(repositoryLinkId: Id64String, modelId: Id64String): Id64String {
+    const xse = this.getExternalSourceElementByLinkId(repositoryLinkId);
+    if (xse !== undefined) {
+      assert(xse.id !== undefined);
+      return xse.id;
+    }
+
+    const xseProps: ExternalSourceProps = {
+      model: modelId,
+      classFullName: ExternalSource.classFullName,
+      repository: { id: repositoryLinkId, relClassName: RepositoryLink.classFullName },
+      code: Code.createEmpty(),
+    };
+
+    return this.imodel.elements.insertElement(xseProps);
+  }
+  // __PUBLISH_EXTRACT_END__
+
+  /** Insert or update a RepositoryLink element to represent the source document. Also inserts or updates an ExternalSourceAspect for provenance.
+   * The document's ID is sourceDocument.docProps.docGuid, if defined; else, sourceDocument.docProps.desktopUrn, if defined; else, sourceDocument.description.
+   * The document's ID is stored in the code value of the RepositoryLink and the identity of its ExternalSourceAspect.
+   * @param sourceDocument Identifies the document.
+   * @throws [[IModelError]] if a RepositoryLink for this document already exists, but there is no matching ExternalSourceAspect.
+   * @see [[SourceItem]] for an explanation of how an entity from an external source is tracked in relation to the RepositoryLink.
+   */
+
+  // __PUBLISH_EXTRACT_START__ Synchronizer-recordDocument.example-code
+  public recordDocument(sourceDocument: SourceDocument): RecordDocumentResults {
+    const code = RepositoryLink.createCode(this.imodel, IModel.repositoryModelId, sourceDocument.docid);
+
+    const sourceItem: ItemWithScopeAndKind = {
+      kind: "DocumentWithBeGuid",
+      scope: IModel.repositoryModelId,
+      id: code.value,
+      version: sourceDocument.lastModifiedTime,
+      checksum: () => { return sourceDocument.checksum?.(); },
+    };
+
+    const key = sourceItem.scope + sourceItem.id.toLowerCase();
+    const existing = this._links.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    // __PUBLISH_EXTRACT_END__
+    const repositoryLink = this.makeRepositoryLink(code, sourceDocument.description, sourceDocument.docProps);
+
+    if (undefined === repositoryLink) {
+      throw new IModelError(IModelStatus.BadElement, `Failed to create repositoryLink for ${JSON.stringify(sourceDocument)}`);
+    }
+
+    const results = {
+      elementProps: repositoryLink.toJSON(),
+      itemState: ItemState.New,
+      source: "", // see below
+    } as RecordDocumentResults;
+
+    // __PUBLISH_EXTRACT_START__ Synchronizer-detectChanges.example-code
+    const changeResults = this.detectChanges(sourceItem);
+    if (Id64.isValidId64(repositoryLink.id) && changeResults.state === ItemState.New) {
+      const error = `A RepositoryLink element with code=${repositoryLink.code} and id=${repositoryLink.id} already exists in the bim file.
+      However, no ExternalSourceAspect with scope=${sourceItem.scope} and kind=${sourceItem.kind} was found for this element.
+      Maybe RecordDocument was previously called on this file with a different scope or kind.`;
+      throw new IModelError(IModelStatus.NotFound, error);
+    }
+
+    results.itemState = changeResults.state;
+    results.preChangeAspect = changeResults.existingExternalSourceAspect;
+    // __PUBLISH_EXTRACT_END__
+
+    // __PUBLISH_EXTRACT_START__ Synchronizer-onElementsSeen.example-code
+    if (changeResults.state === ItemState.Unchanged) {
+      assert(changeResults.id !== undefined);
+      results.elementProps.id = changeResults.id;
+      results.source = this.getOrCreateExternalSource(results.elementProps.id, results.elementProps.model);
+      assert(changeResults.existingExternalSourceAspect !== undefined, "detectChanges must set existingExternalSourceAspect whenever it returns Unchanged or Changed");
+      results.postChangeAspect = changeResults.existingExternalSourceAspect;
+
+      this._unchangedSources.push(changeResults.id);
+      this._links.set(key, results);
+      this.onElementSeen(changeResults.id);
+      return results;
+    }
+    // __PUBLISH_EXTRACT_END__
+
+    // __PUBLISH_EXTRACT_START__ Synchronizer-updateIModel.example-code
+    // Changed or New
+    const status = this.updateIModel(results, sourceItem);
+
+    if (results.elementProps.id === undefined)
+      throw new IModelError(status, `Failed to insert repositoryLink ${JSON.stringify(results.elementProps)}`);
+
+    results.source = this.getOrCreateExternalSource(results.elementProps.id, results.elementProps.model);
+
+    this._links.set(key, results);
+
+    // Fail-safety - see updateRepositoryLinks
+    results.postChangeAspect = this.makeExternalSourceAspectPropsFromSourceItem(sourceItem, results.elementProps.id); // this is what we will write in updateRepositoryLinks at the finish
+    const aspectNoVersion: ExternalSourceAspectProps = { ...results.postChangeAspect, version: undefined, checksum: undefined }; // at the start, erase the version and checksum values
+    this.imodel.elements.updateAspect(aspectNoVersion);
+
+    return results;
+    // __PUBLISH_EXTRACT_END__
+  }
+
+  private setSourceItemDefaults(item: SourceItem) {
+    if (item.scope === undefined)
+      item.scope = this.jobSubjectId;
+    if (item.kind === undefined)
+      item.kind = "";
+    if (item.source === undefined && this.linkCount === 1)
+      item.source = this._links.values().next().value.source;
+    assert(sourceItemHasScopeAndKind(item));
+  }
+
+  /** Detect if the item has changed or is new.
+   * @param item the source item
+   * @returns the results of looking in the iModelDb and comparing the existing source record, if any, with the item's current state.
+   * @beta
+   */
+  public detectChanges(item: SourceItem): ChangeResults {
+    this.setSourceItemDefaults(item);
+    assert(sourceItemHasScopeAndKind(item));
+
+    let ids: any;
+    const results: ChangeResults = {
+      state: ItemState.New,
+    };
+
+    if (item.id !== "") {
+      ids = ExternalSourceAspect.findBySource(this.imodel, item.scope, item.kind, item.id);
+    }
+
+    // If we fail to locate the aspect with its unique (kind, identifier) tuple, we consider the
+    // source item new.
+    if (ids.aspectId === undefined) {
+      return results;
+    }
+
+    let aspect: ExternalSourceAspect | undefined;
+
+    try {
+      aspect = this.imodel.elements.getAspect(ids.aspectId) as ExternalSourceAspect;
+    } catch (err) {
+      // Unfortunately, the only way we can find out if an aspect is NOT there is by getting an
+      // error when asking for it.
+      if (!(err instanceof IModelError) || (err.errorNumber !== IModelStatus.NotFound)) {
+        throw err;
+      }
+
+      return results;
+    }
+
+    if (undefined === aspect)
+      return results;
+
+    this._seenAspects.add(aspect.id);
+
+    results.existingExternalSourceAspect = aspect.toJSON();
+    results.id = ids.elementId;
+
+    if (item.version !== undefined && item.version === aspect.version) {
+      results.state = ItemState.Unchanged;
+      return results;
+    }
+
+    if ((item.checksum?.() ?? item.version) !== (aspect.checksum ?? aspect.version)) {
+      results.state = ItemState.Changed;
+      return results;
+    }
+
+    results.state = ItemState.Unchanged;
+    return results;
+  }
+
+  /** Update the iModel with the results of converting an item to one or more Elements.
+   * If the item is new or changed, the conversion writes are written to the iModel and the associated ExternalSourceAspect is updated.
+   * If the item is known and unchanged, then the iModel is not updated.
+   * In either case, this function will record the id of the element as having been seen.
+   * @param results The Element to be inserted or updated
+   * @param sourceItem Whether the element is new, changed, or unchanged
+   * @see [[SourceItem]] for an explanation of how an entity from an external source is tracked.
+   * @beta
+   */
+  public updateIModel(results: SynchronizationResults, sourceItem: SourceItem): IModelStatus {
+    this.setSourceItemDefaults(sourceItem);
+    assert(sourceItemHasScopeAndKind(sourceItem));
+
+    let status: IModelStatus = IModelStatus.Success;
+
+    if (ItemState.Unchanged === results.itemState) {
+      if (results.elementProps.id === undefined || !Id64.isValidId64(results.elementProps.id)) {
+        throw new IModelError(IModelStatus.BadArg, "missing id");
+      }
+      this.onElementSeen(results.elementProps.id);
+      return status;
+    }
+
+    // __PUBLISH_EXTRACT_START__ Synchronizer-updateIModel.example-code
+    let aspectId: Id64String | undefined;
+    if (sourceItem.id !== "") {
+      const xsa = ExternalSourceAspect.findBySource(this.imodel, sourceItem.scope, sourceItem.kind, sourceItem.id);
+      if (xsa.aspectId !== undefined) {
+        aspectId = xsa.aspectId;
+      }
+    // __PUBLISH_EXTRACT_END__
+    }
+
+    // WIP: Handle the case where we are doing a delete + insert and are re-using the old element's id
+    // let forceInsert: boolean = false;
+    // if (undefined !== eid) {
+    //   if (this._iModelDb.elements.tryGetElement(eid) === undefined) {
+    //     forceInsert = true;
+    //   }
+    // }
+
+    const aspectProps = this.makeExternalSourceAspectPropsFromSourceItem(sourceItem);
+
+    if (undefined !== aspectId) {
+      if (IModelStatus.Success !== (status = this.updateResultsInIModel(results, aspectProps))) {
+        return status;
+      }
+    } else {
+      if (IModelStatus.Success !== (status = this.insertResultsIntoIModel(results, aspectProps))) {
+        return status;
+      }
+    }
+
+    assert(results.elementProps.id !== undefined && Id64.isValidId64(results.elementProps.id));
+
+    return status;
+  }
+
+  /** Adds or updates the external source aspect for the given source item onto the related element - this function is rarely needed,
+   * because updateIModel automatically inserts or updates ExternalSourceAspects for the elements that it processes.
+   * @param element The element to attach the ExternalSourceAspect
+   * @param itemState The state of the source item
+   * @param sourceItem Defines the source item
+   * @beta
+   */
+  public setExternalSourceAspect(element: ElementProps, itemState: ItemState, sourceItem: SourceItem): IModelStatus {
+    assert(element.id !== undefined && Id64.isValidId64(element.id));
+
+    this.setSourceItemDefaults(sourceItem);
+    assert(sourceItemHasScopeAndKind(sourceItem));
+
+    const aspectProps = this.makeExternalSourceAspectPropsFromSourceItem(sourceItem, element.id);
+
+    if (itemState === ItemState.New) {
+      this.imodel.elements.insertAspect(aspectProps); // throws on error
+    } else {
+      this.imodel.elements.updateAspect(aspectProps);
+    }
+
+    return IModelStatus.Success;
+  }
+
+  /** Returns the External Source Element associated with a repository link
+   * @param repositoryLink The repository link associated with the External Source Element
+   * @beta
+   */
+  public getExternalSourceElement(repositoryLink: Element): ExternalSourceProps | undefined {
+    return this.getExternalSourceElementByLinkId(repositoryLink.id);
+  }
+
+  /** Returns the External Source Element associated with a repository link
+   * @param repositoryLinkId The ElementId of the repository link associated with the External Source Element
+   * @beta
+   */
+  public getExternalSourceElementByLinkId(repositoryLinkId: Id64String): ExternalSourceProps | undefined {
+    let sourceId;
+    this.imodel.withStatement(
+      "select * from BisCore.ExternalSource where repository.id=?",
+      (stmt) => {
+        stmt.bindValues([repositoryLinkId]);
+        stmt.step();
+        const row = stmt.getRow();
+        sourceId = row.id;
+      }
+    );
+
+    if (sourceId) {
+      return this.imodel.elements.getElementProps<ExternalSourceProps>(sourceId);
+    }
+
+    return;
+  }
+
+  /** Given synchronizations results for an element (and possibly its children), insert the new element into the bim
+   * @param results The result set to insert
+   * @beta
+   */
+  public insertResultsIntoIModel(results: SynchronizationResults, aspectProps: ExternalSourceAspectProps): IModelStatus {
+    const elementProps = results.elementProps;
+    const elid = this.imodel.elements.insertElement(elementProps); // throws on error
+
+    results.elementProps.id = elid;
+
+    this.imodel.elements.insertAspect({ ...aspectProps, element: { id: elid } }); // throws on error
+
+    this.onElementSeen(elid);
+    if (undefined === results.childElements) {
+      return IModelStatus.Success;
+    }
+
+    for (const child of results.childElements) {
+      const parent = new RelatedElement({ id: elid, relClassName: ElementOwnsChildElements.classFullName });
+      child.elementProps.parent = parent;
+      const status = this.insertResultsIntoIModel(child, aspectProps);
+      if (status !== IModelStatus.Success) {
+        return status;
+      }
+    }
+    return IModelStatus.Success;
+  }
+
+  /** Given synchronizations results for an element (and possibly its children), updates element in the bim
+   * @param results The result set to insert
+   * @beta
+   */
+  public updateResultsInIModel(results: SynchronizationResults, aspectProps: ExternalSourceAspectProps): IModelStatus {
+    const status = this.updateResultInIModelForOneElement(results);
+    if (IModelStatus.Success !== status) {
+      return status;
+    }
+
+    this.imodel.elements.updateAspect({ ...aspectProps, element: { id: results.elementProps.id! } }); // throws on error
+
+    return this.updateResultsInIModelForChildren(results, aspectProps);
+  }
+
+  /** Records that this particular element was visited during this synchronization. This information will later be used to determine which
+   * previously existing elements no longer exist and should be deleted.
+   * @beta
+   */
+  public onElementSeen(id: Id64String) {
+    this._seenElements.add(id);
+  }
+
+  /** Deletes elements from a BriefcaseDb that were previously converted but not longer exist in the source data.
+   * @beta
+   */
+  public detectDeletedElements() {
+    if (this.imodel.isSnapshotDb())
+      return;
+
+    if (this._supportsMultipleFilesPerChannel)
+      this.detectDeletedElementsInFiles();
+    else
+      this.detectDeletedElementsInChannel();
+  }
+
+  /** Detect and delete all elements and models that meet the following conditions:
+   * a) are under the Job Subject,
+   * b) were not "seen" by the Synchronizer, and
+   * c) have an ExternalSourceAspect.
+   * @see [[Synchronizer.onElementSeen]]
+   */
+  public detectDeletedElementsInChannel() {
+    // This detection only is called for connectors that support a single source file per channel. If we skipped that file because it was unchanged, then we don't need to delete anything
+    if (this._unchangedSources.length !== 0)
+      return;
+
+    deleteElementSubTrees(this.imodel, this.jobSubjectId, (elementId) => {
+      if ((elementId === this.jobSubjectId) || this._seenElements.has(elementId))
+        return false;
+
+      // The element was not marked as having been seen.
+
+      // Don't delete it unless we know that it is tracked.
+      // Connectors create various kinds of control elements in the repository model under the Job Subject.
+      // They also create definition models full of definition elements.
+      // They don't always bother to add them to this._seenElements or to put ExternalSourceAspects on them.
+      // We will take the presence of an ExternalSourceAspect as an indication that the element is to be tracked.
+      // This is how the native-code connector framework works.
+      // It's up to the connector to do GC on untracked elements.
+      return this.imodel.elements.getAspects(elementId, ExternalSourceAspect.classFullName).length !== 0;
+    });
+  }
+
+  private detectDeletedElementsInFiles() {
+    for (const value of this._links.values()) {
+      if (value.itemState === ItemState.Unchanged || value.itemState === ItemState.New)
+        continue;
+      assert(value.elementProps.id !== undefined && Id64.isValidId64(value.elementProps.id));
+      this.detectDeletedElementsInScope(value.elementProps.id);
+    }
+  }
+
+  private detectDeletedElementsInScope(scopeId: Id64String) {
+    const sql = `SELECT aspect.Element.Id FROM ${ExternalSourceAspect.classFullName} aspect WHERE aspect.Scope.Id=?`;
+    const elementsToDelete: Id64String[] = [];
+    const defElementsToDelete: Id64String[] = [];
+    this.imodel.withPreparedStatement(sql, (statement: ECSqlStatement): void => {
+      statement.bindId(1, scopeId);
+      while (DbResult.BE_SQLITE_ROW === statement.step()) {
+        const elementId = statement.getValue(0).getId();
+        const element = this.imodel.elements.getElement(elementId);
+        const hasSeenElement = this._seenElements.has(elementId);
+        if (!hasSeenElement) {
+          if (element instanceof DefinitionElement)
+            defElementsToDelete.push(elementId);
+          else
+            elementsToDelete.push(elementId);
+        }
+        this.detectDeletedElementsInScope(elementId);
+      }
+    });
+    this.deleteElements(elementsToDelete, defElementsToDelete);
+  }
+
+  private deleteElements(elementIds: Id64String[], defElementIds: Id64String[]) {
+    for (const elementId of elementIds) {
+      if (this.imodel.elements.tryGetElement(elementId)) {
+        this.imodel.elements.deleteElement(elementIds);
+        const aspects = this.imodel.elements.getAspects(elementId, ElementUniqueAspect.classFullName);
+        for (const aspect of aspects) {
+          if (!this._seenAspects.has(aspect.id))
+            this.imodel.elements.deleteAspect(aspect.id);
+        }
+      }
+    }
+    for (const elementId of defElementIds) {
+      if (this.imodel.elements.tryGetElement(elementId))
+        this.imodel.elements.deleteDefinitionElements(defElementIds);
+    }
+  }
+
+  private updateResultInIModelForOneElement(results: SynchronizationResults): IModelStatus {
+    assert(results.elementProps !== undefined, "don't call this function if you don't have a persistent element");
+    const elementProps = results.elementProps;
+    if (elementProps.id === undefined || !Id64.isValidId64(elementProps.id))
+      throw new IModelError(IModelStatus.BadArg, "don't call this function if you don't have a persistent element");
+    this.onElementSeen(elementProps.id);
+    const existing = this.imodel.elements.tryGetElement(elementProps.id);
+    if (undefined === existing) {
+      return IModelStatus.BadArg;
+    }
+    if (existing.classFullName !== elementProps.classFullName) {
+      const error = `Attempt to change element's class in an update operation. Do delete + add instead. ElementId ${elementProps.id},
+      old class=${existing.classFullName}, new class=${elementProps.classFullName}`;
+      Logger.logError(LoggerCategories.Framework, error);
+      return IModelStatus.WrongClass;
+    }
+    this.imodel.elements.updateElement(elementProps);
+
+    assert(elementProps.id !== undefined && Id64.isValidId64(elementProps.id));
+
+    return IModelStatus.Success;
+  }
+
+  private updateResultsInIModelForChildren(results: SynchronizationResults, parentAspectProps: ExternalSourceAspectProps): IModelStatus {
+    if (undefined === results.childElements || results.childElements.length < 1) {
+      return IModelStatus.Success;
+    }
+    if (results.elementProps.id === undefined || !Id64.isValidId64(results.elementProps.id)) {
+      const error = `Parent element id is invalid.  Unable to update the children.`;
+      Logger.logError(LoggerCategories.Framework, error);
+      return IModelStatus.BadArg;
+    }
+    results.childElements.forEach((child) => {
+      const parent = new RelatedElement({ id: results.elementProps.id!, relClassName: ElementOwnsChildElements.classFullName });
+      child.elementProps.parent = parent;
+    });
+
+    const existingChildren = this.imodel.elements.queryChildren(results.elementProps.id);
+    // While we could just delete all existing children and insert all new ones, we try to do better.
+    // If we can figure out how the new children map to existing children, we can update them.
+
+    // Note that in the update logic below we don't delete existing children that were not mapped.
+    // Instead, we just refrain from calling the change detector's _OnElementSeen method on unmatched child elements.
+    // That will allow the updater in its final phase to infer that they should be deleted.
+
+    // If the specified children have ElementIds, then match existing child elements by ElementId.
+    // This is generally the case only when updating an existing parent element.
+    if (undefined !== results.childElements[0].elementProps && results.childElements[0].elementProps.id !== undefined && Id64.isValidId64(results.childElements[0].elementProps.id)) {
+      for (const childRes of results.childElements) {
+        if (undefined === childRes.elementProps) {
+          continue;
+        }
+        const index = existingChildren.findIndex((c) => c === childRes.elementProps.id);
+        if (-1 !== index) {
+          const stat = this.updateResultsInIModel(childRes, parentAspectProps);
+          if (stat !== IModelStatus.Success) {
+            return stat;
+          }
+        }
+      }
+      return IModelStatus.Success;
+    }
+
+    // The specified children do not have ElementIds.
+    const count = Math.min(existingChildren.length, results.childElements.length);
+    let i = 0;
+    for (; i < count; i++) {
+      this.updateResultsInIModel(results.childElements[i], parentAspectProps);
+    }
+    for (; i < results.childElements.length; i++) {
+      this.insertResultsIntoIModel(results.childElements[i], parentAspectProps);
+    }
+    return IModelStatus.Success;
+  }
+
+  private makeRepositoryLink(code: Code, userLabel: string | undefined, docProps: DocumentProperties | undefined): Element {
+    let repositoryLink = this.imodel.elements.tryGetElement(code) as RepositoryLink;
+    if (undefined === repositoryLink) {
+      const elementProps: RepositoryLinkProps = {
+        classFullName: RepositoryLink.classFullName,
+        model: IModel.repositoryModelId,
+        code,
+        url: docProps?.desktopURN,
+        userLabel,
+        description: userLabel,
+        repositoryGuid: docProps?.docGuid,
+      };
+      if (docProps !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        elementProps.jsonProperties = { DocumentProperties: { desktopURN: docProps.desktopURN, webURN: docProps.webURN, attributes: docProps.attributesJson } };
+      }
+      repositoryLink = this.imodel.elements.createElement(elementProps);
+    }
+    return repositoryLink;
+  }
+
+  /** Utility function to parse the GUID portion of a ProjectWise URI. Returns an empty GUID if the parse fails. */
+  public static parseDocGuidFromPwUri(pwUri: string): GuidString {
+    const emptyGuid: GuidString = Guid.empty;
+    if (!pwUri.startsWith("pw://")) {
+      return emptyGuid;
+    }
+
+    let startDguid = pwUri.indexOf("/D{");
+    if (-1 === startDguid) {
+      startDguid = pwUri.indexOf("/d{");
+    }
+
+    if (-1 === startDguid)
+      return emptyGuid;
+    const endDguid = pwUri.indexOf("}", startDguid);
+    if (-1 === endDguid)
+      return emptyGuid;
+
+    const startGuid = startDguid + 3;
+    const guidStr = pwUri.substring(startGuid, endDguid);
+    if (Guid.isV4Guid(guidStr)) {
+      return guidStr;
+    }
+    return emptyGuid;
+  }
+
+  private makeExternalSourceAspectPropsFromSourceItem(sourceItem: ItemWithScopeAndKind, elementId?: Id64String): ExternalSourceAspectProps {
+    const source = sourceItem.source ? { id: sourceItem.source } : undefined;
+    return {
+      classFullName: ExternalSourceAspect.classFullName,
+      element: { id: elementId ?? "" },
+      scope: { id: sourceItem.scope },
+      identifier: sourceItem.id,
+      kind: sourceItem.kind,
+      checksum: sourceItem.checksum?.(),
+      version: sourceItem.version,
+      source,
+    };
+  }
+
+  public makeExternalSourceAspectProps(sourceItem: SourceItem): ExternalSourceAspectProps {
+    this.setSourceItemDefaults(sourceItem);
+    assert(sourceItemHasScopeAndKind(sourceItem));
+    return this.makeExternalSourceAspectPropsFromSourceItem(sourceItem);
+  }
+
+  public updateRepositoryLinks(): void {
+    for (const link of this._links.values()) {
+      this.imodel.elements.updateAspect(link.postChangeAspect);
+    }
+  }
+
+}

--- a/example-code/snippets/src/connector-framework/TestConnector.ts
+++ b/example-code/snippets/src/connector-framework/TestConnector.ts
@@ -1,0 +1,576 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import type { AccessToken, Id64String } from "@itwin/core-bentley";
+import { assert, IModelStatus } from "@itwin/core-bentley";
+import type { DisplayStyleCreationOptions, PhysicalElement, RelationshipProps} from "@itwin/core-backend";
+import { Subject } from "@itwin/core-backend";
+import {
+  CategorySelector, DefinitionModel, DefinitionPartition, DisplayStyle3d, ElementGroupsMembers, GeometryPart, GroupInformationPartition, IModelJsFs,
+  ModelSelector, OrthographicViewDefinition, PhysicalModel, PhysicalPartition, RenderMaterialElement, SpatialCategory, SubCategory, SubjectOwnsPartitionElements,
+} from "@itwin/core-backend";
+import type { ColorDefProps, GeometryPartProps, InformationPartitionElementProps, SubCategoryAppearance } from "@itwin/core-common";
+import { CodeScopeSpec, CodeSpec, ColorByName, ColorDef, GeometryStreamBuilder, IModel, IModelError, RenderMode, ViewFlags } from "@itwin/core-common";
+import type { SolidPrimitive } from "@itwin/core-geometry";
+import { Box, Cone, LinearSweep, Loop, Point3d, StandardViewIndex, Vector3d } from "@itwin/core-geometry";
+
+import type { SourceDocument, SourceItem, SynchronizationResults } from "../../src/Synchronizer";
+import { ItemState } from "../../src/Synchronizer";
+import { BaseConnector } from "../../src/BaseConnector";
+import { TestConnectorSchema } from "./TestConnectorSchema";
+import { TestConnectorGroupModel } from "./TestConnectorModels";
+import type { TestConnectorGroupProps } from "./TestConnectorElements";
+import { Categories, CodeSpecs, EquilateralTriangleTile, GeometryParts, IsoscelesTriangleTile, LargeSquareTile, Materials, RectangleTile, RightTriangleTile, SmallSquareTile, TestConnectorGroup } from "./TestConnectorElements";
+import type { QuadCasing, TriangleCasing } from "./TestConnectorGeometry";
+import { Casings, EquilateralTriangleCasing, IsoscelesTriangleCasing, LargeSquareCasing, RectangleCasing, RectangularMagnetCasing, RightTriangleCasing, SmallSquareCasing } from "./TestConnectorGeometry";
+import * as hash from "object-hash";
+import * as fs from "fs";
+import * as path from "path";
+
+// __PUBLISH_EXTRACT_START__ TestConnector-extendsBaseConnector.example-code
+export default class TestConnector extends BaseConnector {
+// __PUBLISH_EXTRACT_END__
+
+  private _data: any;
+  private _sourceDataState: ItemState = ItemState.New;
+  private _sourceData?: string;
+  private _repositoryLinkId?: Id64String;
+
+  public static override async create(): Promise<TestConnector> {
+    return new TestConnector();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private get repositoryLinkId(): Id64String {
+    assert(this._repositoryLinkId !== undefined);
+    return this._repositoryLinkId;
+  }
+
+  // __PUBLISH_EXTRACT_START__ TestConnector-initializeJob.example-code
+  public async initializeJob(): Promise<void> {
+    if (ItemState.New === this._sourceDataState) {
+      this.createGroupModel();
+      this.createPhysicalModel();
+      this.createDefinitionModel();
+    }
+  }
+
+  // __PUBLISH_EXTRACT_END__
+
+  // __PUBLISH_EXTRACT_START__ TestConnector-openSourceData.example-code
+  public async openSourceData(sourcePath: string): Promise<void> {
+    // ignore the passed in source and open the test file
+    const json = fs.readFileSync(sourcePath, "utf8");
+    this._data = JSON.parse(json);
+    this._sourceData = sourcePath;
+
+    const documentStatus = this.getDocumentStatus(); // make sure the repository link is created now, while we are in the repository channel
+    this._sourceDataState = documentStatus.itemState;
+    assert(documentStatus.elementProps.id !== undefined);
+    this._repositoryLinkId = documentStatus.elementProps.id;
+  }
+  // __PUBLISH_EXTRACT_END__
+
+  // __PUBLISH_EXTRACT_START__ TestConnector-importDomainSchema.example-code
+  public async importDomainSchema(_requestContext: AccessToken): Promise<any> {
+
+    if (this._sourceDataState === ItemState.Unchanged) {
+      return;
+    }
+    TestConnectorSchema.registerSchema();
+
+    // WIP: JIT compiler in ts-node means that __dirname will be different when we require() this
+    // connector. Hard-code as a hack, I strongly recommend placing the responsibility of the
+    // require() on the node wrapper. I'm open to tooling suggestions too.
+
+    // Not sure how nativeDb.importSchemas reads files, we use an absolute path, which seems to
+    // work.
+
+    // const fileName = TestConnectorSchema.schemaFilePath;
+    const fileName = path.join(__dirname, "..", "..", "..", "test", "assets", "TestConnector.ecschema.xml");
+
+    await this.synchronizer.imodel.importSchemas([fileName]);
+  }
+  // __PUBLISH_EXTRACT_END__
+
+  public async importDynamicSchema(requestContext: AccessToken): Promise<any> {
+    if (null === requestContext)
+      return;
+  }
+
+  // __PUBLISH_EXTRACT_START__ TestConnector-importDefinitions.example-code
+
+  // importDefinitions is for definitions that are written to shared models such as DictionaryModel
+  public async importDefinitions(): Promise<any> {
+    if (this._sourceDataState === ItemState.Unchanged) {
+      return;
+    }
+    this.insertCodeSpecs();
+  }
+  // __PUBLISH_EXTRACT_END__
+
+  // __PUBLISH_EXTRACT_START__ TestConnector-updateExistingData.example-code
+  public async updateExistingData() {
+    const groupModelId = this.queryGroupModel();
+    const physicalModelId = this.queryPhysicalModel();
+    const definitionModelId = this.queryDefinitionModel();
+    if (undefined === groupModelId || undefined === physicalModelId || undefined === definitionModelId) {
+      const error = `Unable to find model Id for ${undefined === groupModelId ? ModelNames.Group : (undefined === physicalModelId ? ModelNames.Physical : ModelNames.Definition)}`;
+      throw new IModelError(IModelStatus.BadArg, error);
+    }
+
+    this.issueReporter?.reportIssue(physicalModelId, "source", "Warning", "Test", "Test Message", "Type");
+
+    if (this._sourceDataState === ItemState.New) {
+      this.insertCategories();
+      this.insertMaterials();
+      this.insertGeometryParts();
+
+      // Create this (unused) Subject here just to generate the following code path for the tests:
+      // While running in its own private channel ...
+      // ... a connector inserts an element that is a child of its channel parent ...
+      // ... and that element is inserted into the repository model.
+      // That is perfectly legal ... as long as the correct locks are held. The HubMock and integration
+      // tests should fail if the correct locks are not held.
+      Subject.insert(this.synchronizer.imodel, this.jobSubject.id, "Child Subject");
+    }
+
+    this.convertGroupElements(groupModelId);
+    this.convertPhysicalElements(physicalModelId, definitionModelId, groupModelId);
+    this.synchronizer.imodel.views.setDefaultViewId(this.createView(definitionModelId, physicalModelId, "TestConnectorView"));
+  }
+  // __PUBLISH_EXTRACT_END__
+
+  public getApplicationVersion(): string {
+    return "1.0.0.0";
+  }
+  public getConnectorName(): string {
+    return "TestConnector";
+  }
+
+  private getDocumentStatus(): SynchronizationResults {
+    let timeStamp = Date.now();
+    assert(this._sourceData !== undefined, "we should not be in this method if the source file has not yet been opened");
+    const stat = IModelJsFs.lstatSync(this._sourceData); // will throw if this._sourceData names a file that does not exist. That would be a bug. Let it abort the job.
+    if (undefined !== stat) {
+      timeStamp = stat.mtimeMs;
+    }
+
+    const sourceDoc: SourceDocument = {
+      docid: this._sourceData,
+      lastModifiedTime: timeStamp.toString(),
+      checksum: () => undefined,
+    };
+    const documentStatus = this.synchronizer.recordDocument(sourceDoc);
+    if (undefined === documentStatus) {
+      const error = `Failed to retrieve a RepositoryLink for ${this._sourceData}`;
+      throw new IModelError(IModelStatus.BadArg, error);
+    }
+    return documentStatus;
+  }
+
+  private createGroupModel(): Id64String {
+    const existingId = this.queryGroupModel();
+    if (undefined !== existingId) {
+      return existingId;
+    }
+    // Create an InformationPartitionElement for the TestConnectorGroupModel to model
+    const partitionProps: InformationPartitionElementProps = {
+      classFullName: GroupInformationPartition.classFullName,
+      model: IModel.repositoryModelId,
+      parent: new SubjectOwnsPartitionElements(this.jobSubject.id),
+      code: GroupInformationPartition.createCode(this.synchronizer.imodel, this.jobSubject.id, ModelNames.Group),
+    };
+    const partitionId = this.synchronizer.imodel.elements.insertElement(partitionProps);
+
+    return this.synchronizer.imodel.models.insertModel({ classFullName: TestConnectorGroupModel.classFullName, modeledElement: { id: partitionId } });
+  }
+
+  private queryGroupModel(): Id64String | undefined {
+    return this.synchronizer.imodel.elements.queryElementIdByCode(GroupInformationPartition.createCode(this.synchronizer.imodel, this.jobSubject.id, ModelNames.Group));
+
+  }
+  private createPhysicalModel(): Id64String {
+    const existingId = this.queryPhysicalModel();
+    if (undefined !== existingId) {
+      return existingId;
+    }
+
+    const modelid = PhysicalModel.insert(this.synchronizer.imodel, this.jobSubject.id, ModelNames.Physical);
+
+    // relate this model to the source data
+    const relationshipProps: RelationshipProps = {
+      sourceId: modelid,
+      targetId: this.repositoryLinkId,
+      classFullName: "BisCore.ElementHasLinks",
+    };
+    this.synchronizer.imodel.relationships.insertInstance(relationshipProps);
+    return modelid;
+  }
+
+  private queryPhysicalModel(): Id64String | undefined {
+    return this.synchronizer.imodel.elements.queryElementIdByCode(PhysicalPartition.createCode(this.synchronizer.imodel, this.jobSubject.id, ModelNames.Physical));
+  }
+
+  private createDefinitionModel(): Id64String {
+    const existingId = this.queryDefinitionModel();
+    if (undefined !== existingId) {
+      return existingId;
+    }
+
+    // Create an InformationPartitionElement for the TestConnectorDefinitionModel to model
+    const partitionProps: InformationPartitionElementProps = {
+      classFullName: DefinitionPartition.classFullName,
+      model: IModel.repositoryModelId,
+      parent: new SubjectOwnsPartitionElements(this.jobSubject.id),
+      code: DefinitionPartition.createCode(this.synchronizer.imodel, this.jobSubject.id, ModelNames.Definition),
+    };
+    const partitionId = this.synchronizer.imodel.elements.insertElement(partitionProps);
+
+    return this.synchronizer.imodel.models.insertModel({ classFullName: DefinitionModel.classFullName, modeledElement: { id: partitionId } });
+  }
+
+  private queryDefinitionModel(): Id64String | undefined {
+    const code = DefinitionPartition.createCode(this.synchronizer.imodel, this.jobSubject.id, ModelNames.Definition);
+    return this.synchronizer.imodel.elements.queryElementIdByCode(code);
+  }
+
+  private insertCodeSpecs() {
+    if (this.synchronizer.imodel.codeSpecs.hasName(CodeSpecs.Group)) {
+      return;
+    }
+    const spec = CodeSpec.create(this.synchronizer.imodel, CodeSpecs.Group, CodeScopeSpec.Type.Model);
+    this.synchronizer.imodel.codeSpecs.insert(spec);
+  }
+
+  private insertCategories() {
+    const categoryId = this.insertCategory(Categories.Category, ColorByName.white);
+    this.insertSubCategory(categoryId, Categories.Casing, ColorByName.white);
+    this.insertSubCategory(categoryId, Categories.Magnet, ColorByName.darkGrey);
+  }
+
+  private insertCategory(name: string, colorDef: ColorDefProps): Id64String {
+    const opts: SubCategoryAppearance.Props = {
+      color: colorDef,
+    };
+    return SpatialCategory.insert(this.synchronizer.imodel, this.queryDefinitionModel()!, name, opts);
+  }
+
+  private insertSubCategory(categoryId: Id64String, name: string, colorDef: ColorDefProps) {
+    const opts: SubCategoryAppearance.Props = {
+      color: colorDef,
+    };
+    return SubCategory.insert(this.synchronizer.imodel, categoryId, name, opts);
+  }
+
+  private insertMaterials() {
+    this.insertMaterial(Materials.ColoredPlastic, this.getColoredPlasticParams());
+    this.insertMaterial(Materials.MagnetizedFerrite, this.getMagnetizedFerriteParams());
+  }
+
+  private insertMaterial(materialName: string, params: RenderMaterialElement.Params) {
+    RenderMaterialElement.insert(this.synchronizer.imodel, this.queryDefinitionModel()!, materialName, params);
+  }
+
+  private getColoredPlasticParams(): RenderMaterialElement.Params {
+    const params = new RenderMaterialElement.Params(Palettes.TestConnector);
+    params.transmit = 0.5;
+    return params;
+  }
+
+  private getMagnetizedFerriteParams(): RenderMaterialElement.Params {
+    const params = new RenderMaterialElement.Params(Palettes.TestConnector);
+    const darkGrey = this.toRgbFactor(ColorByName.darkGrey);
+    params.specularColor = darkGrey;
+    params.color = darkGrey;
+    return params;
+  }
+
+  private toRgbFactor(color: number): number[] {
+    const numbers = ColorDef.getColors(color);
+    const factor: number[] = [
+      numbers.r,
+      numbers.g,
+      numbers.b,
+    ];
+    return factor;
+  }
+
+  private insertGeometryParts() {
+    const definitionModel = this.queryDefinitionModel()!;
+    this.insertBox(definitionModel, new SmallSquareCasing());
+    this.insertBox(definitionModel, new LargeSquareCasing());
+    this.insertBox(definitionModel, new RectangleCasing());
+    this.insertTriangle(definitionModel, new EquilateralTriangleCasing());
+    this.insertTriangle(definitionModel, new IsoscelesTriangleCasing());
+    this.insertTriangle(definitionModel, new RightTriangleCasing());
+    this.insertBox(definitionModel, new RectangularMagnetCasing());
+    this.insertCircularMagnet(definitionModel);
+  }
+
+  private insertBox(definitionModelId: Id64String, casing: QuadCasing) {
+    const center = casing.center();
+    const size = casing.size();
+    const vectorX = Vector3d.unitX();
+    const vectorY = Vector3d.unitY();
+    const baseX = size.x;
+    const baseY = size.y;
+    const topX = size.x;
+    const topY = size.y;
+    const halfHeight: number = size.z / 2;
+
+    const baseCenter = new Point3d(center.x, center.y, center.z - halfHeight);
+    const topCenter = new Point3d(center.x, center.y, center.z + halfHeight);
+
+    let baseOrigin = this.fromSumOf(baseCenter, vectorX, baseX * -0.5);
+    baseOrigin = this.fromSumOf(baseOrigin, vectorY, baseY * -0.5);
+
+    let topOrigin = this.fromSumOf(topCenter, vectorX, baseX * -0.5);
+    topOrigin = this.fromSumOf(topOrigin, vectorY, baseY * -0.5);
+
+    const box = Box.createDgnBox(baseOrigin, vectorX, vectorY, topOrigin, baseX, baseY, topX, topY, true);
+    if (undefined === box) {
+      throw new IModelError(IModelStatus.NoGeometry, `Unable to create geometry for ${casing.name()}`);
+    }
+    this.insertGeometry(definitionModelId, casing.name(), box);
+  }
+
+  private insertTriangle(definitionModelId: Id64String, casing: TriangleCasing) {
+    const loop = Loop.createPolygon(casing.points());
+    const sweep = LinearSweep.create(loop, casing.vec(), true);
+    if (undefined === sweep) {
+      throw new IModelError(IModelStatus.NoGeometry, `Unable to create geometry for ${casing.name()}`);
+    }
+    this.insertGeometry(definitionModelId, casing.name(), sweep);
+  }
+
+  private insertCircularMagnet(definitionModelId: Id64String) {
+    const radius = Casings.MagnetRadius;
+    const baseCenter = new Point3d(0.0, 0.0, -Casings.MagnetThickness / 2);
+    const topCenter = new Point3d(0.0, 0.0, Casings.MagnetThickness / 2);
+    const cone = Cone.createAxisPoints(baseCenter, topCenter, radius, radius, true);
+    const name = GeometryParts.CircularMagnet;
+    if (undefined === cone) {
+      throw new IModelError(IModelStatus.NoGeometry, `Unable to create geometry for ${name}`);
+    }
+    this.insertGeometry(definitionModelId, name, cone);
+  }
+
+  private insertGeometry(definitionModelId: Id64String, name: string, primitive: SolidPrimitive): Id64String {
+    const geometryStreamBuilder = new GeometryStreamBuilder();
+    geometryStreamBuilder.appendGeometry(primitive);
+
+    const geometryPartProps: GeometryPartProps = {
+      classFullName: GeometryPart.classFullName,
+      model: definitionModelId,
+      code: GeometryPart.createCode(this.synchronizer.imodel, definitionModelId, name),
+      geom: geometryStreamBuilder.geometryStream,
+    };
+    return this.synchronizer.imodel.elements.insertElement(geometryPartProps);
+  }
+
+  private fromSumOf(p: Point3d, v: Vector3d, scale: number): Point3d {
+    const result = new Point3d();
+    result.x = p.x + v.x * scale;
+    result.y = p.y + v.y * scale;
+    result.z = p.z + v.z * scale;
+    return result;
+  }
+
+  private convertGroupElements(groupModelId: Id64String) {
+    for (const group of this._data.Groups) {
+      const xse = this.synchronizer.getExternalSourceElementByLinkId(this.repositoryLinkId);
+
+      const str = JSON.stringify(group);
+      const sourceItem: SourceItem = {
+        source: xse?.id,
+        scope: groupModelId,
+        kind: "Group",
+        id: group.guid,
+        checksum: () => hash.MD5(str),
+      };
+      const results = this.synchronizer.detectChanges(sourceItem);
+      if (results.state === ItemState.Unchanged) {
+        this.synchronizer.onElementSeen(results.id!);
+        continue;
+      }
+      if (group.name === undefined) {
+        throw new IModelError(IModelStatus.BadArg, "Name undefined for TestConnector group");
+      }
+
+      const code = TestConnectorGroup.createCode(this.synchronizer.imodel, groupModelId, group.name);
+      const props: TestConnectorGroupProps = {
+        classFullName: TestConnectorGroup.classFullName,
+        model: groupModelId,
+        code,
+        groupType: group.groupType,
+        manufactureDate: group.manufactureDate,
+        manufactureLocation: group.manufactureLocation,
+      };
+      const sync: SynchronizationResults = {
+        elementProps: props,
+        itemState: results.state,
+      };
+      if (results.id !== undefined) // in case this is an update
+        sync.elementProps.id = results.id;
+      this.synchronizer.updateIModel(sync, sourceItem);
+    }
+  }
+
+  private convertPhysicalElements(physicalModelId: Id64String, definitionModelId: Id64String, groupModelId: Id64String) {
+    if ("testConnector_skipTiles" in process.env)
+      return;
+
+    for (const shape of Object.keys(this._data.Tiles)) {
+      if (Array.isArray(this._data.Tiles[shape])) {
+        for (const tile of this._data.Tiles[shape]) {
+          this.convertTile(physicalModelId, definitionModelId, groupModelId, tile, shape);
+        }
+      } else {
+        this.convertTile(physicalModelId, definitionModelId, groupModelId, this._data.Tiles[shape], shape);
+      }
+    }
+  }
+
+  private convertTile(physicalModelId: Id64String, definitionModelId: Id64String, groupModelId: Id64String, tile: any, shape: string) {
+    const xse = this.synchronizer.getExternalSourceElementByLinkId(this.repositoryLinkId);
+    const str = JSON.stringify(tile);
+    const sourceItem: SourceItem = {
+      source: xse?.id,
+      scope: physicalModelId,
+      kind: "Tile",
+      id: tile.guid,
+      checksum: () => hash.MD5(str),
+    };
+    const results = this.synchronizer.detectChanges(sourceItem);
+    if (results.state === ItemState.Unchanged) {
+      this.synchronizer.onElementSeen(results.id!);
+      return;
+    }
+    if (tile.casingMaterial === undefined) {
+      throw new IModelError(IModelStatus.BadArg, `casingMaterial undefined for TestConnector Tile ${tile.guid}`);
+    }
+
+    let element: PhysicalElement;
+    switch (shape) {
+      case "SmallSquareTile":
+        element = SmallSquareTile.create(this.synchronizer.imodel, physicalModelId, definitionModelId, tile);
+        break;
+      case "LargeSquareTile":
+        element = LargeSquareTile.create(this.synchronizer.imodel, physicalModelId, definitionModelId, tile);
+        break;
+      case "IsoscelesTriangleTile":
+        element = IsoscelesTriangleTile.create(this.synchronizer.imodel, physicalModelId, definitionModelId, tile);
+        break;
+      case "EquilateralTriangleTile":
+        element = EquilateralTriangleTile.create(this.synchronizer.imodel, physicalModelId, definitionModelId, tile);
+        break;
+      case "RightTriangleTile":
+        element = RightTriangleTile.create(this.synchronizer.imodel, physicalModelId, definitionModelId, tile);
+        break;
+      case "RectangleTile":
+        element = RectangleTile.create(this.synchronizer.imodel, physicalModelId, definitionModelId, tile);
+        break;
+      default:
+        throw new IModelError(IModelStatus.BadArg, `unknown tile shape ${shape}`);
+    }
+    if (undefined !== results.id) {
+      element.id = results.id;
+    }
+    const sync: SynchronizationResults = {
+      elementProps: element.toJSON(),
+      itemState: results.state,
+    };
+    this.synchronizer.updateIModel(sync, sourceItem);
+    if (!tile.hasOwnProperty("Group")) {
+      return;
+    }
+
+    // for testing purposes only: double check that what I calculated is what was saved in the briefcase
+    // const persistentTile = this.synchronizer.imodel.elements.getElement<TestConnectorPhysicalElement>(sync.elementProps.id!); // not sure why next line is erroring
+    // assert(persistentTile.placement.origin.isExactEqual((sync.elementProps as TestConnectorPhysicalElement).placement.origin));
+
+    const groupCode = TestConnectorGroup.createCode(this.synchronizer.imodel, groupModelId, tile.Group);
+    const groupElement = this.synchronizer.imodel.elements.queryElementIdByCode(groupCode);
+    assert(groupElement !== undefined);
+    let doCreate = results.state === ItemState.New;
+    if (results.state === ItemState.Changed) {
+      try {
+        ElementGroupsMembers.getInstance(this.synchronizer.imodel, { sourceId: groupElement, targetId: element.id });
+        doCreate = false;
+      } catch (err) {
+        doCreate = true;
+      }
+    }
+    if (doCreate) {
+      const rel = ElementGroupsMembers.create(this.synchronizer.imodel, groupElement, sync.elementProps.id!);
+      rel.insert();
+    }
+
+  }
+
+  private createView(definitionModelId: Id64String, physicalModelId: Id64String, name: string): Id64String {
+    const code = OrthographicViewDefinition.createCode(this.synchronizer.imodel, definitionModelId, name);
+    const viewId = this.synchronizer.imodel.elements.queryElementIdByCode(code);
+    if (undefined !== viewId) {
+      return viewId;
+    }
+
+    const categorySelectorId = this.createCategorySelector(definitionModelId);
+    const modelSelectorId = this.createModelSelector(definitionModelId, physicalModelId);
+    const displayStyleId = this.createDisplayStyle(definitionModelId);
+    const view = OrthographicViewDefinition.create(this.synchronizer.imodel, definitionModelId, name, modelSelectorId, categorySelectorId, displayStyleId, this.synchronizer.imodel.projectExtents, StandardViewIndex.Iso);
+    view.insert();
+    return view.id;
+  }
+
+  private createCategorySelector(definitionModelId: Id64String): Id64String {
+    const code = CategorySelector.createCode(this.synchronizer.imodel, definitionModelId, "Default");
+    const selectorId = this.synchronizer.imodel.elements.queryElementIdByCode(code);
+    if (undefined !== selectorId) {
+      return selectorId;
+    }
+
+    const categoryId = SpatialCategory.queryCategoryIdByName(this.synchronizer.imodel, definitionModelId, Categories.Category);
+    if (undefined === categoryId) {
+      throw new IModelError(IModelStatus.BadElement, "Unable to find TestConnector Category");
+    }
+    return CategorySelector.insert(this.synchronizer.imodel, definitionModelId, "Default", [categoryId]);
+  }
+
+  private createModelSelector(definitionModelId: Id64String, physicalModelId: Id64String): Id64String {
+    const code = ModelSelector.createCode(this.synchronizer.imodel, definitionModelId, "Default");
+    const selectorId = this.synchronizer.imodel.elements.queryElementIdByCode(code);
+    if (undefined !== selectorId) {
+      return selectorId;
+    }
+    return ModelSelector.insert(this.synchronizer.imodel, definitionModelId, "Default", [physicalModelId]);
+  }
+
+  private createDisplayStyle(definitionModelId: Id64String): Id64String {
+    const code = DisplayStyle3d.createCode(this.synchronizer.imodel, definitionModelId, "Default");
+    const displayStyleId = this.synchronizer.imodel.elements.queryElementIdByCode(code);
+    if (undefined !== displayStyleId) {
+      return displayStyleId;
+    }
+    const viewFlags: ViewFlags = new ViewFlags({ renderMode: RenderMode.SmoothShade });
+    const options: DisplayStyleCreationOptions = {
+      backgroundColor: ColorDef.fromTbgr(ColorByName.white),
+      viewFlags,
+    };
+    const displayStyle: DisplayStyle3d = DisplayStyle3d.create(this.synchronizer.imodel, definitionModelId, "Default", options);
+    displayStyle.insert();
+    return displayStyle.id;
+  }
+}
+
+export enum ModelNames {
+  Physical = "TestConnector_Physical",
+  Definition = "TestConnector_Definitions",
+  Group = "TestConnector_Groups",
+}
+
+enum Palettes {
+  TestConnector = "TestConnector", // eslint-disable-line @typescript-eslint/no-shadow
+}

--- a/example-code/snippets/src/connector-framework/connector-framework-deps.sh
+++ b/example-code/snippets/src/connector-framework/connector-framework-deps.sh
@@ -1,0 +1,45 @@
+// __PUBLISH_EXTRACT_START__ ConnectorFramework-dependencies.example-code
+
+npm install  @itwin/core-backend
+npm install  @itwin/core-common
+npm install  @itwin/core-bentley
+npm install  @itwin/node-cli-authorization
+
+npm install  --save-dev @itwin/build-tools
+npm install  --save-dev @itwin/core-backend
+npm install  --save-dev @itwin/core-bentley
+npm install  --save-dev @itwin/core-common
+npm install  --save-dev @itwin/core-geometry
+npm install  --save-dev @itwin/core-quantity
+npm install  --save-dev @itwin/ecschema-metadata
+npm install  --save-dev @itwin/eslint-plugin
+npm install  --save-dev @itwin/imodels-access-backend
+npm install  --save-dev @itwin/imodels-client-authoring
+npm install  --save-dev @itwin/node-cli-authorization
+npm install  --save-dev @itwin/oidc-signin-tool
+
+npm install  --save-dev @istanbuljs/nyc-config-typescript
+npm install  --save-dev @types/chai
+npm install  --save-dev @types/chai-as-promised
+npm install  --save-dev @types/mocha
+npm install  --save-dev @types/node
+npm install  --save-dev @types/object-hash
+npm install  --save-dev @types/ws
+npm install  --save-dev chai
+npm install  --save-dev chai-as-promised
+npm install  --save-dev cpx2
+npm install  --save-dev dotenv
+npm install  --save-dev eslint
+npm install  --save-dev eslint-plugin-deprecation
+npm install  --save-dev husky
+npm install  --save-dev lint-staged
+npm install  --save-dev mocha
+npm install  --save-dev mocha-suppress-logs
+npm install  --save-dev nyc
+npm install  --save-dev object-hash
+npm install  --save-dev rimraf
+npm install  --save-dev source-map-support
+npm install  --save-dev ts-node
+npm install  --save-dev typescript
+
+// __PUBLISH_EXTRACT_END__


### PR DESCRIPTION
Update "Write a Connector" documentation to reflect the current state of our new connector-framework release.

For [ADO# 706812](https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/706812)

1. Added comments to source
e.g.

    // __PUBLISH_EXTRACT_START__ TestConnector-extendsBaseConnector.example-code

    // __PUBLISH_EXTRACT_END__

2. Added tags to WriteAConnector.md (in itwinjs-core)
e.g.

    ``` ts
    [[include:TestConnector-updateExistingData.example-code]]
    ```

Refer to ...
https://github.com/iTwin/itwinjs-core/blob/e0a47b42ff521849957a14df863a86252f791487/tools/build/scripts/extract.js