### PR TITLE
Fix frontend-tiles package references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,7 +103,6 @@ rush.json       @iTwin/itwinjs-core-admins
 /core/frontend                  @kabentley @bbastings @iTwin/itwinjs-core-display
 /core/frontend/src/extension    @calebmshafer @wgoehrig @aruniverse @kckst8 @johnnyd710
 /core/frontend-devtools         @iTwin/itwinjs-core-display @Ellord207
-/core/frontend-tiles            @iTwin/itwinjs-core-display @danieliborra
 /core/geometry                  @bbastings @dassaf4 @saeeedtorabi
 /core/hypermodeling             @bbastings @iTwin/itwinjs-core-display
 /core/i18n                      @wgoehrig @calebmshafer
@@ -131,6 +130,7 @@ rush.json       @iTwin/itwinjs-core-admins
 /example-code                         @iTwin/itwinjs-core-admins
 
 /extensions                           @aruniverse @calebmshafer
+/extensions/frontend-tiles            @iTwin/itwinjs-core-display @danieliborra
 /extensions/test-extension            @aruniverse @calebmshafer @wgoehrig
 
 /full-stack-tests/core                    @iTwin/itwinjs-core-admins

--- a/common/changes/@itwin/frontend-tiles/pmc-frontend-tiles-fixes_2023-03-23-14-22.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-frontend-tiles-fixes_2023-03-23-14-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/README.md
+++ b/extensions/frontend-tiles/README.md
@@ -1,4 +1,4 @@
-# @itwin/core-frontend
+# @itwin/frontend-tiles
 
 Copyright © Bentley Systems, Incorporated. All rights reserved. See LICENSE.md for license terms and full copyright notice.
 


### PR DESCRIPTION
As pointed out and fixed in #5269 on release/3.7.x.