### PR TITLE
Missing pound '#' before link causing a 404

### DIFF
--- a/docs/changehistory/index.md
+++ b/docs/changehistory/index.md
@@ -5,7 +5,7 @@ Table of contents:
 
 - [Electron 17 support](#electron-17-support)
 - [IModelSchemaLoader replaced](#imodelschemaloader-replaced)
-- [Improved link table selection](improved-link-table-selection)
+- [Improved link table selection](#improved-link-table-selection)
 - [Cloud storage changes](#cloud-storage-changes)
 - [Display](#display)
   - [Custom terrain providers](#custom-terrain-providers)


### PR DESCRIPTION
Adding the missing pound before `improved-link-table-selection` in the table of contents to avoid getting a 404 when clicking on it.