### PR TITLE
Fix Electron dialog ipc

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5271,6 +5271,8 @@ export class IpcApp {
     static callIpcHost<T extends AsyncMethodsOf<IpcAppFunctions>>(methodName: T, ...args: Parameters<IpcAppFunctions[T]>): Promise<PromiseReturnType<IpcAppFunctions[T]>>;
     static invoke(channel: string, ...args: any[]): Promise<any>;
     static get isValid(): boolean;
+    // @internal
+    static makeIpcFunctionProxy<K>(channelName: string, functionName: string): PickAsyncMethods<K>;
     static makeIpcProxy<K>(channelName: string): PickAsyncMethods<K>;
     static removeListener(channel: string, listener: IpcListener): void;
     static send(channel: string, ...data: any[]): void;

--- a/common/changes/@itwin/core-electron/ipc-function-proxy_2022-10-26-12-47.json
+++ b/common/changes/@itwin/core-electron/ipc-function-proxy_2022-10-26-12-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/changes/@itwin/core-frontend/ipc-function-proxy_2022-10-26-12-47.json
+++ b/common/changes/@itwin/core-frontend/ipc-function-proxy_2022-10-26-12-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/editor-frontend/ipc-function-proxy_2022-10-26-12-47.json
+++ b/common/changes/@itwin/editor-frontend/ipc-function-proxy_2022-10-26-12-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/core/electron/src/frontend/ElectronApp.ts
+++ b/core/electron/src/frontend/ElectronApp.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
+import { PickAsyncMethods, ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
 import { IpcListener, IpcSocketFrontend } from "@itwin/core-common";
 import { IpcApp, NativeApp, NativeAppOpts } from "@itwin/core-frontend";
 import type { IpcRenderer } from "electron";
@@ -85,5 +85,5 @@ export class ElectronApp {
   }
 
   /** Proxy object for calling methods of `Electron.Dialog` */
-  public static dialogIpc = IpcApp.makeIpcProxy<Electron.Dialog>(dialogChannel);
+  public static dialogIpc = IpcApp.makeIpcFunctionProxy<Electron.Dialog>(dialogChannel, "callDialog");
 }

--- a/core/electron/src/frontend/ElectronApp.ts
+++ b/core/electron/src/frontend/ElectronApp.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { PickAsyncMethods, ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
+import { ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
 import { IpcListener, IpcSocketFrontend } from "@itwin/core-common";
 import { IpcApp, NativeApp, NativeAppOpts } from "@itwin/core-frontend";
 import type { IpcRenderer } from "electron";

--- a/core/frontend/src/IpcApp.ts
+++ b/core/frontend/src/IpcApp.ts
@@ -113,6 +113,20 @@ export class IpcApp {
     });
   }
 
+  /** Create a type safe Proxy object to call an IPC function on a of registered backend handler that accepts a "methodName" argument followed by optional arguments
+   * @param channelName the channel registered by the backend handler.
+   * @param functionName the function to call on the handler.
+   * @internal
+   */
+  public static makeIpcFunctionProxy<K>(channelName: string, functionName: string): PickAsyncMethods<K> {
+    return new Proxy({} as PickAsyncMethods<K>, {
+      get(_target, methodName: string) {
+        return async (...args: any[]) =>
+          IpcApp.callIpcChannel(channelName, functionName, methodName, ...args);
+      },
+    });
+  }
+
   /** @deprecated use [[appFunctionIpc]] */
   public static async callIpcHost<T extends AsyncMethodsOf<IpcAppFunctions>>(methodName: T, ...args: Parameters<IpcAppFunctions[T]>) {
     return this.callIpcChannel(IpcAppChannel.Functions, methodName, ...args) as PromiseReturnType<IpcAppFunctions[T]>;

--- a/editor/frontend/src/EditToolIpc.ts
+++ b/editor/frontend/src/EditToolIpc.ts
@@ -8,12 +8,12 @@
 
 import { PickAsyncMethods } from "@itwin/core-bentley";
 import { IpcApp } from "@itwin/core-frontend";
-import { BasicManipulationCommandIpc, editorChannel, SolidModelingCommandIpc } from "@itwin/editor-common";
+import { BasicManipulationCommandIpc, EditCommandIpc, editorChannel, SolidModelingCommandIpc } from "@itwin/editor-common";
 
 /** Create a type safe Proxy object to make IPC calls to methods of the current `EditCommand`
  * @alpha
  */
-export function makeEditToolIpc<K>(): PickAsyncMethods<K> {
+export function makeEditToolIpc<K extends EditCommandIpc>(): PickAsyncMethods<K> {
   return IpcApp.makeIpcFunctionProxy<K>(editorChannel, "callMethod");
 }
 

--- a/editor/frontend/src/EditToolIpc.ts
+++ b/editor/frontend/src/EditToolIpc.ts
@@ -8,18 +8,13 @@
 
 import { PickAsyncMethods } from "@itwin/core-bentley";
 import { IpcApp } from "@itwin/core-frontend";
-import { BasicManipulationCommandIpc, EditCommandIpc, editorChannel, SolidModelingCommandIpc } from "@itwin/editor-common";
+import { BasicManipulationCommandIpc, editorChannel, SolidModelingCommandIpc } from "@itwin/editor-common";
 
 /** Create a type safe Proxy object to make IPC calls to methods of the current `EditCommand`
  * @alpha
  */
-export function makeEditToolIpc<K extends EditCommandIpc>(): PickAsyncMethods<K> {
-  return new Proxy({} as PickAsyncMethods<K>, {
-    get(_target, methodName: string) {
-      return async (...args: any[]) =>
-        IpcApp.callIpcChannel(editorChannel, "callMethod", methodName, ...args);
-    },
-  });
+export function makeEditToolIpc<K>(): PickAsyncMethods<K> {
+  return IpcApp.makeIpcFunctionProxy<K>(editorChannel, "callMethod");
 }
 
 /** Proxy for calling methods in `BasicManipulationCommandIpc`

--- a/test-apps/ui-test-app/src/frontend/tools/editing/PlaceBlockTool.ts
+++ b/test-apps/ui-test-app/src/frontend/tools/editing/PlaceBlockTool.ts
@@ -8,7 +8,7 @@ import { assert } from "@itwin/core-bentley";
 import { AxisOrder, LinearSweep, Matrix3d, Point3d, Transform, Vector3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { Code, ColorDef, ElementGeometry, GeometryStreamBuilder, LinePixels, PhysicalElementProps } from "@itwin/core-common";
 import { BasicManipulationCommandIpc, editorBuiltInCmdIds } from "@itwin/editor-common";
-import { CreateElementTool, EditTools } from "@itwin/editor-frontend";
+import { basicManipulationIpc, CreateElementTool, EditTools } from "@itwin/editor-frontend";
 import {
   AccuDrawHintBuilder, BeButtonEvent, ContextRotationId, CoreTools, DecorateContext, EventHandled, GraphicType, IModelApp, NotifyMessageDetails, OutputMessagePriority, ToolAssistance,
   ToolAssistanceImage, ToolAssistanceInputMethod, ToolAssistanceInstruction, ToolAssistanceSection, Viewport,
@@ -30,8 +30,6 @@ export class PlaceBlockTool extends CreateElementTool {
       return this._startedCmd;
     return EditTools.startCommand<string>(editorBuiltInCmdIds.cmdBasicManipulation, this.iModel.key);
   }
-
-  public commandConnection = EditTools.connect<BasicManipulationCommandIpc>();
 
   protected allowView(vp: Viewport) { return vp.view.isSpatialView() || vp.view.isDrawingView(); }
   public override isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean { return (super.isCompatibleViewport(vp, isSelectedViewChange) && undefined !== vp && this.allowView(vp)); }
@@ -195,7 +193,7 @@ export class PlaceBlockTool extends CreateElementTool {
         return;
 
       const elemProps: PhysicalElementProps = { classFullName: "Generic:PhysicalObject", model, category, code: Code.createEmpty(), placement: { origin, angles }, geom: builder.geometryStream };
-      await this.commandConnection.insertGeometricElement(elemProps);
+      await basicManipulationIpc.insertGeometricElement(elemProps);
       await this.saveChanges();
 
     } catch (err: any) {

--- a/test-apps/ui-test-app/src/frontend/tools/editing/PlaceBlockTool.ts
+++ b/test-apps/ui-test-app/src/frontend/tools/editing/PlaceBlockTool.ts
@@ -7,7 +7,7 @@
 import { assert } from "@itwin/core-bentley";
 import { AxisOrder, LinearSweep, Matrix3d, Point3d, Transform, Vector3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { Code, ColorDef, ElementGeometry, GeometryStreamBuilder, LinePixels, PhysicalElementProps } from "@itwin/core-common";
-import { BasicManipulationCommandIpc, editorBuiltInCmdIds } from "@itwin/editor-common";
+import { editorBuiltInCmdIds } from "@itwin/editor-common";
 import { basicManipulationIpc, CreateElementTool, EditTools } from "@itwin/editor-frontend";
 import {
   AccuDrawHintBuilder, BeButtonEvent, ContextRotationId, CoreTools, DecorateContext, EventHandled, GraphicType, IModelApp, NotifyMessageDetails, OutputMessagePriority, ToolAssistance,


### PR DESCRIPTION
#4533 broke the Electron.Dialog ipc.

Adds `IpcApp.makeIpcFunctionProxy` which is also useful for edit tools.