### PR TITLE
handle deleting already cascade-deleted elements in `processChanges`

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -5579,7 +5579,6 @@ export interface ModelProps extends EntityProps {
     modeledElement: RelatedElementProps;
     // (undocumented)
     name?: string;
-    // (undocumented)
     parentModel?: Id64String;
 }
 

--- a/common/changes/@itwin/core-backend/transformer-dont-double-delete_2022-10-08-02-11.json
+++ b/common/changes/@itwin/core-backend/transformer-dont-double-delete_2022-10-08-02-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/transformer-dont-double-delete_2022-10-08-02-11.json
+++ b/common/changes/@itwin/core-common/transformer-dont-double-delete_2022-10-08-02-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "ModelProps.parentModel doc change",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-transformer/transformer-dont-double-delete_2022-10-08-02-11.json
+++ b/common/changes/@itwin/core-transformer/transformer-dont-double-delete_2022-10-08-02-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "handle cascading deletes in IModelTransformer.processChanges",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -607,6 +607,13 @@ export class IModelTestUtils {
     });
   }
 
+  public static queryByCodeValue(iModelDb: IModelDb, codeValue: string): Id64String {
+    return iModelDb.withPreparedStatement(`SELECT ECInstanceId FROM ${Element.classFullName} WHERE CodeValue=:codeValue`, (statement: ECSqlStatement): Id64String => {
+      statement.bindString("codeValue", codeValue);
+      return DbResult.BE_SQLITE_ROW === statement.step() ? statement.getValue(0).getId() : Id64.invalid;
+    });
+  }
+
   public static insertRepositoryLink(iModelDb: IModelDb, codeValue: string, url: string, format: string): Id64String {
     const repositoryLinkProps: RepositoryLinkProps = {
       classFullName: RepositoryLink.classFullName,

--- a/core/common/src/ModelProps.ts
+++ b/core/common/src/ModelProps.ts
@@ -19,7 +19,8 @@ import { EntityProps, EntityQueryParams } from "./EntityProps";
 export interface ModelProps extends EntityProps {
   modeledElement: RelatedElementProps;
   name?: string;
-  parentModel?: Id64String; // NB! Must always match the model of the modeledElement!
+  /** @note must always match the model of the [[ModelProps.modeledElement]] */
+  parentModel?: Id64String;
   isPrivate?: boolean;
   isTemplate?: boolean;
   jsonProperties?: any;

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -290,12 +290,13 @@ export class IModelExporter {
       for (const elementId of this._sourceDbChanges.element.deleteIds) {
         // We don't know how the handler wants to handle deletions, and we don't have enough information
         // to know if deleted entities were related, so when processing changes, ignore errors from deletion.
-        // Technically, to keep the ignored error scope small, we ignore only the error of deleting an element
-        // that doesn't exist.
+        // Technically, to keep the ignored error scope small, we ignore only the error of looking up a missing element
+        // That approach works at least for the IModelTransformer
         try {
           this.handler.onDeleteElement(elementId);
-        } catch (err: any) {
-          if (err?.message !== "error deleting element: missing id")
+        } catch (err: unknown) {
+          const isMissingErr = err instanceof IModelError && err.errorNumber === IModelStatus.NotFound;
+          if (!isMissingErr)
             throw err;
         }
       }

--- a/core/transformer/src/IModelExporter.ts
+++ b/core/transformer/src/IModelExporter.ts
@@ -289,7 +289,7 @@ export class IModelExporter {
       }
       for (const elementId of this._sourceDbChanges.element.deleteIds) {
         // We don't know how the handler wants to handle deletions, and we don't have enough information
-        // to know if a deleted entities were related, so when processing changes, ignore errors from deletion.
+        // to know if deleted entities were related, so when processing changes, ignore errors from deletion.
         // Technically, to keep the ignored error scope small, we ignore only the error of deleting an element
         // that doesn't exist.
         try {

--- a/core/transformer/src/IModelImporter.ts
+++ b/core/transformer/src/IModelImporter.ts
@@ -11,7 +11,7 @@ import {
   PropertyMetaData, RelatedElement, SubCategoryProps,
 } from "@itwin/core-common";
 import { TransformerLoggerCategory } from "./TransformerLoggerCategory";
-import { ElementAspect, ElementMultiAspect, Entity, IModelDb, Model, Relationship, RelationshipProps, SourceAndTarget, SubCategory } from "@itwin/core-backend";
+import { deleteElementTree, ElementAspect, ElementMultiAspect, Entity, IModelDb, Model, Relationship, RelationshipProps, SourceAndTarget, SubCategory } from "@itwin/core-backend";
 import type { IModelTransformOptions } from "./IModelTransformer";
 
 const loggerCategory: string = TransformerLoggerCategory.IModelImporter;
@@ -254,12 +254,13 @@ export class IModelImporter implements Required<IModelImportOptions> {
     }
   }
 
-  /** Delete the specified Element from the target iModel.
+  /** Delete the specified Element (and all its children) from the target iModel.
+   * Will delete special elements like definition elements and subjects.
    * @note A subclass may override this method to customize delete behavior but should call `super.onDeleteElement`.
    */
   protected onDeleteElement(elementId: Id64String): void {
-    this.targetDb.elements.deleteElement(elementId);
-    Logger.logInfo(loggerCategory, `Deleted element ${elementId}`);
+    deleteElementTree(this.targetDb, elementId);
+    Logger.logInfo(loggerCategory, `Deleted element ${elementId} and its descendants`);
     this.trackProgress();
   }
 

--- a/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -747,9 +747,17 @@ describe("IModelTransformerHub", () => {
       const modelToDeleteWithElem = {
         entity: branchDb.models.getModel<PhysicalModel>(modelToDeleteWithElemId, PhysicalModel),
         submodelingElem: branchDb.elements.getElement<PhysicalPartition>(modelToDeleteWithElemId, PhysicalPartition),
+        aspects: branchDb.elements.getAspects(modelToDeleteWithElemId),
       };
       const elemToDeleteWithChildren = {
         entity: branchDb.elements.getElement<PhysicalObject>(elemToDeleteWithChildrenId, PhysicalObject),
+        aspects: branchDb.elements.getAspects(elemToDeleteWithChildrenId),
+      };
+      const childElemOfDeleted = {
+        aspects: branchDb.elements.getAspects(childElemOfDeletedId),
+      };
+      const elemInModelToDelete = {
+        aspects: branchDb.elements.getAspects(elemInModelToDeleteId),
       };
 
       elemToDeleteWithChildren.entity.delete();
@@ -766,7 +774,6 @@ describe("IModelTransformerHub", () => {
       expect(branchDb.elements.tryGetElement(elemToDeleteWithChildrenId)).to.be.undefined;
       expect(branchDb.elements.tryGetElement(childElemOfDeletedId)).to.be.undefined;
 
-      const aspectIdsOf = (id: Id64String) => branchDb.elements.getAspects(id).map((a) => a.id);
       // expected extracted changed ids
       const branchDbChangesets = await IModelHost.hubAccess.downloadChangesets({ accessToken, iModelId: branchIModelId, targetDir: BriefcaseManager.getChangeSetsPath(branchIModelId) });
       expect(branchDbChangesets).to.have.length(2);
@@ -775,15 +782,17 @@ describe("IModelTransformerHub", () => {
       const expectedChangedIds: IModelJsNative.ChangedInstanceIdsProps = {
         aspect: {
           delete: [
-            childElemOfDeletedId,
-            elemInModelToDeleteId,
-            modelToDeleteWithElemId,
-          ].map(aspectIdsOf).flat(),
+            ...modelToDeleteWithElem.aspects,
+            ...elemInModelToDelete.aspects,
+            ...elemToDeleteWithChildren.aspects,
+            ...childElemOfDeleted.aspects,
+          ].map((a) => a.id),
         },
         element: {
           delete: [
             modelToDeleteWithElemId,
             elemInModelToDeleteId,
+            elemToDeleteWithChildrenId,
             childElemOfDeletedId,
           ],
         },

--- a/docs/bis/guide/intro/modeling-with-bis.md
+++ b/docs/bis/guide/intro/modeling-with-bis.md
@@ -60,7 +60,7 @@ The Element modeling the car-as-a-whole is also in a Model. What Element is **th
 
 ### Relationships
 
-There can be many different kinds of Relationships among Elements within a Model or spanning Models. The various specializations of the ElementHasChildElements relationship are particularly important—they implement parent-child/whole-part relationships among Elements. For example, if Object 1 is a Door, it might have DoorHardware as a Child.
+There can be many different kinds of Relationships among Elements within a Model or spanning Models. The various specializations of the `ElementOwnsChildElements` relationship are particularly important—they implement parent-child/whole-part relationships among Elements. For example, if Object 1 is a Door, it might have DoorHardware as a Child.
 
 &nbsp;
 ![Within a Model, parent Elements allow child Elements](../media/bis-modeling-06.png "Within a Model, parent Elements allow child Elements")


### PR DESCRIPTION
- update existing branch deletion tests to include some cascade delete cases
- try/catch missing element errors when deleting elements in `processChanges`.

  Because the source doesn't have the information on elements which were deleted readily available, it is difficult to determine the previous relationship between elements in the source and anticipate how cascade deletion will occur in the target. It also would depend upon the handler in use by the `IModelExporter`. Instead of figuring that out, just ignore errors of missing elements while trying to delete each of them that may have been cascade-deleted by a previous deletion. In the future, the `ExportHandler` interface may be extended to provide a more robust way of communicating to the exporter that a delete cascaded and `processChanges` shouldn't re-delete.

- use `deleteElementTree` instead of `iModelDb.elements.deleteElement` in the transformer's `IModelHandler.onDeleteElement` implementation, to make it possible to process changes with cascaded deletes in any order

misc:
- promote an inline note to a JSDoc `@note` so that it's shown by VSCode intellisense
- fix a typo in docs 