### PR TITLE
maint: remove dep on uuid

### DIFF
--- a/common/changes/@itwin/appui-layout-react/maint-rmUuid_2022-12-08-17-44.json
+++ b/common/changes/@itwin/appui-layout-react/maint-rmUuid_2022-12-08-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/certa/maint-rmUuid_2022-12-08-17-44.json
+++ b/common/changes/@itwin/certa/maint-rmUuid_2022-12-08-17-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4006,7 +4006,6 @@ importers:
   ../../tools/certa:
     specifiers:
       '@itwin/build-tools': workspace:*
-      '@itwin/core-bentley': workspace:*
       '@itwin/eslint-plugin': workspace:*
       '@types/chai': 4.3.1
       '@types/detect-port': ~1.1.0
@@ -4029,7 +4028,6 @@ importers:
       typescript: ~4.4.0
       yargs: ^17.4.0
     dependencies:
-      '@itwin/core-bentley': link:../../core/bentley
       detect-port: 1.3.0
       express: 4.18.2
       jsonc-parser: 2.0.3

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4006,6 +4006,7 @@ importers:
   ../../tools/certa:
     specifiers:
       '@itwin/build-tools': workspace:*
+      '@itwin/core-bentley': workspace:*
       '@itwin/eslint-plugin': workspace:*
       '@types/chai': 4.3.1
       '@types/detect-port': ~1.1.0
@@ -4013,7 +4014,6 @@ importers:
       '@types/lodash': ^4.14.0
       '@types/mocha': ^8.2.2
       '@types/node': 18.11.5
-      '@types/uuid': ^7.0.2
       '@types/yargs': ^17.0.10
       detect-port: ~1.3.0
       electron: ^17.0.0
@@ -4027,9 +4027,9 @@ importers:
       rimraf: ^3.0.2
       source-map-support: ^0.5.6
       typescript: ~4.4.0
-      uuid: ^7.0.3
       yargs: ^17.4.0
     dependencies:
+      '@itwin/core-bentley': link:../../core/bentley
       detect-port: 1.3.0
       express: 4.18.2
       jsonc-parser: 2.0.3
@@ -4037,7 +4037,6 @@ importers:
       mocha: 10.1.0
       puppeteer: 15.5.0
       source-map-support: 0.5.21
-      uuid: 7.0.3
       yargs: 17.6.2
     devDependencies:
       '@itwin/build-tools': link:../build
@@ -4048,7 +4047,6 @@ importers:
       '@types/lodash': 4.14.191
       '@types/mocha': 8.2.3
       '@types/node': 18.11.5
-      '@types/uuid': 7.0.5
       '@types/yargs': 17.0.16
       electron: 17.4.11
       eslint: 7.32.0
@@ -9799,10 +9797,6 @@ packages:
     dependencies:
       '@types/node': 18.11.5
     dev: false
