### PR TITLE
UI: Fix grip calc usage.

### DIFF
--- a/common/changes/@itwin/appui-layout-react/raplemie-gripWebpackFix_2023-01-25-22-19.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-gripWebpackFix_2023-01-25-22-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Fix Grip.scss webpack variables issue.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.scss
@@ -6,9 +6,9 @@
 @import "variables";
 
 $line-grip-translate: 1px;
-$full-bar-width: calc($nz-grip-width * 0.5);
-$handle-width: calc($nz-grip-width + 1px);
-$line-grip-width: calc($nz-grip-width - 2px);
+$full-bar-width: calc(#{$nz-grip-width} * 0.5);
+$handle-width: calc(#{$nz-grip-width} + 1px);
+$line-grip-width: calc(#{$nz-grip-width} - 2px);
 
 .nz-widgetPanels-grip {
   background-color: transparent;
@@ -83,7 +83,7 @@ $line-grip-width: calc($nz-grip-width - 2px);
     border-bottom-left-radius: 0;
   }
   .nz-right & {
-    transform: translateX(calc($line-grip-translate * -1));
+    transform: translateX(calc(#{$line-grip-translate} * -1));
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
@@ -93,7 +93,7 @@ $line-grip-width: calc($nz-grip-width - 2px);
     border-top-right-radius: 0;
   }
   .nz-bottom & {
-    transform: translateY(calc($line-grip-translate * -1));
+    transform: translateY(calc(#{$line-grip-translate} * -1));
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }


### PR DESCRIPTION
Sass variables were incorrectly used in css `calc` calls for webpack (requires use of `#{$variable}`)

fixes itwin/itwinjs-backlog#621