### PR TITLE
Fix Map Layers widget not updating after an iModel gets geolocated

### DIFF
--- a/common/changes/@itwin/map-layers/gytis-update-map-widget-state-dynamically_2023-01-25-11-52.json
+++ b/common/changes/@itwin/map-layers/gytis-update-map-widget-state-dynamically_2023-01-25-11-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers",
+      "comment": "Fix Map Layers widget not updating after an iModel gets geolocated.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers"
+}

--- a/extensions/map-layers/src/ui/widget/MapLayerManager.tsx
+++ b/extensions/map-layers/src/ui/widget/MapLayerManager.tsx
@@ -120,6 +120,11 @@ export function MapLayerManager(props: MapLayerManagerProps) {
     return false;
   });
 
+  React.useEffect(() => {
+    const updateBackgroundMapVisible = () => setBackgroundMapVisible(activeViewport.viewFlags.backgroundMap);
+    return activeViewport.onDisplayStyleChanged.addListener(updateBackgroundMapVisible);
+  }, [activeViewport]);
+
   // 'isMounted' is used to prevent any async operation once the hook has been
   // unloaded.  Otherwise we get a 'Can't perform a React state update on an unmounted component.' warning in the console.
   const isMounted = React.useRef(false);

--- a/extensions/map-layers/src/ui/widget/MapLayersWidget.tsx
+++ b/extensions/map-layers/src/ui/widget/MapLayersWidget.tsx
@@ -22,8 +22,14 @@ export function MapLayersWidget(props: MapLayersWidgetProps) {
   const [notGeoLocatedMsg] = React.useState(MapLayersUI.localization.getLocalizedString("mapLayers:Messages.NotSupported"));
   const activeViewport = useActiveViewport();
   const ref = React.useRef<HTMLDivElement>(null);
+  const [isGeoLocated, setIsGeoLocated] = React.useState(!!activeViewport?.iModel.isGeoLocated);
 
-  if (activeViewport && !!activeViewport?.iModel.isGeoLocated && activeViewport.view.isSpatialView())
+  React.useEffect(() => {
+    const updateIsGeoLocated = () => setIsGeoLocated(!!activeViewport?.iModel.isGeoLocated);
+    return activeViewport?.iModel.onEcefLocationChanged.addListener(updateIsGeoLocated);
+  }, [activeViewport?.iModel]);
+
+  if (activeViewport && isGeoLocated && activeViewport.view.isSpatialView())
     return (
       <div ref={ref} className="map-manager-layer-host">
         <MapLayerManager activeViewport={activeViewport} mapLayerOptions={props.mapLayerOptions} getContainerForClone={() => {


### PR DESCRIPTION
## Problem

Map Layers widget isn't updated after an iModel is geolocated or `backgroundMap` flag is changed. 

## Solution

Listen to certain events and update widget state when needed.

![PullChangesProgressExample](https://user-images.githubusercontent.com/98940208/214541782-a5c89952-0bb5-4b69-ac55-aff220086fbf.gif)
