### PR TITLE
Clean up error types

### DIFF
--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -128,7 +128,7 @@ export class BeUiEvent<TEventArgs> extends BeEvent<(args: TEventArgs) => void> {
     emit(args: TEventArgs): void;
 }
 
-// @beta
+// @public
 export enum BriefcaseStatus {
     // (undocumented)
     BRIEFCASE_STATUS_BASE = 131072,
@@ -203,7 +203,7 @@ export class ByteStream {
     rewind(numBytes: number): boolean;
 }
 
-// @beta
+// @public
 export enum ChangeSetStatus {
     ApplyError = 90113,
     CannotMergeIntoMaster = 90136,
@@ -668,7 +668,7 @@ export interface IDisposable {
     dispose(): void;
 }
 
-// @beta
+// @public
 export enum IModelHubStatus {
     // (undocumented)
     AnotherUserPushing = 102409,
@@ -1473,7 +1473,7 @@ export enum RealityDataStatus {
     Success = 0
 }
 
-// @beta
+// @internal
 export enum RepositoryStatus {
     CannotCreateChangeSet = 86023,
     ChangeSetRequired = 86025,
@@ -1546,7 +1546,7 @@ export abstract class StatusCategory {
 // @alpha (undocumented)
 export type StatusCategoryHandler = (error: BentleyError) => StatusCategory | undefined;
 
-// @beta
+// @internal
 export interface StatusCodeWithMessage<ErrorCodeType> {
     // (undocumented)
     message: string;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -63,8 +63,6 @@ import { Range2d } from '@itwin/core-geometry';
 import { Range3d } from '@itwin/core-geometry';
 import { Range3dProps } from '@itwin/core-geometry';
 import type { Readable } from 'stream';
-import { RepositoryStatus } from '@itwin/core-bentley';
-import { RpcInterfaceStatus } from '@itwin/core-bentley';
 import type { TransferConfig } from '@itwin/object-storage-core/lib/common';
 import { Transform } from '@itwin/core-geometry';
 import { TransformProps } from '@itwin/core-geometry';
@@ -4689,8 +4687,11 @@ export interface IModelEncryptionProps {
 
 // @public
 export class IModelError extends BentleyError {
-    constructor(errorNumber: number | IModelStatus | DbResult | BentleyStatus | BriefcaseStatus | RepositoryStatus | ChangeSetStatus | RpcInterfaceStatus, message: string, getMetaData?: GetMetaDataFunction);
+    constructor(errorNumber: IModelErrorNumber | number, message: string, getMetaData?: GetMetaDataFunction);
 }
+
+// @public
+export type IModelErrorNumber = IModelStatus | DbResult | BentleyStatus | BriefcaseStatus | ChangeSetStatus;
 
 // @public
 export class IModelNotFoundResponse extends RpcNotFoundResponse {
@@ -7568,8 +7569,6 @@ export interface RepositoryLinkProps extends UrlLinkProps {
     repositoryGuid?: GuidString;
 }
 
-export { RepositoryStatus }
-
 // @public
 export interface RequestNewBriefcaseProps {
     asOf?: IModelVersionProps;
@@ -7816,8 +7815,6 @@ export interface RpcInterfaceEndpoints {
 
 // @internal (undocumented)
 export type RpcInterfaceImplementation<T extends RpcInterface = RpcInterface> = new () => T;
-
-export { RpcInterfaceStatus }
 
 // @internal
 export class RpcInvocation {

--- a/common/api/summary/core-bentley.exports.csv
+++ b/common/api/summary/core-bentley.exports.csv
@@ -18,9 +18,9 @@ public;BentleyLoggerCategory
 public;BentleyStatus
 public;BeTimePoint
 public;BeUiEvent
-beta;BriefcaseStatus
+public;BriefcaseStatus
 public;ByteStream
-beta;ChangeSetStatus
+public;ChangeSetStatus
 public;CloneFunction
 public;compareBooleans(a: boolean, b: boolean): number
 public;compareBooleansOrUndefined(lhs?: boolean, rhs?: boolean): number
@@ -58,7 +58,7 @@ public;Id64Array = Id64String[]
 public;Id64Set = Set
 public;Id64String = string
 public;IDisposable
-beta;IModelHubStatus
+public;IModelHubStatus
 public;IModelStatus
 public;IndexedValue
 public;IndexMap
@@ -108,14 +108,14 @@ public;PromiseReturnType
 public;ReadonlyOrderedSet
 public;ReadonlySortedArray
 alpha;RealityDataStatus
-beta;RepositoryStatus
+internal;RepositoryStatus
 beta;RpcInterfaceStatus
 public;shallowClone
 public;SortedArray
 alpha;SpanKind
 alpha;class StatusCategory
 alpha;StatusCategoryHandler = (error: BentleyError) => StatusCategory | undefined
-beta;StatusCodeWithMessage
+internal;StatusCodeWithMessage
 public;StopWatch
 alpha;class SuccessCategory 
 alpha;Tracing

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -390,6 +390,7 @@ beta;IModelCoordinatesResponseProps
 public;IModelEncryptionProps
 deprecated;IModelEncryptionProps
 public;IModelError 
+public;IModelErrorNumber = IModelStatus | DbResult | BentleyStatus | BriefcaseStatus | ChangeSetStatus
 public;IModelNotFoundResponse 
 public;IModelProps
 internal;class IModelReadRpcInterface 

--- a/common/changes/@itwin/core-backend/pmc-error-types_2022-12-21-16-48.json
+++ b/common/changes/@itwin/core-backend/pmc-error-types_2022-12-21-16-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-bentley/pmc-error-types_2022-12-21-16-48.json
+++ b/common/changes/@itwin/core-bentley/pmc-error-types_2022-12-21-16-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-common/pmc-error-types_2022-12-21-16-48.json
+++ b/common/changes/@itwin/core-common/pmc-error-types_2022-12-21-16-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -9,7 +9,7 @@
 import { mkdirSync } from "fs";
 import { dirname } from "path";
 import { NativeLibrary } from "@bentley/imodeljs-native";
-import { GuidString } from "@itwin/core-bentley";
+import { BriefcaseStatus, GuidString } from "@itwin/core-bentley";
 import { LocalDirName, LocalFileName } from "@itwin/core-common";
 
 /** Types for using SQLite files stored in cloud containers.
@@ -371,7 +371,7 @@ export namespace CloudSqlite {
       onProgress?.(total, total); // make sure we call progress func one last time when download completes
     } catch (err: any) {
       if (err.message === "cancelled")
-        err.errorNumber = 131079; // BriefcaseStatus.DownloadCancelled
+        err.errorNumber = BriefcaseStatus.DownloadCancelled;
 
       throw err;
     } finally {

--- a/core/bentley/src/BentleyError.ts
+++ b/core/bentley/src/BentleyError.ts
@@ -98,8 +98,8 @@ export enum IModelStatus {
   NoActiveCommand = IMODEL_ERROR_BASE + 71,
 }
 
-/** Error status from various briefcase operations
- * @beta Should these be internal?
+/** Error statuses produced by various briefcase operations, typically encountered as the `errorNumber` of an [IModelError]($common).
+ * @public
  */
 export enum BriefcaseStatus {
   BRIEFCASE_STATUS_BASE = 0x20000,
@@ -115,7 +115,7 @@ export enum BriefcaseStatus {
 }
 
 /** RpcInterface status codes
- * @beta Should these be internal?
+ * @beta
  */
 export enum RpcInterfaceStatus {
   Success = 0,
@@ -124,8 +124,8 @@ export enum RpcInterfaceStatus {
   IncompatibleVersion = RPC_INTERFACE_ERROR_BASE,
 }
 
-/** Error status from various Changeset operations
- * @beta Should these be internal?
+/** Error statuses produced by various Changeset operations, typically encountered as the `errorNumber` of an [IModelError]($common).
+ * @public
  */
 export enum ChangeSetStatus { // Note: Values must be kept in sync with ChangeSetStatus in DgnPlatform
   Success = 0,
@@ -185,7 +185,7 @@ export enum ChangeSetStatus { // Note: Values must be kept in sync with ChangeSe
 }
 
 /** Return codes for methods which perform repository management operations
- * @beta Should these be internal?
+ * @internal
  */
 export enum RepositoryStatus {
   Success = 0,
@@ -222,7 +222,7 @@ export enum RepositoryStatus {
 }
 
 /** Status from returned HTTP status code
- * @beta Should these be internal?
+ * @beta
  */
 export enum HttpStatus {
   /** 2xx Success */
@@ -237,8 +237,8 @@ export enum HttpStatus {
   ServerError = 0x17004,
 }
 
-/** iModelHub Services Errors
- * @beta Right package?
+/** Statuses produced by APIs that interact with iModelHub, typically encountered as the `errorNumber` of an [IModelError]($common).
+ * @public
  */
 export enum IModelHubStatus {
   Success = 0,
@@ -336,7 +336,7 @@ export enum RealityDataStatus {
 }
 
 /** When you want to associate an explanatory message with an error status value.
- * @beta Internal?
+ * @internal
  */
 export interface StatusCodeWithMessage<ErrorCodeType> {
   status: ErrorCodeType;

--- a/core/common/src/IModelError.ts
+++ b/core/common/src/IModelError.ts
@@ -8,16 +8,24 @@
 
 import {
   BentleyError, BentleyStatus, BriefcaseStatus, ChangeSetStatus, DbResult, GetMetaDataFunction, IModelStatus, RepositoryStatus,
-  RpcInterfaceStatus,
 } from "@itwin/core-bentley";
 
-export { BentleyStatus, BentleyError, IModelStatus, BriefcaseStatus, GetMetaDataFunction, LogFunction, DbResult, RepositoryStatus, ChangeSetStatus, RpcInterfaceStatus } from "@itwin/core-bentley";
+export {
+  BentleyStatus, BentleyError, IModelStatus, BriefcaseStatus, GetMetaDataFunction, LogFunction, DbResult, ChangeSetStatus,
+} from "@itwin/core-bentley";
 
-/** The error type thrown by this module. See [[IModelStatus]] for `errorNumber` values.
+/** Numeric values for common errors produced by iTwin.js APIs, typically provided by [[IModelError]].
+ * The values within each of these `enum`s are guaranteed not to conflict with one another.
+ * @public
+ */
+export type IModelErrorNumber = IModelStatus | DbResult | BentleyStatus | BriefcaseStatus | ChangeSetStatus
+
+/** The error type thrown by this module.
+ * @see [[IModelErrorNumber]] for commonly-used error codes.
  * @public
  */
 export class IModelError extends BentleyError {
-  public constructor(errorNumber: number | IModelStatus | DbResult | BentleyStatus | BriefcaseStatus | RepositoryStatus | ChangeSetStatus | RpcInterfaceStatus, message: string, getMetaData?: GetMetaDataFunction) {
+  public constructor(errorNumber: IModelErrorNumber | number, message: string, getMetaData?: GetMetaDataFunction) {
     super(errorNumber, message, getMetaData);
   }
 }

--- a/core/common/src/IModelError.ts
+++ b/core/common/src/IModelError.ts
@@ -18,7 +18,7 @@ export {
  * The values within each of these `enum`s are guaranteed not to conflict with one another.
  * @public
  */
-export type IModelErrorNumber = IModelStatus | DbResult | BentleyStatus | BriefcaseStatus | ChangeSetStatus
+export type IModelErrorNumber = IModelStatus | DbResult | BentleyStatus | BriefcaseStatus | ChangeSetStatus;
 
 /** The error type thrown by this module.
  * @see [[IModelErrorNumber]] for commonly-used error codes.


### PR DESCRIPTION
`IModelError` (`@public`) in core-common uses a bunch of `enum`s (many not `@public`) from core-bentley.
api-extractor doesn't enforce release tags across package boundaries.
Clean them up and add some documentation as part of broader effort to stabilize our APIs (many of which have languished in `@beta` or `@alpha` far too long) in preparation for 4.0.