### PR TITLE
Modify if stmts in run_rush_change.py

### DIFF
--- a/common/scripts/run_rush_change.py
+++ b/common/scripts/run_rush_change.py
@@ -16,9 +16,9 @@ print ("Target branch: " + targetBranch)
 
 # Verifying with rush change requires the branch that is being merged into to be provided.  More details, https://rushjs.io/pages/commands/rush_change/.
 # With release/* being a potential target branch in addition to master, special case those branches.
-if targetBranch.find("refs/heads/release") != -1:
+if "refs/heads/release" in targetBranch:
     branchCmd = ["-b", targetBranch.replace("refs/heads/", "origin/")]
-elif targetBranch.find("release") != -1:
+elif "release" in targetBranch or targetBranch == srcBranch:
     # ADOps uses the branch name (i.e. 'release/2.8.0') for GH PR branch names instead of full refs.
     branchCmd = ["-b", "origin/" + targetBranch]
 else:

--- a/common/scripts/run_rush_change.py
+++ b/common/scripts/run_rush_change.py
@@ -20,6 +20,7 @@ if "refs/heads/release" in targetBranch:
     branchCmd = ["-b", targetBranch.replace("refs/heads/", "origin/")]
 elif "release" in targetBranch or targetBranch == srcBranch:
     # ADOps uses the branch name (i.e. 'release/2.8.0') for GH PR branch names instead of full refs.
+    # or for addon validation when there is a change in native side, but not in itwinjs-core
     branchCmd = ["-b", "origin/" + targetBranch]
 else:
     # Uses default head ("origin/master"), if not defined


### PR DESCRIPTION
Modify rush change to not default to master branch when currBranch == targetBranch
Also change if stmts for readability.
Related to PR validation issue
https://github.com/iTwin/itwinjs-core/issues/4086

also a good test for PR validation pipeline