### PR TITLE
Support 8- and 32-bit reality mesh indices

### DIFF
--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -1590,12 +1590,12 @@ export class TupleKeyedMap<K extends readonly any[], V> {
 }
 
 // @public
-export class TypedArrayBuilder<T extends Uint8Array | Uint16Array | Uint32Array> {
+export class TypedArrayBuilder<T extends UintArray> {
     protected constructor(constructor: Constructor<T>, options?: TypedArrayBuilderOptions);
     append(values: T): void;
     at(index: number): number;
     get capacity(): number;
-    protected readonly _constructor: Constructor<T>;
+    protected _constructor: Constructor<T>;
     protected _data: T;
     ensureCapacity(newCapacity: number): number;
     readonly growthFactor: number;
@@ -1625,6 +1625,26 @@ export class Uint32ArrayBuilder extends TypedArrayBuilder<Uint32Array> {
 // @public
 export class Uint8ArrayBuilder extends TypedArrayBuilder<Uint8Array> {
     constructor(options?: TypedArrayBuilderOptions);
+}
+
+// @public
+export type UintArray = Uint8Array | Uint16Array | Uint32Array;
+
+// @public
+export class UintArrayBuilder extends TypedArrayBuilder<UintArray> {
+    constructor(options?: UintArrayBuilderOptions);
+    // @internal
+    append(values: UintArray): void;
+    // (undocumented)
+    get bytesPerElement(): number;
+    protected ensureBytesPerElement(newValues: Iterable<number>): void;
+    // @internal
+    push(value: number): void;
+}
+
+// @public
+export interface UintArrayBuilderOptions extends TypedArrayBuilderOptions {
+    initialType?: typeof Uint8Array | typeof Uint16Array | typeof Uint32Array;
 }
 
 // @public

--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -1633,11 +1633,9 @@ export type UintArray = Uint8Array | Uint16Array | Uint32Array;
 // @public
 export class UintArrayBuilder extends TypedArrayBuilder<UintArray> {
     constructor(options?: UintArrayBuilderOptions);
-    // @internal
     append(values: UintArray): void;
     get bytesPerElement(): number;
     protected ensureBytesPerElement(newValues: Iterable<number>): void;
-    // @internal
     push(value: number): void;
 }
 

--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -1635,7 +1635,6 @@ export class UintArrayBuilder extends TypedArrayBuilder<UintArray> {
     constructor(options?: UintArrayBuilderOptions);
     // @internal
     append(values: UintArray): void;
-    // (undocumented)
     get bytesPerElement(): number;
     protected ensureBytesPerElement(newValues: Iterable<number>): void;
     // @internal

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -314,6 +314,8 @@ import { Tweens } from '@itwin/core-common';
 import { TxnNotifications } from '@itwin/core-common';
 import { UiAdmin } from '@itwin/appui-abstract';
 import { Uint16ArrayBuilder } from '@itwin/core-bentley';
+import { UintArray } from '@itwin/core-bentley';
+import { UintArrayBuilder } from '@itwin/core-bentley';
 import { UnitConversion } from '@itwin/core-quantity';
 import { UnitProps } from '@itwin/core-quantity';
 import { UnitsProvider } from '@itwin/core-quantity';
@@ -8164,7 +8166,7 @@ export interface RealityMeshGraphicParams {
 export interface RealityMeshParams {
     // @alpha
     featureID?: number;
-    indices: Uint16Array;
+    indices: UintArray;
     normals?: Uint16Array;
     positions: QPoint3dBuffer;
     // @alpha
@@ -8195,7 +8197,7 @@ export class RealityMeshParamsBuilder {
     // @internal
     addVertex(position: XYAndZ, uv: XAndY, normal?: number): void;
     finish(): RealityMeshParams;
-    readonly indices: Uint16ArrayBuilder;
+    readonly indices: UintArrayBuilder;
     normals?: Uint16ArrayBuilder;
     readonly positions: QPoint3dBufferBuilder;
     readonly uvs: QPoint2dBufferBuilder;

--- a/common/api/summary/core-bentley.exports.csv
+++ b/common/api/summary/core-bentley.exports.csv
@@ -126,6 +126,9 @@ public;TypedArrayBuilderOptions
 public;Uint16ArrayBuilder 
 public;Uint32ArrayBuilder 
 public;Uint8ArrayBuilder 
+public;UintArray = Uint8Array | Uint16Array | Uint32Array
+public;UintArrayBuilder 
+public;UintArrayBuilderOptions 
 public;UnexpectedErrors
 public;using
 public;utf8ToString(utf8: Uint8Array): string | undefined

--- a/common/changes/@itwin/core-bentley/pmc-32-bit-reality-mesh_2022-12-12-18-38.json
+++ b/common/changes/@itwin/core-bentley/pmc-32-bit-reality-mesh_2022-12-12-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Add UintArrayBuilder for constructing typed arrays of unknown number of bytes per element.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-frontend/pmc-32-bit-reality-mesh_2022-12-12-18-38.json
+++ b/common/changes/@itwin/core-frontend/pmc-32-bit-reality-mesh_2022-12-12-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Support reality meshes with 8- or 32-bit indices.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/bentley/src/TypedArrayBuilder.ts
+++ b/core/bentley/src/TypedArrayBuilder.ts
@@ -28,13 +28,13 @@ export interface TypedArrayBuilderOptions {
   initialCapacity?: number;
 }
 
+/** A [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) containing unsigned 8-, 16-, or 32-bit integers.
+ * @see [[UintArrayBuilder]] to construct such an array.
+ * @public
+ */
 export type UintArray = Uint8Array | Uint16Array | Uint32Array;
 
-export interface UintArrayBuilderOptions extends TypedArrayBuilderOptions {
-  initialType?: typeof Uint8Array | typeof Uint16Array | typeof Uint32Array;
-}
-
-/** Incrementally builds a [TypedArray] of unsigned 8-, 16-, or 32-bit integers.
+/** Incrementally builds a [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of unsigned 8-, 16-, or 32-bit integers.
  * Sometimes you wish to populate a `TypedArray`, but you don't know how many elements you will need.
  * `TypedArray` requires you to specify the size upon construction, and does not permit you to change the size later.
  *
@@ -45,6 +45,7 @@ export interface UintArrayBuilderOptions extends TypedArrayBuilderOptions {
  *
  * Once you've finished adding elements, you can obtain the finished `TypedArray` via [[toTypedArray]].
  * @see [[Uint8ArrayBuilder]], [[Uint16ArrayBuilder]], and [[Uint32ArrayBuilder]] to build specific types of arrays.
+ * @see [[UintArrayBuilder]] when you don't know the maximum number of bytes required for each element in the array.
  * @public
  */
 export class TypedArrayBuilder<T extends UintArray> {
@@ -178,6 +179,43 @@ export class Uint32ArrayBuilder extends TypedArrayBuilder<Uint32Array> {
   }
 }
 
+/** Options used to construct a [[UintArrayBuilder]].
+ * @public
+ */
+export interface UintArrayBuilderOptions extends TypedArrayBuilderOptions {
+  /** The type of the initial empty `TypedArray` created by the builder. For example, if you know that you will be adding values larger than
+   * 255 to the array, specify `{ initialType: Uint16Array }` to avoid replacing the otherwise default `Uint8Array` when the first such value is added.
+   * Default: `Uint8Array`.
+   */
+  initialType?: typeof Uint8Array | typeof Uint16Array | typeof Uint32Array;
+}
+
+/** A [[TypedArrayBuilder]] that can populate a [[UintArray]] with the minimum
+ * [bytes per element](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT) required.
+ *
+ * By default, the underlying array is a `Uint8Array`, though this can be configured via [[UintArrayBuilderOptions.initialType]].
+ * As values are added to the array, if the bytes per element supported by the underlying array is too small to hold one of the new values, the array is
+ * reallocated to a type large enough to hold all of the new values. For example, the following produces a `Uint8Array` because all values are less than 256:
+ *
+ * ```ts
+ *  const builder = new UintArrayBuilder();
+ *  builder.append([1, 2, 254, 255]);
+ *  const array = builder.toTypedArray();
+ *  assert(array instanceof Uint8Array);
+ * ```
+ *
+ * However, the following produces a `Uint16Array` because one of the values is larger than 255 but none are larger than 65,535:
+ *
+ * ```ts
+ *  const builder = new UintArrayBuilder();
+ *  builder.append([1, 255, 257, 65535]);
+ *  const array = builder.toTypedArray();
+ *  assert(array instanceof Uint16Array);
+ * ```
+ *
+ * @see [[Uint8ArrayBuilder]], [[Uint16ArrayBuilder]], or [[Uint32ArrayBuilder]] if you know the number of bytes you want to allocate for each element in the array.
+ * @public
+ */
 export class UintArrayBuilder extends TypedArrayBuilder<UintArray> {
   public constructor(options?: UintArrayBuilderOptions) {
     super(options?.initialType ?? Uint8Array, options);

--- a/core/bentley/src/TypedArrayBuilder.ts
+++ b/core/bentley/src/TypedArrayBuilder.ts
@@ -221,6 +221,9 @@ export class UintArrayBuilder extends TypedArrayBuilder<UintArray> {
     super(options?.initialType ?? Uint8Array, options);
   }
 
+  /** The number of bytes (1, 2, or 4) currently allocated per element by the underlying array.
+   * This may change as larger values are added to the array.
+   */
   public get bytesPerElement(): number {
     return this._data.BYTES_PER_ELEMENT;
   }

--- a/core/bentley/src/TypedArrayBuilder.ts
+++ b/core/bentley/src/TypedArrayBuilder.ts
@@ -228,7 +228,7 @@ export class UintArrayBuilder extends TypedArrayBuilder<UintArray> {
     return this._data.BYTES_PER_ELEMENT;
   }
 
-  /** Ensures that [[_data]] is of a type that can contain the largest value in `newValues`.
+  /** Ensures that the underlying array is of a type that can contain the largest value in `newValues`.
    * For example, if `_data` is a `Uint16Array` and `newValues` contains any value(s) larger than 65,535, it will be replaced with a `Uint32Array`.
    * This method is invoked by [[push]] and [[append]].
    */

--- a/core/bentley/src/TypedArrayBuilder.ts
+++ b/core/bentley/src/TypedArrayBuilder.ts
@@ -255,13 +255,13 @@ export class UintArrayBuilder extends TypedArrayBuilder<UintArray> {
     this._data = new this._constructor(this._data);
   }
 
-  /** @internal override */
+  /** See [[TypedArrayBuilder.push]]. */
   public override push(value: number): void {
     this.ensureBytesPerElement([value]);
     super.push(value);
   }
 
-  /** @internal override */
+  /** See [[TypedArrayBuilder.append]]. */
   public override append(values: UintArray): void {
     this.ensureBytesPerElement(values);
     super.append(values);

--- a/core/bentley/src/test/TypedArrayBuilder.test.ts
+++ b/core/bentley/src/test/TypedArrayBuilder.test.ts
@@ -5,7 +5,7 @@
 import { expect } from "chai";
 import { UintArrayBuilder } from "../TypedArrayBuilder";
 
-describe.only("UintArrayBuilder", () => {
+describe("UintArrayBuilder", () => {
   class Builder extends UintArrayBuilder {
     public get data() {
       return this._data;

--- a/core/bentley/src/test/TypedArrayBuilder.test.ts
+++ b/core/bentley/src/test/TypedArrayBuilder.test.ts
@@ -61,9 +61,30 @@ describe.only("UintArrayBuilder", () => {
     b.expect16([1234]);
     b.push(123456789);
     b.expect32([1234, 123456789]);
+
+    b = new Builder();
+    b.append(new Uint8Array([254, 255]));
+    b.expect8([254, 255]);
+
+    b.append(new Uint16Array([256, 0xffff]));
+    b.expect16([254, 255, 256, 0xffff]);
+
+    b.append(new Uint32Array([0x10000]));
+    b.expect32([254, 255, 256, 0xffff, 0x10000]);
+
+    b = new Builder();
+    b.append(new Uint32Array([1, 123456789]));
+    b.expect32([1, 123456789]);
   });
 
   it("retains previous array if underlying type will fit maximum value and capacity is sufficient", () => {
+    const b = new Builder({ initialCapacity: 4 });
+    const d = b.data;
+    b.append(new Uint32Array([0, 1, 254, 255]));
+    b.expect8([0, 1, 254, 255]);
+    expect(b.data).to.equal(d);
+    b.push(127);
+    expect(b.data).not.to.equal(d);
   });
 
   it("uses initialType if specified", () => {

--- a/core/bentley/src/test/TypedArrayBuilder.test.ts
+++ b/core/bentley/src/test/TypedArrayBuilder.test.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { UintArrayBuilder } from "../TypedArrayBuilder";
+
+describe.only("UintArrayBuilder", () => {
+  class Builder extends UintArrayBuilder {
+    public get data() {
+      return this._data;
+    }
+
+    public expect(type: typeof Uint8Array | typeof Uint16Array | typeof Uint32Array, expected: number[]) {
+      expect(this.data).instanceof(type);
+      const actual = Array.from(this.toTypedArray());
+      expect(actual).to.deep.equal(expected);
+    }
+
+    public expect8(expected: number[]) {
+      this.expect(Uint8Array, expected);
+    }
+
+    public expect16(expected: number[]) {
+      this.expect(Uint16Array, expected);
+    }
+
+    public expect32(expected: number[]) {
+      this.expect(Uint32Array, expected);
+    }
+  }
+
+  it("defaults to Uint8Array initially", () => {
+    new Builder().expect8([]);
+    new Builder({ initialCapacity: 17 }).expect8([]);
+  });
+
+  it("replaces underlying array type to fit maximum values", () => {
+    let b = new Builder();
+    b.push(254);
+    b.push(255);
+    b.expect8([254, 255]);
+
+    b.push(256);
+    b.expect16([254, 255, 256]);
+    b.push(0xffff);
+    b.expect16([254, 255, 256, 0xffff]);
+
+    b.push(0x10000);
+    b.expect32([254, 255, 256, 0xffff, 0x10000]);
+
+    b = new Builder();
+    b.push(1);
+    b.expect8([1]);
+
+    b.push(123456789);
+    b.expect32([1, 123456789]);
+
+    b = new Builder();
+    b.push(1234);
+    b.expect16([1234]);
+    b.push(123456789);
+    b.expect32([1234, 123456789]);
+  });
+
+  it("retains previous array if underlying type will fit maximum value and capacity is sufficient", () => {
+  });
+
+  it("uses initialType if specified", () => {
+    const b8 = new Builder({ initialType: Uint8Array });
+    const b16 = new Builder({ initialType: Uint16Array });
+    const b32 = new Builder({ initialType: Uint32Array });
+
+    b8.expect8([]);
+    b16.expect16([]);
+    b32.expect32([]);
+
+    b8.push(0xffff);
+    b8.expect16([0xffff]);
+    b16.push(0xffff);
+    b16.expect16([0xffff]);
+    b32.push(0xffff);
+    b32.expect32([0xffff]);
+
+    b8.push(0x10000);
+    b16.push(0x10000);
+    b32.push(0x10000);
+    b8.expect32([0xffff, 0x10000]);
+    b16.expect32([0xffff, 0x10000]);
+    b32.expect32([0xffff, 0x10000]);
+  });
+});

--- a/core/frontend/src/render/RealityMeshParams.ts
+++ b/core/frontend/src/render/RealityMeshParams.ts
@@ -6,7 +6,7 @@
  * @module Rendering
  */
 
-import { assert, Uint16ArrayBuilder } from "@itwin/core-bentley";
+import { assert, Uint16ArrayBuilder, UintArray, UintArrayBuilder } from "@itwin/core-bentley";
 import {
   IndexedPolyface, Point2d, Point3d, Polyface, Range2d, Range3d, Transform, Vector3d, XAndY, XYAndZ,
 } from "@itwin/core-geometry";
@@ -20,7 +20,6 @@ import { Mesh } from "./primitives/mesh/MeshPrimitives";
  * A reality mesh is a simple triangle mesh to which a [RenderTexture]($common) image can be mapped. Sources of reality meshes
  * include [[TerrainMeshProvider]]s to which background map imagery is applied, and [ContextRealityModel]($common)s captured using
  * [photogrammetry](https://en.wikipedia.org/wiki/Photogrammetry).
- * @note Currently, reality meshes cannot contain more than 65,535 vertices.
  * @see [[RealityMeshParamsBuilder]] to incrementally construct a `RealityMeshParams`.
  * @beta
  */
@@ -32,7 +31,7 @@ export interface RealityMeshParams {
   /** The optional normal vector for each vertex in the mesh, indexed by [[indices]], stored as [OctEncodedNormal]($common)s. */
   normals?: Uint16Array;
   /** The integer indices of each triangle in the mesh. The array's length must be a multiple of 3. */
-  indices: Uint16Array;
+  indices: UintArray;
   /** @alpha unused by terrain meshes */
   featureID?: number; // default 0
   /** @alpha unused by terrain meshes */
@@ -43,8 +42,8 @@ export interface RealityMeshParams {
 export namespace RealityMeshParams {
   /** @internal */
   export function fromGltfMesh(mesh: GltfMeshData): RealityMeshParams | undefined {
-    // The specialized reality mesh shaders expect a mesh with 16-bit indices, uvs, and no edges.
-    if (mesh.primitive.type !== Mesh.PrimitiveType.Mesh || mesh.primitive.edges || !mesh.pointQParams || !mesh.uvQParams || !mesh.points || !mesh.uvs || !mesh.indices || !(mesh.indices instanceof Uint16Array))
+    // The specialized reality mesh shaders expect a mesh with uvs and no edges.
+    if (mesh.primitive.type !== Mesh.PrimitiveType.Mesh || mesh.primitive.edges || !mesh.pointQParams || !mesh.uvQParams || !mesh.points || !mesh.uvs || !mesh.indices)
       return undefined;
 
     return {
@@ -148,7 +147,7 @@ export class RealityMeshParamsBuilder {
    * @see [[addQuad]] to add 4 indices describing two triangles sharing an edge.
    * @see [[addIndices]] to add any number of indices.
    */
-  public readonly indices: Uint16ArrayBuilder;
+  public readonly indices: UintArrayBuilder;
   /** The 3d position of each vertex in the mesh.
    * @see [[addQuantizedVertex]] and [[addUnquantizedVertex]] to add a vertex.
    */
@@ -170,7 +169,10 @@ export class RealityMeshParamsBuilder {
 
   /** Construct a builder from the specified options. */
   public constructor(options: RealityMeshParamsBuilderOptions) {
-    this.indices = new Uint16ArrayBuilder({ initialCapacity: options.initialIndexCapacity });
+    this.indices = new UintArrayBuilder({
+      initialCapacity: options.initialIndexCapacity,
+    });
+
     if (options.wantNormals)
       this.normals = new Uint16ArrayBuilder({ initialCapacity: options.initialVertexCapacity });
 

--- a/core/frontend/src/render/RealityMeshParams.ts
+++ b/core/frontend/src/render/RealityMeshParams.ts
@@ -169,8 +169,13 @@ export class RealityMeshParamsBuilder {
 
   /** Construct a builder from the specified options. */
   public constructor(options: RealityMeshParamsBuilderOptions) {
+    let initialType;
+    if (undefined !== options.initialVertexCapacity && options.initialVertexCapacity > 0xff)
+      initialType = options.initialVertexCapacity > 0xffff ? Uint32Array : Uint16Array;
+
     this.indices = new UintArrayBuilder({
       initialCapacity: options.initialIndexCapacity,
+      initialType,
     });
 
     if (options.wantNormals)

--- a/core/frontend/src/render/webgl/RealityMesh.ts
+++ b/core/frontend/src/render/webgl/RealityMesh.ts
@@ -7,7 +7,7 @@
  * @module WebGL
  */
 
-import { assert, dispose, disposeArray, IDisposable } from "@itwin/core-bentley";
+import { assert, dispose, disposeArray, IDisposable, UintArray } from "@itwin/core-bentley";
 import { ColorDef, Quantization, RenderTexture } from "@itwin/core-common";
 import { Matrix4d, Range2d, Range3d, Transform, Vector2d } from "@itwin/core-geometry";
 import { GraphicBranch } from "../GraphicBranch";
@@ -194,7 +194,7 @@ export class RealityMeshGeometryParams extends IndexedGeometryParams {
     this.featureID = featureID;
   }
 
-  private static createFromBuffers(posBuf: QBufferHandle3d, uvParamBuf: QBufferHandle2d, indices: Uint16Array, normBuf: BufferHandle | undefined, featureID: number) {
+  private static createFromBuffers(posBuf: QBufferHandle3d, uvParamBuf: QBufferHandle2d, indices: UintArray, normBuf: BufferHandle | undefined, featureID: number) {
     const indBuf = BufferHandle.createBuffer(GL.Buffer.Target.ElementArrayBuffer, indices);
 
     if (undefined === indBuf)


### PR DESCRIPTION
Fixes #4460.
Added `UintArrayBuilder` which allocates a Uint8/16/32Array based on the largest value put into the typed array.
Updated RealityMeshParamsBuilder to use it.
The meshes produced by the ellipsoid terrain provider and some of those produced by CesiumTerrainProvider contain fewer than 256 vertices. We now allocate 8-bit indices for those meshes.

TODO:
- [ ] Await ImageTests results