### PR TITLE
Close widget overflow when panel is collapsed

### DIFF
--- a/common/api/appui-layout-react.api.md
+++ b/common/api/appui-layout-react.api.md
@@ -414,11 +414,12 @@ export interface DragHandleProps extends CommonProps {
 }
 
 // @internal (undocumented)
+export type DragItem = TabDragItem | WidgetDragItem | PanelGripDragItem | ResizeHandleDragItem;
+
+// @internal (undocumented)
 export class DragManager {
     // (undocumented)
     get draggedItem(): Dragged | undefined;
-    // (undocumented)
-    getDraggedIdOfType<T extends DragItem>(type: T["type"]): T["id"] | undefined;
     // (undocumented)
     handleDrag(x: number, y: number): void;
     // (undocumented)
@@ -429,10 +430,6 @@ export class DragManager {
     handleDragUpdate(): void;
     // (undocumented)
     handleTargetChanged(target: DropTargetState | undefined): void;
-    // (undocumented)
-    isDragged(item: DragItem): boolean;
-    // (undocumented)
-    isDraggedType(type: DragItem["type"]): boolean;
     // (undocumented)
     isTargeted(target: DropTargetState): boolean;
     // (undocumented)
@@ -2979,6 +2976,9 @@ export function useDoubleClick(onDoubleClick?: () => void): () => void;
 export function useDrag<T extends HTMLElement>(onDragStart?: (initialPointerPosition: Point, pointerPosition: Point) => void, onDrag?: (position: Point) => void, onDragEnd?: () => void, onTouchStart?: () => void, onDoubleClick?: () => void): (instance: T | null) => void;
 
 // @internal (undocumented)
+export function useDraggedItem(): DragItem | undefined;
+
+// @internal (undocumented)
 export function useDraggedItemId<T extends DragItem>(type: T["type"]): T["id"] | undefined;
 
 // @internal (undocumented)
@@ -3060,9 +3060,6 @@ export interface UseDragWidgetArgs {
     // (undocumented)
     widgetId: WidgetState["id"];
 }
-
-// @internal (undocumented)
-export function useIsDragged(callback: () => boolean): boolean;
 
 // @internal (undocumented)
 export function useIsDraggedItem(item: DragItem): boolean;

--- a/common/api/summary/appui-layout-react.exports.csv
+++ b/common/api/summary/appui-layout-react.exports.csv
@@ -71,6 +71,7 @@ internal;DraggedWidgetManager
 internal;DraggedWidgetManagerProps
 internal;DragHandle 
 internal;DragHandleProps 
+internal;DragItem = TabDragItem | WidgetDragItem | PanelGripDragItem | ResizeHandleDragItem
 internal;DragManager
 internal;DragManagerContext: React_2.Context
 internal;DragProvider: React_2.NamedExoticComponent
@@ -458,6 +459,7 @@ internal;useBorders(widgetId: WidgetState["id"]):
 internal;useCursor(): void
 internal;useDoubleClick(onDoubleClick?: () => void): () => void
 internal;useDrag
+internal;useDraggedItem(): DragItem | undefined
 internal;useDraggedItemId
 internal;useDragItem
 internal;UseDragItemArgs
@@ -471,7 +473,6 @@ internal;useDragToolSettings(args: UseDragToolSettingsArgs): ({ initialPointerPo
 internal;UseDragToolSettingsArgs
 internal;useDragWidget(args: UseDragWidgetArgs): ({ initialPointerPosition, pointerPosition }: DragStartArgs) => void
 internal;UseDragWidgetArgs
-internal;useIsDragged(callback: () => boolean): boolean
 internal;useIsDraggedItem(item: DragItem): boolean
 internal;useIsDraggedType(type: DragItem["type"]): boolean
 internal;useIsMainPanelWidget(): boolean

--- a/common/changes/@itwin/appui-layout-react/close-widget-overflow_2022-10-14-10-17.json
+++ b/common/changes/@itwin/appui-layout-react/close-widget-overflow_2022-10-14-10-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Close widget overflow popup when panel is collapsed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/base/DragManager.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/DragManager.tsx
@@ -376,67 +376,48 @@ export function useDragItem<T extends DragItem>(args: UseDragItemArgs<T>) {
 }
 
 /** @internal */
-export function useIsDragged(callback: () => boolean) {
+export function useDraggedItem() {
   const dragManager = React.useContext(DragManagerContext);
-  const [dragged, setDragged] = React.useState<boolean>(() => callback());
+  const [draggedItem, setDraggedItem] = React.useState<DragItem | undefined>(dragManager.draggedItem?.item);
   React.useEffect(() => {
-    return dragManager.onDragStart.add(() => {
-      setDragged(callback());
+    return dragManager.onDragStart.add((item) => {
+      setDraggedItem(item);
     });
-  }, [callback, dragManager]);
+  }, [dragManager]);
+  React.useEffect(() => {
+    return dragManager.onDragUpdate.add((item) => {
+      setDraggedItem(item);
+    });
+  }, [dragManager]);
   React.useEffect(() => {
     return dragManager.onDragEnd.add(() => {
-      setDragged(callback());
+      setDraggedItem(undefined);
+
     });
-  }, [callback, dragManager]);
-  React.useEffect(() => {
-    return dragManager.onDragUpdate.add(() => {
-      setDragged(callback());
-    });
-  }, [callback, dragManager]);
-  return dragged;
+  }, [dragManager]);
+  return draggedItem;
 }
 
 /** @internal */
 export function useIsDraggedItem(item: DragItem) {
-  const dragManager = React.useContext(DragManagerContext);
-  const handleCallback = React.useCallback(() => {
-    return dragManager.isDragged(item);
-  }, [dragManager, item]);
-  return useIsDragged(handleCallback);
+  const draggedItem = useDraggedItem();
+  return !!draggedItem && draggedItem.id === item.id && draggedItem.type === item.type;
 }
 
 /** @internal */
 export function useIsDraggedType(type: DragItem["type"]) {
-  const dragManager = React.useContext(DragManagerContext);
-  const handleCallback = React.useCallback(() => {
-    return dragManager.isDraggedType(type);
-  }, [dragManager, type]);
-  return useIsDragged(handleCallback);
+  const draggedItem = useDraggedItem();
+  return !!draggedItem && draggedItem.type === type;
 }
 
 /** @internal */
 export function useDraggedItemId<T extends DragItem>(type: T["type"]): T["id"] | undefined {
-  const dragManager = React.useContext(DragManagerContext);
-  const [dragged, setDragged] = React.useState<T["id"] | undefined>(() => {
-    return dragManager.getDraggedIdOfType(type);
-  });
-  React.useEffect(() => {
-    return dragManager.onDragStart.add(() => {
-      setDragged(dragManager.getDraggedIdOfType(type));
-    });
-  }, [dragManager, type]);
-  React.useEffect(() => {
-    return dragManager.onDragEnd.add(() => {
-      setDragged(dragManager.getDraggedIdOfType(type));
-    });
-  }, [dragManager, type]);
-  React.useEffect(() => {
-    return dragManager.onDragUpdate.add(() => {
-      setDragged(dragManager.getDraggedIdOfType(type));
-    });
-  }, [dragManager, type]);
-  return dragged;
+  const draggedItem = useDraggedItem();
+
+  if (draggedItem && draggedItem.type === type) {
+    return draggedItem.id;
+  }
+  return undefined;
 }
 
 /** @internal */
@@ -526,7 +507,8 @@ interface ResizeHandleDragItem {
   widgetId: WidgetState["id"];
 }
 
-type DragItem = TabDragItem | WidgetDragItem | PanelGripDragItem | ResizeHandleDragItem;
+/** @internal */
+export type DragItem = TabDragItem | WidgetDragItem | PanelGripDragItem | ResizeHandleDragItem;
 
 function isResizeHandleDragItem(item: DragItem): item is ResizeHandleDragItem {
   return item.type === "resizeHandle";
@@ -571,10 +553,6 @@ export class DragManager {
     return this._dragged;
   }
 
-  public isDragged(item: DragItem) {
-    return !!this._dragged && this._dragged.item.id === item.id && this._dragged.item.type === item.type;
-  }
-
   public isTargeted(target: DropTargetState) {
     if (!this._dragged)
       return false;
@@ -583,17 +561,6 @@ export class DragManager {
       return false;
 
     return _.isEqual(this._dragged.target, target);
-  }
-
-  public isDraggedType(type: DragItem["type"]) {
-    return !!this._dragged && this._dragged.item.type === type;
-  }
-
-  public getDraggedIdOfType<T extends DragItem>(type: T["type"]): T["id"] | undefined {
-    if (this._dragged && this._dragged.item.type === type) {
-      return this._dragged.item.id;
-    }
-    return undefined;
   }
 
   public get onDragStart(): Event<DragEventHandler> {

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.tsx
@@ -13,7 +13,7 @@ import produce from "immer";
 import { RectangleProps, SizeProps } from "@itwin/core-react";
 import { assert } from "@itwin/core-bentley";
 import { DraggedPanelSideContext } from "../base/DragManager";
-import { AutoCollapseUnpinnedPanelsContext, NineZoneDispatchContext, PanelsStateContext, WidgetsStateContext } from "../base/NineZone";
+import { NineZoneDispatchContext, PanelsStateContext, WidgetsStateContext } from "../base/NineZone";
 import { WidgetState } from "../state/WidgetState";
 import { PanelWidget, PanelWidgetProps } from "../widget/PanelWidget";
 import { WidgetPanelGrip } from "./Grip";
@@ -171,7 +171,6 @@ export const WidgetPanel = React.memo<WidgetPanelProps>(function WidgetPanelComp
   const [transition, setTransition] = React.useState<"init" | "transition" | undefined>();
   const [panelSize, setPanelSize] = React.useState<number | undefined>();
   const [initializing, setInitializing] = React.useState(false);
-  const autoCollapseUnpinnedPanels = React.useContext(AutoCollapseUnpinnedPanelsContext);
 
   const horizontal = isHorizontalPanelSide(panel.side);
   const style = React.useMemo(() => {
@@ -343,26 +342,6 @@ export const WidgetPanel = React.memo<WidgetPanelProps>(function WidgetPanelComp
     }
     return styleToApply;
   }, [horizontal, panel.splitterPercent]);
-
-  React.useLayoutEffect(() => {
-    if (!ref.current || !autoCollapseUnpinnedPanels)
-      return;
-
-    const panelRef = ref.current;
-    const listener = () => {
-      if (collapsing.current || panel.collapsed || panel.pinned)
-        return;
-      dispatch({
-        type: "PANEL_SET_COLLAPSED",
-        collapsed: true,
-        side: panel.side,
-      });
-    };
-    panelRef.addEventListener("mouseleave", listener);
-    return () => {
-      panelRef.removeEventListener("mouseleave", listener);
-    };
-  }, [dispatch, panel.collapsed, panel.pinned, panel.side, autoCollapseUnpinnedPanels]);
 
   const singleSection = panel.widgets.length === 1;
   const showSectionTargets = singleSection && !panel.collapsed;

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Overflow.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Overflow.tsx
@@ -81,12 +81,12 @@ interface WidgetOverflowContextArgs {
 export const WidgetOverflowContext = React.createContext<WidgetOverflowContextArgs | undefined>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
 WidgetOverflowContext.displayName = "nz:WidgetOverflowContext";
 
-function usePanelPopup(onClose?: () => void) {
+function usePanelPopup(onClose: () => void) {
   const panel = React.useContext(PanelStateContext);
   const { collapsed } = panel || {};
   React.useEffect(() => {
     if (collapsed) {
-      onClose?.();
+      onClose();
     }
-  }, [collapsed]);
+  }, [collapsed, onClose]);
 }

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Overflow.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Overflow.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { useRefs, useRefState, useResizeObserver } from "@itwin/core-react";
 import { WidgetMenu } from "./Menu";
 import { useLabel } from "../base/NineZone";
+import { PanelStateContext } from "../widget-panels/Panel";
 
 /** @internal */
 export interface WidgetOverflowProps {
@@ -34,6 +35,7 @@ export const WidgetOverflow = React.memo<WidgetOverflowProps>(function WidgetOve
   const handleClose = React.useCallback(() => {
     setOpen(false);
   }, []);
+  usePanelPopup(handleClose);
   const className = classnames(
     "nz-widget-overflow",
     props.hidden && "nz-hidden",
@@ -78,3 +80,13 @@ interface WidgetOverflowContextArgs {
 /** @internal */
 export const WidgetOverflowContext = React.createContext<WidgetOverflowContextArgs | undefined>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
 WidgetOverflowContext.displayName = "nz:WidgetOverflowContext";
+
+function usePanelPopup(onClose?: () => void) {
+  const panel = React.useContext(PanelStateContext);
+  const { collapsed } = panel || {};
+  React.useEffect(() => {
+    if (collapsed) {
+      onClose?.();
+    }
+  }, [collapsed]);
+}

--- a/ui/appui-layout-react/src/test/base/DragManager.test.tsx
+++ b/ui/appui-layout-react/src/test/base/DragManager.test.tsx
@@ -5,25 +5,11 @@
 import * as React from "react";
 import * as sinon from "sinon";
 import { act, renderHook } from "@testing-library/react-hooks";
-import { DragManager, DragManagerContext, useIsDragged, useIsDraggedType, usePanelTarget, useTabTarget, useTarget, useTargeted } from "../../appui-layout-react";
+import { DragManager, DragManagerContext, useDraggedItem, useIsDraggedType, usePanelTarget, useTabTarget, useTarget, useTargeted } from "../../appui-layout-react";
 import { createDragInfo, createDragStartArgs, setRefValue } from "../Providers";
-import { expect } from "chai";
+import { expect, should } from "chai";
 
 describe("DragManager", () => {
-  describe("isDraggedType", () => {
-    it("should return true", () => {
-      const sut = new DragManager();
-      sut.handleDragStart({
-        info: createDragInfo(),
-        item: {
-          type: "tab",
-          id: "",
-        },
-      });
-      sut.isDraggedType("tab").should.true;
-    });
-  });
-
   describe("handleTargetChanged", () => {
     it("should not update target if not dragging", () => {
       const sut = new DragManager();
@@ -38,7 +24,6 @@ describe("DragManager", () => {
       sinon.assert.calledOnceWithExactly(spy, sinon.match.any, sinon.match.any, undefined);
     });
   });
-
 });
 
 describe("useTabTarget", () => {
@@ -157,6 +142,7 @@ describe("useIsDraggedType", () => {
     const { result } = renderHook(() => useIsDraggedType("tab"), {
       wrapper: (props) => <DragManagerContext.Provider value={dragManager} {...props} />, // eslint-disable-line react/display-name
     });
+    result.current.should.false;
 
     dragManager.handleDragStart({
       info: createDragInfo(),
@@ -169,19 +155,15 @@ describe("useIsDraggedType", () => {
   });
 });
 
-describe("useIsDragged", () => {
-  it("should invoke callback", () => {
+describe("useDraggedItem", () => {
+  it("should return dragged item", () => {
     const dragManager = new DragManager();
-    const stub = sinon.stub();
-    stub.returns(false);
-    const { result } = renderHook(() => useIsDragged(stub), {
+    const { result } = renderHook(() => useDraggedItem(), {
       wrapper: (props) => <DragManagerContext.Provider value={dragManager} {...props} />, // eslint-disable-line react/display-name
     });
-    sinon.assert.calledOnce(stub);
-    expect(result.current).to.be.false;
+    should().equal(result.current, undefined);
 
     act(() => {
-      stub.onCall(1).returns(true);
       dragManager.handleDragStart({
         info: createDragInfo(),
         item: {
@@ -190,21 +172,24 @@ describe("useIsDragged", () => {
         },
       });
     });
-    sinon.assert.calledTwice(stub);
-    expect(result.current).to.be.true;
+    result.current!.should.eql({
+      type: "tab",
+      id: "",
+    });
 
     act(() => {
-      stub.onCall(2).returns(true);
+      dragManager.draggedItem!.item.id = "abc";
       dragManager.handleDragUpdate();
     });
-    sinon.assert.calledThrice(stub);
-    expect(result.current).to.be.true;
+    result.current!.should.eql({
+      type: "tab",
+      id: "abc",
+    });
 
     act(() => {
       dragManager.handleDragEnd();
     });
-    expect(result.current).to.be.false;
-    sinon.assert.callCount(stub, 4);
+    should().equal(result.current, undefined);
   });
 });
 

--- a/ui/appui-layout-react/src/test/widget-panels/AppContent.test.tsx
+++ b/ui/appui-layout-react/src/test/widget-panels/AppContent.test.tsx
@@ -7,8 +7,12 @@ import * as sinon from "sinon";
 import { fireEvent } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { createNineZoneState, NineZoneDispatch, usePanelsAutoCollapse } from "../../appui-layout-react";
-import { setRefValue, TestNineZoneProvider } from "../Providers";
+import { setRefValue, TestNineZoneProvider, TestNineZoneProviderProps } from "../Providers";
 import { updatePanelState } from "../../appui-layout-react/state/internal/PanelStateHelpers";
+
+const wrapper = (props: TestNineZoneProviderProps) => {
+  return (<TestNineZoneProvider {...props} />);
+};
 
 describe("usePanelsAutoCollapse", () => {
   it("should collapse unpinned panels", () => {
@@ -16,11 +20,11 @@ describe("usePanelsAutoCollapse", () => {
     let state = createNineZoneState();
     state = updatePanelState(state, "right", { pinned: false });
     const { result } = renderHook(() => usePanelsAutoCollapse(), {
-      wrapper: (props: any) => <TestNineZoneProvider // eslint-disable-line react/display-name
-        dispatch={dispatch}
-        state={state}
-        {...props}
-      />,
+      wrapper,
+      initialProps: {
+        dispatch,
+        state,
+      },
     });
     const element = document.createElement("div");
     setRefValue(result.current, element);
@@ -32,5 +36,49 @@ describe("usePanelsAutoCollapse", () => {
       side: "right",
       collapsed: true,
     });
+  });
+
+  it("should auto collapse unpinned panels", () => {
+    const dispatch = sinon.stub<NineZoneDispatch>();
+    let state = createNineZoneState();
+    state = updatePanelState(state, "left", { pinned: false });
+    const { result } = renderHook(() => usePanelsAutoCollapse(), {
+      wrapper,
+      initialProps: {
+        dispatch,
+        state,
+        autoCollapseUnpinnedPanels: true,
+      },
+    });
+    const element = document.createElement("div");
+    setRefValue(result.current, element);
+
+    fireEvent.mouseEnter(element);
+
+    sinon.assert.calledOnceWithExactly(dispatch, {
+      type: "PANEL_SET_COLLAPSED",
+      side: "left",
+      collapsed: true,
+    });
+  });
+
+  it("should remove event listeners", () => {
+    const state = createNineZoneState();
+    const { result } = renderHook(() => usePanelsAutoCollapse(), {
+      wrapper,
+      initialProps: {
+        state,
+        autoCollapseUnpinnedPanels: true,
+      },
+    });
+    const element = document.createElement("div");
+    const spy = sinon.spy(element, "removeEventListener");
+    setRefValue(result.current, element);
+    sinon.assert.notCalled(spy);
+
+    setRefValue(result.current, null);
+    sinon.assert.calledTwice(spy);
+    sinon.assert.calledWithExactly(spy, "mousedown", sinon.match.any, sinon.match.any);
+    sinon.assert.calledWithExactly(spy, "mouseenter", sinon.match.any, sinon.match.any);
   });
 });

--- a/ui/appui-layout-react/src/test/widget-panels/Panel.test.tsx
+++ b/ui/appui-layout-react/src/test/widget-panels/Panel.test.tsx
@@ -1035,33 +1035,6 @@ describe("useAnimatePanelWidgets", () => {
     sinon.assert.notCalled(spy);
   });
 
-  it("should transition to panel collapse when collapseUnpinned is set", () => {
-    const dispatch = sinon.stub<NineZoneDispatch>();
-    let state = createNineZoneState();
-    state = addTab(state, "t1");
-    state = addPanelWidget(state, "left", "w1", ["t1"]);
-    state = produce(state, (draft) => {
-      draft.panels.left.size = 200;
-      draft.panels.left.collapsed = false;
-      draft.panels.left.pinned = false;
-    });
-    const { container } = render(
-      <WidgetPanelProvider
-        side="left"
-      />,
-      {
-        wrapper: (props) => <TestNineZoneProvider state={state} {...props} dispatch={dispatch} autoCollapseUnpinnedPanels={true} />,  // eslint-disable-line react/display-name
-      },
-    );
-
-    const panel = container.getElementsByClassName("nz-widgetPanels-panel")[0] as HTMLElement;
-
-    sinon.stub(panel, "getBoundingClientRect").returns(DOMRect.fromRect({ width: 200 }));
-    panel.style.width.should.eq("200px");
-    fireEvent(panel, new MouseEvent("mouseleave"));
-    dispatch.calledWith({ collapsed: true, side: "left", type: "PANEL_SET_COLLAPSED" }).should.be.true;
-  });
-
   it("should not transition to panel collapse when already collapsed and collapseUnpinned is set", () => {
     const dispatch = sinon.stub<NineZoneDispatch>();
 


### PR DESCRIPTION
This PR fixes an issue where widget overflow popup is not closed when a panel is collapsed (when `AutoCollapseUnpinnedPanelsContext` is set to `true`).
Additionally panels will auto-collapse when the app content is hovered instead of when the mouse leaves the panel (since popups are usually rendered outside of panel element tree, resulting in auto-collapse when i.e. a widget overflow popup is hovered).