### PR TITLE
Configure max tiles to skip for batched tile trees

### DIFF
--- a/common/api/frontend-tiles.api.md
+++ b/common/api/frontend-tiles.api.md
@@ -16,7 +16,11 @@ export const createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeRefe
 // @alpha
 export interface FrontendTilesOptions {
     computeSpatialTilesetBaseUrl: ComputeSpatialTilesetBaseUrl;
+    maxLevelsToSkip?: number;
 }
+
+// @internal (undocumented)
+export function getMaxLevelsToSkip(): number;
 
 // @alpha
 export function initializeFrontendTiles(options: FrontendTilesOptions): void;

--- a/common/api/summary/frontend-tiles.exports.csv
+++ b/common/api/summary/frontend-tiles.exports.csv
@@ -3,4 +3,5 @@ Release Tag;API Item
 alpha;ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise
 internal;createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeReferences.create
 alpha;FrontendTilesOptions
+internal;getMaxLevelsToSkip(): number
 alpha;initializeFrontendTiles(options: FrontendTilesOptions): void

--- a/common/changes/@itwin/frontend-tiles/pmc-config-tile-skip_2023-03-24-19-18.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-config-tile-skip_2023-03-24-19-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/src/BatchedTile.ts
+++ b/extensions/frontend-tiles/src/BatchedTile.ts
@@ -12,6 +12,7 @@ import {
 import { loggerCategory } from "./LoggerCategory";
 import { BatchedTileTree } from "./BatchedTileTree";
 import { BatchedTileContentReader } from "./BatchedTileContentReader";
+import { getMaxLevelsToSkip } from "./FrontendTiles";
 
 /** @internal */
 export interface BatchedTileParams extends TileParams {
@@ -105,7 +106,7 @@ export class BatchedTile extends Tile {
     // This tile is too coarse to draw. Try to draw something more appropriate.
     // If it is not ready to draw, we may want to skip loading in favor of loading its descendants.
     // If we previously loaded and later unloaded content for this tile to free memory, don't force it to reload its content - proceed to children.
-    const maximumLevelsToSkip = IModelApp.tileAdmin.maximumLevelsToSkip;
+    const maximumLevelsToSkip = getMaxLevelsToSkip();
     let canSkipThisTile = (this._hadGraphics && !this.hasGraphics) /* || this.depth < this.iModelTree.maxInitialTilesToSkip */ ;
     if (canSkipThisTile) {
       numSkipped = 1;

--- a/extensions/frontend-tiles/src/FrontendTiles.ts
+++ b/extensions/frontend-tiles/src/FrontendTiles.ts
@@ -20,14 +20,33 @@ export type ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise
 export interface FrontendTilesOptions {
   /** Provide the base URL for the pre-published tileset for a given iModel. */
   computeSpatialTilesetBaseUrl: ComputeSpatialTilesetBaseUrl;
+  /** The maximum number of levels in the tile tree to skip loading if they do not provide the desired level of detail for the current view.
+   * Default: 4.
+   * Reducing this value will load more intermediate tiles, which causes more gradual refinement: low-resolution tiles will display quickly, followed more gradually by
+   * successively higher-resolution ones.
+   * Increasing the value jumps more directly to tiles of the exact level of detail desired, which may load more, smaller tiles up-front, leaving some areas of the view
+   * vacant for longer; and when zooming out some newly-exposed areas of the view may remain vacant for longer because no lower-resolution tiles are initially available to
+   * fill them. However, tiles close to the viewer (and therefore likely of most interest to them) will refine to an appropriate level of detail more quickly.
+   */
+  maxLevelsToSkip?: number;
 }
 
 /** @internal */
 export const createFallbackSpatialTileTreeReferences = SpatialTileTreeReferences.create;
 
+let maxLevelsToSkip = 4;
+
+/** @internal */
+export function getMaxLevelsToSkip(): number {
+  return maxLevelsToSkip;
+}
+
 /** Initialize the frontend-tiles package to obtain tiles for spatial views.
  * @alpha
  */
 export function initializeFrontendTiles(options: FrontendTilesOptions): void {
+  if (undefined !== options.maxLevelsToSkip && options.maxLevelsToSkip >= 0)
+    maxLevelsToSkip = options.maxLevelsToSkip;
+
   SpatialTileTreeReferences.create = (view: SpatialViewState) => createBatchedSpatialTileTreeReferences(view, options.computeSpatialTilesetBaseUrl);
 }


### PR DESCRIPTION
[Restructuring of tile tree](https://dev.azure.com/bentleycs/iModelTechnologies/_git/graphics-exporter-services/pullrequest/323662?iteration=10&base=9) leads BatchedTile to load many more intermediate tiles when refining the view.
Add an option to indicate how many intermediate tiles to skip, and default it to 4.