### PR TITLE
Presentation: Fix filter to ECExpression conversion

### DIFF
--- a/common/changes/@itwin/presentation-components/presentation-filter_to_execpression_conversion_2023-01-25-12-49.json
+++ b/common/changes/@itwin/presentation-components/presentation-filter_to_execpression_conversion_2023-01-25-12-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-components",
+      "comment": "Fixed PresentationInstanceFilter to InstanceFilterDefinition coversion to use operator supported by ECExpressions",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-components"
+}

--- a/presentation/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
+++ b/presentation/components/src/presentation-components/instance-filter-builder/InstanceFilterConverter.ts
@@ -150,15 +150,15 @@ function getRuleOperatorString(operator: PropertyFilterRuleOperator) {
     case PropertyFilterRuleOperator.IsEqual:
       return "=";
     case PropertyFilterRuleOperator.IsFalse:
-      return "IS FALSE";
+      return "= FALSE";
     case PropertyFilterRuleOperator.IsNotEqual:
       return "<>";
     case PropertyFilterRuleOperator.IsNotNull:
-      return "IS NOT NULL";
+      return "<> NULL";
     case PropertyFilterRuleOperator.IsNull:
-      return "IS NULL";
+      return "= NULL";
     case PropertyFilterRuleOperator.IsTrue:
-      return "IS TRUE";
+      return "= TRUE";
     case PropertyFilterRuleOperator.Less:
       return "<";
     case PropertyFilterRuleOperator.LessOrEqual:

--- a/presentation/components/src/test/instance-filter-builder/InstanceFilterConverter.test.ts
+++ b/presentation/components/src/test/instance-filter-builder/InstanceFilterConverter.test.ts
@@ -33,7 +33,7 @@ describe("convertToInstanceFilterDefinition", () => {
           operator: PropertyFilterRuleOperator.IsNull,
         };
         const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
-        expect(expression).to.be.eq(`${propertyAccessor} IS NULL`);
+        expect(expression).to.be.eq(`${propertyAccessor} = NULL`);
       });
 
       it("'IsNotNull'", async () => {
@@ -42,7 +42,7 @@ describe("convertToInstanceFilterDefinition", () => {
           operator: PropertyFilterRuleOperator.IsNotNull,
         };
         const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
-        expect(expression).to.be.eq(`${propertyAccessor} IS NOT NULL`);
+        expect(expression).to.be.eq(`${propertyAccessor} <> NULL`);
       });
 
       it("'IsTrue'", async () => {
@@ -51,7 +51,7 @@ describe("convertToInstanceFilterDefinition", () => {
           operator: PropertyFilterRuleOperator.IsTrue,
         };
         const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
-        expect(expression).to.be.eq(`${propertyAccessor} IS TRUE`);
+        expect(expression).to.be.eq(`${propertyAccessor} = TRUE`);
       });
 
       it("'IsFalse'", async () => {
@@ -60,7 +60,7 @@ describe("convertToInstanceFilterDefinition", () => {
           operator: PropertyFilterRuleOperator.IsFalse,
         };
         const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
-        expect(expression).to.be.eq(`${propertyAccessor} IS FALSE`);
+        expect(expression).to.be.eq(`${propertyAccessor} = FALSE`);
       });
 
       it("'='", async () => {
@@ -204,7 +204,7 @@ describe("convertToInstanceFilterDefinition", () => {
         }],
       };
       const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
-      expect(expression).to.be.eq(`(${propertyAccessor} IS NULL AND ${propertyAccessor} IS NOT NULL)`);
+      expect(expression).to.be.eq(`(${propertyAccessor} = NULL AND ${propertyAccessor} <> NULL)`);
     });
 
     it("'OR' operator", async () => {
@@ -219,7 +219,7 @@ describe("convertToInstanceFilterDefinition", () => {
         }],
       };
       const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
-      expect(expression).to.be.eq(`(${propertyAccessor} IS NULL OR ${propertyAccessor} IS NOT NULL)`);
+      expect(expression).to.be.eq(`(${propertyAccessor} = NULL OR ${propertyAccessor} <> NULL)`);
     });
 
     it("nested condition group", async () => {
@@ -240,7 +240,7 @@ describe("convertToInstanceFilterDefinition", () => {
         }],
       };
       const { expression } = await convertToInstanceFilterDefinition(filter, testImodel);
-      expect(expression).to.be.eq(`(${propertyAccessor} IS NULL OR (${propertyAccessor} IS NULL AND ${propertyAccessor} IS NOT NULL))`);
+      expect(expression).to.be.eq(`(${propertyAccessor} = NULL OR (${propertyAccessor} = NULL AND ${propertyAccessor} <> NULL))`);
     });
 
     it("invalid operator", async () => {
@@ -303,7 +303,7 @@ describe("convertToInstanceFilterDefinition", () => {
         operator: PropertyFilterRuleOperator.IsNull,
       };
       const { expression, relatedInstances } = await convertToInstanceFilterDefinition(filter, testImodel);
-      expect(expression).to.be.eq(`${createAlias("C")}.${propertyInfo.name} IS NULL`);
+      expect(expression).to.be.eq(`${createAlias("C")}.${propertyInfo.name} = NULL`);
       expect(relatedInstances).to.be.lengthOf(1).and.containSubset([{
         pathFromSelectToPropertyClass: [{
           sourceClassName: classBInfo.name,
@@ -328,7 +328,7 @@ describe("convertToInstanceFilterDefinition", () => {
         }],
       };
       const { expression, relatedInstances } = await convertToInstanceFilterDefinition(filter, testImodel);
-      expect(expression).to.be.eq(`(${createAlias("C")}.${propertyInfo.name} IS NULL AND ${createAlias("C")}.${propertyInfo.name} IS NOT NULL)`);
+      expect(expression).to.be.eq(`(${createAlias("C")}.${propertyInfo.name} = NULL AND ${createAlias("C")}.${propertyInfo.name} <> NULL)`);
       expect(relatedInstances).to.be.lengthOf(1).and.containSubset([{
         pathFromSelectToPropertyClass: [{
           sourceClassName: classBInfo.name,
@@ -347,7 +347,7 @@ describe("convertToInstanceFilterDefinition", () => {
         operator: PropertyFilterRuleOperator.IsNull,
       };
       const { expression, relatedInstances } = await convertToInstanceFilterDefinition(filter, testImodel);
-      expect(expression).to.be.eq(`${createAlias("C")}.${propertyInfo.name} IS NULL`);
+      expect(expression).to.be.eq(`${createAlias("C")}.${propertyInfo.name} = NULL`);
       expect(relatedInstances).to.be.lengthOf(1).and.containSubset([{
         pathFromSelectToPropertyClass: [{
           sourceClassName: classAInfo.name,

--- a/presentation/components/src/test/tree/DataProvider.test.ts
+++ b/presentation/components/src/test/tree/DataProvider.test.ts
@@ -578,7 +578,7 @@ function is(expected: Paged<HierarchyRequestOptions<IModelConnection, NodeKey, R
 function applyInstanceFilter(node: PresentationTreeNodeItem, propName: string = "prop"): InstanceFilterDefinition {
   const property = createTestPropertyInfo({ name: propName });
   const field = createTestPropertiesContentField({ properties: [{ property }], name: property.name });
-  const instanceFilter = `this.${property.name} IS NULL`;
+  const instanceFilter = `this.${property.name} = NULL`;
   node.filtering = {
     descriptor: createTestContentDescriptor({ fields: [] }),
     active: {


### PR DESCRIPTION
Fixed coversion to not use `IS` operator as it is not supported by ECExpressions.

Closes https://github.com/iTwin/itwinjs-core/issues/4972