### PR TITLE
Add support for more 3d tile providers

### DIFF
--- a/common/changes/@itwin/core-frontend/dwl-3dtiles_2022-10-27-04-30.json
+++ b/common/changes/@itwin/core-frontend/dwl-3dtiles_2022-10-27-04-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Added support for more 3D Tile providers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -2109,7 +2109,8 @@ export class GltfGraphicsReader extends GltfReader {
   private readonly _featureTable?: FeatureTable;
   public readonly binaryData?: Uint8Array; // strictly for tests
 
-  public constructor(props: GltfReaderProps, args: ReadGltfGraphicsArgs) {
+  public constructor(props: GltfReaderProps, args: ReadGltfGraphicsArgs, private _range?: ElementAlignedBox3d| undefined,
+    private _transformToRoot?: Transform) {
     super({
       props,
       iModel: args.iModel,
@@ -2126,7 +2127,8 @@ export class GltfGraphicsReader extends GltfReader {
 
   public async read(): Promise<GltfReaderResult> {
     await this.resolveResources();
-    return this.readGltfAndCreateGraphics(true, this._featureTable, undefined);
+    const isLeafTemp = false;
+    return this.readGltfAndCreateGraphics(isLeafTemp, this._featureTable, this._range, this._transformToRoot);
   }
 
   public get nodes(): GltfDictionary<GltfNode> { return this._nodes; }

--- a/core/frontend/src/tile/RealityTileLoader.ts
+++ b/core/frontend/src/tile/RealityTileLoader.ts
@@ -14,7 +14,7 @@ import { GraphicBranch } from "../render/GraphicBranch";
 import { RenderSystem } from "../render/RenderSystem";
 import { ScreenViewport, Viewport } from "../Viewport";
 import {
-  B3dmReader, BatchedTileIdMap, createDefaultViewFlagOverrides, GltfReader, GltfWrapMode, I3dmReader, readPointCloudTileContent, RealityTile, RealityTileContent, Tile, TileContent,
+  B3dmReader, BatchedTileIdMap, createDefaultViewFlagOverrides, GltfGraphicsReader, GltfReader, GltfReaderProps, GltfWrapMode, I3dmReader, readPointCloudTileContent, RealityTile, RealityTileContent, Tile, TileContent,
   TileDrawArgs, TileLoadPriority, TileRequest, TileRequestChannel, TileUser,
 } from "./internal";
 
@@ -112,6 +112,13 @@ export abstract class RealityTileLoader {
         break;
       case TileFormat.I3dm:
         reader = I3dmReader.create(streamBuffer, iModel, modelId, is3d, tile.contentRange, system, yAxisUp, tile.isLeaf, isCanceled, undefined, this.wantDeduplicatedVertices);
+        break;
+      case TileFormat.Gltf:
+        const props = GltfReaderProps.create(streamBuffer.nextBytes(streamBuffer.arrayBuffer.byteLength), yAxisUp);
+        if (undefined === props) {
+          break;
+        }
+        reader = new GltfGraphicsReader(props, {iModel, gltf: props.glTF}, tile.contentRange, tile.transformToRoot);
         break;
       case TileFormat.Cmpt:
         const header = new CompositeTileHeader(streamBuffer);

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -19,7 +19,7 @@ import { GraphicBuilder } from "../render/GraphicBuilder";
 import { SceneContext } from "../ViewContext";
 import {
   GraphicsCollectorDrawArgs, MapTile, RealityTile, RealityTileDrawArgs, RealityTileLoader, RealityTileParams, Tile, TileDrawArgs, TileGeometryCollector,
-  TileGraphicType, TileParams, TileTree, TileTreeParams,
+  TileGraphicType, TileTree, TileTreeParams,
 } from "./internal";
 
 /** @internal */
@@ -196,7 +196,7 @@ export class RealityTileTree extends TileTree {
   public override get parentsAndChildrenExclusive() { return this.loader.parentsAndChildrenExclusive; }
 
   /** @internal */
-  public createTile(props: TileParams): RealityTile { return new RealityTile(props, this); }
+  public createTile(props: RealityTileParams): RealityTile { return new RealityTile(props, this); }
 
   /** Collect tiles from this tile tree based on the criteria implemented by `collector`.
    * @internal

--- a/core/frontend/src/tile/TileDrawArgs.ts
+++ b/core/frontend/src/tile/TileDrawArgs.ts
@@ -168,7 +168,7 @@ export class TileDrawArgs {
   /** Compute the size in meters of one pixel at the point on a sphere closest to the camera.
    * Device scaling is not applied.
    */
-  protected computePixelSizeInMetersAtClosestPoint(center: Point3d, radius: number): number {
+  public computePixelSizeInMetersAtClosestPoint(center: Point3d, radius: number): number {
     if (this.context.viewport.view.is3d() && this.context.viewport.isCameraOn && this._nearFrontCenter) {
       const toFront = Vector3d.createStartEnd(center, this._nearFrontCenter);
       const viewZ = this.context.viewport.rotation.rowZ();

--- a/core/frontend/src/tile/map/ImageryTileTree.ts
+++ b/core/frontend/src/tile/map/ImageryTileTree.ts
@@ -15,8 +15,8 @@ import { RenderMemory } from "../../render/RenderMemory";
 import { RenderSystem } from "../../render/RenderSystem";
 import { ScreenViewport } from "../../Viewport";
 import {
-  MapCartoRectangle, MapLayerFeatureInfo, MapLayerImageryProvider, MapLayerTileTreeReference, MapTile, MapTilingScheme, QuadId, RealityTile, RealityTileLoader, RealityTileTree,
-  RealityTileTreeParams, Tile, TileContent, TileDrawArgs, TileLoadPriority, TileParams, TileRequest, TileTree, TileTreeLoadStatus, TileTreeOwner,
+  MapCartoRectangle, MapLayerFeatureInfo, MapLayerImageryProvider, MapLayerTileTreeReference, MapTile, MapTilingScheme, QuadId, RealityTile, RealityTileLoader, RealityTileParams,
+  RealityTileTree, RealityTileTreeParams, Tile, TileContent, TileDrawArgs, TileLoadPriority, TileRequest, TileTree, TileTreeLoadStatus, TileTreeOwner,
   TileTreeSupplier,
 } from "../internal";
 
@@ -29,7 +29,8 @@ export interface ImageryTileContent extends TileContent {
 export class ImageryMapTile extends RealityTile {
   private _texture?: RenderTexture;
   private _mapTileUsageCount = 0;
-  constructor(params: TileParams, public imageryTree: ImageryMapTileTree, public quadId: QuadId, public rectangle: MapCartoRectangle) {
+
+  constructor(params: RealityTileParams, public imageryTree: ImageryMapTileTree, public quadId: QuadId, public rectangle: MapCartoRectangle) {
     super(params, imageryTree);
   }
   public get texture() { return this._texture; }
@@ -100,7 +101,7 @@ export class ImageryMapTile extends RealityTile {
         const rectangle = imageryTree.tilingScheme.tileXYToRectangle(quadId.column, quadId.row, quadId.level);
         const range = Range3d.createXYZXYZ(rectangle.low.x, rectangle.low.x, 0, rectangle.high.x, rectangle.high.y, 0);
         const maximumSize = (childrenAreDisabled ?  0 : imageryTree.imageryLoader.maximumScreenSize);
-        children.push(new ImageryMapTile({ parent: this, isLeaf: childrenAreLeaves, contentId: quadId.contentId, range, maximumSize }, imageryTree, quadId, rectangle));
+        children.push(new ImageryMapTile({ geometricError: undefined, parent: this, isLeaf: childrenAreLeaves, contentId: quadId.contentId, range, maximumSize }, imageryTree, quadId, rectangle));
       });
 
       resolve(children);
@@ -291,7 +292,7 @@ class ImageryMapLayerTreeSupplier implements TileTreeSupplier {
     const rootLevel =  (1 === tilingScheme.numberOfLevelZeroTilesX && 1 === tilingScheme.numberOfLevelZeroTilesY) ? 0 : -1;
     const rootTileId = new QuadId(rootLevel, 0, 0).contentId;
     const rootRange = Range3d.createXYZXYZ(-Angle.piRadians, -Angle.piOver2Radians, 0, Angle.piRadians, Angle.piOver2Radians, 0);
-    const rootTileProps = { contentId: rootTileId, range: rootRange, maximumSize: 0 };
+    const rootTileProps = { contentId: rootTileId, range: rootRange, maximumSize: 0, geometricError: undefined };
     const loader = new ImageryTileLoader(imageryProvider, iModel);
     const treeProps = { rootTile: rootTileProps, id: modelId, modelId, iModel, location: Transform.createIdentity(), priority: TileLoadPriority.Map, loader, gcsConverterAvailable: false };
     return new ImageryMapTileTree(treeProps, loader);

--- a/core/frontend/src/tile/map/MapTile.ts
+++ b/core/frontend/src/tile/map/MapTile.ts
@@ -413,7 +413,7 @@ export class MapTile extends RealityTile {
           const chordHeight = globeMode === GlobeMode.Ellipsoid ? Math.sqrt(diagonal * diagonal + Constant.earthRadiusWGS84.equator * Constant.earthRadiusWGS84.equator) - Constant.earthRadiusWGS84.equator : 0.0;
           const rangeCorners = MapTile.computeRangeCorners(corners, normal, chordHeight, undefined, heightRange);
           const range = Range3d.createArray(rangeCorners);
-          const child = this.mapTree.createPlanarChild({ contentId: quadId.contentId, maximumSize: 512, range, parent: this, isLeaf: childrenAreLeaves }, quadId, corners, normal, rectangle, chordHeight, heightRange);
+          const child = this.mapTree.createPlanarChild({ geometricError: undefined, contentId: quadId.contentId, maximumSize: 512, range, parent: this, isLeaf: childrenAreLeaves }, quadId, corners, normal, rectangle, chordHeight, heightRange);
           if (child)
             children.push(child);
         }
@@ -443,7 +443,7 @@ export class MapTile extends RealityTile {
         if (undefined !== heightRange)
           range.expandInPlace(heightRange.high - heightRange.low);
 
-        children.push(this.mapTree.createGlobeChild({ contentId: quadId.contentId, maximumSize: 512, range, parent: this, isLeaf: false }, quadId, range.corners(), rectangle, ellipsoidPatch, heightRange));
+        children.push(this.mapTree.createGlobeChild({ geometricError: undefined, contentId: quadId.contentId, maximumSize: 512, range, parent: this, isLeaf: false }, quadId, range.corners(), rectangle, ellipsoidPatch, heightRange));
       }
     }
 

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -27,7 +27,7 @@ import {
   BingElevationProvider, createDefaultViewFlagOverrides, createMapLayerTreeReference, DisclosedTileTreeSet, EllipsoidTerrainProvider, GeometryTileTreeReference,
   GraphicsCollectorDrawArgs, ImageryMapLayerTreeReference, ImageryMapTileTree, MapCartoRectangle, MapLayerFeatureInfo,
   MapLayerTileTreeReference, MapTile, MapTileLoader, MapTilingScheme, ModelMapLayerTileTreeReference, PlanarTilePatch, QuadId,
-  RealityTile, RealityTileDrawArgs, RealityTileTree, RealityTileTreeParams, TerrainMeshProviderOptions, Tile, TileDrawArgs, TileLoadPriority, TileParams, TileTree,
+  RealityTile, RealityTileDrawArgs, RealityTileParams, RealityTileTree, RealityTileTreeParams, TerrainMeshProviderOptions, Tile, TileDrawArgs, TileLoadPriority, TileTree,
   TileTreeLoadStatus, TileTreeOwner, TileTreeReference, TileTreeSupplier, UpsampledMapTile, WebMercatorTilingScheme,
 } from "../internal";
 
@@ -135,7 +135,7 @@ export class MapTileTree extends RealityTileTree {
       range = Range3d.createArray(MapTile.computeRangeCorners(corners, Vector3d.create(0, 0, 1), 0, scratchCorners, globalHeightRange));
     }
 
-    this._rootTile = this.createGlobeChild({ contentId: quadId.contentId, maximumSize: 0, range }, quadId, range.corners(), globalRectangle, rootPatch, undefined);
+    this._rootTile = this.createGlobeChild({ geometricError: undefined, contentId: quadId.contentId, maximumSize: 0, range }, quadId, range.corners(), globalRectangle, rootPatch, undefined);
   }
 
   /** @internal */
@@ -197,7 +197,7 @@ export class MapTileTree extends RealityTileTree {
   }
 
   /** @internal */
-  public createPlanarChild(params: TileParams, quadId: QuadId, corners: Point3d[], normal: Vector3d, rectangle: MapCartoRectangle, chordHeight: number, heightRange?: Range1d): MapTile | undefined{
+  public createPlanarChild(params: RealityTileParams, quadId: QuadId, corners: Point3d[], normal: Vector3d, rectangle: MapCartoRectangle, chordHeight: number, heightRange?: Range1d): MapTile | undefined{
     const childAvailable = this.mapLoader.isTileAvailable(quadId);
     if (!childAvailable && this.produceGeometry)
       return undefined;
@@ -208,7 +208,7 @@ export class MapTileTree extends RealityTileTree {
   }
 
   /** @internal */
-  public createGlobeChild(params: TileParams, quadId: QuadId, _rangeCorners: Point3d[], rectangle: MapCartoRectangle, ellipsoidPatch: EllipsoidPatch, heightRange?: Range1d): MapTile {
+  public createGlobeChild(params: RealityTileParams, quadId: QuadId, _rangeCorners: Point3d[], rectangle: MapCartoRectangle, ellipsoidPatch: EllipsoidPatch, heightRange?: Range1d): MapTile {
     return new MapTile(params, this, quadId, ellipsoidPatch, rectangle, heightRange, this.getCornerRays(rectangle));
   }
 
@@ -470,9 +470,10 @@ class MapTileTreeProps implements RealityTileTreeParams {
   public location = Transform.createIdentity();
   public yAxisUp = true;
   public is3d = true;
-  public rootTile = { contentId: "", range: Range3d.createNull(), maximumSize: 0 };
+  public rootTile = { contentId: "", range: Range3d.createNull(), maximumSize: 0, geometricError: undefined };
   public loader: MapTileLoader;
   public iModel: IModelConnection;
+  public readonly geometricError = undefined;
   public get priority(): TileLoadPriority { return this.loader.priority; }
 
   public constructor(modelId: Id64String, loader: MapTileLoader, iModel: IModelConnection, public gcsConverterAvailable: boolean) {


### PR DESCRIPTION
From https://github.com/iTwin/itwinjs-core/pull/4558. Fixes https://github.com/iTwin/itwinjs-backlog/issues/482.
This is a temporary unpolished set of changes to get the tiles minimally working.
- Use geometricError for tile refinement instead of trying to compute a "maximum tile screen size" from the geometric error.
- Add support for [3DTILES_content_gltf](https://www.google.com/search?q=3dtiles_content_gltf&oq=3dtiles_con&aqs=chrome.1.69i57j69i59j0i13i30j0i10i30j0i13i15i30j69i60l3.1981j0j4&sourceid=chrome&ie=UTF-8) draft extension.
- Awkwardly extract API key required for this particular tile provider.
- Awkwardly support tileset URLs that don't end in ".json".

TODO
- [ ] Clean up
- [ ] Run ImageTests
- [ ] Revisit ASAP for a more permanent solution
- [ ] Try to isolate the changes to apply only to the new tileset of interest (opt-in)
- [ ] Use OBB to compute tile's distance from camera rather than bounding sphere.
- [ ] Don't include API keys in tileset URLs (they get stored in saved views, become stale when keys are rotated, etc).