### PR TITLE
Improve presentation-common compatibility with ESM

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -150,6 +150,7 @@ export class Presentation {
 // @public
 export interface PresentationAssetsRootConfig {
     backend: string;
+    // @deprecated
     common: string;
 }
 

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -2007,9 +2007,6 @@ export type PartialNode = AllOrNone<Partial<Node_2>, "key" | "label">;
 export type PartialNodeJSON = AllOrNone<Partial<NodeJSON>, "key" | "labelDefinition">;
 
 // @internal (undocumented)
-export const PRESENTATION_COMMON_ROOT: string;
-
-// @internal (undocumented)
 export const PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface";
 
 // @public

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -263,7 +263,6 @@ public;PartialHierarchyModification
 public;PartialHierarchyModificationJSON = NodeInsertionInfoJSON | NodeDeletionInfoJSON | NodeUpdateInfoJSON
 public;PartialNode = AllOrNone
 public;PartialNodeJSON = AllOrNone
-internal;PRESENTATION_COMMON_ROOT: string
 internal;PRESENTATION_IPC_CHANNEL_NAME = "presentation-ipc-interface"
 public;PresentationError 
 alpha;PresentationIpcEvents

--- a/common/changes/@itwin/presentation-backend/presentation-esm-compatibility_2022-11-22-12-26.json
+++ b/common/changes/@itwin/presentation-backend/presentation-esm-compatibility_2022-11-22-12-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Deprecate unused `PresentationAssetsRootConfig.common`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-esm-compatibility_2022-11-22-12-11.json
+++ b/common/changes/@itwin/presentation-common/presentation-esm-compatibility_2022-11-22-12-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/presentation-common",
-      "comment": "Avoid reading `__dirname` variable in ESM context.",
+      "comment": "Remove uses of `__dirname`, which is not available in ESM context.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/presentation-common/presentation-esm-compatibility_2022-11-22-12-11.json
+++ b/common/changes/@itwin/presentation-common/presentation-esm-compatibility_2022-11-22-12-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Avoid reading `__dirname` variable in ESM context.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/backend/src/presentation-backend/Constants.ts
+++ b/presentation/backend/src/presentation-backend/Constants.ts
@@ -7,7 +7,6 @@
  */
 
 import * as path from "path";
-import { PRESENTATION_COMMON_ROOT } from "@itwin/presentation-common";
 
 /**
  * Path to presentation-backend assets root directory.
@@ -15,10 +14,3 @@ import { PRESENTATION_COMMON_ROOT } from "@itwin/presentation-common";
  */
 // istanbul ignore next
 export const PRESENTATION_BACKEND_ASSETS_ROOT = (-1 !== __dirname.indexOf("presentation-backend")) ? path.join(__dirname, "../assets") : path.join(__dirname, "assets");
-
-/**
- * Path to presentation-common assets root directory.
- * @internal
- */
-// istanbul ignore next
-export const PRESENTATION_COMMON_ASSETS_ROOT = (-1 !== PRESENTATION_COMMON_ROOT.indexOf("presentation-common")) ? path.join(PRESENTATION_COMMON_ROOT, "../assets") : path.join(__dirname, "assets");

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -206,7 +206,12 @@ export interface MultiElementPropertiesResponse {
 export interface PresentationAssetsRootConfig {
   /** Path to `presentation-backend` assets */
   backend: string;
-  /** Path to `presentation-common` assets */
+
+  /**
+   * Path to `presentation-common` assets.
+   *
+   * @deprecated This path is not used anymore
+   */
   common: string;
 }
 
@@ -216,33 +221,21 @@ export interface PresentationAssetsRootConfig {
  */
 export interface PresentationManagerProps {
   /**
-   * Path overrides for presentation assets. Need to be overriden by application if it puts these assets someplace else than the default.
+   * Path overrides for presentation backend assets. Need to be overriden by application if it puts these assets someplace else than the default.
    *
-   * By default paths to asset directories are determined during the call of [[Presentation.initialize]] using this algorithm:
+   * By default the path to assets directory is determined during the call of [[Presentation.initialize]] using this algorithm:
    *
-   * - for `presentation-backend` assets:
+   * - if path of `.js` file that contains [[PresentationManager]] definition contains "presentation-backend", assume the package is in `node_modules` and the directory structure is:
+   *   - `assets/*\*\/*`
+   *   - `presentation-backend/{presentation-backend source files}`
    *
-   *   - if path of `.js` file that contains [[PresentationManager]] definition contains "presentation-backend", assume the package is in `node_modules` and the directory structure is:
-   *     - `assets/*\*\/*`
-   *     - `presentation-backend/{presentation-backend source files}`
+   *   which means the assets can be found through a relative path `../assets/` from the JS file being executed.
    *
-   *     which means the assets can be found through a relative path `../assets/` from the JS file being executed.
-   *
-   * - for `presentation-common` assets:
-   *
-   *   - if path of `.js` files of `presentation-common` package contain "presentation-common", assume the package is in `node_modules` and the directory structure is:
-   *     - `assets/*\*\/*`
-   *     - `presentation-common/{presentation-common source files}`
-   *
-   *     which means the assets can be found through a relative path `../assets/` from the package's source files.
-   *
-   * - in both cases, if we determine that source files are not in `node_modules`, assume the backend is webpacked into a single file with assets next to it:
+   * - else, assume the backend is webpacked into a single file with assets next to it:
    *   - `assets/*\*\/*`
    *   - `{source file being executed}.js`
    *
    *   which means the assets can be found through a relative path `./assets/` from the `{source file being executed}`.
-   *
-   * The overrides can be specified as a single path (when assets of both `presentation-backend` and `presentation-common` packages are merged into a single directory) or as an object with two separate paths for each package.
    */
   presentationAssetsRoot?: string | PresentationAssetsRootConfig;
 

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -14,7 +14,7 @@ import {
   KeySet, LabelDefinition, Node, NodeKey, NodePathElement, Paged, PagedResponse, PresentationError, PresentationStatus, Prioritized, Ruleset,
   RulesetVariable, SelectClassInfo, SingleElementPropertiesRequestOptions, WithCancelEvent,
 } from "@itwin/presentation-common";
-import { PRESENTATION_BACKEND_ASSETS_ROOT, PRESENTATION_COMMON_ASSETS_ROOT } from "./Constants";
+import { PRESENTATION_BACKEND_ASSETS_ROOT } from "./Constants";
 import { buildElementsProperties } from "./ElementPropertiesHelper";
 import {
   createDefaultNativePlatform, NativePlatformDefinition, NativePlatformRequestTypes, NativePlatformResponse, NativePresentationDefaultUnitFormats,
@@ -39,10 +39,10 @@ export class PresentationManagerDetail implements IDisposable {
   constructor(params: PresentationManagerProps) {
     this._disposed = false;
 
-    const presentationAssetsRoot = params.presentationAssetsRoot ?? {
-      common: PRESENTATION_COMMON_ASSETS_ROOT,
-      backend: PRESENTATION_BACKEND_ASSETS_ROOT,
-    };
+    const backendAssetsRoot = ((typeof params.presentationAssetsRoot === "string")
+      ? params.presentationAssetsRoot
+      : params.presentationAssetsRoot?.backend
+    ) ?? PRESENTATION_BACKEND_ASSETS_ROOT;
     const mode = params.mode ?? PresentationManagerMode.ReadWrite;
     const changeTrackingEnabled = mode === PresentationManagerMode.ReadWrite && !!params.updatesPollInterval;
     this._nativePlatform = params.addon ?? createNativePlatform(
@@ -67,7 +67,7 @@ export class PresentationManagerDetail implements IDisposable {
 
     setupRulesetDirectories(
       this._nativePlatform,
-      typeof presentationAssetsRoot === "string" ? presentationAssetsRoot : presentationAssetsRoot.backend,
+      backendAssetsRoot,
       params.supplementalRulesetDirectories ?? [],
       params.rulesetDirectories ?? [],
     );

--- a/presentation/common/src/presentation-common/Utils.ts
+++ b/presentation/common/src/presentation-common/Utils.ts
@@ -83,6 +83,3 @@ export const getInstancesCount = (keys: Readonly<KeySet>): number => {
  * @public
  */
 export const DEFAULT_KEYS_BATCH_SIZE = 5000;
-
-/** @internal */
-export const PRESENTATION_COMMON_ROOT = typeof __dirname !== "undefined" ? __dirname : "__dirname";

--- a/presentation/common/src/presentation-common/Utils.ts
+++ b/presentation/common/src/presentation-common/Utils.ts
@@ -85,4 +85,4 @@ export const getInstancesCount = (keys: Readonly<KeySet>): number => {
 export const DEFAULT_KEYS_BATCH_SIZE = 5000;
 
 /** @internal */
-export const PRESENTATION_COMMON_ROOT = __dirname;
+export const PRESENTATION_COMMON_ROOT = typeof __dirname !== "undefined" ? __dirname : "__dirname";


### PR DESCRIPTION
`__dirname` is replaced with `import.meta.url` in ESM contexts, but we must keep this module as CJS for now.

This change fixes one failure point when users try to build their iTwin.js app with Vite.