### PR TITLE
Fix point cloud classified hiliter

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-point-cloud-shader-assertion_2022-10-12-21-12.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-point-cloud-shader-assertion_2022-10-12-21-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/glsl/PointCloud.ts
+++ b/core/frontend/src/render/webgl/glsl/PointCloud.ts
@@ -17,6 +17,7 @@ import { addModelViewProjectionMatrix } from "./Vertex";
 import { addViewportTransformation } from "./Viewport";
 import { addThematicDisplay } from "./Thematic";
 import { addTexture } from "./Surface";
+import { assignFragColor } from "./Fragment";
 
 // Revert components if color format is BGR instead of RGB.
 const computeColor = `
@@ -116,10 +117,12 @@ export function createPointCloudBuilder(classified: IsClassified, featureMode: F
 /** @internal */
 export function createPointCloudHiliter(classified: IsClassified): ProgramBuilder {
   const builder = createBuilder();
-  if (classified)
+  if (classified) {
     addHilitePlanarClassifier(builder, false);
-  else
+    builder.frag.set(FragmentShaderComponent.AssignFragData, assignFragColor);
+  } else {
     addUniformHiliter(builder);
+  }
 
   return builder;
 }


### PR DESCRIPTION
#4466 removed assignment of frag color. Would have been caught by assertion, but tests don't run with assertions enabled (why?). It appears we have no ImageTests views that cover classified, hilited point clouds.