### PR TITLE
Support external docs builds

### DIFF
--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -18,6 +18,13 @@ parameters:
     type: boolean
     default: false
 
+resources:
+  repositories:
+    - repository: itwinjs-core
+      type: github
+      endpoint: iModelJs
+      name: iTwin/itwinjs-core
+
 jobs:
   - job:
     workspace:
@@ -27,7 +34,7 @@ jobs:
       demands: Agent.OS -equals Windows_NT
 
     steps:
-      - checkout: self
+      - checkout: itwinjs-core
         path: itwinjs-core
         clean: true
 

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -2,6 +2,9 @@
 # and running a step to combine everything.
 
 parameters:
+  - name: checkout
+    type: string
+    default: self
   - name: workingDir
     type: string
     default: $(Pipeline.Workspace)/itwinjs-core
@@ -18,13 +21,6 @@ parameters:
     type: boolean
     default: false
 
-resources:
-  repositories:
-    - repository: itwinjs-core
-      type: github
-      endpoint: iModelJs
-      name: iTwin/itwinjs-core
-
 jobs:
   - job:
     workspace:
@@ -34,7 +30,7 @@ jobs:
       demands: Agent.OS -equals Windows_NT
 
     steps:
-      - checkout: itwinjs-core
+      - checkout: ${{ parameters.checkout }}
         path: itwinjs-core
         clean: true
 


### PR DESCRIPTION
External repositories with pipelines trying to use the docs build template would fail due to the "checkout: self" step, which will always check out the repository which is hosting the pipeline's YAML file. This is fine in the itwinjs-core repo, but other repositories using this template must supply a repository alias in order to check out this repo (and not themselves) when using the docs build template.

This parameter allows for external pipelines to supply this alias while defaulting to "self" if no alias is specified.