### PR TITLE
Remove obsolete terrain lighting code

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-remove-terrain-lighting_2022-10-24-19-50.json
+++ b/common/changes/@itwin/core-frontend/pmc-remove-terrain-lighting_2022-10-24-19-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/primitives/SurfaceParams.ts
+++ b/core/frontend/src/render/primitives/SurfaceParams.ts
@@ -67,7 +67,6 @@ export interface SurfaceParams {
   readonly indices: VertexIndices;
   readonly fillFlags: FillFlags;
   readonly hasBakedLighting: boolean;
-  readonly hasFixedNormals: boolean;
   readonly textureMapping?: {
     texture: RenderTexture;
     alwaysDisplayed: boolean;

--- a/core/frontend/src/render/primitives/VertexTable.ts
+++ b/core/frontend/src/render/primitives/VertexTable.ts
@@ -290,7 +290,6 @@ export class MeshParams {
       indices: surfaceIndices,
       fillFlags: args.fillFlags,
       hasBakedLighting: true === args.hasBakedLighting,
-      hasFixedNormals: true === args.hasFixedNormals,
       textureMapping: undefined !== args.textureMapping ? { texture: args.textureMapping.texture, alwaysDisplayed: false } : undefined,
       material: createSurfaceMaterial(args.material),
     };

--- a/core/frontend/src/render/primitives/VertexTableSplitter.ts
+++ b/core/frontend/src/render/primitives/VertexTableSplitter.ts
@@ -670,7 +670,6 @@ export function splitMeshParams(args: SplitMeshArgs): Map<number, MeshParams> {
         indices,
         fillFlags: args.params.surface.fillFlags,
         hasBakedLighting: args.params.surface.hasBakedLighting,
-        hasFixedNormals: args.params.surface.hasFixedNormals,
         textureMapping: args.params.surface.textureMapping,
         material: material !== undefined ? material : args.params.surface.material,
       },

--- a/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshPrimitives.ts
@@ -131,7 +131,6 @@ export interface MeshArgs {
   is2d?: boolean;
   hasBakedLighting?: boolean;
   isVolumeClassifier?: boolean;
-  hasFixedNormals?: boolean;
   auxChannels?: ReadonlyArray<AuxChannel>;
   material?: RenderMaterial;
   textureMapping?: {
@@ -185,7 +184,6 @@ export namespace MeshArgs {
       isPlanar: mesh.isPlanar,
       is2d: mesh.is2d,
       hasBakedLighting: true === mesh.hasBakedLighting,
-      hasFixedNormals: false,
       isVolumeClassifier: true === mesh.isVolumeClassifier,
       edges,
       auxChannels: mesh.auxChannels,

--- a/core/frontend/src/render/webgl/MeshData.ts
+++ b/core/frontend/src/render/webgl/MeshData.ts
@@ -30,7 +30,6 @@ export class MeshData implements WebGLDisposable {
   public readonly edgeLineCode: number; // Must call LineCode.valueFromLinePixels(val: LinePixels) and set the output to edgeLineCode
   public readonly isPlanar: boolean;
   public readonly hasBakedLighting: boolean;
-  public readonly hasFixedNormals: boolean;   // Fixed normals will not be flipped to face front (Terrain skirts).
   public readonly lut: VertexLUT;
   public readonly viewIndependentOrigin?: Point3d;
   private readonly _textureAlwaysDisplayed: boolean;
@@ -57,7 +56,6 @@ export class MeshData implements WebGLDisposable {
     this.fillFlags = params.surface.fillFlags;
     this.isPlanar = params.isPlanar;
     this.hasBakedLighting = params.surface.hasBakedLighting;
-    this.hasFixedNormals = params.surface.hasFixedNormals;
     const edges = params.edges;
     this.edgeWidth = undefined !== edges ? edges.weight : 1;
     this.edgeLineCode = LineCode.valueFromLinePixels(undefined !== edges ? edges.linePixels : LinePixels.Solid);

--- a/core/frontend/src/render/webgl/MeshGeometry.ts
+++ b/core/frontend/src/render/webgl/MeshGeometry.ts
@@ -36,7 +36,6 @@ export abstract class MeshGeometry extends LUTGeometry {
   public get uniformColor(): FloatRgba | undefined { return this.colorInfo.isUniform ? this.colorInfo.uniform : undefined; }
   public get texture() { return this.mesh.texture; }
   public override get hasBakedLighting() { return this.mesh.hasBakedLighting; }
-  public get hasFixedNormals() { return this.mesh.hasFixedNormals; }
   public get lut() { return this.mesh.lut; }
   public get hasScalarAnimation() { return this.mesh.lut.hasScalarAnimation; }
 

--- a/core/frontend/src/render/webgl/RenderFlags.ts
+++ b/core/frontend/src/render/webgl/RenderFlags.ts
@@ -242,7 +242,7 @@ export const enum SurfaceBitIndex {
   BackgroundFill,
   HasColorAndNormal,
   OverrideRgb,
-  NoFaceFront,
+  HasNormalMap,
   HasMaterialAtlas,
   Count,
 }
@@ -272,7 +272,7 @@ export const enum SurfaceFlags {
   // For textured meshes, use rgb from v_color instead of from texture.
   OverrideRgb = 1 << SurfaceBitIndex.OverrideRgb,
   // For geometry with fixed normals (terrain meshes) we must avoid front facing normal reversal or skirts will be incorrectly lit.
-  NoFaceFront = 1 << SurfaceBitIndex.NoFaceFront,
+  HasNormalMap = 1 << SurfaceBitIndex.HasNormalMap,
   HasMaterialAtlas = 1 << SurfaceBitIndex.HasMaterialAtlas,
 }
 

--- a/core/frontend/src/render/webgl/SurfaceGeometry.ts
+++ b/core/frontend/src/render/webgl/SurfaceGeometry.ts
@@ -107,7 +107,6 @@ export class SurfaceGeometry extends MeshGeometry {
   public get techniqueId(): TechniqueId { return TechniqueId.Surface; }
   public override get isLitSurface() { return this.isLit; }
   public override get hasBakedLighting() { return this.mesh.hasBakedLighting; }
-  public override get hasFixedNormals() { return this.mesh.hasFixedNormals; }
   public get renderOrder(): RenderOrder {
     if (FillFlags.Behind === (this.fillFlags & FillFlags.Behind))
       return RenderOrder.BlankingRegion;
@@ -216,15 +215,12 @@ export class SurfaceGeometry extends MeshGeometry {
     flags[SurfaceBitIndex.HasMaterialAtlas] = useMaterial && this.hasMaterialAtlas ? 1 : 0;
 
     flags[SurfaceBitIndex.ApplyLighting] = 0;
-    flags[SurfaceBitIndex.NoFaceFront] = 0;
+    flags[SurfaceBitIndex.HasNormalMap] = 0;
     flags[SurfaceBitIndex.HasColorAndNormal] = 0;
     if (this.isLit) {
       flags[SurfaceBitIndex.HasNormals] = 1;
-      if (wantLighting(vf)) {
+      if (wantLighting(vf))
         flags[SurfaceBitIndex.ApplyLighting] = 1;
-        if (this.hasFixedNormals)
-          flags[SurfaceBitIndex.NoFaceFront] = 1;
-      }
 
       // Textured meshes store normal in place of color index.
       // Untextured lit meshes store normal where textured meshes would store UV coords.

--- a/core/frontend/src/render/webgl/glsl/Lighting.ts
+++ b/core/frontend/src/render/webgl/glsl/Lighting.ts
@@ -27,7 +27,7 @@ const applyLighting = `
   // Extract surface properties
   vec3 rgb = baseColor.rgb;
   vec3 normal = normalize(v_n.xyz);
-  normal *= 2.0 * float(!u_surfaceFlags[kSurfaceBitIndex_NoFaceFront] &&  gl_FrontFacing) - 1.0;
+  normal *= 2.0 * float(gl_FrontFacing) - 1.0;
   vec3 toEye = kFrustumType_Perspective == u_frustum.z ? normalize(v_eyeSpace.xyz) : vec3(0.0, 0.0, -1.0);
 
   // Extract material properties

--- a/core/frontend/src/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/render/webgl/glsl/Surface.ts
@@ -285,7 +285,7 @@ function addSurfaceFlagsLookup(builder: ShaderBuilder) {
   builder.addConstant("kSurfaceBitIndex_BackgroundFill", VariableType.Int, SurfaceBitIndex.BackgroundFill.toString());
   builder.addConstant("kSurfaceBitIndex_HasColorAndNormal", VariableType.Int, SurfaceBitIndex.HasColorAndNormal.toString());
   builder.addConstant("kSurfaceBitIndex_OverrideRgb", VariableType.Int, SurfaceBitIndex.OverrideRgb.toString());
-  builder.addConstant("kSurfaceBitIndex_NoFaceFront", VariableType.Int, SurfaceBitIndex.NoFaceFront.toString());
+  builder.addConstant("kSurfaceBitIndex_HasNormalMap", VariableType.Int, SurfaceBitIndex.HasNormalMap.toString());
   builder.addConstant("kSurfaceBitIndex_HasMaterialAtlas", VariableType.Int, SurfaceBitIndex.HasMaterialAtlas.toString());
 
   // Surface flags which get modified in vertex shader are still passed to fragment shader as a single float & are thus

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -1086,7 +1086,6 @@ export class ImdlReader {
       indices,
       fillFlags: displayParams.fillFlags,
       hasBakedLighting: false,
-      hasFixedNormals: false,
       material,
       textureMapping,
     };


### PR DESCRIPTION
`SurfaceFlags.NoFaceFront` was set only if `SurfaceParams.hasFixedNormals`, which is always false.
It was introduced to enable applying lighting to terrain, but applying lighting to terrain was silly so we disabled that.
@MarcNeely intends to replace this flag with one that indicates the surface uses a normal map.