### PR TITLE
Batched tiles: fit to viewed models

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-batched-tile-model-ranges_2023-03-27-19-46.json
+++ b/common/changes/@itwin/core-frontend/pmc-batched-tile-model-ranges_2023-03-27-19-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/frontend-tiles/pmc-batched-tile-model-ranges_2023-03-27-19-46.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-batched-tile-model-ranges_2023-03-27-19-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "Ensure fitting the view fits to the extents of the currently-viewed models.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -800,7 +800,7 @@ export namespace IModelConnection { // eslint-disable-line no-redeclare
      * @param modelIds the Id or Ids of the [GeometricModel]($backend)s for which to query the ranges.
      * @returns An array containing the range of each model of each unique model Id, omitting the range for any Id which did no identify a GeometricModel.
      * @note The contents of the returned array do not follow a deterministic order.
-     * @throws [IModelError]($common) if exactly one model Id is specified and that Id does not identify a GeoemtricModel.
+     * @throws [IModelError]($common) if exactly one model Id is specified and that Id does not identify a GeometricModel.
      * @see [[queryExtents]] for a similar function that does not throw and produces a deterministically-ordered result.
      */
     public async queryModelRanges(modelIds: Id64Arg): Promise<Range3dProps[]> {

--- a/extensions/frontend-tiles/src/BatchedTileTreeReference.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTreeReference.ts
@@ -49,8 +49,10 @@ export class BatchedTileTreeReference extends TileTreeReference implements Featu
   public updateViewedModels(): void {
     this._viewedModels.clear();
     this._viewedModels.addIds(this._view.modelSelector.models);
-    if (!this._onModelSelectorChanged)
+    if (!this._onModelSelectorChanged) {
+      // Don't bother updating model ranges if we're not attached to a viewport.
       return;
+    }
 
     this._onModelSelectorChanged();
 


### PR DESCRIPTION
Previously fitting the view always fit the the extents of the entire tileset - i.e., all of the spatial models.
Instead, fit only to the union of the extents of those models that are currently in the model selector.