### PR TITLE
Only publish packages from version bumps

### DIFF
--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -12,14 +12,14 @@ jobs:
         OS: windows-latest
         platform: Windows_NT
         name: $(win_pool)
-      # "Linux_${{ parameters.name }}":
-      #   OS: ubuntu-latest
-      #   platform: Linux
-      #   name: $(linux_pool)
-      # "MacOS_${{ parameters.name }}":
-      #   OS: macOS-latest
-      #   platform: Darwin
-      #   name: $(mac_pool)
+      "Linux_${{ parameters.name }}":
+        OS: ubuntu-latest
+        platform: Linux
+        name: $(linux_pool)
+      "MacOS_${{ parameters.name }}":
+        OS: macOS-latest
+        platform: Darwin
+        name: $(mac_pool)
 
   timeoutInMinutes: 120
 
@@ -29,37 +29,37 @@ jobs:
     clean: all
 
   steps:
-    # - checkout: self
-    #   clean: true
-    # - task: NodeTool@0
-    #   displayName: "Use Node ${{ parameters.nodeVersion }}"
-    #   inputs:
-    #     versionSpec: ${{ parameters.nodeVersion }}
-    #     checkLatest: true
+    - checkout: self
+      clean: true
+    - task: NodeTool@0
+      displayName: "Use Node ${{ parameters.nodeVersion }}"
+      inputs:
+        versionSpec: ${{ parameters.nodeVersion }}
+        checkLatest: true
 
-    # - script: |
-    #     git config --local user.email imodeljs-admin@users.noreply.github.com
-    #     git config --local user.name imodeljs-admin
-    #   displayName: git config
+    - script: |
+        git config --local user.email imodeljs-admin@users.noreply.github.com
+        git config --local user.name imodeljs-admin
+      displayName: git config
 
-    # - powershell: |
-    #     # Get the new version number.
-    #     $json = Get-Content -Raw -Path common/config/rush/version-policies.json | ConvertFrom-Json
-    #     $currVersion = $json[0].version
+    - powershell: |
+        # Get the new version number.
+        $json = Get-Content -Raw -Path common/config/rush/version-policies.json | ConvertFrom-Json
+        $currVersion = $json[0].version
 
-    #     $newBuildNumber = $currVersion + "_$(Build.BuildNumber)"
+        $newBuildNumber = $currVersion + "_$(Build.BuildNumber)"
 
-    #     Write-Host "##vso[build.updatebuildnumber]$newBuildNumber"
-    #   displayName: Set build number
-    #   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+        Write-Host "##vso[build.updatebuildnumber]$newBuildNumber"
+      displayName: Set build number
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-    # - template: ../templates/core-build.yaml
-    #   parameters:
-    #     buildIos: ${{ parameters.buildIos}}
+    - template: ../templates/core-build.yaml
+      parameters:
+        buildIos: ${{ parameters.buildIos}}
 
-    # # Will run if even there is a failure somewhere else in the pipeline.
-    # - template: ../templates/publish-test-results.yaml
-    #   parameters:
-    #     NodeVersion: ${{ parameters.nodeVersion }}
-    # # The publish script identifies any new packages not previously published and tags the build
+    # Will run if even there is a failure somewhere else in the pipeline.
+    - template: ../templates/publish-test-results.yaml
+      parameters:
+        NodeVersion: ${{ parameters.nodeVersion }}
+    # The publish script identifies any new packages not previously published and tags the build
     - template: ../templates/publish.yaml

--- a/common/config/azure-pipelines/jobs/ci-core.yaml
+++ b/common/config/azure-pipelines/jobs/ci-core.yaml
@@ -12,14 +12,14 @@ jobs:
         OS: windows-latest
         platform: Windows_NT
         name: $(win_pool)
-      "Linux_${{ parameters.name }}":
-        OS: ubuntu-latest
-        platform: Linux
-        name: $(linux_pool)
-      "MacOS_${{ parameters.name }}":
-        OS: macOS-latest
-        platform: Darwin
-        name: $(mac_pool)
+      # "Linux_${{ parameters.name }}":
+      #   OS: ubuntu-latest
+      #   platform: Linux
+      #   name: $(linux_pool)
+      # "MacOS_${{ parameters.name }}":
+      #   OS: macOS-latest
+      #   platform: Darwin
+      #   name: $(mac_pool)
 
   timeoutInMinutes: 120
 