-
-  /@types/uuid/7.0.5:
-    resolution: {integrity: sha512-hKB88y3YHL8oPOs/CNlaXtjWn93+Bs48sDQR37ZUqG2tLeCS7EA1cmnkKsuQsub9OKEB/y/Rw9zqJqqNSbqVlQ==}
-    dev: true
 
   /@types/validator/13.7.10:
     resolution: {integrity: sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4339,7 +4339,6 @@ importers:
       '@types/react-dom': ^17.0.0
       '@types/react-transition-group': ^4.4.4
       '@types/sinon': ^9.0.0
-      '@types/uuid': ^7.0.2
       '@wojtekmaj/enzyme-adapter-react-17': ^0.6.3
       chai: ^4.1.2
       chai-as-promised: ^7
@@ -4367,7 +4366,6 @@ importers:
       ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~4.4.0
-      uuid: ^7.0.3
       xmlhttprequest: ^1.8.0
     dependencies:
       '@itwin/itwinui-css': 0.63.1
@@ -4376,7 +4374,6 @@ importers:
       immer: 9.0.6
       lodash: 4.17.21
       react-transition-group: 4.4.5_react-dom@17.0.2+react@17.0.2
-      uuid: 7.0.3
     devDependencies:
       '@itwin/appui-abstract': link:../appui-abstract
       '@itwin/build-tools': link:../../tools/build
@@ -4397,7 +4394,6 @@ importers:
       '@types/react-dom': 17.0.18
       '@types/react-transition-group': 4.4.5
       '@types/sinon': 9.0.11
-      '@types/uuid': 7.0.5
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.7_139404e387ad12a3919093d103c0dae6
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -31,7 +31,6 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
-    "@itwin/core-bentley": "workspace:*",
     "detect-port": "~1.3.0",
     "express": "^4.16.3",
     "jsonc-parser": "~2.0.3",

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -31,6 +31,7 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
+    "@itwin/core-bentley": "workspace:*",
     "detect-port": "~1.3.0",
     "express": "^4.16.3",
     "jsonc-parser": "~2.0.3",
@@ -38,7 +39,6 @@
     "mocha": "^10.0.0",
     "puppeteer": "15.5.0",
     "source-map-support": "^0.5.6",
-    "uuid": "^7.0.3",
     "yargs": "^17.4.0"
   },
   "devDependencies": {
@@ -50,7 +50,6 @@
     "@types/lodash": "^4.14.0",
     "@types/mocha": "^8.2.2",
     "@types/node": "18.11.5",
-    "@types/uuid": "^7.0.2",
     "@types/yargs": "^17.0.10",
     "electron": "^17.0.0",
     "eslint": "^7.11.0",

--- a/tools/certa/src/utils/CoverageUtils.ts
+++ b/tools/certa/src/utils/CoverageUtils.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 import * as fs from "fs";
 import * as path from "path";
-import { Guid } from "@itwin/core-bentley";
 import { onExit, spawnChildProcess } from "./SpawnUtils";
 
 /**
@@ -59,7 +58,7 @@ export function writeCoverageData(coverageData: any): void {
   if (!fs.existsSync(nycTempDirAbsolute))
     throw new Error(`Cannot save coverage data - nyc temp directory "${nycTempDirAbsolute}" does not exist.`);
 
-  // Use Guid to generate a unique filename, just like `nyc` does.
-  const coverageFileName = path.join(nycTempDirAbsolute, `${Guid.createValue()}.json`);
+  // Generate a unique filename, just like `nyc` does.
+  const coverageFileName = path.join(nycTempDirAbsolute, `${Math.random().toString(36).substring(2)}.json`);
   fs.writeFileSync(coverageFileName, JSON.stringify(coverageData));
 }

--- a/tools/certa/src/utils/CoverageUtils.ts
+++ b/tools/certa/src/utils/CoverageUtils.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as fs from "fs";
 import * as path from "path";
-import * as uuid from "uuid";
+import { Guid } from "@itwin/core-bentley";
 import { onExit, spawnChildProcess } from "./SpawnUtils";
 
 /**
@@ -59,7 +59,7 @@ export function writeCoverageData(coverageData: any): void {
   if (!fs.existsSync(nycTempDirAbsolute))
     throw new Error(`Cannot save coverage data - nyc temp directory "${nycTempDirAbsolute}" does not exist.`);
 
-  // Use uuid/v4 to generate a unique filename, just like `nyc` does.
-  const coverageFileName = path.join(nycTempDirAbsolute, `${uuid.v4()}.json`);
+  // Use Guid to generate a unique filename, just like `nyc` does.
+  const coverageFileName = path.join(nycTempDirAbsolute, `${Guid.createValue()}.json`);
   fs.writeFileSync(coverageFileName, JSON.stringify(coverageData));
 }

--- a/ui/appui-layout-react/package.json
+++ b/ui/appui-layout-react/package.json
@@ -66,7 +66,6 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-transition-group": "^4.4.4",
     "@types/sinon": "^9.0.0",
-    "@types/uuid": "^7.0.2",
     "chai": "^4.1.2",
     "chai-as-promised": "^7",
     "chai-jest-snapshot": "^2.0.0",
@@ -102,8 +101,7 @@
     "classnames": "^2.3.1",
     "immer": "9.0.6",
     "lodash": "^4.17.10",
-    "react-transition-group": "^4.4.2",
-    "uuid": "^7.0.3"
+    "react-transition-group": "^4.4.2"
   },
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc",

--- a/ui/appui-layout-react/src/appui-layout-react/base/NineZone.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/NineZone.tsx
@@ -7,14 +7,13 @@
  */
 
 import * as React from "react";
-import { v4 } from "uuid";
+import { assert, Guid } from "@itwin/core-bentley";
 import { Rectangle, useRefs, useResizeObserver } from "@itwin/core-react";
 import { CursorType } from "../widget-panels/CursorOverlay";
 import { PanelSide } from "../widget-panels/Panel";
 import { WidgetContentManager } from "../widget/ContentManager";
 import { FloatingWidget, FloatingWidgetResizeHandle } from "../widget/FloatingWidget";
 import { DraggedPanelSideContext, DraggedResizeHandleContext, DraggedWidgetIdContext, DragProvider } from "./DragManager";
-import { assert } from "@itwin/core-bentley";
 import { WidgetTab } from "../widget/Tab";
 import { NineZoneAction } from "../state/NineZoneAction";
 import { NineZoneState } from "../state/NineZoneState";
@@ -298,7 +297,7 @@ export function handleToCursorType(handle: FloatingWidgetResizeHandle): CursorTy
 
 /** @internal */
 export function getUniqueId() {
-  return v4();
+  return Guid.createValue();
 }
 
 /** @internal */


### PR DESCRIPTION
as mentioned in scrum today, no need for this dep.

ideally will replace usage with the standard api (available on both node and web), `crypto.randomUUID` but this would be breaking since we still support node12. see https://github.com/iTwin/itwinjs-core/issues/4777

