### PR TITLE
Fix restore of hidden widget panel location

### DIFF
--- a/common/changes/@itwin/appui-react/hidden-location_2022-11-16-20-45.json
+++ b/common/changes/@itwin/appui-react/hidden-location_2022-11-16-20-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Maintain widget panel location after frontstage is changed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/full-stack-tests/ui/tests/Utils.ts
+++ b/full-stack-tests/ui/tests/Utils.ts
@@ -100,3 +100,11 @@ export async function expectTabInPanelSection(tab: Locator, side: PanelSide, sec
   await expect(panel).toHaveClass(new RegExp(`nz-${side}`));
   await expect(section, `expected tab to be in section '${sectionId}'`).toBeVisible();
 }
+
+export async function openFrontstage(page: Page, frontstageId: string) {
+  const toggleBackstage = page.locator(`.nz-app-button button`);
+  await toggleBackstage.click();
+
+  const backstageItem = page.locator(`[data-item-type="backstage-item"][data-item-id="${frontstageId}"]`);
+  await backstageItem.click();
+}

--- a/full-stack-tests/ui/tests/widget-state.test.ts
+++ b/full-stack-tests/ui/tests/widget-state.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { test, expect, Page } from '@playwright/test';
 import assert from 'assert';
-import { activeTabLocator, expectSavedFrontstageState, expectTabInPanelSection, floatingWidgetLocator, panelLocator, runKeyin, tabLocator, widgetLocator } from './Utils';
+import { activeTabLocator, expectSavedFrontstageState, expectTabInPanelSection, floatingWidgetLocator, openFrontstage, panelLocator, runKeyin, tabLocator, widgetLocator } from './Utils';
 
 enum WidgetState {
   Open = 0,
@@ -134,6 +134,22 @@ test.describe("widget state", () => {
     await setWidgetState(page, "FW-1", WidgetState.Open);
     const newWidgetBounds = await widget.boundingBox();
     expect(newWidgetBounds).toEqual(widgetBounds);
+  });
+
+  test("should maintain location of a hidden panel widget (after frontstage change)", async ({ context, page }) => {
+    const tab = tabLocator(page, "WT-2");
+    await expectTabInPanelSection(tab, "top", 1);
+
+    await setWidgetState(page, "WT-2", WidgetState.Hidden);
+    await expectSavedFrontstageState(context, (state) => {
+      return !!state.widgets.find((w) => w.id === "WT-2");
+    });
+
+    await openFrontstage(page, "appui-test-app:main-stage");
+
+    await openFrontstage(page, "appui-test-providers:WidgetApi");
+    await setWidgetState(page, "WT-2", WidgetState.Open);
+    await expectTabInPanelSection(tab, "top", 1);
   });
 
   test("should maintain location of a panel widget (after reload)", async ({ context, page }) => {


### PR DESCRIPTION
This PR fixes an issue where a hidden widget panel location is restored to a default value after a frontstage is changed.
This caused a widget to move to a left start panel section in this scenario:
1. Hide a widget **W** (widget must be docked to a panel)
2. Change the frontstage
3. Navigate to a previously active frontstage
4. Show a widget **W**