### PR TITLE
Added RegionBooleanTool to unite, subtract, or intersect planar regions.

### DIFF
--- a/common/api/editor-frontend.api.md
+++ b/common/api/editor-frontend.api.md
@@ -58,6 +58,7 @@ import { Path } from '@itwin/core-geometry';
 import { PickAsyncMethods } from '@itwin/core-bentley';
 import { Placement } from '@itwin/core-common';
 import { PlacementProps } from '@itwin/core-common';
+import { Plane3dByOriginAndUnitNormal } from '@itwin/core-geometry';
 import { Point3d } from '@itwin/core-geometry';
 import { PrimitiveTool } from '@itwin/core-frontend';
 import { Range1d } from '@itwin/core-geometry';
@@ -1709,6 +1710,8 @@ export abstract class ModifyCurveTool extends ModifyElementWithDynamicsTool {
     // (undocumented)
     protected getGeometryProps(ev: BeButtonEvent, isAccept: boolean): JsonGeometryStream | FlatBufferGeometryStream | undefined;
     // (undocumented)
+    static isInPlane(curve: CurveCollection | CurvePrimitive, plane: Plane3dByOriginAndUnitNormal): boolean;
+    // (undocumented)
     static isSingleCurve(info: ElementGeometryInfo): {
         curve: CurveCollection | CurvePrimitive;
         params: GeometryParams;
@@ -1746,15 +1749,23 @@ export abstract class ModifyElementTool extends ElementSetTool {
     // (undocumented)
     protected doUpdateElement(_props: GeometricElementProps): Promise<boolean>;
     // (undocumented)
+    protected getDragSelectCandidates(vp: Viewport, origin: Point3d, corner: Point3d, method: SelectionMethod, overlap: boolean): Promise<Id64Arg>;
+    // (undocumented)
     protected abstract getElementProps(ev: BeButtonEvent): GeometricElementProps | undefined;
     // (undocumented)
     protected abstract getGeometryProps(ev: BeButtonEvent, isAccept: boolean): JsonGeometryStream | FlatBufferGeometryStream | undefined;
+    // (undocumented)
+    protected getGroupIds(id: Id64String): Promise<Id64Arg>;
+    // (undocumented)
+    protected getSelectionSetCandidates(ss: SelectionSet): Promise<Id64Arg>;
     // (undocumented)
     isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean;
     // (undocumented)
     protected isElementValidForOperation(hit: HitDetail, out?: LocateResponse): Promise<boolean>;
     // (undocumented)
     protected onGeometryFilterChanged(): void;
+    // (undocumented)
+    protected postFilterIds(arg: Id64Arg): Promise<Id64Arg>;
     // (undocumented)
     processAgenda(ev: BeButtonEvent): Promise<void>;
     // (undocumented)
@@ -2264,6 +2275,65 @@ export class RedoTool extends Tool {
     run(): Promise<boolean>;
     // (undocumented)
     static toolId: string;
+}
+
+// @alpha (undocumented)
+export enum RegionBooleanMode {
+    Intersect = 2,
+    Subtract = 1,
+    Unite = 0
+}
+
+// @alpha
+export class RegionBooleanTool extends ModifyCurveTool {
+    // (undocumented)
+    protected acceptCurve(curve: CurveCollection | CurvePrimitive): boolean;
+    // (undocumented)
+    protected get allowDragSelect(): boolean;
+    // (undocumented)
+    protected get allowSelectionSet(): boolean;
+    // (undocumented)
+    protected applyAgendaOperation(ev: BeButtonEvent): Promise<boolean>;
+    // (undocumented)
+    applyToolSettingPropertyChange(updatedValue: DialogPropertySyncItem): Promise<boolean>;
+    // (undocumented)
+    protected get clearSelectionSet(): boolean;
+    // (undocumented)
+    protected get controlKeyContinuesSelection(): boolean;
+    // (undocumented)
+    protected doRegionBoolean(_ev: BeButtonEvent): Promise<void>;
+    // (undocumented)
+    static iconSpec: string;
+    // (undocumented)
+    get makeCopy(): boolean;
+    set makeCopy(value: boolean);
+    // (undocumented)
+    get makeCopyProperty(): DialogProperty<boolean>;
+    // (undocumented)
+    get mode(): RegionBooleanMode;
+    set mode(mode: RegionBooleanMode);
+    // (undocumented)
+    get modeProperty(): DialogProperty<number>;
+    // (undocumented)
+    protected modifyCurve(_ev: BeButtonEvent, _isAccept: boolean): GeometryQuery | undefined;
+    // (undocumented)
+    protected onAgendaModified(): Promise<void>;
+    // (undocumented)
+    onRestartTool(): Promise<void>;
+    // (undocumented)
+    processAgenda(ev: BeButtonEvent): Promise<void>;
+    // (undocumented)
+    protected get requiredElementCount(): number;
+    // (undocumented)
+    supplyToolSettingsProperties(): DialogItem[] | undefined;
+    // (undocumented)
+    static toolId: string;
+    // (undocumented)
+    protected get wantAccuSnap(): boolean;
+    // (undocumented)
+    protected get wantDynamics(): boolean;
+    // (undocumented)
+    protected get wantModifyOriginal(): boolean;
 }
 
 // @alpha

--- a/common/api/summary/editor-frontend.exports.csv
+++ b/common/api/summary/editor-frontend.exports.csv
@@ -68,6 +68,8 @@ beta;ProjectLocationHideTool
 beta;ProjectLocationSaveTool 
 beta;ProjectLocationShowTool 
 alpha;RedoTool 
+alpha;RegionBooleanMode
+alpha;RegionBooleanTool 
 alpha;RevolveCurveTool 
 alpha;RotateAbout
 alpha;RotateElementsTool 

--- a/common/changes/@itwin/core-frontend/master_2022-12-02-15-58.json
+++ b/common/changes/@itwin/core-frontend/master_2022-12-02-15-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Send single change event for deletion of selected/hilited elements.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/editor-frontend/master_2022-12-02-15-58.json
+++ b/common/changes/@itwin/editor-frontend/master_2022-12-02-15-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "Added RegionBooleanTool to unite, subtract, or intersect planar regions.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/core/frontend/src/SelectionSet.ts
+++ b/core/frontend/src/SelectionSet.ts
@@ -266,6 +266,8 @@ export class HiliteSet {
    * @param onOff True to add the elements to the hilited set, false to remove them.
    */
   public setHilite(arg: Id64Arg, onOff: boolean): void {
+    const oldSize = this.elements.size;
+
     for (const id of Id64.iterable(arg)) {
       if (onOff)
         this.elements.addId(id);
@@ -273,7 +275,8 @@ export class HiliteSet {
         this.elements.deleteId(id);
     }
 
-    IModelApp.viewManager.onSelectionSetChanged(this.iModel);
+    if (oldSize !== this.elements.size)
+      IModelApp.viewManager.onSelectionSetChanged(this.iModel);
   }
 }
 

--- a/editor/frontend/src/EditTool.ts
+++ b/editor/frontend/src/EditTool.ts
@@ -9,7 +9,7 @@
 import { IModelApp, IpcApp } from "@itwin/core-frontend";
 import { editorChannel } from "@itwin/editor-common";
 import { DeleteElementsTool } from "./DeleteElementsTool";
-import { BreakCurveTool, ExtendCurveTool, OffsetCurveTool } from "./ModifyCurveTools";
+import { BreakCurveTool, ExtendCurveTool, OffsetCurveTool, RegionBooleanTool } from "./ModifyCurveTools";
 import {
   ProjectLocationCancelTool, ProjectLocationHideTool, ProjectLocationSaveTool, ProjectLocationShowTool,
 } from "./ProjectLocation/ProjectExtentsDecoration";
@@ -140,6 +140,7 @@ export class EditTools {
         CreateTorusTool,
         ExtrudeCurveTool,
         RevolveCurveTool,
+        RegionBooleanTool,
         UniteSolidElementsTool,
         SubtractSolidElementsTool,
         IntersectSolidElementsTool,

--- a/editor/frontend/src/ModifyElementTool.ts
+++ b/editor/frontend/src/ModifyElementTool.ts
@@ -2,9 +2,10 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { Id64, Id64String } from "@itwin/core-bentley";
+import { Id64, Id64Arg, Id64Array, Id64String } from "@itwin/core-bentley";
 import { FeatureAppearance, FlatBufferGeometryStream, GeometricElementProps, JsonGeometryStream } from "@itwin/core-common";
-import { BeButtonEvent, DynamicsContext, ElementSetTool, FeatureOverrideProvider, FeatureSymbology, HitDetail, IModelApp, LocateResponse, Viewport } from "@itwin/core-frontend";
+import { BeButtonEvent, DynamicsContext, ElementSetTool, FeatureOverrideProvider, FeatureSymbology, HitDetail, IModelApp, LocateResponse, SelectionMethod, SelectionSet, Viewport } from "@itwin/core-frontend";
+import { Point3d } from "@itwin/core-geometry";
 import { computeChordToleranceFromPoint, DynamicGraphicsProvider } from "./CreateElementTool";
 
 /** @alpha Edit tool base class for updating existing elements. */
@@ -40,6 +41,29 @@ export abstract class ModifyElementTool extends ElementSetTool {
       return false;
 
     return this.acceptElementForOperation(hit.sourceId);
+  }
+
+  protected async postFilterIds(arg: Id64Arg): Promise<Id64Arg> {
+    const ids: Id64Array = [];
+
+    for (const id of Id64.iterable(arg)) {
+      if (await this.acceptElementForOperation(id))
+        ids.push(id);
+    }
+
+    return ids;
+  }
+
+  protected override async getGroupIds(id: Id64String): Promise<Id64Arg> {
+    return this.postFilterIds(await super.getGroupIds(id));
+  }
+
+  protected override async getSelectionSetCandidates(ss: SelectionSet): Promise<Id64Arg> {
+    return this.postFilterIds(await super.getSelectionSetCandidates(ss));
+  }
+
+  protected override async getDragSelectCandidates(vp: Viewport, origin: Point3d, corner: Point3d, method: SelectionMethod, overlap: boolean): Promise<Id64Arg> {
+    return this.postFilterIds(await super.getDragSelectCandidates(vp, origin, corner, method, overlap));
   }
 
   protected setupAccuDraw(): void { }

--- a/editor/frontend/src/public/locales/en/Editor.json
+++ b/editor/frontend/src/public/locales/en/Editor.json
@@ -238,6 +238,22 @@
         "AxisDirection": "Define axis direction"
       }
     },
+    "RegionBoolean": {
+      "keyin": "editor region boolean",
+      "flyover": "Perform boolean on selected regions",
+      "Label": {
+        "Mode": "Mode",
+        "KeepOriginal": "Keep Original"
+      },
+      "Mode": {
+        "Unite": "Unite",
+        "Subtract": "Subtract",
+        "Intersect": "Intersect"
+      },
+      "Error": {
+        "NonCoplanar": "Regions are non coplanar"
+      }
+    },
     "UniteSolids": {
       "keyin": "editor unite solids",
       "flyover": "Unite selected solids"


### PR DESCRIPTION
Incidental changes:
- Make GraphicalEditingScope.notifyGeometryChanged notify of all deleted elements in one call instead of one call per element. Otherwise Selection/HiliteSet events get produced for every deleted element present in those sets.
- Only invoke onSelectionSetChanged from HiliteSet.setHilite if the hilite set actually changed.