### PR TITLE
Translate element graphics to origin

### DIFF
--- a/core/common/src/tile/ElementGraphics.ts
+++ b/core/common/src/tile/ElementGraphics.ts
@@ -55,8 +55,20 @@ export interface GraphicsRequestProps {
   readonly sectionCut?: string;
   /** If true, vertex positions will be quantized to [[QPoint3d]]s to conserve space at the expense of accuracy. Quantization may produce
    * perceptible inaccuracies when producing graphics for large and/or highly-detailed elements.
+   * If false, vertex positions will not be quantized; instead, each coordinate will be represented using 32-bit floating point numbers.
+   * Note that for coordinates very far from the origin, 32-bit precision can still produce inaccuracies. Those inaccuracies can be mitigated using [[useAbsolutePositions]].
    */
   quantizePositions?: boolean;
+  /** Determines whether unquantized positions are specified in relative or absolute coordinates.
+   * This property has no effect if [[quantizePositions]] is `true`.
+   * When [[quantizePositions]] is `false`, each vertex's position is represented by three 32-bit floating point numbers. If the vertices are located very far from the origin,
+   * 32-bit precision can produce perceptible inaccuracies when displaying the graphics.
+   * ###TODO rewrite this.
+   * This property has no effect if [[quantizePositions]] is `true`. Otherwise, if this property is `true` then vertex positions will be represented exactly as
+   * specified in the element's geometry stream, after applying the [[location]] transform. If this property is `false` then a translation will be applied to each vertex position
+   * to move it closer to the origin; and the resultant [RenderGraphic]($frontend) will have the inverse, 64-bit translation applied, reducing inaccuracies introduced when
+   */
+  useAbsolutePositions?: boolean;
 }
 
 /** Wire format describing a request to produce graphics in "iMdl" format for a single element.

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -445,6 +445,10 @@ export interface Imdl {
   scene: string;
   /** The collection of ImdlScenes included in the tile. */
   scenes: ImdlDictionary<ImdlScene>;
+  /** Specifies point to which all vertex positions in the tile are relative, as an array of 3 numbers.
+   * Currently only used for requestElementGraphics - see GraphicsRequestProps.useAbsolutePositions.
+   */
+  rtcCenter?: number[];
   /** Maps each node Id to the Id of the corresponding mesh in [[meshes]]. */
   nodes: ImdlDictionary<string>;
   meshes: ImdlDictionary<ImdlMesh>;
