### PR TITLE
Use default material if none specified in glTF

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-gltf-default-material_2023-02-21-15-34.json
+++ b/common/changes/@itwin/core-frontend/pmc-gltf-default-material_2023-02-21-15-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "When reading glTF, use a default material if none is specified, per the glTF spec.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1411,7 +1411,7 @@ export abstract class GltfReader {
 
   protected readMeshPrimitive(primitive: GltfMeshPrimitive, featureTable?: FeatureTable, pseudoRtcBias?: Vector3d): GltfMeshData | undefined {
     const materialName = JsonUtils.asString(primitive.material);
-    const material = 0 < materialName.length ? this._materials[materialName] : undefined;
+    const material = 0 < materialName.length ? this._materials[materialName] : { };
     if (!material)
       return undefined;
 


### PR DESCRIPTION
Per [the spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#meshes-overview).
