### PR TITLE
UI: Fix filtering input placeholder

### DIFF
--- a/common/changes/@itwin/components-react/ui-fix_filtering_input_placeholder_2022-12-13-15-00.json
+++ b/common/changes/@itwin/components-react/ui-fix_filtering_input_placeholder_2022-12-13-15-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fixed 'FilteringInput' placeholder text localization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/filtering/FilteringInput.tsx
+++ b/ui/components-react/src/components-react/filtering/FilteringInput.tsx
@@ -153,7 +153,7 @@ export class FilteringInput extends React.PureComponent<FilteringInputProps, Fil
       >
         <span className="components-filtering-input-input">
           <Input type="text"
-            placeholder={UiComponents.translate("filteringInput:placeholder")}
+            placeholder={UiComponents.translate("filteringInput.placeholder")}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={this.props.autoFocus}
             onKeyDown={this._onFilterKeyDown}


### PR DESCRIPTION
Invalid localized string key is passed to `translate` function with causes key to be shown in component.