### PR TITLE
Presentation: Convert FilterBuilder output to InstanceFilterDefinition

### DIFF
--- a/presentation/common/src/presentation-common.ts
+++ b/presentation/common/src/presentation-common.ts
@@ -22,6 +22,7 @@ export * from "./presentation-common/Update";
 export * from "./presentation-common/Utils";
 export * from "./presentation-common/PresentationIpcInterface";
 export * from "./presentation-common/LocalizationHelper";
+export * from "./presentation-common/InstanceFilterDefinition";
 
 /**
  * @module RPC

--- a/presentation/common/src/presentation-common/InstanceFilterDefinition.ts
+++ b/presentation/common/src/presentation-common/InstanceFilterDefinition.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Core
+ */
+
+import { StrippedRelationshipPath } from "./EC";
+
+/**
+  * @alpha
+  */
+export interface InstanceFilterDefinition {
+  /**
+    * Select class filter that may be used to select only instances of specific class.
+    *
+    * If specified, the [[relatedInstances]] attribute should specify paths from this
+    * class. Also, the [[expression]] attribute's `this` symbol points to instances of this class.
+    */
+  selectClassName?: string;
+
+  /**
+    * Relationship paths pointing to related instances used in the [[expression]] attribute.
+    *
+    * Sometimes there's a need to filter on a related instance property. In that case, the relationship
+    * needs to be named by specifying the path and alias for the target (or the relationship). Then, the
+    * related instance's symbol context can be accessed through the root symbol named as specified in the
+    * [[alias]] (or [[relationshipAlias]]) attribute.
+    */
+  relatedInstances?: Array<{
+    /**
+      * A relationship path from select class (either specified through [[selectClassName]] or taken from context)
+      * to the target related instance containing the properties used in [[expression]].
+      */
+    pathFromSelectToPropertyClass: StrippedRelationshipPath;
+    /**
+      * An optional flag indicating that the target instance must exist. Setting this allows to filter out all
+      * select instances that don't have a related instance by following the [[pathFromSelectToPropertyClass]] path.
+      */
+    isRequired?: boolean;
+  } & ({
+    /**
+      * An alias for the target class in the [[pathFromSelectToPropertyClass]] path. This alias can be used to
+      * access related instance symbols context in the [[expression]].
+      */
+    alias: string;
+  } | {
+    /**
+      * An alias for the relationship in the last step of the [[pathFromSelectToPropertyClass]] path. This alias can be
+      * used to access the relationship instance symbols context in the [[expression]].
+      */
+    relationshipAlias: string;
+  })>;
+
+  /**
+    * [ECExpression]($docs/presentation/advanced/ECExpressions.md) for filtering the select instances.
+    */
+  expression: string;
+}

--- a/presentation/components/src/presentation-components.ts
+++ b/presentation/components/src/presentation-components.ts
@@ -113,6 +113,7 @@ export * from "./presentation-components/instance-filter-builder/InstanceFilterB
 export * from "./presentation-components/instance-filter-builder/PresentationInstanceFilterBuilder";
 export * from "./presentation-components/instance-filter-builder/Types";
 export * from "./presentation-components/instance-filter-builder/Utils";
+export * from "./presentation-components/instance-filter-builder/InstanceFilterConverter";
 
 Presentation.registerInitializationHandler(initializeLocalization);
 Presentation.registerInitializationHandler(initializePropertyValueRenderers);

--- a/presentation/components/src/presentation-components/instance-filter-builder/ECClassesHierarchy.ts
+++ b/presentation/components/src/presentation-components/instance-filter-builder/ECClassesHierarchy.ts
@@ -16,7 +16,7 @@ export class ClassHierarchy {
   ) {
   }
 
