### PR TITLE
Deprecate TransientIdSequence.next

### DIFF
--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -1583,6 +1583,8 @@ export class Tracing {
 
 // @public
 export class TransientIdSequence {
+    getNext(): Id64String;
+    // @deprecated
     get next(): Id64String;
 }
 

--- a/common/changes/@itwin/core-bentley/pmc-transient-id-getter_2022-12-20-22-03.json
+++ b/common/changes/@itwin/core-bentley/pmc-transient-id-getter_2022-12-20-22-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Deprecate TransientIdSequence.next property in favor of getNext method.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-common/pmc-transient-id-getter_2022-12-20-22-03.json
+++ b/common/changes/@itwin/core-common/pmc-transient-id-getter_2022-12-20-22-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/pmc-transient-id-getter_2022-12-20-22-03.json
+++ b/common/changes/@itwin/core-frontend/pmc-transient-id-getter_2022-12-20-22-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/editor-frontend/pmc-transient-id-getter_2022-12-20-22-03.json
+++ b/common/changes/@itwin/editor-frontend/pmc-transient-id-getter_2022-12-20-22-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/common/changes/@itwin/frontend-devtools/pmc-transient-id-getter_2022-12-20-22-03.json
+++ b/common/changes/@itwin/frontend-devtools/pmc-transient-id-getter_2022-12-20-22-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/bentley/src/Id.ts
+++ b/core/bentley/src/Id.ts
@@ -664,8 +664,17 @@ export namespace Id64 {
 export class TransientIdSequence {
   private _localId: number = 0;
 
+  /** Generate and return the next transient Id64String in the sequence.
+   * @deprecated Use [[getNext]].
+   */
+  public get next(): Id64String {
+    return this.getNext();
+  }
+
   /** Generate and return the next transient Id64String in the sequence. */
-  public get next(): Id64String { return Id64.fromLocalAndBriefcaseIds(++this._localId, 0xffffff); }
+  public getNext(): Id64String {
+    return Id64.fromLocalAndBriefcaseIds(++this._localId, 0xffffff);
+  }
 }
 
 /**

--- a/core/common/src/test/ModelGeometryChanges.test.ts
+++ b/core/common/src/test/ModelGeometryChanges.test.ts
@@ -34,13 +34,13 @@ class ElementChangeSets {
 function generateElementChanges(numInserts: number, numUpdates: number, numDeletes: number): ElementChangeSets {
   const changes = new ElementChangeSets();
   for (let i = 0; i < numInserts; i++)
-    changes.inserts.add({ id: ids.next, type: DbOpcode.Insert, range: nextRange() });
+    changes.inserts.add({ id: ids.getNext(), type: DbOpcode.Insert, range: nextRange() });
 
   for (let i = 0; i < numUpdates; i++)
-    changes.updates.add({ id: ids.next, type: DbOpcode.Update, range: nextRange() });
+    changes.updates.add({ id: ids.getNext(), type: DbOpcode.Update, range: nextRange() });
 
   for (let i = 0; i < numDeletes; i++)
-    changes.deletes.add({ id: ids.next, type: DbOpcode.Delete });
+    changes.deletes.add({ id: ids.getNext(), type: DbOpcode.Delete });
 
   return changes;
 }
@@ -91,7 +91,7 @@ function elementChangesToJSON(changes: ElementChangeSets): ModelGeometryChangesP
   const updated = updatedIds && updatedRanges ? { ids: updatedIds, ranges: updatedRanges } : undefined;
   return {
     inserted, updated, deleted,
-    id: ids.next,
+    id: ids.getNext(),
     guid: Guid.createValue(),
     range: nextRange().toJSON(),
   };

--- a/core/frontend-devtools/src/effects/Explosion.ts
+++ b/core/frontend-devtools/src/effects/Explosion.ts
@@ -91,7 +91,7 @@ class ParticleSystem {
 
   public constructor(texture: RenderTexture, iModel: IModelConnection, numEmissions: number) {
     this._texture = texture;
-    this._pickableId = iModel.transientIds.next;
+    this._pickableId = iModel.transientIds.getNext();
     this._numEmissions = numEmissions;
     this._lastUpdateTime = Date.now();
 

--- a/core/frontend/src/AccuDraw.ts
+++ b/core/frontend/src/AccuDraw.ts
@@ -1943,7 +1943,7 @@ export class AccuDraw {
     if (context.viewport.viewFlags.acsTriad) {
       context.viewport.view.auxiliaryCoordinateSystem.display(context, (ACSDisplayOptions.CheckVisible | ACSDisplayOptions.Active));
       if (undefined === this._acsPickId)
-        this._acsPickId = context.viewport.iModel.transientIds.next;
+        this._acsPickId = context.viewport.iModel.transientIds.getNext();
       const acsPickBuilder = context.createGraphicBuilder(GraphicType.WorldDecoration, undefined, this._acsPickId);
       const color = ColorDef.blue.adjustedForContrast(context.viewport.view.backgroundColor, 50);
       acsPickBuilder.setSymbology(color, color, 6);

--- a/core/frontend/src/test/render/webgl/PickableDecorations.test.ts
+++ b/core/frontend/src/test/render/webgl/PickableDecorations.test.ts
@@ -20,7 +20,7 @@ describe("Pickable decorations", () => {
 
     public test(vp: Viewport, type: GraphicType, expectPickable = true): void {
       this._type = type;
-      this._curId = vp.iModel.transientIds.next;
+      this._curId = vp.iModel.transientIds.getNext();
       this._x++;
       this._y++;
 
@@ -31,7 +31,7 @@ describe("Pickable decorations", () => {
     }
 
     public decorate(context: DecorateContext): void {
-      this._curId = context.viewport.iModel.transientIds.next;
+      this._curId = context.viewport.iModel.transientIds.getNext();
       const pt = new Point3d(this._x++, this._y++, 0);
       if (GraphicType.ViewBackground !== this._type && GraphicType.ViewOverlay !== this._type)
         context.viewport.viewToWorld(pt, pt);

--- a/core/frontend/src/test/render/webgl/RenderMemory.test.ts
+++ b/core/frontend/src/test/render/webgl/RenderMemory.test.ts
@@ -72,7 +72,7 @@ function createGraphic(geom: RenderGeometry, instances?: InstancedGraphicParams)
 
 function createTexture(iModel: IModelConnection, persistent: boolean): RenderTexture {
   const source = ImageBuffer.create(new Uint8Array([255, 255, 255, 255]), ImageBufferFormat.Rgba, 1);
-  const key = persistent ? iModel.transientIds.next : undefined;
+  const key = persistent ? iModel.transientIds.getNext() : undefined;
   const tex = IModelApp.renderSystem.createTexture({
     ownership: key ? { iModel, key } : undefined,
     image: { source, transparency: TextureTransparency.Translucent },

--- a/core/frontend/src/test/render/webgl/SurfaceTransparency.test.ts
+++ b/core/frontend/src/test/render/webgl/SurfaceTransparency.test.ts
@@ -74,14 +74,14 @@ describe("Surface transparency", () => {
 
     const opaqueImage = ImageBuffer.create(new Uint8Array([255, 255, 255]), ImageBufferFormat.Rgb, 1);
     opaqueTexture = IModelApp.renderSystem.createTexture({
-      ownership: { iModel: imodel, key: imodel.transientIds.next },
+      ownership: { iModel: imodel, key: imodel.transientIds.getNext() },
       image: { source: opaqueImage, transparency: TextureTransparency.Opaque },
     })!;
     expect(opaqueTexture).not.to.be.undefined;
 
     const translucentImage = ImageBuffer.create(new Uint8Array([255, 255, 255, 127]), ImageBufferFormat.Rgba, 1);
     translucentTexture = IModelApp.renderSystem.createTexture({
-      ownership: { iModel: imodel, key: imodel.transientIds.next },
+      ownership: { iModel: imodel, key: imodel.transientIds.getNext() },
       image: { source: translucentImage, transparency: TextureTransparency.Translucent },
     })!;
     expect(translucentTexture).not.to.be.undefined;
@@ -266,7 +266,7 @@ describe("Surface transparency", () => {
     const img = ImageBuffer.create(new Uint8Array([255, 255, 255, 127]), ImageBufferFormat.Rgba, 1);
     const tx = IModelApp.renderSystem.createTexture({
       type: RenderTexture.Type.Glyph,
-      ownership: { iModel: imodel, key: imodel.transientIds.next },
+      ownership: { iModel: imodel, key: imodel.transientIds.getNext() },
       image: { source: img, transparency: TextureTransparency.Translucent },
     });
     expect(tx).not.to.be.undefined;

--- a/core/frontend/src/tile/BatchedTileIdMap.ts
+++ b/core/frontend/src/tile/BatchedTileIdMap.ts
@@ -34,7 +34,7 @@ export class BatchedTileIdMap {
     const key = JSON.stringify(properties);
     let entry = this._featureMap.get(key);
     if (undefined === entry) {
-      const id = this._iModel.transientIds.next;
+      const id = this._iModel.transientIds.getNext();
       entry = { id, properties };
       this._featureMap.set(key, entry);
       this._idMap.set(id, properties);

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -605,7 +605,7 @@ export namespace RealityModelTileTree {
     public constructor(props: RealityModelTileTree.ReferenceBaseProps) {
       super();
       this._name = undefined !== props.name ? props.name : "";
-      this._modelId = props.modelId ? props.modelId : props.iModel.transientIds.next;
+      this._modelId = props.modelId ? props.modelId : props.iModel.transientIds.getNext();
       let transform;
       if (undefined !== props.tilesetToDbTransform) {
         const tf = Transform.fromJSON(props.tilesetToDbTransform);

--- a/core/frontend/src/tile/map/ImageryTileTree.ts
+++ b/core/frontend/src/tile/map/ImageryTileTree.ts
@@ -293,7 +293,7 @@ class ImageryMapLayerTreeSupplier implements TileTreeSupplier {
       return undefined;
 
     await imageryProvider.initialize();
-    const modelId = iModel.transientIds.next;
+    const modelId = iModel.transientIds.getNext();
     const tilingScheme = imageryProvider.tilingScheme;
     const rootLevel =  (1 === tilingScheme.numberOfLevelZeroTilesX && 1 === tilingScheme.numberOfLevelZeroTilesY) ? 0 : -1;
     const rootTileId = new QuadId(rootLevel, 0, 0).contentId;

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -561,7 +561,7 @@ class MapTreeSupplier implements TileTreeSupplier {
   public async createTileTree(id: MapTreeId, iModel: IModelConnection): Promise<TileTree | undefined> {
     let bimElevationBias = 0, terrainProvider, geodeticOffset = 0;
     let applyTerrain = id.applyTerrain;
-    const modelId = iModel.transientIds.next;
+    const modelId = iModel.transientIds.getNext();
     const gcsConverterAvailable = await getGcsConverterAvailable(iModel);
 
     const terrainOpts: TerrainMeshProviderOptions = {

--- a/core/frontend/src/tools/ClipViewTool.ts
+++ b/core/frontend/src/tools/ClipViewTool.ts
@@ -1310,7 +1310,7 @@ export class ViewClipDecoration extends EditManipulator.HandleProvider {
     super(_clipView.iModel);
     if (!this.getClipData())
       return;
-    this._clipId = this.iModel.transientIds.next;
+    this._clipId = this.iModel.transientIds.getNext();
     this.updateDecorationListener(true);
     this._removeViewCloseListener = IModelApp.viewManager.onViewClose.addListener(this.onViewClose, this); // eslint-disable-line @typescript-eslint/unbound-method
     if (undefined !== this._clipEventHandler && this._clipEventHandler.selectOnCreate())
@@ -1401,7 +1401,7 @@ export class ViewClipDecoration extends EditManipulator.HandleProvider {
     if (numCurrent < numReqControls) {
       const transientIds = this.iModel.transientIds;
       for (let i: number = numCurrent; i < numReqControls; i++)
-        this._controlIds[i] = transientIds.next;
+        this._controlIds[i] = transientIds.getNext();
     } else if (numCurrent > numReqControls) {
       this._controlIds.length = numReqControls;
     }

--- a/core/frontend/src/tools/MeasureTool.ts
+++ b/core/frontend/src/tools/MeasureTool.ts
@@ -390,7 +390,7 @@ export class MeasureDistanceTool extends PrimitiveTool {
       return;
 
     if (undefined === this._snapGeomId)
-      this._snapGeomId = this.iModel.transientIds.next;
+      this._snapGeomId = this.iModel.transientIds.getNext();
 
     const builderSnapPts = context.createGraphicBuilder(GraphicType.WorldOverlay, undefined, this._snapGeomId);
     const colorAccPts = ColorDef.white.adjustedForContrast(context.viewport.view.backgroundColor);

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -50,6 +50,8 @@ A bug preventing users from interacting with [pickable decorations](../learning/
 
 [ByteStream]($bentley)'s `next` property getters like [ByteStream.nextUint32]($bentley) and [ByteStream.nextFloat64]($bentley) have been deprecated and replaced with corresponding `read` methods like [ByteStream.readUint32]($bentley) and [ByteStream.readFloat64]($bentley). The property getters have the side effect of incrementing the stream's current read position, which can result in surprising behavior and may [trip up code optimizers](https://github.com/angular/angular-cli/issues/12128#issuecomment-472309593) that assume property access is free of side effects.
 
+Similarly, [TransientIdSequence.next]($bentley) returns a new Id each time it is called. Code optimizers like [Angular](https://github.com/angular/angular-cli/issues/12128#issuecomment-472309593)'s may elide repeated calls to `next` assuming it will return the same value each time. Prefer to use the new [TransientIdSequence.getNext]($bentley) method instead.
+
 ### @itwin/core-frontend
 
 [ScreenViewport.setEventController]($frontend) was only ever intended to be used by [ViewManager]($frontend). In the unlikely event that you are using it for some (probably misguided) purpose, it will continue to behave as before, but it will be removed in a future major version.

--- a/docs/learning/guidelines/typescript-coding-guidelines.md
+++ b/docs/learning/guidelines/typescript-coding-guidelines.md
@@ -310,6 +310,8 @@ If a public method takes no parameters and its name begins with a keyword such a
 
 If the value being returned is expensive to compute, consider using a different name to reflect this. Possible prefixes are "compute" or "calculate", etc.
 
+A getter should have no side effects, with the possible exception of a getter that computes and caches its value the first time it is called. In particular, avoid getters that return a different value each time they are called, as some code optimizers [may assume](https://github.com/angular/angular-cli/issues/12128#issuecomment-472309593) a property access always returns the same value.
+
 ## Don't export const enums
 
 Exported `const enum`s require a .d.ts file to be present when a file that consumes one is transpiled. This prevents the [--isolatedModules](https://www.typescriptlang.org/docs/handbook/compiler-options.html) option required by [create-react-app](https://reactjs.org/docs/create-a-new-react-app.html) and are therefore forbidden. An ESLint rule enforces this.

--- a/editor/frontend/src/ProjectLocation/ProjectExtentsDecoration.ts
+++ b/editor/frontend/src/ProjectLocation/ProjectExtentsDecoration.ts
@@ -117,9 +117,9 @@ export class ProjectExtentsClipDecoration extends EditManipulator.HandleProvider
     if (!this.init())
       return;
 
-    this._monumentId = this.iModel.transientIds.next;
-    this._northId = this.iModel.transientIds.next;
-    this._clipId = this.iModel.transientIds.next;
+    this._monumentId = this.iModel.transientIds.getNext();
+    this._northId = this.iModel.transientIds.getNext();
+    this._clipId = this.iModel.transientIds.getNext();
 
     this.start();
   }
@@ -193,7 +193,7 @@ export class ProjectExtentsClipDecoration extends EditManipulator.HandleProvider
     if (numCurrent < numReqControls) {
       const transientIds = this.iModel.transientIds;
       for (let i: number = numCurrent; i < numReqControls; i++)
-        this._controlIds[i] = transientIds.next;
+        this._controlIds[i] = transientIds.getNext();
     } else if (numCurrent > numReqControls) {
       this._controlIds.length = numReqControls;
     }

--- a/editor/frontend/src/SketchTools.ts
+++ b/editor/frontend/src/SketchTools.ts
@@ -486,7 +486,7 @@ export abstract class CreateOrContinuePathTool extends CreateElementWithDynamics
       return;
 
     if (undefined === this._snapGeomId)
-      this._snapGeomId = this.iModel.transientIds.next;
+      this._snapGeomId = this.iModel.transientIds.getNext();
 
     const builder = context.createGraphic({ type: GraphicType.WorldDecoration, pickable: { id: this._snapGeomId, locateOnly: true } });
     builder.setSymbology(ColorDef.white, ColorDef.white, 1);

--- a/example-code/snippets/src/frontend/ViewDecorations.ts
+++ b/example-code/snippets/src/frontend/ViewDecorations.ts
@@ -43,7 +43,7 @@ export class ExamplePickableGraphicDecoration {
 
     // Get next available Id to represent our decoration for it's life span.
     if (undefined === this._decoId)
-      this._decoId = vp.iModel.transientIds.next;
+      this._decoId = vp.iModel.transientIds.getNext();
 
     const builder = context.createGraphicBuilder(GraphicType.WorldDecoration, undefined, this._decoId);
     builder.setSymbology(vp.getContrastToBackgroundColor(), ColorDef.black, 2);
@@ -378,7 +378,7 @@ export async function displayGltfAsset(iModel: IModelConnection): Promise<boolea
     const buffer = await file.arrayBuffer();
 
     // Allocate a new transient Id to identify the graphic so it can be picked.
-    const id = iModel.transientIds.next;
+    const id = iModel.transientIds.getNext();
 
     // Convert the glTF into a RenderGraphic.
     let graphic = await readGltfGraphics({

--- a/full-stack-tests/core/src/frontend/hub/HyperModeling.test.ts
+++ b/full-stack-tests/core/src/frontend/hub/HyperModeling.test.ts
@@ -261,7 +261,7 @@ describe("HyperModeling (#integration)", () => {
           sectionType: type,
           drawingToSpatialTransform: JSON.stringify(state.drawingToSpatialTransform.toJSON()),
           spatialViewId: state.spatialViewId,
-          sectionLocationId: hypermodel.transientIds.next,
+          sectionLocationId: hypermodel.transientIds.getNext(),
           sectionLocationModelId: model ?? state.model,
           sectionViewId: state.drawingViewId,
           categoryId: categoryId ?? state.category,

--- a/full-stack-tests/core/src/frontend/hub/IModelConnection.test.ts
+++ b/full-stack-tests/core/src/frontend/hub/IModelConnection.test.ts
@@ -196,7 +196,7 @@ describe("IModelConnection (#integration)", () => {
 
   it("should generate unique transient IDs", () => {
     for (let i = 1; i < 40; i++) {
-      const id = iModel.transientIds.next;
+      const id = iModel.transientIds.getNext();
       expect(Id64.getLocalId(id)).to.equal(i); // auto-incrementing local ID beginning at 1
       expect(Id64.getBriefcaseId(id)).to.equal(0xffffff); // illegal briefcase ID
       expect(Id64.isTransient(id)).to.be.true;

--- a/full-stack-tests/core/src/frontend/standalone/Transparency.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/Transparency.test.ts
@@ -195,7 +195,7 @@ describe("Transparency", async () => {
   });
 
   it("should be overridden per-feature", async () => {
-    const pickableId = imodel.transientIds.next;
+    const pickableId = imodel.transientIds.getNext();
     await test(
       (vp) => {
         decorator.overrideTransparency(pickableId, 0);
@@ -334,7 +334,7 @@ describe("Transparency", async () => {
   });
 
   it("should use element alpha and ignore texture if symbology overrides ignore material", async () => {
-    const pickableId = imodel.transientIds.next;
+    const pickableId = imodel.transientIds.getNext();
     await test(
       (vp) => {
         decorator.ignoreMaterial(pickableId);
@@ -356,7 +356,7 @@ describe("Transparency", async () => {
   });
 
   it("should replace material alpha with symbology override", async () => {
-    const pickableId = imodel.transientIds.next;
+    const pickableId = imodel.transientIds.getNext();
 
     await test(
       (vp) => {
@@ -419,7 +419,7 @@ describe("Transparency", async () => {
   // Unclear if this is what we want. Without it, there's no way to make a very-transparent textured surface more visible via symbology overrides -
   // but any value other than zero will multiply, making transparent textures always more transparent, never less.
   it("should multiply texture alpha with symbology override", async () => {
-    const pickableId = imodel.transientIds.next;
+    const pickableId = imodel.transientIds.getNext();
     async function testCase(color: ColorDef, transparencyOverride: number, material: RenderMaterial, expectedColor: ColorDef): Promise<void> {
       await test(
         (vp) => {
@@ -444,7 +444,7 @@ describe("Transparency", async () => {
   });
 
   it("symbology override applies regardless of render mode and view flags unless explicitly specified", async () => {
-    const pickableId = imodel.transientIds.next;
+    const pickableId = imodel.transientIds.getNext();
     for (let iTransp = 0; iTransp < 2; iTransp++) {
       for (let iViewDep = 0; iViewDep < 2; iViewDep++) {
         const viewDep = iViewDep > 0;

--- a/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
+++ b/test-apps/display-test-app/src/frontend/AnalysisStyleExample.ts
@@ -189,7 +189,7 @@ class AnalysisDecorator {
   public constructor(viewport: Viewport, mesh: AnalysisMesh) {
     this._viewport = viewport;
     this.mesh = mesh;
-    this._id = viewport.iModel.transientIds.next;
+    this._id = viewport.iModel.transientIds.getNext();
 
     const removeDisposalListener = viewport.onDisposed.addOnce(() => this.dispose());
     const removeAnalysisStyleListener = viewport.addOnAnalysisStyleChangedListener(() => {

--- a/test-apps/display-test-app/src/frontend/DecorationGeometryExample.ts
+++ b/test-apps/display-test-app/src/frontend/DecorationGeometryExample.ts
@@ -135,11 +135,11 @@ class GeometryDecorator {
     const points = [
       new Point3d(ox, oy, 0), new Point3d(ox + 1, oy, 0), new Point3d(ox + 1, oy + 1, 1), new Point3d(ox, oy + 1, 1), new Point3d(ox, oy, 0),
     ];
-    this._decorators.set(this._iModel.transientIds.next, (builder) => builder.addShape(points));
+    this._decorators.set(this._iModel.transientIds.getNext(), (builder) => builder.addShape(points));
   }
 
   private addDecorator(decorate: (builder: GraphicBuilder) => void): void {
-    this._decorators.set(this._iModel.transientIds.next, decorate);
+    this._decorators.set(this._iModel.transientIds.getNext(), decorate);
   }
 
   private addBox(cx: number, cy: number = 0): void {
@@ -161,11 +161,11 @@ class GeometryDecorator {
 
   private addMultiFeatureDecoration(): void {
     const y = 9;
-    const boxId = this._iModel.transientIds.next,
-      sphereId = this._iModel.transientIds.next,
-      coneId = this._iModel.transientIds.next;
+    const boxId = this._iModel.transientIds.getNext(),
+      sphereId = this._iModel.transientIds.getNext(),
+      coneId = this._iModel.transientIds.getNext();
 
-    this._decorators.set(this._iModel.transientIds.next, (builder) => {
+    this._decorators.set(this._iModel.transientIds.getNext(), (builder) => {
       builder.addShape([ new Point3d(0, y, 0), new Point3d(1, y, 0), new Point3d(1, y + 1, 1), new Point3d(0, y + 1, 1), new Point3d(0, y, 0) ]);
 
       builder.activatePickableId(boxId);

--- a/test-apps/display-test-app/src/frontend/DrawingAidTestTool.ts
+++ b/test-apps/display-test-app/src/frontend/DrawingAidTestTool.ts
@@ -51,7 +51,7 @@ export class DrawingAidTestTool extends PrimitiveTool {
       return;
 
     if (undefined === this._snapGeomId)
-      this._snapGeomId = this.iModel.transientIds.next;
+      this._snapGeomId = this.iModel.transientIds.getNext();
 
     const builder = context.createGraphicBuilder(GraphicType.WorldDecoration, undefined, this._snapGeomId);
 

--- a/test-apps/display-test-app/src/frontend/EditingTools.ts
+++ b/test-apps/display-test-app/src/frontend/EditingTools.ts
@@ -122,7 +122,7 @@ export class PlaceLineStringTool extends CreateElementTool {
       return;
 
     if (undefined === this._snapGeomId)
-      this._snapGeomId = this.iModel.transientIds.next;
+      this._snapGeomId = this.iModel.transientIds.getNext();
 
     const builder = context.createGraphicBuilder(GraphicType.WorldDecoration, undefined, this._snapGeomId);
     builder.setSymbology(context.viewport.getContrastToBackgroundColor(), ColorDef.black, 1);

--- a/test-apps/display-test-app/src/frontend/GltfDecoration.ts
+++ b/test-apps/display-test-app/src/frontend/GltfDecoration.ts
@@ -78,7 +78,7 @@ export class GltfDecorationTool extends Tool {
         return false;
 
       // Convert the glTF into a RenderGraphic.
-      const id = iModel.transientIds.next;
+      const id = iModel.transientIds.getNext();
       let graphic = await readGltfGraphics({
         gltf: new Uint8Array(buffer),
         iModel,
@@ -86,7 +86,7 @@ export class GltfDecorationTool extends Tool {
         pickableOptions: {
           id,
           // The modelId must be different from the pickable Id for the decoration to be selectable and hilite-able.
-          modelId: iModel.transientIds.next,
+          modelId: iModel.transientIds.getNext(),
         },
       });
 

--- a/test-apps/display-test-app/src/frontend/PathDecorationTest.ts
+++ b/test-apps/display-test-app/src/frontend/PathDecorationTest.ts
@@ -36,7 +36,7 @@ export class PathDecorationTest {
   /** We added this class as a ViewManager.decorator below. This method is called to ask for our decorations. Here we add the line string. */
   public decorate(context: DecorateContext) {
     if (undefined === this._pickId)
-      this._pickId = context.viewport.iModel.transientIds.next;
+      this._pickId = context.viewport.iModel.transientIds.getNext();
     const pathBuilder = context.createGraphicBuilder(GraphicType.WorldDecoration, undefined, this._pickId);
     pathBuilder.addPath(this._path);
     context.addDecorationFromBuilder(pathBuilder);


### PR DESCRIPTION
Favor `getNext` method. See changes to NextVersion.md and typescript-coding-guidelines.md.
Those and the changes in core-bentley are the only functional changes; the rest are just `/s/next/getNext()` to satisfy linter.

Note we're never going to eliminate all cases where some over-eager code optimizer assumes that `a === b` given:
```
  const a = obj.prop; // a getter
  // some more code that may affect return value of getter
  const b = obj.prop; // a not necessarily equal to b
```

For example,
```
  const prevView = viewport.view;
  viewport.changeView(newView);
  const newView = viewport.view; // optimizer elides second call => incorrect behavior
```

But an API that by design returns a different value on each call should be a method, not a property.