### PR TITLE
allow docs ci build to publish artifacts on manual trigger

### DIFF
--- a/common/config/azure-pipelines/jobs/docs-ci.yaml
+++ b/common/config/azure-pipelines/jobs/docs-ci.yaml
@@ -27,4 +27,4 @@ jobs:
   parameters:
     workingDir: $(Pipeline.Workspace)/itwinjs-core
     outputDir: $(Agent.BuildDirectory)/tempDocsBuild/public_build
-    shouldPublish: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}
+    shouldPublish: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release')) }}

--- a/common/config/azure-pipelines/jobs/docs-ci.yaml
+++ b/common/config/azure-pipelines/jobs/docs-ci.yaml
@@ -27,4 +27,4 @@ jobs:
   parameters:
     workingDir: $(Pipeline.Workspace)/itwinjs-core
     outputDir: $(Agent.BuildDirectory)/tempDocsBuild/public_build
-    shouldPublish: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}
+    shouldPublish: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}


### PR DESCRIPTION
The ci build for docs relies upon a published artifact produced by the last run of the same build on master. However, we cannot select the last run _which produces an artifact_ (without using ADO's REST api) and so the build fails anytime the docs ci was run manually. This changes the build to produce artifacts any time it is run off master or release. 