### PR TITLE
Remove FAQ

### DIFF
--- a/docs/learning/faq.md
+++ b/docs/learning/faq.md
@@ -1,8 +1,0 @@
-# Frequently Asked Questions
-
-This document provides answers to some of the frequently asked questions about iTwin.js.
-If you have a question that is not covered here, you might find an answer on one of the iTwin.js [Community Resources](./CommunityResources.md).
-
-1. How are labels calculated in presentation-driven components like tree and property grid?
-
-    Presentation-driven components apply default BIS rules when creating content for these components. The rules include some label overrides whose behavior is described in detail [here](../presentation/Advanced/DefaultBisRules.md#label-overrides).

--- a/docs/learning/index.md
+++ b/docs/learning/index.md
@@ -72,4 +72,3 @@ Tutorials:
 See also:
 
 - [Glossary of terms used in iTwin.js](./Glossary)
-- [Frequently asked Questions](./faq)

--- a/docs/learning/leftNav.md
+++ b/docs/learning/leftNav.md
@@ -29,6 +29,5 @@
 - [Display system](./display/index.md)
 - [iModelHub](./iModelHub/index.md)
 - [Wire format](./WireFormat.md)
-- [Frequently asked questions](./faq.md)
 - [Guidelines and tips](./guidelines/index.md)
 - [Glossary](./Glossary.md)


### PR DESCRIPTION
It contained one lonely, probably-not-actually-very-frequently-asked question about presentation.
@grigasp agreed.

I want to more fundamentally reorganize this corner of the docs - grab bags of assorted "helpful links" are not all that helpful to users - but that's for a separate PR.