### PR TITLE
Fix tests of appui-layout-react when running in development environment

### DIFF
--- a/common/changes/@itwin/appui-layout-react/appui-layout-react-fix-tests-dev-env_2023-01-30-12-51.json
+++ b/common/changes/@itwin/appui-layout-react/appui-layout-react-fix-tests-dev-env_2023-01-30-12-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/target/useAllowedWidgetTarget.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/target/useAllowedWidgetTarget.tsx
@@ -24,6 +24,7 @@ export function useAllowedWidgetTarget(widgetId: WidgetState["id"]) {
   let allowedTarget: boolean = false;
   let side: PanelSide | undefined;
 
+  // istanbul ignore if
   if (!widgetLocation || isPopoutWidgetLocation(widgetLocation))  {
     allowedTarget = false;
     side = undefined;

--- a/ui/appui-layout-react/src/test/target/PanelTargets.test.tsx
+++ b/ui/appui-layout-react/src/test/target/PanelTargets.test.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { render } from "@testing-library/react";
-import { addPanelWidget, addTab, createNineZoneState, NineZoneState, PanelStateContext } from "../../appui-layout-react";
+import { addPanelWidget, addTab, createNineZoneState, NineZoneState, PanelSideContext, PanelStateContext } from "../../appui-layout-react";
 import { TargetOptionsContext } from "../../appui-layout-react/target/TargetOptions";
 import { PanelTargets } from "../../appui-layout-react/target/PanelTargets";
 import { TestNineZoneProvider } from "../Providers";
@@ -21,9 +21,11 @@ function Wrapper({ children, state }: React.PropsWithChildren<WrapperProps>) {
       version: "2",
     }}>
       <TestNineZoneProvider state={state}>
-        <PanelStateContext.Provider value={state.panels.left}>
-          {children}
-        </PanelStateContext.Provider>
+        <PanelSideContext.Provider value="left">
+          <PanelStateContext.Provider value={state.panels.left}>
+            {children}
+          </PanelStateContext.Provider>
+        </PanelSideContext.Provider>
       </TestNineZoneProvider>
     </TargetOptionsContext.Provider>
   );

--- a/ui/appui-layout-react/src/test/target/SectionTargets.test.tsx
+++ b/ui/appui-layout-react/src/test/target/SectionTargets.test.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { render } from "@testing-library/react";
-import { addPanelWidget, addTab, createNineZoneState, NineZoneState, PanelStateContext } from "../../appui-layout-react";
+import { addPanelWidget, addTab, createNineZoneState, NineZoneState, PanelSideContext, PanelStateContext } from "../../appui-layout-react";
 import { TargetOptionsContext } from "../../appui-layout-react/target/TargetOptions";
 import { TestNineZoneProvider } from "../Providers";
 import { SectionTargets } from "../../appui-layout-react/target/SectionTargets";
@@ -19,9 +19,11 @@ function Wrapper({ children, state }: React.PropsWithChildren<WrapperProps>) {
       version: "2",
     }}>
       <TestNineZoneProvider state={state}>
-        <PanelStateContext.Provider value={state.panels.left}>
-          {children}
-        </PanelStateContext.Provider>
+        <PanelSideContext.Provider value="left">
+          <PanelStateContext.Provider value={state.panels.left}>
+            {children}
+          </PanelStateContext.Provider>
+        </PanelSideContext.Provider>
       </TestNineZoneProvider>
     </TargetOptionsContext.Provider>
   );

--- a/ui/appui-layout-react/src/test/target/TabTarget.test.tsx
+++ b/ui/appui-layout-react/src/test/target/TabTarget.test.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { render } from "@testing-library/react";
-import { addPanelWidget, addTab, createNineZoneState, DraggedTabStateContext, DraggedWidgetIdContext, NineZoneState, WidgetState, WidgetStateContext } from "../../appui-layout-react";
+import { addPanelWidget, addTab, createNineZoneState, DraggedTabStateContext, DraggedWidgetIdContext, NineZoneState, WidgetIdContext, WidgetState, WidgetStateContext } from "../../appui-layout-react";
 import { TargetOptionsContext } from "../../appui-layout-react/target/TargetOptions";
 import { TestNineZoneProvider } from "../Providers";
 import { TabTarget } from "../../appui-layout-react/target/TabTarget";
