### PR TITLE
enable WAL mode in SetToStandalone

### DIFF
--- a/test-apps/display-test-app/src/backend/SetToStandalone.ts
+++ b/test-apps/display-test-app/src/backend/SetToStandalone.ts
@@ -48,6 +48,7 @@ function setToStandalone(iModelName: string) {
   try {
     const nativeDb = new IModelHost.platform.DgnDb();
     nativeDb.openIModel(iModelName, OpenMode.ReadWrite);
+    nativeDb.enableWalMode();
     nativeDb.setITwinId(Guid.empty); // empty iTwinId means "standalone"
     nativeDb.saveChanges(); // save change to iTwinId
     nativeDb.deleteAllTxns(); // necessary before resetting briefcaseId


### PR DESCRIPTION
When converting an existing file to be a Standalone iModel, enable WAL mode too. Extends #4853