### PR TITLE
Fix typo in class name in BIS guide

### DIFF
--- a/docs/bis/guide/fundamentals/element-fundamentals.md
+++ b/docs/bis/guide/fundamentals/element-fundamentals.md
@@ -228,7 +228,7 @@ All Element parent-child relationships descend from `ElementOwnsChildElements`, 
 There are specializations (subclasses) of the `ElementOwnsChildElements` relationship that clarify the relationship of the parent and child.
 Examples include:
 
-- `PhysicalElementEAssemblesElements` – used to indicate that the child Elements are aggregated into the parent Element, whose geometry is entirely an aggregation.
+- `PhysicalElementAssemblesElements` – used to indicate that the child Elements are aggregated into the parent Element, whose geometry is entirely an aggregation.
 - `ElementEncapsulatesChildElements` – used when the child Elements represent internal data that is not typically exposed to user or useful outside of the parent Element’s context.
 - `SubjectOwnsSubjects`, `SubjectOwnsPartitionElements` - these relationships are used to constrain the set of Elements that are valid *children* of a `Subject` Element.
 


### PR DESCRIPTION
Small typo I noticed while reading the documentation.