### PR TITLE
Rename RestoreFrontstagesLayoutTool to RestoreAllFrontstagesTool

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4489,6 +4489,16 @@ export const ReducerRegistryInstance: ReducerRegistry;
 export function removeMissingWidgets(frontstageDef: FrontstageDef, initialState: NineZoneState): NineZoneState;
 
 // @alpha
+export class RestoreAllFrontstagesTool extends Tool {
+    // (undocumented)
+    static iconSpec: string;
+    // (undocumented)
+    run(): Promise<boolean>;
+    // (undocumented)
+    static toolId: string;
+}
+
+// @alpha
 export class RestoreFrontstageLayoutTool extends Tool {
     // (undocumented)
     static iconSpec: string;
@@ -4500,16 +4510,6 @@ export class RestoreFrontstageLayoutTool extends Tool {
     parseAndRun(...args: string[]): Promise<boolean>;
     // (undocumented)
     run(frontstageId?: string): Promise<boolean>;
-    // (undocumented)
-    static toolId: string;
-}
-
-// @alpha
-export class RestoreFrontstagesLayoutTool extends Tool {
-    // (undocumented)
-    static iconSpec: string;
-    // (undocumented)
-    run(): Promise<boolean>;
     // (undocumented)
     static toolId: string;
 }

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -474,8 +474,8 @@ public;ReducerMapActions
 beta;ReducerRegistry
 beta;ReducerRegistryInstance: ReducerRegistry
 internal;removeMissingWidgets(frontstageDef: FrontstageDef, initialState: NineZoneState): NineZoneState
+alpha;RestoreAllFrontstagesTool 
 alpha;RestoreFrontstageLayoutTool 
-alpha;RestoreFrontstagesLayoutTool 
 internal;restoreNineZoneState(frontstageDef: FrontstageDef, saved: SavedNineZoneState): NineZoneState
 beta;ReviewToolWidget 
 beta;ReviewToolWidgetProps

--- a/common/changes/@itwin/appui-react/rename-restore-frontstages_2022-10-17-11-54.json
+++ b/common/changes/@itwin/appui-react/rename-restore-frontstages_2022-10-17-11-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Rename RestoreFrontstagesLayoutTool to RestoreAllFrontstagesTool.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/public/locales/en/UiFramework.json
+++ b/ui/appui-react/public/locales/en/UiFramework.json
@@ -211,16 +211,16 @@
     "OpenSettings": {
       "keyin": "open settings"
     },
+    "RestoreAllFrontstages": {
+      "keyin": "restore all frontstages",
+      "description": "Restore all Frontstages to Default Layout",
+      "flyover": "Restore all Stages to Default Layout"
+    },
     "RestoreFrontstageLayout": {
       "keyin": "restore frontstage layout",
       "description": "Restore Frontstage to Default Layout",
       "flyover": "Restore Stage to Default Layout",
       "noStageFound": "Specified stage not found."
-    },
-    "RestoreFrontstagesLayout": {
-      "keyin": "restore frontstages layout",
-      "description": "Restore all Frontstages to Default Layout",
-      "flyover": "Restore all Stages to Default Layout"
     },
     "ClearKeyinPaletteHistory": {
       "keyin": "clear keyin history",

--- a/ui/appui-react/src/appui-react/tools/RestoreLayoutTool.ts
+++ b/ui/appui-react/src/appui-react/tools/RestoreLayoutTool.ts
@@ -49,8 +49,8 @@ export class RestoreFrontstageLayoutTool extends Tool {
  * Immediate tool that will reset the layout of all frontstages to that specified in the stage definition.
  * @alpha
  */
-export class RestoreFrontstagesLayoutTool extends Tool {
-  public static override toolId = "RestoreFrontstagesLayout";
+export class RestoreAllFrontstagesTool extends Tool {
+  public static override toolId = "RestoreAllFrontstages";
   public static override iconSpec = "icon-view-layouts";
 
   public override async run() {


### PR DESCRIPTION
This PR renames `RestoreFrontstagesLayoutTool` to `RestoreAllFrontstagesTool`.