### PR TITLE
UI: Allow focus on widget tabs and keyboard navigation

### DIFF
--- a/common/changes/@itwin/appui-layout-react/release-3.7.x_2023-03-15-20-52.json
+++ b/common/changes/@itwin/appui-layout-react/release-3.7.x_2023-03-15-20-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Allow focus on widget tabs and keyboard tab navigation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/base/PointerCaptor.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/PointerCaptor.tsx
@@ -124,7 +124,6 @@ export const usePointerCaptor = <T extends HTMLElement>(
   const setRef = useRefEffect((instance: T | null) => {
     let touchTarget: EventTarget | null = null;
     const mouseDown = (e: MouseEvent) => {
-      e.preventDefault();
       onPointerDown && onPointerDown(e, e);
       isDown.current = true;
     };

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Tab.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Tab.tsx
@@ -253,10 +253,10 @@ export function useTabInteractions<T extends HTMLElement>({
       }
     };
     const instance = ref.current;
-    instance?.addEventListener("keydown", keydown);
+    instance && instance.addEventListener("keydown", keydown);
     return () => {
       timer.setOnExecute(undefined);
-      instance?.removeEventListener("keydown", keydown);
+      instance && instance.removeEventListener("keydown", keydown);
     };
   }, [handleClick, handleDoubleClick]);
   return refs;

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Tab.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Tab.tsx
@@ -23,6 +23,7 @@ import { TabIdContext } from "./ContentRenderer";
 import { TabTarget } from "../target/TabTarget";
 import { WidgetMenuTab } from "./MenuTab";
 import { WidgetOverflowContext } from "./Overflow";
+import { SpecialKey } from "@itwin/appui-abstract";
 
 /** @internal */
 export interface WidgetTabProviderProps extends TabPositionContextArgs {
@@ -105,6 +106,7 @@ const WidgetTabComponent = React.memo<WidgetTabProps>(function WidgetTabComponen
       role="tab"
       style={props.style}
       title={tab.label}
+      tabIndex={0}
     >
       {(showWidgetIcon || showIconOnly) && tab.iconSpec && <Icon iconSpec={tab.iconSpec} />}
       {showLabel && <span>{tab.label}</span>}
@@ -245,8 +247,16 @@ export function useTabInteractions<T extends HTMLElement>({
         handleDoubleClick();
       clickCount.current = 0;
     });
+    const keydown = (e: KeyboardEvent) => {
+      if(e.key === SpecialKey.Space || e.key === SpecialKey.Enter) {
+        handleClick();
+      }
+    };
+    const instance = ref.current;
+    instance?.addEventListener("keydown", keydown);
     return () => {
       timer.setOnExecute(undefined);
+      instance?.removeEventListener("keydown", keydown);
     };
   }, [handleClick, handleDoubleClick]);
   return refs;

--- a/ui/appui-layout-react/src/test/widget-panels/Panel.test.snap
+++ b/ui/appui-layout-react/src/test/widget-panels/Panel.test.snap
@@ -35,6 +35,7 @@ exports[`WidgetPanelProvider should render captured 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -147,6 +148,7 @@ exports[`WidgetPanelProvider should render collapsed 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -259,6 +261,7 @@ exports[`WidgetPanelProvider should render horizontal 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -369,6 +372,7 @@ exports[`WidgetPanelProvider should render multiple widgets 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -448,6 +452,7 @@ exports[`WidgetPanelProvider should render multiple widgets 1`] = `
               data-item-id="t2"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -539,6 +544,7 @@ exports[`WidgetPanelProvider should render spanned 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -651,6 +657,7 @@ exports[`WidgetPanelProvider should render vertical 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -763,6 +770,7 @@ exports[`WidgetPanelProvider should render with span bottom 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />
@@ -875,6 +883,7 @@ exports[`WidgetPanelProvider should render with top spanned 1`] = `
               data-item-id="t1"
               data-item-type="widget-tab"
               role="tab"
+              tabindex="0"
               title=""
             >
               <span />

--- a/ui/appui-layout-react/src/test/widget-panels/Panels.test.snap
+++ b/ui/appui-layout-react/src/test/widget-panels/Panels.test.snap
@@ -69,6 +69,7 @@ exports[`WidgetPanels should render widget content 1`] = `
                 data-item-id="t1"
                 data-item-type="widget-tab"
                 role="tab"
+                tabindex="0"
                 title=""
               >
                 <span />

--- a/ui/appui-layout-react/src/test/widget/FloatingWidget.test.snap
+++ b/ui/appui-layout-react/src/test/widget/FloatingWidget.test.snap
@@ -24,6 +24,7 @@ exports[`FloatingWidget should render 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />
@@ -113,6 +114,7 @@ exports[`FloatingWidget should render dragged 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />
@@ -202,6 +204,7 @@ exports[`FloatingWidget should render hidden 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />
@@ -291,6 +294,7 @@ exports[`FloatingWidget should render hidden when hideWithUiWhenFloating is true
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />
@@ -380,6 +384,7 @@ exports[`FloatingWidget should render minimized 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />

--- a/ui/appui-layout-react/src/test/widget/FloatingWidgets.test.snap
+++ b/ui/appui-layout-react/src/test/widget/FloatingWidgets.test.snap
@@ -24,6 +24,7 @@ exports[`FloatingWidgets should render 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />

--- a/ui/appui-layout-react/src/test/widget/PanelWidget.test.snap
+++ b/ui/appui-layout-react/src/test/widget/PanelWidget.test.snap
@@ -22,6 +22,7 @@ exports[`PanelWidget should render 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />
@@ -98,6 +99,7 @@ exports[`PanelWidget should render horizontal with fit-content 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />
@@ -155,6 +157,7 @@ exports[`PanelWidget should render minimized 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />
@@ -231,6 +234,7 @@ exports[`PanelWidget should render with fit-content 1`] = `
         data-item-id="t1"
         data-item-type="widget-tab"
         role="tab"
+        tabindex="0"
         title=""
       >
         <span />

--- a/ui/appui-layout-react/src/test/widget/Tab.test.snap
+++ b/ui/appui-layout-react/src/test/widget/Tab.test.snap
@@ -6,6 +6,7 @@ exports[`WidgetTab should render active 1`] = `
   data-item-id="t1"
   data-item-type="widget-tab"
   role="tab"
+  tabindex="0"
   title=""
 >
   <span />
@@ -18,6 +19,7 @@ exports[`WidgetTab should render badge 1`] = `
   data-item-id="t1"
   data-item-type="widget-tab"
   role="tab"
+  tabindex="0"
   title=""
 >
   <span />
@@ -35,6 +37,7 @@ exports[`WidgetTab should render first inactive 1`] = `
   data-item-id="t1"
   data-item-type="widget-tab"
   role="tab"
+  tabindex="0"
   title=""
 >
   <span />
@@ -47,6 +50,7 @@ exports[`WidgetTab should render last not overflown 1`] = `
   data-item-id="t1"
   data-item-type="widget-tab"
   role="tab"
+  tabindex="0"
   title=""
 >
   <span />
@@ -59,6 +63,7 @@ exports[`WidgetTab should render minimized 1`] = `
   data-item-id="t1"
   data-item-type="widget-tab"
   role="tab"
+  tabindex="0"
   title=""
 >
   <span />
@@ -71,6 +76,7 @@ exports[`WidgetTab should render tab with icon only 1`] = `
   data-item-id="t1"
   data-item-type="widget-tab"
   role="tab"
+  tabindex="0"
   title=""
 >
   <i
@@ -85,6 +91,7 @@ exports[`WidgetTab should render tab with text and icon 1`] = `
   data-item-id="t1"
   data-item-type="widget-tab"
   role="tab"
+  tabindex="0"
   title=""
 >
   <i

--- a/ui/appui-layout-react/src/test/widget/Tab.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/Tab.test.tsx
@@ -11,6 +11,7 @@ import {
   WidgetContext, WidgetOverflowContext, WidgetStateContext, WidgetTab, WidgetTabProvider, WidgetTabsEntryContext,
 } from "../../appui-layout-react";
 import { TestNineZoneProvider } from "../Providers";
+import { SpecialKey } from "@itwin/appui-abstract";
 
 describe("WidgetTab", () => {
   it("should render active", () => {
@@ -186,7 +187,7 @@ describe("WidgetTab", () => {
     container.firstChild!.should.matchSnapshot();
   });
 
-  it("should dispatch WIDGET_TAB_CLICK", () => {
+  it("should dispatch WIDGET_TAB_CLICK on click", () => {
     const fakeTimers = sinon.useFakeTimers();
     const dispatch = sinon.stub<NineZoneDispatch>();
     let state = createNineZoneState();
@@ -220,6 +221,106 @@ describe("WidgetTab", () => {
       widgetId: "w1",
       id: "t1",
     }));
+  });
+
+  it("should dispatch WIDGET_TAB_CLICK on 'Enter'", () => {
+    const fakeTimers = sinon.useFakeTimers();
+    const dispatch = sinon.stub<NineZoneDispatch>();
+    let state = createNineZoneState();
+    state = addTab(state, "t1");
+    state = addPanelWidget(state, "left", "w1", ["t1"]);
+    render(
+      <TestNineZoneProvider
+        state={state}
+        dispatch={dispatch}
+      >
+        <PanelSideContext.Provider value="left">
+          <WidgetStateContext.Provider value={state.widgets.w1}>
+            <WidgetTabsEntryContext.Provider value={{
+              lastNotOverflown: false,
+            }}>
+              <WidgetTabProvider tab={state.tabs.t1} />
+            </WidgetTabsEntryContext.Provider>
+          </WidgetStateContext.Provider>
+        </PanelSideContext.Provider>
+      </TestNineZoneProvider>,
+    );
+    const tab = document.getElementsByClassName("nz-widget-tab")[0];
+    act(() => {
+      fireEvent.keyDown(tab, { key: SpecialKey.Enter});
+      fakeTimers.tick(300);
+    });
+    sinon.assert.calledOnceWithExactly(dispatch, sinon.match({
+      type: "WIDGET_TAB_CLICK",
+      side: "left",
+      widgetId: "w1",
+      id: "t1",
+    }));
+  });
+
+  it("should dispatch WIDGET_TAB_CLICK on 'space'", () => {
+    const fakeTimers = sinon.useFakeTimers();
+    const dispatch = sinon.stub<NineZoneDispatch>();
+    let state = createNineZoneState();
+    state = addTab(state, "t1");
+    state = addPanelWidget(state, "left", "w1", ["t1"]);
+    render(
+      <TestNineZoneProvider
+        state={state}
+        dispatch={dispatch}
+      >
+        <PanelSideContext.Provider value="left">
+          <WidgetStateContext.Provider value={state.widgets.w1}>
+            <WidgetTabsEntryContext.Provider value={{
+              lastNotOverflown: false,
+            }}>
+              <WidgetTabProvider tab={state.tabs.t1} />
+            </WidgetTabsEntryContext.Provider>
+          </WidgetStateContext.Provider>
+        </PanelSideContext.Provider>
+      </TestNineZoneProvider>,
+    );
+    const tab = document.getElementsByClassName("nz-widget-tab")[0];
+    act(() => {
+      fireEvent.keyDown(tab, { key: SpecialKey.Space});
+      fakeTimers.tick(300);
+    });
+    sinon.assert.calledOnceWithExactly(dispatch, sinon.match({
+      type: "WIDGET_TAB_CLICK",
+      side: "left",
+      widgetId: "w1",
+      id: "t1",
+    }));
+  });
+
+  it("should not dispatch WIDGET_TAB_CLICK on other key", () => {
+    const fakeTimers = sinon.useFakeTimers();
+    const dispatch = sinon.stub<NineZoneDispatch>();
+    let state = createNineZoneState();
+    state = addTab(state, "t1");
+    state = addPanelWidget(state, "left", "w1", ["t1"]);
+    render(
+      <TestNineZoneProvider
+        state={state}
+        dispatch={dispatch}
+      >
+        <PanelSideContext.Provider value="left">
+          <WidgetStateContext.Provider value={state.widgets.w1}>
+            <WidgetTabsEntryContext.Provider value={{
+              lastNotOverflown: false,
+            }}>
+              <WidgetTabProvider tab={state.tabs.t1} />
+            </WidgetTabsEntryContext.Provider>
+          </WidgetStateContext.Provider>
+        </PanelSideContext.Provider>
+      </TestNineZoneProvider>,
+    );
+    const tab = document.getElementsByClassName("nz-widget-tab")[0];
+    act(() => {
+      fireEvent.keyDown(tab, { key: "a"});
+      fakeTimers.tick(300);
+    });
+    sinon.assert.notCalled(dispatch);
   });
 
   it("should dispatch WIDGET_TAB_DOUBLE_CLICK", () => {

--- a/ui/appui-layout-react/src/test/widget/Tabs.test.snap
+++ b/ui/appui-layout-react/src/test/widget/Tabs.test.snap
@@ -34,6 +34,7 @@ exports[`WidgetTabs should render 1`] = `
     data-item-id="t1"
     data-item-type="widget-tab"
     role="tab"
+    tabindex="0"
     title=""
   >
     <span />
@@ -70,6 +71,7 @@ exports[`WidgetTabs should render overflow panel 1`] = `
     data-item-id="t1"
     data-item-type="widget-tab"
     role="tab"
+    tabindex="0"
     title=""
   >
     <span />
@@ -106,6 +108,7 @@ exports[`WidgetTabs should render tabs with icons 1`] = `
     data-item-id="t1"
     data-item-type="widget-tab"
     role="tab"
+    tabindex="0"
     title=""
   >
     <span />


### PR DESCRIPTION
When clicking on a tab, the focus will now be moved to the tab, and keyboard navigation is now enabled on tab, press `Space` or `Enter` to open the widget.

close https://github.com/iTwin/appui/issues/195