### PR TITLE
Smoother viewport resizing

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -9526,6 +9526,10 @@ export class ScreenViewport extends Viewport {
     mouseMovementFromEvent(ev: MouseEvent): XAndY;
     // @internal (undocumented)
     mousePosFromEvent(ev: MouseEvent): XAndY;
+    // @internal
+    onViewManagerAdd(): void;
+    // @internal
+    onViewManagerDrop(): void;
     openToolTip(message: HTMLElement | string, location?: XAndY, options?: ToolTipOptions): void;
     readonly parentDiv: HTMLDivElement;
     // @internal (undocumented)
@@ -9548,6 +9552,7 @@ export class ScreenViewport extends Viewport {
     resetUndo(): void;
     saveViewUndo(): void;
     setCursor(cursor?: string): void;
+    // @deprecated
     setEventController(controller?: EventController): void;
     // @internal
     static setToParentSize(div: HTMLElement): void;

--- a/common/changes/@itwin/core-frontend/pmc-viewport-resize_2022-12-14-16-49.json
+++ b/common/changes/@itwin/core-frontend/pmc-viewport-resize_2022-12-14-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Make the contents of a Viewport react more smoothly when the containing div is resized.\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ViewManager.ts
+++ b/core/frontend/src/ViewManager.ts
@@ -11,7 +11,6 @@ import { HitDetail } from "./HitDetail";
 import { IModelApp } from "./IModelApp";
 import { IModelConnection } from "./IModelConnection";
 import { DisclosedTileTreeSet, TileTree } from "./tile/internal";
-import { EventController } from "./tools/EventController";
 import { BeButtonEvent, EventHandled } from "./tools/Tool";
 import { ScreenViewport, ViewportDecorator } from "./Viewport";
 import { System } from "./render/webgl/System";
@@ -272,7 +271,8 @@ export class ViewManager implements Iterable<ScreenViewport> {
     if (this.hasViewport(newVp)) // make sure its not already added
       return BentleyStatus.ERROR;
 
-    newVp.setEventController(new EventController(newVp)); // this will direct events to the viewport
+    newVp.onViewManagerAdd();
+
     this._viewports.push(newVp);
     this.updateRenderToScreen();
     this.setSelectedView(newVp);// eslint-disable-line @typescript-eslint/no-floating-promises
@@ -308,7 +308,8 @@ export class ViewManager implements Iterable<ScreenViewport> {
     // make sure tools don't think the cursor is still in this viewport
     IModelApp.toolAdmin.forgetViewport(vp);
 
-    vp.setEventController(undefined);
+    vp.onViewManagerDrop();
+
     this._viewports.splice(index, 1);
 
     if (this.selectedView === vp) // if removed viewport was selectedView, set it to undefined.

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -2820,6 +2820,7 @@ export class ScreenViewport extends Viewport {
   };
 
   private _evController?: EventController;
+  private _resizeObserver?: ResizeObserver;
   private _viewCmdTargetCenter?: Point3d;
   /** The number of entries in the view undo/redo buffer. */
   public maxUndoSteps = 20;
@@ -3005,12 +3006,36 @@ export class ScreenViewport extends Viewport {
     return { x: ev.movementX, y: ev.movementY };
   }
 
-  /** Set the event controller for this Viewport. Destroys previous controller, if one was defined. */
+  /** Set the event controller for this Viewport. Destroys previous controller, if one was defined.
+   * @deprecated this was intended for internal use only.
+   */
   public setEventController(controller?: EventController) {
     if (this._evController)
       this._evController.destroy();
 
     this._evController = controller;
+  }
+
+  /** Invoked by ViewManager.addViewport.
+   * @internal
+   */
+  public onViewManagerAdd(): void {
+    this.onViewManagerDrop();
+
+    this._evController = new EventController(this);
+    this._resizeObserver = new ResizeObserver(() => {
+      this.requestRedraw();
+    });
+    this._resizeObserver.observe(this.canvas);
+  }
+
+  /** Invoked by ViewManager.dropViewport.
+   * @internal
+   */
+  public onViewManagerDrop(): void {
+    this._evController?.destroy();
+    this._resizeObserver?.disconnect();
+    this._evController = this._resizeObserver = undefined;
   }
 
   /** Find a point on geometry visible in this Viewport, within a radius of supplied pick point.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,6 +11,7 @@ Table of contents:
   - [Smooth viewport resizing](#smooth-viewport-resizing)
 - [Deprecations](#deprecations)
   - [@itwin/core-bentley](#itwincore-bentley)
+  - [@itwin/core-frontend](#itwincore-frontend)
 
 ## Electron 22 support
 
@@ -43,3 +44,7 @@ Previously, when a [Viewport]($frontend)'s canvas was resized there would be a d
 ### @itwin/core-bentley
 
 [ByteStream]($bentley)'s `next` property getters like [ByteStream.nextUint32]($bentley) and [ByteStream.nextFloat64]($bentley) have been deprecated and replaced with corresponding `read` methods like [ByteStream.readUint32]($bentley) and [ByteStream.readFloat64]($bentley). The property getters have the side effect of incrementing the stream's current read position, which can result in surprising behavior and may [trip up code optimizers](https://github.com/angular/angular-cli/issues/12128#issuecomment-472309593) that assume property access is free of side effects.
+
+### @itwin/core-frontend
+
+[Viewport.setEventController]($frontend) was only ever intended to be used by [ViewManager]($frontend). In the unlikely event that you are using it for some (probably misguided) purpose, it will continue to behave as before, but it will be removed in a future major version.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -47,4 +47,4 @@ Previously, when a [Viewport]($frontend)'s canvas was resized there would be a d
 
 ### @itwin/core-frontend
 
-[Viewport.setEventController]($frontend) was only ever intended to be used by [ViewManager]($frontend). In the unlikely event that you are using it for some (probably misguided) purpose, it will continue to behave as before, but it will be removed in a future major version.
+[ScreenViewport.setEventController]($frontend) was only ever intended to be used by [ViewManager]($frontend). In the unlikely event that you are using it for some (probably misguided) purpose, it will continue to behave as before, but it will be removed in a future major version.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -8,6 +8,7 @@ Table of contents:
 - [Electron 22 support](#electron-22-support)
 - [Display system](#display-system)
   - [Eye-dome lighting of Point Clouds](#eye-dome-lighting-of-point-clouds)
+  - [Smooth viewport resizing](#smooth-viewport-resizing)
 - [Deprecations](#deprecations)
   - [@itwin/core-bentley](#itwincore-bentley)
 
@@ -32,6 +33,10 @@ To apply eye-dome lighting to a point cloud, you must apply a [RealityModelDispl
 - [PointCloudDisplaySettings.edlMixWts1]($common) specifies a weighting value (a floating point number between 0 and 1 inclusive) to apply to the full image when combining it with the half and quarter sized ones; this only applies if edlMode is "full". This defaults to 1.0.
 - [PointCloudDisplaySettings.edlMixWts2]($common) specifies a weighting value (a floating point number between 0 and 1 inclusive) to apply to the half image when combining it with the full and quarter sized ones; this only applies if edlMode is "full". This defaults to 0.5.
 - [PointCloudDisplaySettings.edlMixWts4]($common) specifies a weighting value (a floating point number between 0 and 1 inclusive) to apply to the full image when combining it with the full and half sized ones; this only applies if edlMode is "full". This defaults to 0.25.
+
+### Smooth viewport resizing
+
+Previously, when a [Viewport]($frontend)'s canvas was resized there would be a delay of up to one second during which the viewport's contents would appear stretched or squished, before they were redrawn to match the new canvas dimensions. This was due to the unavailability of [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) in some browsers. Now that `ResizeObserver` is supported by all major browsers, we are able to use it to make the contents of the viewport update smoothly during a resize operation.
 
 ## Deprecations
 


### PR DESCRIPTION
When the div containing a viewport changes size, we want to redraw the viewport's contents based on the new size. However, at the inception of iTwin.js, some popular browsers lacked support for `ResizeObserver`; the alternative was to manually check for size changes in `requestAnimationFrame`. We did not want to do this every frame out of concern for people's laptop battery life, so we defaulted to polling once per second.

The result is that after resizing a viewport there is up to a 1 second delay during which its contents appear stretched or squished until we realize we need to redraw them.

Now that `ResizeObserver` is supported everywhere, we can use it to immediately request a redraw after a resize occurs. The contents of the viewport will smoothly adjust during a resize operation.

Incidientally, `Viewport.setEventController` is `@public`. This was unintentional and not useful - nobody should be trying to replace a viewport's event controller. I deprecated that function and it is no longer invoked from anywhere in itwinjs-core.
Related: `EventController` is also `@public` and part of the `@extensions` API. It should not be, but I am not addressing that here.