### PR TITLE
Fix greenUp flag for GLTF normal maps

### DIFF
--- a/common/changes/@itwin/core-frontend/mn-gltf-greenup-fix_2023-01-20-21-39.json
+++ b/common/changes/@itwin/core-frontend/mn-gltf-greenup-fix_2023-01-20-21-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix greenUp flag for GLTF normal maps (set to true).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -2089,13 +2089,15 @@ export abstract class GltfReader {
 
     let nMap;
     if (normalMap) {
+      const greenUp = true;
       if (texture) {
         nMap = {
           normalMap,
+          greenUp,
         };
       } else {
         texture = normalMap;
-        nMap = {};
+        nMap = { greenUp };
       }
     }
 


### PR DESCRIPTION
GLTF 2.0 spec specifies that Y (green channel) is up for normal maps.