### PR TITLE
UI: Priorize panel handles over panel splitters

### DIFF
--- a/common/changes/@itwin/appui-layout-react/raplemie-panelHandlePriority_2022-10-06-16-15.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-panelHandlePriority_2022-10-06-16-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Bring panel handle on top of panel splitter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.scss
@@ -17,6 +17,7 @@
     >.nz-grip {
       pointer-events: all;
       position: absolute;
+      z-index: 1;
     }
   }
 


### PR DESCRIPTION
This brings the handle on top of the splitter so the full handle area is usable even if the spliter occupy the same space.
Fixes iTwin/itwinjs-backlog#457
