### PR TITLE
SQLite 3.40.0 change order or rows when traversing a tree in a CTE

### DIFF
--- a/common/changes/@itwin/core-backend/sqltie_changed_order_of_props_2022-12-19-14-53.json
+++ b/common/changes/@itwin/core-backend/sqltie_changed_order_of_props_2022-12-19-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Update test as order of row traverse by sqlite 3.40 has changed and doing it correct now on 3.40.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/ecdb/CTE.test.ts
+++ b/core/backend/src/test/ecdb/CTE.test.ts
@@ -12,7 +12,7 @@ import { SequentialLogMatcher } from "../SequentialLogMatcher";
 
 async function executeQuery(iModel: IModelDb, ecsql: string, bindings?: any[] | object, abbreviateBlobs?: boolean): Promise<any[]> {
   const rows: any[] = [];
-  for await (const row of iModel.query(ecsql, QueryBinder.from(bindings), {rowFormat:QueryRowFormat.UseJsPropertyNames, abbreviateBlobs })) {
+  for await (const row of iModel.query(ecsql, QueryBinder.from(bindings), { rowFormat: QueryRowFormat.UseJsPropertyNames, abbreviateBlobs })) {
     rows.push(row);
   }
   return rows;
@@ -42,7 +42,7 @@ describe("Common table expression support in ECSQL", () => {
             )
         SELECT group_concat( DISTINCT p.Name) prop from base_classes join meta.ECPropertyDef p on p.Class.id = aId`;
     const rows = await executeQuery(imodel1, query, ["Element"]);
-    const expected = ["BBoxHigh", "BBoxLow", "Category", "GeometryStream", "Origin", "Rotation", "TypeDefinition", "CodeScope", "CodeSpec", "CodeValue", "FederationGuid", "JsonProperties", "LastMod", "Model", "Parent", "UserLabel", "Description", "Rank", "IsPrivate", "Recipe", "Data", "Type", "Angle", "Pitch", "Roll", "Yaw", "BaseModel", "Extents", "RotationAngle", "CategorySelector", "DisplayStyle", "Properties", "Name", "InSpatialIndex", "Enabled", "ModelSelector", "EyePoint", "FocusDistance", "IsCameraOn", "LensAngle", "RepositoryGuid", "Url", "PaletteName", "Height", "Scale", "SheetTemplate", "Width", "Border", "BorderTemplate", "Flags", "Format", "View", "DrawingModel", "ViewAttachment"];
+    const expected = ["CodeScope", "CodeSpec", "CodeValue", "FederationGuid", "JsonProperties", "LastMod", "Model", "Parent", "UserLabel", "BBoxHigh", "BBoxLow", "Category", "GeometryStream", "Origin", "Rotation", "TypeDefinition", "IsPrivate", "Description", "Rank", "Recipe", "Data", "Type", "Angle", "Pitch", "Roll", "Yaw", "CategorySelector", "DisplayStyle", "BaseModel", "Extents", "RotationAngle", "Properties", "Name", "InSpatialIndex", "Enabled", "EyePoint", "FocusDistance", "IsCameraOn", "LensAngle", "ModelSelector", "Url", "RepositoryGuid", "PaletteName", "Height", "Scale", "SheetTemplate", "Width", "Border", "BorderTemplate", "Flags", "Format", "View", "DrawingModel", "ViewAttachment"];
     const actual = (rows[0].prop as string).split(",");
     assert.sameOrderedMembers(actual, expected);
   });


### PR DESCRIPTION
It's not particularly important that default order of row should be preserved. But this test was checking if we collect base to derive classes. It seems pre 3.40 we were getting Geom3d property before Element which was wrong. So, 3.40 fixes the ordering issue in which CTE traverses the tree.

