### PR TITLE
Fix auto-hide UI issues

### DIFF
--- a/common/api/appui-layout-react.api.md
+++ b/common/api/appui-layout-react.api.md
@@ -535,7 +535,7 @@ export interface FloatingTabLocation {
 }
 
 // @internal (undocumented)
-export const FloatingWidget: React_2.NamedExoticComponent<FloatingWidgetProps>;
+export function FloatingWidget(props: FloatingWidgetProps): JSX.Element;
 
 // @internal (undocumented)
 export function floatingWidgetBringToFront(state: NineZoneState, floatingWidgetId: FloatingWidgetState["id"]): NineZoneState;
@@ -589,7 +589,21 @@ export interface FloatingWidgetLocation {
 }
 
 // @internal (undocumented)
+export const FloatingWidgetNodeContext: React_2.Context<React_2.ReactNode>;
+
+// @internal (undocumented)
 export interface FloatingWidgetProps {
+    // (undocumented)
+    onMouseEnter?: (event: React_2.MouseEvent<HTMLElement, MouseEvent>) => void;
+    // (undocumented)
+    onMouseLeave?: (event: React_2.MouseEvent<HTMLElement, MouseEvent>) => void;
+}
+
+// @internal (undocumented)
+export function FloatingWidgetProvider(props: FloatingWidgetProviderProps): JSX.Element;
+
+// @internal (undocumented)
+export interface FloatingWidgetProviderProps {
     // (undocumented)
     floatingWidget: FloatingWidgetState;
     // (undocumented)
@@ -1395,6 +1409,8 @@ export interface NineZoneProps {
     children?: React_2.ReactNode;
     // (undocumented)
     dispatch: NineZoneDispatch;
+    // (undocumented)
+    floatingWidget?: React_2.ReactNode;
     // (undocumented)
     labels?: NineZoneLabels;
     // (undocumented)
@@ -3417,6 +3433,10 @@ export interface WidgetPanelsProps extends CommonProps {
 export interface WidgetProps extends CommonProps {
     // (undocumented)
     children?: React_2.ReactNode;
+    // (undocumented)
+    onMouseEnter?: (event: React_2.MouseEvent<HTMLElement, MouseEvent>) => void;
+    // (undocumented)
+    onMouseLeave?: (event: React_2.MouseEvent<HTMLElement, MouseEvent>) => void;
     // (undocumented)
     onTransitionEnd?(): void;
     // (undocumented)

--- a/common/api/summary/appui-layout-react.exports.csv
+++ b/common/api/summary/appui-layout-react.exports.csv
@@ -89,7 +89,7 @@ beta;ExpandableItemProps
 deprecated;ExpandableItemProps 
 internal;FloatingTab(): JSX.Element
 internal;FloatingTabLocation
-internal;FloatingWidget: React_2.NamedExoticComponent
+internal;FloatingWidget(props: FloatingWidgetProps): JSX.Element
 internal;floatingWidgetBringToFront(state: NineZoneState, floatingWidgetId: FloatingWidgetState["id"]): NineZoneState
 internal;FloatingWidgetBringToFrontAction
 internal;FloatingWidgetClearUserSizedAction
@@ -98,7 +98,10 @@ internal;FloatingWidgetDropTargetState
 internal;FloatingWidgetHomeState
 internal;FloatingWidgetIdContext: React_2.Context
 internal;FloatingWidgetLocation
+internal;FloatingWidgetNodeContext: React_2.Context
 internal;FloatingWidgetProps
+internal;FloatingWidgetProvider(props: FloatingWidgetProviderProps): JSX.Element
+internal;FloatingWidgetProviderProps
 internal;FloatingWidgetResizeAction
 internal;FloatingWidgetResizeHandle = FloatingWidgetEdgeHandle | FloatingWidgetCornerHandle
 internal;FloatingWidgets: React_2.NamedExoticComponent

--- a/common/changes/@itwin/appui-layout-react/auto-hide-fixes_2022-10-05-10-29.json
+++ b/common/changes/@itwin/appui-layout-react/auto-hide-fixes_2022-10-05-10-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Expose onMouseEnter and onMouseLeave events for a FloatingWidget.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/appui-react/auto-hide-fixes_2022-10-05-10-29.json
+++ b/common/changes/@itwin/appui-react/auto-hide-fixes_2022-10-05-10-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Do not auto-hide the UI when floating widget is hovered.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/base/NineZone.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/NineZone.tsx
@@ -12,7 +12,7 @@ import { Rectangle, useRefs, useResizeObserver } from "@itwin/core-react";
 import { CursorType } from "../widget-panels/CursorOverlay";
 import { PanelSide } from "../widget-panels/Panel";
 import { WidgetContentManager } from "../widget/ContentManager";
-import { FloatingWidgetResizeHandle } from "../widget/FloatingWidget";
+import { FloatingWidget, FloatingWidgetResizeHandle } from "../widget/FloatingWidget";
 import { DraggedPanelSideContext, DraggedResizeHandleContext, DraggedWidgetIdContext, DragProvider } from "./DragManager";
 import { assert } from "@itwin/core-bentley";
 import { WidgetTab } from "../widget/Tab";
@@ -35,6 +35,7 @@ export interface NineZoneProps {
   toolSettingsContent?: React.ReactNode;
   widgetContent?: React.ReactNode;
   tab?: React.ReactNode;
+  floatingWidget?: React.ReactNode;
   showWidgetIcon?: boolean;
   autoCollapseUnpinnedPanels?: boolean;
   animateDockedToolSettings?: boolean;
@@ -79,6 +80,7 @@ export interface NineZoneProviderProps extends NineZoneProps {
 }
 
 const tab = <WidgetTab />;
+const floatingWidget = <FloatingWidget />;
 
 /** @internal */
 export function NineZoneProvider(props: NineZoneProviderProps) {
@@ -92,31 +94,33 @@ export function NineZoneProvider(props: NineZoneProviderProps) {
                 <WidgetContentNodeContext.Provider value={props.widgetContent}>
                   <ToolSettingsNodeContext.Provider value={props.toolSettingsContent}>
                     <TabNodeContext.Provider value={props.tab || tab}>
-                      <DraggedTabStateContext.Provider value={props.state.draggedTab}>
-                        <DraggedTabContext.Provider value={!!props.state.draggedTab}>
-                          <TabsStateContext.Provider value={props.state.tabs}>
-                            <WidgetsStateContext.Provider value={props.state.widgets}>
-                              <PanelsStateContext.Provider value={props.state.panels}>
-                                <FloatingWidgetsStateContext.Provider value={props.state.floatingWidgets}>
-                                  <ToolSettingsStateContext.Provider value={props.state.toolSettings}>
-                                    <AnimateDockedToolSettingsContext.Provider value={!!props.animateDockedToolSettings}>
-                                      <DragProvider>
-                                        <CursorTypeProvider>
-                                          <WidgetContentManager>
-                                            <MeasureContext.Provider value={props.measure}>
-                                              {props.children}
-                                            </MeasureContext.Provider>
-                                          </WidgetContentManager>
-                                        </CursorTypeProvider>
-                                      </DragProvider>
-                                    </AnimateDockedToolSettingsContext.Provider>
-                                  </ToolSettingsStateContext.Provider>
-                                </FloatingWidgetsStateContext.Provider>
-                              </PanelsStateContext.Provider>
-                            </WidgetsStateContext.Provider>
-                          </TabsStateContext.Provider>
-                        </DraggedTabContext.Provider>
-                      </DraggedTabStateContext.Provider>
+                      <FloatingWidgetNodeContext.Provider value={props.floatingWidget || floatingWidget}>
+                        <DraggedTabStateContext.Provider value={props.state.draggedTab}>
+                          <DraggedTabContext.Provider value={!!props.state.draggedTab}>
+                            <TabsStateContext.Provider value={props.state.tabs}>
+                              <WidgetsStateContext.Provider value={props.state.widgets}>
+                                <PanelsStateContext.Provider value={props.state.panels}>
+                                  <FloatingWidgetsStateContext.Provider value={props.state.floatingWidgets}>
+                                    <ToolSettingsStateContext.Provider value={props.state.toolSettings}>
+                                      <AnimateDockedToolSettingsContext.Provider value={!!props.animateDockedToolSettings}>
+                                        <DragProvider>
+                                          <CursorTypeProvider>
+                                            <WidgetContentManager>
+                                              <MeasureContext.Provider value={props.measure}>
+                                                {props.children}
+                                              </MeasureContext.Provider>
+                                            </WidgetContentManager>
+                                          </CursorTypeProvider>
+                                        </DragProvider>
+                                      </AnimateDockedToolSettingsContext.Provider>
+                                    </ToolSettingsStateContext.Provider>
+                                  </FloatingWidgetsStateContext.Provider>
+                                </PanelsStateContext.Provider>
+                              </WidgetsStateContext.Provider>
+                            </TabsStateContext.Provider>
+                          </DraggedTabContext.Provider>
+                        </DraggedTabStateContext.Provider>
+                      </FloatingWidgetNodeContext.Provider>
                     </TabNodeContext.Provider>
                   </ToolSettingsNodeContext.Provider>
                 </WidgetContentNodeContext.Provider>
@@ -192,6 +196,10 @@ ToolSettingsNodeContext.displayName = "nz:ToolSettingsNodeContext";
 /** @internal */
 export const TabNodeContext = React.createContext<React.ReactNode>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
 TabNodeContext.displayName = "nz:TabNodeContext";
+
+/** @internal */
+export const FloatingWidgetNodeContext = React.createContext<React.ReactNode>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+FloatingWidgetNodeContext.displayName = "nz:FloatingWidgetNodeContext";
 
 /** @internal */
 export const ToolSettingsStateContext = React.createContext<ToolSettingsState>(null!); // eslint-disable-line @typescript-eslint/naming-convention

--- a/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
@@ -32,6 +32,7 @@
 
   &.nz-hidden {
     opacity: 0;
+    pointer-events: none;
   }
 
   &.nz-dragged {

--- a/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.tsx
@@ -10,10 +10,10 @@ import "./FloatingWidget.scss";
 import classnames from "classnames";
 import * as React from "react";
 import { PointProps } from "@itwin/appui-abstract";
-import { CommonProps, Point, Rectangle, useRefs } from "@itwin/core-react";
+import { Point, Rectangle, useRefs } from "@itwin/core-react";
 import { assert } from "@itwin/core-bentley";
 import { DragManagerContext, useDragResizeHandle, UseDragResizeHandleArgs, useIsDraggedItem } from "../base/DragManager";
-import { MeasureContext, NineZoneDispatchContext, TabsStateContext, UiIsVisibleContext } from "../base/NineZone";
+import { FloatingWidgetNodeContext, MeasureContext, NineZoneDispatchContext, TabsStateContext, UiIsVisibleContext } from "../base/NineZone";
 import { FloatingWidgetState, WidgetState } from "../state/WidgetState";
 import { WidgetContentContainer } from "./ContentContainer";
 import { WidgetTabBar } from "./TabBar";
@@ -31,21 +31,75 @@ type FloatingWidgetCornerHandle = "topLeft" | "topRight" | "bottomLeft" | "botto
 export type FloatingWidgetResizeHandle = FloatingWidgetEdgeHandle | FloatingWidgetCornerHandle;
 
 /** @internal */
-export interface FloatingWidgetProps {
+export interface FloatingWidgetProviderProps {
   floatingWidget: FloatingWidgetState;
   widget: WidgetState;
 }
 
 /** @internal */
-export const FloatingWidget = React.memo<FloatingWidgetProps>(function FloatingWidget(props) { // eslint-disable-line @typescript-eslint/naming-convention, no-shadow
-  const { id, bounds, userSized } = props.floatingWidget;
-  const { minimized, tabs, activeTabId } = props.widget;
-  const isSingleTab = 1 === tabs.length;
+export function FloatingWidgetProvider(props: FloatingWidgetProviderProps) {
+  const floatingWidget = React.useContext(FloatingWidgetNodeContext);
+  return (
+    <FloatingWidgetIdContext.Provider value={props.floatingWidget.id}>
+      <FloatingWidgetContext.Provider value={props.floatingWidget}>
+        <WidgetProvider
+          widget={props.widget}
+        >
+          {floatingWidget}
+        </WidgetProvider>
+      </FloatingWidgetContext.Provider>
+    </FloatingWidgetIdContext.Provider>
+  );
+}
+
+/** @internal */
+export const FloatingWidgetIdContext = React.createContext<FloatingWidgetState["id"] | undefined>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+FloatingWidgetIdContext.displayName = "nz:FloatingWidgetIdContext";
+
+/** @internal */
+export const FloatingWidgetContext = React.createContext<FloatingWidgetState | undefined>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+FloatingWidgetContext.displayName = "nz:FloatingWidgetContext";
+
+/** @internal */
+export interface FloatingWidgetProps {
+  onMouseEnter?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  onMouseLeave?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+}
+
+/** @internal */
+export function FloatingWidget(props: FloatingWidgetProps) {
+  const widget = React.useContext(WidgetStateContext);
+  const floatingWidget = React.useContext(FloatingWidgetContext);
   const tabsState = React.useContext(TabsStateContext);
+  const uiIsVisible = React.useContext(UiIsVisibleContext);
+  assert(!!widget);
+  assert(!!floatingWidget);
+  const { id, bounds, userSized } = floatingWidget;
+  const { minimized, tabs, activeTabId } = widget;
+  const isSingleTab = 1 === tabs.length;
   const activeTab = tabsState[activeTabId];
   const hideWithUiWhenFloating = activeTab.hideWithUiWhenFloating;
-  const uiIsVisible = React.useContext(UiIsVisibleContext);
   const autoSized = isSingleTab && !userSized;
+  const hideFloatingWidget = !uiIsVisible && hideWithUiWhenFloating;
+  const isToolSettingsTab = widget.tabs[0] === toolSettingsTabId;
+
+  // Never allow resizing of tool settings - always auto-fit them.
+  const isResizable = (undefined === widget.isFloatingStateWindowResizable || widget.isFloatingStateWindowResizable) && !isToolSettingsTab;
+
+  const item = React.useMemo(() => ({
+    id,
+    type: "widget" as const,
+  }), [id]);
+  const dragged = useIsDraggedItem(item);
+  const ref = useHandleAutoSize(dragged);
+
+  const className = classnames(
+    "nz-widget-floatingWidget",
+    dragged && "nz-dragged",
+    isToolSettingsTab && "nz-floating-toolsettings",
+    minimized && "nz-minimized",
+    hideFloatingWidget && "nz-hidden",
+  );
   const style = React.useMemo(() => {
     const boundsRect = Rectangle.create(bounds);
     const { height, width } = boundsRect.getSize();
@@ -59,65 +113,14 @@ export const FloatingWidget = React.memo<FloatingWidgetProps>(function FloatingW
       maxWidth: autoSized ? "60%" : undefined,
     };
   }, [autoSized, bounds, minimized]);
-  const hideFloatingWidget = !uiIsVisible && hideWithUiWhenFloating;
-  const className = React.useMemo(() => classnames(
-    minimized && "nz-minimized",
-    hideFloatingWidget && "nz-hidden",
-  ), [minimized, hideFloatingWidget]);
-
-  return (
-    <FloatingWidgetIdContext.Provider value={id}>
-      <FloatingWidgetContext.Provider value={props.floatingWidget}>
-        <WidgetProvider
-          widget={props.widget}
-        >
-          <FloatingWidgetComponent
-            className={className}
-            style={style}
-          />
-        </WidgetProvider>
-      </FloatingWidgetContext.Provider>
-    </FloatingWidgetIdContext.Provider>
-  );
-});
-
-/** @internal */
-export const FloatingWidgetIdContext = React.createContext<FloatingWidgetState["id"] | undefined>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
-FloatingWidgetIdContext.displayName = "nz:FloatingWidgetIdContext";
-
-/** @internal */
-export const FloatingWidgetContext = React.createContext<FloatingWidgetState | undefined>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
-FloatingWidgetContext.displayName = "nz:FloatingWidgetContext";
-
-const FloatingWidgetComponent = React.memo<CommonProps>(function FloatingWidgetComponent(props) { // eslint-disable-line @typescript-eslint/no-shadow, @typescript-eslint/naming-convention
-  const widget = React.useContext(WidgetStateContext);
-  const floatingWidgetId = React.useContext(FloatingWidgetIdContext);
-  assert(!!widget);
-  assert(!!floatingWidgetId);
-  const item = React.useMemo(() => ({
-    id: floatingWidgetId,
-    type: "widget" as const,
-  }), [floatingWidgetId]);
-  const dragged = useIsDraggedItem(item);
-  const ref = useHandleAutoSize(dragged);
-
-  const isToolSettingsTab = widget.tabs[0] === toolSettingsTabId;
-  const className = classnames(
-    "nz-widget-floatingWidget",
-    dragged && "nz-dragged",
-    props.className,
-    isToolSettingsTab && "nz-floating-toolsettings",
-  );
-
-  // never allow resizing of tool settings - always auto-fit them
-  const isResizable = (undefined === widget.isFloatingStateWindowResizable || widget.isFloatingStateWindowResizable) && !isToolSettingsTab;
-
   return (
     <Widget
       className={className}
-      widgetId={floatingWidgetId}
-      style={props.style}
+      widgetId={id}
+      style={style}
       ref={ref}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
     >
       <WidgetTabBar separator={!widget.minimized} />
       <WidgetContentContainer>
@@ -136,7 +139,7 @@ const FloatingWidgetComponent = React.memo<CommonProps>(function FloatingWidgetC
       </>}
     </Widget >
   );
-});
+}
 
 // Re-adjust bounds so that widget is behind pointer when auto-sized.
 // istanbul ignore next

--- a/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidgets.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidgets.tsx
@@ -8,7 +8,7 @@
 
 import * as React from "react";
 import { FloatingWidgetsStateContext, WidgetsStateContext } from "../base/NineZone";
-import { FloatingWidget } from "./FloatingWidget";
+import { FloatingWidgetProvider } from "./FloatingWidget";
 import { FloatingTab } from "./FloatingTab";
 
 /** This component renders all floating widgets.
@@ -22,9 +22,9 @@ export const FloatingWidgets = React.memo(function FloatingWidgets() { // eslint
       {floatingWidgets.allIds.map((floatingWidgetId) => {
         const widget = widgets[floatingWidgetId];
         const floatingWidget = floatingWidgets.byId[floatingWidgetId];
-        return <FloatingWidget
-          floatingWidget={floatingWidget}
+        return <FloatingWidgetProvider
           key={floatingWidgetId}
+          floatingWidget={floatingWidget}
           widget={widget}
         />;
       })}

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Widget.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Widget.tsx
@@ -40,6 +40,8 @@ export const WidgetProvider = React.memo<WidgetProviderProps>(function WidgetPro
 /** @internal */
 export interface WidgetProps extends CommonProps {
   children?: React.ReactNode;
+  onMouseEnter?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  onMouseLeave?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   onTransitionEnd?(): void;
   widgetId?: string;
 }
@@ -136,6 +138,8 @@ export const Widget = React.memo( // eslint-disable-line react/display-name, @ty
         <WidgetContext.Provider value={widgetContextValue}>
           <div
             className={className}
+            onMouseEnter={props.onMouseEnter}
+            onMouseLeave={props.onMouseLeave}
             onTransitionEnd={props.onTransitionEnd}
             ref={elementRef}
             style={props.style}

--- a/ui/appui-layout-react/src/test/widget/FloatingWidget.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/FloatingWidget.test.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import * as sinon from "sinon";
 import { act, fireEvent, render } from "@testing-library/react";
-import { addFloatingWidget, addTab, createNineZoneState, FloatingWidget, getResizeBy, NineZoneDispatch } from "../../appui-layout-react";
+import { addFloatingWidget, addTab, createNineZoneState, FloatingWidgetProvider, getResizeBy, NineZoneDispatch } from "../../appui-layout-react";
 import { TestNineZoneProvider } from "../Providers";
 
 describe("FloatingWidget", () => {
@@ -17,7 +17,7 @@ describe("FloatingWidget", () => {
       <TestNineZoneProvider
         state={state}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1!}
           widget={state.widgets.w1}
         />
@@ -34,7 +34,7 @@ describe("FloatingWidget", () => {
       <TestNineZoneProvider
         state={state}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1!}
           widget={state.widgets.w1}
         />
@@ -51,7 +51,7 @@ describe("FloatingWidget", () => {
       <TestNineZoneProvider
         state={state}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1!}
           widget={state.widgets.w1}
         />
@@ -68,7 +68,7 @@ describe("FloatingWidget", () => {
       <TestNineZoneProvider
         state={state}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1!}
           widget={state.widgets.w1}
         />
@@ -85,7 +85,7 @@ describe("FloatingWidget", () => {
       <TestNineZoneProvider
         state={state}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1!}
           widget={state.widgets.w1}
         />
@@ -110,7 +110,7 @@ describe("FloatingWidget", () => {
         state={state}
         dispatch={dispatch}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1!}
           widget={state.widgets.w1}
         />
@@ -137,7 +137,7 @@ describe("FloatingWidget", () => {
         state={state}
         dispatch={dispatch}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.toolSettings!}
           widget={state.widgets.toolSettings}
         />

--- a/ui/appui-layout-react/src/test/widget/TabBar.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/TabBar.test.tsx
@@ -7,7 +7,7 @@ import * as sinon from "sinon";
 import { act, fireEvent, render } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import {
-  addFloatingWidget, addPanelWidget, addTab, createNineZoneState, FloatingWidget, NineZoneDispatch, PanelStateContext,
+  addFloatingWidget, addPanelWidget, addTab, createNineZoneState, FloatingWidgetProvider, NineZoneDispatch, PanelStateContext,
   PanelTarget, useDrag, WidgetIdContext, WidgetTabTarget,
 } from "../../appui-layout-react";
 import * as NineZoneModule from "../../appui-layout-react/base/NineZone";
@@ -25,7 +25,7 @@ describe("WidgetTitleBar", () => {
         state={state}
         dispatch={dispatch}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1}
           widget={state.widgets.w1}
         />
@@ -60,7 +60,7 @@ describe("WidgetTitleBar", () => {
         state={state}
         dispatch={dispatch}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1}
           widget={state.widgets.w1}
         />
@@ -97,7 +97,7 @@ describe("WidgetTitleBar", () => {
         <WidgetIdContext.Provider value="w2">
           <WidgetTabTarget tabIndex={0} first />
         </WidgetIdContext.Provider>
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1}
           widget={state.widgets.w1}
         />
@@ -137,7 +137,7 @@ describe("WidgetTitleBar", () => {
         state={state}
         dispatch={dispatch}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1}
           widget={state.widgets.w1}
         />
@@ -177,7 +177,7 @@ describe("WidgetTitleBar", () => {
         state={state}
         dispatch={dispatch}
       >
-        <FloatingWidget
+        <FloatingWidgetProvider
           floatingWidget={state.floatingWidgets.byId.w1}
           widget={state.widgets.w1}
         />

--- a/ui/appui-react/src/appui-react/widget-panels/FloatingWidget.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/FloatingWidget.tsx
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import * as React from "react";
+import { FloatingWidget as FloatingWidgetComponent } from "@itwin/appui-layout-react";
+import { UiShowHideManager } from "../utils/UiShowHideManager";
+
+/** @internal */
+export function FloatingWidget() {
+  return (
+    <FloatingWidgetComponent
+      onMouseEnter={UiShowHideManager.handleWidgetMouseEnter}
+    />
+  );
+}

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -45,6 +45,7 @@ import { FrameworkRootState } from "../redux/StateManager";
 import { useSelector } from "react-redux";
 import { useUiVisibility } from "../hooks/useUiVisibility";
 import { IModelApp } from "@itwin/core-frontend";
+import { FloatingWidget } from "./FloatingWidget";
 
 const panelZoneKeys: StagePanelZoneDefKeys[] = ["start", "end"];
 
@@ -214,6 +215,7 @@ export const WidgetPanelsFrontstage = React.memo(function WidgetPanelsFrontstage
 
 const defaultNineZone = createNineZoneState();
 const tabElement = <WidgetPanelsTab />;
+const floatingWidgetElement = <FloatingWidget />;
 
 /** @internal */
 export function ActiveFrontstageDefProvider({ frontstageDef }: { frontstageDef: FrontstageDef }) {
@@ -256,6 +258,7 @@ export function ActiveFrontstageDefProvider({ frontstageDef }: { frontstageDef: 
         labels={labels}
         state={nineZone}
         tab={tabElement}
+        floatingWidget={floatingWidgetElement}
         showWidgetIcon={showWidgetIcon}
         autoCollapseUnpinnedPanels={autoCollapseUnpinnedPanels}
         toolSettingsContent={toolSettingsContent}


### PR DESCRIPTION
This PR fixes auto-hide UI related issues.
1. Hovering a hidden floating widget consumes the pointer event w/o showing the UI (content area/viewport doesn't receive pointer events).
2. UI (with floating widgets) is hidden when mouse is hovering over a floating widget.