### PR TITLE
support ui items provider callbacks when registering

### DIFF
--- a/common/api/appui-abstract.api.md
+++ b/common/api/appui-abstract.api.md
@@ -2138,7 +2138,7 @@ export class UiItemsManager {
     static getWidgets(stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection, zoneLocation?: AbstractZoneLocation, stageAppData?: any): ReadonlyArray<AbstractWidgetProps>;
     static get hasRegisteredProviders(): boolean;
     static readonly onUiProviderRegisteredEvent: BeEvent<(ev: UiItemProviderRegisteredEventArgs) => void>;
-    static register(uiProvider: UiItemsProvider, overrides?: UiItemProviderOverrides): void;
+    static register(uiProvider: UiItemsProvider, overrides?: UiItemProviderOverrides, callbacks?: UiItemsProviderCallbacks): void;
     static get registeredProviderIds(): string[];
     static unregister(uiProviderId: string): void;
 }
@@ -2151,6 +2151,18 @@ export interface UiItemsProvider {
     provideStatusBarItems?: (stageId: string, stageUsage: string, stageAppData?: any) => CommonStatusBarItem[];
     provideToolbarButtonItems?: (stageId: string, stageUsage: string, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation, stageAppData?: any) => CommonToolbarItem[];
     provideWidgets?: (stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection, zoneLocation?: AbstractZoneLocation, stageAppData?: any) => ReadonlyArray<AbstractWidgetProps>;
+}
+
+// @public
+export interface UiItemsProviderCallbacks {
+    // (undocumented)
+    onBackstageItemsCreated?: (items: BackstageItem[]) => void;
+    // (undocumented)
+    onStatusBarItemsCreated?: (items: CommonStatusBarItem[]) => void;
+    // (undocumented)
+    onToolbarButtonItemsCreated?: (items: CommonToolbarItem[]) => void;
+    // (undocumented)
+    onWidgetsCreated?: (items: ReadonlyArray<AbstractWidgetProps>) => void;
 }
 
 // @public (undocumented)

--- a/common/api/summary/appui-abstract.exports.csv
+++ b/common/api/summary/appui-abstract.exports.csv
@@ -174,6 +174,7 @@ public;UiItemsApplicationAction
 deprecated;UiItemsApplicationAction
 public;UiItemsManager
 public;UiItemsProvider
+public;UiItemsProviderCallbacks
 public;class UiLayoutDataProvider 
 public;UiSyncEvent 
 public;UiSyncEventArgs

--- a/common/changes/@itwin/appui-abstract/jasonC-ui-items-provider-callbacks_2022-10-13-14-15.json
+++ b/common/changes/@itwin/appui-abstract/jasonC-ui-items-provider-callbacks_2022-10-13-14-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-abstract",
+      "comment": "support ui item provider callback when registering a provider in the ui items manager",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-abstract"
+}

--- a/ui/appui-abstract/src/appui-abstract/UiItemsManager.ts
+++ b/ui/appui-abstract/src/appui-abstract/UiItemsManager.ts
@@ -68,7 +68,7 @@ export type UiItemProviderOverrides = MarkRequired<AllowedUiItemProviderOverride
  * Callbacks to interact with items created by the ui provider before being handled by the UiItemsManager
  * Can be used for telemetry / error checking / mutating items
  * Note that callbacks will only be invoked when items exist
- * @beta
+ * @public
  */
 export interface UiItemsProviderCallbacks {
   onToolbarButtonItemsCreated?: (items: CommonToolbarItem[]) => void;


### PR DESCRIPTION
This is intended to be a compromise for an ongoing discussion on extending the scope of `UiItemsProvider` overrides set when registering a provider with the `UiItemsManager`.

Instead of committing to that expansion, this PR includes support for passing an optional third argument to the register routine that can be comprised of callbacks which would be invoked with the items created by the provider if any exist before those items are applied in the ui.

This gives an opportunity for the app to mutate those items, but this can also be used for logging / error checking and therefore seems generally useful to have.

@raplemie @NancyMcCallB @GerardasB @JoeZman @calebmshafer 