### PR TITLE
Deprecate APIs to be removed in 4.0 version of AppUI

### DIFF
--- a/docs/learning/ui/appui-react/StatusBar.md
+++ b/docs/learning/ui/appui-react/StatusBar.md
@@ -22,9 +22,9 @@ export class AppStatusBarWidgetControl extends StatusBarWidgetControl {
 
       this._statusBarItems = [
         StatusBarItemUtilities.createStatusBarItem("ToolAssistance", StatusBarSection.Left, 10, <ToolAssistance />),
-        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, (<FooterMode> <FooterSeparator /> </FooterMode>)),
+        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, (<FooterMode> <StatusBarSeparator /> </FooterMode>)),
         StatusBarItemUtilities.createStatusBarItem("MessageCenter", StatusBarSection.Left, 20, <MessageCenter />),
-        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, (<FooterMode> <FooterSeparator /> </FooterMode>)),
+        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, (<FooterMode> <StatusBarSeparator /> </FooterMode>)),
         StatusBarItemUtilities.createStatusBarItem("DisplayStyle", StatusBarSection.Center, 40, <DisplayStyle />),
         StatusBarItemUtilities.createStatusBarItem("ActivityCenter", StatusBarSection.Center, 10, <ActivityCenter />),
         StatusBarItemUtilities.createStatusBarItem("ViewAttributes", StatusBarSection.Center, 60, <ViewAttributes />),

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/statusfields/DisplayStyleField.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/statusfields/DisplayStyleField.tsx
@@ -11,8 +11,7 @@ import classnames from "classnames";
 import * as React from "react";
 import { Id64String } from "@itwin/core-bentley";
 import { DisplayStyle2dState, DisplayStyle3dState, DisplayStyleState, ScreenViewport } from "@itwin/core-frontend";
-import { ContentControl, ContentControlActivatedEventArgs, ContentViewManager, FrontstageManager } from "@itwin/appui-react";
-import { FooterIndicator } from "@itwin/appui-layout-react";
+import { ContentControl, ContentControlActivatedEventArgs, ContentViewManager, FrontstageManager, StatusBarIndicator } from "@itwin/appui-react";
 import { Select, SelectOption } from "@itwin/itwinui-react";
 import { AppUiTestProviders } from "../../AppUiTestProviders";
 import { CommonProps } from "@itwin/core-react";
@@ -92,15 +91,14 @@ export function DisplayStyleField(props: CommonProps) {
     return null;
 
   return (
-    <FooterIndicator
+    <StatusBarIndicator
       className={classnames("uifw-statusFields-displayStyle", props.className)}
       style={props.style}
-      isInFooterMode={true}
     >
       <Select options={styleEntries} value={displayStyleId} onChange={handleDisplayStyleSelected}
         title={tooltip} aria-label={label}
         className="uifw-statusFields-displayStyle-selector"
         size="small" />
-    </FooterIndicator >
+    </StatusBarIndicator >
   );
 }

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -12,14 +12,13 @@ import { BrowserAuthorizationCallbackHandler, BrowserAuthorizationClient } from 
 import { Project as ITwin, ProjectsAccessClient, ProjectsSearchableProperty } from "@itwin/projects-client";
 import { RealityDataAccessClient, RealityDataClientOptions } from "@itwin/reality-data-client";
 import { getClassName, UiItemsManager } from "@itwin/appui-abstract";
-import { SafeAreaInsets } from "@itwin/appui-layout-react";
 import { TargetOptions, TargetOptionsContext } from "@itwin/appui-layout-react/lib/cjs/appui-layout-react/target/TargetOptions";
 import {
   ActionsUnion, AppNotificationManager, AppUiSettings, BackstageComposer, ConfigurableUiContent, createAction, DeepReadonly, FrameworkAccuDraw, FrameworkReducer,
   FrameworkRootState, FrameworkToolAdmin, FrameworkUiAdmin, FrameworkVersion, FrontstageDeactivatedEventArgs, FrontstageDef, FrontstageManager,
   IModelViewportControl,
   InitialAppUiSettings,
-  ModalFrontstageClosedEventArgs, SafeAreaContext, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
+  ModalFrontstageClosedEventArgs, SafeAreaContext, SafeAreaInsets, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
   ToolbarDragInteractionContext, UiFramework, UiStateStorageHandler,
 } from "@itwin/appui-react";
 import { Id64String, Logger, LogLevel, ProcessDetector, UnexpectedErrors } from "@itwin/core-bentley";
