### PR TITLE
Measure area fix

### DIFF
--- a/common/changes/@itwin/core-frontend/measureArea-fix_2023-01-05-16-18.json
+++ b/common/changes/@itwin/core-frontend/measureArea-fix_2023-01-05-16-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Save the tool settings property before reinitialize the tool when a property change in the tool settings of the MeasureAreaByPointsTool",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/MeasureTool.ts
+++ b/core/frontend/src/tools/MeasureTool.ts
@@ -903,8 +903,8 @@ export class MeasureAreaByPointsTool extends PrimitiveTool {
       this._orientationValue = updatedValue.value;
       if (!this._orientationValue)
         return false;
-      await this.onReinitialize();
       IModelApp.toolAdmin.toolSettingsState.saveToolSettingProperty(this.toolId, { propertyName: MeasureAreaByPointsTool._orientationName, value: this._orientationValue });
+      await this.onReinitialize();
       return true;
     }
     return false;


### PR DESCRIPTION
Save the tool settings property before reinitialize the tool when a property change in the tool settings of the MeasureAreaByPointsTool

Modification suggest by Brien Bastings