### PR TITLE
Example tool to clip view based on element geometry

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -1095,6 +1095,10 @@
       "allowedCategories": [ "frontend", "tools" ]
     },
     {
+      "name": "vhacd-js",
+      "allowedCategories": [ "internal" ]
+    },
+    {
       "name": "webpack",
       "allowedCategories": [ "backend", "common", "frontend", "integration-testing", "internal", "tools" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3317,6 +3317,7 @@ importers:
       semver: ^7.3.5
       ts-node: ^10.8.2
       typescript: ~4.4.0
+      vhacd-js: ^0.0.1
       webpack: ^5.64.4
     dependencies:
       '@bentley/icons-generic': 1.0.34
@@ -3348,6 +3349,7 @@ importers:
       '@itwin/reality-data-client': 0.9.0
       '@itwin/webgl-compatibility': link:../../core/webgl-compatibility
       body-parser: 1.20.1
+      vhacd-js: 0.0.1
     devDependencies:
       '@bentley/react-scripts': 5.0.3_ts-node@10.9.1+typescript@4.4.4
       '@itwin/backend-webpack-tools': link:../../tools/backend-webpack
@@ -22254,6 +22256,10 @@ packages:
   /vary/1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  /vhacd-js/0.0.1:
+    resolution: {integrity: sha512-UfFbxWkl59mjtMX1z5AhWxGu91RdHK67JOHyfgIUA/gk+XD30djG6XJgEpVY65X4W/a04U9urWQnlLjsWwlgKA==}
+    dev: false
 
   /vscode-oniguruma/1.7.0:
     resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -284,6 +284,7 @@ display-test-app has access to all key-ins defined in the `@itwin/core-frontend`
   * `elementId=Id` The element for which to obtain graphics
   * `tolerance=number` The log10 of the desired chord tolerance in meters. Defaults to -2 (1 centimeter).
 * `dta reality model settings` - Open a dialog in which settings controlling the display of reality models within the currently-selected viewport can be edited. Currently, it always edits the settings for the first reality model it can find. It produces an error if no reality models are found.
+* `dta clip element geometry` - Starts a tool that clips the view based on the geometry of the selected element(s).
 
 ## Editing
 

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -70,7 +70,8 @@
     "@itwin/map-layers-formats": "workspace:*",
     "@itwin/reality-data-client": "0.9.0",
     "@itwin/webgl-compatibility": "workspace:*",
-    "body-parser": "^1.18.2"
+    "body-parser": "^1.18.2",
+    "vhacd-js": "^0.0.1"
   },
   "devDependencies": {
     "@bentley/react-scripts": "^5.0.0",

--- a/test-apps/display-test-app/public/locales/en/SVTTools.json
+++ b/test-apps/display-test-app/public/locales/en/SVTTools.json
@@ -166,6 +166,9 @@
     },
     "AttachCustomRealityData": {
       "keyin": "dta attach reality"
+    },
+    "DtaClipByElementGeometry": {
+      "keyin": "dta clip element geometry"
     }
   }
 }

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -27,6 +27,7 @@ import { ToggleAspectRatioSkewDecoratorTool } from "./AspectRatioSkewDecorator";
 import { ApplyModelDisplayScaleTool } from "./DisplayScale";
 import { ApplyModelTransformTool } from "./DisplayTransform";
 import { GenerateElementGraphicsTool, GenerateTileContentTool } from "./TileContentTool";
+import { ViewClipByElementGeometryTool } from "./ViewClipByElementGeometryTool";
 import { DrawingAidTestTool } from "./DrawingAidTestTool";
 import { EditingScopeTool, PlaceLineStringTool } from "./EditingTools";
 import { FenceClassifySelectedTool } from "./Fence";
@@ -338,6 +339,7 @@ export class DisplayTestApp {
       ToggleAspectRatioSkewDecoratorTool,
       TimePointComparisonTool,
       ToggleShadowMapTilesTool,
+      ViewClipByElementGeometryTool,
       ZoomToSelectedElementsTool,
     ].forEach((tool) => tool.register(svtToolNamespace));
 

--- a/test-apps/display-test-app/src/frontend/SectionTools.ts
+++ b/test-apps/display-test-app/src/frontend/SectionTools.ts
@@ -8,6 +8,7 @@ import { ClipPlane, ClipPrimitive, ClipVector, ConvexClipPlaneSet, Point3d, Vect
 import { ModelClipGroup, ModelClipGroups } from "@itwin/core-common";
 import { AccuDrawHintBuilder, IModelApp, ScreenViewport, ViewClipDecorationProvider, Viewport } from "@itwin/core-frontend";
 import { ToolBarDropDown } from "./ToolBar";
+import { ViewClipByElementGeometryTool } from "./ViewClipByElementGeometryTool";
 
 function setFocusToHome(): void {
   const element = document.activeElement as HTMLElement;
@@ -40,6 +41,7 @@ export class SectionsPanel extends ToolBarDropDown {
         { name: "Range", value: "ViewClip.ByRange" },
         { name: "Element", value: "ViewClip.ByElement" },
         { name: "Shape", value: "ViewClip.ByShape" },
+        { name: "Geometry", value: ViewClipByElementGeometryTool.toolId },
       ],
     });
 

