### PR TITLE
UI: Reset UiShowHideManager fields on `terminate`

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-flacky-uishowhidemanager_2022-11-15-21-16.json
+++ b/common/changes/@itwin/appui-react/raplemie-flacky-uishowhidemanager_2022-11-15-21-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/utils/UiShowHideManager.ts
+++ b/ui/appui-react/src/appui-react/utils/UiShowHideManager.ts
@@ -213,5 +213,13 @@ export class UiShowHideManager {
   /** @internal */
   public static terminate() {
     UiShowHideManager.cancelTimer();
+    // Ensure that next use will have default values for tests.
+    UiShowHideManager._isUiVisible = true;
+    UiShowHideManager._autoHideUi = true;
+    UiShowHideManager._showHidePanels = false;
+    UiShowHideManager._showHideFooter = false;
+    UiShowHideManager._inactivityTime = INACTIVITY_TIME_DEFAULT;
+    UiShowHideManager._useProximityOpacity = false;
+    UiShowHideManager._snapWidgetOpacity = false;
   }
 }


### PR DESCRIPTION
Resolves iTwin/itwinjs-backlog#517

The hide timer sometime reach it's limit before being cancelled, which causes the UiShowHideManager to stay in a Hidden state because the `terminate` is canceling the timeout, but did not reset the values to their defaults (like other terminate would usually do)

This wasnt a concern for real applications, but as this is a static, tests would hence depend on the last value and expect it to be the default when the test start, which was not always the case.