### PR TITLE
Undeprecate RpcPendingResponse and RpcNotFoundResponse

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -7754,7 +7754,7 @@ export class RpcControlChannel {
     static obtain(configuration: RpcConfiguration): RpcControlChannel;
 }
 
-// @public @deprecated
+// @public
 export abstract class RpcControlResponse {
     // (undocumented)
     message: string;
@@ -7903,7 +7903,7 @@ export class RpcMultipart {
     static writeValueToForm(form: FormDataCommon, value: RpcSerializedValue): void;
 }
 
-// @public @deprecated
+// @public
 export class RpcNotFoundResponse extends RpcControlResponse {
     // (undocumented)
     message: string;
@@ -7971,7 +7971,7 @@ export class RpcPendingQueue {
     static instance: RpcPendingQueue;
 }
 
-// @public @deprecated
+// @public
 export class RpcPendingResponse extends RpcControlResponse {
     constructor(message?: string);
     message: string;

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -646,7 +646,6 @@ public;RpcContentType
 deprecated;RpcContentType
 internal;RpcControlChannel
 public;class RpcControlResponse
-deprecated;class RpcControlResponse
 internal;RpcDefaultConfiguration 
 internal;RpcDirectProtocol 
 internal;RpcDirectRequest 
@@ -662,7 +661,6 @@ internal;RpcManager
 internal;RpcMarshaling
 internal;RpcMultipart
 public;RpcNotFoundResponse 
-deprecated;RpcNotFoundResponse 
 internal;RpcOpenAPIDescription
 internal;RpcOperation
 internal;RpcOperation
@@ -671,7 +669,6 @@ internal;RpcOperationPolicyProps = Partial
 internal;RpcOperationsProfile
 internal;RpcPendingQueue
 public;RpcPendingResponse 
-deprecated;RpcPendingResponse 
 internal;class RpcProtocol
 public;RpcProtocolEvent
 deprecated;RpcProtocolEvent

--- a/common/changes/@itwin/core-common/undeprecate-rpc-pending_2023-01-31-16-54.json
+++ b/common/changes/@itwin/core-common/undeprecate-rpc-pending_2023-01-31-16-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Undeprecate RpcPendingResponse and RpcNotFoundResponse\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-common/undeprecate-rpc-pending_2023-01-31-16-54.json
+++ b/common/changes/@itwin/core-common/undeprecate-rpc-pending_2023-01-31-16-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-common",
-      "comment": "Undeprecate RpcPendingResponse and RpcNotFoundResponse\"",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/core/common/src/rpc/core/RpcControl.ts
+++ b/core/common/src/rpc/core/RpcControl.ts
@@ -19,7 +19,6 @@ import { RpcRegistry } from "./RpcRegistry";
 
 /** An RPC operation control response.
  * @public
- * @deprecated in 3.6. The RPC system will be significantly refactored (or replaced) in version 5.0.
  */
 export abstract class RpcControlResponse {
   public message = "RpcControlResponse";
@@ -27,7 +26,6 @@ export abstract class RpcControlResponse {
 
 /** A pending RPC operation response.
  * @public
- * @deprecated in 3.6. The RPC system will be significantly refactored (or replaced) in version 5.0.
  */
 export class RpcPendingResponse extends RpcControlResponse {
   /** Extended status regarding the pending operation. */
@@ -42,7 +40,6 @@ export class RpcPendingResponse extends RpcControlResponse {
 
 /** A RPC operation response.
  * @public
- * @deprecated in 3.6. The RPC system will be significantly refactored (or replaced) in version 5.0.
  */
 export class RpcNotFoundResponse extends RpcControlResponse {
   public override message = "Not found";


### PR DESCRIPTION
These classes fall into the same category as RpcInterface and RpcManager for now (there is a common usage and we don't have anything to offer as a replacement at this point).

They should not have been deprecated in my initial PR (which evolved to only deprecated classes that should become internal going forward).