### PR TITLE
update rush and pnpm versions

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/rushstack/main/libraries/rush-lib/src/schemas/pnpm-config.schema.json",
+  "useWorkspaces": true,
+  "strictPeerDependencies": false,
+  "globalPeerDependencyRules": {
+    "ignoreMissing": [
+      "@babel/core",
+      "@babel/plugin-syntax-flow",
+      "@babel/plugin-transform-react-jsx",
+      "@testing-library/dom",
+      "@types/node",
+      "@typescript-eslint/parser"
+    ],
+    "allowedVersions": {
+      "react": "17",
+      "react-dom": "17"
+    }
+  }
+}

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -15,5 +15,14 @@
       "react": "17",
       "react-dom": "17"
     }
+  },
+  "globalPackageExtensions": {
+    "@bentley/react-scripts": {
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    }
   }
 }

--- a/common/scripts/install-run-rush.js
+++ b/common/scripts/install-run-rush.js
@@ -40,6 +40,7 @@ const fs = __importStar(require("fs"));
 const install_run_1 = require("./install-run");
 const PACKAGE_NAME = '@microsoft/rush';
 const RUSH_PREVIEW_VERSION = 'RUSH_PREVIEW_VERSION';
+const INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE = 'INSTALL_RUN_RUSH_LOCKFILE_PATH';
 function _getRushVersion(logger) {
     const rushPreviewVersion = process.env[RUSH_PREVIEW_VERSION];
     if (rushPreviewVersion !== undefined) {
@@ -104,7 +105,11 @@ function _run() {
     (0, install_run_1.runWithErrorAndStatusCode)(logger, () => {
         const version = _getRushVersion(logger);
         logger.info(`The rush.json configuration requests Rush version ${version}`);
-        return (0, install_run_1.installAndRun)(logger, PACKAGE_NAME, version, bin, packageBinArgs);
+        const lockFilePath = process.env[INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE];
+        if (lockFilePath) {
+            logger.info(`Found ${INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE}="${lockFilePath}", installing with lockfile.`);
+        }
+        return (0, install_run_1.installAndRun)(logger, PACKAGE_NAME, version, bin, packageBinArgs, lockFilePath);
     });
 }
 _run();

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -42,6 +42,7 @@ const os = __importStar(require("os"));
 const path = __importStar(require("path"));
 exports.RUSH_JSON_FILENAME = 'rush.json';
 const RUSH_TEMP_FOLDER_ENV_VARIABLE_NAME = 'RUSH_TEMP_FOLDER';
+const INSTALL_RUN_LOCKFILE_PATH_VARIABLE = 'INSTALL_RUN_LOCKFILE_PATH';
 const INSTALLED_FLAG_FILENAME = 'installed.flag';
 const NODE_MODULES_FOLDER_NAME = 'node_modules';
 const PACKAGE_JSON_FILENAME = 'package.json';
@@ -307,25 +308,40 @@ function _isPackageAlreadyInstalled(packageInstallFolder) {
     }
 }
 /**
+ * Delete a file. Fail silently if it does not exist.
+ */
+function _deleteFile(file) {
+    try {
+        fs.unlinkSync(file);
+    }
+    catch (err) {
+        if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
+            throw err;
+        }
+    }
+}
+/**
  * Removes the following files and directories under the specified folder path:
  *  - installed.flag
  *  -
  *  - node_modules
  */
