### PR TITLE
Fix faulty assertion

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-sse-assert_2022-11-01-19-34.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-sse-assert_2022-11-01-19-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -691,10 +691,11 @@ export namespace RealityModelTileTree {
       if (args) {
         args.graphics.realityModelDisplaySettings = this._getDisplaySettings();
 
-        assert(args.tree instanceof RealityTileTree);
-        const maxSSE = args.tree.loader.maximumScreenSpaceError;
-        if (undefined !== maxSSE)
-          args.maximumScreenSpaceError = maxSSE;
+        if (args.tree instanceof RealityTileTree) {
+          const maxSSE = args.tree.loader.maximumScreenSpaceError;
+          if (undefined !== maxSSE)
+            args.maximumScreenSpaceError = maxSSE;
+        }
       }
 
       return args;


### PR DESCRIPTION
#4572 introduced `RealityTileLoader.maximumScreenSpaceError`, with an assertion that a `RealityModelTileTree.Reference` always refers to a `RealityTileTree`. In the case of an Orbit point cloud, that's not true and we produce an exception trying to access the property of the non-existent loader.