### PR TITLE
Presentation: deprecate manager mode

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -250,7 +250,7 @@ export interface PresentationManagerCachingConfig {
     workerConnectionCacheSize?: number;
 }
 
-// @public
+// @public @deprecated
 export enum PresentationManagerMode {
     ReadOnly = 0,
     ReadWrite = 1
@@ -277,6 +277,7 @@ export interface PresentationManagerProps {
     id?: string;
     // @deprecated
     localeDirectories?: string[];
+    // @deprecated
     mode?: PresentationManagerMode;
     presentationAssetsRoot?: string | PresentationAssetsRootConfig;
     rulesetDirectories?: string[];

--- a/common/api/summary/presentation-backend.exports.csv
+++ b/common/api/summary/presentation-backend.exports.csv
@@ -23,6 +23,7 @@ public;PresentationBackendNativeLoggerCategory
 public;PresentationManager
 public;PresentationManagerCachingConfig
 public;PresentationManagerMode
+deprecated;PresentationManagerMode
 public;PresentationManagerProps
 public;PresentationProps = MultiManagerPresentationProps | SingleManagerPresentationProps
 public;PresentationPropsBase 

--- a/common/changes/@itwin/presentation-backend/presentation-deprecate_manager_mode_2022-11-11-13-15.json
+++ b/common/changes/@itwin/presentation-backend/presentation-deprecate_manager_mode_2022-11-11-13-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Deprecated PresentationManagerProps.mode property",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-testing/presentation-deprecate_manager_mode_2022-11-11-13-15.json
+++ b/common/changes/@itwin/presentation-testing/presentation-deprecate_manager_mode_2022-11-11-13-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-testing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-testing"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,6 +18,7 @@ Table of contents:
 - [Deprecations](#deprecations)
   - [@itwin/core-backend](#itwincore-backend)
   - [@itwin/core-transformer](#itwincore-transformer)
+  - [@itwin/presentation-backend](#itwinpresentation-backend)
 - [New packages](#new-packages)
   - [@itwin/map-layers-formats](#map-layers-formats)
 
@@ -40,12 +41,15 @@ Point clouds provide the following additional customizations:
 Functions like [ViewState.lookAtVolume]($frontend) and [Viewport.zoomToElements]($frontend) fit a view to a specified volume. They accept a [MarginOptions]($frontend) that allows the caller to customize how tightly the view fits to the volume, via [MarginPercent]($frontend). However, the amount by which the volume is enlarged to add extra space can yield surprising results. For example, a [MarginPercent]($frontend) that specifies a margin of 25% on each side - `{left: .25, right: .25, top: .25, bottom: .25}` - actually *doubles* the width and height of the volume, adding 50% of the original volume's size to each side. Moreover, [MarginPercent]($frontend)'s constructor clamps the margin values to a minimum of zero and maximum of 0.25.
 
 Now, [MarginOptions]($frontend) has an alternative way to specify how to adjust the size of the viewed volume, using [MarginOptions.paddingPercent]($frontend). Like [MarginPercent]($frontend), a [PaddingPercent]($frontend) specifies the extra space as a percentage of the original volume's space on each side - though it may also specify a single padding to be applied to all four sides, or omit any side that should have no padding applied. For example,
+
 ```
 {paddingPercent: {{left: .2, right: .2, top: .2, bottom: .2}}
 // is equivalent to
 {paddingPercent: .2}
 ```
+
 and
+
 ```
 {paddingPercent: {left: 0, top: 0, right: .5, bottom: .5}}
 // is equivalent to
@@ -127,7 +131,6 @@ the ids returned are not unique from all element ids and may collide.
 
 When defining a Widget with AbstractWidgetProperties, you can now specify on which sides of the ContentArea the it can be docked. The optional prop allowedPanelTargets is an array of any of the following: "left", "right", "top", "bottom". By default, all regions are allowed. You must specify at least one allowed target in the array.
 
-
 ## New packages
 
 ### @itwin/map-layers-formats
@@ -154,3 +157,7 @@ The [IModelCloneContext]($backend) class in `@itwin/core-backend` has been renam
 ### @itwin/core-transformer
 
 [IModelTransformer.initFromExternalSourceAspects]($transformer) is deprecated and in most cases no longer needed, because the transformer now handles referencing properties on out-of-order non-element entities like aspects, models, and relationships. If you are not using a method like `processAll` or `processChanges` to run the transformer, then you do need to replace `initFromExternalSourceAspects` with [IModelTransformer.initialize]($transformer).
+
+### @itwin/presentation-backend
+
+[PresentationManagerProps.mode]($presentation-backend) has been deprecated because there is no performance difference between [PresentationManager]($presentation-backend) working in `ReadOnly` or `ReadWrite` modes.

--- a/full-stack-tests/presentation/src/backend/NativePlatform.test.ts
+++ b/full-stack-tests/presentation/src/backend/NativePlatform.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { SnapshotDb } from "@itwin/core-backend";
-import { HierarchyCacheMode, PresentationManagerMode } from "@itwin/presentation-backend";
+import { HierarchyCacheMode } from "@itwin/presentation-backend";
 import { createDefaultNativePlatform, NativePlatformDefinition } from "@itwin/presentation-backend/lib/cjs/presentation-backend/NativePlatform";
 import { PresentationError } from "@itwin/presentation-common";
 import { initialize, terminate } from "../IntegrationTests";
@@ -29,7 +29,6 @@ describe("NativePlatform", () => {
     const TNativePlatform = createDefaultNativePlatform({ // eslint-disable-line @typescript-eslint/naming-convention
       id: "",
       taskAllocationsMap: {},
-      mode: PresentationManagerMode.ReadWrite,
       isChangeTrackingEnabled: false,
       cacheConfig: { mode: HierarchyCacheMode.Memory },
     });

--- a/full-stack-tests/presentation/src/backend/RulesetsRoundtrip.test.ts
+++ b/full-stack-tests/presentation/src/backend/RulesetsRoundtrip.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { using } from "@itwin/core-bentley";
-import { PresentationManagerMode, RulesetManagerImpl} from "@itwin/presentation-backend";
+import { RulesetManagerImpl } from "@itwin/presentation-backend";
 import { createDefaultNativePlatform, NativePlatformDefinition } from "@itwin/presentation-backend/lib/cjs/presentation-backend/NativePlatform";
 import { Ruleset } from "@itwin/presentation-common";
 import { createRandomRuleset } from "@itwin/presentation-common/lib/cjs/test";
@@ -22,7 +22,6 @@ describe("Rulesets roundtrip", () => {
     const TNativePlatform = createDefaultNativePlatform({ // eslint-disable-line @typescript-eslint/naming-convention
       id: "",
       taskAllocationsMap: {},
-      mode: PresentationManagerMode.ReadWrite,
       isChangeTrackingEnabled: false,
     });
     nativePlatform = new TNativePlatform();

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -12,7 +12,7 @@ import { FormatProps } from "@itwin/core-quantity";
 import {
   DiagnosticsScopeLogs, NodeKeyJSON, PresentationError, PresentationStatus, UpdateInfoJSON, VariableValue, VariableValueJSON, VariableValueTypes,
 } from "@itwin/presentation-common";
-import { HierarchyCacheMode, PresentationManagerMode } from "./PresentationManager";
+import { HierarchyCacheMode } from "./PresentationManager";
 
 /** @internal */
 export enum NativePlatformRequestTypes {
@@ -90,7 +90,6 @@ export interface NativePlatformDefinition extends IDisposable {
 export interface DefaultNativePlatformProps {
   id: string;
   taskAllocationsMap: { [priority: number]: number };
-  mode: PresentationManagerMode;
   isChangeTrackingEnabled: boolean;
   cacheConfig?: IModelJsNative.ECPresentationHierarchyCacheConfig;
   contentCacheSize?: number;
@@ -106,10 +105,9 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
   return class implements NativePlatformDefinition {
     private _nativeAddon: IModelJsNative.ECPresentationManager;
     public constructor() {
-      const mode = (props.mode === PresentationManagerMode.ReadOnly) ? IModelJsNative.ECPresentationManagerMode.ReadOnly : IModelJsNative.ECPresentationManagerMode.ReadWrite;
       const cacheConfig = props.cacheConfig ?? { mode: HierarchyCacheMode.Disk, directory: "" };
       const defaultFormats = props.defaultFormats ? this.getSerializedDefaultFormatsMap(props.defaultFormats) : {};
-      this._nativeAddon = new IModelHost.platform.ECPresentationManager({ ...props, mode, cacheConfig, defaultFormats });
+      this._nativeAddon = new IModelHost.platform.ECPresentationManager({ ...props, cacheConfig, defaultFormats });
     }
     private getStatus(responseStatus: IModelJsNative.ECPresentationStatus): PresentationStatus {
       switch (responseStatus) {

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -28,7 +28,8 @@ import { BackendDiagnosticsAttribute, BackendDiagnosticsOptions, getLocalizedStr
 
 /**
  * Presentation manager working mode.
- * @public @deprecated
+ * @public
+ * @deprecated The attribute is not used by [[PresentationManager]] anymore
  */
 export enum PresentationManagerMode {
   /**
@@ -307,7 +308,7 @@ export interface PresentationManagerProps {
    *
    * Defaults to [[PresentationManagerMode.ReadWrite]].
    *
-   * @deprecated
+   * @deprecated The attribute is not used by [[PresentationManager]] anymore
    */
   mode?: PresentationManagerMode; // eslint-disable-line deprecation/deprecation
 

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -28,7 +28,7 @@ import { BackendDiagnosticsAttribute, BackendDiagnosticsOptions, getLocalizedStr
 
 /**
  * Presentation manager working mode.
- * @public
+ * @public @deprecated
  */
 export enum PresentationManagerMode {
   /**
@@ -306,8 +306,10 @@ export interface PresentationManagerProps {
    * use `ReadWrite`, others might want to set to `ReadOnly` for better performance.
    *
    * Defaults to [[PresentationManagerMode.ReadWrite]].
+   *
+   * @deprecated
    */
-  mode?: PresentationManagerMode;
+  mode?: PresentationManagerMode; // eslint-disable-line deprecation/deprecation
 
   /**
    * The interval (in milliseconds) used to poll for presentation data changes. Only has

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -20,7 +20,7 @@ import {
   createDefaultNativePlatform, NativePlatformDefinition, NativePlatformRequestTypes, NativePlatformResponse, NativePresentationDefaultUnitFormats,
   NativePresentationKeySetJSON, NativePresentationUnitSystem,
 } from "./NativePlatform";
-import { HierarchyCacheConfig, HierarchyCacheMode, PresentationManagerMode, PresentationManagerProps, UnitSystemFormat } from "./PresentationManager";
+import { HierarchyCacheConfig, HierarchyCacheMode, PresentationManagerProps, UnitSystemFormat } from "./PresentationManager";
 import { RulesetManager, RulesetManagerImpl } from "./RulesetManager";
 import { UpdatesTracker } from "./UpdatesTracker";
 import { BackendDiagnosticsAttribute, BackendDiagnosticsOptions, combineDiagnosticsOptions, getElementKey, reportDiagnostics } from "./Utils";
@@ -43,12 +43,10 @@ export class PresentationManagerDetail implements IDisposable {
       common: PRESENTATION_COMMON_ASSETS_ROOT,
       backend: PRESENTATION_BACKEND_ASSETS_ROOT,
     };
-    const mode = params.mode ?? PresentationManagerMode.ReadWrite;
-    const changeTrackingEnabled = mode === PresentationManagerMode.ReadWrite && !!params.updatesPollInterval;
+    const changeTrackingEnabled = !!params.updatesPollInterval;
     this._nativePlatform = params.addon ?? createNativePlatform(
       params.id ?? "",
       params.workerThreadsCount ?? 2,
-      mode,
       changeTrackingEnabled,
       params.caching,
       params.defaultFormats,
@@ -447,7 +445,6 @@ interface UnitFormatMap {
 function createNativePlatform(
   id: string,
   workerThreadsCount: number,
-  mode: PresentationManagerMode,
   changeTrackingEnabled: boolean,
   caching: PresentationManagerProps["caching"],
   defaultFormats: UnitFormatMap | undefined,
@@ -456,7 +453,6 @@ function createNativePlatform(
   return new (createDefaultNativePlatform({
     id,
     taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: workerThreadsCount },
-    mode,
     isChangeTrackingEnabled: changeTrackingEnabled,
     cacheConfig: createCacheConfig(caching?.hierarchies),
     contentCacheSize: caching?.content?.size,

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -8,7 +8,6 @@ import * as moq from "typemoq";
 import { IModelDb, IModelHost, IModelJsNative } from "@itwin/core-backend";
 import { DiagnosticsScopeLogs, PresentationError, UpdateInfo, VariableValueTypes } from "@itwin/presentation-common";
 import { createDefaultNativePlatform, NativePlatformDefinition } from "../presentation-backend/NativePlatform";
-import { PresentationManagerMode } from "../presentation-backend/PresentationManager";
 import { BeEvent } from "@itwin/core-bentley";
 import sinon from "sinon";
 import { join } from "path";
@@ -35,7 +34,6 @@ describe("default NativePlatform", () => {
     const TNativePlatform = createDefaultNativePlatform({
       id: faker.random.uuid(),
       taskAllocationsMap: {},
-      mode: PresentationManagerMode.ReadOnly,
       isChangeTrackingEnabled: false,
     });
     nativePlatform = new TNativePlatform();

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -31,7 +31,7 @@ import {
 import { PRESENTATION_BACKEND_ASSETS_ROOT } from "../presentation-backend/Constants";
 import { NativePlatformDefinition, NativePlatformRequestTypes, NativePresentationUnitSystem } from "../presentation-backend/NativePlatform";
 import {
-  HierarchyCacheMode, HybridCacheConfig, PresentationManager, PresentationManagerMode, PresentationManagerProps,
+  HierarchyCacheMode, HybridCacheConfig, PresentationManager, PresentationManagerProps,
 } from "../presentation-backend/PresentationManager";
 import { getKeysForContentRequest } from "../presentation-backend/PresentationManagerDetail";
 import { RulesetManagerImpl } from "../presentation-backend/RulesetManager";
@@ -91,7 +91,6 @@ describe("PresentationManager", () => {
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
-            mode: IModelHost.platform.ECPresentationManagerMode.ReadWrite,
             isChangeTrackingEnabled: false,
             cacheConfig: { mode: HierarchyCacheMode.Disk, directory: "" },
             contentCacheSize: undefined,
@@ -125,7 +124,6 @@ describe("PresentationManager", () => {
           id: faker.random.uuid(),
           presentationAssetsRoot: "/test",
           workerThreadsCount: testThreadsCount,
-          mode: PresentationManagerMode.ReadWrite,
           updatesPollInterval: 1,
           caching: {
             hierarchies: hierarchyCacheConfig,
@@ -147,7 +145,6 @@ describe("PresentationManager", () => {
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: props.id,
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 999 },
-            mode: IModelHost.platform.ECPresentationManagerMode.ReadWrite,
             isChangeTrackingEnabled: true,
             cacheConfig: expectedCacheConfig,
             contentCacheSize: 999,
@@ -167,7 +164,6 @@ describe("PresentationManager", () => {
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
-            mode: IModelHost.platform.ECPresentationManagerMode.ReadWrite,
             isChangeTrackingEnabled: false,
             cacheConfig: { mode: HierarchyCacheMode.Disk, directory: "" },
             contentCacheSize: undefined,
@@ -188,7 +184,6 @@ describe("PresentationManager", () => {
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
-            mode: IModelHost.platform.ECPresentationManagerMode.ReadWrite,
             isChangeTrackingEnabled: false,
             cacheConfig: expectedConfig,
             contentCacheSize: undefined,
@@ -206,7 +201,6 @@ describe("PresentationManager", () => {
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
-            mode: IModelHost.platform.ECPresentationManagerMode.ReadWrite,
             isChangeTrackingEnabled: false,
             cacheConfig: { mode: HierarchyCacheMode.Hybrid, disk: undefined },
             contentCacheSize: undefined,
@@ -232,7 +226,6 @@ describe("PresentationManager", () => {
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
-            mode: IModelHost.platform.ECPresentationManagerMode.ReadWrite,
             isChangeTrackingEnabled: false,
             cacheConfig: expectedConfig,
             contentCacheSize: undefined,
@@ -320,11 +313,11 @@ describe("PresentationManager", () => {
         });
       });
 
-      it("creates an `UpdateTracker` when in read-write mode, `updatesPollInterval` is specified and IPC host is available", () => {
+      it("creates an `UpdateTracker` when `updatesPollInterval` is specified and IPC host is available", () => {
         sinon.stub(IpcHost, "isValid").get(() => true);
         const tracker = sinon.createStubInstance(UpdatesTracker) as unknown as UpdatesTracker;
         const stub = sinon.stub(UpdatesTracker, "create").returns(tracker);
-        using(new PresentationManager({ addon: addon.object, mode: PresentationManagerMode.ReadWrite, updatesPollInterval: 123 }), (_) => {
+        using(new PresentationManager({ addon: addon.object, updatesPollInterval: 123 }), (_) => {
           expect(stub).to.be.calledOnceWith(sinon.match({ pollInterval: 123 }));
           expect(tracker.dispose).to.not.be.called; // eslint-disable-line @typescript-eslint/unbound-method
         });
@@ -334,7 +327,7 @@ describe("PresentationManager", () => {
       it("doesn't create an `UpdateTracker` when IPC host is unavailable", () => {
         sinon.stub(IpcHost, "isValid").get(() => false);
         const stub = sinon.stub(UpdatesTracker, "create");
-        using(new PresentationManager({ addon: addon.object, mode: PresentationManagerMode.ReadWrite, updatesPollInterval: 123 }), (_) => {
+        using(new PresentationManager({ addon: addon.object, updatesPollInterval: 123 }), (_) => {
           expect(stub).to.not.be.called;
         });
       });

--- a/presentation/testing/src/presentation-testing/Helpers.ts
+++ b/presentation/testing/src/presentation-testing/Helpers.ts
@@ -49,6 +49,7 @@ export const getTestOutputDir = (): string => {
   return testOutputDir ?? defaultTestOutputDir;
 };
 
+// eslint-disable-next-line deprecation/deprecation
 export { HierarchyCacheMode, PresentationManagerMode, PresentationBackendProps };
 
 /** @public */

--- a/test-apps/presentation-test-app/src/backend/main.ts
+++ b/test-apps/presentation-test-app/src/backend/main.ts
@@ -12,7 +12,7 @@ import { RpcInterfaceDefinition } from "@itwin/core-common";
 import { Presentation, PresentationProps } from "@itwin/presentation-backend";
 // __PUBLISH_EXTRACT_END__
 // eslint-disable-next-line no-duplicate-imports
-import { PresentationBackendLoggerCategory, PresentationBackendNativeLoggerCategory, PresentationManagerMode } from "@itwin/presentation-backend";
+import { PresentationBackendLoggerCategory, PresentationBackendNativeLoggerCategory } from "@itwin/presentation-backend";
 import rpcs from "../common/Rpcs";
 
 (async () => { // eslint-disable-line @typescript-eslint/no-floating-promises
@@ -43,7 +43,6 @@ import rpcs from "../common/Rpcs";
   // __PUBLISH_EXTRACT_END__
 
   // props that we don't want to show in documentation set up example
-  presentationBackendProps.mode = PresentationManagerMode.ReadWrite;
   presentationBackendProps.workerThreadsCount = 1;
   presentationBackendProps.useMmap = true;
   presentationBackendProps.updatesPollInterval = 20;


### PR DESCRIPTION
Deprecate PresentationManager mode because there is no difference in performance between PresentationManager working in `ReadOnly` or `ReadWrite` mode. Previously we were used to collect additional data for updates after iModel changes in `ReadWrite` mode but this is not the case after update handling was changed.

Closes #4587

Native changes: https://github.com/iTwin/imodel-native/pull/29