### PR TITLE
Presentation: Fix `PresentationRpcImpl` cancelling requests when it's configured to not use request timeout

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-fix-rpc-impl-cancelling-requests-by-mistake_2022-10-11-12-05.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix-rpc-impl-cancelling-requests-by-mistake_2022-10-11-12-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fix `PresentationRpcImpl` cancelling requests when it's configured to not use a request timeout at all",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -52,7 +52,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
     this._pendingRequests = new TemporaryStorage({
       // remove the pending request after request timeout + 10 seconds - this gives
       // frontend 10 seconds to re-send the request until it's removed from requests' cache
-      unusedValueLifetime: this._requestTimeout + 10 * 1000,
+      unusedValueLifetime: (this._requestTimeout > 0) ? (this._requestTimeout + 10 * 1000) : undefined,
 
       // attempt to clean up every second
       cleanupInterval: 1000,
@@ -74,6 +74,8 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
   }
 
   public get requestTimeout() { return this._requestTimeout; }
+
+  public get pendingRequests() { return this._pendingRequests; }
 
   /** Returns an ok response with result inside */
   private successResponse<TResult>(result: TResult, diagnostics?: ClientDiagnostics) {

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -57,6 +57,12 @@ describe("PresentationRpcImpl", () => {
     });
   });
 
+  it("doesn't cancel requests if request timeout is 0", () => {
+    using(new PresentationRpcImpl({ requestTimeout: 0 }), (impl) => {
+      expect(impl.pendingRequests.props.unusedValueLifetime).to.be.undefined;
+    });
+  });
+
   it("returns all diagnostics when `PresentationManager` calls diagnostics handler multiple times", async () => {
     const rulesetsMock = moq.Mock.ofType<RulesetManager>();
     const variablesMock = moq.Mock.ofType<RulesetVariablesManager>();


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/462.

Turns out the `CloudCache`-related crash with app verifier enabled was a false alarm (probably). That was a continuable stop related to freeing an active critical section.

The actual problem was that we didn't account for zero requests timeout, which should mean "no timeouts" in our RPC code. That means we cancelled the requests after 10 seconds and it seems on slower machines we may sometimes exceed that. When the request is cancelled, the backend returns an error response with "cancelled" status and our frontend code "eats" the error and returns some default value - `0`, `[]`, etc. Filed an issue https://github.com/iTwin/itwinjs-core/issues/4467 to look into that.