@@ -29,37 +29,37 @@ jobs:
     clean: all
 
   steps:
-    - checkout: self
-      clean: true
-    - task: NodeTool@0
-      displayName: "Use Node ${{ parameters.nodeVersion }}"
-      inputs:
-        versionSpec: ${{ parameters.nodeVersion }}
-        checkLatest: true
+    # - checkout: self
+    #   clean: true
+    # - task: NodeTool@0
+    #   displayName: "Use Node ${{ parameters.nodeVersion }}"
+    #   inputs:
+    #     versionSpec: ${{ parameters.nodeVersion }}
+    #     checkLatest: true
 
-    - script: |
-        git config --local user.email imodeljs-admin@users.noreply.github.com
-        git config --local user.name imodeljs-admin
-      displayName: git config
+    # - script: |
+    #     git config --local user.email imodeljs-admin@users.noreply.github.com
+    #     git config --local user.name imodeljs-admin
+    #   displayName: git config
 
-    - powershell: |
-        # Get the new version number.
-        $json = Get-Content -Raw -Path common/config/rush/version-policies.json | ConvertFrom-Json
-        $currVersion = $json[0].version
+    # - powershell: |
+    #     # Get the new version number.
+    #     $json = Get-Content -Raw -Path common/config/rush/version-policies.json | ConvertFrom-Json
+    #     $currVersion = $json[0].version
 
-        $newBuildNumber = $currVersion + "_$(Build.BuildNumber)"
+    #     $newBuildNumber = $currVersion + "_$(Build.BuildNumber)"
 
-        Write-Host "##vso[build.updatebuildnumber]$newBuildNumber"
-      displayName: Set build number
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+    #     Write-Host "##vso[build.updatebuildnumber]$newBuildNumber"
+    #   displayName: Set build number
+    #   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-    - template: ../templates/core-build.yaml
-      parameters:
-        buildIos: ${{ parameters.buildIos}}
+    # - template: ../templates/core-build.yaml
+    #   parameters:
+    #     buildIos: ${{ parameters.buildIos}}
 
-    # Will run if even there is a failure somewhere else in the pipeline.
-    - template: ../templates/publish-test-results.yaml
-      parameters:
-        NodeVersion: ${{ parameters.nodeVersion }}
-    # The publish script identifies any new packages not previously published and tags the build
+    # # Will run if even there is a failure somewhere else in the pipeline.
+    # - template: ../templates/publish-test-results.yaml
+    #   parameters:
+    #     NodeVersion: ${{ parameters.nodeVersion }}
+    # # The publish script identifies any new packages not previously published and tags the build
     - template: ../templates/publish.yaml

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -6,23 +6,22 @@ parameters:
 steps:
 - powershell: |
     $commitMsg = '$(Build.SourceVersionMessage)'
-    Write-Host $commitMsg
     if ($commitMsg -match '^(\d+.\d+.\d+)(-dev.\d+)?$') {
       Write-Host `'$commitMsg`'` is a version bump
-      Write-Host ##vso[task.setvariable variable=shouldPublish;]true
+      Write-Host '##vso[task.setvariable variable=ShouldPublish;]True'
     } else {
       Write-Host `'$commitMsg`'` is not a version bump
-      Write-Host ##vso[task.setvariable variable=shouldPublish;]false
+      Write-Host '##vso[task.setvariable variable=ShouldPublish;]False'
     }
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - powershell: |
     Write-Host Publishing!
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['shouldPublish'], true))
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
 
 - powershell: |
     Write-Host Not publishing!
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['shouldPublish'], false))
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'False'))
 
 # - script: node common/scripts/install-run-rush.js publish --publish --pack --include-all
 #   displayName: rush publish pack

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -13,34 +13,26 @@ steps:
       Write-Host `'$commitMsg`'` is not a version bump
       Write-Host '##vso[task.setvariable variable=ShouldPublish;]False'
     }
+  displayName: Publish if version bump
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
 
-- powershell: |
-    Write-Host Publishing! (not really)
+- script: node common/scripts/install-run-rush.js publish --publish --pack --include-all
+  displayName: rush publish pack
+  workingDirectory: ${{ parameters.workingDir }}
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
 
-- powershell: |
-    Write-Host Not publishing!
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'False'))
+- task: PythonScript@0
+  displayName: Gather packages for release
+  inputs:
+    workingDirectory: ${{ parameters.workingDir }}
+    scriptSource: filepath
+    scriptPath: common/scripts/gather_packages.py
+    arguments: '$(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory) $(Build.SourceBranch)'
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
 
