### PR TITLE
Update Dialog.scss for iTwinUI

### DIFF
--- a/common/changes/@itwin/core-react/ui-dialog-backstop_2022-11-23-16-33.json
+++ b/common/changes/@itwin/core-react/ui-dialog-backstop_2022-11-23-16-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Change core-dialog-hidden class so that modeless dialogs will be compatible with iTwinUI components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/SampleModelessDialog.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/SampleModelessDialog.tsx
@@ -5,7 +5,7 @@
 import * as React from "react";
 import { IModelApp, MessageBoxIconType, MessageBoxType } from "@itwin/core-frontend";
 import { ModelessDialog, ModelessDialogManager } from "@itwin/appui-react";
-import { Button } from "@itwin/itwinui-react";
+import { Button, ComboBox } from "@itwin/itwinui-react";
 import "./SampleModelessDialog.scss";
 
 export interface SampleModelessDialogProps {
@@ -35,7 +35,7 @@ export class SampleModelessDialog extends React.Component<SampleModelessDialogPr
         opened={this.state.opened}
         dialogId={this.props.dialogId}
         width={450}
-        height={150}
+        height={250}
         onClose={this._handleCancel}
         onEscape={this._handleCancel}
         movable={true}
@@ -44,6 +44,28 @@ export class SampleModelessDialog extends React.Component<SampleModelessDialogPr
           <div>
                         To demonstrate messagebox behaviour in modeless dialog
           </div>
+          <ComboBox
+            value={"hello"}
+            inputProps={{
+              placeholder: "localized1 placeholder",
+            }}
+            // onChange={(value: string) => memoizedOnViewDefinitionSelected(value)}
+            options={
+
+              [{
+                disabled: false,
+                label: "mm",
+                sublabel: "Millimeter",
+                value: "MM",
+              },
+              {
+                disabled: false,
+                label: "cm",
+                sublabel: "Centimeter",
+                value: "CM",
+              }]}
+          />
+
           <div className="sample-grid">
             <Button styleType="cta" onClick={this._onShowMessageBox}>Show Message box</Button>
             <Button styleType="cta" onClick={this._handleCancel}>Close</Button>

--- a/ui/core-react/src/core-react/dialog/Dialog.scss
+++ b/ui/core-react/src/core-react/dialog/Dialog.scss
@@ -34,8 +34,9 @@
   }
 
   &.core-dialog-hidden {
-    width: 0;
-    height: 0;
+    background-color: transparent;
+    pointer-events: none;
+    &>*{pointer-events: all;}
   }
 
   .core-dialog-container {

--- a/ui/core-react/src/core-react/dialog/Dialog.scss
+++ b/ui/core-react/src/core-react/dialog/Dialog.scss
@@ -36,7 +36,10 @@
   &.core-dialog-hidden {
     background-color: transparent;
     pointer-events: none;
-    &>*{pointer-events: all;}
+
+    & > * {
+      pointer-events: all;
+    }
   }
 
   .core-dialog-container {


### PR DESCRIPTION
Using an iTwinUI component that has a popup (e.g., Select) does not work with AppUi modeless dialogs because of the way AppUi hides the dialog backstop. Changed the core-dialog-hidden class to make it compatible with the Tippy package used by iTwinUI.