### PR TITLE
Memoize getCustomViewState3dData rpc requests

### DIFF
--- a/common/changes/@itwin/core-backend/pmc-pending-viewstate-request_2022-10-20-17-54.json
+++ b/common/changes/@itwin/core-backend/pmc-pending-viewstate-request_2022-10-20-17-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Return a pending response from calls to IModelReadRpcInterface.getCustomViewState3dData if they take too long.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/PromiseMemoizer.ts
+++ b/core/backend/src/PromiseMemoizer.ts
@@ -114,6 +114,7 @@ export class PromiseMemoizer<T> implements IDisposable {
   public dispose() {
     for (const timer of this._timers.values())
       clearTimeout(timer);
+
     this._timers.clear();
     this.clearCache();
   }

--- a/core/backend/src/PromiseMemoizer.ts
+++ b/core/backend/src/PromiseMemoizer.ts
@@ -67,7 +67,7 @@ export class PromiseMemoizer<T> implements IDisposable {
   }
 
   /** Call the memoized function */
-  public memoize = (...args: any[]): QueryablePromise<T> => {
+  public memoize(...args: any[]): QueryablePromise<T> {
     const key: string = this._generateKeyFn(...args);
     let qp: QueryablePromise<T> | undefined = this._cachedPromises.get(key);
     if (qp)
@@ -95,26 +95,26 @@ export class PromiseMemoizer<T> implements IDisposable {
     qp = new QueryablePromise<T>(p);
     this._cachedPromises.set(key, qp);
     return qp;
-  };
+  }
 
   /** Delete the memoized function */
-  public deleteMemoized = (...args: any[]) => {
+  public deleteMemoized(...args: any[]) {
     const key: string = this._generateKeyFn(...args);
     this._cachedPromises.delete(key);
     const timer = this._timers.get(key);
     if (timer)
       clearTimeout(timer);
-  };
+  }
 
   /** Clear all entries in the memoizer cache */
-  public clearCache = () => {
+  public clearCache() {
     this._cachedPromises.clear();
-  };
+  }
 
-  public dispose = () => {
+  public dispose() {
     for (const timer of this._timers.values())
       clearTimeout(timer);
     this._timers.clear();
     this.clearCache();
-  };
+  }
 }

--- a/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
@@ -53,13 +53,13 @@ abstract class TileRequestMemoizer<Result, Props extends TileRequestProps> exten
     super(memoizeFn, generateKeyFn);
   }
 
-  public override memoize = (props: Props): QueryablePromise<Result> => {
+  public override memoize(props: Props): QueryablePromise<Result> {
     return super.memoize(props);
-  };
+  }
 
-  public override deleteMemoized = (props: Props) => {
+  public override deleteMemoized(props: Props) {
     super.deleteMemoized(props);
-  };
+  }
 
   private log(status: string, props: Props): void {
     const descr = `${this._operationName}(${this.stringify(props)})`;

--- a/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
@@ -53,14 +53,12 @@ abstract class TileRequestMemoizer<Result, Props extends TileRequestProps> exten
     super(memoizeFn, generateKeyFn);
   }
 
-  private _superMemoize = this.memoize;
   public override memoize = (props: Props): QueryablePromise<Result> => {
-    return this._superMemoize(props);
+    return super.memoize(props);
   };
 
-  private _superDeleteMemoized = this.deleteMemoized;
   public override deleteMemoized = (props: Props) => {
-    this._superDeleteMemoized(props);
+    super.deleteMemoized(props);
   };
 
   private log(status: string, props: Props): void {


### PR DESCRIPTION
Fixes #4517
There are no existing tests for `getCustomViewState3dData`, and the new memoization bit would be quite tricky to test.