### PR TITLE
Promote terrain provider-related APIs to public

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2946,18 +2946,18 @@ export class ElementState extends EntityState implements ElementProps {
     readonly userLabel?: string;
 }
 
-// @internal
+// @public
 export class EllipsoidTerrainProvider extends TerrainMeshProvider {
     constructor(opts: TerrainMeshProviderOptions);
-    // (undocumented)
+    // @internal
     getChildHeightRange(_quadId: QuadId, _rectangle: MapCartoRectangle, _parent: MapTile): Range1d | undefined;
-    // (undocumented)
+    // @internal
     get maxDepth(): number;
-    // (undocumented)
+    // @internal
     readMesh(args: ReadMeshArgs): Promise<RealityMeshParams | undefined>;
-    // (undocumented)
+    // @internal
     requestMeshData(): Promise<TileRequest.Response>;
-    // (undocumented)
+    // @internal
     get tilingScheme(): MapTilingScheme;
 }
 
@@ -4800,7 +4800,6 @@ export class IModelApp {
     static readonly telemetry: TelemetryManager;
     // @internal (undocumented)
     static get tentativePoint(): TentativePoint;
-    // @beta
     static get terrainProviderRegistry(): TerrainProviderRegistry;
     static get tileAdmin(): TileAdmin;
     static get toolAdmin(): ToolAdmin;
@@ -5669,7 +5668,7 @@ export class MapBoxLayerImageryProvider extends MapLayerImageryProvider {
     get tileWidth(): number;
 }
 
-// @beta
+// @public
 export class MapCartoRectangle extends Range2d {
     protected constructor(west: number, south: number, east: number, north: number);
     get cartoCenter(): Cartographic;
@@ -6052,7 +6051,7 @@ export interface MapSubLayerFeatureInfo {
     subLayerName: string;
 }
 
-// @beta
+// @public
 export class MapTile extends RealityTile {
     // @internal
     constructor(params: RealityTileParams, mapTree: MapTileTree, quadId: QuadId, patch: TilePatch, rectangle: MapCartoRectangle, heightRange: Range1d | undefined, cornerRays: Ray3d[] | undefined);
@@ -6224,7 +6223,7 @@ export class MapTileLoader extends RealityTileLoader {
     get terrainProvider(): TerrainMeshProvider;
 }
 
-// @beta
+// @public
 export abstract class MapTileProjection {
     // @alpha (undocumented)
     get ellipsoidPatch(): EllipsoidPatch | undefined;
@@ -6236,7 +6235,7 @@ export abstract class MapTileProjection {
     abstract get transformFromLocal(): Transform;
 }
 
-// @beta
+// @public
 export class MapTileTree extends RealityTileTree {
     // @internal
     constructor(params: RealityTileTreeParams, ecefToDb: Transform, bimElevationBias: number, geodeticOffset: number, sourceTilingScheme: MapTilingScheme, id: MapTreeId, applyTerrain: boolean);
@@ -6405,7 +6404,7 @@ export enum MapTileTreeScaleRangeVisibility {
     Visible = 1
 }
 
-// @beta
+// @public
 export abstract class MapTilingScheme {
     protected constructor(numberOfLevelZeroTilesX: number, numberOfLevelZeroTilesY: number, rowZeroAtNorthPole: boolean);
     cartographicToFraction(latitudeRadians: number, longitudeRadians: number, result: Point2d): Point2d;
@@ -7973,7 +7972,7 @@ export interface PullChangesOptions {
     progressInterval?: number;
 }
 
-// @beta
+// @public
 export class QuadId {
     constructor(level: number, column: number, row: number);
     bordersNorthPole(mapTilingScheme: MapTilingScheme): boolean;
@@ -8154,7 +8153,7 @@ export interface ReadImageBufferArgs {
     upsideDown?: boolean;
 }
 
-// @beta
+// @public
 export interface ReadMeshArgs {
     data: any;
     isCanceled(): boolean;
@@ -8253,7 +8252,7 @@ export interface RealityMeshGraphicParams {
     readonly tileRectangle: MapCartoRectangle;
 }
 
-// @beta
+// @public
 export interface RealityMeshParams {
     // @alpha
     featureID?: number;
@@ -8265,7 +8264,7 @@ export interface RealityMeshParams {
     uvs: QPoint2dBuffer;
 }
 
-// @beta (undocumented)
+// @public (undocumented)
 export namespace RealityMeshParams {
     // @internal (undocumented)
     export function fromGltfMesh(mesh: GltfMeshData): RealityMeshParams | undefined;
@@ -8411,7 +8410,7 @@ export class RealityModelTileUtils {
     static transformFromJson(jTrans: number[] | undefined): Transform;
 }
 
-// @beta
+// @public
 export class RealityTile extends Tile {
     // @internal
     constructor(props: RealityTileParams, tree: RealityTileTree);
@@ -8634,7 +8633,7 @@ export class RealityTileRegion {
     minLongitude: number;
 }
 
-// @beta
+// @public
 export class RealityTileTree extends TileTree {
     // @internal
     constructor(params: RealityTileTreeParams);
@@ -9382,7 +9381,7 @@ export abstract class RenderTextureDrape implements IDisposable {
     abstract dispose(): void;
 }
 
-// @beta
+// @public
 export interface RequestMeshDataArgs {
     isCanceled(): boolean;
     tile: MapTile;
@@ -10772,7 +10771,7 @@ export class TerrainDisplayOverrides {
     wantSkirts?: boolean;
 }
 
-// @beta
+// @public
 export abstract class TerrainMeshProvider {
     addLogoCards(_cards: HTMLTableElement, _vp: ScreenViewport): void;
     forceTileLoad(_tile: MapTile): boolean;
@@ -10784,19 +10783,19 @@ export abstract class TerrainMeshProvider {
     abstract get tilingScheme(): MapTilingScheme;
 }
 
-// @beta
+// @public
 export interface TerrainMeshProviderOptions {
     exaggeration: number;
     wantNormals: boolean;
     wantSkirts: boolean;
 }
 
-// @beta
+// @public
 export interface TerrainProvider {
     createTerrainMeshProvider(options: TerrainMeshProviderOptions): Promise<TerrainMeshProvider | undefined>;
 }
 
-// @beta
+// @public
 export class TerrainProviderRegistry {
     // @internal
     constructor();

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -154,7 +154,7 @@ public;ElementLocateManager
 public;ElementPicker
 alpha;class ElementSetTool 
 public;ElementState 
-internal;EllipsoidTerrainProvider 
+public;EllipsoidTerrainProvider 
 public;EmphasizeElements 
 beta;EngineeringLengthDescription 
 public;EntityState 
@@ -349,7 +349,7 @@ internal;LRUTileList
 internal;LRUTileListNode
 public;ManipulatorToolEvent
 internal;MapBoxLayerImageryProvider 
-beta;MapCartoRectangle 
+public;MapCartoRectangle 
 alpha;MapFeatureInfo
 alpha;MapFeatureInfoRecord 
 beta;MapLayerAccessClient
@@ -374,14 +374,14 @@ public;MapLayerSourceValidation
 internal;class MapLayerTileTreeReference 
 beta;MapLayerTokenEndpoint
 alpha;MapSubLayerFeatureInfo
-beta;MapTile 
+public;MapTile 
 internal;MapTiledGraphicsProvider 
 internal;MapTileLoader 
-beta;class MapTileProjection
-beta;MapTileTree 
+public;class MapTileProjection
+public;MapTileTree 
 internal;MapTileTreeReference 
 beta;MapTileTreeScaleRangeVisibility
-beta;class MapTilingScheme
+public;class MapTilingScheme
 public;MarginOptions
 public;MarginPercent
 public;Marker 
@@ -474,7 +474,7 @@ public;class PrimitiveTool
 internal;PrimitiveVisibility
 alpha;PublisherProductInfo
 public;PullChangesOptions
-beta;QuadId
+public;QuadId
 public;QuantityFormatOverridesChangedArgs
 public;QuantityFormatsChangedArgs
 public;QuantityFormatter 
@@ -493,7 +493,7 @@ public;readElementGraphics(bytes: Uint8Array, iModel: IModelConnection, modelId:
 public;readGltfGraphics(args: ReadGltfGraphicsArgs): Promise
 public;ReadGltfGraphicsArgs
 public;ReadImageBufferArgs
-beta;ReadMeshArgs
+public;ReadMeshArgs
 internal;ReadonlyTileUserSet 
 internal;readPointCloudTileContent(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, _is3d: boolean, range: ElementAlignedBox3d, system: RenderSystem): Promise
 alpha;RealityDataError 
@@ -507,8 +507,8 @@ alpha;fromKey(key: RealityDataSourceKey, iTwinId: GuidString | undefined): Promi
 alpha;RealityDataSourceProvider
 alpha;RealityDataSourceProviderRegistry
 internal;RealityMeshGraphicParams
-beta;RealityMeshParams
-beta;RealityMeshParams
+public;RealityMeshParams
+public;RealityMeshParams
 internal;fromGltfMesh(mesh: GltfMeshData): RealityMeshParams | undefined
 alpha;toPolyface(params: RealityMeshParams, options?:
 beta;RealityMeshParamsBuilder
@@ -517,14 +517,14 @@ internal;RealityModelSource = ViewState | DisplayStyleState
 internal;RealityModelTileTree 
 internal;RealityModelTileTree
 internal;RealityModelTileUtils
-beta;RealityTile 
+public;RealityTile 
 internal;RealityTileContent 
 internal;RealityTileDrawArgs 
 alpha;RealityTileGeometry
 internal;class RealityTileLoader
 internal;RealityTileParams 
 internal;RealityTileRegion
-beta;RealityTileTree 
+public;RealityTileTree 
 internal;RealityTileTreeParams 
 internal;RealityTreeReference 
 alpha;RemoteExtensionProvider 
@@ -551,7 +551,7 @@ internal;class RenderTarget
 internal;RenderTargetDebugControl
 internal;class RenderTerrainGeometry 
 internal;class RenderTextureDrape 
-beta;RequestMeshDataArgs
+public;RequestMeshDataArgs
 internal;RequestTileTreePropsFunc = (iModel: IModelConnection, treeId: string) => Promise
 alpha;ResolveFunc = () => Promise
 alpha;ResolveManifestFunc = () => Promise
@@ -620,10 +620,10 @@ internal;class Target
 internal;TentativeOrAccuSnap
 public;TentativePoint
 internal;TerrainDisplayOverrides
-beta;class TerrainMeshProvider
-beta;TerrainMeshProviderOptions
-beta;TerrainProvider
-beta;TerrainProviderRegistry
+public;class TerrainMeshProvider
+public;TerrainMeshProviderOptions
+public;TerrainProvider
+public;TerrainProviderRegistry
 internal;TerrainTexture
 internal;TerrainTileContent 
 public;TextInputFormatPropEditorSpec 

--- a/common/changes/@itwin/core-frontend/pmc-ellipsoid-terrain-meshes_2023-02-16-20-56.json
+++ b/common/changes/@itwin/core-frontend/pmc-ellipsoid-terrain-meshes_2023-02-16-20-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Promote terrain-related APIs to public.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -229,9 +229,7 @@ export class IModelApp {
    * @internal
    */
   public static get mapLayerFormatRegistry(): MapLayerFormatRegistry { return this._mapLayerFormatRegistry; }
-  /** The [[TerrainProviderRegistry]] for this session.
-   * @beta
-   */
+  /** The [[TerrainProviderRegistry]] for this session. */
   public static get terrainProviderRegistry(): TerrainProviderRegistry { return this._terrainProviderRegistry; }
   /** The [[RealityDataSourceProviderRegistry]] for this session.
    * @alpha

--- a/core/frontend/src/render/RealityMeshParams.ts
+++ b/core/frontend/src/render/RealityMeshParams.ts
@@ -31,7 +31,7 @@ function precondition(condition: boolean, message: string | (() => string)): ass
  * include [[TerrainMeshProvider]]s to which background map imagery is applied, and [ContextRealityModel]($common)s captured using
  * [photogrammetry](https://en.wikipedia.org/wiki/Photogrammetry).
  * @see [[RealityMeshParamsBuilder]] to incrementally construct a `RealityMeshParams`.
- * @beta
+ * @public
  */
 export interface RealityMeshParams {
   /** The 3d position of each vertex in the mesh, indexed by [[indices]]. */
@@ -48,7 +48,7 @@ export interface RealityMeshParams {
   texture?: RenderTexture;
 }
 
-/** @beta */
+/** @public */
 export namespace RealityMeshParams {
   /** @internal */
   export function fromGltfMesh(mesh: GltfMeshData): RealityMeshParams | undefined {

--- a/core/frontend/src/tile/RealityTile.ts
+++ b/core/frontend/src/tile/RealityTile.ts
@@ -50,7 +50,7 @@ const additiveRefinementDepthLimit = 20;
 const scratchFrustum = new Frustum();
 
 /** A [[Tile]] within a [[RealityTileTree]], representing part of a reality model (e.g., a point cloud or photogrammetry mesh) or 3d terrain with map imagery.
- * @beta
+ * @public
  */
 export class RealityTile extends Tile {
   /** @internal */

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -133,7 +133,7 @@ export interface RealityTileTreeParams extends TileTreeParams {
 
 /** Base class for a [[TileTree]] representing a reality model (e.g., a point cloud or photogrammetry mesh) or 3d terrain with map imagery.
  * The tiles within the tree are instances of [[RealityTile]]s.
- * @beta
+ * @public
  */
 export class RealityTileTree extends TileTree {
   /** @internal */

--- a/core/frontend/src/tile/map/EllipsoidTerrainProvider.ts
+++ b/core/frontend/src/tile/map/EllipsoidTerrainProvider.ts
@@ -18,24 +18,36 @@ const scratchPoint = Point3d.createZero();
 const scratchEllipsoid = Ellipsoid.create(Transform.createIdentity());
 const scratchZeroRange = Range1d.createXX(0, 0);
 
-/** Terrain provider that produces geometry that represents a smooth ellipsoid without any height perturbations.
+/** A terrain mesh provider that produces geometry that represents a smooth ellipsoid without any height perturbations.
  * The area within the project extents are represented as planar tiles and other tiles are facetted approximations
  * of the WGS84 ellipsoid.
- * @see [[TerrainMeshProvider]]
- * @internal
+ * This is the terrain provider used when the background map is enabled but 3d terrain is disabled.
+ * @public
  */
 export class EllipsoidTerrainProvider extends TerrainMeshProvider {
   private _tilingScheme = new WebMercatorTilingScheme();
   private readonly _wantSkirts: boolean;
 
+  /** Construct a new terrain provider.
+   * @note [[TerrainMeshProviderOptions.wantNormals]] is ignored - no normals are produced.
+   */
   public constructor(opts: TerrainMeshProviderOptions) {
     super();
     this._wantSkirts = opts.wantSkirts;
   }
 
+  /** @internal override */
   public get maxDepth(): number { return 22; }
-  public override getChildHeightRange(_quadId: QuadId, _rectangle: MapCartoRectangle, _parent: MapTile): Range1d | undefined { return scratchZeroRange; }
-  public get tilingScheme(): MapTilingScheme { return this._tilingScheme; }
+
+  /** @internal override */
+  public override getChildHeightRange(_quadId: QuadId, _rectangle: MapCartoRectangle, _parent: MapTile): Range1d | undefined {
+    return scratchZeroRange;
+  }
+
+  /** @internal override */
+  public override get tilingScheme(): MapTilingScheme {
+    return this._tilingScheme;
+  }
 
   private createSkirtlessPlanarMesh(tile: MapTile): RealityMeshParams {
     const projection = tile.getProjection();
@@ -94,6 +106,7 @@ export class EllipsoidTerrainProvider extends TerrainMeshProvider {
     return builder.finish();
   }
 
+  /** @internal override */
   public override async readMesh(args: ReadMeshArgs): Promise<RealityMeshParams | undefined> {
     const tile = args.tile;
     if (tile.isPlanar)
@@ -174,6 +187,7 @@ export class EllipsoidTerrainProvider extends TerrainMeshProvider {
     return builder.finish();
   }
 
+  /** @internal override */
   public override async requestMeshData(): Promise<TileRequest.Response> {
     return "";
   }

--- a/core/frontend/src/tile/map/MapCartoRectangle.ts
+++ b/core/frontend/src/tile/map/MapCartoRectangle.ts
@@ -20,7 +20,7 @@ const scratchPoint2d = Point2d.createZero();
  * The `y` components of the `low` and `high` points refer to the southern and northern latitudes, respectively.
  * Longitudes are stored in radians in the range [-pi, pi].
  * Latitudes are stored in radians in the range [-pi/2, pi/2].
- * @beta
+ * @public
  */
 export class MapCartoRectangle extends Range2d {
   /** Construct a new rectangle with angles specified in radians.

--- a/core/frontend/src/tile/map/MapTile.ts
+++ b/core/frontend/src/tile/map/MapTile.ts
@@ -47,7 +47,7 @@ export type TilePatch = PlanarTilePatch | EllipsoidPatch;
 
 /** Projects points within the rectangular region of a [[MapTile]] into 3d space.
  * @see [[MapTile.getProjection]] to obtain the projection for a [[MapTile]].
- * @beta
+ * @public
  */
 export abstract class MapTileProjection {
   /** The extents of the volume of space associated with the projected [[MapTile]]. */
@@ -126,7 +126,7 @@ const scratchClipPlanes = [ClipPlane.createNormalAndPoint(scratchNormal, scratch
 const scratchCorners = [Point3d.createZero(), Point3d.createZero(), Point3d.createZero(), Point3d.createZero(), Point3d.createZero(), Point3d.createZero(), Point3d.createZero(), Point3d.createZero()];
 
 /** A [[Tile]] belonging to a [[MapTileTree]] representing a rectangular region of a map of the Earth.
- * @beta
+ * @public
  */
 export class MapTile extends RealityTile {
   private static _maxParentHeightDepth = 4;

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -68,7 +68,7 @@ export enum MapTileTreeScaleRangeVisibility {
  *
  * The map or globe may be smooth, or feature 3d geometry supplied by a [[TerrainProvider]].
  * The terrain displayed in a [[Viewport]] is determined by its [TerrainSettings]($common).
- * @beta
+ * @public
  */
 
 export class MapTileTree extends RealityTileTree {

--- a/core/frontend/src/tile/map/MapTilingScheme.ts
+++ b/core/frontend/src/tile/map/MapTilingScheme.ts
@@ -19,7 +19,7 @@ import { MapCartoRectangle } from "../internal";
  * An X fraction of 0 corresponds to the easternmost longitude and an X fraction of 1 to the westernmost longitude.
  * The scheme can choose to correlate a Y fraction of 0 with either the north or south pole, as specified by [[rowZeroAtNorthPole]].
  * Implementing a tiling scheme only requires implementing the abstract method [[yFractionToLatitude]] and its inverse, [[latitudeToYFraction]].
- * @beta
+ * @public
  */
 export abstract class MapTilingScheme {
   /** If true, the fractional Y coordinate 0 corresponds to the north pole and 1 to the south pole; otherwise,

--- a/core/frontend/src/tile/map/QuadId.ts
+++ b/core/frontend/src/tile/map/QuadId.ts
@@ -17,7 +17,7 @@ const scratchCartographic2 = Cartographic.createZero();
 /** Identifies a node within a [quad tree](https://en.wikipedia.org/wiki/Quadtree), such as a [[MapTile]] within a [[MapTileTree]].
  * A quad tree recursively sub-divides a two-dimensional space along the X and Y axes such that each node on level L has four child nodes on
  * level L+1.
- * @beta
+ * @public
  */
 export class QuadId {
   /** The level of the node within the tree, increasing with each subdivision, as a non-negative integer. */

--- a/core/frontend/src/tile/map/TerrainMeshProvider.ts
+++ b/core/frontend/src/tile/map/TerrainMeshProvider.ts
@@ -15,7 +15,7 @@ import {
 } from "../internal";
 
 /** Options supplied to [[TerrainProvider.createTerrainMeshProvider]] to construct a [[TerrainMeshProvider]].
- * @beta
+ * @public
  */
 export interface TerrainMeshProviderOptions {
   /** A scale factor to be applied to the height of the terrain meshes.
@@ -39,7 +39,7 @@ export interface TerrainMeshProviderOptions {
 }
 
 /** Arguments supplied to [[TerrainMeshProvider.requestMeshData]].
- * @beta
+ * @public
  */
 export interface RequestMeshDataArgs {
   /** The tile for which the terrain mesh is being requested. */
@@ -49,7 +49,7 @@ export interface RequestMeshDataArgs {
 }
 
 /** Arguments supplied to [[TerrainMeshProvider.readMesh]].
- * @beta
+ * @public
  */
 export interface ReadMeshArgs {
   /** The mesh data obtained from [[TerrainMeshProvider.requestMeshData]]. */
@@ -64,7 +64,12 @@ export interface ReadMeshArgs {
  * Each mesh represents the terrain within a rectangular region of the Earth associated with a [[MapTile]].
  * The display system drapes background map imagery onto these meshes.
  * `TerrainMeshProvider`s are obtained from [[TerrainProvider]]s.
- * @beta
+ * @note A terrain mesh provider is expected to produce terrain for all areas of the globe. If it lacks terrain data for an area of the globe,
+ * it might choose to fall back to producing smooth terrain using an [[EllipsoidTerrainProvider]].
+ * @see [[EllipsoidTerrainProvider]] for an example implementation that provides smooth terrain meshes.
+ * @see [BingTerrainMeshProvider](https://github.com/iTwin/itwinjs-core/blob/master/test-apps/display-test-app/src/frontend/BingTerrainProvider.ts) for an example
+ * implementation that produces 3d terrain meshes from elevations provided by [[BingElevationProvider]].
+ * @public
  */
 export abstract class TerrainMeshProvider {
   /** Obtain a representation of the terrain for a specific [[MapTile]]. The result will subsequently be supplied to [[readMesh]] to produce the mesh.

--- a/core/frontend/src/tile/map/TerrainProvider.ts
+++ b/core/frontend/src/tile/map/TerrainProvider.ts
@@ -11,7 +11,7 @@ import { getCesiumTerrainProvider, TerrainMeshProvider, TerrainMeshProviderOptio
 /** Interface adopted by an object that can supply [[TerrainMeshProvider]]s enabling the display of 3d terrain in a [[Viewport]].
  * @see [[TerrainProviderRegistry]] to register or look up a `TerrainProvider` by its name.
  * @see [TerrainSettings.providerName]($common) to specify the terrain provider used by a [DisplayStyle]($backend).
- * @beta
+ * @public
  */
 export interface TerrainProvider {
   /** Produce a [[TerrainMeshProvider]] using the specified options. */
@@ -23,7 +23,7 @@ export interface TerrainProvider {
  * Any number of additional providers can be [[register]]ed.
  *
  * When terrain is enabled for a [[Viewport]], the display system will attempt to look up the [[TerrainProvider]] corresponding to the [TerrainSettings.providerName]($common) specified by the [[Viewport]]'s [DisplayStyleSettings]($common). If a provider by that name is registered, it will be used to obtain terrain meshes; otherwise, the display system will produce flat terrain meshes.
- * @beta
+ * @public
  */
 export class TerrainProviderRegistry {
   private readonly _providers = new Map<string, TerrainProvider>();


### PR DESCRIPTION
Some implementations of `TerrainMeshProvider` only have terrain data available for specific parts of the globe (e.g., within the region their terrain service supports). But (as now documented) a terrain provider is required to provide terrain meshes for the entire globe. Make it easy to fall back to producing smooth meshes for areas with no data by promoting `EllipsoidTerrainProvider` to public. Also, promote from beta to public the various APIs required to implement a terrain provider.