@@ -23,9 +23,11 @@ function Wrapper({ children, state, widgetId }: React.PropsWithChildren<WrapperP
       version: "2",
     }}>
       <TestNineZoneProvider state={state}>
-        <WidgetStateContext.Provider value={state.widgets[widgetId]}>
-          {children}
-        </WidgetStateContext.Provider>
+        <WidgetIdContext.Provider value={widgetId}>
+          <WidgetStateContext.Provider value={state.widgets[widgetId]}>
+            {children}
+          </WidgetStateContext.Provider>
+        </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     </TargetOptionsContext.Provider>
   );

--- a/ui/appui-layout-react/src/test/target/TitleBarTarget.test.tsx
+++ b/ui/appui-layout-react/src/test/target/TitleBarTarget.test.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { render } from "@testing-library/react";
-import { addPanelWidget, addTab, createNineZoneState, NineZoneState, WidgetState, WidgetStateContext } from "../../appui-layout-react";
+import { addPanelWidget, addTab, createNineZoneState, NineZoneState, WidgetIdContext, WidgetState, WidgetStateContext } from "../../appui-layout-react";
 import { TargetOptionsContext } from "../../appui-layout-react/target/TargetOptions";
 import { TitleBarTarget } from "../../appui-layout-react/target/TitleBarTarget";
 import { TestNineZoneProvider } from "../Providers";
@@ -20,9 +20,11 @@ function Wrapper({ children, state, widgetId }: React.PropsWithChildren<WrapperP
       version: "2",
     }}>
       <TestNineZoneProvider state={state}>
-        <WidgetStateContext.Provider value={state.widgets[widgetId]}>
-          {children}
-        </WidgetStateContext.Provider>
+        <WidgetIdContext.Provider value={widgetId}>
+          <WidgetStateContext.Provider value={state.widgets[widgetId]}>
+            {children}
+          </WidgetStateContext.Provider>
+        </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     </TargetOptionsContext.Provider>
   );

--- a/ui/appui-layout-react/src/test/widget/MenuTab.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/MenuTab.test.tsx
@@ -46,7 +46,9 @@ describe("MenuTab", () => {
     state = addTab(state, "t1");
     state = addPanelWidget(state, "top", "w1", ["t1"]);
     const { container } = render(
-      <WidgetMenuTab />,
+      <WidgetOverflowContext.Provider value={{ close: sinon.spy() }}>
+        <WidgetMenuTab />
+      </WidgetOverflowContext.Provider>,
       {
         wrapper: (props) => <Wrapper // eslint-disable-line react/display-name
           state={state}
@@ -64,9 +66,11 @@ describe("MenuTab", () => {
     state = addTab(state, "t1", { iconSpec: <div>icon</div> });
     state = addPanelWidget(state, "top", "w1", ["t1"]);
     const { findByText } = render(
-      <ShowWidgetIconContext.Provider value={true}>
-        <WidgetMenuTab badge={<div>badge</div>} />
-      </ShowWidgetIconContext.Provider>,
+      <WidgetOverflowContext.Provider value={{ close: sinon.spy() }}>
+        <ShowWidgetIconContext.Provider value={true}>
+          <WidgetMenuTab badge={<div>badge</div>} />
+        </ShowWidgetIconContext.Provider>
+      </WidgetOverflowContext.Provider>,
       {
         wrapper: (props) => <Wrapper // eslint-disable-line react/display-name
           state={state}


### PR DESCRIPTION
This PR fixes tests that are failing when running in development environment.
Assertions are only failing when running in development environment. Since we do not run tests in development env by default a couple of tests were affected by missing context providers.