### PR TITLE
Disable native SQLite logger category when calling 'updateToRequestedVersion'

### DIFF
--- a/common/changes/@itwin/core-backend/nick-disable-sqlite-category_2023-03-10-17-02.json
+++ b/common/changes/@itwin/core-backend/nick-disable-sqlite-category_2023-03-10-17-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "disable native sqlite logger category when calling 'updateToRequestedVersion'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}


### PR DESCRIPTION
Applications are outputting noisy log messages when in this function 'updateToRequestedVersion', even if they don't have to applyChangesets. Some of these logs appear to occur just when opening the database for write. Affan says  applyChangesets handles a lot of these errors under the hood so they just clutter logs and confuse people who read the logs.