### PR TITLE
Enable WAL mode for all read-write `StandaloneDb`s

### DIFF
--- a/common/changes/@itwin/core-backend/core-wal-mode-for-standalone-imodels_2023-01-30-13-26.json
+++ b/common/changes/@itwin/core-backend/core-wal-mode-for-standalone-imodels_2023-01-30-13-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Enable WAL mode for read-write `StandaloneDb`s",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2715,6 +2715,7 @@ export class StandaloneDb extends BriefcaseDb {
   public static createEmpty(filePath: LocalFileName, args: CreateEmptyStandaloneIModelProps): StandaloneDb {
     const nativeDb = new IModelHost.platform.DgnDb();
     nativeDb.createIModel(filePath, args);
+    nativeDb.enableWalMode();
     nativeDb.saveLocalValue(BriefcaseLocalValue.StandaloneEdit, args.allowEdit);
     nativeDb.setITwinId(Guid.empty);
     nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
@@ -2747,6 +2748,8 @@ export class StandaloneDb extends BriefcaseDb {
     const nativeDb = this.openDgnDb(file, openMode, undefined, options);
 
     try {
+      if (openMode === OpenMode.ReadWrite)
+        nativeDb.enableWalMode();
       const iTwinId = nativeDb.getITwinId();
       if (iTwinId !== Guid.empty) // a "standalone" iModel means it is not associated with an iTwin
         throw new IModelError(IModelStatus.WrongIModel, `${filePath} is not a Standalone iModel. iTwinId=${iTwinId}`);

--- a/core/backend/src/test/changesets/ChangeMerging.test.ts
+++ b/core/backend/src/test/changesets/ChangeMerging.test.ts
@@ -43,6 +43,7 @@ describe("ChangeMerging", () => {
     IModelJsFs.copySync(seedFileName, testFileName);
     const upgradedDb = StandaloneDb.openFile(testFileName, OpenMode.ReadWrite);
     createChangeset(upgradedDb);
+    upgradedDb.performCheckpoint();
 
     // Open copies of the seed file.
     const firstFileName = IModelTestUtils.prepareOutputFile("ChangeMerging", "first.bim");


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/488.

This is an extension of the following PRs:
- https://github.com/iTwin/itwinjs-core/pull/4853
- https://github.com/iTwin/itwinjs-core/pull/4861
- https://github.com/iTwin/itwinjs-core/pull/4905

In some of our tests we use `StandaloneDb` where we concurrently read and write to it. Need the iModel to use WAL mode or otherwise we may get into a deadlock of:
- main thread holding connection's mutex and waiting for iModel to unlock for write
- worker thread holding a read transaction open and trying to acquire connection's mutex
