### PR TITLE
Prevent distorted graphics when transforming elements far from the origin

### DIFF
--- a/common/changes/@bentley/imodeljs-editor-frontend/pmc-transform-elements-2.19.x_2022-10-06-11-36.json
+++ b/common/changes/@bentley/imodeljs-editor-frontend/pmc-transform-elements-2.19.x_2022-10-06-11-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodeljs-editor-frontend",
+      "comment": "Fix distorted graphics when transforming elements located far from the origin.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/imodeljs-editor-frontend",
+  "email": "22944042+pmconne@users.noreply.github.com"
+}


### PR DESCRIPTION
Fixes #4404.
Is really a band-aid because we're limited in what we can change in 2.19.x.
Fix properly in 3.x.