### PR TITLE
UI: Fix missing icon

### DIFF
--- a/common/changes/@itwin/appui-react/ui-fix-missing-icon_2023-02-09-08-27.json
+++ b/common/changes/@itwin/appui-react/ui-fix-missing-icon_2023-02-09-08-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `@itwin/itwinui-icons-react` dependency version",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/ui-fix-missing-icon_2023-02-09-08-27.json
+++ b/common/changes/@itwin/components-react/ui-fix-missing-icon_2023-02-09-08-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Update `@itwin/itwinui-icons-react` dependency to version `^1.15`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/presentation-components/ui-fix-missing-icon_2023-02-09-08-27.json
+++ b/common/changes/@itwin/presentation-components/ui-fix-missing-icon_2023-02-09-08-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-components",
+      "comment": "Update `@itwin/itwinui-icons-react` dependency to version `^1.15`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-components"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2446,7 +2446,7 @@ importers:
       '@itwin/eslint-plugin': workspace:*
       '@itwin/imodel-components-react': workspace:*
       '@itwin/itwinui-css': 0.x
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@itwin/presentation-common': workspace:*
       '@itwin/presentation-frontend': workspace:*
@@ -2770,7 +2770,7 @@ importers:
       '@itwin/eslint-plugin': workspace:*
       '@itwin/imodel-components-react': workspace:*
       '@itwin/itwinui-css': 0.x
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@itwin/presentation-common': workspace:*
       '@itwin/presentation-components': workspace:*
@@ -2866,7 +2866,7 @@ importers:
       '@itwin/imodels-client-authoring': ^2.2.1
       '@itwin/imodels-client-management': ^2.2.1
       '@itwin/itwinui-css': 0.x
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@itwin/map-layers': workspace:*
       '@itwin/map-layers-auth': workspace:*
@@ -3040,7 +3040,7 @@ importers:
       '@itwin/imodels-client-authoring': ^2.2.1
       '@itwin/imodels-client-management': ^2.2.1
       '@itwin/itwinui-css': 0.x
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@itwin/map-layers': workspace:*
       '@itwin/map-layers-auth': workspace:*
@@ -3726,7 +3726,7 @@ importers:
       '@itwin/core-react': workspace:*
       '@itwin/eslint-plugin': workspace:*
       '@itwin/itwinui-css': 0.x
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@itwin/presentation-common': workspace:*
       '@itwin/presentation-components': workspace:*
@@ -3812,7 +3812,7 @@ importers:
       '@itwin/imodels-client-authoring': ^2.2.1
       '@itwin/imodels-client-management': ^2.2.1
       '@itwin/itwinui-css': 0.x
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@itwin/map-layers': workspace:*
       '@itwin/map-layers-auth': workspace:*
@@ -4441,7 +4441,7 @@ importers:
       '@itwin/imodel-components-react': workspace:*
       '@itwin/itwinui-css': 0.x
       '@itwin/itwinui-icons': ^1.14.0
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@itwin/presentation-common': workspace:*
       '@itwin/presentation-components': workspace:*
@@ -4591,7 +4591,7 @@ importers:
       '@itwin/core-react': workspace:*
       '@itwin/eslint-plugin': workspace:*
       '@itwin/itwinui-css': 0.x
-      '@itwin/itwinui-icons-react': ^1.8.0
+      '@itwin/itwinui-icons-react': ^1.15.0
       '@itwin/itwinui-react': ~1.46.0
       '@testing-library/dom': ^8.11.2
       '@testing-library/react': ^12.0.0

--- a/presentation/components/package.json
+++ b/presentation/components/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@itwin/itwinui-css": "0.x",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/itwinui-react": "~1.46.0",
     "classnames": "^2.3.1",
     "fast-deep-equal": "^3.1.3",

--- a/test-apps/appui-test-app/appui-test-providers/package.json
+++ b/test-apps/appui-test-app/appui-test-providers/package.json
@@ -55,7 +55,7 @@
     "@itwin/presentation-components": "workspace:*",
     "@itwin/imodel-components-react": "workspace:*",
     "@itwin/itwinui-react": "~1.46.0",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/itwinui-css": "0.x",
     "classnames": "^2.3.1",
     "react": "^17.0.0",

--- a/test-apps/appui-test-app/connected/package.json
+++ b/test-apps/appui-test-app/connected/package.json
@@ -108,7 +108,7 @@
     "@itwin/imodels-client-management": "^2.2.1",
     "@itwin/itwinui-react": "~1.46.0",
     "@itwin/itwinui-css": "0.x",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/map-layers": "workspace:*",
     "@itwin/map-layers-auth": "workspace:*",
     "@itwin/map-layers-formats": "workspace:*",

--- a/test-apps/appui-test-app/standalone/package.json
+++ b/test-apps/appui-test-app/standalone/package.json
@@ -108,7 +108,7 @@
     "@itwin/imodels-client-management": "^2.2.1",
     "@itwin/itwinui-react": "~1.46.0",
     "@itwin/itwinui-css": "0.x",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/map-layers": "workspace:*",
     "@itwin/map-layers-auth": "workspace:*",
     "@itwin/map-layers-formats": "workspace:*",

--- a/test-apps/ui-items-providers-test/package.json
+++ b/test-apps/ui-items-providers-test/package.json
@@ -51,7 +51,7 @@
     "@itwin/presentation-frontend": "workspace:*",
     "@itwin/presentation-components": "workspace:*",
     "@itwin/itwinui-react": "~1.46.0",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/itwinui-css": "0.x",
     "classnames": "^2.3.1",
     "react": "^17.0.0",

--- a/test-apps/ui-test-app/package.json
+++ b/test-apps/ui-test-app/package.json
@@ -107,7 +107,7 @@
     "@itwin/imodels-client-management": "^2.2.1",
     "@itwin/itwinui-react": "~1.46.0",
     "@itwin/itwinui-css": "0.x",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/map-layers": "workspace:*",
     "@itwin/map-layers-auth": "workspace:*",
     "@itwin/map-layers-formats": "workspace:*",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -138,7 +138,7 @@
     "@itwin/presentation-components": "workspace:*",
     "@itwin/itwinui-css": "0.x",
     "@itwin/itwinui-react": "~1.46.0",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/itwinui-icons": "^1.14.0",
     "classnames": "^2.3.1",
     "immer": "9.0.6",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -117,7 +117,7 @@
   "dependencies": {
     "@bentley/icons-generic-webfont": "^1.0.15",
     "@itwin/itwinui-css": "0.x",
-    "@itwin/itwinui-icons-react": "^1.8.0",
+    "@itwin/itwinui-icons-react": "^1.15.0",
     "@itwin/itwinui-react": "~1.46.0",
     "@types/shortid": "~0.0.29",
     "callable-instance2": "1.0.0",


### PR DESCRIPTION
`ToolAssistanceField` in `appui-react` uses `SvgPinHollow` that was only added to `@itwin/itwinui-icons-react` in version `1.15.0`: https://github.com/iTwin/iTwinUI-icons/pull/46. Update the dependency version.