### PR TITLE
fix Mobile lifecycle events (frontend)

### DIFF
--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -211,10 +211,6 @@ export interface MobileNotifications {
     // (undocumented)
     notifyAuthAccessTokenChanged: (accessToken: string | undefined, expirationDate: string | undefined) => void;
     // (undocumented)
-    notifyEnterBackground: () => void;
-    // (undocumented)
-    notifyEnterForeground: () => void;
-    // (undocumented)
     notifyMemoryWarning: () => void;
     // (undocumented)
     notifyOrientationChanged: () => void;

--- a/common/changes/@itwin/core-mobile/mobile-lifecycle-forwarding_2023-01-20-16-14.json
+++ b/common/changes/@itwin/core-mobile/mobile-lifecycle-forwarding_2023-01-20-16-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "Fixed bug which prevented mobile lifecycle events from being received on frontend.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -182,12 +182,6 @@ export class MobileHost {
       this.onOrientationChanged.addListener(() => {
         MobileHost.notifyMobileFrontend("notifyOrientationChanged");
       });
-      this.onEnterForeground.addListener(() => {
-        MobileHost.notifyMobileFrontend("notifyEnterForeground");
-      });
-      this.onEnterBackground.addListener(() => {
-        MobileHost.notifyMobileFrontend("notifyEnterBackground");
-      });
       this.onWillTerminate.addListener(() => {
         MobileHost.notifyMobileFrontend("notifyWillTerminate");
       });

--- a/core/mobile/src/common/MobileAppProps.ts
+++ b/core/mobile/src/common/MobileAppProps.ts
@@ -28,8 +28,6 @@ export enum BatteryState {
 export interface MobileNotifications {
   notifyMemoryWarning: () => void;
   notifyOrientationChanged: () => void;
-  notifyEnterForeground: () => void;
-  notifyEnterBackground: () => void;
   notifyWillTerminate: () => void;
   notifyAuthAccessTokenChanged: (accessToken: string | undefined, expirationDate: string | undefined) => void;
 }


### PR DESCRIPTION
TS side of fix.
Mobile lifecycle events (suspend and resume) are now properly received on the frontend.

My initial approach (attempting to use the websocket) proved unreliable for suspend. Too much is happening in the app during the suspend/resume sequence to guarantee that the message will be transmitted before the socket goes away.

This approach directly calls the JS event handlers in the frontend webivew from platform-specific code.