### PR TITLE
Fix tests that broke due to WAL mode

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2827,6 +2827,7 @@ export abstract class IModelDb extends IModel {
         key?: string;
     }, openMode: OpenMode, upgradeOptions?: UpgradeOptions, props?: SnapshotOpenOptions & CloudContainerArgs): IModelJsNative.DgnDb;
     get pathName(): LocalFileName;
+    performCheckpoint(): void;
     // @internal
     prepareSqliteStatement(sql: string, logErrors?: boolean): SqliteStatement;
     prepareStatement(sql: string, logErrors?: boolean): ECSqlStatement;

--- a/common/changes/@itwin/core-transformer/checkpoint-WAL_2023-01-11-12-29.json
+++ b/common/changes/@itwin/core-transformer/checkpoint-WAL_2023-01-11-12-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-transformer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-transformer"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -751,11 +751,11 @@ export abstract class IModelDb extends IModel {
 
   /**
    * Save all changes and perform a [checkpoint](https://www.sqlite.org/c3ref/wal_checkpoint_v2.html) on this IModelDb.
-   * This is only necessary to ensure that all changes to the database since it was opened are saved to the iModel's file
+   * This is necessary to ensure that all changes to the database since it was opened are saved to the iModel's file
    * (and the WAL file is truncated) so that it may be copied while it is open for write. iModel files should
    * rarely be copied, and even less so while they're opened. But this scenario is sometimes encountered for tests.
-   * Otherwise, this function should not be used.
-   * @note Checkpoint automatically happens when IModelDbs are closed.
+   * @note Checkpoint automatically happens when IModelDbs are closed. However, the checkpoint operation itself can take some time.
+   * It may sometimes be useful to call this method prior to closing so that the checkpoint "penalty" is paid first.
    */
   public performCheckpoint() {
     if (!this.isReadonly) {

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -751,11 +751,11 @@ export abstract class IModelDb extends IModel {
 
   /**
    * Save all changes and perform a [checkpoint](https://www.sqlite.org/c3ref/wal_checkpoint_v2.html) on this IModelDb.
-   * This is necessary to ensure that all changes to the database since it was opened are saved to the iModel's file
-   * (and the WAL file is truncated) so that it may be copied while it is open for write. iModel files should
+   * This ensures that all changes to the database since it was opened are saved to its file and the WAL file is truncated.
+   * @note Checkpoint automatically happens when IModelDbs are closed. However, the checkpoint
+   * operation itself can take some time. It may be useful to call this method prior to closing so that the checkpoint "penalty" is paid earlier.
+   * @note Another use for this function is to permit the file to be copied while it is open for write. iModel files should
    * rarely be copied, and even less so while they're opened. But this scenario is sometimes encountered for tests.
-   * @note Checkpoint automatically happens when IModelDbs are closed. However, the checkpoint operation itself can take some time.
-   * It may sometimes be useful to call this method prior to closing so that the checkpoint "penalty" is paid first.
    */
   public performCheckpoint() {
     if (!this.isReadonly) {

--- a/core/backend/src/LocalHub.ts
+++ b/core/backend/src/LocalHub.ts
@@ -113,9 +113,7 @@ export class LocalHub {
     if (!arg.version0) { // if they didn't supply a version0 file, create a blank one.
       IModelJsFs.recursiveMkDirSync(version0Root);
       IModelJsFs.removeSync(version0);
-      const blank = SnapshotDb.createEmpty(version0, { rootSubject: { name: arg.description ?? arg.iModelName } });
-      blank.saveChanges();
-      blank.close();
+      SnapshotDb.createEmpty(version0, { rootSubject: { name: arg.description ?? arg.iModelName } }).close();
     }
 
     const path = this.uploadCheckpoint({ changesetIndex: 0, localFile: version0 });

--- a/core/backend/src/test/standalone/ServerBasedLocks.test.ts
+++ b/core/backend/src/test/standalone/ServerBasedLocks.test.ts
@@ -27,6 +27,7 @@ describe("Server-based locks", () => {
     await ExtensiveTestScenario.prepareDb(sourceDb);
     ExtensiveTestScenario.populateDb(sourceDb);
     sourceDb.saveChanges();
+    sourceDb.close();
     return dbName;
   };
 

--- a/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -358,6 +358,7 @@ describe("IModelTransformerHub", () => {
     assert.equal(masterDb.iModelId, masterIModelId);
     assertPhysicalObjects(masterDb, state0);
     const changesetMasterState0 = masterDb.changeset.id;
+    masterDb.performCheckpoint();
 
     // create Branch1 iModel using Master as a template
     const branchIModelName1 = "Branch1";
@@ -598,6 +599,8 @@ describe("IModelTransformerHub", () => {
 
       // create target branch
       const targetIModelName = "ModelSelectorTarget";
+      sourceDb.performCheckpoint();
+
       targetIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: targetIModelName, noLocks: true, version0: sourceDb.pathName });
       assert.isTrue(Guid.isGuid(targetIModelId));
       const targetDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: targetIModelId });
@@ -721,7 +724,7 @@ describe("IModelTransformerHub", () => {
       const modelInChildSubjectId = PhysicalModel.insert(masterDb, childSubjectId, "model-in-child-subject");
       const childSubjectChildId = Subject.insert(masterDb, childSubjectId, "child-subject-child");
       const modelInChildSubjectChildId = PhysicalModel.insert(masterDb, childSubjectChildId, "model-in-child-subject-child");
-      masterDb.saveChanges();
+      masterDb.performCheckpoint();
       await masterDb.pushChanges({ accessToken, description: "setup master" });
 
       // create and initialize branch from master

--- a/core/transformer/src/test/standalone/IModelTransformerResumption.test.ts
+++ b/core/transformer/src/test/standalone/IModelTransformerResumption.test.ts
@@ -248,12 +248,12 @@ describe("test resuming transformations", () => {
     iTwinId = HubMock.iTwinId;
     accessToken = await HubWrappers.getAccessToken(BackendTestUtils.TestUserType.Regular);
     const seedPath = IModelTransformerTestUtils.prepareOutputFile("IModelTransformerResumption", "seed.bim");
-    SnapshotDb.createEmpty(seedPath, { rootSubject: { name: "resumption-tests-seed" } });
+    SnapshotDb.createEmpty(seedPath, { rootSubject: { name: "resumption-tests-seed" } }).close();
     seedDbId = await IModelHost.hubAccess.createNewIModel({ iTwinId, iModelName: "ResumeTestsSeed", description: "seed for resumption tests", version0: seedPath, noLocks: true });
     seedDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: seedDbId });
     await BackendTestUtils.ExtensiveTestScenario.prepareDb(seedDb);
     BackendTestUtils.ExtensiveTestScenario.populateDb(seedDb);
-    seedDb.saveChanges();
+    seedDb.performCheckpoint();
     await seedDb.pushChanges({ accessToken, description: "populated seed db" });
   });
 
@@ -656,7 +656,7 @@ describe("test resuming transformations", () => {
     const sourceDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: sourceDbId });
     await BackendTestUtils.ExtensiveTestScenario.prepareDb(sourceDb);
     BackendTestUtils.ExtensiveTestScenario.populateDb(sourceDb);
-    sourceDb.saveChanges();
+    sourceDb.performCheckpoint();
     await sourceDb.pushChanges({ accessToken, description: "populated source db" });
 
     const targetDbRev0Path = IModelTransformerTestUtils.prepareOutputFile("IModelTransformerResumption", "processChanges-targetDbRev0.bim");
@@ -664,7 +664,7 @@ describe("test resuming transformations", () => {
     const provenanceTransformer = new IModelTransformer(sourceDb, targetDbRev0, { wasSourceIModelCopiedToTarget: true });
     await provenanceTransformer.processAll();
     provenanceTransformer.dispose();
-    targetDbRev0.saveChanges();
+    targetDbRev0.performCheckpoint();
 
     BackendTestUtils.ExtensiveTestScenario.updateDb(sourceDb);
     sourceDb.saveChanges();
@@ -765,9 +765,11 @@ describe("test resuming transformations", () => {
   // TRANSFORMER_RESUMPTION_TEST_MAX_CRASHING_TRANSFORMATIONS (defaults to 200)
   it.skip("crashing transforms stats gauntlet", async () => {
     let crashableCallsMade = 0;
-    const { enableCrashes } = setupCrashingNativeAndTransformer({ onCrashableCallMade() {
-      ++crashableCallsMade;
-    } });
+    const { enableCrashes } = setupCrashingNativeAndTransformer({
+      onCrashableCallMade() {
+        ++crashableCallsMade;
+      },
+    });
 
     // TODO: don't run a new control test to compare with every crash test,
     // right now trying to run assertIdentityTransform against the control transform target dbs in the control loop yields

--- a/example-code/snippets/src/backend/IModelBranchingOperations.test.ts
+++ b/example-code/snippets/src/backend/IModelBranchingOperations.test.ts
@@ -177,8 +177,9 @@ describe("IModelBranchingOperations", () => {
 
   before(async () => {
     HubMock.startup("IModelBranchingOperations", KnownTestLocations.outputDir);
-    if (!fs.existsSync(version0Path))
-      SnapshotDb.createEmpty(version0Path, { rootSubject: { name: "branching-ops" } });
+    if (fs.existsSync(version0Path))
+      fs.unlinkSync(version0Path);
+    SnapshotDb.createEmpty(version0Path, { rootSubject: { name: "branching-ops" } }).close();
   });
 
   after(() => {


### PR DESCRIPTION
Tests that copy an IModel while it is opened for write must call `IModelDb.performCheckpoint`.