### PR TITLE
UI: Fix React BriefMessage breaking toast display.

### DIFF
--- a/ui/appui-react/src/appui-react/messages/MessageManager.tsx
+++ b/ui/appui-react/src/appui-react/messages/MessageManager.tsx
@@ -253,12 +253,9 @@ export class MessageManager {
     };
     toaster.setSettings({ placement: "bottom", order: "ascending", ...settings });
     const content = <>
-      {message.briefMessage}
+      {(message.briefMessage as ReactMessage).reactNode || message.briefMessage}
       {message.detailedMessage &&
-      <>
-        <br/>
-        <Small>{(message.detailedMessage as ReactMessage).reactNode || message.detailedMessage}</Small>
-      </>
+        <Small style={{display: "block"}}>{(message.detailedMessage as ReactMessage).reactNode || message.detailedMessage}</Small>
       }
     </>;
     switch (message.priority) {


### PR DESCRIPTION
This validates that if a reactNode is present, it should be used as the `briefMessage` rather than being put directly in the output (which was throwing an error)

Also changed the additional `<br/>` that was added in #4895 for a solution closer to the previous behavior (`display: "block"` instead of a new line, as this have a bigger impact when the briefMessage is a react node.

Fixes #5081 