-function _cleanInstallFolder(rushTempFolder, packageInstallFolder) {
+function _cleanInstallFolder(rushTempFolder, packageInstallFolder, lockFilePath) {
     try {
         const flagFile = path.resolve(packageInstallFolder, INSTALLED_FLAG_FILENAME);
-        if (fs.existsSync(flagFile)) {
-            fs.unlinkSync(flagFile);
-        }
+        _deleteFile(flagFile);
         const packageLockFile = path.resolve(packageInstallFolder, 'package-lock.json');
-        if (fs.existsSync(packageLockFile)) {
-            fs.unlinkSync(packageLockFile);
+        if (lockFilePath) {
+            fs.copyFileSync(lockFilePath, packageLockFile);
         }
-        const nodeModulesFolder = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME);
-        if (fs.existsSync(nodeModulesFolder)) {
-            const rushRecyclerFolder = _ensureAndJoinPath(rushTempFolder, 'rush-recycler');
-            fs.renameSync(nodeModulesFolder, path.join(rushRecyclerFolder, `install-run-${Date.now().toString()}`));
+        else {
+            // Not running `npm ci`, so need to cleanup
+            _deleteFile(packageLockFile);
+            const nodeModulesFolder = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME);
+            if (fs.existsSync(nodeModulesFolder)) {
+                const rushRecyclerFolder = _ensureAndJoinPath(rushTempFolder, 'rush-recycler');
+                fs.renameSync(nodeModulesFolder, path.join(rushRecyclerFolder, `install-run-${Date.now().toString()}`));
+            }
         }
     }
     catch (e) {
@@ -354,17 +370,17 @@ function _createPackageJson(packageInstallFolder, name, version) {
 /**
  * Run "npm install" in the package install folder.
  */
-function _installPackage(logger, packageInstallFolder, name, version) {
+function _installPackage(logger, packageInstallFolder, name, version, command) {
     try {
         logger.info(`Installing ${name}...`);
         const npmPath = getNpmPath();
-        const result = childProcess.spawnSync(npmPath, ['install'], {
+        const result = childProcess.spawnSync(npmPath, [command], {
             stdio: 'inherit',
             cwd: packageInstallFolder,
             env: process.env
         });
         if (result.status !== 0) {
-            throw new Error('"npm install" encountered an error');
+            throw new Error(`"npm ${command}" encountered an error`);
         }
         logger.info(`Successfully installed ${name}@${version}`);
     }
@@ -392,18 +408,19 @@ function _writeFlagFile(packageInstallFolder) {
         throw new Error(`Unable to create installed.flag file in ${packageInstallFolder}`);
     }
 }
-function installAndRun(logger, packageName, packageVersion, packageBinName, packageBinArgs) {
+function installAndRun(logger, packageName, packageVersion, packageBinName, packageBinArgs, lockFilePath = process.env[INSTALL_RUN_LOCKFILE_PATH_VARIABLE]) {
     const rushJsonFolder = findRushJsonFolder();
     const rushCommonFolder = path.join(rushJsonFolder, 'common');
     const rushTempFolder = _getRushTempFolder(rushCommonFolder);
     const packageInstallFolder = _ensureAndJoinPath(rushTempFolder, 'install-run', `${packageName}@${packageVersion}`);
     if (!_isPackageAlreadyInstalled(packageInstallFolder)) {
         // The package isn't already installed
-        _cleanInstallFolder(rushTempFolder, packageInstallFolder);
+        _cleanInstallFolder(rushTempFolder, packageInstallFolder, lockFilePath);
         const sourceNpmrcFolder = path.join(rushCommonFolder, 'config', 'rush');
         _syncNpmrc(logger, sourceNpmrcFolder, packageInstallFolder);
         _createPackageJson(packageInstallFolder, packageName, packageVersion);
-        _installPackage(logger, packageInstallFolder, packageName, packageVersion);
+        const command = lockFilePath ? 'ci' : 'install';
+        _installPackage(logger, packageInstallFolder, packageName, packageVersion, command);
         _writeFlagFile(packageInstallFolder);
     }
     const statusMessage = `Invoking "${packageBinName} ${packageBinArgs.join(' ')}"`;

--- a/rush.json
+++ b/rush.json
@@ -1,14 +1,11 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-  "rushVersion": "5.77.3",
-  "pnpmVersion": "6.24.4",
+  "rushVersion": "5.83.1",
+  "pnpmVersion": "6.35.1",
   "nodeSupportedVersionRange": ">=12.17.0 <19.0.0",
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,
   "ensureConsistentVersions": true,
-  "pnpmOptions": {
-    "useWorkspaces": true
-  },
   "approvedPackagesPolicy": {
     "reviewCategories": [
       "frontend",


### PR DESCRIPTION
Update rush to 5.83.1
- https://github.com/microsoft/rushstack/blob/main/apps/rush/CHANGELOG.md#5833
- [5.79.0](https://github.com/microsoft/rushstack/blob/main/apps/rush/CHANGELOG.md#5790) added support for setting pnpm config options

Update pnpm to 6.35.1
- https://github.com/pnpm/pnpm/blob/v6.35.1/packages/pnpm/CHANGELOG.md
- [6.26.0](https://pnpm.io/6.x/package_json#pnpmpeerdependencyrulesignoremissing) added support for surpressing missing peer deps

This should significantly cleanup the garbage output during `rush install` and `rush update`