### PR TITLE
run rush change -b if targetBranch equal imodel02

### DIFF
--- a/common/scripts/run_rush_change.py
+++ b/common/scripts/run_rush_change.py
@@ -19,7 +19,7 @@ branchCmd = []
 # Verifying with rush change requires the branch that is being merged into to be provided.  More details, https://rushjs.io/pages/commands/rush_change/.
 # With release/* being a potential target branch in addition to master, special case those branches.
 if targetBranch == "refs/heads/master":
-    # For builds when target and current branch == refs/heads
+    # For builds when target and current branch == refs/heads/master
     branchCmd = []
 elif "refs/heads/release" in targetBranch:
     branchCmd = ["-b", targetBranch.replace("refs/heads/", "origin/")]

--- a/common/scripts/run_rush_change.py
+++ b/common/scripts/run_rush_change.py
@@ -14,17 +14,19 @@ if buildReason == "PullRequest":
 print ("Current branch: " + srcBranch)
 print ("Target branch: " + targetBranch)
 
+# Uses default head ("origin/master"), if not defined
+branchCmd = []
 # Verifying with rush change requires the branch that is being merged into to be provided.  More details, https://rushjs.io/pages/commands/rush_change/.
 # With release/* being a potential target branch in addition to master, special case those branches.
-if "refs/heads/release" in targetBranch:
+if targetBranch == "refs/heads/master":
+    # For builds when target and current branch == refs/heads
+    branchCmd = []
+elif "refs/heads/release" in targetBranch:
     branchCmd = ["-b", targetBranch.replace("refs/heads/", "origin/")]
 elif "release" in targetBranch or targetBranch == srcBranch:
     # ADOps uses the branch name (i.e. 'release/2.8.0') for GH PR branch names instead of full refs.
     # or for addon validation when there is a change in native side, but not in itwinjs-core
     branchCmd = ["-b", "origin/" + targetBranch]
-else:
-    # Uses default head ("origin/master"), if not defined
-    branchCmd = []
 
 command = ["node", "common/scripts/install-run-rush.js", "change", "-v"] + branchCmd
 print ("Executing: " + " ".join(command))

--- a/common/scripts/run_rush_change.py
+++ b/common/scripts/run_rush_change.py
@@ -14,19 +14,17 @@ if buildReason == "PullRequest":
 print ("Current branch: " + srcBranch)
 print ("Target branch: " + targetBranch)
 
-# Uses default head ("origin/master"), if not defined
-branchCmd = []
 # Verifying with rush change requires the branch that is being merged into to be provided.  More details, https://rushjs.io/pages/commands/rush_change/.
 # With release/* being a potential target branch in addition to master, special case those branches.
-if targetBranch == "refs/heads/master":
-    # For builds when target and current branch == refs/heads/master
-    branchCmd = []
-elif "refs/heads/release" in targetBranch:
+if "refs/heads/release" in targetBranch:
     branchCmd = ["-b", targetBranch.replace("refs/heads/", "origin/")]
-elif "release" in targetBranch or targetBranch == srcBranch:
+elif "release" in targetBranch or targetBranch == "imodel02":
     # ADOps uses the branch name (i.e. 'release/2.8.0') for GH PR branch names instead of full refs.
     # or for addon validation when there is a change in native side, but not in itwinjs-core
     branchCmd = ["-b", "origin/" + targetBranch]
+else:
+    # Uses default head ("origin/master"), if not defined
+    branchCmd = []
 
 command = ["node", "common/scripts/install-run-rush.js", "change", "-v"] + branchCmd
 print ("Executing: " + " ".join(command))

--- a/common/scripts/run_rush_change.py
+++ b/common/scripts/run_rush_change.py
@@ -20,7 +20,7 @@ if "refs/heads/release" in targetBranch:
     branchCmd = ["-b", targetBranch.replace("refs/heads/", "origin/")]
 elif "release" in targetBranch or targetBranch == "imodel02":
     # ADOps uses the branch name (i.e. 'release/2.8.0') for GH PR branch names instead of full refs.
-    # or for addon validation when there is a change in native side, but not in itwinjs-core
+    # or for addon validation when there is a change in native side, but not in itwinjs-core. In this case keep target branch as imodel02
     branchCmd = ["-b", "origin/" + targetBranch]
 else:
     # Uses default head ("origin/master"), if not defined


### PR DESCRIPTION
Change logic from
targetBranch == currentBranch
to
targetBranch == "imodel02"
when Running rush change -b

Issue was caused by a previous change that changed logic when current branch == target branch
Previous change: https://github.com/iTwin/itwinjs-core/pull/4819