### PR TITLE
promote DeepCompare, RegionOps

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -1818,15 +1818,15 @@ export class CutLoopMergeContext {
     sortAndMergeLoops(): void;
 }
 
-// @internal
+// @public
 export class DeepCompare {
     constructor(numberRelTol?: number);
     compare(a: any, b: any, tolerance?: number): boolean;
-    compareNumber(_a: number, _b: number): boolean;
+    compareNumber(a: number, b: number): boolean;
     errorTracker: any[];
     numberRelTol: number;
     propertyCounts: {
-        [key: string]: any;
+        [key: string]: number;
     };
     typeCounts: {
         numbers: number;
@@ -5223,18 +5223,18 @@ export class RegionMomentsXY extends NullGeometryHandler {
     handleUnionRegion(region: UnionRegion): MomentData | undefined;
 }
 
-// @beta
+// @public
 export class RegionOps {
     // @internal
     static addLoopsToGraph(graph: HalfEdgeGraph, data: MultiLineStringDataVariant, announceIsolatedLoop: (graph: HalfEdgeGraph, seed: HalfEdge) => void): void;
     // @internal
     static addLoopsWithEdgeTagToGraph(graph: HalfEdgeGraph, data: MultiLineStringDataVariant, mask: HalfEdgeMask, edgeTag: any): HalfEdge[] | undefined;
-    static cloneCurvesWithXYSplitFlags(curvesToCut: CurvePrimitive | CurveCollection | undefined, cutterCurves: CurveCollection): CurveCollection | CurvePrimitive | undefined;
-    static collectChains(fragments: GeometryQuery[], gapTolerance?: number): ChainTypes;
+    static cloneCurvesWithXYSplits(curvesToCut: AnyCurve | undefined, cutterCurves: CurveCollection): AnyCurve | undefined;
+    static collectChains(fragments: AnyCurve[], gapTolerance?: number): ChainTypes;
     static collectCurvePrimitives(candidates: AnyCurve | AnyCurve[], collectorArray?: CurvePrimitive[], smallestPossiblePrimitives?: boolean, explodeLinestrings?: boolean): CurvePrimitive[];
-    static collectInsideAndOutsideOffsets(fragments: GeometryQuery[], offsetDistance: number, gapTolerance: number): {
-        insideOffsets: GeometryQuery[];
-        outsideOffsets: GeometryQuery[];
+    static collectInsideAndOutsideOffsets(fragments: AnyCurve[], offsetDistance: number, gapTolerance: number): {
+        insideOffsets: AnyCurve[];
+        outsideOffsets: AnyCurve[];
         chains: ChainTypes;
     };
     static computeXYArea(root: AnyRegion): number | undefined;
@@ -5242,7 +5242,6 @@ export class RegionOps {
     static computeXYAreaTolerance(range: Range3d, distanceTolerance?: number): number;
     static computeXYZWireMomentSums(root: AnyCurve): MomentData | undefined;
     static consolidateAdjacentPrimitives(curves: CurveCollection, options?: ConsolidateAdjacentCurvePrimitivesOptions): void;
-    // @alpha
     static constructAllXYRegionLoops(curvesAndRegions: AnyCurve | AnyCurve[]): SignedLoops[];
     static constructCurveXYOffset(curves: Path | Loop, offsetDistanceOrOptions: number | JointOptions | OffsetOptions): CurveCollection | undefined;
     static constructPolygonWireXYOffset(points: Point3d[], wrap: boolean, offsetDistance: number): CurveCollection | undefined;
@@ -5255,17 +5254,17 @@ export class RegionOps {
     static polygonXYAreaIntersectLoopsToPolyface(loopsA: MultiLineStringDataVariant, loopsB: MultiLineStringDataVariant, triangulate?: boolean): Polyface | undefined;
     static polygonXYAreaUnionLoopsToPolyface(loopsA: MultiLineStringDataVariant, loopsB: MultiLineStringDataVariant, triangulate?: boolean): Polyface | undefined;
     static rectangleEdgeTransform(data: AnyCurve | Point3d[] | IndexedXYZCollection, requireClosurePoint?: boolean): Transform | undefined;
-    // @alpha
     static regionBooleanXY(loopsA: AnyRegion | AnyRegion[] | undefined, loopsB: AnyRegion | AnyRegion[] | undefined, operation: RegionBinaryOpType, mergeTolerance?: number): AnyRegion | undefined;
     // @internal
     static setCheckPointFunction(f?: GraphCheckPointFunction): void;
     static sortOuterAndHoleLoopsXY(loops: Array<Loop | IndexedXYZCollection>): AnyRegion;
-    static splitPathsByRegionInOnOutXY(curvesToCut: CurveCollection | CurvePrimitive | undefined, region: AnyRegion): {
+    static splitPathsByRegionInOnOutXY(curvesToCut: AnyCurve | undefined, region: AnyRegion): {
         insideParts: AnyCurve[];
         outsideParts: AnyCurve[];
         coincidentParts: AnyCurve[];
     };
-    static splitToPathsBetweenFlagBreaks(source: CurveCollection | CurvePrimitive | undefined, makeClones: boolean): BagOfCurves | Path | CurvePrimitive | Loop | undefined;
+    // @internal
+    static splitToPathsBetweenBreaks(source: AnyCurve | undefined, makeClones: boolean): ChainTypes;
     static testPointInOnOutRegionXY(curves: AnyRegion, x: number, y: number): number;
 }
 

--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -5263,7 +5263,6 @@ export class RegionOps {
         outsideParts: AnyCurve[];
         coincidentParts: AnyCurve[];
     };
-    // @internal
     static splitToPathsBetweenBreaks(source: AnyCurve | undefined, makeClones: boolean): ChainTypes;
     static testPointInOnOutRegionXY(curves: AnyRegion, x: number, y: number): number;
 }

--- a/common/api/summary/core-geometry.exports.csv
+++ b/common/api/summary/core-geometry.exports.csv
@@ -107,7 +107,7 @@ public;CurvePrimitiveType = "arc" | "lineSegment" | "lineString" | "bsplineCurve
 public;CurveSearchStatus
 internal;CutLoop
 internal;CutLoopMergeContext
-internal;DeepCompare
+public;DeepCompare
 internal;Degree2PowerPolynomial
 internal;Degree3PowerPolynomial
 internal;Degree4PowerPolynomial
@@ -249,7 +249,7 @@ public;class RecursiveCurveProcessor
 public;class RecursiveCurveProcessorWithStack 
 public;RegionBinaryOpType
 internal;RegionMomentsXY 
-beta;RegionOps
+public;RegionOps
 public;RotationalSweep 
 public;RuledSweep 
 alpha;Sample

--- a/common/changes/@itwin/core-geometry/da4-geometry-promotions_2023-03-20-22-17.json
+++ b/common/changes/@itwin/core-geometry/da4-geometry-promotions_2023-03-20-22-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "geometry API promotions",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/curve/ChainCollectorContext.ts
+++ b/core/geometry/src/curve/ChainCollectorContext.ts
@@ -126,7 +126,7 @@ export class ChainCollectorContext {
       }
     }
   }
-  /** Transfer markup (e.g. isCutAtStart, isCutAtEnd) from source to destination */
+  /** Transfer markup (e.g. startCut, endCut) from source to destination */
   private transferMarkup(source: CurvePrimitive, dest: CurvePrimitive) {
     if (source && dest) {
       dest.startCut = source.startCut;
@@ -165,8 +165,8 @@ export class ChainCollectorContext {
     return bag;
   }
   /** test if there is a break between primitiveA and primitiveB, due to any condition such as
-   * * primitiveA.isCutAtEnd
-   * * primitiveB.isCutAtStart
+   * * primitiveA.endCut
+   * * primitiveB.startCut
    * * physical gap between primitives.
    */
   public static needBreakBetweenPrimitives(primitiveA: CurvePrimitive | undefined, primitiveB: CurvePrimitive | undefined, isXYOnly: boolean = false): boolean {

--- a/core/geometry/src/curve/CurveChainWithDistanceIndex.ts
+++ b/core/geometry/src/curve/CurveChainWithDistanceIndex.ts
@@ -388,10 +388,9 @@ export class CurveChainWithDistanceIndex extends CurvePrimitive {
   }
   /**
    * Return an array containing only the curve primitives.
-   * * This DEFAULT simply pushes `this` to the collectorArray.
-   * * CurvePrimitiveWithDistanceIndex optionally collects its members.
    * @param collectorArray array to receive primitives (pushed -- the array is not cleared)
-   * @param smallestPossiblePrimitives if false, CurvePrimitiveWithDistanceIndex returns only itself.  If true, it recurses to its (otherwise hidden) children.
+   * @param smallestPossiblePrimitives if true, recurse on the (otherwise hidden) children. If false, only push `this`.
+   * @param explodeLinestrings (if smallestPossiblePrimitives is true) whether to push a [[LineSegment3d]] for each segment of a [[LineString3d]] child. If false, push only the [[LineString3d]].
    */
   public override collectCurvePrimitivesGo(collectorArray: CurvePrimitive[], smallestPossiblePrimitives: boolean = false, explodeLineStrings: boolean = false) {
     if (smallestPossiblePrimitives) {

--- a/core/geometry/src/curve/CurvePrimitive.ts
+++ b/core/geometry/src/curve/CurvePrimitive.ts
@@ -712,10 +712,10 @@ export abstract class CurvePrimitive extends GeometryQuery {
   }
   /**
    * Return an array containing only the curve primitives.
-   * * This DEFAULT simply pushes `this` to the collectorArray.
-   * * CurvePrimitiveWithDistanceIndex optionally collects its members.
+   * * This DEFAULT implementation simply pushes `this` to the collectorArray.
    * @param collectorArray array to receive primitives (pushed -- the array is not cleared)
-   * @param smallestPossiblePrimitives if false, CurvePrimitiveWithDistanceIndex returns only itself.  If true, it recurses to its (otherwise hidden) children.
+   * @param smallestPossiblePrimitives if true, a [[CurvePrimitiveWithDistanceIndex]] recurses on its (otherwise hidden) children. If false, it returns only itself.
+   * @param explodeLinestrings if true, push a [[LineSegment3d]] for each segment of a [[LineString3d]]. If false, push only the [[LineString3d]].
    */
   public collectCurvePrimitivesGo(collectorArray: CurvePrimitive[], _smallestPossiblePrimitives: boolean, _explodeLinestrings: boolean = false) {
     collectorArray.push(this);
@@ -723,7 +723,7 @@ export abstract class CurvePrimitive extends GeometryQuery {
 
   /**
    * Return an array containing only the curve primitives.
-   * * This DEFAULT captures the default result construction and calls collectCurvePrimitivesGo
+   * * This DEFAULT implementation captures the optional collector and calls [[collectCurvePrimitivesGo]].
    * @param collectorArray optional array to receive primitives.   If present, new primitives are ADDED (without clearing the array.)
    * @param smallestPossiblePrimitives if false, CurvePrimitiveWithDistanceIndex returns only itself.  If true, it recurses to its (otherwise hidden) children.
    */

--- a/core/geometry/src/curve/LineString3d.ts
+++ b/core/geometry/src/curve/LineString3d.ts
@@ -1345,10 +1345,9 @@ public override rangeBetweenFractions(fraction0: number, fraction1: number, tran
   }
   /**
    * Return an array containing only the curve primitives.
-   * * This DEFAULT simply pushes `this` to the collectorArray.
-   * * CurvePrimitiveWithDistanceIndex optionally collects its members.
    * @param collectorArray array to receive primitives (pushed -- the array is not cleared)
-   * @param smallestPossiblePrimitives if false, CurvePrimitiveWithDistanceIndex returns only itself.  If true, it recurses to its (otherwise hidden) children.
+   * @param _smallestPossiblePrimitives unused
+   * @param explodeLinestrings if true, push a [[LineSegment3d]] for each segment. If false, only push `this`.
    */
   public override collectCurvePrimitivesGo(collectorArray: CurvePrimitive[], _smallestPossiblePrimitives: boolean, explodeLinestrings: boolean = false) {
     if (explodeLinestrings) {

--- a/core/geometry/src/curve/Loop.ts
+++ b/core/geometry/src/curve/Loop.ts
@@ -88,7 +88,7 @@ export class Loop extends CurveChain {
 }
 
 /**
- * structure carrying a pair of loops with curve geometry.
+ * Structure carrying a pair of loops with curve geometry.
  * @public
  */
 export class LoopCurveLoopCurve {
@@ -129,5 +129,4 @@ export interface SignedLoops {
   slivers: Loop[];
 /** Array indicating edges between loops */
   edges?: LoopCurveLoopCurve[];
-
 }

--- a/core/geometry/src/curve/Query/CurveSplitContext.ts
+++ b/core/geometry/src/curve/Query/CurveSplitContext.ts
@@ -8,6 +8,7 @@
  */
 
 import { Geometry } from "../../Geometry";
+import { AnyCurve } from "../CurveChain";
 import { CurveChain, CurveCollection } from "../CurveCollection";
 import { CurveCurve } from "../CurveCurve";
 import { CurveLocationDetail, CurveLocationDetailPair } from "../CurveLocationDetail";
@@ -46,6 +47,7 @@ class CutFractionDescriptor {
 }
 /**
  * Context for splitting curves.
+ * * Sets startCut and endCut details on CurvePrimitive fragments.
  * @internal
  */
 export class CurveSplitContext {
@@ -89,7 +91,7 @@ export class CurveSplitContext {
     cutB.set(1.0, undefined);
     this.collectFragmentAndAdvanceCut(curveToCut, cutA, cutB, fragments);
   }
-  public static cloneCurvesWithXYSplitFlags(curvesToCut: CurvePrimitive | CurveCollection | undefined, cutterCurves: CurveCollection): CurveCollection | CurvePrimitive | undefined {
+  public static cloneCurvesWithXYSplits(curvesToCut: AnyCurve | undefined, cutterCurves: CurveCollection): AnyCurve | undefined {
     const context = new CurveSplitContext();
     if (curvesToCut instanceof CurvePrimitive) {
       const result: CurvePrimitive[] = [];
@@ -98,7 +100,6 @@ export class CurveSplitContext {
       if (result.length === 1)
         return result[0];
       return Path.createArray(result);
-
     } else if (curvesToCut instanceof CurveChain) {
       const result: CurvePrimitive[] = [];
       for (const primitive of curvesToCut.children) {

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -431,10 +431,8 @@ export class RegionOps {
   }
   /**
    * Create paths assembled from many curves.
-   * * Assemble paths from consecutive curves NOT separated by either startCut/endCut details or gaps.
-   * * Recognizes startCut/endCut curve annotations set by cloneCurvesWithXYSplits.
+   * * Assemble paths from consecutive curves NOT separated by either gaps or the split markup set by [[cloneCurvesWithXYSplits]].
    * * Return simplest form -- single primitive, single path, or bag of curves.
-   * @internal
    */
   public static splitToPathsBetweenBreaks(source: AnyCurve | undefined, makeClones: boolean): ChainTypes {
     if (source === undefined)

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -595,7 +595,7 @@ export class RegionOps {
    * given sufficiently imprecise input. Input geometry consisting of regions can be merged for better results: call
    * [[regionBooleanXY]](regions, undefined, RegionBinaryOpType.Union) and pass the merged region into [[constructAllXYRegionLoops]].
    * @param curvesAndRegions Any collection of curves. Each Loop/ParityRegion/UnionRegion contributes its curve primitives.
-   * @returns array of [[SignedLoop]], each entry of which describes the faces in a single connected component:
+   * @returns array of [[SignedLoops]], each entry of which describes the faces in a single connected component:
    *    * `positiveAreaLoops` contains "interior" loops, _including holes in ParityRegion input_. These loops have positive area and counterclockwise orientation.
    *    * `negativeAreaLoops` contains (probably just one) "exterior" loop which is ordered clockwise.
    *    * `slivers` contains sliver loops that have zero area, such as appear between coincident curves.

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -591,7 +591,7 @@ export class RegionOps {
   }
   /**
    * Find all areas bounded by the unstructured, possibly intersecting curves.
-   * @remarks This method performs no merging of nearly coincident edges and vertices, which can lead to unexpected results
+   * * This method performs no merging of nearly coincident edges and vertices, which can lead to unexpected results
    * given sufficiently imprecise input. Input geometry consisting of regions can be merged for better results: call
    * [[regionBooleanXY]](regions, undefined, RegionBinaryOpType.Union) and pass the merged region into [[constructAllXYRegionLoops]].
    * @param curvesAndRegions Any collection of curves. Each Loop/ParityRegion/UnionRegion contributes its curve primitives.

--- a/core/geometry/src/geometry3d/PolygonOps.ts
+++ b/core/geometry/src/geometry3d/PolygonOps.ts
@@ -815,7 +815,7 @@ export class PolygonOps {
    * @returns array of arrays of polygons that capture the input pointers. In each first level array:
    * * The first polygon is an outer loop, oriented counterclockwise.
    * * Any subsequent polygons are holes of the outer loop, oriented clockwise.
-   * @see RegionOps.sortOuterAndHoleLoopsXY
+   * @see [[RegionOps.sortOuterAndHoleLoopsXY]]
    */
   public static sortOuterAndHoleLoopsXY(loops: IndexedReadWriteXYZCollection[]): IndexedReadWriteXYZCollection[][] {
     const loopAndArea: SortablePolygon[] = [];
@@ -829,7 +829,7 @@ export class PolygonOps {
    * Exactly like `sortOuterAndHoleLoopsXY` but allows loops in any plane.
    * @param loops multiple loops to sort and reverse.
    * @param defaultNormal optional normal for the loops, if known
-   * @see sortOuterAndHoleLoopsXY
+   * @see [[sortOuterAndHoleLoopsXY]]
    */
   public static sortOuterAndHoleLoops(loops: IndexedReadWriteXYZCollection[], defaultNormal: Vector3d | undefined): IndexedReadWriteXYZCollection[][] {
     const localToWorld = FrameBuilder.createRightHandedFrame(defaultNormal, loops);

--- a/core/geometry/src/geometry4d/PlaneByOriginAndVectors4d.ts
+++ b/core/geometry/src/geometry4d/PlaneByOriginAndVectors4d.ts
@@ -11,8 +11,8 @@ import { Point3d } from "../geometry3d/Point3dVector3d";
 import { Point4d } from "./Point4d";
 
 /**
- * A Plane4dByOriginAndVectors is a 4d origin and pair of 4d "vectors" defining a 4d plane.
- * * The parameterization of the plane is    `X = origin + vectorU*u + vectorV * v`
+ * A PlaneByOriginAndVectors4d is a 4d origin and pair of 4d "vectors" defining a 4d plane.
+ * * The parameterization of the plane is    `X = origin + vectorU * u + vectorV * v`
  * * With particular weight values `origin.w === 1, vectorU.w === 0, vectorV.w === 0` this is like `Plane3dByOriginAndVectors`
  * * With other weights, the deweighted xyz coordinates of points on the 4d plane still form a 3d plane.
  * @public

--- a/core/geometry/src/numerics/Polynomials.ts
+++ b/core/geometry/src/numerics/Polynomials.ts
@@ -1118,7 +1118,7 @@ export class PowerPolynomial {
     return this.degreeKnownEvaluate(coff, degree, x);
   }
   /**
-   * * Accumulate Q*scale into P.Both are treated as full degree.
+   * * Accumulate Q*scale into P. Both are treated as full degree.
    * * (Expect Address exceptions if P is smaller than Q)
    * * Returns degree of result as determined by comparing trailing coefficients to zero
    */
@@ -1217,7 +1217,7 @@ export class TrigPolynomial {
         // No roots, but not degenerate.
         // status = true;
       } else if (degree === 1) {
-        // p(t) = coff[1] * t + coff[0]...
+        // p(t) = coff[1] * t + coff[0]
         roots.push(- coff[0] / coff[1]);
       } else if (degree === 2) {
         AnalyticRoots.appendQuadraticRoots(coff, roots);
@@ -1251,16 +1251,16 @@ export class TrigPolynomial {
   }
   private static readonly _coefficientRelTol = 1.0e-12;
   /**
-   * Compute intersections of unit circle `x ^ 2 + y 2 = 1` with general quadric
-   * `axx * x ^ 2 + axy * x * y + ayy * y ^ 2 + ax * x + ay * y + a1 = 0`
-   * Solutions are returned as angles.Sine and Cosine of the angles are the x, y results.
-   * @param axx  Coefficient of x ^ 2
+   * Compute intersections of unit circle `x^2 + y^2 = 1` with general quadric
+   * `axx * x^2 + axy * x * y + ayy * y^2 + ax * x + ay * y + a1 = 0`
+   * Solutions are returned as angles. Sine and Cosine of the angles are the x, y results.
+   * @param axx  Coefficient of x^2
    * @param axy  Coefficient of xy
-   * @param ayy  Coefficient of y ^ 2
+   * @param ayy  Coefficient of y^2
    * @param ax  Coefficient of x
    * @param ay  Coefficient of y
    * @param a1  Constant coefficient
-   * @param angles  solution angles
+   * @param radians  solution angles
    * @param numAngle  number of solution angles(Passed as array to make changes to reference)
    */
   public static solveUnitCircleImplicitQuadricIntersection(axx: number, axy: number, ayy: number,
@@ -1337,7 +1337,7 @@ export class TrigPolynomial {
     return status;
   }
   /**
-   * Compute intersections of unit circle x^2 + y 2 = w^2 with the ellipse
+   * Compute intersections of unit circle x^2 + y^2 = w^2 with the ellipse
    *         (x,y) = (cx + ux Math.Cos + vx sin, cy + uy Math.Cos + vy sin)/ (cw + uw Math.Cos + vw * Math.Sin)
    * Solutions are returned as angles in the ellipse space.
    * @param cx center x

--- a/core/geometry/src/serialization/DeepCompare.ts
+++ b/core/geometry/src/serialization/DeepCompare.ts
@@ -10,8 +10,8 @@
 /* eslint-disable quote-props */
 
 /**
- * Utilities to compare json objects by search through properties.
- * @internal
+ * Utilities to compare json objects by searching through their properties.
+ * @public
  */
 export class DeepCompare {
   /** Statistical accumulations during searchers. */
@@ -25,22 +25,23 @@ export class DeepCompare {
     undefined: 0,
   };
   /** Counts of property names encountered during various searches. */
-  public propertyCounts: { [key: string]: any } = {};
+  public propertyCounts: { [key: string]: number } = {};
   /** Array of error descriptions. */
   public errorTracker: any[] = [];
   /** relative tolerance for declaring numeric values equal. */
   public numberRelTol: number;
+  /** Construct comparison object with relative tolerance. */
   public constructor(numberRelTol = 1.0e-12) { this.numberRelTol = numberRelTol; }
 
-  /** test if _a and _b are within tolerance.
+  /** Test if a and b are within tolerance.
    * * If not, push error message to errorTracker.
    */
-  public compareNumber(_a: number, _b: number) {
-    if (Math.abs(_b - _a) < this.numberRelTol * (1 + Math.abs(_a) + Math.abs(_b))) {
+  public compareNumber(a: number, b: number) {
+    if (Math.abs(b - a) < this.numberRelTol * (1 + Math.abs(a) + Math.abs(b))) {
       return this.announce(true);
     } else {
-      this.errorTracker.unshift(_b);
-      this.errorTracker.unshift(_a);
+      this.errorTracker.unshift(b);
+      this.errorTracker.unshift(a);
       this.errorTracker.unshift(`In ${this.errorTracker[this.errorTracker.length - 1]} property: Mismatched values`);
       return this.announce(false);
     }
@@ -154,8 +155,7 @@ export class DeepCompare {
   private compareInternal(a: any, b: any): boolean {
     if (typeof a !== typeof b) {
       return this.announce(false);
-    }
-    if ((typeof a === "number") && (typeof b === "number")) {
+    } else if ((typeof a === "number") && (typeof b === "number")) {
       this.typeCounts.numbers++;
       return this.compareNumber(a, b);
     } else if (Array.isArray(a) && Array.isArray(b)) {

--- a/core/geometry/src/test/topology/ChainCollector.test.ts
+++ b/core/geometry/src/test/topology/ChainCollector.test.ts
@@ -6,25 +6,25 @@
 /* eslint-disable no-console */
 
 import { expect } from "chai";
-import { Checker } from "../Checker";
-
-import { GeometryCoreTestIO } from "../GeometryCoreTestIO";
-import { GeometryQuery } from "../../curve/GeometryQuery";
-import { IModelJson } from "../../serialization/IModelJsonSchema";
 import * as fs from "fs";
-import { OffsetHelpers } from "../../curve/internalContexts/MultiChainCollector";
-import { Range3d } from "../../geometry3d/Range";
-import { Sample, SteppedIndexFunctionFactory } from "../../serialization/GeometrySamples";
-import { LineSegment3d } from "../../curve/LineSegment3d";
+import { AnyCurve } from "../../curve/CurveChain";
 import { BagOfCurves, CurveChain, CurveCollection } from "../../curve/CurveCollection";
+import { GeometryQuery } from "../../curve/GeometryQuery";
+import { OffsetHelpers } from "../../curve/internalContexts/MultiChainCollector";
+import { JointOptions } from "../../curve/internalContexts/PolygonOffsetContext";
+import { LineSegment3d } from "../../curve/LineSegment3d";
 import { LineString3d } from "../../curve/LineString3d";
 import { Loop } from "../../curve/Loop";
-import { RegionOps } from "../../curve/RegionOps";
 import { Path } from "../../curve/Path";
-import { PolylineOps } from "../../geometry3d/PolylineOps";
-import { JointOptions } from "../../curve/internalContexts/PolygonOffsetContext";
-import { PolygonOps } from "../../geometry3d/PolygonOps";
+import { RegionOps } from "../../curve/RegionOps";
 import { Geometry } from "../../Geometry";
+import { PolygonOps } from "../../geometry3d/PolygonOps";
+import { PolylineOps } from "../../geometry3d/PolylineOps";
+import { Range3d } from "../../geometry3d/Range";
+import { Sample, SteppedIndexFunctionFactory } from "../../serialization/GeometrySamples";
+import { IModelJson } from "../../serialization/IModelJsonSchema";
+import { Checker } from "../Checker";
+import { GeometryCoreTestIO } from "../GeometryCoreTestIO";
 
 const chainCollectorInputDirectory = "./src/test/testInputs/ChainCollector/";
 const noOffset0 = "aecc_alignment";
@@ -223,14 +223,14 @@ describe("ChainCollector", () => {
       GeometryCoreTestIO.captureCloneGeometry(allGeometry, offsets.outsideOffsets, x0, y0, -0.1);
       const outsideOffsetLength = OffsetHelpers.sumLengths(offsets.outsideOffsets);
       // skip the inside and outside ..
-      const myOffsetA: GeometryQuery[] = [];
-      OffsetHelpers.appendOffsets(primitives, -offsetDistance, myOffsetA, true);
+      const myOffsetA: AnyCurve[] = [];
+      OffsetHelpers.appendOffsets(primitives, -offsetDistance, myOffsetA);
       const myLengthA = OffsetHelpers.sumLengths(myOffsetA);
       y0 += yShift;
       GeometryCoreTestIO.captureCloneGeometry(allGeometry, myOffsetA, x0, y0);
 
-      const myOffsetB: GeometryQuery[] = [];
-      OffsetHelpers.appendOffsets([primitives], -offsetDistance, myOffsetB, false);
+      const myOffsetB: AnyCurve[] = [];
+      OffsetHelpers.appendOffsets([primitives], -offsetDistance, myOffsetB);
       const myLengthB = OffsetHelpers.sumLengths(myOffsetB);
       y0 += yShift;
       GeometryCoreTestIO.captureCloneGeometry(allGeometry, myOffsetB, x0, y0);

--- a/core/geometry/src/test/topology/RegionOps.test.ts
+++ b/core/geometry/src/test/topology/RegionOps.test.ts
@@ -777,12 +777,12 @@ describe("CloneSplitCurves", () => {
       Path.create(line010.clone(), LineSegment3d.create(line010.endPoint(), Point3d.create(0, y2))),   // two lines that will rejoin in output
       Path.create(line010.clone(), linestring10, Arc3d.createCircularStartMiddleEnd(linestring10.endPoint(), Point3d.create(5, y1), Point3d.create(0, 2 * y1))!)];
     for (const source of pathsToCut) {
-      const cut = RegionOps.cloneCurvesWithXYSplitFlags(source, cutters) as CurveCollection;
+      const cut = RegionOps.cloneCurvesWithXYSplits(source, cutters) as CurveCollection;
       ck.testCoordinate(cut.sumLengths(), curveLength(source), "split curve markup preserves length");
 
       GeometryCoreTestIO.captureCloneGeometry(allGeometry, [source, cutters], x0, y0);
       GeometryCoreTestIO.captureCloneGeometry(allGeometry, cut, x0, y0 + yStep);
-      const splits = RegionOps.splitToPathsBetweenFlagBreaks(cut, true);
+      const splits = RegionOps.splitToPathsBetweenBreaks(cut, true);
       if (splits)
         GeometryCoreTestIO.captureCloneGeometry(allGeometry, cutters, x0, y0 + 2 * yStep);
       if (splits instanceof BagOfCurves)
@@ -946,17 +946,17 @@ describe("CloneSplitCurves", () => {
         testOffsetWrapper(ck, allGeometry, delta, chain, options);
 
     // Bezier splines
-    const poles: Point3d[] = [Point3d.createZero(), Point3d.create(1,1), Point3d.create(2,-1), Point3d.create(3,2), Point3d.create(4,-2), Point3d.create(5,3)];
+    const poles: Point3d[] = [Point3d.createZero(), Point3d.create(1, 1), Point3d.create(2, -1), Point3d.create(3, 2), Point3d.create(4, -2), Point3d.create(5, 3)];
     const mirrorPoles: Point3d[] = [];
-    poles.forEach((pt) => {mirrorPoles.push(Point3d.create(-pt.x, pt.y));});
+    poles.forEach((pt) => { mirrorPoles.push(Point3d.create(-pt.x, pt.y)); });
     mirrorPoles.reverse();
     const rotatedPoles: Point3d[] = [];
-    mirrorPoles.forEach((pt) => {rotatedPoles.push(Point3d.create(pt.x, -pt.y));});
+    mirrorPoles.forEach((pt) => { rotatedPoles.push(Point3d.create(pt.x, -pt.y)); });
     testOffsetWrapper(ck, allGeometry, delta, Path.create(BezierCurve3d.create(mirrorPoles)!, BezierCurve3d.create(poles)!), options);
     testOffsetWrapper(ck, allGeometry, delta, Path.create(BezierCurve3d.create(rotatedPoles)!, BezierCurve3d.create(poles)!), options);
 
     // unclamped splines
-    const knots: number[] = [1,2,3,4,5,6,7,8];
+    const knots: number[] = [1, 2, 3, 4, 5, 6, 7, 8];
     const curve = BSplineCurve3dH.create(poles, knots, 4)!;
     const mirrorCurve = BSplineCurve3dH.create(mirrorPoles, knots, 4)!;
     const rotatedCurve = BSplineCurve3dH.create(rotatedPoles, knots, 4)!;
@@ -967,7 +967,7 @@ describe("CloneSplitCurves", () => {
     testOffsetWrapper(ck, allGeometry, delta, Path.create(mirrorCurve, LineSegment3d.create(mirrorCurve.endPoint(), curve.startPoint()), curve), options);
     testOffsetWrapper(ck, allGeometry, delta, Path.create(rotatedCurve, LineSegment3d.create(rotatedCurve.endPoint(), curve.startPoint()), curve), options);
     // save unclamped, clamped, control polygon, start point, end point
-    GeometryCoreTestIO.saveGeometry([curve, curve.clonePartialCurve(0,1), LineString3d.create(curve.copyXYZFloat64Array(true)), Arc3d.createXY(curve.startPoint(), 0.5), Arc3d.createXY(curve.endPoint(), 0.5)], "BSplineCurve", "Unclamped");
+    GeometryCoreTestIO.saveGeometry([curve, curve.clonePartialCurve(0, 1), LineString3d.create(curve.copyXYZFloat64Array(true)), Arc3d.createXY(curve.startPoint(), 0.5), Arc3d.createXY(curve.endPoint(), 0.5)], "BSplineCurve", "Unclamped");
 
     GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps", "OffsetCurves");
     expect(ck.getNumErrors()).equals(0);


### PR DESCRIPTION
Promote classes to published API for #4851:
* `DeepCompare` from `@internal` to `@public`
* `RegionOps` from `@beta` to `@public`

API changes:
* Narrow the value type of the map member `DeepCompare.propertyCounts` from `any` to `number`.
* In `RegionOps`, prefer `AnyCurve` to `GeometryQuery` when only handling curves.
* Substitute `AnyCurve` for `CurveCollection | CurvePrimitive` as they are the same type.
* New method names `RegionOps.cloneCurvesWithXYSplits` and `RegionOps.splitToPathsBetweenBreaks` to remove outdated references to `CurveLocationDetail` markup as "flags".

Plus documentation clarifications.