@@ -643,7 +642,6 @@ const SampleAppViewer2 = () => {
   return (
     <Provider store={SampleAppIModelApp.store} >
       <ThemeManager>
-        {/* eslint-disable-next-line deprecation/deprecation */}
         <SafeAreaContext.Provider value={SafeAreaInsets.All}>
           <AppDragInteraction>
             <AppFrameworkVersion>

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -570,7 +570,7 @@ function AppDragInteractionComponent(props: { dragInteraction: boolean, children
 
 function AppFrameworkVersionComponent(props: { frameworkVersion: string, children: React.ReactNode }) {
   return (
-    <FrameworkVersion>
+    <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
       {props.children}
     </FrameworkVersion>
   );

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -10,14 +10,13 @@ import { Store } from "redux"; // createStore,
 import reactAxe from "@axe-core/react";
 import { RealityDataAccessClient, RealityDataClientOptions } from "@itwin/reality-data-client";
 import { getClassName, UiItemsManager } from "@itwin/appui-abstract";
-import { SafeAreaInsets } from "@itwin/appui-layout-react";
 import { TargetOptions, TargetOptionsContext } from "@itwin/appui-layout-react/lib/cjs/appui-layout-react/target/TargetOptions";
 import {
   ActionsUnion, AppNotificationManager, AppUiSettings, BackstageComposer, ConfigurableUiContent, createAction, DeepReadonly, FrameworkAccuDraw, FrameworkReducer,
   FrameworkRootState, FrameworkToolAdmin, FrameworkUiAdmin, FrameworkVersion, FrontstageDeactivatedEventArgs, FrontstageManager,
   IModelViewportControl,
   InitialAppUiSettings,
-  ModalFrontstageClosedEventArgs, SafeAreaContext, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
+  ModalFrontstageClosedEventArgs, SafeAreaContext, SafeAreaInsets, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
   ToolbarDragInteractionContext, UiFramework, UiStateStorageHandler,
 } from "@itwin/appui-react";
 import { Id64String, Logger, LogLevel, ProcessDetector, UnexpectedErrors } from "@itwin/core-bentley";

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -380,7 +380,7 @@ function AppDragInteractionComponent(props: { dragInteraction: boolean, children
 
 function AppFrameworkVersionComponent(props: { frameworkVersion: string, children: React.ReactNode }) {
   return (
-    <FrameworkVersion>
+    <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
       {props.children}
     </FrameworkVersion>
   );

--- a/test-apps/ui-items-providers-test/src/ui/widgets/PresentationPropertyGridWidget.tsx
+++ b/test-apps/ui-items-providers-test/src/ui/widgets/PresentationPropertyGridWidget.tsx
@@ -96,7 +96,7 @@ export function PresentationPropertyGridWidget() {
   const [contextMenu, setContextMenu] = React.useState<PropertyGridContextMenuArgs | undefined>(undefined);
   const [contextMenuItemInfos, setContextMenuItemInfos] = React.useState<ContextMenuItemInfo[] | undefined>(undefined);
 
-  const version = useFrameworkVersion();
+  const version = useFrameworkVersion(); // eslint-disable-line deprecation/deprecation
   const componentId = ("2" === version) ? "uifw-v2-container" : "uifw-v1-container";
   const style: React.CSSProperties = ("2" === version) ? { height: "100%", width: "100%", position: "absolute" } : { height: "100%" };
 

--- a/test-apps/ui-test-app/src/frontend/appui/imodelopen/IModelOpen.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/imodelopen/IModelOpen.tsx
@@ -222,7 +222,7 @@ export class IModelOpen extends React.Component<IModelOpenProps, IModelOpenState
             {this.renderIModels()}
           </div>
         </div>
-        <ActivityMessagePopup />
+        <ActivityMessagePopup /> {/* eslint-disable-line deprecation/deprecation */}
       </>
     );
   }

--- a/test-apps/ui-test-app/src/frontend/appui/statusbars/AppStatusBar.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/statusbars/AppStatusBar.tsx
@@ -7,10 +7,9 @@ import * as React from "react";
 import { ConditionalBooleanValue, StatusBarSection } from "@itwin/appui-abstract";
 import {
   ActivityCenterField, ClearEmphasisStatusField, ConfigurableUiManager, MessageCenterField, SectionsStatusField, SelectionInfoField,
-  SelectionScopeField, SnapModeField, StatusBarComposer, StatusBarItem, StatusBarItemUtilities, StatusBarWidgetControl, StatusBarWidgetControlArgs,
+  SelectionScopeField, SnapModeField, StatusBarComposer, StatusBarItem, StatusBarItemUtilities, StatusBarSeparator, StatusBarWidgetControl, StatusBarWidgetControlArgs,
   TileLoadingIndicator, ToolAssistanceField, ViewAttributesStatusField,
 } from "@itwin/appui-react";
-import { FooterSeparator } from "@itwin/appui-layout-react";
 import { SampleAppIModelApp, SampleAppUiActionId } from "../..";
 import { DisplayStyleField } from "../statusfields/DisplayStyleField";
 
@@ -23,9 +22,9 @@ export class AppStatusBarWidgetControl extends StatusBarWidgetControl {
 
       this._statusBarItems = [
         StatusBarItemUtilities.createStatusBarItem("ToolAssistance", StatusBarSection.Left, 10, <ToolAssistanceField style={{ minWidth: "21em" }} />),
-        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, (<FooterSeparator />)),
+        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, <StatusBarSeparator />),
         StatusBarItemUtilities.createStatusBarItem("MessageCenter", StatusBarSection.Left, 20, <MessageCenterField />),
-        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, (<FooterSeparator />)),
+        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, <StatusBarSeparator />),
         StatusBarItemUtilities.createStatusBarItem("DisplayStyle", StatusBarSection.Center, 40, <DisplayStyleField />),
         StatusBarItemUtilities.createStatusBarItem("ActivityCenter", StatusBarSection.Center, 10, <ActivityCenterField />),
         StatusBarItemUtilities.createStatusBarItem("ViewAttributes", StatusBarSection.Center, 60, <ViewAttributesStatusField />),

--- a/test-apps/ui-test-app/src/frontend/appui/statusbars/SmallStatusBar.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/statusbars/SmallStatusBar.tsx
@@ -6,9 +6,8 @@ import * as React from "react";
 import { ConditionalBooleanValue, StatusBarSection } from "@itwin/appui-abstract";
 import {
   ActivityCenterField, ConfigurableUiManager, MessageCenterField, SnapModeField, StatusBarComposer, StatusBarItem,
-  StatusBarItemUtilities, StatusBarWidgetControl, StatusBarWidgetControlArgs, ToolAssistanceField,
+  StatusBarItemUtilities, StatusBarSeparator, StatusBarWidgetControl, StatusBarWidgetControlArgs, ToolAssistanceField,
 } from "@itwin/appui-react";
-import { FooterSeparator } from "@itwin/appui-layout-react";
 import { SampleAppIModelApp, SampleAppUiActionId } from "../..";
 
 export class SmallStatusBarWidgetControl extends StatusBarWidgetControl {
@@ -20,9 +19,9 @@ export class SmallStatusBarWidgetControl extends StatusBarWidgetControl {
 
       this._statusBarItems = [
         StatusBarItemUtilities.createStatusBarItem("ToolAssistance", StatusBarSection.Left, 10, <ToolAssistanceField />),
-        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, (<FooterSeparator />)),
+        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, <StatusBarSeparator />),
         StatusBarItemUtilities.createStatusBarItem("MessageCenter", StatusBarSection.Left, 20, <MessageCenterField />),
-        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, (<FooterSeparator />)),
+        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, <StatusBarSeparator />),
         StatusBarItemUtilities.createStatusBarItem("ActivityCenter", StatusBarSection.Left, 30, <ActivityCenterField />),
         StatusBarItemUtilities.createStatusBarItem("SnapMode", StatusBarSection.Center, 10, <SnapModeField />, { isHidden: isHiddenCondition }),
       ];

--- a/test-apps/ui-test-app/src/frontend/appui/statusbars/editing/EditStatusBar.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/statusbars/editing/EditStatusBar.tsx
@@ -7,10 +7,9 @@ import * as React from "react";
 import { StatusBarSection } from "@itwin/appui-abstract";
 import {
   ActivityCenterField, ClearEmphasisStatusField, ConfigurableUiManager, MessageCenterField, SectionsStatusField, SelectionInfoField,
-  SelectionScopeField, SnapModeField, StatusBarComposer, StatusBarItem, StatusBarItemUtilities, StatusBarWidgetControl, StatusBarWidgetControlArgs,
+  SelectionScopeField, SnapModeField, StatusBarComposer, StatusBarItem, StatusBarItemUtilities, StatusBarSeparator, StatusBarWidgetControl, StatusBarWidgetControlArgs,
   TileLoadingIndicator, ToolAssistanceField, ViewAttributesStatusField,
 } from "@itwin/appui-react";
-import { FooterSeparator } from "@itwin/appui-layout-react";
 import { DisplayStyleField } from "../../statusfields/DisplayStyleField";
 import { PushPullStatusField } from "../../statusfields/editing/PushPullStatusField";
 
@@ -21,9 +20,9 @@ export class EditStatusBarWidgetControl extends StatusBarWidgetControl {
     if (!this._statusBarItems) {
       this._statusBarItems = [
         StatusBarItemUtilities.createStatusBarItem("ToolAssistance", StatusBarSection.Left, 10, <ToolAssistanceField />),
-        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, (<FooterSeparator />)),
+        StatusBarItemUtilities.createStatusBarItem("ToolAssistanceSeparator", StatusBarSection.Left, 15, <StatusBarSeparator />),
         StatusBarItemUtilities.createStatusBarItem("MessageCenter", StatusBarSection.Left, 20, <MessageCenterField />),
-        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, (<FooterSeparator />)),
+        StatusBarItemUtilities.createStatusBarItem("MessageCenterSeparator", StatusBarSection.Left, 25, <StatusBarSeparator />),
         StatusBarItemUtilities.createStatusBarItem("DisplayStyle", StatusBarSection.Center, 10, <DisplayStyleField />),
         StatusBarItemUtilities.createStatusBarItem("ActivityCenter", StatusBarSection.Center, 20, <ActivityCenterField />),
         StatusBarItemUtilities.createStatusBarItem("PushPull", StatusBarSection.Center, 30, <PushPullStatusField />),

--- a/test-apps/ui-test-app/src/frontend/appui/statusfields/DisplayStyleField.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/statusfields/DisplayStyleField.tsx
@@ -11,8 +11,7 @@ import classnames from "classnames";
 import * as React from "react";
 import { Id64String } from "@itwin/core-bentley";
 import { DisplayStyle2dState, DisplayStyle3dState, DisplayStyleState, IModelApp, ScreenViewport } from "@itwin/core-frontend";
-import { ContentControl, ContentControlActivatedEventArgs, ContentViewManager, FrontstageManager } from "@itwin/appui-react";
-import { FooterIndicator } from "@itwin/appui-layout-react";
+import { ContentControl, ContentControlActivatedEventArgs, ContentViewManager, FrontstageManager, StatusBarIndicator } from "@itwin/appui-react";
 import { Select, SelectOption } from "@itwin/itwinui-react";
 import { CommonProps } from "@itwin/core-react";
 
@@ -110,7 +109,7 @@ export class DisplayStyleField extends React.Component<CommonProps, DisplayStyle
     const displayStyleId = this.state.viewport.view.displayStyle.id;
 
     return (
-      <FooterIndicator
+      <StatusBarIndicator
         className={classnames("uifw-statusFields-displayStyle", this.props.className)}
         style={this.props.style}
       >
@@ -118,7 +117,7 @@ export class DisplayStyleField extends React.Component<CommonProps, DisplayStyle
           title={this._tooltip} aria-label={this._label}
           className="uifw-statusFields-displayStyle-selector"
           size="small" />
-      </FooterIndicator >
+      </StatusBarIndicator >
     );
   }
 }

--- a/test-apps/ui-test-app/src/frontend/appui/statusfields/SampleStatusField.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/statusfields/SampleStatusField.tsx
@@ -9,8 +9,7 @@
 import * as React from "react";
 import { IModelApp } from "@itwin/core-frontend";
 import { CommonProps, FillCentered } from "@itwin/core-react";
-import { Indicator } from "@itwin/appui-react";
-import { Dialog, TitleBar } from "@itwin/appui-layout-react";
+import { StatusBarDialog, StatusBarLabelIndicator } from "@itwin/appui-react";
 import { ColorPickerPopup } from "@itwin/imodel-components-react";
 import { ColorDef } from "@itwin/core-common";
 import { Button } from "@itwin/itwinui-react";
@@ -37,14 +36,19 @@ export class SampleStatusField extends React.Component<CommonProps> {
 
   public override render() {
     return (
-      <Indicator
-        iconName="icon-placeholder"
-        dialog={<Dialog titleBar={<TitleBar title={this._title} />}>
-          <TestStatusBarDialog />
-        </Dialog>}
+      <StatusBarLabelIndicator
+        iconSpec="icon-placeholder"
+        popup={
+          <StatusBarDialog
+            titleBar={
+              <StatusBarDialog.TitleBar  title={this._title} />
+            }
+          >
+            <TestStatusBarDialog />
+          </StatusBarDialog>
+        }
         label="Left"
-        isLabelVisible={true}
-        toolTip={this._title}
+        title={this._title}
         labelSide={StatusBarLabelSide.Left}
       />
     );

--- a/test-apps/ui-test-app/src/frontend/appui/statusfields/ShadowField.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/statusfields/ShadowField.tsx
@@ -11,8 +11,7 @@ import classnames from "classnames";
 import * as React from "react";
 import { RenderMode } from "@itwin/core-common";
 import { ScreenViewport } from "@itwin/core-frontend";
-import { ContentControl, ContentControlActivatedEventArgs, ContentViewManager, FrontstageManager } from "@itwin/appui-react";
-import { FooterIndicator } from "@itwin/appui-layout-react";
+import { ContentControl, ContentControlActivatedEventArgs, ContentViewManager, FrontstageManager, StatusBarIndicator } from "@itwin/appui-react";
 import { Checkbox } from "@itwin/itwinui-react";
 import { CommonProps } from "@itwin/core-react";
 
@@ -96,12 +95,12 @@ export class ShadowField extends React.Component<CommonProps, ShadowFieldState> 
     }
 
     return (
-      <FooterIndicator
+      <StatusBarIndicator
         className={classnames("uifw-statusFields-shadowField", this.props.className)}
         style={this.props.style}
       >
         <Checkbox style={cbStyle} label="Shadows" checked={isChecked} onChange={this._onChange} disabled={isDisabled} className="statusfield-checkbox" />
-      </FooterIndicator >
+      </StatusBarIndicator >
     );
   }
 }

--- a/test-apps/ui-test-app/src/frontend/appui/statusfields/editing/PushPullStatusField.tsx
+++ b/test-apps/ui-test-app/src/frontend/appui/statusfields/editing/PushPullStatusField.tsx
@@ -9,8 +9,7 @@ import {
   BriefcaseConnection, IModelApp, NotifyMessageDetails, OutputMessageAlert, OutputMessagePriority, OutputMessageType,
 } from "@itwin/core-frontend";
 import { CommonProps, Icon } from "@itwin/core-react";
-import { UiFramework } from "@itwin/appui-react";
-import { FooterIndicator } from "@itwin/appui-layout-react";
+import { StatusBarIndicator, UiFramework } from "@itwin/appui-react";
 import { ProgressRadial } from "@itwin/itwinui-react";
 
 function translate(prompt: string) {
@@ -183,7 +182,7 @@ export class PushPullStatusField extends React.Component<CommonProps, PushPullSt
 
     if (this.state.isSynchronizing) {
       return (
-        <FooterIndicator
+        <StatusBarIndicator
           className={"simple-editor-app-statusFields-pushPull"}
           style={this.props.style}
         >
@@ -196,7 +195,7 @@ export class PushPullStatusField extends React.Component<CommonProps, PushPullSt
               <Icon iconSpec="icon icon-blank" />
             </div>
           </div>
-        </FooterIndicator >
+        </StatusBarIndicator >
       );
     }
     const mustPush = this.mustPush && !this.state.isSynchronizing;
@@ -209,7 +208,7 @@ export class PushPullStatusField extends React.Component<CommonProps, PushPullSt
     const pullTitleTxt = translate(mustPull ? "pullButtonTitle" : "pullButtonDisabledTitle");
 
     return (
-      <FooterIndicator
+      <StatusBarIndicator
         className={"simple-editor-app-statusFields-pushPull"}
         style={this.props.style}
       >
@@ -224,7 +223,7 @@ export class PushPullStatusField extends React.Component<CommonProps, PushPullSt
             {pullChangeCount}<Icon iconSpec={pullIcon} />
           </div>
         </div>
-      </FooterIndicator>
+      </StatusBarIndicator>
     );
   }
 

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -333,7 +333,7 @@ export class SampleAppIModelApp {
 
     await FrontendDevTools.initialize();
     await HyperModeling.initialize();
-    await MapLayersUI.initialize({ iTwinConfig: new MichelTestPrefs(), featureInfoOpts: { onMapHit: DefaultMapFeatureInfoTool.onMapHit } });
+    await MapLayersUI.initialize({ featureInfoOpts: { onMapHit: DefaultMapFeatureInfoTool.onMapHit } });
     MapLayersFormats.initialize();
 
     AppSettingsTabsProvider.initializeAppSettingProvider();
@@ -673,7 +673,7 @@ function AppDragInteractionComponent(props: { dragInteraction: boolean, children
 
 function AppFrameworkVersionComponent(props: { frameworkVersion: string, children: React.ReactNode }) {
   return (
-    <FrameworkVersion>
+    <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
       {props.children}
     </FrameworkVersion>
   );

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -12,13 +12,12 @@ import { BrowserAuthorizationCallbackHandler, BrowserAuthorizationClient } from 
 import { Project as ITwin, ProjectsAccessClient, ProjectsSearchableProperty } from "@itwin/projects-client";
 import { RealityDataAccessClient, RealityDataClientOptions } from "@itwin/reality-data-client";
 import { getClassName } from "@itwin/appui-abstract";
-import { SafeAreaInsets } from "@itwin/appui-layout-react";
 import { TargetOptions, TargetOptionsContext } from "@itwin/appui-layout-react/lib/cjs/appui-layout-react/target/TargetOptions";
 import {
   ActionsUnion, AppNotificationManager, AppUiSettings, ConfigurableUiContent, createAction, DeepReadonly, FrameworkAccuDraw, FrameworkReducer,
   FrameworkRootState, FrameworkToolAdmin, FrameworkUiAdmin, FrameworkVersion, FrontstageDeactivatedEventArgs, FrontstageDef, FrontstageManager,
   InitialAppUiSettings,
-  ModalFrontstageClosedEventArgs, SafeAreaContext, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
+  ModalFrontstageClosedEventArgs, SafeAreaContext, SafeAreaInsets, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
   ToolbarDragInteractionContext, UiFramework, UiStateStorageContext, UiStateStorageHandler,
 } from "@itwin/appui-react";
 import { BeDragDropContext } from "@itwin/components-react";
@@ -368,7 +367,7 @@ export class SampleAppIModelApp {
       redirectUri: "http://localhost:3000/esri-oauth2-callback",
       clientIds: {
         arcgisOnlineClientId: SampleAppIModelApp?.testAppConfiguration?.arcGisOnlineClientId,
-        enterpriseClientIds: [{serviceBaseUrl: "", clientId: "Bentley_TestApp"}],
+        enterpriseClientIds: [{ serviceBaseUrl: "", clientId: "Bentley_TestApp" }],
       },
     });
 

--- a/test-apps/ui-test-app/src/frontend/tools/ToolSpecifications.tsx
+++ b/test-apps/ui-test-app/src/frontend/tools/ToolSpecifications.tsx
@@ -23,10 +23,9 @@ import {
 import { Dialog, FillCentered, ReactMessage, SvgPath, SvgSprite, UnderlinedButton } from "@itwin/core-react";
 import {
   Backstage, CommandItemDef, ContentGroup, ContentGroupProps, ContentLayoutManager, ContentProps, ContentViewManager,
-  FrontstageManager, IModelViewportControl, Indicator, MessageManager, ModalDialogManager, ReactNotifyMessageDetails,
-  StatusBarItemUtilities, SyncUiEventDispatcher, SyncUiEventId, ToolItemDef,
+  FrontstageManager, IModelViewportControl, MessageManager, ModalDialogManager, ReactNotifyMessageDetails, StatusBarDialog,
+  StatusBarItemUtilities, StatusBarLabelIndicator, StatusBarSeparator, SyncUiEventDispatcher, SyncUiEventId, ToolItemDef,
 } from "@itwin/appui-react";
-import { FooterPopupContentType, FooterSeparator, Dialog as NZ_Dialog, TitleBar } from "@itwin/appui-layout-react";
 import { SampleAppIModelApp } from "../";
 import { AppUi } from "../appui/AppUi";
 import { TestMessageBox } from "../appui/dialogs/TestMessageBox";
@@ -123,25 +122,23 @@ class AppItemsProvider implements UiItemsProvider {
   public provideStatusBarItems(_stageId: string, _stageUsage: string): CommonStatusBarItem[] {
     const statusBarItems: CommonStatusBarItem[] = [];
     const isHiddenCondition = new ConditionalBooleanValue(() => !AppItemsProvider._sampleBackstageItemVisible, [AppItemsProvider.syncEventId]);
-    statusBarItems.push(StatusBarItemUtilities.createStatusBarItem(AppItemsProvider.sampleStatusSeparatorId, StatusBarSection.Left, 11, <FooterSeparator />, { isHidden: isHiddenCondition }));
+    statusBarItems.push(StatusBarItemUtilities.createStatusBarItem(AppItemsProvider.sampleStatusSeparatorId, StatusBarSection.Left, 11, <StatusBarSeparator />, { isHidden: isHiddenCondition }));
     statusBarItems.push(StatusBarItemUtilities.createStatusBarItem(AppItemsProvider.sampleStatusFieldId, StatusBarSection.Left, 12, <SampleStatusField />, { isHidden: isHiddenCondition }));
     statusBarItems.push(StatusBarItemUtilities.createStatusBarItem(AppItemsProvider.sampleStatusField2Id, StatusBarSection.Left, 13,
-      <Indicator
-        iconName="icon-app-1"
-        dialog={<TestStatusBarDialog />}
-        toolTip="Middle"
-        contentType={FooterPopupContentType.Panel}
+      <StatusBarLabelIndicator
+        iconSpec="icon-app-1"
+        popup={<TestStatusBarDialog />}
+        title="Middle"
       />, { isHidden: isHiddenCondition }));
 
     statusBarItems.push(StatusBarItemUtilities.createStatusBarItem(AppItemsProvider.sampleStatusField3Id, StatusBarSection.Left, 14,
-      <Indicator
-        iconName="icon-app-2"
-        dialog={<NZ_Dialog titleBar={<TitleBar title="Right Test" />}>
+      <StatusBarLabelIndicator
+        iconSpec="icon-app-2"
+        popup={<StatusBarDialog titleBar={<StatusBarDialog.TitleBar title="Right Test" />}>
           <TestStatusBarDialog />
-        </NZ_Dialog>}
+        </StatusBarDialog>}
         label="Right"
-        isLabelVisible={true}
-        toolTip="Right Test"
+        title="Right Test"
         labelSide={StatusBarLabelSide.Right}
       />, { isHidden: isHiddenCondition }));
     return statusBarItems;

--- a/ui/appui-layout-react/src/appui-layout-react/footer/Indicator.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/footer/Indicator.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { CommonProps } from "@itwin/core-react";
 
 /** Properties of [[FooterIndicator]] component.
+ * @deprecated Props of a deprecated component.
  * @beta
  */
 export interface FooterIndicatorProps extends CommonProps {
@@ -28,10 +29,10 @@ export interface FooterIndicatorProps extends CommonProps {
 }
 
 /** Indicator used in [[Footer]] component.
+ * @deprecated Use [StatusBarIndicator]($appui-react) instead.
  * @beta
  */
-export function FooterIndicator(props: FooterIndicatorProps) {
-
+export const FooterIndicator = React.forwardRef<HTMLDivElement, FooterIndicatorProps>(function FooterIndicator(props, ref) {
   const { isInFooterMode, children, ...attributes } = props;
 
   const className = classnames(
@@ -41,8 +42,8 @@ export function FooterIndicator(props: FooterIndicatorProps) {
   );
 
   return (
-    <div {...{ ...attributes, className }}>
+    <div ref={ref} {...{ ...attributes, className }}>
       {children}
     </div>
   );
-}
+});

--- a/ui/appui-layout-react/src/appui-layout-react/footer/Popup.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/footer/Popup.tsx
@@ -13,6 +13,7 @@ import { RelativePosition } from "@itwin/appui-abstract";
 import { Popup, PopupProps } from "@itwin/core-react";
 
 /** Available footer popup content types.
+ * @deprecated Type used in a deprecated component.
  * @beta
  */
 export enum FooterPopupContentType {
@@ -23,6 +24,7 @@ export enum FooterPopupContentType {
 }
 
 /** Properties of [[FooterPopup]] component.
+ * @deprecated Props of a deprecated component.
  * @beta
  */
 export interface FooterPopupProps extends Partial<PopupProps> {
@@ -31,11 +33,13 @@ export interface FooterPopupProps extends Partial<PopupProps> {
 }
 
 /** Default properties of [[FooterPopup]] component.
+ * @deprecated Default props of a deprecated component.
  * @beta
  */
 export type FooterPopupDefaultProps = Pick<FooterPopupProps, "contentType">;
 
 /** Popup component used in [[Footer]] component.
+ * @deprecated Use [StatusBarIndicator] instead.
  * @beta
  */
 export class FooterPopup extends React.PureComponent<FooterPopupProps> {

--- a/ui/appui-layout-react/src/appui-layout-react/footer/Separator.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/footer/Separator.tsx
@@ -12,12 +12,14 @@ import * as React from "react";
 import { CommonProps, NoChildrenProps } from "@itwin/core-react";
 
 /** Properties of [[FooterSeparator]] component.
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface FooterSeparatorProps extends CommonProps, NoChildrenProps {
 }
 
 /** Footer indicator separator used in [[Footer]] component.
+ * @deprecated Use [StatusBarSeparator]($appui-react) instead.
  * @public
  */
 export class FooterSeparator extends React.PureComponent<FooterSeparatorProps> {

--- a/ui/appui-layout-react/src/appui-layout-react/footer/dialog/Dialog.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/footer/dialog/Dialog.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { CommonProps } from "@itwin/core-react";
 
 /** Properties of [[Dialog]] component.
+ * @deprecated Props of a deprecated component.
  * @beta
  */
 export interface DialogProps extends CommonProps {
@@ -23,6 +24,7 @@ export interface DialogProps extends CommonProps {
 
 /** Dialog used in footer indicators.
  * @note See [[MessageCenter]], [[ToolAssistance]]
+ * @deprecated Use [StatusBarDialog]($appui-react) instead.
  * @beta
  */
 export class Dialog extends React.PureComponent<DialogProps> {

--- a/ui/appui-layout-react/src/appui-layout-react/footer/dialog/TitleBar.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/footer/dialog/TitleBar.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { CommonProps } from "@itwin/core-react";
 
 /** Properties of [[TitleBar]] component.
+ * @deprecated Props of a deprecated component.
  * @beta
  */
 export interface TitleBarProps extends CommonProps {
@@ -22,6 +23,7 @@ export interface TitleBarProps extends CommonProps {
 }
 
 /** Title bar of [[Dialog]] component.
+ * @deprecated Use [StatusBarDialog.TitleBar]($appui-react) instead.
  * @beta
  */
 export class TitleBar extends React.PureComponent<TitleBarProps> {

--- a/ui/appui-layout-react/src/appui-layout-react/utilities/SafeAreaInsets.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/utilities/SafeAreaInsets.ts
@@ -8,6 +8,7 @@
 
 /** Describes available safe area insets.
  * @beta
+ * @deprecated Use [SafeAreaInsets]($appui-react) instead.
  */
 export enum SafeAreaInsets {
   None = 0,

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -141,6 +141,7 @@ export * from "./appui-react/redux/ReducerRegistry";
 export * from "./appui-react/redux/redux-ts";
 
 export * from "./appui-react/safearea/SafeAreaContext";
+export * from "./appui-react/safearea/SafeAreaInsets";
 
 export * from "./appui-react/selection/SelectionContextItemDef";
 export * from "./appui-react/selection/HideIsolateEmphasizeManager";

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -172,6 +172,8 @@ export * from "./appui-react/stagepanels/StagePanelHeader";
 
 export * from "./appui-react/statusbar/dialog/Dialog";
 
+export * from "./appui-react/statusbar/Indicator";
+export * from "./appui-react/statusbar/LabelIndicator";
 export * from "./appui-react/statusbar/Separator";
 export * from "./appui-react/statusbar/StatusBar";
 export * from "./appui-react/statusbar/StatusBarWidgetControl";

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -172,6 +172,7 @@ export * from "./appui-react/stagepanels/StagePanelHeader";
 
 export * from "./appui-react/statusbar/dialog/Dialog";
 
+export * from "./appui-react/statusbar/Separator";
 export * from "./appui-react/statusbar/StatusBar";
 export * from "./appui-react/statusbar/StatusBarWidgetControl";
 export * from "./appui-react/statusbar/StatusBarComposer";

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -170,6 +170,8 @@ export * from "./appui-react/stagepanels/StagePanel";
 export * from "./appui-react/stagepanels/StagePanelDef";
 export * from "./appui-react/stagepanels/StagePanelHeader";
 
+export * from "./appui-react/statusbar/dialog/Dialog";
+
 export * from "./appui-react/statusbar/StatusBar";
 export * from "./appui-react/statusbar/StatusBarWidgetControl";
 export * from "./appui-react/statusbar/StatusBarComposer";

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -69,8 +69,8 @@ export class UiVisibilityChangedEvent extends UiEvent<UiVisibilityEventArgs> { }
  * @internal
  */
 export interface FrameworkVersionChangedEventArgs {
-  oldVersion: FrameworkVersionId;
-  version: FrameworkVersionId;
+  oldVersion: FrameworkVersionId; // eslint-disable-line deprecation/deprecation
+  version: FrameworkVersionId; // eslint-disable-line deprecation/deprecation
 }
 
 /** FrameworkVersion Changed Event class.
@@ -97,7 +97,7 @@ export class UiFramework {
   private static _frameworkStateKeyInStore: string = "frameworkState";  // default name
   private static _backstageManager?: BackstageManager;
   private static _widgetManager?: WidgetManager;
-  private static _uiVersion: FrameworkVersionId = "2";
+  private static _uiVersion: FrameworkVersionId = "2"; // eslint-disable-line deprecation/deprecation
   private static _hideIsolateEmphasizeActionHandler?: HideIsolateEmphasizeActionHandler;
   /** this provides a default state storage handler */
   private static _uiStateStorage: UiStateStorage = new LocalStateStorage();
@@ -503,11 +503,11 @@ export class UiFramework {
   /** Returns the Ui Version.
    * @public
    */
-  public static get uiVersion(): FrameworkVersionId {
+  public static get uiVersion(): FrameworkVersionId { // eslint-disable-line deprecation/deprecation
     return UiFramework.frameworkState ? UiFramework.frameworkState.configurableUiState.frameworkVersion : this._uiVersion;
   }
 
-  public static setUiVersion(version: FrameworkVersionId) {
+  public static setUiVersion(version: FrameworkVersionId) { // eslint-disable-line deprecation/deprecation
     if (UiFramework.uiVersion === version)
       return;
 

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -38,6 +38,7 @@ import { FrontstageManager } from "./frontstage/FrontstageManager";
 // cSpell:ignore Mobi
 
 /** Defined that available UI Versions. It is recommended to always use the latest version available.
+ * @deprecated Used to toggle between UI1.0 and UI2.0.
  * @public
  */
 export type FrameworkVersionId = "1" | "2";

--- a/ui/appui-react/src/appui-react/backstage/Backstage.tsx
+++ b/ui/appui-react/src/appui-react/backstage/Backstage.tsx
@@ -24,11 +24,13 @@ export interface BackstageEventArgs {
 }
 
 /** Backstage Event class.
+ * @deprecated Use [BackstageManager.onToggled]($appui-react) instead.
  * @public
  */
 export class BackstageEvent extends UiEvent<BackstageEventArgs> { } // eslint-disable-line deprecation/deprecation
 
 /** Properties for the [[Backstage]] React component.
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface BackstageProps extends CommonProps {
@@ -46,6 +48,7 @@ interface BackstageState {
 }
 
 /** Backstage React component.
+ * @deprecated Use [BackstageComposer]($appui-react) instead.
  * @public
  */
 export class Backstage extends React.Component<BackstageProps, BackstageState> { // eslint-disable-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/backstage/Backstage.tsx
+++ b/ui/appui-react/src/appui-react/backstage/Backstage.tsx
@@ -53,7 +53,7 @@ interface BackstageState {
  */
 export class Backstage extends React.Component<BackstageProps, BackstageState> { // eslint-disable-line deprecation/deprecation
 
-  public static readonly onBackstageEvent = new BackstageEvent();
+  public static readonly onBackstageEvent = new BackstageEvent(); // eslint-disable-line deprecation/deprecation
   public static isBackstageVisible: boolean;
 
   /** Shows the Backstage */

--- a/ui/appui-react/src/appui-react/backstage/CommandLaunch.tsx
+++ b/ui/appui-react/src/appui-react/backstage/CommandLaunch.tsx
@@ -21,7 +21,7 @@ import { BackstageItemUtilities } from "./BackstageItemUtilities";
 // cspell:ignore safearea
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const BackstageItem = withSafeArea(NZ_BackstageItem);
+const BackstageItem = withSafeArea(NZ_BackstageItem); // eslint-disable-line deprecation/deprecation
 
 /** Properties for a [[CommandLaunchBackstageItem]] component
  * @public

--- a/ui/appui-react/src/appui-react/childwindow/ChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/ChildWindowManager.tsx
@@ -104,7 +104,7 @@ export class ChildWindowManager {
             <Provider store={StateManager.store} >
               <UiStateStorageHandler>
                 <ThemeManager>
-                  <FrameworkVersion>
+                  <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
                     <div className="uifw-child-window-container-host">
                       <PopupRenderer />
                       <ModalDialogRenderer />

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -45,7 +45,7 @@ export interface ConfigurableUiContentProps extends CommonProps {
  * @public
  */
 export function ConfigurableUiContent(props: ConfigurableUiContentProps) {
-  const version = useFrameworkVersion();
+  const version = useFrameworkVersion(); // eslint-disable-line deprecation/deprecation
   React.useEffect(() => {
     KeyboardShortcutManager.setFocusToHome();
   }, []);

--- a/ui/appui-react/src/appui-react/configurableui/state.ts
+++ b/ui/appui-react/src/appui-react/configurableui/state.ts
@@ -40,7 +40,7 @@ export interface ConfigurableUiState {
   theme: string;
   widgetOpacity: number;
   useDragInteraction: boolean;
-  frameworkVersion: FrameworkVersionId;
+  frameworkVersion: FrameworkVersionId; // eslint-disable-line deprecation/deprecation
   showWidgetIcon: boolean;
   autoCollapseUnpinnedPanels: boolean;
   viewOverlayDisplay: boolean;
@@ -78,7 +78,7 @@ export const ConfigurableUiActions = {   // eslint-disable-line @typescript-esli
     // istanbul ignore next
     (opacity: number) => createAction(ConfigurableUiActionId.SetWidgetOpacity, opacity),
   setDragInteraction: (dragInteraction: boolean) => createAction(ConfigurableUiActionId.SetDragInteraction, dragInteraction),
-  setFrameworkVersion: (frameworkVersion: FrameworkVersionId) => createAction(ConfigurableUiActionId.SetFrameworkVersion, frameworkVersion),
+  setFrameworkVersion: (frameworkVersion: FrameworkVersionId) => createAction(ConfigurableUiActionId.SetFrameworkVersion, frameworkVersion), // eslint-disable-line deprecation/deprecation
   setShowWidgetIcon: (showWidgetIcon: boolean) => createAction(ConfigurableUiActionId.SetShowWidgetIcon, showWidgetIcon),
   setAutoCollapseUnpinnedPanels: (autoCollapse: boolean) => createAction(ConfigurableUiActionId.AutoCollapseUnpinnedPanels, autoCollapse),
   setViewOverlayDisplay: (displayViewOverlay: boolean) => createAction(ConfigurableUiActionId.SetViewOverlayDisplay, displayViewOverlay),

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.tsx
@@ -11,8 +11,8 @@ import * as React from "react";
 import classnames from "classnames";
 import { PointProps, RelativePosition } from "@itwin/appui-abstract";
 import { CommonDivProps, CommonProps, Div, RectangleProps, Size, SizeProps } from "@itwin/core-react";
-import { TitleBar } from "@itwin/appui-layout-react";
 import { CursorPopupFadeOutEventArgs, CursorPopupManager } from "./CursorPopupManager";
+import { StatusBarDialog } from "../../statusbar/dialog/Dialog";
 
 /** Properties for the [[CursorPopup]] React component
  * @public
@@ -181,7 +181,7 @@ export class CursorPopup extends React.Component<CursorPopupProps, CursorPopupSt
     return (
       <div className={classNames} ref={(e) => this.setDivRef(e)} style={positioningStyle}>
         {this.props.title &&
-          <TitleBar
+          <StatusBarDialog.TitleBar
             title={this.props.title}
             className="uifw-cursorpopup-title" />
         }

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageComposer.tsx
@@ -44,6 +44,7 @@ export interface WidgetChangeHandler {
 }
 
 /** Interface defining callbacks for stage panel changes
+ * @deprecated Used in UI1.0 only.
  * @public
  */
 export interface StagePanelChangeHandler {
@@ -68,6 +69,7 @@ export interface TargetChangeHandler {
 }
 
 /** Interface defining callbacks for nine zone changes
+ * @deprecated Used in UI1.0 only.
  * @public
  */
 export interface NineZoneChangeHandler {
@@ -76,6 +78,7 @@ export interface NineZoneChangeHandler {
 }
 
 /** Interface defining a provider for Zone definitions
+ * @deprecated Used in UI1.0 only.
  * @public
  */
 export interface ZoneDefProvider {

--- a/ui/appui-react/src/appui-react/hooks/useFrameworkVersion.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useFrameworkVersion.tsx
@@ -11,15 +11,24 @@ import { useSelector } from "react-redux";
 import { FrameworkRootState } from "../redux/StateManager";
 import { FrameworkVersionId, UiFramework } from "../UiFramework";
 
-/** @public */
+/**
+ * @deprecated Used to toggle between UI1.0 and UI2.0.
+ * @public
+ */
 export function useFrameworkVersion(): FrameworkVersionId {
   return React.useContext(FrameworkVersionContext);
 }
 
-/** @public */
+/**
+ * @deprecated Used to toggle between UI1.0 and UI2.0.
+ * @public
+ */
 export const FrameworkVersionContext = React.createContext<FrameworkVersionId>("2"); // eslint-disable-line @typescript-eslint/naming-convention
 
-/** @public */
+/**
+ * @deprecated Used to toggle between UI1.0 and UI2.0.
+ * @public
+ */
 export interface FrameworkVersionProps {
   children?: React.ReactNode;
 }
@@ -28,6 +37,7 @@ export interface FrameworkVersionProps {
  * component uses the property frameworkState.configurableUiState.frameworkVersion from the redux store
  * to determine the ui version. This version will default to "2" and should only be set to "1" for older
  * iModelApp applications.
+ * @deprecated Used to toggle between UI1.0 and UI2.0.
  * @public
  */
 export function FrameworkVersion(props: FrameworkVersionProps) { // eslint-disable-line @typescript-eslint/no-redeclare

--- a/ui/appui-react/src/appui-react/hooks/useFrameworkVersion.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useFrameworkVersion.tsx
@@ -15,15 +15,15 @@ import { FrameworkVersionId, UiFramework } from "../UiFramework";
  * @deprecated Used to toggle between UI1.0 and UI2.0.
  * @public
  */
-export function useFrameworkVersion(): FrameworkVersionId {
-  return React.useContext(FrameworkVersionContext);
+export function useFrameworkVersion(): FrameworkVersionId { // eslint-disable-line deprecation/deprecation
+  return React.useContext(FrameworkVersionContext); // eslint-disable-line deprecation/deprecation
 }
 
 /**
  * @deprecated Used to toggle between UI1.0 and UI2.0.
  * @public
  */
-export const FrameworkVersionContext = React.createContext<FrameworkVersionId>("2"); // eslint-disable-line @typescript-eslint/naming-convention
+export const FrameworkVersionContext = React.createContext<FrameworkVersionId>("2"); // eslint-disable-line @typescript-eslint/naming-convention, deprecation/deprecation
 
 /**
  * @deprecated Used to toggle between UI1.0 and UI2.0.
@@ -40,12 +40,12 @@ export interface FrameworkVersionProps {
  * @deprecated Used to toggle between UI1.0 and UI2.0.
  * @public
  */
-export function FrameworkVersion(props: FrameworkVersionProps) { // eslint-disable-line @typescript-eslint/no-redeclare
+export function FrameworkVersion(props: FrameworkVersionProps) { // eslint-disable-line @typescript-eslint/no-redeclare, deprecation/deprecation
   const uiVersion = useSelector((state: FrameworkRootState) => {
     const frameworkState = (state as any)[UiFramework.frameworkStateKey];
-    return frameworkState ? frameworkState.configurableUiState.frameworkVersion as FrameworkVersionId : "2";
+    return frameworkState ? frameworkState.configurableUiState.frameworkVersion as FrameworkVersionId : "2"; // eslint-disable-line deprecation/deprecation
   });
-  return <FrameworkVersionContext.Provider
+  return <FrameworkVersionContext.Provider // eslint-disable-line deprecation/deprecation
     children={props.children} // eslint-disable-line react/no-children-prop
     value={uiVersion}
   />;
@@ -59,7 +59,7 @@ export interface FrameworkVersionSwitchProps {
 
 /** @internal */
 export function FrameworkVersionSwitch(props: FrameworkVersionSwitchProps) {
-  const version = useFrameworkVersion();
+  const version = useFrameworkVersion(); // eslint-disable-line deprecation/deprecation
   switch (version) {
     case "1": {
       return <>{props.v1}</>;

--- a/ui/appui-react/src/appui-react/messages/ActivityMessage.tsx
+++ b/ui/appui-react/src/appui-react/messages/ActivityMessage.tsx
@@ -37,7 +37,7 @@ export interface ActivityMessageProps {
  * @public
  * @deprecated
  */
-export function ActivityMessage(props: ActivityMessageProps) {
+export function ActivityMessage(props: ActivityMessageProps) { // eslint-disable-line deprecation/deprecation
   const messageDetails = props.activityMessageInfo.details;
   const [percentCompleteLabel] = React.useState(UiFramework.translate("activityCenter.percentComplete"));
   const [cancelLabel] = React.useState(UiCore.translate("dialog.cancel"));

--- a/ui/appui-react/src/appui-react/messages/ActivityMessage.tsx
+++ b/ui/appui-react/src/appui-react/messages/ActivityMessage.tsx
@@ -24,6 +24,7 @@ import { HollowIcon } from "./HollowIcon";
 import { ToasterSettings } from "@itwin/itwinui-react/cjs/core/Toast/Toaster";
 
 /** Properties for a [[ActivityMessage]]
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface ActivityMessageProps {

--- a/ui/appui-react/src/appui-react/messages/ActivityMessagePopup.tsx
+++ b/ui/appui-react/src/appui-react/messages/ActivityMessagePopup.tsx
@@ -25,7 +25,7 @@ export interface ActivityMessagePopupProps extends CommonProps {
  * @deprecated Activity messages are set-up automatically in a StatusBar.
  * @public
  */
-export function ActivityMessagePopup(props: ActivityMessagePopupProps) {
+export function ActivityMessagePopup(props: ActivityMessagePopupProps) { // eslint-disable-line deprecation/deprecation
   const [activityMessageInfo, setActivityMessageInfo] = React.useState<ActivityMessageEventArgs | undefined>(undefined);
 
   React.useEffect(() => {

--- a/ui/appui-react/src/appui-react/messages/ActivityMessagePopup.tsx
+++ b/ui/appui-react/src/appui-react/messages/ActivityMessagePopup.tsx
@@ -13,6 +13,7 @@ import { CommonProps } from "@itwin/core-react";
 import { useActivityMessage } from "./ActivityMessage";
 
 /** Properties for [[ActivityMessagePopup]] component
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface ActivityMessagePopupProps extends CommonProps {
@@ -21,6 +22,7 @@ export interface ActivityMessagePopupProps extends CommonProps {
 }
 
 /** Activity Message Popup React component
+ * @deprecated Activity messages are set-up automatically in a StatusBar.
  * @public
  */
 export function ActivityMessagePopup(props: ActivityMessagePopupProps) {

--- a/ui/appui-react/src/appui-react/messages/StatusMessageRenderer.tsx
+++ b/ui/appui-react/src/appui-react/messages/StatusMessageRenderer.tsx
@@ -39,7 +39,7 @@ export function StatusMessageRenderer({
   closeMessage,
   cancelActivityMessage: cancelActivityMessageProp,
   dismissActivityMessage,
-}: StatusMessageRendererProps) {
+}: StatusMessageRendererProps) { // eslint-disable-line deprecation/deprecation
   const messages = React.useRef<StatusMessageRendererrMessage[]>([]);
   const [activityMessageInfo, setActivityMessageInfo] = React.useState<ActivityMessageEventArgs | undefined>(undefined);
 

--- a/ui/appui-react/src/appui-react/messages/StatusMessageRenderer.tsx
+++ b/ui/appui-react/src/appui-react/messages/StatusMessageRenderer.tsx
@@ -21,6 +21,7 @@ interface StatusMessageRendererrMessage {
 }
 
 /** Properties for [[StatusMessageRenderer]] component
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface StatusMessageRendererProps extends CommonProps {
@@ -65,8 +66,8 @@ export function StatusMessageRenderer({
           { onRemove: () => onRemove(msg.id) },
           { placement: "top", order: "descending" }
         );
-        if(!!displayedMessage)
-          messages.current.push({close: displayedMessage.close, id: msg.id});
+        if (!!displayedMessage)
+          messages.current.push({ close: displayedMessage.close, id: msg.id });
       });
     };
 
@@ -106,7 +107,7 @@ export function StatusMessageRenderer({
     cancelActivityMessageProp && cancelActivityMessageProp();
   }, [cancelActivityMessageProp]);
 
-  useActivityMessage({activityMessageInfo, cancelActivityMessage, dismissActivityMessage});
+  useActivityMessage({ activityMessageInfo, cancelActivityMessage, dismissActivityMessage });
 
   return <></>;
 }

--- a/ui/appui-react/src/appui-react/messages/StickyMessage.tsx
+++ b/ui/appui-react/src/appui-react/messages/StickyMessage.tsx
@@ -22,6 +22,7 @@ import { HollowIcon } from "./HollowIcon";
 import { Icon, MessageContainer } from "@itwin/core-react";
 
 /** Properties for a [[StickyMessage]]
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface StickyMessageProps {

--- a/ui/appui-react/src/appui-react/messages/StickyMessage.tsx
+++ b/ui/appui-react/src/appui-react/messages/StickyMessage.tsx
@@ -36,7 +36,7 @@ export interface StickyMessageProps {
  * @public
  * @deprecated
  */
-export function StickyMessage(props: StickyMessageProps) {
+export function StickyMessage(props: StickyMessageProps) { // eslint-disable-line deprecation/deprecation
   const { id, messageDetails, severity, closeMessage } = props;
   const [closing, setClosing] = React.useState(false);
 

--- a/ui/appui-react/src/appui-react/messages/ToastMessage.tsx
+++ b/ui/appui-react/src/appui-react/messages/ToastMessage.tsx
@@ -20,6 +20,7 @@ import { HollowIcon } from "./HollowIcon";
 import { MessageContainer } from "@itwin/core-react";
 
 /** Properties for a [[ToastMessage]]
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface ToastMessageProps {

--- a/ui/appui-react/src/appui-react/messages/ToastMessage.tsx
+++ b/ui/appui-react/src/appui-react/messages/ToastMessage.tsx
@@ -35,7 +35,7 @@ export interface ToastMessageProps {
  * @public
  * @deprecated
  */
-export function ToastMessage(props: ToastMessageProps) {
+export function ToastMessage(props: ToastMessageProps) { // eslint-disable-line deprecation/deprecation
   const { id, messageDetails, severity, toastTarget, closeMessage } = props;
 
   return (

--- a/ui/appui-react/src/appui-react/pickers/ListPicker.tsx
+++ b/ui/appui-react/src/appui-react/pickers/ListPicker.tsx
@@ -226,6 +226,7 @@ export function getListPanel(props: ListPickerProps): React.ReactNode {
 /**
  * List picker base class.
  * Used to provide an expandable list of items to enable/disable items.
+ * @deprecated Used in UI1.0 only.
  * @beta
  */
 export class ListPickerBase extends React.PureComponent<ListPickerProps, ListPickerState> {

--- a/ui/appui-react/src/appui-react/pickers/ListPicker.tsx
+++ b/ui/appui-react/src/appui-react/pickers/ListPicker.tsx
@@ -60,7 +60,7 @@ interface ListPickerState {
   expanded: boolean;
 }
 
-let lastOpenedPicker: ListPickerBase | undefined;
+let lastOpenedPicker: ListPickerBase | undefined; // eslint-disable-line deprecation/deprecation
 
 /** Properties for the [[ListPickerItem]] component
  * @beta
@@ -523,7 +523,7 @@ export class ListPicker extends React.Component<ListPickerPropsExtended> {
     return (
       <FrameworkVersionSwitch
         v1={
-          <ListPickerBase
+          <ListPickerBase // eslint-disable-line deprecation/deprecation
             {...this.props}
             title={this.props.title}
             setEnabled={this._setEnabled}

--- a/ui/appui-react/src/appui-react/safearea/SafeAreaContext.tsx
+++ b/ui/appui-react/src/appui-react/safearea/SafeAreaContext.tsx
@@ -15,10 +15,10 @@ import { SafeAreaInsets } from "@itwin/appui-layout-react";
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const SafeAreaContext = React.createContext<SafeAreaInsets>(SafeAreaInsets.None);
+export const SafeAreaContext = React.createContext<SafeAreaInsets>(SafeAreaInsets.None); // eslint-disable-line deprecation/deprecation
 
 interface InjectedWithSafeAreaProps {
-  readonly safeAreaInsets?: SafeAreaInsets;
+  readonly safeAreaInsets?: SafeAreaInsets; // eslint-disable-line deprecation/deprecation
 }
 
 /** HOC that injects SafeAreaInsets.

--- a/ui/appui-react/src/appui-react/safearea/SafeAreaContext.tsx
+++ b/ui/appui-react/src/appui-react/safearea/SafeAreaContext.tsx
@@ -22,6 +22,7 @@ interface InjectedWithSafeAreaProps {
 }
 
 /** HOC that injects SafeAreaInsets.
+ * @deprecated Use [SafeAreaContext] instead.
  * @public
  */
 export const withSafeArea = <P extends InjectedWithSafeAreaProps, C>(

--- a/ui/appui-react/src/appui-react/safearea/SafeAreaInsets.ts
+++ b/ui/appui-react/src/appui-react/safearea/SafeAreaInsets.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utilities
+ */
+
+import { SafeAreaInsets as LayoutSafeAreaInsets } from "@itwin/appui-layout-react";
+
+// Re-export `SafeAreaInsets` enum in a non-breaking way to deprecate it in an `appui-layout-react` package.
+
+/** Describes available safe area insets.
+ * @beta
+ */
+export type SafeAreaInsets = LayoutSafeAreaInsets;
+
+/** Describes available safe area insets.
+ * @beta
+ */
+export const SafeAreaInsets = LayoutSafeAreaInsets;

--- a/ui/appui-react/src/appui-react/safearea/SafeAreaInsets.ts
+++ b/ui/appui-react/src/appui-react/safearea/SafeAreaInsets.ts
@@ -13,9 +13,9 @@ import { SafeAreaInsets as LayoutSafeAreaInsets } from "@itwin/appui-layout-reac
 /** Describes available safe area insets.
  * @beta
  */
-export type SafeAreaInsets = LayoutSafeAreaInsets;
+export type SafeAreaInsets = LayoutSafeAreaInsets; // eslint-disable-line deprecation/deprecation
 
 /** Describes available safe area insets.
  * @beta
  */
-export const SafeAreaInsets = LayoutSafeAreaInsets;
+export const SafeAreaInsets = LayoutSafeAreaInsets; // eslint-disable-line @typescript-eslint/no-redeclare, deprecation/deprecation

--- a/ui/appui-react/src/appui-react/selection/ClearEmphasisStatusField.tsx
+++ b/ui/appui-react/src/appui-react/selection/ClearEmphasisStatusField.tsx
@@ -64,7 +64,7 @@ export function ClearEmphasisStatusField(props: ClearEmphasisStatusFieldProps) {
   };
 
   return (
-    <Indicator toolTip={toolTip} className={classes} opened={false} onClick={clearEmphasize} iconName="icon-visibility"
+    <Indicator toolTip={toolTip} className={classes} opened={false} onClick={clearEmphasize} iconName="icon-visibility" // eslint-disable-line deprecation/deprecation
       // eslint-disable-next-line deprecation/deprecation
       isInFooterMode={props.isInFooterMode ?? true} />
   );

--- a/ui/appui-react/src/appui-react/shared/ActionButtonItemDef.tsx
+++ b/ui/appui-react/src/appui-react/shared/ActionButtonItemDef.tsx
@@ -82,7 +82,7 @@ export abstract class ActionButtonItemDef extends ItemDefBase {
     const key = this.getKey(index);
 
     return (
-      <ActionItemButton
+      <ActionItemButton // eslint-disable-line deprecation/deprecation
         key={key}
         actionItem={this}
         onSizeKnown={this.handleSizeKnown}

--- a/ui/appui-react/src/appui-react/statusbar/Indicator.scss
+++ b/ui/appui-react/src/appui-react/statusbar/Indicator.scss
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+@import "~@itwin/appui-layout-react/lib/cjs/appui-layout-react/footer/variables";
+@import "~@itwin/core-react/lib/cjs/core-react/style/colors";
+@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+
+@keyframes uifw-indicator-fadeIn {
+  0% {
+    opacity: 0;
+    -webkit-transform: scale(.5);
+    transform: scale(.5);
+  }
+
+  50% {
+    -webkit-transform: scale(1.5);
+    transform: scale(1.5);
+  }
+
+  100% {
+    -webkit-transform: scale(1.0);
+    transform: scale(1.0);
+    opacity: 1;
+  }
+}
+
+@keyframes uifw-indicator-fadeOut {
+  0% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+.uifw-statusbar-indicator {
+  visibility: visible;
+  gap: 8px;
+
+  &.uifw-action {
+    cursor: pointer;
+
+    &:hover {
+      color: $buic-foreground-primary;
+    }
+  }
+
+  &.uifw-indicator-fade-in {
+    animation: uifw-indicator-fadeIn 1s linear;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  &.uifw-indicator-fade-out {
+    animation: uifw-indicator-fadeOut 500ms linear;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  >.nz-balloon-container {
+    height: 100%;
+    position: relative;
+    display: grid;
+    align-content: center;
+
+    >.nz-balloon {
+      background-color: $buic-text-color;
+      text-align: center;
+      cursor: pointer;
+      min-width: $min-balloon-width;
+      min-height: $min-balloon-height;
+      border-radius: 50%;
+      padding: $balloon-padding;
+      filter: $icon-shadow;
+      position: relative;
+      align-self: center;
+
+      >.nz-arrow {
+        position: absolute;
+        width: 0;
+        bottom: -3px;
+        left: 0;
+        display: block;
+        border-width: 0;
+        border-bottom-width: $balloon-arrow-height;
+        border-left-width: $balloon-arrow-width;
+        border-style: solid;
+        border-color: transparent $buic-text-color;
+        transform: rotate(25deg);
+      }
+
+      >.nz-content {
+        position: relative;
+        color: #FFFFFF;
+        line-height: $min-balloon-height;
+        font-size: 11px;
+      }
+    }
+
+    >.nz-dialog {
+      height: 100%;
+      width: 100%;
+      position: absolute;
+      top: 0;
+      left: 50%;
+    }
+  }
+}

--- a/ui/appui-react/src/appui-react/statusbar/Indicator.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Indicator.tsx
@@ -46,7 +46,7 @@ export function StatusBarIndicator(props: StatusBarIndicatorProps) {
   );
   return (
     <>
-      <FooterIndicator
+      <FooterIndicator // eslint-disable-line deprecation/deprecation
         ref={target}
         className={classNames}
         title={props.title}
@@ -59,7 +59,7 @@ export function StatusBarIndicator(props: StatusBarIndicatorProps) {
       >
         {props.children}
       </FooterIndicator>
-      {props.popup && <FooterPopup
+      {props.popup && <FooterPopup // eslint-disable-line deprecation/deprecation
         target={target.current}
         onClose={() => setIsOpen(false)}
         isOpen={isOpen}

--- a/ui/appui-react/src/appui-react/statusbar/Indicator.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Indicator.tsx
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import "./Indicator.scss";
+import classnames from "classnames";
+import * as React from "react";
+import { CommonProps } from "@itwin/core-react";
+import { FooterIndicator, FooterPopup } from "@itwin/appui-layout-react";
+
+/** Properties of [[StatusBarIndicator]] component.
+ * @beta
+ */
+export interface StatusBarIndicatorProps extends CommonProps {
+  /** Indicator content. */
+  children?: React.ReactNode;
+  /** Content to display in a popup when indicator is clicked. */
+  popup?: React.ReactNode;
+  /** Function called when indicator is clicked. */
+  onClick?: () => void;
+  /** Default state of an indicator popup. */
+  defaultIsOpen?: boolean;
+  /** Title of an indicator. */
+  title?: string;
+}
+
+/** General-purpose [[StatusBar]] indicator.
+ * @beta
+ */
+export function StatusBarIndicator(props: StatusBarIndicatorProps) {
+  const hasClickAction = !!props.onClick || !!props.popup;
+  const [isOpen, setIsOpen] = React.useState(!!props.defaultIsOpen);
+  const handleOnIndicatorClick = () => {
+    setIsOpen(!isOpen);
+    props.onClick?.();
+  };
+  const target = React.useRef<HTMLDivElement>(null);
+  const classNames = classnames(
+    "uifw-statusbar-indicator",
+    hasClickAction && "uifw-action",
+    props.className,
+  );
+  return (
+    <>
+      <FooterIndicator
+        ref={target}
+        className={classNames}
+        title={props.title}
+        style={props.style}
+        onClick={handleOnIndicatorClick}
+        {...{
+          role: "button",
+          tabIndex: -1,
+        }}
+      >
+        {props.children}
+      </FooterIndicator>
+      {props.popup && <FooterPopup
+        target={target.current}
+        onClose={() => setIsOpen(false)}
+        isOpen={isOpen}
+      >
+        {props.popup}
+      </FooterPopup>}
+    </>
+  );
+}

--- a/ui/appui-react/src/appui-react/statusbar/LabelIndicator.scss
+++ b/ui/appui-react/src/appui-react/statusbar/LabelIndicator.scss
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+@import "~@itwin/appui-layout-react/lib/cjs/appui-layout-react/footer/variables";
+@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+
+.uifw-statusbar-labelIndicator {
+  &.uifw-reversed {
+    flex-direction: row-reverse;
+  }
+
+  >.uifw-label {
+    font-size: $text-font-size;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @include for-tablet-landscape-down {
+      display: none;
+    }
+  }
+
+  >.uifw-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: $icon-size;
+    width: $icon-size;
+
+    /* Medium devices */
+    @include for-tablet-landscape-down {
+      font-size: $icon-size-medium;
+      width: $icon-size-medium;
+    }
+
+    /* Small devices */
+    @include for-phone-only {
+      font-size: $icon-size-small;
+      width: $icon-size-small;
+    }
+  }
+}

--- a/ui/appui-react/src/appui-react/statusbar/LabelIndicator.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/LabelIndicator.tsx
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import "./LabelIndicator.scss";
+import classnames from "classnames";
+import * as React from "react";
+import { StatusBarIndicator, StatusBarIndicatorProps } from "./Indicator";
+import { Icon, IconSpec } from "@itwin/core-react";
+import { StatusBarLabelSide } from "@itwin/appui-abstract";
+
+/** Properties of [[StatusBarLabelIndicator]] component.
+ * @beta
+ */
+export interface StatusBarLabelIndicatorProps extends Omit<StatusBarIndicatorProps, "children"> {
+  /** Specification of an icon. */
+  iconSpec?: IconSpec;
+  /** Indicator label. */
+  label?: string;
+  /** Side to display label. */
+  labelSide?: StatusBarLabelSide;
+}
+
+/** [[StatusBar]] indicator that shows a label with an icon.
+ * @beta
+ */
+export function StatusBarLabelIndicator(props: StatusBarLabelIndicatorProps) {
+  const { className, iconSpec, label, labelSide, ...other } = props;
+  const classNames = classnames(
+    "uifw-statusbar-labelIndicator",
+    labelSide === StatusBarLabelSide.Right && "uifw-reversed",
+    className,
+  );
+  return (
+    <StatusBarIndicator
+      className={classNames}
+      {...other}
+    >
+      {label && <span className="uifw-label">{label}</span>}
+      {iconSpec && <div className="uifw-icon"><Icon iconSpec={iconSpec} /></div>}
+    </StatusBarIndicator>
+  );
+}

--- a/ui/appui-react/src/appui-react/statusbar/Separator.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Separator.tsx
@@ -16,6 +16,6 @@ import { FooterSeparator } from "@itwin/appui-layout-react";
  */
 export function StatusBarSeparator(props: CommonProps) {
   return (
-    <FooterSeparator {...props} />
+    <FooterSeparator {...props} /> // eslint-disable-line deprecation/deprecation
   );
 }

--- a/ui/appui-react/src/appui-react/statusbar/Separator.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Separator.tsx
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import "./Separator.scss";
+import * as React from "react";
+import { CommonProps } from "@itwin/core-react";
+import { FooterSeparator } from "@itwin/appui-layout-react";
+
+/** Component used to separate status fields in a status bar.
+ * @public
+ */
+export function StatusBarSeparator(props: CommonProps) {
+  return (
+    <FooterSeparator {...props} />
+  );
+}

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
@@ -132,7 +132,7 @@ function useStatusBarItemSyncEffect(itemsManager: StatusBarItemsManager, syncIds
 /** function to produce a StatusBarItem component from an AbstractStatusBarLabelItem */
 function generateActionStatusLabelItem(item: AbstractStatusBarLabelItem, isInFooterMode: boolean): React.ReactNode {
   const iconPaddingClass = item.labelSide === StatusBarLabelSide.Left ? "nz-icon-padding-right" : "nz-icon-padding-left";
-  return (<FooterIndicator
+  return (<FooterIndicator // eslint-disable-line deprecation/deprecation
     isInFooterMode={isInFooterMode}
   >
     {item.icon && <Icon iconSpec={item.icon} />}
@@ -143,7 +143,7 @@ function generateActionStatusLabelItem(item: AbstractStatusBarLabelItem, isInFoo
 
 /** function to produce a StatusBarItem component from an AbstractStatusBarActionItem */
 function generateActionStatusBarItem(item: AbstractStatusBarActionItem, isInFooterMode: boolean): React.ReactNode {
-  return <Indicator toolTip={ConditionalStringValue.getValue(item.tooltip)} opened={false} onClick={item.execute} iconSpec={item.icon}
+  return <Indicator toolTip={ConditionalStringValue.getValue(item.tooltip)} opened={false} onClick={item.execute} iconSpec={item.icon} // eslint-disable-line deprecation/deprecation
     isInFooterMode={isInFooterMode} />;
 }
 

--- a/ui/appui-react/src/appui-react/statusbar/dialog/Button.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/dialog/Button.tsx
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import * as React from "react";
+import { CommonProps } from "@itwin/core-react";
+import { TitleBarButton } from "@itwin/appui-layout-react";
+
+/** Properties of [[StatusBarDialogTitleBarButton]] component.
+ * @beta
+ */
+export interface StatusBarDialogTitleBarButtonProps extends CommonProps {
+  /** Button content. */
+  children?: React.ReactNode;
+  /** Function called when button is clicked. */
+  onClick?: () => void;
+  /** Button title. */
+  title?: string;
+}
+
+/** Dialog component used in a [[StatusBarDialog]] component.
+* @beta
+*/
+export function StatusBarDialogTitleBarButton(props: StatusBarDialogTitleBarButtonProps) {
+  return (
+    <TitleBarButton {...props} />
+  );
+}

--- a/ui/appui-react/src/appui-react/statusbar/dialog/Dialog.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/dialog/Dialog.tsx
@@ -26,7 +26,7 @@ export interface StatusBarDialogProps extends CommonProps {
  * @beta
  */
 export function StatusBarDialog(props: StatusBarDialogProps) {
-  return <Dialog {...props} />;
+  return <Dialog {...props} />; // eslint-disable-line deprecation/deprecation
 }
 
 /** Components used in a [[StatusBarDialog]].

--- a/ui/appui-react/src/appui-react/statusbar/dialog/Dialog.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/dialog/Dialog.tsx
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import * as React from "react";
+import { CommonProps } from "@itwin/core-react";
+import { Dialog } from "@itwin/appui-layout-react";
+import { StatusBarDialogTitleBar } from "./TitleBar";
+import { StatusBarDialogTitleBarButton } from "./Button";
+
+/** Properties of [[StatusBarDialog]] component.
+ * @beta
+ */
+export interface StatusBarDialogProps extends CommonProps {
+  /** Dialog content.  */
+  children?: React.ReactNode;
+  /** Dialog title bar. See [[StatusBarDialog.TitleBar]] */
+  titleBar?: React.ReactNode;
+}
+
+/** Dialog component used in a [[StatusBarIndicator]] component.
+ * @beta
+ */
+export function StatusBarDialog(props: StatusBarDialogProps) {
+  return <Dialog {...props} />;
+}
+
+/** Components used in a [[StatusBarDialog]].
+ * @beta
+ */
+export namespace StatusBarDialog {
+  /** Title bar of a [[StatusBarDialog]]. */
+  export const TitleBar = StatusBarDialogTitleBar;
+
+  /** Title bar button of a [[StatusBarDialog]]. */
+  export const TitleBarButton = StatusBarDialogTitleBarButton;
+}

--- a/ui/appui-react/src/appui-react/statusbar/dialog/TitleBar.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/dialog/TitleBar.tsx
@@ -24,5 +24,5 @@ export interface StatusBarDialogTitleBarProps extends CommonProps {
 * @beta
 */
 export function StatusBarDialogTitleBar(props: StatusBarDialogTitleBarProps) {
-  return <TitleBar {...props} />;
+  return <TitleBar {...props} />; // eslint-disable-line deprecation/deprecation
 }

--- a/ui/appui-react/src/appui-react/statusbar/dialog/TitleBar.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/dialog/TitleBar.tsx
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import * as React from "react";
+import { CommonProps } from "@itwin/core-react";
+import { TitleBar } from "@itwin/appui-layout-react";
+
+/** Properties of [[StatusBarDialogTitleBar]] component.
+ * @beta
+ */
+export interface StatusBarDialogTitleBarProps extends CommonProps {
+  /** Title bar buttons. */
+  children?: React.ReactNode;
+  /** Title bar title. */
+  title?: string;
+}
+
+/** Dialog component used in a [[StatusBarDialog]] component.
+* @beta
+*/
+export function StatusBarDialogTitleBar(props: StatusBarDialogTitleBarProps) {
+  return <TitleBar {...props} />;
+}

--- a/ui/appui-react/src/appui-react/statusfields/Indicator.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/Indicator.tsx
@@ -40,7 +40,7 @@ interface IndicatorProps extends CommonProps {
   /** Tooltip text if not specified label is used */
   toolTip?: string;
   /** ContentType is used to determine color of popup arrow. If not set defaults to FooterPopupContentType.Dialog */
-  contentType?: FooterPopupContentType;
+  contentType?: FooterPopupContentType; // eslint-disable-line deprecation/deprecation
 }
 
 /** General-purpose [[Footer]] indicator. Shows an icon and supports an optional popup dialog.
@@ -81,7 +81,7 @@ export function Indicator(props: IndicatorProps) {
         {isLabelVisible && label && <span className="nz-label">{ConditionalStringValue.getValue(label)}</span>}
         {icon && <div className="uifw-indicator-icon"><Icon iconSpec={icon} /></div>}
       </div>
-      {dialog && <FooterPopup contentType={contentType}
+      {dialog && <FooterPopup contentType={contentType} // eslint-disable-line deprecation/deprecation
         target={target.current}
         onClose={() => setIsOpen(false)}
         isOpen={isOpen}>

--- a/ui/appui-react/src/appui-react/statusfields/Indicator.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/Indicator.tsx
@@ -44,6 +44,7 @@ interface IndicatorProps extends CommonProps {
 }
 
 /** General-purpose [[Footer]] indicator. Shows an icon and supports an optional popup dialog.
+ * @deprecated Use [StatusBarIndicator] or [StatusBarLabelIndicator] instead.
  * @beta
  */
 export function Indicator(props: IndicatorProps) {
@@ -68,7 +69,6 @@ export function Indicator(props: IndicatorProps) {
     labelSide === StatusBarLabelSide.Right && "uifw-footer-label-reversed",
     className);
   return (
-
     <>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
       <div ref={target}

--- a/ui/appui-react/src/appui-react/statusfields/MessageCenter.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/MessageCenter.tsx
@@ -122,9 +122,8 @@ export class MessageCenterField extends React.Component<MessageCenterFieldProps,
             {this.state.messageCount.toString()}
           </MessageCenter>
         </div>
-        <FooterPopup
-          // eslint-disable-next-line deprecation/deprecation
-          isOpen={(this.props.openWidget ?? this.state.openWidget) === this._className}
+        <FooterPopup // eslint-disable-line deprecation/deprecation
+          isOpen={(this.props.openWidget ?? this.state.openWidget) === this._className} // eslint-disable-line deprecation/deprecation
           onClose={this._handleClose}
           onOutsideClick={this._handleOutsideClick}
           target={this.state.target}

--- a/ui/appui-react/src/appui-react/statusfields/PromptField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/PromptField.tsx
@@ -34,7 +34,7 @@ class PromptFieldComponent extends React.Component<PromptFieldProps> {
 
   public override render(): React.ReactNode {
     return (
-      <FooterIndicator
+      <FooterIndicator // eslint-disable-line deprecation/deprecation
         className={classnames("uifw-statusFields-promptField", this.props.className)}
         style={this.props.style}
         // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/statusfields/SectionsField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SectionsField.tsx
@@ -10,12 +10,13 @@ import "./SectionsField.scss";
 import classnames from "classnames";
 import * as React from "react";
 import { ClipEventType, IModelApp, ViewClipClearTool, ViewClipDecoration, ViewClipDecorationProvider, Viewport } from "@itwin/core-frontend";
-import { Dialog, FooterPopup, TitleBar } from "@itwin/appui-layout-react";
+import { FooterPopup } from "@itwin/appui-layout-react";
 import { Button, ToggleSwitch } from "@itwin/itwinui-react";
 import { useActiveViewport } from "../hooks/useActiveViewport";
 import { UiFramework } from "../UiFramework";
 import { Indicator } from "./Indicator";
 import { StatusFieldProps } from "./StatusFieldProps";
+import { StatusBarDialog } from "../statusbar/dialog/Dialog";
 
 /** Sections Status Field Props
  * @beta
@@ -79,7 +80,7 @@ export function SectionsStatusField(props: SectionsStatusFieldProps) {
       {showIndicator &&
         <>
           <div ref={targetDiv} title={toolTip}>
-            <Indicator className={classes}
+            <Indicator className={classes} // eslint-disable-line deprecation/deprecation
               iconName="icon-section-tool"
               onClick={() => setPopupOpen(!isPopupOpen)}
               opened={isPopupOpen}
@@ -87,13 +88,13 @@ export function SectionsStatusField(props: SectionsStatusFieldProps) {
               isInFooterMode={props.isInFooterMode ?? true}
             />
           </div>
-          <FooterPopup
+          <FooterPopup // eslint-disable-line deprecation/deprecation
             target={targetDiv.current}
             onClose={() => setPopupOpen(false)}
             isOpen={isPopupOpen}>
-            <Dialog
+            <StatusBarDialog
               titleBar={
-                <TitleBar title={toolTip} />
+                <StatusBarDialog.TitleBar title={toolTip} />
               }>
               <div className="uifw-sections-footer-contents">
                 <Button onClick={handleClear}>{clearLabel}</Button>
@@ -102,7 +103,7 @@ export function SectionsStatusField(props: SectionsStatusFieldProps) {
                   <ToggleSwitch className="uifw-sections-toggle" onChange={toggleManipulators} checked={hasManipulatorsShown} />
                 </div>
               </div>
-            </Dialog>
+            </StatusBarDialog>
           </FooterPopup>
         </>
       }

--- a/ui/appui-react/src/appui-react/statusfields/SelectionInfo.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionInfo.tsx
@@ -33,7 +33,7 @@ class SelectionInfoFieldComponent extends React.Component<SelectionInfoFieldProp
 
   public override render(): React.ReactNode {
     return (
-      <FooterIndicator
+      <FooterIndicator // eslint-disable-line deprecation/deprecation
         className={classnames("uifw-statusFields-selectionInfo", this.props.className)}
         style={this.props.style}
         // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
@@ -56,7 +56,7 @@ class SelectionScopeFieldComponent extends React.Component<SelectionScopeFieldPr
   public override render(): React.ReactNode {
 
     return (
-      <FooterIndicator
+      <FooterIndicator // eslint-disable-line deprecation/deprecation
         className={classnames("uifw-statusFields-selectionScope", this.props.className)}
         style={this.props.style}
         // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/statusfields/SnapMode.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SnapMode.tsx
@@ -77,7 +77,7 @@ class SnapModeFieldComponent extends React.Component<SnapModeFieldProps, SnapMod
   public override render(): React.ReactNode {
     return (
       <>
-        <Indicator
+        <Indicator // eslint-disable-line deprecation/deprecation
           iconName={`icon-${this.getSnapModeIconNameFromMode(this.props.snapMode)}`}
           toolTip={this._title}
           label={this._title}

--- a/ui/appui-react/src/appui-react/statusfields/ViewAttributes.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/ViewAttributes.tsx
@@ -10,11 +10,11 @@ import "./ViewAttributes.scss";
 import * as React from "react";
 import { ViewFlagProps, ViewFlags } from "@itwin/core-common";
 import { IModelApp } from "@itwin/core-frontend";
-import { Dialog, TitleBar } from "@itwin/appui-layout-react";
 import { Checkbox } from "@itwin/itwinui-react";
 import { UiFramework } from "../UiFramework";
 import { Indicator } from "./Indicator";
 import { StatusFieldProps } from "./StatusFieldProps";
+import { StatusBarDialog } from "../statusbar/dialog/Dialog";
 
 interface ViewAttributesStatusFieldState {
   viewFlags: ViewFlagProps;
@@ -112,16 +112,16 @@ export class ViewAttributesStatusField extends React.Component<StatusFieldProps,
     const isOpen = this.props.openWidget === this._className;
     return (
       <>
-        <Indicator
+        <Indicator // eslint-disable-line deprecation/deprecation
           iconName="icon-window-settings"
           opened={isOpen}
           toolTip={this._title}
-          dialog={<Dialog
+          dialog={<StatusBarDialog
             titleBar={
-              <TitleBar title={this._title} />
+              <StatusBarDialog.TitleBar title={this._title} />
             }>
             {this.getViewFlags()}
-          </Dialog>}
+          </StatusBarDialog>}
           // eslint-disable-next-line deprecation/deprecation
           isInFooterMode={this.props.isInFooterMode ?? true}
         />

--- a/ui/appui-react/src/appui-react/toolbar/ActionItemButton.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ActionItemButton.tsx
@@ -31,7 +31,7 @@ export interface ActionItemButtonProps extends CommonProps {
 }
 
 /** Helper method to set state from props */
-const getItemStateFromProps = (props: ActionItemButtonProps): BaseItemState => {
+const getItemStateFromProps = (props: ActionItemButtonProps): BaseItemState => { // eslint-disable-line deprecation/deprecation
 
   // Parent Component can only modify the isEnable state if the actionItem.isEnabled value is set to true.
   return {
@@ -45,13 +45,13 @@ const getItemStateFromProps = (props: ActionItemButtonProps): BaseItemState => {
  * @deprecated Use [ActionButton]($appui-abstract) instead.
  * @public
  */
-export class ActionItemButton extends React.Component<ActionItemButtonProps, BaseItemState> {
+export class ActionItemButton extends React.Component<ActionItemButtonProps, BaseItemState> { // eslint-disable-line deprecation/deprecation
   private _componentUnmounting = false;
 
   /** @internal */
   public override readonly state: Readonly<BaseItemState>;
 
-  constructor(props: ActionItemButtonProps) {
+  constructor(props: ActionItemButtonProps) { // eslint-disable-line deprecation/deprecation
     super(props);
 
     this.state = getItemStateFromProps(props);
@@ -98,7 +98,7 @@ export class ActionItemButton extends React.Component<ActionItemButtonProps, Bas
   };
 
   /** @internal */
-  public static getDerivedStateFromProps(props: ActionItemButtonProps, state: BaseItemState) {
+  public static getDerivedStateFromProps(props: ActionItemButtonProps, state: BaseItemState) { // eslint-disable-line deprecation/deprecation
     const updatedState = getItemStateFromProps(props);
     // istanbul ignore else
     if (!PropsHelper.isShallowEqual(updatedState, state))

--- a/ui/appui-react/src/appui-react/toolbar/ActionItemButton.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ActionItemButton.tsx
@@ -18,6 +18,7 @@ import { PropsHelper } from "../utils/PropsHelper";
 import { onEscapeSetFocusToHome } from "../hooks/useEscapeSetFocusToHome";
 
 /** Properties that must be specified for an [[ActionItemButton]] component
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface ActionItemButtonProps extends CommonProps {
@@ -41,6 +42,7 @@ const getItemStateFromProps = (props: ActionItemButtonProps): BaseItemState => {
 };
 
 /** A Toolbar button React Component that executes an action defined by a CommandItemDef or a ToolItemDef.
+ * @deprecated Use [ActionButton]($appui-abstract) instead.
  * @public
  */
 export class ActionItemButton extends React.Component<ActionItemButtonProps, BaseItemState> {

--- a/ui/appui-react/src/appui-react/toolbar/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/GroupItem.tsx
@@ -659,7 +659,7 @@ export interface GroupButtonProps extends GroupItemProps, CommonProps { }
  * @deprecated Use [GroupButton]($appui-abstract) instead.
  * @public
  */
-export function GroupButton(props: GroupButtonProps) {
+export function GroupButton(props: GroupButtonProps) { // eslint-disable-line deprecation/deprecation
   const groupItemDef = new GroupItemDef(props);
   groupItemDef.resolveItems();
   return (

--- a/ui/appui-react/src/appui-react/toolbar/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/GroupItem.tsx
@@ -650,11 +650,13 @@ export class GroupItem extends React.Component<GroupItemComponentProps, GroupIte
 }
 
 /** Properties for the [[GroupButton]] React component
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface GroupButtonProps extends GroupItemProps, CommonProps { }
 
 /** Group Button React component
+ * @deprecated Use [GroupButton]($appui-abstract) instead.
  * @public
  */
 export function GroupButton(props: GroupButtonProps) {

--- a/ui/appui-react/src/appui-react/toolbar/ToolButton.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolButton.tsx
@@ -20,11 +20,13 @@ import { PropsHelper } from "../utils/PropsHelper";
 import { onEscapeSetFocusToHome } from "../hooks/useEscapeSetFocusToHome";
 
 /** Properties for the [[ToolButton]] React Component.
+ * @deprecated Props of a deprecated component.
  * @public
  */
 export interface ToolButtonProps extends ToolItemProps, CommonProps { }
 
 /** Tool Button React Component.
+ * @deprecated Use [CommonToolbarItem]($appui-abstract) instead.
  * @public
  */
 export class ToolButton extends React.Component<ToolButtonProps, BaseItemState> {

--- a/ui/appui-react/src/appui-react/toolbar/ToolButton.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolButton.tsx
@@ -29,7 +29,7 @@ export interface ToolButtonProps extends ToolItemProps, CommonProps { }
  * @deprecated Use [CommonToolbarItem]($appui-abstract) instead.
  * @public
  */
-export class ToolButton extends React.Component<ToolButtonProps, BaseItemState> {
+export class ToolButton extends React.Component<ToolButtonProps, BaseItemState> { // eslint-disable-line deprecation/deprecation
   private _componentUnmounting = false;
   private _label: string | StringGetter | ConditionalStringValue = "";
 

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
@@ -268,7 +268,7 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
   const expandsTo = toolbarOrientation === Orientation.Horizontal ? Direction.Bottom : usage === ToolbarUsage.ViewNavigation ? Direction.Left : Direction.Right;
   // eslint-disable-next-line deprecation/deprecation
   const panelAlignment = (toolbarOrientation === Orientation.Horizontal && usage === ToolbarUsage.ViewNavigation) ? ToolbarPanelAlignment.End : ToolbarPanelAlignment.Start;
-  const version = useFrameworkVersion();
+  const version = useFrameworkVersion(); // eslint-disable-line deprecation/deprecation
   const isDragEnabled = React.useContext(ToolbarDragInteractionContext);
   const useProximityOpacity = useProximityOpacitySetting();
 

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarItemsProvider.tsx
@@ -8,7 +8,6 @@
 
 import * as React from "react";
 import { BaseUiItemsProvider, CommonStatusBarItem, StatusBarSection, UiItemsManager } from "@itwin/appui-abstract";
-import { FooterSeparator } from "@itwin/appui-layout-react";
 import { StatusBarItemUtilities } from "../statusbar/StatusBarItemUtilities";
 import { ToolAssistanceField } from "../statusfields/toolassistance/ToolAssistanceField";
 import { withStatusFieldProps } from "../statusbar/withStatusFieldProps";
@@ -20,6 +19,7 @@ import { SelectionInfoField } from "../statusfields/SelectionInfo";
 import { TileLoadingIndicator } from "../statusfields/tileloading/TileLoadingIndicator";
 import { SelectionScopeField } from "../statusfields/SelectionScope";
 import { DefaultStatusbarItems } from "./StandardStatusbarUiItemsProvider";
+import { StatusBarSeparator } from "../statusbar/Separator";
 
 /**
  * Provide standard statusbar fields for the SimpleStatusbarWidget
@@ -54,14 +54,14 @@ export class StandardStatusbarItemsProvider extends BaseUiItemsProvider {
     }
     if (!this._defaultItems || this._defaultItems.toolAssistance) {
       if (!this._defaultItems || this._defaultItems.preToolAssistanceSeparator)
-        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PreToolAssistance", StatusBarSection.Left, 15, <FooterSeparator />));
+        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PreToolAssistance", StatusBarSection.Left, 15, <StatusBarSeparator />));
 
       // eslint-disable-next-line deprecation/deprecation
       const ToolAssistance = withStatusFieldProps(ToolAssistanceField);
       statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.ToolAssistance", StatusBarSection.Left, 20, <ToolAssistance />));
 
       if (!this._defaultItems || this._defaultItems.postToolAssistanceSeparator)
-        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PostToolAssistance", StatusBarSection.Left, 25, <FooterSeparator />));
+        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PostToolAssistance", StatusBarSection.Left, 25, <StatusBarSeparator />));
     }
     if (this._defaultItems?.activityCenter) {
       // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
@@ -8,7 +8,6 @@
 
 import * as React from "react";
 import { CommonStatusBarItem, StatusBarSection, UiItemsProvider } from "@itwin/appui-abstract";
-import { FooterSeparator } from "@itwin/appui-layout-react";
 import { StatusBarItemUtilities } from "../statusbar/StatusBarItemUtilities";
 import { ToolAssistanceField } from "../statusfields/toolassistance/ToolAssistanceField";
 import { withStatusFieldProps } from "../statusbar/withStatusFieldProps";
@@ -19,6 +18,7 @@ import { SnapModeField } from "../statusfields/SnapMode";
 import { SelectionInfoField } from "../statusfields/SelectionInfo";
 import { TileLoadingIndicator } from "../statusfields/tileloading/TileLoadingIndicator";
 import { SelectionScopeField } from "../statusfields/SelectionScope";
+import { StatusBarSeparator } from "../statusbar/Separator";
 
 /**
  * Defines what items to include from the provider. If any items are
@@ -57,14 +57,14 @@ export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
     // istanbul ignore else
     if (!this._defaultItems || this._defaultItems.toolAssistance) {
       if (!this._defaultItems || this._defaultItems.preToolAssistanceSeparator)
-        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PreToolAssistance", StatusBarSection.Left, 15, <FooterSeparator />));
+        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PreToolAssistance", StatusBarSection.Left, 15, <StatusBarSeparator />));
 
       // eslint-disable-next-line deprecation/deprecation
       const ToolAssistance = withStatusFieldProps(ToolAssistanceField);
       statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.ToolAssistance", StatusBarSection.Left, 20, <ToolAssistance />));
 
       if (!this._defaultItems || this._defaultItems.postToolAssistanceSeparator)
-        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PostToolAssistance", StatusBarSection.Left, 25, <FooterSeparator />));
+        statusBarItems.push(StatusBarItemUtilities.createStatusBarItem("uifw.PostToolAssistance", StatusBarSection.Left, 25, <StatusBarSeparator />));
     }
     // istanbul ignore else
     if (this._defaultItems?.activityCenter) {

--- a/ui/appui-react/src/appui-react/uiprovider/DefaultDialogGridContainer.tsx
+++ b/ui/appui-react/src/appui-react/uiprovider/DefaultDialogGridContainer.tsx
@@ -25,7 +25,7 @@ enum LayoutMode {
  */
 export function ToolSettingsGridContainer({ componentGenerator }: { componentGenerator: ComponentGenerator }) {
   const { availableContentWidth } = React.useContext(ToolSettingsContentContext);
-  const version = useFrameworkVersion();
+  const version = useFrameworkVersion(); // eslint-disable-line deprecation/deprecation
   const layoutMode = toLayoutMode(availableContentWidth);
   const className = classnames(
     "uifw-tool-settings-grid-container",

--- a/ui/appui-react/src/appui-react/uistate/AppUiSettings.ts
+++ b/ui/appui-react/src/appui-react/uistate/AppUiSettings.ts
@@ -19,7 +19,7 @@ import { FrameworkVersionId, UiFramework, UserSettingsProvider } from "../UiFram
 export interface InitialAppUiSettings {
   colorTheme: string;
   dragInteraction: boolean;
-  frameworkVersion: FrameworkVersionId;
+  frameworkVersion: FrameworkVersionId; // eslint-disable-line deprecation/deprecation
   widgetOpacity: number;
   showWidgetIcon?: boolean;
   /** @alpha */
@@ -48,7 +48,7 @@ export class AppUiSettings implements UserSettingsProvider {
 
   public colorTheme: UiStateEntry<string>;
   public dragInteraction: UiStateEntry<boolean>;
-  public frameworkVersion: UiStateEntry<FrameworkVersionId>;
+  public frameworkVersion: UiStateEntry<FrameworkVersionId>; // eslint-disable-line deprecation/deprecation
   public widgetOpacity: UiStateEntry<number>;
   public showWidgetIcon: UiStateEntry<boolean>;
   public autoCollapseUnpinnedPanels: UiStateEntry<boolean>;
@@ -82,9 +82,9 @@ export class AppUiSettings implements UserSettingsProvider {
       (value: boolean) => UiFramework.setAutoCollapseUnpinnedPanels(value), defaults.autoCollapseUnpinnedPanels);
     this._settings.push(this.autoCollapseUnpinnedPanels);
 
-    this.frameworkVersion = new UiStateEntry<FrameworkVersionId>(AppUiSettings._settingNamespace, "FrameworkVersion",
+    this.frameworkVersion = new UiStateEntry<FrameworkVersionId>(AppUiSettings._settingNamespace, "FrameworkVersion", // eslint-disable-line deprecation/deprecation
       () => UiFramework.uiVersion,
-      (value: FrameworkVersionId) => UiFramework.setUiVersion(value), defaults.frameworkVersion);
+      (value: FrameworkVersionId) => UiFramework.setUiVersion(value), defaults.frameworkVersion); // eslint-disable-line deprecation/deprecation
     this._settings.push(this.frameworkVersion);
 
     this.widgetOpacity = new UiStateEntry<number>(AppUiSettings._settingNamespace, "WidgetOpacity",

--- a/ui/appui-react/src/appui-react/widget-panels/useWidgetDirection.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/useWidgetDirection.tsx
@@ -15,7 +15,7 @@ import { useFrameworkVersion } from "../hooks/useFrameworkVersion";
  * @alpha
  */
 export function useWidgetDirection(): "horizontal" | "vertical" {
-  const version = useFrameworkVersion();
+  const version = useFrameworkVersion(); // eslint-disable-line deprecation/deprecation
   const tabId = React.useContext(TabIdContext);
   const nineZone = React.useContext(NineZoneContext);
   // istanbul ignore else

--- a/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
+++ b/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
@@ -38,7 +38,7 @@ export function BackstageAppButton(props: BackstageAppButtonProps) {
   const backstageLabel = React.useMemo(() => props.label || backstageToggleCommand.tooltip, [backstageToggleCommand.tooltip, props.label]);
   const [icon, setIcon] = React.useState(props.icon ? props.icon : IconSpecUtilities.createWebComponentIconSpec(widgetIconSvg));
   const isInitialMount = React.useRef(true);
-  const useSmallAppButton = "1" !== useFrameworkVersion();
+  const useSmallAppButton = "1" !== useFrameworkVersion(); // eslint-disable-line deprecation/deprecation
   const divClassName = useSmallAppButton ? "uifw-app-button-small" : undefined;
   const { onElementRef, proximityScale } = useWidgetOpacityContext();
   const ref = React.useRef<HTMLDivElement>(null);
@@ -62,7 +62,7 @@ export function BackstageAppButton(props: BackstageAppButtonProps) {
 
   let buttonProximityScale: number | undefined;
 
-  if ("1" !== useFrameworkVersion() && UiShowHideManager.useProximityOpacity && !UiFramework.isMobile()) {
+  if ("1" !== useFrameworkVersion() && UiShowHideManager.useProximityOpacity && !UiFramework.isMobile()) { // eslint-disable-line deprecation/deprecation
     buttonProximityScale = proximityScale;
   }
 

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -106,7 +106,7 @@ export function NavigationAidHost(props: NavigationAidHostProps) {
   };
 
   // istanbul ignore else
-  if ("1" !== useFrameworkVersion() && UiShowHideManager.useProximityOpacity && !UiFramework.isMobile()) {
+  if ("1" !== useFrameworkVersion() && UiShowHideManager.useProximityOpacity && !UiFramework.isMobile()) { // eslint-disable-line deprecation/deprecation
     const navigationAidOpacity = (0.30 * proximityScale) + 0.70;
     divStyle.opacity = `${navigationAidOpacity}`;
   }

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -134,7 +134,7 @@ export class WidgetDef {
   private _stateChanged: boolean = false;
   private _fillZone: boolean = false;
   private _syncEventIds: string[] = [];
-  private _stateFunc?: WidgetStateFunc;
+  private _stateFunc?: WidgetStateFunc; // eslint-disable-line deprecation/deprecation
   private _widgetType: WidgetType = WidgetType.Rectangular;
   private _applicationData?: any;
   private _iconSpec?: string | ConditionalStringValue | React.ReactNode;
@@ -187,7 +187,7 @@ export class WidgetDef {
   public get stateChanged(): boolean { return this._stateChanged; }
   public get fillZone(): boolean { return this._fillZone; }
   public get syncEventIds(): string[] { return this._syncEventIds; }
-  public get stateFunc(): WidgetStateFunc | undefined { return this._stateFunc; }
+  public get stateFunc(): WidgetStateFunc | undefined { return this._stateFunc; } // eslint-disable-line deprecation/deprecation
   public get applicationData(): any | undefined { return this._applicationData; }
   public get isFloating(): boolean { return this.state === WidgetState.Floating; }
   public get iconSpec(): IconSpec { return this._iconSpec === IconHelper.reactIconKey ? IconHelper.getIconReactNode(this._iconSpec, this._internalData) : this._iconSpec; }

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -96,6 +96,7 @@ export interface NavigationWidgetProps extends ToolbarWidgetProps {
 export type AnyWidgetProps = WidgetProps | ToolWidgetProps | NavigationWidgetProps;
 
 /** Prototype for WidgetDef StateFunc (UI 1.0 only deprecate ???)
+ * @deprecated Used in UI1.0 only.
  * @public
  */
 export type WidgetStateFunc = (state: Readonly<WidgetState>) => WidgetState;

--- a/ui/appui-react/src/test/CoreToolDefinitions.test.tsx
+++ b/ui/appui-react/src/test/CoreToolDefinitions.test.tsx
@@ -26,19 +26,19 @@ describe("CoreToolDefinitions", () => {
         expandsTo={Direction.Bottom} // eslint-disable-line deprecation/deprecation
         items={
           <>
-            <ActionItemButton actionItem={CoreTools.selectElementCommand} />
-            <ActionItemButton actionItem={CoreTools.fitViewCommand} />
-            <ActionItemButton actionItem={CoreTools.windowAreaCommand} />
-            <ActionItemButton actionItem={CoreTools.zoomViewCommand} />
-            <ActionItemButton actionItem={CoreTools.panViewCommand} />
-            <ActionItemButton actionItem={CoreTools.rotateViewCommand} />
-            <ActionItemButton actionItem={CoreTools.walkViewCommand} />
-            <ActionItemButton actionItem={CoreTools.toggleCameraViewCommand} />
-            <ActionItemButton actionItem={CoreTools.flyViewCommand} />
-            <ActionItemButton actionItem={CoreTools.sectionByPlaneCommandItemDef} />
-            <ActionItemButton actionItem={CoreTools.sectionByElementCommandItemDef} />
-            <ActionItemButton actionItem={CoreTools.sectionByShapeCommandItemDef} />
-            <ActionItemButton actionItem={CoreTools.sectionByRangeCommandItemDef} />
+            <ActionItemButton actionItem={CoreTools.selectElementCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.fitViewCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.windowAreaCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.zoomViewCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.panViewCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.rotateViewCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.walkViewCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.toggleCameraViewCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.flyViewCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.sectionByPlaneCommandItemDef} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.sectionByElementCommandItemDef} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.sectionByShapeCommandItemDef} /> {/* eslint-disable-line deprecation/deprecation */}
+            <ActionItemButton actionItem={CoreTools.sectionByRangeCommandItemDef} /> {/* eslint-disable-line deprecation/deprecation */}
           </>
         }
       />;

--- a/ui/appui-react/src/test/messages/ActivityMessagePopup.test.tsx
+++ b/ui/appui-react/src/test/messages/ActivityMessagePopup.test.tsx
@@ -35,7 +35,7 @@ describe("ActivityMessagePopup", () => {
 
   it("Popup should render an Activity message", async () => {
     render(
-      <ActivityMessagePopup
+      <ActivityMessagePopup // eslint-disable-line deprecation/deprecation
         cancelActivityMessage={() => {}}
         dismissActivityMessage={() => {}}
       />
@@ -56,7 +56,7 @@ describe("ActivityMessagePopup", () => {
 
   it("Popup should render an Activity message without details", async () => {
     render(
-      <ActivityMessagePopup
+      <ActivityMessagePopup // eslint-disable-line deprecation/deprecation
         cancelActivityMessage={() => {}}
         dismissActivityMessage={() => {}}
       />
@@ -77,7 +77,7 @@ describe("ActivityMessagePopup", () => {
   it("Activity message should be canceled", async () => {
     const spy = sinon.spy();
     render(
-      <ActivityMessagePopup
+      <ActivityMessagePopup // eslint-disable-line deprecation/deprecation
         cancelActivityMessage={spy}
         dismissActivityMessage={() => {}}
       />
@@ -100,7 +100,7 @@ describe("ActivityMessagePopup", () => {
   it("Activity message should be dismissed & restored", async () => {
     const spy = sinon.spy();
     render(
-      <ActivityMessagePopup
+      <ActivityMessagePopup // eslint-disable-line deprecation/deprecation
         cancelActivityMessage={() => {}}
         dismissActivityMessage={spy}
       />

--- a/ui/appui-react/src/test/pickers/ViewSelector.test.tsx
+++ b/ui/appui-react/src/test/pickers/ViewSelector.test.tsx
@@ -33,7 +33,7 @@ describe("ViewSelector", () => {
   it("should render correctly", () => {
     const wrapper = shallow(
       <Provider store={TestUtils.store}>
-        <FrameworkVersion>
+        <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
           <ViewSelector imodel={imodelMock.object} />
         </FrameworkVersion>
       </Provider>
@@ -44,7 +44,7 @@ describe("ViewSelector", () => {
   it("should set Show settings by ViewSelector.updateShowSettings", () => {
     const wrapper = mount(
       <Provider store={TestUtils.store}>
-        <FrameworkVersion>
+        <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
           <ViewSelector imodel={imodelMock.object} listenForShowUpdates={true} />
         </FrameworkVersion>
       </Provider>
@@ -68,7 +68,7 @@ describe("ViewSelector", () => {
   it("should trigger componentDidUpdate processing", async () => {
     const wrapper = mount(
       <Provider store={TestUtils.store}>
-        <FrameworkVersion>
+        <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
           <ViewSelector imodel={imodelMock.object} />
         </FrameworkVersion>
       </Provider>

--- a/ui/appui-react/src/test/statusfields/ConditionalField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/ConditionalField.test.tsx
@@ -4,8 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import * as React from "react";
-import { FooterSeparator } from "@itwin/appui-layout-react";
-import { ConditionalField } from "../../appui-react";
+import { ConditionalField, StatusBarSeparator } from "../../appui-react";
 import { mount } from "../TestUtils";
 
 /* eslint-disable deprecation/deprecation */
@@ -15,36 +14,36 @@ describe("ConditionalField", () => {
     const wrapper = mount(
       <ConditionalField isInFooterMode={true} onOpenWidget={() => { }} openWidget="test"
         boolFunc={(props): boolean => props.isInFooterMode} >
-        {(isInFooterMode: boolean) => isInFooterMode && <FooterSeparator />}
+        {(isInFooterMode: boolean) => isInFooterMode && <StatusBarSeparator />}
       </ConditionalField>);
-    expect(wrapper.find(FooterSeparator).length).to.eq(1);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(1);
   });
 
   it("should mount with isInFooterMode=false (deprecated)", () => {
     const wrapper = mount(
       <ConditionalField isInFooterMode={false} onOpenWidget={() => { }} openWidget="test"
         boolFunc={(props): boolean => props.isInFooterMode} >
-        {(isInFooterMode: boolean) => isInFooterMode && <FooterSeparator />}
+        {(isInFooterMode: boolean) => isInFooterMode && <StatusBarSeparator />}
       </ConditionalField>);
-    expect(wrapper.find(FooterSeparator).length).to.eq(0);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(0);
   });
 
   it("should mount with isInFooterMode undefined", () => {
     const wrapper = mount(
       <ConditionalField
         boolFunc={(props): boolean => props.isInFooterMode} >
-        {(isInFooterMode: boolean) => isInFooterMode && <FooterSeparator />}
+        {(isInFooterMode: boolean) => isInFooterMode && <StatusBarSeparator />}
       </ConditionalField>);
-    expect(wrapper.find(FooterSeparator).length).to.eq(1);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(1);
   });
 
   it("should mount with children", () => {
     const wrapper = mount(
       <ConditionalField isInFooterMode={true} onOpenWidget={() => { }} openWidget="test"
         boolFunc={(props): boolean => props.isInFooterMode} defaultValue={false} >
-        <FooterSeparator />
+        <StatusBarSeparator />
       </ConditionalField>);
-    expect(wrapper.find(FooterSeparator).length).to.eq(1);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(1);
   });
 
   it("should mount with no children", () => {

--- a/ui/appui-react/src/test/statusfields/FooterModeField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/FooterModeField.test.tsx
@@ -6,9 +6,8 @@
 import { expect } from "chai";
 import * as React from "react";
 import { WidgetState } from "@itwin/appui-abstract";
-import { FooterSeparator } from "@itwin/appui-layout-react";
 import {
-  ConfigurableCreateInfo, ConfigurableUiControlType, FooterModeField, StatusBar, StatusBarWidgetControl, StatusBarWidgetControlArgs, WidgetDef,
+  ConfigurableCreateInfo, ConfigurableUiControlType, FooterModeField, StatusBar, StatusBarSeparator, StatusBarWidgetControl, StatusBarWidgetControlArgs, WidgetDef,
 } from "../../appui-react";
 import TestUtils, { mount } from "../TestUtils";
 
@@ -22,7 +21,7 @@ describe("FooterModeField", () => {
     public getReactNode({ isInFooterMode }: StatusBarWidgetControlArgs): React.ReactNode {
       return (
         <>
-          <FooterModeField isInFooterMode={isInFooterMode}> <FooterSeparator /> </FooterModeField>
+          <FooterModeField isInFooterMode={isInFooterMode}> <StatusBarSeparator /> </FooterModeField>
         </>
       );
     }
@@ -48,25 +47,25 @@ describe("FooterModeField", () => {
 
   it("should mount with isInFooterMode (deprecated)", () => {
     const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-    expect(wrapper.find(FooterSeparator).length).to.eq(1);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(1);
   });
 
   it("should mount without isInFooterMode", () => {
     const wrapper = mount(<StatusBar widgetControl={widgetControl} />);
-    expect(wrapper.find(FooterSeparator).length).to.eq(1);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(1);
   });
 
   it("should mount with isInFooterMode=false (deprecated)", () => {
     const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={false} />);
-    expect(wrapper.find(FooterSeparator).length).to.eq(0);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(0);
   });
 
   it("should change with Props change", () => {
     const wrapper = mount(<StatusBar widgetControl={widgetControl} isInFooterMode={true} />);
-    expect(wrapper.find(FooterSeparator).length).to.eq(1);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(1);
     wrapper.setProps({ isInFooterMode: false });
     wrapper.update();
-    expect(wrapper.find(FooterSeparator).length).to.eq(0);
+    expect(wrapper.find(StatusBarSeparator).length).to.eq(0);
   });
 
 });

--- a/ui/appui-react/src/test/statusfields/Indicator.test.tsx
+++ b/ui/appui-react/src/test/statusfields/Indicator.test.tsx
@@ -11,7 +11,7 @@ import { Indicator } from "../../appui-react";
 describe("Indicator", () => {
   it("Should render label on left", () => {
     const wrapper = render(
-      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={true} labelSide={StatusBarLabelSide.Left} />);
+      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={true} labelSide={StatusBarLabelSide.Left} />); // eslint-disable-line deprecation/deprecation
     expect(wrapper).not.to.be.undefined;
     expect(wrapper.container.querySelector(".uifw-footer-label-reversed")).to.be.null;
     expect(wrapper.container.querySelector(".icon.test-icon")).not.to.be.null;
@@ -21,7 +21,7 @@ describe("Indicator", () => {
 
   it("Should render label on right", () => {
     const wrapper = render(
-      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={true} labelSide={StatusBarLabelSide.Right} />);
+      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={true} labelSide={StatusBarLabelSide.Right} />); // eslint-disable-line deprecation/deprecation
     expect(wrapper).not.to.be.undefined;
     expect(wrapper.container.querySelector(".uifw-footer-label-reversed")).not.to.be.null;
     expect(wrapper.container.querySelector(".icon.test-icon")).not.to.be.null;
@@ -31,7 +31,7 @@ describe("Indicator", () => {
 
   it("Should not render label", () => {
     const wrapper = render(
-      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={false} labelSide={StatusBarLabelSide.Right} />);
+      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={false} labelSide={StatusBarLabelSide.Right} />); // eslint-disable-line deprecation/deprecation
     expect(wrapper).not.to.be.undefined;
     expect(wrapper.container.querySelector(".uifw-footer-label-reversed")).not.to.be.null;
     expect(wrapper.container.querySelector(".icon.test-icon")).not.to.be.null;
@@ -41,7 +41,7 @@ describe("Indicator", () => {
 
   it("Should support isInfooterMode=false (deprecated)", () => {
     const wrapper = render(
-      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={false} labelSide={StatusBarLabelSide.Right} isInFooterMode={false} />);
+      <Indicator iconSpec={"test-icon"} label="test-label" isLabelVisible={false} labelSide={StatusBarLabelSide.Right} isInFooterMode={false} />); // eslint-disable-line deprecation/deprecation
     expect(wrapper).not.to.be.undefined;
     expect(wrapper.container.querySelector(".uifw-footer-label-reversed")).not.to.be.null;
     expect(wrapper.container.querySelector(".icon.test-icon")).not.to.be.null;

--- a/ui/appui-react/src/test/statusfields/MessageCenter.test.tsx
+++ b/ui/appui-react/src/test/statusfields/MessageCenter.test.tsx
@@ -109,7 +109,7 @@ import TestUtils, { mount } from "../TestUtils";
 
     it("Message Center should close on outside click", () => {
       const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} />);
-      const footerPopup = wrapper.find(FooterPopup);
+      const footerPopup = wrapper.find(FooterPopup); // eslint-disable-line deprecation/deprecation
       const messageCenterField = wrapper.find(MessageCenterField);
       const messageCenter = wrapper.find("div.nz-indicator");
 
@@ -134,7 +134,7 @@ import TestUtils, { mount } from "../TestUtils";
 
     it("Message Center should not close on outside click", () => {
       const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} />);
-      const footerPopup = wrapper.find(FooterPopup);
+      const footerPopup = wrapper.find(FooterPopup); // eslint-disable-line deprecation/deprecation
 
       const statusBarInstance = wrapper.instance();
       statusBarInstance.setState(() => ({ openWidget: "test-widget" }));

--- a/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
@@ -356,7 +356,7 @@ import { render } from "@testing-library/react";
 
     it("should close on outside click", () => {
       const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} />);
-      const footerPopup = wrapper.find(FooterPopup);
+      const footerPopup = wrapper.find(FooterPopup); // eslint-disable-line deprecation/deprecation
       const toolAssistanceField = wrapper.find(ToolAssistanceField);
       const toolAssistance = wrapper.find("div.nz-indicator");
 
@@ -379,7 +379,7 @@ import { render } from "@testing-library/react";
 
     it("should not close on outside click if pinned", () => {
       const wrapper = mount<StatusBar>(<StatusBar widgetControl={widgetControl} />);
-      const footerPopup = wrapper.find(FooterPopup);
+      const footerPopup = wrapper.find(FooterPopup); // eslint-disable-line deprecation/deprecation
       const toolAssistance = wrapper.find("div.nz-indicator");
       const toolAssistanceField = wrapper.find(ToolAssistanceField);
 

--- a/ui/appui-react/src/test/toolbar/ActionItemButton.test.tsx
+++ b/ui/appui-react/src/test/toolbar/ActionItemButton.test.tsx
@@ -35,23 +35,23 @@ describe("ActionItemButton", () => {
   });
 
   it("should render", () => {
-    mount(<ActionItemButton actionItem={testCommand} />);
+    mount(<ActionItemButton actionItem={testCommand} />); // eslint-disable-line deprecation/deprecation
   });
 
   it("renders correctly", () => {
-    shallow(<ActionItemButton actionItem={testCommand} />).should.matchSnapshot();
+    shallow(<ActionItemButton actionItem={testCommand} />).should.matchSnapshot(); // eslint-disable-line deprecation/deprecation
   });
 
   it("hidden renders correctly", () => {
     const myCommand = testCommand;
     myCommand.isVisible = false; // eslint-disable-line deprecation/deprecation
-    shallow(<ActionItemButton actionItem={myCommand} />).should.matchSnapshot();
+    shallow(<ActionItemButton actionItem={myCommand} />).should.matchSnapshot(); // eslint-disable-line deprecation/deprecation
   });
 
   it("enabled renders correctly", () => {
     const myCommand = testCommand;
     myCommand.isEnabled = true; // eslint-disable-line deprecation/deprecation
-    shallow(<ActionItemButton actionItem={myCommand} />).should.matchSnapshot();
+    shallow(<ActionItemButton actionItem={myCommand} />).should.matchSnapshot(); // eslint-disable-line deprecation/deprecation
   });
 
   it("should execute a function", () => {
@@ -64,13 +64,13 @@ describe("ActionItemButton", () => {
         execute: spyMethod,
       });
 
-    const wrapper = mount(<ActionItemButton actionItem={spyCommand} />);
+    const wrapper = mount(<ActionItemButton actionItem={spyCommand} />); // eslint-disable-line deprecation/deprecation
     wrapper.find(".nz-toolbar-item-item").simulate("click");
     spyMethod.should.have.been.called;
   });
 
   it("should set focus to home on Esc", () => {
-    const wrapper = mount(<ActionItemButton actionItem={testCommand} />);
+    const wrapper = mount(<ActionItemButton actionItem={testCommand} />); // eslint-disable-line deprecation/deprecation
     const element = wrapper.find(".nz-toolbar-item-item");
     element.length.should.eq(1);
     element.simulate("focus");
@@ -95,7 +95,7 @@ describe("ActionItemButton", () => {
         execute: () => { },
       });
 
-    const wrapper = mount(<ActionItemButton actionItem={testSyncStateCommand} />);
+    const wrapper = mount(<ActionItemButton actionItem={testSyncStateCommand} />); // eslint-disable-line deprecation/deprecation
     expect(stateFunctionCalled).to.eq(false);
     // force to state[0]
     SyncUiEventDispatcher.dispatchImmediateSyncUiEvent(testEventId);
@@ -129,7 +129,7 @@ describe("ActionItemButton", () => {
         execute: () => { },
       });
 
-    const wrapper = mount(<ActionItemButton actionItem={testSyncStateCommand} />);
+    const wrapper = mount(<ActionItemButton actionItem={testSyncStateCommand} />); // eslint-disable-line deprecation/deprecation
     expect(stateFunctionCalled).to.eq(false);
     SyncUiEventDispatcher.dispatchImmediateSyncUiEvent(testEventId);
     expect(stateFunctionCalled).to.eq(true);
@@ -139,7 +139,7 @@ describe("ActionItemButton", () => {
   it("should handle changing state via props", () => {
     const myCommand = testCommand;
     myCommand.isEnabled = true; // eslint-disable-line deprecation/deprecation
-    const wrapper = mount(<ActionItemButton actionItem={myCommand} isEnabled={false} />);
+    const wrapper = mount(<ActionItemButton actionItem={myCommand} isEnabled={false} />); // eslint-disable-line deprecation/deprecation
     expect(wrapper.state("isEnabled")).to.be.false;
     wrapper.setProps({ isEnabled: true });
     expect(wrapper.state("isEnabled")).to.be.true;
@@ -154,7 +154,7 @@ it("should render with badgeType", () => {
       badgeType: BadgeType.New,
     });
 
-  const wrapper = mount(<ActionItemButton actionItem={myCommand} />);
+  const wrapper = mount(<ActionItemButton actionItem={myCommand} />); // eslint-disable-line deprecation/deprecation
   const badge = wrapper.find("div.nz-badge");
   badge.length.should.eq(1);
   const newBadge = wrapper.find("div.core-new-badge");

--- a/ui/appui-react/src/test/toolbar/GroupItem.test.tsx
+++ b/ui/appui-react/src/test/toolbar/GroupItem.test.tsx
@@ -61,7 +61,7 @@ describe("GroupItem", () => {
   describe("<GroupButton />", () => {
     it("should render", () => {
       mount(
-        <GroupButton
+        <GroupButton // eslint-disable-line deprecation/deprecation
           labelKey="UiFramework:tests.label"
           iconSpec="icon-placeholder"
           items={[tool1, tool2]}
@@ -73,7 +73,7 @@ describe("GroupItem", () => {
 
     it("should not render if not visible", () => {
       mount(
-        <GroupButton
+        <GroupButton // eslint-disable-line deprecation/deprecation
           labelKey="UiFramework:tests.label"
           iconSpec="icon-placeholder"
           items={[tool1, tool2]}
@@ -86,7 +86,7 @@ describe("GroupItem", () => {
 
     it("renders correctly", () => {
       shallow(
-        <GroupButton
+        <GroupButton // eslint-disable-line deprecation/deprecation
           labelKey="UiFramework:tests.label"
           iconSpec="icon-placeholder"
           items={[tool1, tool2]}
@@ -98,7 +98,7 @@ describe("GroupItem", () => {
 
     it("should handle props change", () => {
       const wrapper = mount(
-        <GroupButton
+        <GroupButton // eslint-disable-line deprecation/deprecation
           labelKey="UiFramework:tests.label"
           iconSpec="icon-placeholder"
           items={[tool1, tool2]}
@@ -116,7 +116,7 @@ describe("GroupItem", () => {
       const testStateFunc = (state: Readonly<BaseItemState>): BaseItemState => { stateFunctionCalled = true; return state; };
 
       mount(
-        <GroupButton
+        <GroupButton // eslint-disable-line deprecation/deprecation
           labelKey="UiFramework:tests.label"
           iconSpec="icon-placeholder"
           items={[tool1, tool2]}
@@ -140,7 +140,7 @@ describe("GroupItem", () => {
       const testEventId = "test-button-state";
 
       mount(
-        <GroupButton
+        <GroupButton // eslint-disable-line deprecation/deprecation
           labelKey="UiFramework:tests.label"
           iconSpec="icon-placeholder"
           items={[tool1, tool2]}
@@ -153,7 +153,7 @@ describe("GroupItem", () => {
     });
 
     it("should set focus to home on Esc", () => {
-      const wrapper = mount(<GroupButton items={[tool1, tool2]} />);
+      const wrapper = mount(<GroupButton items={[tool1, tool2]} />); // eslint-disable-line deprecation/deprecation
       const element = wrapper.find(".nz-toolbar-item-item");
       element.simulate("focus");
       element.simulate("keyDown", { key: "Escape" });
@@ -236,7 +236,7 @@ describe("GroupItem", () => {
       it("should include a GroupToolExpander when a GroupItemDef is included", () => {
         const wrapper = mount(
           <ToolbarDragInteractionContext.Provider value={true}>
-            <GroupButton items={[tool1, tool2, group1]} />
+            <GroupButton items={[tool1, tool2, group1]} /> {/* eslint-disable-line deprecation/deprecation */}
           </ToolbarDragInteractionContext.Provider>,
         );
 

--- a/ui/appui-react/src/test/toolbar/ToolButton.test.tsx
+++ b/ui/appui-react/src/test/toolbar/ToolButton.test.tsx
@@ -22,48 +22,50 @@ describe("ToolButton", () => {
   });
 
   it("should render", () => {
-    mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" />);
+    mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" />); // eslint-disable-line deprecation/deprecation
   });
 
   it("should render active & pressed", () => {
-    mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" isActive={true} isPressed={true} />);
+    mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" isActive={true} isPressed={true} />); // eslint-disable-line deprecation/deprecation
   });
 
   it("renders active correctly", () => {
     FrontstageManager.setActiveToolId("tool1");
-    shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" />).should.matchSnapshot();
+    shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" />).should.matchSnapshot(); // eslint-disable-line deprecation/deprecation
   });
 
   it("hidden renders correctly", () => {
-    shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" isVisible={false} />).should.matchSnapshot();
+    shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" isVisible={false} />).should.matchSnapshot(); // eslint-disable-line deprecation/deprecation
   });
 
   it("disabled renders correctly", () => {
-    shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" isEnabled={false} />).should.matchSnapshot();
+    shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" isEnabled={false} />).should.matchSnapshot(); // eslint-disable-line deprecation/deprecation
   });
 
   it("renders correctly with beta badge", () => {
+    // eslint-disable-next-line deprecation/deprecation
     shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" badgeType={BadgeType.TechnicalPreview} />).should.matchSnapshot();
   });
 
   it("renders correctly with new badge", () => {
+    // eslint-disable-next-line deprecation/deprecation
     shallow(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" badgeType={BadgeType.New} />).should.matchSnapshot();
   });
 
   it("should execute a function", () => {
     const spyMethod = sinon.spy();
-    const wrapper = mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" execute={spyMethod} />);
+    const wrapper = mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" execute={spyMethod} />); // eslint-disable-line deprecation/deprecation
     wrapper.find(".nz-toolbar-item-item").simulate("click");
     spyMethod.should.have.been.called;
   });
 
   it("should execute a tool", () => {
-    const wrapper = mount(<ToolButton toolId={SelectionTool.toolId} />);
+    const wrapper = mount(<ToolButton toolId={SelectionTool.toolId} />); // eslint-disable-line deprecation/deprecation
     wrapper.find(".nz-toolbar-item-item").simulate("click");
   });
 
   it("should set focus to home on Esc", () => {
-    const wrapper = mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" />);
+    const wrapper = mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" />); // eslint-disable-line deprecation/deprecation
     const element = wrapper.find(".nz-toolbar-item-item");
     element.simulate("focus");
     element.simulate("keyDown", { key: "Escape" });
@@ -71,7 +73,7 @@ describe("ToolButton", () => {
   });
 
   it("should use a label function", () => {
-    mount(<ToolButton toolId="tool1" label={() => "test"} />);
+    mount(<ToolButton toolId="tool1" label={() => "test"} />); // eslint-disable-line deprecation/deprecation
   });
 
   it("sync event should trigger stateFunc", () => {
@@ -82,6 +84,7 @@ describe("ToolButton", () => {
       return { ...state, isActive: true };
     };
 
+    // eslint-disable-next-line deprecation/deprecation
     const wrapper = mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" stateSyncIds={[testEventId]} stateFunc={testStateFunc} />);
     const element = wrapper.find(".nz-toolbar-item-item");
     element.simulate("focus");
@@ -101,6 +104,7 @@ describe("ToolButton", () => {
       return { ...state, isVisible: true, isActive: true, isEnabled: true };
     };
 
+    // eslint-disable-next-line deprecation/deprecation
     mount(<ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="UiFramework:tests.label" stateSyncIds={[testEventId]} stateFunc={testStateFunc} />);
 
     expect(stateFunctionCalled).to.eq(false);

--- a/ui/appui-react/src/test/toolbar/ToolbarComposer.test.tsx
+++ b/ui/appui-react/src/test/toolbar/ToolbarComposer.test.tsx
@@ -208,7 +208,7 @@ describe("<ToolbarComposer  />", async () => {
     it("should render with specified items", async () => {
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, tool2, group1, custom1])} />
@@ -232,7 +232,7 @@ describe("<ToolbarComposer  />", async () => {
 
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool2, group1, custom1])} />
@@ -245,7 +245,7 @@ describe("<ToolbarComposer  />", async () => {
 
       renderedComponent.rerender(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool2a, tool2b])} />
@@ -272,7 +272,7 @@ describe("<ToolbarComposer  />", async () => {
 
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool2, group1, custom1, tool2, group1, custom1])} />
@@ -304,7 +304,7 @@ describe("<ToolbarComposer  />", async () => {
     it("should render with specified items", async () => {
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, tool2, group1, custom1])} />
@@ -318,7 +318,7 @@ describe("<ToolbarComposer  />", async () => {
     it("should render", async () => {
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, tool2])} />
@@ -330,7 +330,7 @@ describe("<ToolbarComposer  />", async () => {
     it("should render with specified items", async () => {
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, tool2, group1, custom1])} />
@@ -342,7 +342,7 @@ describe("<ToolbarComposer  />", async () => {
     it("should render with updated items", async () => {
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, tool2, group1, custom1])} />
@@ -353,7 +353,7 @@ describe("<ToolbarComposer  />", async () => {
       expect(renderedComponent.queryByTitle("Tool_Group")).not.to.be.null;
       renderedComponent.rerender(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, group1])} />
@@ -366,7 +366,7 @@ describe("<ToolbarComposer  />", async () => {
     it("sync event should not refresh if no items updated", () => {
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, tool2])} />
@@ -387,7 +387,7 @@ describe("<ToolbarComposer  />", async () => {
 
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={items} />
@@ -410,7 +410,7 @@ describe("<ToolbarComposer  />", async () => {
       const fakeTimers = sinon.useFakeTimers();
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={ToolbarHelper.createToolbarItemsFromItemDefs([tool1, tool2, group1])} />
@@ -453,7 +453,7 @@ describe("<ToolbarComposer  />", async () => {
 
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={items} />
@@ -480,7 +480,7 @@ describe("<ToolbarComposer  />", async () => {
 
       const renderedComponent = render(
         <Provider store={TestUtils.store}>
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <ToolbarComposer usage={ToolbarUsage.ContentManipulation}
               orientation={ToolbarOrientation.Horizontal}
               items={[]} />

--- a/ui/appui-react/src/test/utils/ToolbarButtonHelper.test.tsx
+++ b/ui/appui-react/src/test/utils/ToolbarButtonHelper.test.tsx
@@ -41,7 +41,7 @@ describe("Locate Toolbar items", () => {
         expandsTo={Direction.Bottom} // eslint-disable-line deprecation/deprecation
         items={
           <>
-            <ToolButton toolId="tool1" iconSpec="icon-placeholder" label="SampleApp:buttons.tool1" />
+            <ToolButton toolId="tool1" iconSpec="icon-placeholder" label="SampleApp:buttons.tool1" /> {/* eslint-disable-line deprecation/deprecation */}
           </>
         }
       />;
@@ -51,8 +51,8 @@ describe("Locate Toolbar items", () => {
         expandsTo={Direction.Right} // eslint-disable-line deprecation/deprecation
         items={
           <>
-            <ToolButton toolId="tool2" iconSpec="icon-placeholder" label="SampleApp:buttons.tool2" />
-            <GroupButton
+            <ToolButton toolId="tool2" iconSpec="icon-placeholder" label="SampleApp:buttons.tool2" /> {/* eslint-disable-line deprecation/deprecation */}
+            <GroupButton // eslint-disable-line deprecation/deprecation
               label="SampleApp:group"
               iconSpec="icon-placeholder"
               items={[tool1, tool2]}

--- a/ui/appui-react/src/test/widget-panels/useWidgetDirection.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/useWidgetDirection.test.tsx
@@ -46,7 +46,7 @@ describe("useWidgetDirection", () => {
         <Provider store={TestUtils.store} >
           <NineZoneContext.Provider value={nineZone}>
             <TabIdContext.Provider value="t1">
-              <FrameworkVersion>
+              <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
                 {children}
               </FrameworkVersion>
             </TabIdContext.Provider>
@@ -69,7 +69,7 @@ describe("useWidgetDirection", () => {
         <Provider store={TestUtils.store} >
           <NineZoneContext.Provider value={nineZone}>
             <TabIdContext.Provider value="t1">
-              <FrameworkVersion>
+              <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
                 {children}
               </FrameworkVersion>
             </TabIdContext.Provider>

--- a/ui/appui-react/src/test/widgets/NavigationWidget.test.tsx
+++ b/ui/appui-react/src/test/widgets/NavigationWidget.test.tsx
@@ -81,8 +81,8 @@ describe("NavigationWidget localStorage Wrapper", () => {
         expandsTo={Direction.Bottom} // eslint-disable-line deprecation/deprecation
         items={
           <>
-            <ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" />
-            <ToolButton toolId="tool2" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" />
+            <ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" /> {/* eslint-disable-line deprecation/deprecation */}
+            <ToolButton toolId="tool2" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" /> {/* eslint-disable-line deprecation/deprecation */}
           </>
         }
       />;
@@ -92,8 +92,8 @@ describe("NavigationWidget localStorage Wrapper", () => {
         expandsTo={Direction.Left} // eslint-disable-line deprecation/deprecation
         items={
           <>
-            <ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" />
-            <ToolButton toolId="tool2" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" />
+            <ToolButton toolId="tool1" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" /> {/* eslint-disable-line deprecation/deprecation */}
+            <ToolButton toolId="tool2" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" /> {/* eslint-disable-line deprecation/deprecation */}
           </>
         }
       />;
@@ -101,7 +101,7 @@ describe("NavigationWidget localStorage Wrapper", () => {
     it("NavigationWidget should render", async () => {
       mount(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <NavigationWidget // eslint-disable-line deprecation/deprecation
               horizontalToolbar={horizontalToolbar}
               verticalToolbar={verticalToolbar}
@@ -114,7 +114,7 @@ describe("NavigationWidget localStorage Wrapper", () => {
     it("NavigationWidget should render correctly", async () => {
       shallow(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <NavigationWidget // eslint-disable-line deprecation/deprecation
               id="navigationWidget"
               horizontalToolbar={horizontalToolbar}
@@ -130,7 +130,7 @@ describe("NavigationWidget localStorage Wrapper", () => {
       const vItemList = new ItemList([CoreTools.fitViewCommand]);
       mount(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <NavigationWidget // eslint-disable-line deprecation/deprecation
               horizontalItems={hItemList}
               verticalItems={vItemList}
@@ -147,11 +147,11 @@ describe("NavigationWidget localStorage Wrapper", () => {
           verticalToolbar={verticalToolbar}
         />,
       );
-      expect(wrapper.find(ToolButton).length).to.eq(4);
+      expect(wrapper.find(ToolButton).length).to.eq(4); {/* eslint-disable-line deprecation/deprecation */}
 
       wrapper.setProps({ verticalToolbar: undefined });
       wrapper.update();
-      expect(wrapper.find(ToolButton).length).to.eq(2);
+      expect(wrapper.find(ToolButton).length).to.eq(2); {/* eslint-disable-line deprecation/deprecation */}
     });
 
     class TestContentControl extends ContentControl {
@@ -204,7 +204,7 @@ describe("NavigationWidget localStorage Wrapper", () => {
 
       mount(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <NavigationAidHost />
           </FrameworkVersion>
         </Provider>);
@@ -214,7 +214,7 @@ describe("NavigationWidget localStorage Wrapper", () => {
       UiShowHideManager.snapWidgetOpacity = true;
       mount(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <NavigationAidHost />
           </FrameworkVersion>
         </Provider>);

--- a/ui/appui-react/src/test/widgets/ToolWidget.test.tsx
+++ b/ui/appui-react/src/test/widgets/ToolWidget.test.tsx
@@ -41,10 +41,10 @@ describe("ToolWidget", () => {
           expandsTo={Direction.Bottom} // eslint-disable-line deprecation/deprecation
           items={
             <>
-              <ActionItemButton actionItem={CoreTools.selectElementCommand} />
-              <ToolButton toolId="tool1a" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" />
-              <ToolButton toolId="tool2a" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" />
-              <GroupButton
+              <ActionItemButton actionItem={CoreTools.selectElementCommand} /> {/* eslint-disable-line deprecation/deprecation */}
+              <ToolButton toolId="tool1a" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" /> {/* eslint-disable-line deprecation/deprecation */}
+              <ToolButton toolId="tool2a" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" /> {/* eslint-disable-line deprecation/deprecation */}
+              <GroupButton // eslint-disable-line deprecation/deprecation
                 iconSpec="icon-placeholder"
                 items={[tool1, tool2]}
                 direction={Direction.Bottom} // eslint-disable-line deprecation/deprecation
@@ -59,11 +59,11 @@ describe("ToolWidget", () => {
           expandsTo={Direction.Right} // eslint-disable-line deprecation/deprecation
           items={
             <>
-              <ToolButton toolId="tool1b" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" />
-              <ToolButton toolId="tool2b" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" />
-              <ToolButton toolId="tool1c" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" isEnabled={false} />
-              <ToolButton toolId="tool2c" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" isVisible={false} />
-              <GroupButton
+              <ToolButton toolId="tool1b" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" /> {/* eslint-disable-line deprecation/deprecation */}
+              <ToolButton toolId="tool2b" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" /> {/* eslint-disable-line deprecation/deprecation */}
+              <ToolButton toolId="tool1c" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool1" isEnabled={false} /> {/* eslint-disable-line deprecation/deprecation */}
+              <ToolButton toolId="tool2c" iconSpec="icon-placeholder" labelKey="SampleApp:buttons.tool2" isVisible={false} /> {/* eslint-disable-line deprecation/deprecation */}
+              <GroupButton // eslint-disable-line deprecation/deprecation
                 iconSpec="icon-placeholder"
                 items={[tool1, tool2]}
               />
@@ -144,11 +144,11 @@ describe("ToolWidget", () => {
           verticalToolbar={verticalToolbar}
         />,
       );
-      expect(wrapper.find(ToolButton).length).to.eq(6);
+      expect(wrapper.find(ToolButton).length).to.eq(6); // eslint-disable-line deprecation/deprecation
 
       wrapper.setProps({ verticalToolbar: undefined });
       wrapper.update();
-      expect(wrapper.find(ToolButton).length).to.eq(2);
+      expect(wrapper.find(ToolButton).length).to.eq(2); // eslint-disable-line deprecation/deprecation
     });
 
     it("ToolWidget should tool activated", () => {

--- a/ui/appui-react/src/test/widgets/ToolWidgetComposer.test.tsx
+++ b/ui/appui-react/src/test/widgets/ToolWidgetComposer.test.tsx
@@ -66,7 +66,7 @@ describe("FrameworkAccuDraw localStorage Wrapper", () => {
     it("BackstageAppButton should render in 2.0 mode", () => {
       mount(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <BackstageAppButton icon={"icon-test"} />
           </FrameworkVersion>
         </Provider>);
@@ -76,7 +76,7 @@ describe("FrameworkAccuDraw localStorage Wrapper", () => {
       const spy = sinon.spy();
       const component = render(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <BackstageAppButton icon={"icon-test"} execute={spy} label="Hello" />
           </FrameworkVersion>
         </Provider>);
@@ -91,7 +91,7 @@ describe("FrameworkAccuDraw localStorage Wrapper", () => {
       const spy = sinon.spy(UiFramework.backstageManager, "toggle");
       const component = render(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <BackstageAppButton />
           </FrameworkVersion>
         </Provider>);
@@ -105,7 +105,7 @@ describe("FrameworkAccuDraw localStorage Wrapper", () => {
       await TestUtils.flushAsyncOperations();
       mount(
         <Provider store={TestUtils.store} >
-          <FrameworkVersion>
+          <FrameworkVersion> {/* eslint-disable-line deprecation/deprecation */}
             <BackstageAppButton icon={"icon-test"} />
           </FrameworkVersion>
         </Provider>


### PR DESCRIPTION
This PR deprecates various UI APIs in preparation of AppUI 4.0 - next major version:
* Removal of UI1.0 related components
* Making an `appui-layout-react` package internal
* Renaming a couple of `appui-react` components