### PR TITLE
hard code last docs build with published artifacts

### DIFF
--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -64,10 +64,19 @@ steps:
   - task: DownloadPipelineArtifact@2
     displayName: Download Pipeline Artifact - .updated.json
     inputs:
-      buildType: specific
-      project: 2c48216e-e72f-48b4-a4eb-40ff1c04e8e4
-      pipeline: 7436 # iTwin.js/Docs/iTwin.js Docs - YAML
-      buildVersionToDownload: latestFromBranch
-      branchName: refs/heads/master
-      artifactName: .updated.json
+      buildType: 'specific'
+      project: '2c48216e-e72f-48b4-a4eb-40ff1c04e8e4'
+      definition: '7436'
+      buildVersionToDownload: 'specific'
+      pipelineId: '1890016'
+      artifactName: '.updated.json'
       targetPath: ${{ parameters.stagingDir }}/config/
+
+
+      # restore after docs "build stalemate" is resolved
+
+      # pipeline: 7436 # iTwin.js/Docs/iTwin.js Docs - YAML
+      # buildVersionToDownload: latestFromBranch
+      # branchName: refs/heads/master
+      # artifactName: .updated.json
+


### PR DESCRIPTION
This is a quick-fix to get docs builds working again: Hard coding the last successful build with published artifacts so the next run off master will succeed. Following that, we can revert this change and rethink this workflow.