### PR TITLE
core-frontend API promotions for presentation

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -4314,7 +4314,6 @@ export interface Hilites {
 
 // @public
 export class HiliteSet {
-    // @internal
     constructor(iModel: IModelConnection, syncWithSelectionSet?: boolean);
     clear(): void;
     get elements(): Id64.Uint32Set;
@@ -7239,9 +7238,8 @@ export interface NativeAppOpts extends IpcAppOptions {
     nativeApp?: {};
 }
 
-// @internal
+// @public
 export class NoRenderApp {
-    // (undocumented)
     static startup(opts?: IModelAppOptions): Promise<void>;
 }
 

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -417,7 +417,7 @@ internal;MutableChangeFlags
 public;NativeApp
 internal;NativeAppLogger
 public;NativeAppOpts 
-internal;NoRenderApp
+public;NoRenderApp
 public;class NotificationHandler
 public;NotificationManager 
 public;NotifyMessageDetails

--- a/common/changes/@itwin/core-frontend/pmc-promotions-for-presentation_2023-02-10-12-55.json
+++ b/common/changes/@itwin/core-frontend/pmc-promotions-for-presentation_2023-02-10-12-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Promote HiliteSet constructor and NoRenderApp to public.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/NoRenderApp.ts
+++ b/core/frontend/src/NoRenderApp.ts
@@ -2,6 +2,10 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module IModelApp
+ */
+
 import { EmptyLocalization } from "@itwin/core-common";
 import { IModelApp, IModelAppOptions } from "./IModelApp";
 import { AnimationBranchStates } from "./render/GraphicBranch";

--- a/core/frontend/src/NoRenderApp.ts
+++ b/core/frontend/src/NoRenderApp.ts
@@ -60,12 +60,16 @@ export class NullRenderSystem extends RenderSystem {
   public override createRenderGraphic() { return undefined; }
 }
 
-/**
- * A class for applications that must run in environments where WebGL is not present.
- * This is typically used in tests.
- * @internal
+/** A utility class intended for applications (primarily test-runners) that run in environments that lack support for WebGL.
+ * It installs a [[RenderSystem]] that produces no graphics.
+ * Use [[NoRenderApp.startup]] instead of [[IModelApp.startup]] to initialize your application frontend.
+ * You may then use the [[IModelApp]] API as normal.
+ * @public
  */
 export class NoRenderApp {
+  /** Initializes [[IModelApp]] with a [[RenderSystem]] that produces no graphics.
+   * Use this in place of [[IModelApp.startup]], then proceed to use [[IModelApp]]'s API as normal.
+   */
   public static async startup(opts?: IModelAppOptions): Promise<void> {
     opts = opts ? opts : {};
     opts.renderSys = new NullRenderSystem();

--- a/core/frontend/src/SelectionSet.ts
+++ b/core/frontend/src/SelectionSet.ts
@@ -235,7 +235,6 @@ export class HiliteSet {
   /** Construct a HiliteSet
    * @param iModel The iModel containing the entities to be hilited.
    * @param syncWithSelectionSet If true, the contents of the `elements` set will be synchronized with those in the `iModel`'s [[SelectionSet]].
-   * @internal
    */
   public constructor(public iModel: IModelConnection, syncWithSelectionSet = true) {
     this._elements = new HilitedElementIds(iModel, syncWithSelectionSet);


### PR DESCRIPTION
To address [usage of `internal` APIs](https://github.com/iTwin/presentation/pull/60#issuecomment-1425265546) in presentation packages.