-# - script: node common/scripts/install-run-rush.js publish --publish --pack --include-all
-#   displayName: rush publish pack
-#   workingDirectory: ${{ parameters.workingDir }}
-#   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
-
-# - task: PythonScript@0
-#   displayName: Gather packages for release
-#   inputs:
-#     workingDirectory: ${{ parameters.workingDir }}
-#     scriptSource: filepath
-#     scriptPath: common/scripts/gather_packages.py
-#     arguments: '$(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory) $(Build.SourceBranch)'
-#     condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
-
-# - task: PublishBuildArtifacts@1
-#   displayName: 'Publish Artifact: packages'
-#   inputs:
-#     PathtoPublish: '$(Build.ArtifactStagingDirectory)/imodeljs/packages'
-#     ArtifactName: packages
-#   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
-
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: packages'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/imodeljs/packages'
+    ArtifactName: packages
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - powershell: |
-    $commitMsg = $(Build.SourceVersionMessage)
+    $commitMsg = '$(Build.SourceVersionMessage)'
     Write-Host $commitMsg
     if ($commitMsg -match '^(\d+.\d+.\d+)(-dev.\d+)?$') {
       Write-Host `'$commitMsg`'` is a version bump

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -4,24 +4,44 @@ parameters:
     default: $(System.DefaultWorkingDirectory)
 
 steps:
-- script: node common/scripts/install-run-rush.js publish --publish --pack --include-all
-  displayName: rush publish pack
-  workingDirectory: ${{ parameters.workingDir }}
+- powershell: |
+    $commitMsg = $(Build.SourceVersionMessage)
+    Write-Host $commitMsg
+    if ($commitMsg -match '^(\d+.\d+.\d+)(-dev.\d+)?$') {
+      Write-Host `'$commitMsg`'` is a version bump
+      Write-Host ##vso[task.setvariable variable=shouldPublish;]true
+    } else {
+      Write-Host `'$commitMsg`'` is not a version bump
+      Write-Host ##vso[task.setvariable variable=shouldPublish;]false
+    }
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
 
-- task: PythonScript@0
-  displayName: Gather packages for release
-  inputs:
-    workingDirectory: ${{ parameters.workingDir }}
-    scriptSource: filepath
-    scriptPath: common/scripts/gather_packages.py
-    arguments: '$(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory) $(Build.SourceBranch)'
-    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
+- powershell: |
+    Write-Host Publishing!
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['shouldPublish'], true))
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: packages'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/imodeljs/packages'
-    ArtifactName: packages
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
+- powershell: |
+    Write-Host Not publishing!
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['shouldPublish'], false))
+
+# - script: node common/scripts/install-run-rush.js publish --publish --pack --include-all
+#   displayName: rush publish pack
+#   workingDirectory: ${{ parameters.workingDir }}
+#   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
+
+# - task: PythonScript@0
+#   displayName: Gather packages for release
+#   inputs:
+#     workingDirectory: ${{ parameters.workingDir }}
+#     scriptSource: filepath
+#     scriptPath: common/scripts/gather_packages.py
+#     arguments: '$(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory) $(Build.SourceBranch)'
+#     condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
+
+# - task: PublishBuildArtifacts@1
+#   displayName: 'Publish Artifact: packages'
+#   inputs:
+#     PathtoPublish: '$(Build.ArtifactStagingDirectory)/imodeljs/packages'
+#     ArtifactName: packages
+#   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
 

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -16,7 +16,7 @@ steps:
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - powershell: |
-    Write-Host Publishing!
+    Write-Host Publishing! (not really)
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
 
 - powershell: |

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -28,7 +28,7 @@ steps:
     scriptSource: filepath
     scriptPath: common/scripts/gather_packages.py
     arguments: '$(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory) $(Build.SourceBranch)'
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
+    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: packages'


### PR DESCRIPTION
Currently, to determine whether to publish a new set of itwinjs packages, we check npmjs to see if the local package versions have already been published. Generally, when we commit a new version bump as part of our release procedures, the new packages are picked up and published from that commit. 

If the CI build for a version bump commit fails due to some transient issue (flaky tests), it is possible for a new CI build triggered after the version bump to be picked up as the new release. This PR adds additional validation so that we can only trigger the release of a new iTwin.js version from the CI build of a version bump.