### PR TITLE
Skip audit Stage During PR Val

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -63,7 +63,7 @@ steps:
   - script: node common/scripts/install-run-rush.js audit
     displayName: rush audit
     workingDirectory: ${{ parameters.workingDir }}
-    condition: and(eq('{{ parameters.runRushAudit }}', 'true'), ne(variables['System.PullRequest.TargetBranch'], 'imodel02'))
+    condition: and(eq('${{ parameters.runRushAudit }}', 'true'), ne('${{ parameters.targetBranch }}', 'imodel02'))
   - script: node common/scripts/install-run-rush.js build:ci -v -p max
     displayName: rush build:ci
     workingDirectory: ${{ parameters.workingDir }}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -60,7 +60,7 @@ steps:
   - script: node common/scripts/install-run-rush.js audit
     displayName: rush audit
     workingDirectory: ${{ parameters.workingDir }}
-    condition: and(succeeded(), ne(variables['Agent.OS'], 'Darwin'), or(eq(variables[Build.SourceBranch],'release'), eq(variables[Build.SourceBranch],'master')))
+    condition: or(eq(variables[Build.SourceBranch],'release'), eq(variables[Build.SourceBranch],'master'))
   - script: node common/scripts/install-run-rush.js build:ci -v -p max
     displayName: rush build:ci
     workingDirectory: ${{ parameters.workingDir }}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -60,7 +60,7 @@ steps:
   - script: node common/scripts/install-run-rush.js audit
     displayName: rush audit
     workingDirectory: ${{ parameters.workingDir }}
-    condition: or(eq(variables[Build.SourceBranch],'release'), eq(variables[Build.SourceBranch],'master'))
+    condition: or(eq(variables['Build.SourceBranch'],'release'), eq(variables['Build.SourceBranch'],'master'))
   - script: node common/scripts/install-run-rush.js build:ci -v -p max
     displayName: rush build:ci
     workingDirectory: ${{ parameters.workingDir }}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -17,6 +17,9 @@ parameters:
     default: $(Build.SourceBranch)
   - name: targetBranch
     default: $(System.PullRequest.TargetBranch)
+  - name: runRushAudit
+    type: boolean
+    default: true
 
 steps:
   - task: NodeTool@0
@@ -60,7 +63,7 @@ steps:
   - script: node common/scripts/install-run-rush.js audit
     displayName: rush audit
     workingDirectory: ${{ parameters.workingDir }}
-    condition: or(eq(variables['Build.SourceBranch'],'release'), eq(variables['Build.SourceBranch'],'master'))
+    condition: eq('parameters.runRushAudit }}', 'true')
   - script: node common/scripts/install-run-rush.js build:ci -v -p max
     displayName: rush build:ci
     workingDirectory: ${{ parameters.workingDir }}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -63,7 +63,7 @@ steps:
   - script: node common/scripts/install-run-rush.js audit
     displayName: rush audit
     workingDirectory: ${{ parameters.workingDir }}
-    condition: and(eq('${{ parameters.runRushAudit }}', 'true'), ne('${{ parameters.targetBranch }}', 'imodel02'))
+    condition: and(succeeded(), eq('${{ parameters.runRushAudit }}', 'true'), ne('${{ parameters.targetBranch }}', 'imodel02'))
   - script: node common/scripts/install-run-rush.js build:ci -v -p max
     displayName: rush build:ci
     workingDirectory: ${{ parameters.workingDir }}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -60,7 +60,7 @@ steps:
   - script: node common/scripts/install-run-rush.js audit
     displayName: rush audit
     workingDirectory: ${{ parameters.workingDir }}
-    condition: and(succeeded(), ne(variables['Agent.OS'], 'Darwin'))
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'Darwin'), or(eq(variables[Build.SourceBranch],'release'), eq(variables[Build.SourceBranch],'master')))
   - script: node common/scripts/install-run-rush.js build:ci -v -p max
     displayName: rush build:ci
     workingDirectory: ${{ parameters.workingDir }}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -63,7 +63,7 @@ steps:
   - script: node common/scripts/install-run-rush.js audit
     displayName: rush audit
     workingDirectory: ${{ parameters.workingDir }}
-    condition: eq('parameters.runRushAudit }}', 'true')
+    condition: and(eq('{{ parameters.runRushAudit }}', 'true'), ne(variables['System.PullRequest.TargetBranch'], 'imodel02'))
   - script: node common/scripts/install-run-rush.js build:ci -v -p max
     displayName: rush build:ci
     workingDirectory: ${{ parameters.workingDir }}


### PR DESCRIPTION
Related to https://github.com/iTwin/imodel-native-internal/pull/76.
Audit stage now skips when source branch is not master or release