### PR TITLE
Add restore frontstages tool

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -2729,6 +2729,8 @@ export class FrontstageManager {
     // @internal
     static ensureToolInformationIsSet(toolId: string): void;
     static findWidget(widgetId: string): WidgetDef | undefined;
+    // @internal (undocumented)
+    static get frontstageDefs(): ReadonlyMap<string, FrontstageDef>;
     static getFrontstageDef(id?: string): Promise<FrontstageDef | undefined>;
     // (undocumented)
     static hasFrontstage(frontstageId: string): boolean;
@@ -4498,6 +4500,16 @@ export class RestoreFrontstageLayoutTool extends Tool {
     parseAndRun(...args: string[]): Promise<boolean>;
     // (undocumented)
     run(frontstageId?: string): Promise<boolean>;
+    // (undocumented)
+    static toolId: string;
+}
+
+// @alpha
+export class RestoreFrontstagesLayoutTool extends Tool {
+    // (undocumented)
+    static iconSpec: string;
+    // (undocumented)
+    run(): Promise<boolean>;
     // (undocumented)
     static toolId: string;
 }

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -475,6 +475,7 @@ beta;ReducerRegistry
 beta;ReducerRegistryInstance: ReducerRegistry
 internal;removeMissingWidgets(frontstageDef: FrontstageDef, initialState: NineZoneState): NineZoneState
 alpha;RestoreFrontstageLayoutTool 
+alpha;RestoreFrontstagesLayoutTool 
 internal;restoreNineZoneState(frontstageDef: FrontstageDef, saved: SavedNineZoneState): NineZoneState
 beta;ReviewToolWidget 
 beta;ReviewToolWidgetProps

--- a/common/changes/@itwin/appui-react/restore-frontstages_2022-10-10-13-17.json
+++ b/common/changes/@itwin/appui-react/restore-frontstages_2022-10-10-13-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add RestoreFrontstagesLayout tool.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/public/locales/en/UiFramework.json
+++ b/ui/appui-react/public/locales/en/UiFramework.json
@@ -171,7 +171,7 @@
       "animateToolSettingsDescription": "Animate tool settings when they appear in the docked bar.",
       "useToolAsToolSettingsLabelTitle": "Use tool as tool settings label",
       "useToolAsToolSettingsLabelDescription": "Use active tool name as the Tool Settings tab label, if false, will always be titled 'Tool Settings'."
-   }
+    }
   },
   "tools": {
     "clearSelection": "Clear Selection",
@@ -185,7 +185,7 @@
     "isolateModels": "Isolate Models",
     "emphasizeSelected": "Emphasize Selected",
     "clearVisibility": "Clear Isolated, Hidden, and Emphasized Elements",
-    "noToolSettings": "No settings for this tool." ,
+    "noToolSettings": "No settings for this tool.",
     "sectionTools": "Section Tools",
     "sectionClear": "Clear Sections",
     "sectionPanelLabel": "Section",
@@ -205,7 +205,7 @@
         "description": "Turn on/off use of camera in active view",
         "flyover": "Toggle Camera",
         "turnOnFlyover": "Turn Camera On",
-        "turnOffFlyover":"Turn Camera Off"
+        "turnOffFlyover": "Turn Camera Off"
       }
     },
     "OpenSettings": {
@@ -216,6 +216,11 @@
       "description": "Restore Frontstage to Default Layout",
       "flyover": "Restore Stage to Default Layout",
       "noStageFound": "Specified stage not found."
+    },
+    "RestoreFrontstagesLayout": {
+      "keyin": "restore frontstages layout",
+      "description": "Restore all Frontstages to Default Layout",
+      "flyover": "Restore all Stages to Default Layout"
     },
     "ClearKeyinPaletteHistory": {
       "keyin": "clear keyin history",

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageManager.ts
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageManager.ts
@@ -272,6 +272,11 @@ export class FrontstageManager {
     FrontstageManager._nineZoneSize = size;
   }
 
+  /** @internal */
+  public static get frontstageDefs(): ReadonlyMap<string, FrontstageDef> {
+    return this._frontstageDefs;
+  }
+
   /** Get Frontstage Deactivated event. */
   public static readonly onFrontstageDeactivatedEvent = new FrontstageDeactivatedEvent();
 

--- a/ui/appui-react/src/appui-react/tools/RestoreLayoutTool.ts
+++ b/ui/appui-react/src/appui-react/tools/RestoreLayoutTool.ts
@@ -44,3 +44,20 @@ export class RestoreFrontstageLayoutTool extends Tool {
     return this.run(args[0]);
   }
 }
+
+/**
+ * Immediate tool that will reset the layout of all frontstages to that specified in the stage definition.
+ * @alpha
+ */
+export class RestoreFrontstagesLayoutTool extends Tool {
+  public static override toolId = "RestoreFrontstagesLayout";
+  public static override iconSpec = "icon-view-layouts";
+
+  public override async run() {
+    const frontstages = FrontstageManager.frontstageDefs;
+    for (const [, frontstage] of frontstages) {
+      frontstage.restoreLayout();
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
This PR adds a `RestoreFrontstagesLayoutTool` that restores layout of all frontstages.
The tool can be invoked via `restore frontstages layout` key-in, which supplements existing `restore frontstage layout {frontstageId}` (which is used to restore currently active OR specific frontstage by providing optional frontstageId).