### PR TITLE
Fix flaky `BriefcaseConnection` test

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
@@ -97,9 +97,6 @@ if (ProcessDetector.isElectronAppFrontend) {
         assert.isDefined(progress.total);
         lastProgressReport = { ...progress, total: progress.total! };
 
-        // eslint-disable-next-line no-console
-        console.log(`Changeset download progress: ${progress.loaded} / ${progress.total}`);
-
         if (progress.loaded > progress.total! / 3)
           abortSignal.abort();
       };

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
@@ -97,6 +97,9 @@ if (ProcessDetector.isElectronAppFrontend) {
         assert.isDefined(progress.total);
         lastProgressReport = { ...progress, total: progress.total! };
 
+        // eslint-disable-next-line no-console
+        console.log(`Changeset download progress: ${progress.loaded} / ${progress.total}`);
+
         if (progress.loaded > progress.total! / 2)
           abortSignal.abort();
       };

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
@@ -100,18 +100,18 @@ if (ProcessDetector.isElectronAppFrontend) {
         // eslint-disable-next-line no-console
         console.log(`Changeset download progress: ${progress.loaded} / ${progress.total}`);
 
-        if (progress.loaded > progress.total! / 2)
+        if (progress.loaded > progress.total! / 3)
           abortSignal.abort();
       };
 
-      const pullPromise = connection.pullChanges(20, { progressCallback, abortSignal, progressInterval: 50 });
+      const pullPromise = connection.pullChanges(50, { progressCallback, abortSignal, progressInterval: 50 });
 
       try {
         await expect(pullPromise).to.eventually.be.rejectedWith(/cancelled|aborted/i);
         // Use following assert when BackendIModelsAccess returns IModelError with ChangeSetStatus.DownloadCancelled.
         // await expect(pullPromise).to.eventually.be.rejected.and.have.property("errorNumber", ChangeSetStatus.DownloadCancelled);
       } finally {
-        await connection.pullChanges(20); // Finish pulling changes so that the changesets files would be deleted.
+        await connection.pullChanges(51); // Finish pulling changes so that the changesets files would be deleted.
         await connection.close();
         await NativeApp.deleteBriefcase(fileName);
       }

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseConnection.test.ts
@@ -97,7 +97,7 @@ if (ProcessDetector.isElectronAppFrontend) {
         assert.isDefined(progress.total);
         lastProgressReport = { ...progress, total: progress.total! };
 
-        if (progress.loaded > progress.total! / 3)
+        if (progress.loaded > progress.total! / 4)
           abortSignal.abort();
       };
 


### PR DESCRIPTION
Test "_should cancel pulling changes after abort signal_" keeps failing on pipeline runs with inconsistent frequency (test doesn't fail locally). Most likely cause: download gets completed before cancel is fired. Increasing number of changesets and cancelling sooner should fix test flakiness.