### PR TITLE
suppress rush audit failure

### DIFF
--- a/common/changes/@bentley/build-tools/fix-2.19-audit_2023-01-04-18-23.json
+++ b/common/changes/@bentley/build-tools/fix-2.19-audit_2023-01-04-18-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/build-tools",
+  "email": "32379572+skirby1996@users.noreply.github.com"
+}

--- a/common/changes/@bentley/config-loader/fix-2.19-audit_2023-01-04-18-23.json
+++ b/common/changes/@bentley/config-loader/fix-2.19-audit_2023-01-04-18-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/config-loader",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@bentley/config-loader",
+  "email": "32379572+skirby1996@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4298,14 +4298,14 @@ importers:
       dotenv: ^8.2.0
       dotenv-expand: ^5.1.0
       eslint: ^7.11.0
-      json5: ^2.1.0
+      json5: ^2.2.2
       rimraf: ^3.0.2
       typescript: ~4.3.0
     dependencies:
       chalk: 3.0.0
       dotenv: 8.6.0
       dotenv-expand: 5.1.0
-      json5: 2.2.1
+      json5: 2.2.3
     devDependencies:
       '@bentley/build-tools': link:../build
       '@bentley/eslint-plugin': link:../eslint-plugin
@@ -5658,7 +5658,7 @@ packages:
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.1
+      json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.19.0
       semver: 5.7.1
@@ -5684,7 +5684,7 @@ packages:
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.1
+      json5: 2.2.3
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -5702,7 +5702,7 @@ packages:
       '@babel/types': 7.17.0
       convert-source-map: 1.8.0
       debug: 4.3.4
-      json5: 2.2.1
+      json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.19.0
       semver: 5.7.1
@@ -5725,7 +5725,7 @@ packages:
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.1
+      json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.19.0
       semver: 5.7.1
@@ -19208,8 +19208,8 @@ packages:
       minimist: 1.2.6
     dev: true
 
-  /json5/2.2.1:
-    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
+  /json5/2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -19505,7 +19505,7 @@ packages:
     dependencies:
       big.js: 5.2.2
       emojis-list: 3.0.0
-      json5: 2.2.1
+      json5: 2.2.3
 
   /loader-utils/2.0.2:
     resolution: {integrity: sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==}
@@ -19513,7 +19513,7 @@ packages:
     dependencies:
       big.js: 5.2.2
       emojis-list: 3.0.0
-      json5: 2.2.1
+      json5: 2.2.3
 
   /locate-path/2.0.0:
     resolution: {integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=}
@@ -25130,7 +25130,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       jest: 26.6.0
       jest-util: 26.6.2
-      json5: 2.2.1
+      json5: 2.2.3
       lodash: 4.17.21
       make-error: 1.3.6
       mkdirp: 1.0.4

--- a/tools/build/scripts/rush/audit.js
+++ b/tools/build/scripts/rush/audit.js
@@ -54,6 +54,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-3rfm-jhwj-7488", // https://github.com/advisories/GHSA-3rfm-jhwj-7488 @bentley/react-scripts>react-dev-utils>loader-utils
     "GHSA-hhq3-ff78-jv3g", // https://github.com/advisories/GHSA-hhq3-ff78-jv3g @bentley/react-scripts>react-dev-utils>loader-utils
     "GHSA-27h2-hvpr-p74q", // https://github.com/advisories/GHSA-27h2-hvpr-p74q @bentley/core-backend>azurite>jsonwebtoken
+    "GHSA-9c47-m6qq-7p4h", // https://github.com/advisories/GHSA-9c47-m6qq-7p4h @bentley/backend-application-insights-client>webpack>loader-utils>json5, @bentley/geonames-extension>svg-sprite-loader>html-webpack-plugin>loader-utils>json5, @bentley/ecschema-editing>i18next-node-fs-backend>json5
   ];
 
   let shouldFailBuild = false;

--- a/tools/config-loader/package.json
+++ b/tools/config-loader/package.json
@@ -32,7 +32,7 @@
     "chalk": "^3.0.0",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
-    "json5": "^2.1.0"
+    "json5": "^2.2.2"
   },
   "devDependencies": {
     "@bentley/build-tools": "workspace:*",


### PR DESCRIPTION
[Prototype Pollution in JSON5 via Parse Method](https://github.com/advisories/GHSA-9c47-m6qq-7p4h)
@bentley/backend-application-insights-client>webpack>loader-utils>json5, @bentley/geonames-extension>svg-sprite-loader>html-webpack-plugin>loader-utils>json5, @bentley/ecschema-editing>i18next-node-fs-backend>json5

Update json5 in config loader package, suppress audit failure for other packages we don't have control of.