### PR TITLE
Put detailed message on a new line in toast

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-detailedMessageNewLine_2023-01-09-21-15.json
+++ b/common/changes/@itwin/appui-react/raplemie-detailedMessageNewLine_2023-01-09-21-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix detailed output message on a new line in toasts.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/messages/MessageManager.tsx
+++ b/ui/appui-react/src/appui-react/messages/MessageManager.tsx
@@ -256,7 +256,10 @@ export class MessageManager {
     const content = <>
       {message.briefMessage}
       {message.detailedMessage &&
-      <Small>{(message.detailedMessage as ReactMessage).reactNode || message.detailedMessage}</Small>
+      <>
+        <br/>
+        <Small>{(message.detailedMessage as ReactMessage).reactNode || message.detailedMessage}</Small>
+      </>
       }
     </>;
     switch (message.priority) {


### PR DESCRIPTION
Put back the detailed message on a new line in outputMessage toast messages.

Fixes https://github.com/iTwin/itwinjs-backlog/issues/604