### PR TITLE
IModelDb.elements.getElementProps should throw IModelError

### DIFF
--- a/common/changes/@itwin/core-backend/getElementProps-exception_2022-10-18-17-24.json
+++ b/common/changes/@itwin/core-backend/getElementProps-exception_2022-10-18-17-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1545,7 +1545,11 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       } else if (props instanceof Code) {
         props = { code: props };
       }
-      return this._iModel.nativeDb.getElement(props) as T;
+      try {
+        return this._iModel.nativeDb.getElement(props) as T;
+      } catch (err: any) {
+        throw new IModelError(err.errorNumber, err.message);
+      }
     }
 
     /** Get properties of an Element by Id, FederationGuid, or Code

--- a/core/backend/src/test/standalone/TxnManager.test.ts
+++ b/core/backend/src/test/standalone/TxnManager.test.ts
@@ -86,7 +86,7 @@ describe("TxnManager", () => {
     return makeEntity(IModel.getDefaultSubCategoryId(categoryId), "BisCore:SubCategory");
   }
 
-  it("TxnManager", async () => {
+  it.only("TxnManager", async () => {
     const models = imodel.models;
     const elements = imodel.elements;
     const modelId = props.model;
@@ -158,6 +158,7 @@ describe("TxnManager", () => {
     assert.equal(afterUndo, 1);
     assert.equal(undoAction, TxnAction.Reverse);
 
+    assert.throws(() => elements.getElementProps(elementId), IModelError, "reading element");
     assert.throws(() => elements.getElement(elementId), IModelError);
     assert.equal(IModelStatus.Success, txns.reinstateTxn());
     model = models.getModel(modelId);

--- a/core/backend/src/test/standalone/TxnManager.test.ts
+++ b/core/backend/src/test/standalone/TxnManager.test.ts
@@ -86,7 +86,7 @@ describe("TxnManager", () => {
     return makeEntity(IModel.getDefaultSubCategoryId(categoryId), "BisCore:SubCategory");
   }
 
-  it.only("TxnManager", async () => {
+  it("TxnManager", async () => {
     const models = imodel.models;
     const elements = imodel.elements;
     const modelId = props.model;


### PR DESCRIPTION
Fixes Issue #4505 

in 3.4.0, it was throwing `Error`, which is different than older versions and the documentation.