-  public is(classId: Id64String, {isDerived, isBase}: {isDerived?: boolean, isBase?: boolean}) {
+  public is(classId: Id64String, { isDerived, isBase }: { isDerived?: boolean, isBase?: boolean }) {
     if (classId === this._id)
       return true;
 
@@ -32,9 +32,11 @@ export class ClassHierarchy {
 
 /** @internal */
 export class ClassHierarchiesSet {
-  constructor(private _classSets: ClassHierarchy[]) {}
+  constructor(private _classSets: ClassHierarchy[]) { }
 
-  public has(classId: Id64String, options: {isDerived?: boolean, isBase?: boolean}) {
+  public has(classId: Id64String, options: { isDerived?: boolean, isBase?: boolean }, all?: boolean) {
+    if (all)
+      return this._classSets.every((idsSet) => idsSet.is(classId, options));
     return this._classSets.some((idsSet) => idsSet.is(classId, options));
   }
 }
@@ -93,7 +95,7 @@ export class ECClassHierarchyProvider {
   private getAllBaseClassIds(classId: Id64String): Id64String[] {
     const baseClassIds = this._baseClasses.get(classId) ?? [];
     return baseClassIds.reduce<Id64String[]>((arr, id) => {
-      arr.push(id,...this.getAllBaseClassIds(id));
+      arr.push(id, ...this.getAllBaseClassIds(id));
       return arr;
     }, []);
   }

--- a/presentation/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
+++ b/presentation/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module InstancesFilter
+ */
+
+import { Primitives, PrimitiveValue } from "@itwin/appui-abstract";
+import { isUnaryPropertyFilterOperator, PropertyFilterRuleGroupOperator, PropertyFilterRuleOperator } from "@itwin/components-react";
+import { IModelConnection } from "@itwin/core-frontend";
+import { ClassInfo, InstanceFilterDefinition, NestedContentField, PropertiesField, PropertyInfo, RelationshipPath } from "@itwin/presentation-common";
+import { ECClassHierarchyProvider } from "./ECClassesHierarchy";
+import { PresentationInstanceFilter, PresentationInstanceFilterCondition, PresentationInstanceFilterConditionGroup } from "./Types";
+
+/** @alpha */
+export async function convertToInstanceFilterDefinition(filter: PresentationInstanceFilter, imodel: IModelConnection): Promise<InstanceFilterDefinition> {
+  const context: ConvertContext = { relatedInstances: [], propertyClasses: [] };
+  const expression = convertFilter(filter, context);
+
+  const baseClass = await findBaseExpressionClass(imodel, context.propertyClasses);
+
+  return {
+    expression,
+    selectClassName: baseClass.name,
+    relatedInstances: context.relatedInstances.map((related) => ({
+      pathFromSelectToPropertyClass: RelationshipPath.strip(related.path),
+      alias: related.alias,
+    })),
+  };
+}
+
+interface RelatedInstanceDescription {
+  path: RelationshipPath;
+  alias: string;
+}
+
+interface ConvertContext {
+  relatedInstances: RelatedInstanceDescription[];
+  propertyClasses: ClassInfo[];
+}
+
+function convertFilter(filter: PresentationInstanceFilter, ctx: ConvertContext) {
+  if (isFilterConditionGroup(filter))
+    return convertConditionGroup(filter, ctx);
+  return convertCondition(filter, ctx);
+}
+
+function convertConditionGroup(group: PresentationInstanceFilterConditionGroup, ctx: ConvertContext): string {
+  const convertedConditions = group.conditions.map((condition) => convertFilter(condition, ctx));
+  return `(${convertedConditions.join(` ${getGroupOperatorString(group.operator)} `)})`;
+}
+
+function convertCondition(condition: PresentationInstanceFilterCondition, ctx: ConvertContext): string {
+  const { field, operator, value } = condition;
+  const property = field.properties[0].property;
+  const relatedInstance = getRelatedInstanceDescription(field, property.classInfo.name, ctx);
+  addClassInfoToContext(relatedInstance ? relatedInstance.path[0].sourceClassInfo : property.classInfo, ctx);
+  const propertyAlias = relatedInstance?.alias ?? "this";
+
+  return createComparison(property, propertyAlias, operator, value);
+}
+
+function addClassInfoToContext(classInfo: ClassInfo, ctx: ConvertContext) {
+  if (ctx.propertyClasses.find((existing) => existing.id === classInfo.id))
+    return;
+
+  ctx.propertyClasses.push(classInfo);
+}
+
+function getRelatedInstanceDescription(field: PropertiesField, propClassName: string, ctx: ConvertContext): RelatedInstanceDescription | undefined {
+  if (!field.parent)
+    return undefined;
+
+  const pathToProperty = RelationshipPath.reverse(getPathToPrimaryClass(field.parent));
+  const existing = ctx.relatedInstances.find((instance) => RelationshipPath.equals(pathToProperty, instance.path));
+  if (existing)
+    return existing;
+
+  const newRelated = {
+    path: pathToProperty,
+    alias: `rel_${propClassName.split(":")[1]}`,
+  };
+
+  ctx.relatedInstances.push(newRelated);
+  return newRelated;
+}
+
+function getPathToPrimaryClass(field: NestedContentField): RelationshipPath {
+  if (field.parent) {
+    return [...field.pathToPrimaryClass, ...getPathToPrimaryClass(field.parent)];
+  }
+  return [...field.pathToPrimaryClass];
+}
+
+function createComparison(property: PropertyInfo, alias: string, operator: PropertyFilterRuleOperator, propValue?: PrimitiveValue): string {
+  const propertyAccessor = `${alias}.${property.name}`;
+  const operatorExpression = getRuleOperatorString(operator);
+  if (propValue === undefined || isUnaryPropertyFilterOperator(operator)) {
+    return `${propertyAccessor} ${operatorExpression}`;
+  }
+
+  const value = propValue.value;
+  if (operator === PropertyFilterRuleOperator.Like && typeof value === "string") {
+    return `${propertyAccessor} ${operatorExpression} "%${value.replace(/"/g, `""`)}%"`;
+  }
+
+  let valueExpression = "";
+  switch (typeof value) {
+    case "string":
+      valueExpression = `"${value.replace(/"/g, `""`)}"`;
+      break;
+    case "number":
+      valueExpression = value.toString();
+      break;
+  }
+  if (property.type === "navigation") {
+    valueExpression = (value as Primitives.InstanceKey).id;
+  }
+
+  if (property.type === "double")
+    return `CompareDoubles(${propertyAccessor}, ${valueExpression}) ${operatorExpression} 0`;
+  if (property.type === "dateTime")
+    return `CompareDateTimes(${propertyAccessor}, ${valueExpression}) ${operatorExpression} 0`;
+
+  return `${propertyAccessor} ${operatorExpression} ${valueExpression}`;
+}
+
+function getGroupOperatorString(operator: PropertyFilterRuleGroupOperator) {
+  switch (operator) {
+    case PropertyFilterRuleGroupOperator.And:
+      return "AND";
+    case PropertyFilterRuleGroupOperator.Or:
+      return "OR";
+    default:
+      throw new Error(`Invalid PropertyFilterRuleGroupOperator encountered: ${operator}`);
+  }
+}
+
+function getRuleOperatorString(operator: PropertyFilterRuleOperator) {
+  switch (operator) {
+    case PropertyFilterRuleOperator.Greater:
+      return ">";
+    case PropertyFilterRuleOperator.GreaterOrEqual:
+      return ">=";
+    case PropertyFilterRuleOperator.IsEqual:
+      return "=";
+    case PropertyFilterRuleOperator.IsFalse:
+      return "IS FALSE";
+    case PropertyFilterRuleOperator.IsNotEqual:
+      return "<>";
+    case PropertyFilterRuleOperator.IsNotNull:
+      return "IS NOT NULL";
+    case PropertyFilterRuleOperator.IsNull:
+      return "IS NULL";
+    case PropertyFilterRuleOperator.IsTrue:
+      return "IS TRUE";
+    case PropertyFilterRuleOperator.Less:
+      return "<";
+    case PropertyFilterRuleOperator.LessOrEqual:
+      return "<=";
+    case PropertyFilterRuleOperator.Like:
+      return "LIKE";
+    default:
+      throw new Error(`Invalid PropertyFilterRuleOperator encountered: ${operator}`);
+  }
+}
+
+function isFilterConditionGroup(obj: PresentationInstanceFilter): obj is PresentationInstanceFilterConditionGroup {
+  return (obj as PresentationInstanceFilterConditionGroup).conditions !== undefined;
+}
+
+const hierarchyProviders = new Map<string, ECClassHierarchyProvider>();
+async function getImodelClassHierarchyProvider(imodel: IModelConnection) {
+  let hierarchyProvider = hierarchyProviders.get(imodel.key);
+  if (!hierarchyProvider) {
+    hierarchyProvider = await ECClassHierarchyProvider.create(imodel);
+    hierarchyProviders.set(imodel.key, hierarchyProvider);
+    // istanbul ignore next
+    imodel.onClose.addOnce(() => {
+      hierarchyProviders.delete(imodel.key);
+    });
+  }
+  return hierarchyProvider;
+}
+
+async function findBaseExpressionClass(imodel: IModelConnection, propertyClasses: ClassInfo[]) {
+  if (propertyClasses.length === 1)
+    return propertyClasses[0];
+
+  const hierarchyProvider = await getImodelClassHierarchyProvider(imodel);
+  const [firstClass, ...restClasses] = propertyClasses;
+  let currentBaseClass = firstClass;
+  for (const propClass of restClasses) {
+    const propHierarchy = hierarchyProvider.getClassHierarchy(propClass.id);
+    if (propHierarchy.is(currentBaseClass.id, { isBase: true })) {
+      currentBaseClass = propClass;
+    }
+  }
+  return currentBaseClass;
+}

--- a/presentation/components/src/presentation-components/instance-filter-builder/Types.ts
+++ b/presentation/components/src/presentation-components/instance-filter-builder/Types.ts
@@ -6,7 +6,7 @@
  * @module InstancesFilter
  */
 
-import { PropertyDescription, PropertyValue } from "@itwin/appui-abstract";
+import { PrimitiveValue, PropertyDescription } from "@itwin/appui-abstract";
 import { PropertyFilterRuleGroupOperator, PropertyFilterRuleOperator } from "@itwin/components-react";
 import { ClassId, PropertiesField } from "@itwin/presentation-common";
 
@@ -23,12 +23,12 @@ export interface PresentationInstanceFilterConditionGroup {
 export interface PresentationInstanceFilterCondition {
   operator: PropertyFilterRuleOperator;
   field: PropertiesField;
-  value?: PropertyValue;
+  value?: PrimitiveValue;
 }
 
 /** @alpha */
 export interface InstanceFilterPropertyInfo {
-  sourceClassIds: ClassId[];
+  sourceClassId: ClassId;
   field: PropertiesField;
   propertyDescription: PropertyDescription;
   className: string;

--- a/presentation/components/src/test/instance-filter-builder/InstanceFilterConverter.test.ts
+++ b/presentation/components/src/test/instance-filter-builder/InstanceFilterConverter.test.ts
@@ -1,0 +1,477 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import sinon from "sinon";
+import { PropertyValue, PropertyValueFormat } from "@itwin/appui-abstract";
+import { PropertyFilterRuleGroupOperator, PropertyFilterRuleOperator } from "@itwin/components-react";
+import { BeEvent, Id64String } from "@itwin/core-bentley";
+import { IModelConnection } from "@itwin/core-frontend";
+import { ClassInfo, RelationshipPath } from "@itwin/presentation-common";
+import { createTestNestedContentField, createTestPropertiesContentField, createTestPropertyInfo } from "@itwin/presentation-common/lib/cjs/test";
+import { ClassHierarchy, ECClassHierarchyProvider } from "../../presentation-components/instance-filter-builder/ECClassesHierarchy";
+import { convertToInstanceFilterDefinition } from "../../presentation-components/instance-filter-builder/InstanceFilterConverter";
+import {
+  PresentationInstanceFilterCondition, PresentationInstanceFilterConditionGroup,
+} from "../../presentation-components/instance-filter-builder/Types";
+
+describe("convertToInstanceFilterDefinition", () => {
+  describe("converts single condition with", () => {
+    const testImodel = {} as IModelConnection;
+    const property = createTestPropertyInfo();
+    const field = createTestPropertiesContentField({ properties: [{ property }] });
+    const value: PropertyValue = { valueFormat: PropertyValueFormat.Primitive, value: 1 };
+    const propertyAccessor = `this.${property.name}`;
+
+    describe("operator", () => {
+      it("'IsNull'", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.IsNull,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} IS NULL`);
+      });
+
+      it("'IsNotNull'", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.IsNotNull,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} IS NOT NULL`);
+      });
+
+      it("'IsTrue'", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.IsTrue,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} IS TRUE`);
+      });
+
+      it("'IsFalse'", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.IsFalse,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} IS FALSE`);
+      });
+
+      it("'='", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.IsEqual,
+          value,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} = 1`);
+      });
+
+      it("'!='", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.IsNotEqual,
+          value,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} <> 1`);
+      });
+
+      it("'>'", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.Greater,
+          value,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} > 1`);
+      });
+
+      it("'>='", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.GreaterOrEqual,
+          value,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} >= 1`);
+      });
+
+      it("'<'", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.Less,
+          value,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} < 1`);
+      });
+
+      it("'<='", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.LessOrEqual,
+          value,
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} <= 1`);
+      });
+
+      it("'Like'", async () => {
+        const filter: PresentationInstanceFilterCondition = {
+          field,
+          operator: PropertyFilterRuleOperator.Like,
+          value: { valueFormat: PropertyValueFormat.Primitive, value: `someString` },
+        };
+        const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+        expect(expression).to.be.eq(`${propertyAccessor} LIKE "%someString%"`);
+      });
+    });
+
+    it("quoted string value", async () => {
+      const filter: PresentationInstanceFilterCondition = {
+        field,
+        operator: PropertyFilterRuleOperator.IsEqual,
+        value: { ...value, value: `string "with" quotation marks` },
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`${propertyAccessor} = "string ""with"" quotation marks"`);
+    });
+
+    it("instance key value", async () => {
+      const propertyInfo = createTestPropertyInfo({ type: "navigation" });
+      const filter: PresentationInstanceFilterCondition = {
+        field: createTestPropertiesContentField({ properties: [{ property: propertyInfo }] }),
+        operator: PropertyFilterRuleOperator.IsEqual,
+        value: { ...value, value: { className: "TestSchema:TestClass", id: "0x1" } },
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`${propertyAccessor} = 0x1`);
+    });
+
+    it("double value", async () => {
+      const propertyInfo = createTestPropertyInfo({ type: "double" });
+      const filter: PresentationInstanceFilterCondition = {
+        field: createTestPropertiesContentField({ properties: [{ property: propertyInfo }] }),
+        operator: PropertyFilterRuleOperator.IsEqual,
+        value: { ...value, value: 1.5 },
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`CompareDoubles(${propertyAccessor}, 1.5) = 0`);
+    });
+
+    it("dateTime value", async () => {
+      const propertyInfo = createTestPropertyInfo({ type: "dateTime" });
+      const filter: PresentationInstanceFilterCondition = {
+        field: createTestPropertiesContentField({ properties: [{ property: propertyInfo }] }),
+        operator: PropertyFilterRuleOperator.IsEqual,
+        value: { ...value, value: "2021-10-12T08:45:41" },
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`CompareDateTimes(${propertyAccessor}, "2021-10-12T08:45:41") = 0`);
+    });
+
+    it("invalid operator", async () => {
+      const filter: PresentationInstanceFilterCondition = {
+        field: createTestPropertiesContentField({ properties: [{ property }] }),
+        operator: "invalid" as unknown as PropertyFilterRuleOperator,
+      };
+      await expect(convertToInstanceFilterDefinition(filter, testImodel)).to.be.rejected;
+    });
+  });
+
+  describe("converts condition group with", () => {
+    const testImodel = {} as IModelConnection;
+    const property = createTestPropertyInfo();
+    const field = createTestPropertiesContentField({ properties: [{ property }] });
+    const propertyAccessor = `this.${property.name}`;
+
+    it("'AND' operator", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.And,
+        conditions: [{
+          field,
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field,
+          operator: PropertyFilterRuleOperator.IsNotNull,
+        }],
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`(${propertyAccessor} IS NULL AND ${propertyAccessor} IS NOT NULL)`);
+    });
+
+    it("'AND' operator", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.Or,
+        conditions: [{
+          field,
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field,
+          operator: PropertyFilterRuleOperator.IsNotNull,
+        }],
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`(${propertyAccessor} IS NULL OR ${propertyAccessor} IS NOT NULL)`);
+    });
+
+    it("nested condition group", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.Or,
+        conditions: [{
+          field,
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          operator: PropertyFilterRuleGroupOperator.And,
+          conditions: [{
+            field,
+            operator: PropertyFilterRuleOperator.IsNull,
+          }, {
+            field,
+            operator: PropertyFilterRuleOperator.IsNotNull,
+          }],
+        }],
+      };
+      const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`(${propertyAccessor} IS NULL OR (${propertyAccessor} IS NULL AND ${propertyAccessor} IS NOT NULL))`);
+    });
+
+    it("invalid operator", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: "invalid" as unknown as PropertyFilterRuleGroupOperator,
+        conditions: [{
+          field,
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field,
+          operator: PropertyFilterRuleOperator.IsNotNull,
+        }],
+      };
+      await expect(convertToInstanceFilterDefinition(filter, testImodel)).to.be.rejected;
+    });
+  });
+
+  describe("handles related property", () => {
+    function createAlias(className: string) {
+      return `rel_${className}`;
+    }
+
+    const testImodel = {} as IModelConnection;
+    const classAInfo: ClassInfo = { id: "0x1", name: "TestSchema:A", label: "A Class" };
+    const classBInfo: ClassInfo = { id: "0x2", name: "TestSchema:B", label: "B Class" };
+    const classCInfo: ClassInfo = { id: "0x3", name: "TestSchema:C", label: "C Class" };
+    const classAToBInfo: ClassInfo = { id: "0x4", name: "TestSchema:AToB", label: "A To B" };
+    const classBToCInfo: ClassInfo = { id: "0x5", name: "TestSchema:BToC", label: "B TO C" };
+    const pathBToA: RelationshipPath = [{
+      sourceClassInfo: classBInfo,
+      targetClassInfo: classAInfo,
+      relationshipInfo: classAToBInfo,
+      isForwardRelationship: false,
+      isPolymorphicRelationship: true,
+      isPolymorphicTargetClass: true,
+    }];
+    const pathCToB: RelationshipPath = [{
+      sourceClassInfo: classCInfo,
+      targetClassInfo: classBInfo,
+      relationshipInfo: classBToCInfo,
+      isForwardRelationship: false,
+      isPolymorphicRelationship: true,
+      isPolymorphicTargetClass: true,
+    }];
+    const propertyInfo = createTestPropertyInfo({ classInfo: classCInfo });
+    const classCPropertiesField = createTestPropertiesContentField({ properties: [{ property: propertyInfo }] });
+    const classCNestedField = createTestNestedContentField({ nestedFields: [classCPropertiesField], pathToPrimaryClass: pathCToB });
+    const classBNestedField = createTestNestedContentField({ nestedFields: [classCNestedField], pathToPrimaryClass: pathBToA });
+
+    beforeEach(() => {
+      classCPropertiesField.resetParentship();
+      classCNestedField.resetParentship();
+      classBNestedField.resetParentship();
+    });
+
+    it("in single condition", async () => {
+      classCPropertiesField.rebuildParentship(classCNestedField);
+      const filter: PresentationInstanceFilterCondition = {
+        field: classCPropertiesField,
+        operator: PropertyFilterRuleOperator.IsNull,
+      };
+      const { expression, relatedInstances } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`${createAlias("C")}.${propertyInfo.name} IS NULL`);
+      expect(relatedInstances).to.be.lengthOf(1).and.containSubset([{
+        pathFromSelectToPropertyClass: [{
+          sourceClassName: classBInfo.name,
+          targetClassName: classCInfo.name,
+          relationshipName: classBToCInfo.name,
+          isForwardRelationship: true,
+        }],
+        alias: createAlias("C"),
+      }]);
+    });
+
+    it("in multiple conditions", async () => {
+      classCPropertiesField.rebuildParentship(classCNestedField);
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.And,
+        conditions: [{
+          field: classCPropertiesField,
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field: classCPropertiesField,
+          operator: PropertyFilterRuleOperator.IsNotNull,
+        }],
+      };
+      const { expression, relatedInstances } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`(${createAlias("C")}.${propertyInfo.name} IS NULL AND ${createAlias("C")}.${propertyInfo.name} IS NOT NULL)`);
+      expect(relatedInstances).to.be.lengthOf(1).and.containSubset([{
+        pathFromSelectToPropertyClass: [{
+          sourceClassName: classBInfo.name,
+          targetClassName: classCInfo.name,
+          relationshipName: classBToCInfo.name,
+          isForwardRelationship: true,
+        }],
+        alias: createAlias("C"),
+      }]);
+    });
+
+    it("in deeply nested condition field", async () => {
+      classCPropertiesField.rebuildParentship(classCNestedField);
+      classCNestedField.rebuildParentship(classBNestedField);
+      const filter: PresentationInstanceFilterCondition = {
+        field: classCPropertiesField,
+        operator: PropertyFilterRuleOperator.IsNull,
+      };
+      const { expression, relatedInstances } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(expression).to.be.eq(`${createAlias("C")}.${propertyInfo.name} IS NULL`);
+      expect(relatedInstances).to.be.lengthOf(1).and.containSubset([{
+        pathFromSelectToPropertyClass: [{
+          sourceClassName: classAInfo.name,
+          targetClassName: classBInfo.name,
+          relationshipName: classAToBInfo.name,
+          isForwardRelationship: true,
+        }, {
+          sourceClassName: classBInfo.name,
+          targetClassName: classCInfo.name,
+          relationshipName: classBToCInfo.name,
+          isForwardRelationship: true,
+        }],
+        alias: createAlias("C"),
+      }]);
+    });
+  });
+
+  describe("returns base properties class", () => {
+    const testImodel = {
+      key: "imodel_key",
+      onClose: new BeEvent(),
+    } as IModelConnection;
+
+    const classAInfo: ClassInfo = { id: "0x1", name: "TestSchema:A", label: "A Class" };
+    const classBInfo: ClassInfo = { id: "0x2", name: "TestSchema:B", label: "B Class" };
+    const classCInfo: ClassInfo = { id: "0x3", name: "TestSchema:C", label: "C Class" };
+
+    beforeEach(() => {
+      const hierarchyProvider = {
+        getClassHierarchy: (id: Id64String) => {
+          switch (id) {
+            case classAInfo.id:
+              return new ClassHierarchy(classAInfo.id, new Set(), new Set([classBInfo.id, classCInfo.id]));
+            case classBInfo.id:
+              return new ClassHierarchy(classBInfo.id, new Set([classAInfo.id]), new Set([classCInfo.id]));
+            case classCInfo.id:
+              return new ClassHierarchy(classCInfo.id, new Set([classAInfo.id, classBInfo.id]), new Set());
+          }
+          return new ClassHierarchy(classCInfo.id, new Set(), new Set());
+        },
+      } as ECClassHierarchyProvider;
+
+      sinon.stub(ECClassHierarchyProvider, "create").resolves(hierarchyProvider);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("when one property is used", async () => {
+      const filter: PresentationInstanceFilterCondition = {
+        field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classAInfo, name: "PropA" }) }] }),
+        operator: PropertyFilterRuleOperator.IsNull,
+      };
+
+      const { selectClassName } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(selectClassName).to.be.eq(classAInfo.name);
+    });
+
+    it("when all properties from same class", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.And,
+        conditions: [{
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classAInfo, name: "PropA1" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classAInfo, name: "PropA2" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }],
+      };
+
+      const { selectClassName } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(selectClassName).to.be.eq(classAInfo.name);
+    });
+
+    it("when second condition property is derived from first condition property", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.And,
+        conditions: [{
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classAInfo, name: "PropA" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classBInfo, name: "PropB" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }],
+      };
+
+      const { selectClassName } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(selectClassName).to.be.eq(classBInfo.name);
+    });
+
+    it("when first condition property is derived from second condition property", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.And,
+        conditions: [{
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classBInfo, name: "PropB" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classAInfo, name: "PropA" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }],
+      };
+
+      const { selectClassName } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(selectClassName).to.be.eq(classBInfo.name);
+    });
+
+    it("when properties from different derived classes are used", async () => {
+      const filter: PresentationInstanceFilterConditionGroup = {
+        operator: PropertyFilterRuleGroupOperator.And,
+        conditions: [{
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classAInfo, name: "PropA" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classCInfo, name: "PropC" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }, {
+          field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ classInfo: classBInfo, name: "PropB" }) }] }),
+          operator: PropertyFilterRuleOperator.IsNull,
+        }],
+      };
+
+      const { selectClassName } = await convertToInstanceFilterDefinition(filter, testImodel);
+      expect(selectClassName).to.be.eq(classCInfo.name);
+    });
+  });
+});

