### PR TITLE
rm cjs import causing warnings for optimizated angular builds

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-rmCjsImportCoreFrontend_2022-12-09-17-46.json
+++ b/common/changes/@itwin/core-frontend/fix-rmCjsImportCoreFrontend_2022-12-09-17-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/UniformHandle.ts
+++ b/core/frontend/src/render/webgl/UniformHandle.ts
@@ -6,8 +6,7 @@
  * @module WebGL
  */
 
-import { assert } from "@itwin/core-bentley";
-import { Logger } from "@itwin/core-bentley/lib/cjs/Logger";
+import { assert, Logger } from "@itwin/core-bentley";
 import { FrontendLoggerCategory } from "../../FrontendLoggerCategory";
 import { Matrix3, Matrix4 } from "./Matrix";
 import { ShaderProgram } from "./ShaderProgram";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11051042/206761825-cc263beb-1b22-4fe5-95b6-14d48dd803e6.png)
fix what we can from the core side, just rm the erroneous cjs import
rest will require updates to angular webpack config or consumption of esm ver of the pkgs