--- a/test-apps/display-test-app/src/frontend/ViewClipByElementGeometryTool.ts
+++ b/test-apps/display-test-app/src/frontend/ViewClipByElementGeometryTool.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import {
+  ClipPrimitive, ClipVector, ConvexClipPlaneSet, UnionOfConvexClipPlaneSets,
+} from "@itwin/core-geometry";
+import {
+  ElementMeshOptions, readElementMeshes,
+} from "@itwin/core-common";
+import {
+  BeButtonEvent, CoordinateLockOverrides, EventHandled, IModelApp, LocateResponse, ViewClipTool, Viewport,
+} from "@itwin/core-frontend";
+
+interface Settings extends ElementMeshOptions {
+  offset?: number;
+}
+
+// Out of laziness, settings are global.
+const settings: Settings = {
+  chordTolerance: 0.1,
+};
+
+export class ViewClipByElementGeometryTool extends ViewClipTool {
+  public static override toolId = "DtaClipByElementGeometry";
+  public static override iconSpec = "icon-section-element";
+
+  public override async onPostInstall() {
+    await super.onPostInstall();
+    if (this.targetView && this.targetView.iModel.selectionSet.isActive) {
+      await this.doClipToSelectedElements(this.targetView);
+      return;
+    }
+
+    this.initLocateElements(true, false, "default", CoordinateLockOverrides.All);
+  }
+
+  public override async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
+    if (!this.targetView)
+      return EventHandled.No;
+
+    const hit = await IModelApp.locateManager.doLocate(new LocateResponse(), true, ev.point, ev.viewport, ev.inputSource);
+    if (!hit || !hit.isElementHit)
+      return EventHandled.No;
+
+    return await this.doClipToElements(this.targetView, new Set<string>([hit.sourceId])) ? EventHandled.Yes : EventHandled.No;
+  }
+
+  private async doClipToSelectedElements(viewport: Viewport): Promise<boolean> {
+    if (await this.doClipToElements(viewport, viewport.iModel.selectionSet.elements))
+      return true;
+
+    await this.exitTool();
+    return false;
+  }
+
+  private async doClipToElements(viewport: Viewport, ids: Set<string>): Promise<boolean> {
+    try {
+      let polyfaces = [];
+      for (const source of ids) {
+        const meshData = await viewport.iModel.generateElementMeshes({
+          ...settings,
+          source,
+        });
+
+        for (const polyface of readElementMeshes(meshData))
+          polyfaces.push(polyface);
+      }
+
+      if (polyfaces.length === 0)
+        return false;
+
+      const union = UnionOfConvexClipPlaneSets.createEmpty();
+      for (const polyface of polyfaces)
+        union.addConvexSet(ConvexClipPlaneSet.createConvexPolyface(polyface).clipper);
+
+      ViewClipTool.enableClipVolume(viewport);
+      const primitive = ClipPrimitive.createCapture(union);
+      const clip = ClipVector.createCapture([primitive]);
+      ViewClipTool.setViewClip(viewport, clip);
+
+      this._clipEventHandler?.onNewClip(viewport);
+
+      await this.onReinitialize();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/test-apps/display-test-app/src/frontend/ViewClipByElementGeometryTool.ts
+++ b/test-apps/display-test-app/src/frontend/ViewClipByElementGeometryTool.ts
@@ -15,12 +15,22 @@ import {
   ConvexMeshDecomposition, Options as DecompositionOptions,
 } from "vhacd-js";
 
+/** Settings that control the behavior of the ViewClipByElementGeometryTool. */
 interface Settings extends ElementMeshOptions {
+  /** If true, produce convex hulls from the element geometry. Convex hulls are required for proper clipping; if this is
+   * set to false, make sure to only select elements that already have convex geometry.
+   */
   computeConvexHulls: boolean;
+  /** Options used to produce convex hulls, if computeConvexHulls is true. */
   decomposition: DecompositionOptions;
+  /** An offset in meters by which to expand or contract the surfaces of the clipping polyfaces.
+   * This is useful primarily for expanding the clipped volume slightly so that the element(s) from which the clip was produced are not clipped out.
+   * ###TODO Awaiting an API that will apply the offset - unused for now.
+   */
   offset?: number;
 }
 
+/** Uses vhacd-js to convert IndexedPolyfaces to convex IndexedPolyfaces. */
 class ConvexDecomposer {
   private readonly _impl: ConvexMeshDecomposition;
   private readonly _opts: DecompositionOptions;
@@ -41,12 +51,20 @@ class ConvexDecomposer {
 
     for (const polyface of polyfaces) {
       const points = polyface.data.point;
+
+      // `points` is a GrowableXYZArray, which may allocate more space than it needs for the number of points it stores.
+      // Make sure to only pass the used portion of the allocation to vhacd-js.
       const positions = new Float64Array(points.float64Data().buffer, 0, points.float64Length);
+
+      // Unfortunately we must copy the indices rather than passing them directly to vhacd-js.
       const indices = new Uint32Array(polyface.data.pointIndex);
       if (indices.length === 0 || positions.length === 0)
         continue;
 
+      // Decompose the polyface into any number of convex hulls.
       const meshes = this._impl.computeConvexHulls({ positions, indices }, this._opts);
+
+      // Convert each hull into a polyface.
       for (const mesh of meshes) {
         const builder = PolyfaceBuilder.create();
         for (let i = 0; i < mesh.indices.length; i += 3) {
@@ -69,7 +87,7 @@ class ConvexDecomposer {
   }
 }
 
-// Out of laziness, settings are global.
+// For demo purposes, settings are global and the only way to change them is to edit the code below.
 const settings: Settings = {
   computeConvexHulls: true,
   chordTolerance: 0.1,
@@ -79,17 +97,28 @@ const settings: Settings = {
   },
 };
 
+/** Clips the view based on the geometry of one or more geometric elements.
+ * We obtain polyfaces from the backend for each element and produce convex hulls from each polyface.
+ * Then we create a ClipVector that clips out any geometry not inside one of the hulls.
+ *
+ * This tool exists for example purposes only. Some inefficiencies exist, including:
+ *  - Convex mesh decomposition can take some time. Ideally it would be performed in a WebWorker so as not to block the UI thread.
+ *  - If we had a way to determine if a polyface is already convex, we could avoid performing unnecessary decomposition on such polyfaces.
+ */
 export class ViewClipByElementGeometryTool extends ViewClipTool {
   public static override toolId = "DtaClipByElementGeometry";
   public static override iconSpec = "icon-section-element";
 
   public override async onPostInstall() {
     await super.onPostInstall();
+
+    // If some elements are already selected, immediately clip the view using their geometry.
     if (this.targetView && this.targetView.iModel.selectionSet.isActive) {
       await this.doClipToSelectedElements(this.targetView);
       return;
     }
 
+    // Wait for the user to select the elements to use for clipping.
     this.initLocateElements(true, false, "default", CoordinateLockOverrides.All);
   }
 
@@ -97,13 +126,16 @@ export class ViewClipByElementGeometryTool extends ViewClipTool {
     if (!this.targetView)
       return EventHandled.No;
 
+    // Identify the element selected.
     const hit = await IModelApp.locateManager.doLocate(new LocateResponse(), true, ev.point, ev.viewport, ev.inputSource);
     if (!hit || !hit.isElementHit)
       return EventHandled.No;
 
+    // Clip the view using the selected element's geometry.
     return await this.doClipToElements(this.targetView, new Set<string>([hit.sourceId])) ? EventHandled.Yes : EventHandled.No;
   }
 
+  /** Clip the view using the geometry of all elements currently in the selection set. */
   private async doClipToSelectedElements(viewport: Viewport): Promise<boolean> {
     if (await this.doClipToElements(viewport, viewport.iModel.selectionSet.elements))
       return true;
@@ -112,21 +144,27 @@ export class ViewClipByElementGeometryTool extends ViewClipTool {
     return false;
   }
 
+  /** Clip the view using the geometry of the specified elements. */
   private async doClipToElements(viewport: Viewport, ids: Set<string>): Promise<boolean> {
     try {
       const union = UnionOfConvexClipPlaneSets.createEmpty();
       const decomposer = settings.computeConvexHulls ? await ConvexDecomposer.create(settings.decomposition) : undefined;
 
       for (const source of ids) {
+        // Obtain polyfaces for this element.
         const meshData = await viewport.iModel.generateElementMeshes({ ...settings, source });
         let polyfaces = readElementMeshes(meshData);
+
+        // Convert to convex hulls unless otherwise specified.
         if (decomposer)
           polyfaces = decomposer.decompose(polyfaces);
 
+        // Add each polyface as a clipper.
         for (const polyface of polyfaces)
           union.addConvexSet(ConvexClipPlaneSet.createConvexPolyface(polyface).clipper);
       }
 
+      // Apply the clip to the view.
       ViewClipTool.enableClipVolume(viewport);
       const primitive = ClipPrimitive.createCapture(union);
       const clip = ClipVector.createCapture([primitive]);


### PR DESCRIPTION
Fixes #3883.
Select one or more elements. The backend produces polyfaces from their geometry. We create a ClipVector from those polyfaces and apply it to the view.

TODO:
- [x] ~~Add support for applying an offset to the polyfaces to expand them outward~~ @EarlinLutz has WIP API on EDL/MeshOffset branch - not yet available.
- [x] Integrate V-HACD.js to perform convex mesh decomposition.
  - [x] ~~Ideally, do this in a WebWorker~~ for demo purposes probably won't bother.
- [x] ~~Add a keyin to configure the tolerances, mesh offset, and decomposition parameters.~~ meh.
- [x] ~~An API to ask whether a polyface is already convex, to avoid potentially expensive decomposition?~~ none such exists.