### PR TITLE
Fix iterator for ProxySpatialTileTreeReferences

### DIFF
--- a/common/changes/@itwin/frontend-tiles/pmc-fix-proxy-iterator_2023-03-24-15-58.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-fix-proxy-iterator_2023-03-24-15-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/src/BatchedSpatialTileTreeRefs.ts
+++ b/extensions/frontend-tiles/src/BatchedSpatialTileTreeRefs.ts
@@ -119,10 +119,12 @@ class ProxySpatialTileTreeReferences implements SpatialTileTreeReferences {
   public setDeactivated(): void { }
 
   public *[Symbol.iterator](): Iterator<TileTreeReference> {
-    if (this._impl)
-      return this._impl[Symbol.iterator]();
-
-    yield this._proxyRef;
+    if (this._impl) {
+      for (const ref of this._impl)
+        yield ref;
+    } else {
+      yield this._proxyRef;
+    }
   }
 }
 


### PR DESCRIPTION
If you opened to a non-spatial view, then a spatial view, no tiles would display. If you then opened a different spatial view, the tiles would display.