### PR TITLE
implement PolyfaceBuilder.addGeometryQuery for Loops and ParityRegions

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -4476,6 +4476,8 @@ export class PolyfaceBuilder extends NullGeometryHandler {
     handleBox(g: Box): any;
     handleCone(g: Cone): any;
     handleLinearSweep(g: LinearSweep): any;
+    handleLoop(g: Loop): any;
+    handleParityRegion(g: ParityRegion): any;
     handleRotationalSweep(g: RotationalSweep): any;
     handleRuledSweep(g: RuledSweep): any;
     handleSphere(g: Sphere): any;

--- a/common/changes/@itwin/core-geometry/da4-parity-region-polyface-builder_2023-02-22-23-46.json
+++ b/common/changes/@itwin/core-geometry/da4-parity-region-polyface-builder_2023-02-22-23-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "implement PolyfaceBuilder.addGeometryQuery for Loops and ParityRegions",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/polyface/PolyfaceBuilder.ts
+++ b/core/geometry/src/polyface/PolyfaceBuilder.ts
@@ -15,11 +15,13 @@ import { CurveFactory } from "../curve/CurveFactory";
 import { CurvePrimitive } from "../curve/CurvePrimitive";
 import { GeometryQuery } from "../curve/GeometryQuery";
 import { LineString3d } from "../curve/LineString3d";
+import { Loop } from "../curve/Loop";
 import { ParityRegion } from "../curve/ParityRegion";
 import { CylindricalRangeQuery } from "../curve/Query/CylindricalRange";
 import { StrokeCountSection } from "../curve/Query/StrokeCountChain";
 import { StrokeOptions } from "../curve/StrokeOptions";
 import { AxisOrder, Geometry } from "../Geometry";
+import { Angle } from "../geometry3d/Angle";
 import { BarycentricTriangle } from "../geometry3d/BarycentricTriangle";
 import { BilinearPatch } from "../geometry3d/BilinearPatch";
 import { FrameBuilder } from "../geometry3d/FrameBuilder";
@@ -38,6 +40,7 @@ import { Range1d, Range3d } from "../geometry3d/Range";
 import { Segment1d } from "../geometry3d/Segment1d";
 import { Transform } from "../geometry3d/Transform";
 import { UVSurfaceOps } from "../geometry3d/UVSurfaceOps";
+import { XAndY } from "../geometry3d/XYZProps";
 import { Box } from "../solid/Box";
 import { Cone } from "../solid/Cone";
 import { LinearSweep } from "../solid/LinearSweep";
@@ -50,12 +53,10 @@ import { HalfEdge, HalfEdgeGraph, HalfEdgeToBooleanFunction } from "../topology/
 import { Triangulator } from "../topology/Triangulation";
 import { BoxTopology } from "./BoxTopology";
 import { GreedyTriangulationBetweenLineStrings } from "./GreedyTriangulationBetweenLineStrings";
-import { IndexedPolyface, PolyfaceVisitor } from "./Polyface";
-import { XAndY } from "../geometry3d/XYZProps";
-import { PolyfaceQuery } from "./PolyfaceQuery";
-import { Angle } from "../geometry3d/Angle";
-import { IndexedPolyfaceSubsetVisitor } from "./IndexedPolyfaceVisitor";
 import { SortableEdge, SortableEdgeCluster } from "./IndexedEdgeMatcher";
+import { IndexedPolyfaceSubsetVisitor } from "./IndexedPolyfaceVisitor";
+import { IndexedPolyface, PolyfaceVisitor } from "./Polyface";
+import { PolyfaceQuery } from "./PolyfaceQuery";
 
 /* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/prefer-for-of */
 /**
@@ -1141,7 +1142,7 @@ export class PolyfaceBuilder extends NullGeometryHandler {
   public addTriangulatedRegion(region: AnyRegion) {
     const contour = SweepContour.createForLinearSweep(region);
     if (contour)
-      contour.emitFacets(this, true, undefined);
+      contour.emitFacets(this, this.reversedFlag, undefined);
   }
 
   /**
@@ -1553,6 +1554,10 @@ export class PolyfaceBuilder extends NullGeometryHandler {
   public override handleRotationalSweep(g: RotationalSweep): any { return this.addRotationalSweep(g); }
   /** Double dispatch handler for RuledSweep */
   public override handleRuledSweep(g: RuledSweep): any { return this.addRuledSweep(g); }
+  /** Double dispatch handler for Loop */
+  public override handleLoop(g: Loop): any { return this.addTriangulatedRegion(g); }
+  /** Double dispatch handler for ParityRegion */
+  public override handleParityRegion(g: ParityRegion): any { return this.addTriangulatedRegion(g); }
   /** add facets for a GeometryQuery object.   This is double dispatch through `dispatchToGeometryHandler(this)` */
   public addGeometryQuery(g: GeometryQuery) { g.dispatchToGeometryHandler(this); }
 

--- a/core/geometry/src/test/polyface/Polyface.test.ts
+++ b/core/geometry/src/test/polyface/Polyface.test.ts
@@ -35,7 +35,6 @@ import { Box } from "../../solid/Box";
 import { Cone } from "../../solid/Cone";
 import { SolidPrimitive } from "../../solid/SolidPrimitive";
 import { Sphere } from "../../solid/Sphere";
-import { SweepContour } from "../../solid/SweepContour";
 import { TorusPipe } from "../../solid/TorusPipe";
 import { Checker } from "../Checker";
 import { GeometryCoreTestIO } from "../GeometryCoreTestIO";
@@ -875,14 +874,11 @@ it("PartialSawToothTriangulation", () => {
     let y0 = 0.0;
     const polygonPoints = fullSawtooth.slice(0, numPoints);
     const loop = Loop.createPolygon(polygonPoints);
-    const sweepContour = SweepContour.createForLinearSweep(loop);
-
     const options = new StrokeOptions();
-    options.needParams = false;
+    options.needNormals = false;
     options.needParams = false;
     const builder = PolyfaceBuilder.create(options);
-
-    sweepContour!.emitFacets(builder, false);
+    builder.addGeometryQuery(loop);
     const polyface = builder.claimPolyface(true);
     if (!ck.testExactNumber(polygonPoints.length - 2, polyface.facetCount, "Triangle count in polygon")) {
       const jsPolyface = IModelJson.Writer.toIModelJson(polyface);
@@ -918,16 +914,16 @@ it("facets from sweep contour with holes", () => {
   let x1 = x0;
 
   const options = new StrokeOptions();
-  options.needParams = false;
+  options.needNormals = false;
   options.needParams = false;
   const builder = PolyfaceBuilder.create(options);
-  builder.addTriangulatedRegion(region);
+  builder.addGeometryQuery(region);
   GeometryCoreTestIO.captureGeometry(allGeometry, builder.claimPolyface(), x1, y1);
   for (const e of [1, 0.5]) {
     x1 += step;
     options.maxEdgeLength = e;
     const builder1 = PolyfaceBuilder.create(options);
-    builder1.addTriangulatedRegion(region);
+    builder1.addGeometryQuery(region);
     GeometryCoreTestIO.captureGeometry(allGeometry, builder1.claimPolyface(), x1, y1);
   }
 


### PR DESCRIPTION
An oversight left unfinished the final step in the double dispatch implementation for `Loops` and `ParityRegions` in `PolyfaceBuilder.addGeometryQuery`. This won't work for `UnionRegions`.

Now you can facet such planar regions with e.g., `builder.addGeometryQuery(loop)`. The builder's stroke options (and reversed flag) will control the triangulation.

In support of #5108.