--- a/presentation/components/src/test/instance-filter-builder/PresentationInstanceFilterBuilder.test.tsx
+++ b/presentation/components/src/test/instance-filter-builder/PresentationInstanceFilterBuilder.test.tsx
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 import { expect } from "chai";
 import * as React from "react";
 import sinon from "sinon";
@@ -28,7 +29,7 @@ import { INSTANCE_FILTER_FIELD_SEPARATOR } from "../../presentation-components/i
 import { stubRaf } from "./Common";
 
 export const createTestInstanceFilterPropertyInfo = (props?: Partial<InstanceFilterPropertyInfo>) => ({
-  sourceClassIds: ["0x1"],
+  sourceClassId: "0x1",
   field: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo() }], category: createTestCategoryDescription() }),
   propertyDescription: {
     name: "TestName",
@@ -119,7 +120,6 @@ describe("usePresentationInstanceFilteringProps", () => {
   interface HookProps {
     descriptor: Descriptor;
     classHierarchyProvider?: ECClassHierarchyProvider;
-    enableClassFiltering?: boolean;
   }
 
   const category = createTestCategoryDescription({ name: "root", label: "Root" });
@@ -166,7 +166,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
   it("initializes class list from descriptor", () => {
     const { result } = renderHook(
-      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
       { initialProps });
     expect(result.current.classes).to.have.lengthOf(2).and.to.containSubset([
       concreteClass1,
@@ -176,7 +176,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
   it("updates selected classes when 'onClassSelected' is called", () => {
     const { result } = renderHook(
-      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
       { initialProps });
     result.current.onClassSelected(concreteClass1);
     expect(result.current.selectedClasses).to.have.lengthOf(1).and.to.containSubset([
@@ -186,7 +186,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
   it("updates selected classes when 'onClassDeselected' is called", () => {
     const { result } = renderHook(
-      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
       { initialProps });
     result.current.onClassSelected(concreteClass1);
     expect(result.current.selectedClasses).to.have.lengthOf(1).and.to.containSubset([
@@ -198,7 +198,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
   it("does not change selected classes when 'onClassDeselected' is called with not selected class", () => {
     const { result } = renderHook(
-      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
       { initialProps });
     result.current.onClassSelected(concreteClass1);
     expect(result.current.selectedClasses).to.have.lengthOf(1).and.to.containSubset([
@@ -212,7 +212,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
   it("clears selected classes when 'onClearClasses' is called", () => {
     const { result } = renderHook(
-      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+      (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
       { initialProps });
     result.current.onClassSelected(concreteClass1);
     expect(result.current.selectedClasses).to.have.lengthOf(1).and.to.containSubset([
@@ -238,7 +238,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
     it("returns properties only of selected class", () => {
       const { result } = renderHook(
-        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
         { initialProps: { ...initialProps, classHierarchyProvider } });
 
       result.current.onClassSelected(concreteClass2);
@@ -247,27 +247,8 @@ describe("usePresentationInstanceFilteringProps", () => {
 
     it("selects classes that have selected property", () => {
       const { result } = renderHook(
-        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
-        { initialProps: { ...initialProps, classHierarchyProvider, enableClassFiltering: true } });
-
-      const property = result.current.properties.find((prop) => prop.displayLabel === concretePropertiesField2.label);
-      result.current.onPropertySelected(property!);
-      expect(result.current.selectedClasses).to.have.lengthOf(1).and.containSubset([
-        concreteClass2,
-      ]);
-    });
-
-    it("removes selected class that does not have selected property", () => {
-      const { result } = renderHook(
-        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
-        { initialProps: { ...initialProps, classHierarchyProvider, enableClassFiltering: true } });
-
-      result.current.onClassSelected(concreteClass1);
-      result.current.onClassSelected(concreteClass2);
-      expect(result.current.selectedClasses).to.have.lengthOf(2).and.containSubset([
-        concreteClass1,
-        concreteClass2,
-      ]);
+        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
+        { initialProps: { ...initialProps, classHierarchyProvider } });
 
       const property = result.current.properties.find((prop) => prop.displayLabel === concretePropertiesField2.label);
       result.current.onPropertySelected(property!);
@@ -278,7 +259,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
     it("selects all derived classes that have selected property", () => {
       const { result } = renderHook(
-        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
         { initialProps: { ...initialProps, classHierarchyProvider, enableClassFiltering: true } });
 
       const property = result.current.properties.find((prop) => prop.displayLabel === basePropertiesField.label);
@@ -291,7 +272,7 @@ describe("usePresentationInstanceFilteringProps", () => {
 
     it("does not change selected classes when selected property class is already selected", () => {
       const { result } = renderHook(
-        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
         { initialProps: { ...initialProps, classHierarchyProvider, enableClassFiltering: true } });
 
       result.current.onClassSelected(concreteClass2);
@@ -305,19 +286,9 @@ describe("usePresentationInstanceFilteringProps", () => {
       ]);
     });
 
-    it("does not change selected classes when filtering by properties is disabled", () => {
-      const { result } = renderHook(
-        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
-        { initialProps: { ...initialProps, classHierarchyProvider, enableClassFiltering: false } });
-
-      const property = result.current.properties.find((prop) => prop.displayLabel === concretePropertiesField2.label);
-      result.current.onPropertySelected(property!);
-      expect(result.current.selectedClasses).to.be.empty;
-    });
-
     it("does not change selected classes when 'onPropertySelected' is invoked with invalid property", () => {
       const { result } = renderHook(
-        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider, props.enableClassFiltering),
+        (props: HookProps) => usePresentationInstanceFilteringProps(props.descriptor, props.classHierarchyProvider),
         { initialProps: { ...initialProps, classHierarchyProvider, enableClassFiltering: true } });
 
       result.current.onPropertySelected({ name: "invalidProp", displayLabel: "InvalidProp", typename: "string" });

--- a/presentation/components/src/test/instance-filter-builder/Utils.test.snap
+++ b/presentation/components/src/test/instance-filter-builder/Utils.test.snap
@@ -36,9 +36,7 @@ Array [
       "name": "nested1#PropertiesField",
       "typename": "string",
     },
-    "sourceClassIds": Array [
-      "0x1",
-    ],
+    "sourceClassId": "0x1",
   },
   Object {
     "categoryLabel": "Nested Category 2 | Nested Category 2 1",
@@ -74,9 +72,7 @@ Array [
       "name": "nested2/nested21#PropertiesField",
       "typename": "string",
     },
-    "sourceClassIds": Array [
-      "0x1",
-    ],
+    "sourceClassId": "0x1",
   },
 ]
 `;
@@ -117,9 +113,7 @@ Array [
       "name": "#PropertiesField",
       "typename": "string",
     },
-    "sourceClassIds": Array [
-      "0x1",
-    ],
+    "sourceClassId": "0x1",
   },
   Object {
     "categoryLabel": undefined,
@@ -155,9 +149,7 @@ Array [
       "name": "#PropertiesField",
       "typename": "string",
     },
-    "sourceClassIds": Array [
-      "0x1",
-    ],
+    "sourceClassId": "0x1",
   },
 ]
 `;
@@ -198,7 +190,7 @@ Array [
       "name": "#NestedContentField$PropertiesField",
       "typename": "string",
     },
-    "sourceClassIds": Array [],
+    "sourceClassId": "0x2",
   },
   Object {
     "categoryLabel": undefined,
@@ -234,7 +226,7 @@ Array [
       "name": "#NestedContentField$PropertiesField",
       "typename": "string",
     },
-    "sourceClassIds": Array [],
+    "sourceClassId": "0x2",
   },
 ]
 `;

--- a/presentation/components/src/test/instance-filter-builder/Utils.test.ts
+++ b/presentation/components/src/test/instance-filter-builder/Utils.test.ts
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { PropertyDescription } from "@itwin/appui-abstract";
-import { PropertyFilterRuleGroup, PropertyFilterRuleGroupOperator, PropertyFilterRuleOperator } from "@itwin/components-react";
+import { PropertyDescription, PropertyValueFormat } from "@itwin/appui-abstract";
+import { PropertyFilterRule, PropertyFilterRuleGroup, PropertyFilterRuleGroupOperator, PropertyFilterRuleOperator } from "@itwin/components-react";
 import { Field } from "@itwin/presentation-common";
 import {
   createTestCategoryDescription, createTestContentDescriptor, createTestECClassInfo, createTestNestedContentField, createTestPropertiesContentField,
@@ -150,6 +150,15 @@ describe("createPresentationInstanceFilter", () => {
         property: { name: `${INSTANCE_FILTER_FIELD_SEPARATOR}invalidFieldName`, displayLabel: "Prop2", typename: "string" },
         operator: PropertyFilterRuleOperator.IsNull,
       }],
+    };
+    expect(createPresentationInstanceFilter(descriptor, filter)).to.be.undefined;
+  });
+
+  it("returns undefined when rule has non primitive value", () => {
+    const filter: PropertyFilterRule = {
+      property: { name: getPropertyDescriptionName(propertyField1), displayLabel: "Prop1", typename: "string" },
+      operator: PropertyFilterRuleOperator.IsEqual,
+      value: { valueFormat: PropertyValueFormat.Array, items: [], itemsTypeName: "number" },
     };
     expect(createPresentationInstanceFilter(descriptor, filter)).to.be.undefined;
   });

--- a/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleProperty.tsx
+++ b/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleProperty.tsx
@@ -50,6 +50,7 @@ export function PropertyFilterBuilderRuleProperty(props: PropertyFilterBuilderRu
         placeholder: UiComponents.translate("filterBuilder.chooseProperty"),
       }}
       itemRenderer={itemRenderer}
+      enableVirtualization={true}
     />
   </div>;
 }

--- a/ui/components-react/src/test/filter-builder/FilterBuilderRule.test.tsx
+++ b/ui/components-react/src/test/filter-builder/FilterBuilderRule.test.tsx
@@ -100,8 +100,13 @@ describe("PropertyFilterBuilderRuleRenderer", () => {
     it("renders with property renderer", () => {
       const actions = new PropertyFilterBuilderActions(sinon.spy());
       const propertyRendererSpy = sinon.spy();
-      renderWithContext(<PropertyFilterBuilderRuleRenderer {...defaultProps} />,
+      const { container } = renderWithContext(<PropertyFilterBuilderRuleRenderer {...defaultProps} />,
         { actions, properties: [defaultProperty] }, { propertyRenderer: propertyRendererSpy });
+
+      // open property selector menu
+      const selector = container.querySelector<HTMLInputElement>(".rule-property input");
+      expect(selector).to.not.be.null;
+      fireEvent.focus(selector!);
 
       expect(propertyRendererSpy).to.be.calledWith(defaultProperty.name);
     });


### PR DESCRIPTION
* Added type for more complex instance filters than string ECExpression based on #3618
* Added convert function to allow converting PresentationInstanceFilterBuilder output to the new InstanceFilterDefinition object.
* Changed PresentationInstanceFilterBuilder to always select classes when selecting properties in rules instead of controlling this behavior through props.
* Changed PresentationInstanceFilterBuilder to show only properties that are available on all selected classes.
* Enabled properties selector virtualization in FilterBuilder.