### PR TITLE
Allow applications to configure max tile cache size

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3071,6 +3071,8 @@ export class IModelHostConfiguration implements IModelHostOptions {
     static defaultLogTileLoadTimeThreshold: number;
     // (undocumented)
     static defaultLogTileSizeThreshold: number;
+    // @internal (undocumented)
+    static defaultMaxTileCacheDbSize: number;
     // (undocumented)
     static defaultTileRequestTimeout: number;
     // @beta (undocumented)
@@ -3110,6 +3112,8 @@ export interface IModelHostOptions {
     logTileLoadTimeThreshold?: number;
     // @internal
     logTileSizeThreshold?: number;
+    // @beta
+    maxTileCacheDbSize?: number;
     // @beta
     restrictTileUrlsByClientIp?: boolean;
     // @beta

--- a/common/changes/@itwin/core-backend/pmc-tile-cache-cleanup_2022-10-15-14-21.json
+++ b/common/changes/@itwin/core-backend/pmc-tile-cache-cleanup_2022-10-15-14-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add IModelHostOptions.maxTileCacheDbSize for limiting the amount of disk space consumed by local tile cache databases.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/IModelHost.test.ts
+++ b/core/backend/src/test/IModelHost.test.ts
@@ -8,7 +8,7 @@ import * as sinon from "sinon";
 import { RpcRegistry } from "@itwin/core-common";
 import { BriefcaseManager } from "../BriefcaseManager";
 import { SnapshotDb } from "../IModelDb";
-import { IModelHost, IModelHostOptions, KnownLocations } from "../IModelHost";
+import { IModelHost, IModelHostConfiguration, IModelHostOptions, KnownLocations } from "../IModelHost";
 import { Schemas } from "../Schema";
 import { AzureBlobStorage } from "../CloudStorageBackend";
 import { KnownTestLocations } from "./KnownTestLocations";
@@ -125,9 +125,9 @@ describe("IModelHost", () => {
       accessKey: "testAccessKey",
     };
 
-    const setUseTileCacheStub = sinon.stub();
+    const setMaxTileCacheSizeStub = sinon.stub();
     sinon.stub(IModelHost, "platform").get(() => ({
-      setUseTileCache: setUseTileCacheStub,
+      setMaxTileCacheSize: setMaxTileCacheSizeStub,
     }));
 
     await IModelHost.startup(config);
@@ -137,7 +137,7 @@ describe("IModelHost", () => {
     assert.isDefined(IModelHost.tileStorage);
     assert.instanceOf(IModelHost.tileStorage!.storage, AzureServerStorage);
     assert.equal((IModelHost.tileStorage!.storage as any)._config.accountName, config.tileCacheAzureCredentials.account);
-    assert.isTrue(setUseTileCacheStub.calledOnceWithExactly(false));
+    assert.isTrue(setMaxTileCacheSizeStub.calledOnceWithExactly(0));
   });
 
   it("should set custom cloud storage provider for tile cache", async () => {
@@ -145,9 +145,9 @@ describe("IModelHost", () => {
     config.tileCacheService = {} as AzureBlobStorage;
     config.tileCacheStorage = {} as ServerStorage;
 
-    const setUseTileCacheStub = sinon.stub();
+    const setMaxTileCacheSizeStub = sinon.stub();
     sinon.stub(IModelHost, "platform").get(() => ({
-      setUseTileCache: setUseTileCacheStub,
+      setMaxTileCacheSize: setMaxTileCacheSizeStub,
     }));
 
     await IModelHost.startup(config);
@@ -155,7 +155,7 @@ describe("IModelHost", () => {
     assert.equal(IModelHost.tileCacheService, config.tileCacheService);
     assert.isDefined(IModelHost.tileStorage);
     assert.equal(IModelHost.tileStorage!.storage, config.tileCacheStorage);
-    assert.isTrue(setUseTileCacheStub.calledOnceWithExactly(false));
+    assert.isTrue(setMaxTileCacheSizeStub.calledOnceWithExactly(0));
   });
 
   it("should throw if both tileCacheService and tileCacheAzureCredentials are set", async () => {
@@ -181,16 +181,33 @@ describe("IModelHost", () => {
   });
 
   it("should use local cache if cloud storage provider for tile cache is not set", async () => {
-    const setUseTileCacheStub = sinon.stub();
+    const setMaxTileCacheSizeStub = sinon.stub();
     sinon.stub(IModelHost, "platform").get(() => ({
-      setUseTileCache: setUseTileCacheStub,
+      setMaxTileCacheSize: setMaxTileCacheSizeStub,
     }));
 
     await IModelHost.startup(opts);
 
     assert.isUndefined(IModelHost.tileCacheService);
     assert.isUndefined(IModelHost.tileUploader);
-    assert.isTrue(setUseTileCacheStub.calledOnceWithExactly(true));
+    assert.isTrue(setMaxTileCacheSizeStub.calledOnceWithExactly(IModelHostConfiguration.defaultMaxTileCacheDbSize));
+  });
+
+  it("should use configured size for local cache", async () => {
+    const setMaxTileCacheSizeStub = sinon.stub();
+    sinon.stub(IModelHost, "platform").get(() => ({
+      setMaxTileCacheSize: setMaxTileCacheSizeStub,
+    }));
+
+    const maxTileCacheDbSize = 123456;
+    await IModelHost.startup({
+      ...opts,
+      maxTileCacheDbSize,
+    });
+
+    assert.isUndefined(IModelHost.tileCacheService);
+    assert.isUndefined(IModelHost.tileUploader);
+    assert.isTrue(setMaxTileCacheSizeStub.calledOnceWithExactly(maxTileCacheDbSize));
   });
 
   it("should cleanup tileCacheService, tileStorageService and tileUploader on shutdown", async () => {


### PR DESCRIPTION
Adds `IModelHostOptions.maxTileCacheDbSize`.
[Corresponding native PR](https://dev.azure.com/bentleycs/iModelTechnologies/_git/imodel02/pullrequest/286803).