@@ -515,6 +519,7 @@ export class ImdlReader {
   private readonly _patternGeometry = new Map<string, RenderGeometry[]>();
   private readonly _containsTransformNodes: boolean;
   private readonly _timeline?: RenderSchedule.ModelTimeline;
+  private readonly _rtcCenter?: Point3d;
 
   private get _isCanceled(): boolean { return undefined !== this._canceled && this._canceled(this); }
   private get _isVolumeClassifier(): boolean { return BatchType.VolumeClassifier === this._type; }
@@ -553,6 +558,7 @@ export class ImdlReader {
         renderMaterials: JsonUtils.asObject(sceneValue.renderMaterials),
         namedTextures: JsonUtils.asObject(sceneValue.namedTextures),
         patternSymbols: JsonUtils.asObject(sceneValue.patternSymbols),
+        rtcCenter: JsonUtils.asArray(sceneValue.rtcCenter),
       };
 
       return undefined !== imdl.meshes ? new ImdlReader(imdl, gltfHeader.binaryPosition, args) : undefined;
@@ -573,6 +579,7 @@ export class ImdlReader {
     this._renderMaterials = imdl.renderMaterials ?? { };
     this._namedTextures = imdl.namedTextures ?? { };
     this._patternSymbols = imdl.patternSymbols ?? {};
+    this._rtcCenter = imdl.rtcCenter ? Point3d.fromJSON(imdl.rtcCenter) : undefined;
 
     this._iModel = args.iModel;
     this._modelId = args.modelId;
@@ -1437,8 +1444,14 @@ export class ImdlReader {
         break;
     }
 
-    if (undefined !== tileGraphic && false !== this._options)
+    if (tileGraphic && false !== this._options)
       tileGraphic = this._system.createBatch(tileGraphic, featureTable, contentRange, this._options);
+
+    if (tileGraphic && this._rtcCenter) {
+      const rtcBranch = new GraphicBranch(true);
+      rtcBranch.add(tileGraphic);
+      tileGraphic = this._system.createBranch(rtcBranch, Transform.createTranslation(this._rtcCenter));
+    }
 
     return {
       readStatus: TileReadStatus.Success,

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -695,8 +695,14 @@ export class TileAdmin {
     if (true !== requestProps.omitEdges && undefined === requestProps.edgeType)
       requestProps = { ...requestProps, edgeType: this.enableIndexedEdges ? 2 : 1 };
 
-    if (undefined === requestProps.quantizePositions)
-      requestProps = { ...requestProps, quantizePositions: false };
+    // For backwards compatibility, these options default to true in the backend. Explicitly set them to false in (newer) frontends if not supplied.
+    if (undefined === requestProps.quantizePositions || undefined === requestProps.useAbsolutePositions) {
+      requestProps = {
+        ...requestProps,
+        quantizePositions: requestProps.quantizePositions ?? false,
+        useAbsolutePositions: requestProps.useAbsolutePositions ?? false,
+      };
+    }
 
     this.initializeRpc();
     const intfc = IModelTileRpcInterface.getClient();

--- a/full-stack-tests/core/src/frontend/standalone/tile/ElementGraphics.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/tile/ElementGraphics.test.ts
@@ -4,11 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { Guid } from "@itwin/core-bentley";
+import { Transform } from "@itwin/core-geometry";
 import { PersistentGraphicsRequestProps } from "@itwin/core-common";
 import { IModelApp, MockRender, readElementGraphics, SnapshotConnection } from "@itwin/core-frontend";
 import { TestUtility } from "../../TestUtility";
 
-describe("requestElementGraphics", () => {
+describe.only("requestElementGraphics", () => {
   let imodel: SnapshotConnection;
 
   before(async () => {
@@ -23,40 +24,98 @@ describe("requestElementGraphics", () => {
     await TestUtility.shutdownFrontend();
   });
 
-  async function expectQuantized(requestQuantized: boolean | undefined, expected: boolean): Promise<void> {
-    const requestProps: PersistentGraphicsRequestProps = {
-      elementId: "0x29",
-      id: Guid.createValue(),
-      toleranceLog10: -3,
-    };
+  describe("quantization", () => {
+    async function expectQuantized(requestQuantized: boolean | undefined, expected: boolean): Promise<void> {
+      const requestProps: PersistentGraphicsRequestProps = {
+        elementId: "0x29",
+        id: Guid.createValue(),
+        toleranceLog10: -3,
+      };
 
-    if (undefined !== requestQuantized)
-      requestProps.quantizePositions = requestQuantized;
+      if (undefined !== requestQuantized)
+        requestProps.quantizePositions = requestQuantized;
 
-    const bytes = await IModelApp.tileAdmin.requestElementGraphics(imodel, requestProps);
-    expect(bytes).not.to.be.undefined;
+      const bytes = await IModelApp.tileAdmin.requestElementGraphics(imodel, requestProps);
+      expect(bytes).not.to.be.undefined;
 
-    let createdMesh = false;
-    IModelApp.renderSystem.createMeshGeometry = (params, _origin) => {
-      expect(params.vertices.usesUnquantizedPositions).to.equal(!expected);
-      createdMesh = true;
-      return new MockRender.Geometry();
-    };
+      let createdMesh = false;
+      IModelApp.renderSystem.createMeshGeometry = (params, _origin) => {
+        expect(params.vertices.usesUnquantizedPositions).to.equal(!expected);
+        createdMesh = true;
+        return new MockRender.Geometry();
+      };
 
-    const gfx = await readElementGraphics(bytes!, imodel, "0", true);
-    expect(gfx).not.to.be.undefined;
-    expect(createdMesh).to.be.true;
-  }
+      const gfx = await readElementGraphics(bytes!, imodel, "0", true);
+      expect(gfx).not.to.be.undefined;
+      expect(createdMesh).to.be.true;
+    }
 
-  it("does not quantize positions by default", async () => {
-    await expectQuantized(undefined, false);
+    it("is not applied by default", async () => {
+      await expectQuantized(undefined, false);
+    });
+
+    it("is applied if `quantizePositions` is true", async () => {
+      await expectQuantized(true, true);
+    });
+
+    it("is not applied if `quantizePositions` is false", async () => {
+      await expectQuantized(false, false);
+    });
   });
 
-  it("quantizes positions if explicitly requested", async () => {
-    await expectQuantized(true, true);
-  });
+  describe("relative-to-center transform", () => {
+    async function expectRtc(options: {
+      quantize?: boolean;
+      absolute?: boolean;
+      location?: Transform;
+    }, expectedRtc: number[] | undefined
+    ): Promise<void> {
+      const requestProps: PersistentGraphicsRequestProps = {
+        elementId: "0x29",
+        id: Guid.createValue(),
+        toleranceLog10: -3,
+        quantizePositions: options.quantize,
+        useAbsolutePositions: options.absolute,
+        location: options.location?.toJSON(),
+      };
 
-  it("produces unquantized positions if explicitly requested", async () => {
-    await expectQuantized(false, false);
+      const bytes = (await IModelApp.tileAdmin.requestElementGraphics(imodel, requestProps))!;
+      expect(bytes).not.to.be.undefined;
+
+      let createdMesh = false;
+      IModelApp.renderSystem.createMeshGeometry = (params) => {
+        expect(params.vertices.usesUnquantizedPositions).to.equal(true === options.quantize);
+        // ###TODO inspect mesh geometry
+        createdMesh = true;
+        return new MockRender.Geometry();
+      };
+
+      let actualRtc: number[] | undefined;
+      IModelApp.renderSystem.createGraphicBranch = (branch, transform, options) => {
+        actualRtc = transform.origin.toArray();
+        return new MockRender.Branch(branch, transform, options);
+      };
+
+      const gfx = await readElementGraphics(bytes, imodel, "0", true);
+      expect(gfx).not.to.be.undefined;
+      expect(createdMesh).to.be.true;
+      expect(actualRtc).to.deep.equal(expectedRtc);
+    }
+
+    it("is applied by default", async () => {
+      expectRtc({}, [12, 34, 56]);
+    });
+
+    it("is not applied to quantized positions", async () => {
+    });
+
+    it("is not applied if `useAbsolutePositions` is true", async () => {
+    });
+
+    it("is applied if `useAbsolutePositions` is false", async () => {
+    });
+
+    it("is adjusted based on location transform", async () => {
+    });
   });
 });

--- a/full-stack-tests/core/src/frontend/standalone/tile/ElementGraphics.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/tile/ElementGraphics.test.ts
@@ -9,7 +9,7 @@ import { PersistentGraphicsRequestProps } from "@itwin/core-common";
 import { IModelApp, MockRender, readElementGraphics, SnapshotConnection } from "@itwin/core-frontend";
 import { TestUtility } from "../../TestUtility";
 
-describe.only("requestElementGraphics", () => {
+describe("requestElementGraphics", () => {
   let imodel: SnapshotConnection;
 
   before(async () => {

--- a/full-stack-tests/core/src/frontend/standalone/tile/ElementGraphics.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/tile/ElementGraphics.test.ts
@@ -135,6 +135,7 @@ describe.only("requestElementGraphics", () => {
     });
 
     it("is adjusted based on location transform", async () => {
+      await expectRtc({ location: Transform.createTranslationXYZ(100, -200, 500) }, [elemRtc[0] - 100, elemRtc[1] + 200, elemRtc[2] - 500]);
     });
   });
 });


### PR DESCRIPTION
Fixes #4444.

Add `GraphicsRequestProps.useAbsolutePositions`. It defaults to `true` to preserve behavior for older frontends. Newer frontends will set it to `false` if caller does not explicitly specify it.
If `false`, the backend will translate the center of the graphics' range to the origin, and the frontend will apply that translation to the resultant RenderGraphic.

[Related native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/286061).