### PR TITLE
UI: New side panel grips

### DIFF
--- a/common/changes/@itwin/appui-layout-react/raplemie-newGrips_2022-12-07-16-49.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-newGrips_2022-12-07-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Updated the side panel handles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.scss
@@ -5,24 +5,18 @@
 @import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
 @import "variables";
 
-@mixin hover-style {
-  background-color: $buic-accessory-primary;
-
-  >.nz-dot {
-    background-color: $buic-foreground-accessory;
-  }
-}
+$line-grip-translate: 1px;
+$full-bar-width: calc($nz-grip-width * 0.5);
+$handle-width: calc($nz-grip-width + 1px);
+$line-grip-width: calc($nz-grip-width - 2px);
 
 .nz-widgetPanels-grip {
-  $handle-length: 3em;
-  $handle-width: 1.5em;
-
-  background-color: $buic-background-5;
+  background-color: transparent;
   align-items: center;
   justify-content: center;
-  border-radius: 3px;
   position: relative;
   display: flex;
+  transition: background-color 0.2s ease-out;
 
   >.nz-handle {
     position: absolute;
@@ -31,60 +25,100 @@
     transform: translate(-50%, -50%);
   }
 
-  >.nz-dot {
-    $size: 0.25em;
-    width: $size;
-    height: $size;
-    border-radius: 50%;
-    background-color: $buic-foreground-disabled;
-  }
-
   &.nz-left,
   &.nz-right {
     flex-direction: column;
     cursor: ew-resize;
-    width: $nz-grip-width;
-    height: $nz-grip-height;
-
-    >.nz-dot {
-      &:not(:first-child) {
-        margin-top: 3px;
-      }
-    }
+    width: $full-bar-width;
+    height: 100%;
 
     >.nz-handle {
-      height: $handle-length;
+      height: 100%;
       width: $handle-width;
     }
   }
 
   &.nz-top,
   &.nz-bottom {
-    flex-direction: row;
     cursor: ns-resize;
-    width: $nz-grip-height;
-    height: $nz-grip-width;
-
-    >.nz-dot {
-      &:not(:first-child) {
-        margin-left: 3px;
-      }
-    }
+    width: 100%;
+    height: $full-bar-width;
 
     >.nz-handle {
       height: $handle-width;
-      width: $handle-length;
+      width: 100%;
     }
   }
 
-  @media (hover: hover) {
-    &:hover {
-      @include hover-style;
+  &:hover, &.nz-resizing {
+    background-color: $buic-foreground-primary;
+  }
+}
+
+.nz-line-grip {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s ease-out, height 0.2s ease-out, width 0.2s ease-out;
+
+  .nz-captured &, .nz-widgetPanels-grip.nz-resizing &,
+  .nz-collapsed .nz-widgetPanels-grip:hover & {
+    opacity: 0;
+    height: 100%;
+    width: 100%;
+    }
+
+  .nz-collapsed & {
+    display: flex;
+    background-color: $buic-background-5;
+    border: 1px solid $buic-text-color-muted;
+    border-radius: 999px;
+    box-sizing: border-box;
+    opacity: 1;
+  }
+
+  .nz-left & {
+    transform: translateX($line-grip-translate);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  .nz-right & {
+    transform: translateX(calc($line-grip-translate * -1));
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  .nz-top & {
+    transform: translateY($line-grip-translate);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+  .nz-bottom & {
+    transform: translateY(calc($line-grip-translate * -1));
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .nz-left &, .nz-right & {
+    height: 20%;
+    width: $line-grip-width;
+
+    .nz-line-grip-detail {
+      width: 1px;
+      height: 70%;
     }
   }
 
-  &.nz-active,
-  &.nz-resizing {
-    @include hover-style;
+  .nz-top &, .nz-bottom & {
+    height: $line-grip-width;
+    width: 20%;
+
+    .nz-line-grip-detail {
+      width: 70%;
+      height: 1px;
+    }
+  }
+
+  .nz-line-grip-detail {
+     background-color: $buic-text-color-muted;
   }
 }

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.tsx
@@ -39,10 +39,9 @@ export const WidgetPanelGrip = React.memo(function WidgetPanelGrip(props: Common
       title={resizeGripTitle}
       style={props.style}
     >
-      <div className="nz-dot" />
-      <div className="nz-dot" />
-      <div className="nz-dot" />
-      <div className="nz-dot" />
+      <div className="nz-line-grip">
+        <div className="nz-line-grip-detail" />
+      </div>
       <div
         className="nz-handle"
         ref={ref}

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.scss
@@ -81,7 +81,7 @@
 
       >.nz-grip {
         right: 0;
-        transform: translate(50%, -50%);
+        transform: translate(0, -50%);
       }
     }
 
@@ -113,7 +113,7 @@
 
       >.nz-grip {
         left: 0;
-        transform: translate(-50%, -50%);
+        transform: translate(0, -50%);
       }
     }
 
@@ -167,7 +167,7 @@
 
       >.nz-grip {
         bottom: 0;
-        transform: translate(-50%, 50%);
+        transform: translate(-50%, 0);
       }
     }
 
@@ -207,7 +207,7 @@
 
       >.nz-grip {
         top: 0;
-        transform: translate(-50%, -50%);
+        transform: translate(-50%, 0);
       }
     }
 

--- a/ui/appui-layout-react/src/test/widget-panels/Grip.test.snap
+++ b/ui/appui-layout-react/src/test/widget-panels/Grip.test.snap
@@ -5,17 +5,12 @@ exports[`WidgetPanelGrip should not start resize w/o pointer down 1`] = `
   class="nz-widgetPanels-grip nz-left"
 >
   <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
+    class="nz-line-grip"
+  >
+    <div
+      class="nz-line-grip-detail"
+    />
+  </div>
   <div
     class="nz-handle"
   />
@@ -27,17 +22,12 @@ exports[`WidgetPanelGrip should render resizing 1`] = `
   class="nz-widgetPanels-grip nz-left nz-active nz-resizing"
 >
   <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
+    class="nz-line-grip"
+  >
+    <div
+      class="nz-line-grip-detail"
+    />
+  </div>
   <div
     class="nz-handle"
   />
@@ -49,17 +39,12 @@ exports[`WidgetPanelGrip should reset initial position on pointer up 1`] = `
   class="nz-widgetPanels-grip nz-left"
 >
   <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
-  <div
-    class="nz-dot"
-  />
+    class="nz-line-grip"
+  >
+    <div
+      class="nz-line-grip-detail"
+    />
+  </div>
   <div
     class="nz-handle"
   />

--- a/ui/appui-layout-react/src/test/widget-panels/Panel.test.snap
+++ b/ui/appui-layout-react/src/test/widget-panels/Panel.test.snap
@@ -98,17 +98,12 @@ exports[`WidgetPanelProvider should render captured 1`] = `
       class="nz-widgetPanels-grip nz-left nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />
@@ -215,17 +210,12 @@ exports[`WidgetPanelProvider should render collapsed 1`] = `
       class="nz-widgetPanels-grip nz-left nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />
@@ -332,17 +322,12 @@ exports[`WidgetPanelProvider should render horizontal 1`] = `
       class="nz-widgetPanels-grip nz-top nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />
@@ -505,17 +490,12 @@ exports[`WidgetPanelProvider should render multiple widgets 1`] = `
       class="nz-widgetPanels-grip nz-left nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />
@@ -622,17 +602,12 @@ exports[`WidgetPanelProvider should render spanned 1`] = `
       class="nz-widgetPanels-grip nz-top nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />
@@ -739,17 +714,12 @@ exports[`WidgetPanelProvider should render vertical 1`] = `
       class="nz-widgetPanels-grip nz-left nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />
@@ -856,17 +826,12 @@ exports[`WidgetPanelProvider should render with span bottom 1`] = `
       class="nz-widgetPanels-grip nz-left nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />
@@ -973,17 +938,12 @@ exports[`WidgetPanelProvider should render with top spanned 1`] = `
       class="nz-widgetPanels-grip nz-left nz-grip"
     >
       <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
-      <div
-        class="nz-dot"
-      />
+        class="nz-line-grip"
+      >
+        <div
+          class="nz-line-grip-detail"
+        />
+      </div>
       <div
         class="nz-handle"
       />

--- a/ui/appui-layout-react/src/test/widget-panels/Panels.test.snap
+++ b/ui/appui-layout-react/src/test/widget-panels/Panels.test.snap
@@ -140,17 +140,12 @@ exports[`WidgetPanels should render widget content 1`] = `
         class="nz-widgetPanels-grip nz-left nz-grip"
       >
         <div
-          class="nz-dot"
-        />
-        <div
-          class="nz-dot"
-        />
-        <div
-          class="nz-dot"
-        />
-        <div
-          class="nz-dot"
-        />
+          class="nz-line-grip"
+        >
+          <div
+            class="nz-line-grip-detail"
+          />
+        </div>
         <div
           class="nz-handle"
         />


### PR DESCRIPTION
This is changing the look and behavior of the AppUI panel grips:
1. When the panel are open, only the blue bar will show on hover, the full panel side is interactive.
2. When the panel are collapsed, the handle will be larger and look like a pull tab, the full panel side is interactive.
3. When the handle is hovered, it will morph into the blue full width bar indicating that the full panel side is interactive.
![image](https://user-images.githubusercontent.com/1904889/206251034-b68fb15f-1698-496c-a4e1-0d01ed60c0fe.png)
