### PR TITLE
exportGraphics: add test for fixed-block mesh

### DIFF
--- a/common/changes/@itwin/core-backend/da4-eg-add-rejected-mesh-test_2022-10-10-21-14.json
+++ b/common/changes/@itwin/core-backend/da4-eg-add-rejected-mesh-test_2022-10-10-21-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "add exportGraphics test for fixed-block mesh",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/standalone/ExportGraphics.test.ts
+++ b/core/backend/src/test/standalone/ExportGraphics.test.ts
@@ -1010,4 +1010,36 @@ describe("exportGraphics", () => {
     assert.isTrue(Math.abs(knownArea - areaSum) < 1.0e-13);
     assert.isTrue(numFacetsA === numFacets, "facet count");
   });
+
+  it("creates output for mesh without zero blocking", () => {
+    const meshWithoutBlocking: GeometryStreamProps = JSON.parse(`[{
+      "indexedMesh": {
+        "numPerFace": 3,
+        "expectedClosure": 0,
+        "point": [
+          [0, 0, 0],
+          [1, 0, 0],
+          [1, 1, 0],
+          [0, 1, 0]
+        ],
+        "pointIndex": [1, 2, 3, 1, 3, 4],
+        "normal": [[0, 0, 1]],
+        "normalIndex": [1, 1, 1, 1, 1, 1]
+      }
+    }]`);
+    const newId = insertPhysicalElement(meshWithoutBlocking);
+
+    const infos: ExportGraphicsInfo[] = [];
+    const exportGraphicsOptions: ExportGraphicsOptions = {
+      elementIdArray: [newId],
+      onGraphics: (info: ExportGraphicsInfo) => infos.push(info),
+    };
+
+    const exportStatus = iModel.exportGraphics(exportGraphicsOptions);
+    assert.strictEqual(exportStatus, DbResult.BE_SQLITE_OK);
+    assert.strictEqual(infos.length, 1);
+    assert.strictEqual(infos[0].elementId, newId);
+    assert.strictEqual(infos[0].mesh.indices.length, 6);
+  });
+
 });


### PR DESCRIPTION
Add exportGraphics test for fixed-block meshes.
* This tests the native fix for https://github.com/iTwin/itwinjs-core/issues/4368 from 2 weeks ago.
* This is not needed for 3.4.