### PR TITLE
Fix `betools docs` to find correct relative path from root to package source

### DIFF
--- a/common/changes/@itwin/build-tools/fix_add_source_dir_script_2023-02-14-13-42.json
+++ b/common/changes/@itwin/build-tools/fix_add_source_dir_script_2023-02-14-13-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Fixed 'betools docs' script to set 'packageRoot' to correct relative path from root to package source.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/scripts/utils/addSourceDir.js
+++ b/tools/build/scripts/utils/addSourceDir.js
@@ -17,15 +17,15 @@ if (process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER) {
   rootPackageJsonPath = path.resolve("../../../../package.json");
 }
 
-const rootPackageJson = require(rootPackageJsonPath);
+// Check if path to root package.json is valid.
+require(rootPackageJsonPath);
 
 // Appends the directory of the package root to the Typedoc JSON output
 function addSourceDir(file, directory) {
   if (FS.existsSync(file) && FS.statSync(file).isFile()) {
     const contents = FS.readFileSync(file, "utf-8");
-    const packageRoot = directory.substring(
-      directory.indexOf(rootPackageJson.name) + rootPackageJson.name.length + 1
-    );
+    const pathToRootFolder = path.dirname(rootPackageJsonPath);
+    const packageRoot = directory.substring(pathToRootFolder.length + 1);
     const jsonContents = JSON.parse(contents);
     jsonContents["packageRoot"] = packageRoot.endsWith("src")
       ? packageRoot

--- a/tools/build/scripts/utils/addSourceDir.js
+++ b/tools/build/scripts/utils/addSourceDir.js
@@ -8,17 +8,12 @@ const path = require("path");
 
 // We cannot guarantee the folder structure of a project
 // so find the project root using rush env variable if available.
-if (process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER) {
-  rootPackageJsonPath = path.resolve(
-    process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER,
-    "package.json"
-  );
-} else {
-  rootPackageJsonPath = path.resolve("../../../../package.json");
-}
+const rootPackageJson = process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER
+  ? path.join(process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER, "package.json")
+  : "../../../../package.json"
 
 // Check if path to root package.json is valid.
-require(rootPackageJsonPath);
+const rootPackageJsonPath = require.resolve(rootPackageJson);
 
 // Appends the directory of the package root to the Typedoc JSON output
 function addSourceDir(file, directory) {


### PR DESCRIPTION
Previous implementation to find relative path from root to package source folder was very sensitive to folder layout. It was depending on that root folder name matches `name` value in root package.json file and that path up to root folder does not contain it.

Before changes `packageRoot` was resolved to:
`D:\itwinjs-core\itwin-1\itwinjs-core\core\backend\src` -> `itwin-1\itwinjs-core\core\backend\src`

After changes it is resolved correctly:
`D:\itwinjs-core\itwin-1\itwinjs-core\core\backend\src` -> `core\backend\src`