### PR TITLE
Added getOriginPropertyName() method to column info

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1553,6 +1553,7 @@ export class ECSqlBinder {
 // @public
 export interface ECSqlColumnInfo {
     getAccessString(): string;
+    getOriginPropertyName(): string | undefined;
     getPropertyName(): string;
     getRootClassAlias(): string;
     getRootClassName(): string;

--- a/common/changes/@itwin/core-backend/get-origin-property2_2023-01-03-10-29.json
+++ b/common/changes/@itwin/core-backend/get-origin-property2_2023-01-03-10-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added getOriginPropertyName() method to column info.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/ECSqlStatement.ts
+++ b/core/backend/src/ECSqlStatement.ts
@@ -689,6 +689,13 @@ export interface ECSqlColumnInfo {
    */
   getPropertyName(): string;
 
+  /** Gets the name of the original property that the column data is from.
+   * > Other than getPropertyName(), this ignores aliases and allows getting the name
+   * > of the property which is being used for the column. A column may not be backed
+   * > by a property, in which case this returns undefined.
+   */
+  getOriginPropertyName(): string | undefined;
+
   /** Gets the full access string to the corresponding ECSqlValue starting from the root class.
    * > If this column is backed by a generated property, i.e. it represents ECSQL expression,
    * > the access string consists of the ECSQL expression.

--- a/core/backend/src/ECSqlStatement.ts
+++ b/core/backend/src/ECSqlStatement.ts
@@ -685,12 +685,13 @@ export interface ECSqlColumnInfo {
 
   /** Gets the name of the property backing the column.
    * > If this column is backed by a generated property, i.e. it represents ECSQL expression,
-   * > the access string consists of the name of the generated property.
+   * > the access string consists of the name of the generated property. [[ECSqlColumnInfo.getOriginPropertyName]]
+   * > can be used to obtain the non-aliased name in that case.
    */
   getPropertyName(): string;
 
   /** Gets the name of the original property that the column data is from.
-   * > Other than getPropertyName(), this ignores aliases and allows getting the name
+   * > Other than [[ECSqlColumnInfo.getPropertyName]], this ignores aliases and allows getting the name
    * > of the property which is being used for the column. A column may not be backed
    * > by a property, in which case this returns undefined.
    */

--- a/core/backend/src/test/ecdb/ECSqlStatement.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlStatement.test.ts
@@ -6,7 +6,7 @@ import { assert } from "chai";
 import { DbResult, Guid, GuidString, Id64, Id64String, using } from "@itwin/core-bentley";
 import { NavigationValue, QueryBinder, QueryOptions, QueryOptionsBuilder, QueryRowFormat } from "@itwin/core-common";
 import { Point2d, Point3d, Range3d, XAndY, XYAndZ } from "@itwin/core-geometry";
-import { ECDb, ECEnumValue, ECSqlInsertResult, ECSqlStatement, ECSqlValue, SnapshotDb } from "../../core-backend";
+import { ECDb, ECEnumValue, ECSqlColumnInfo, ECSqlInsertResult, ECSqlStatement, ECSqlValue, SnapshotDb } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { SequentialLogMatcher } from "../SequentialLogMatcher";
@@ -2847,6 +2847,47 @@ describe("ECSqlStatement", () => {
       ecdb.saveChanges();
       assert.equal(r.status, DbResult.BE_SQLITE_DONE);
       assert.equal(r.id, "0x1");
+    });
+  });
+
+  it("check column info", async () => {
+    await using(ECDbTestHelper.createECDb(outDir, "columnInfo.ecdb",
+      `<ECSchema schemaName="Test" alias="test" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECEntityClass typeName="MyClass" modifier="Sealed">
+          <ECProperty propertyName="MyProperty" typeName="string"/>
+       </ECEntityClass>
+      </ECSchema>`), async (ecdb: ECDb) => {
+      assert.isTrue(ecdb.isOpen);
+
+      const id: Id64String = ecdb.withPreparedStatement("INSERT INTO test.MyClass(MyProperty) VALUES('Value')", (stmt: ECSqlStatement) => {
+        const res: ECSqlInsertResult = stmt.stepForInsert();
+        assert.equal(res.status, DbResult.BE_SQLITE_DONE);
+        assert.isDefined(res.id);
+        return res.id!;
+      });
+
+      ecdb.withPreparedStatement("SELECT MyProperty as MyAlias, 1 as MyGenerated FROM test.MyClass WHERE ECInstanceId=?", (stmt: ECSqlStatement) => {
+        stmt.bindId(1, id);
+        assert.equal(stmt.step(), DbResult.BE_SQLITE_ROW);
+        // getRow just returns the enum values
+        const row: any = stmt.getRow();
+        assert.equal(row.myAlias, "Value");
+        assert.equal(row.myGenerated, 1);
+
+        const val0: ECSqlValue = stmt.getValue(0);
+        const colInfo0: ECSqlColumnInfo = val0.columnInfo;
+
+        assert.equal(colInfo0.getPropertyName(), "MyAlias");
+        const originPropertyName = colInfo0.getOriginPropertyName();
+        assert.isDefined(originPropertyName);
+        assert.equal(originPropertyName, "MyProperty");
+
+        const val1: ECSqlValue = stmt.getValue(1);
+        const colInfo1: ECSqlColumnInfo = val1.columnInfo;
+
+        assert.equal(colInfo1.getPropertyName(), "MyGenerated");
+        assert.isUndefined(colInfo1.getOriginPropertyName());
+      });
     });
   });
 });


### PR DESCRIPTION
Method allows getting the backing property name, if any. It's different from getPropertyName as it does still return the property name even if an alias is used for the column.
Native addon changes are already live and included in the latest build that we consume.