### PR TITLE
Presentation: Values formatting on frontend

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -44,12 +44,13 @@ import { Prioritized } from '@itwin/presentation-common';
 import { RegisteredRuleset } from '@itwin/presentation-common';
 import { Ruleset } from '@itwin/presentation-common';
 import { RulesetVariable } from '@itwin/presentation-common';
+import { SchemaContext } from '@itwin/ecschema-metadata';
 import { SelectClassInfo } from '@itwin/presentation-common';
 import { SelectionScope } from '@itwin/presentation-common';
 import { SelectionScopeRequestOptions } from '@itwin/presentation-common';
 import { SingleElementPropertiesRequestOptions } from '@itwin/presentation-common';
 import { UnitSystemKey } from '@itwin/core-quantity';
-import { UpdateInfoJSON } from '@itwin/presentation-common';
+import { UpdateInfo } from '@itwin/presentation-common';
 import { VariableValue } from '@itwin/presentation-common';
 import { VariableValueTypes } from '@itwin/presentation-common';
 import { WithCancelEvent } from '@itwin/presentation-common';
@@ -279,6 +280,8 @@ export interface PresentationManagerProps {
     mode?: PresentationManagerMode;
     presentationAssetsRoot?: string | PresentationAssetsRootConfig;
     rulesetDirectories?: string[];
+    // @alpha
+    schemaContextProvider?: (imodel: IModelDb) => SchemaContext;
     supplementalRulesetDirectories?: string[];
     // @beta
     updatesPollInterval?: number;

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -331,6 +331,13 @@ export enum ContentFlags {
     ShowLabels = 4
 }
 
+// @alpha (undocumented)
+export class ContentFormatter {
+    constructor(_propertyValueFormatter: ContentPropertyValueFormatter, _unitSystem?: UnitSystemKey | undefined);
+    // (undocumented)
+    formatContent(content: Content): Promise<Content>;
+}
+
 // @public
 export interface ContentInstanceKeysRequestOptions<TIModel, TKeySet, TRulesetVariable = RulesetVariable> extends Paged<RequestOptionsWithRuleset<TIModel, TRulesetVariable>> {
     displayType?: string;
@@ -375,9 +382,17 @@ export interface ContentModifiersList {
 
 // @alpha (undocumented)
 export class ContentPropertyValueFormatter {
-    constructor(_propertyValueFormatter: PropertyValueFormatter, _unitSystem: UnitSystemKey);
+    constructor(_koqValueFormatter: KoqPropertyValueFormatter);
     // (undocumented)
-    formatContent(content: Content): Promise<Content>;
+    formatArrayValue(type: ArrayTypeDescription, value: Value): DisplayValue[];
+    // (undocumented)
+    formatPrimitiveValue(type: PrimitiveTypeDescription, value: Value): string;
+    // (undocumented)
+    formatPropertyValue(field: Field, value: Value, unitSystem?: UnitSystemKey): Promise<DisplayValue>;
+    // (undocumented)
+    formatStructValue(type: StructTypeDescription, value: Value): DisplayValuesMap;
+    // (undocumented)
+    formatValue(type: TypeDescription, value: Value): DisplayValue;
 }
 
 // @public
@@ -391,6 +406,8 @@ export interface ContentRelatedInstancesSpecification extends ContentSpecificati
 export interface ContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
     descriptor: TDescriptor;
     keys: TKeySet;
+    // @alpha
+    omitFormattedValues?: boolean;
 }
 
 // @public
@@ -444,6 +461,9 @@ export enum ContentSpecificationTypes {
 
 // @alpha (undocumented)
 export type ContentUpdateInfo = typeof UPDATE_FULL;
+
+// @alpha (undocumented)
+export function createContentFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey): ContentFormatter;
 
 // @public
 export function createFieldHierarchies(fields: Field[], ignoreCategories?: Boolean): FieldHierarchy[];
@@ -923,28 +943,6 @@ export interface EnumerationInfo {
     isStrict: boolean;
 }
 
-// @alpha (undocumented)
-export interface ExpandedNodeUpdateRecord {
-    // (undocumented)
-    node: Node_2;
-    // (undocumented)
-    position: number;
-}
-
-// @alpha (undocumented)
-export namespace ExpandedNodeUpdateRecord {
-    export function fromJSON(json: ExpandedNodeUpdateRecordJSON): ExpandedNodeUpdateRecord;
-    export function toJSON(obj: ExpandedNodeUpdateRecord): ExpandedNodeUpdateRecordJSON;
-}
-
-// @alpha (undocumented)
-export interface ExpandedNodeUpdateRecordJSON {
-    // (undocumented)
-    node: NodeJSON;
-    // (undocumented)
-    position: number;
-}
-
 // @public
 export interface ExtendedDataRule extends RuleBase {
     condition?: string;
@@ -1042,7 +1040,7 @@ export interface FormatOptions {
     // (undocumented)
     koqName: string;
     // (undocumented)
-    unitSystem: UnitSystemKey;
+    unitSystem?: UnitSystemKey;
 }
 
 // @internal (undocumented)
@@ -1175,46 +1173,7 @@ export interface HierarchyRequestOptions<TIModel, TNodeKey, TRulesetVariable = R
 export type HierarchyRpcRequestOptions = PresentationRpcRequestOptions<HierarchyRequestOptions<never, NodeKey, RulesetVariableJSON>>;
 
 // @alpha (undocumented)
-export type HierarchyUpdateInfo = typeof UPDATE_FULL | HierarchyUpdateRecord[];
-
-// @alpha (undocumented)
-export namespace HierarchyUpdateInfo {
-    export function fromJSON(json: HierarchyUpdateInfoJSON): HierarchyUpdateInfo;
-    export function toJSON(obj: HierarchyUpdateInfo): HierarchyUpdateInfoJSON;
-}
-
-// @alpha (undocumented)
-export type HierarchyUpdateInfoJSON = typeof UPDATE_FULL | HierarchyUpdateRecordJSON[];
-
-// @alpha (undocumented)
-export interface HierarchyUpdateRecord {
-    // (undocumented)
-    expandedNodes?: ExpandedNodeUpdateRecord[];
-    // (undocumented)
-    instanceFilter?: string;
-    // (undocumented)
-    nodesCount: number;
-    // (undocumented)
-    parent?: NodeKey;
-}
-
-// @alpha (undocumented)
-export namespace HierarchyUpdateRecord {
-    export function fromJSON(json: HierarchyUpdateRecordJSON): HierarchyUpdateRecord;
-    export function toJSON(obj: HierarchyUpdateRecord): HierarchyUpdateRecordJSON;
-}
-
-// @alpha (undocumented)
-export interface HierarchyUpdateRecordJSON {
-    // (undocumented)
-    expandedNodes?: ExpandedNodeUpdateRecordJSON[];
-    // (undocumented)
-    instanceFilter?: string;
-    // (undocumented)
-    nodesCount: number;
-    // (undocumented)
-    parent?: NodeKeyJSON;
-}
+export type HierarchyUpdateInfo = typeof UPDATE_FULL;
 
 // @public
 export interface IContentVisitor {
@@ -1592,6 +1551,17 @@ export interface KindOfQuantityInfo {
     persistenceUnit: string;
 }
 
+// @alpha (undocumented)
+export class KoqPropertyValueFormatter {
+    constructor(_schemaContext: SchemaContext);
+    // (undocumented)
+    format(value: number, options: FormatOptions): Promise<string | undefined>;
+    // (undocumented)
+    getFormatterSpec(options: FormatOptions): Promise<FormatterSpec | undefined>;
+    // (undocumented)
+    getParserSpec(options: FormatOptions): Promise<ParserSpec | undefined>;
+}
+
 // @public
 export interface LabelCompositeValue {
     // (undocumented)
@@ -1751,6 +1721,13 @@ export interface NavigationPropertyInfoJSON<TClassInfoJSON = ClassInfoJSON> {
     isTargetPolymorphic: boolean;
     // (undocumented)
     targetClassInfo: TClassInfoJSON;
+}
+
+// @public
+export interface NavigationPropertyValue {
+    className: string;
+    id: InstanceId;
+    label: LabelDefinition;
 }
 
 // @public
@@ -2150,7 +2127,6 @@ export enum PresentationIpcEvents {
 export interface PresentationIpcInterface {
     setRulesetVariable(params: SetRulesetVariableParams<RulesetVariableJSON>): Promise<void>;
     unsetRulesetVariable(params: UnsetRulesetVariableParams): Promise<void>;
-    updateHierarchyState(params: UpdateHierarchyStateParams<NodeKey>): Promise<void>;
 }
 
 // @alpha
@@ -2499,17 +2475,6 @@ export enum PropertyValueFormat {
     Array = "Array",
     Primitive = "Primitive",
     Struct = "Struct"
-}
-
-// @alpha (undocumented)
-export class PropertyValueFormatter {
-    constructor(_schemaContext: SchemaContext);
-    // (undocumented)
-    format(value: number, options: FormatOptions): Promise<string | undefined>;
-    // (undocumented)
-    getFormatterSpec(options: FormatOptions): Promise<FormatterSpec | undefined>;
-    // (undocumented)
-    getParserSpec(options: FormatOptions): Promise<ParserSpec | undefined>;
 }
 
 // @public
@@ -3154,20 +3119,6 @@ export interface UnsetRulesetVariableParams extends CommonIpcParams {
 // @alpha (undocumented)
 export const UPDATE_FULL = "FULL";
 
-// @internal (undocumented)
-export interface UpdateHierarchyStateParams<TNodeKey> extends CommonIpcParams {
-    // (undocumented)
-    imodelKey: string;
-    // (undocumented)
-    rulesetId: string;
-    // (undocumented)
-    stateChanges: Array<{
-        nodeKey: TNodeKey | undefined;
-        isExpanded?: boolean;
-        instanceFilters?: string[];
-    }>;
-}
-
 // @alpha (undocumented)
 export interface UpdateInfo {
     // (undocumented)
@@ -3179,25 +3130,8 @@ export interface UpdateInfo {
     };
 }
 
-// @alpha (undocumented)
-export namespace UpdateInfo {
-    export function fromJSON(json: UpdateInfoJSON): UpdateInfo;
-    export function toJSON(obj: UpdateInfo): UpdateInfoJSON;
-}
-
-// @alpha (undocumented)
-export interface UpdateInfoJSON {
-    // (undocumented)
-    [imodel: string]: {
-        [rulesetId: string]: {
-            hierarchy?: HierarchyUpdateInfoJSON;
-            content?: ContentUpdateInfo;
-        };
-    };
-}
-
 // @public
-export type Value = string | number | boolean | undefined | ValuesMap | ValuesArray | NestedContentValue[];
+export type Value = string | number | boolean | undefined | ValuesMap | ValuesArray | NavigationPropertyValue | NestedContentValue[];
 
 // @public (undocumented)
 export namespace Value {
@@ -3205,6 +3139,7 @@ export namespace Value {
     export function fromJSON(json: ValueJSON): Value;
     export function isArray(value: Value): value is ValuesArray;
     export function isMap(value: Value): value is ValuesMap;
+    export function isNavigationValue(value: Value): value is NavigationPropertyValue;
     export function isNestedContent(value: Value): value is NestedContentValue[];
     export function isPrimitive(value: Value): value is string | number | boolean | undefined;
     // @deprecated
@@ -3212,7 +3147,7 @@ export namespace Value {
 }
 
 // @public @deprecated
-export type ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NestedContentValueJSON[];
+export type ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NavigationPropertyValue | NestedContentValueJSON[];
 
 // @public
 export interface ValuesArray extends Array<Value> {

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -462,9 +462,6 @@ export enum ContentSpecificationTypes {
 // @alpha (undocumented)
 export type ContentUpdateInfo = typeof UPDATE_FULL;
 
-// @alpha (undocumented)
-export function createContentFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey): ContentFormatter;
-
 // @public
 export function createFieldHierarchies(fields: Field[], ignoreCategories?: Boolean): FieldHierarchy[];
 

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -48,6 +48,7 @@ import { RegisteredRuleset } from '@itwin/presentation-common';
 import { RpcRequestsHandler } from '@itwin/presentation-common';
 import { Ruleset } from '@itwin/presentation-common';
 import { RulesetVariable } from '@itwin/presentation-common';
+import { SchemaContext } from '@itwin/ecschema-metadata';
 import { SelectClassInfo } from '@itwin/presentation-common';
 import { SelectionScope } from '@itwin/presentation-common';
 import { SelectionScopeProps } from '@itwin/presentation-common';
@@ -55,7 +56,6 @@ import { SetRulesetVariableParams } from '@itwin/presentation-common';
 import { SingleElementPropertiesRequestOptions } from '@itwin/presentation-common';
 import { UnitSystemKey } from '@itwin/core-quantity';
 import { UnsetRulesetVariableParams } from '@itwin/presentation-common';
-import { UpdateHierarchyStateParams } from '@itwin/presentation-common';
 import { VariableValue } from '@itwin/presentation-common';
 
 // @internal (undocumented)
@@ -229,22 +229,6 @@ export interface ISelectionProvider {
     selectionChange: SelectionChangeEvent;
 }
 
-// @internal
-export interface NodeIdentifier {
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    key: NodeKey;
-}
-
-// @internal (undocumented)
-export interface NodeState {
-    // (undocumented)
-    instanceFilter?: string;
-    // (undocumented)
-    isExpanded?: boolean;
-}
-
 // @internal (undocumented)
 export class NoopFavoritePropertiesStorage implements IFavoritePropertiesStorage {
     // (undocumented)
@@ -354,8 +338,6 @@ export class PresentationManager implements IDisposable {
     // @internal (undocumented)
     get rpcRequestsHandler(): RpcRequestsHandler;
     rulesets(): RulesetManager;
-    // @internal (undocumented)
-    get stateTracker(): StateTracker | undefined;
     vars(rulesetId: string): RulesetVariablesManager;
 }
 
@@ -370,8 +352,8 @@ export interface PresentationManagerProps {
     requestTimeout?: number;
     // @internal (undocumented)
     rpcRequestsHandler?: RpcRequestsHandler;
-    // @internal (undocumented)
-    stateTracker?: StateTracker;
+    // @alpha
+    schemaContextProvider?: (imodel: IModelConnection) => SchemaContext;
 }
 
 // @public
@@ -551,18 +533,6 @@ export class SelectionScopesManager {
 export interface SelectionScopesManagerProps {
     localeProvider?: () => string | undefined;
     rpcRequestsHandler: RpcRequestsHandler;
-}
-
-// @internal
-export class StateTracker {
-    constructor(ipcRequestsHandler: IpcRequestsHandler);
-    // (undocumented)
-    onHierarchyClosed(imodel: IModelConnection, rulesetId: string, sourceId: string): Promise<void>;
-    // (undocumented)
-    onHierarchyStateChanged(imodel: IModelConnection, rulesetId: string, sourceId: string, newHierarchyState: Array<{
-        node: NodeIdentifier | undefined;
-        state: NodeState;
-    }>): Promise<void>;
 }
 
 // @internal (undocumented)

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -66,7 +66,6 @@ public;ContentSpecification = ContentInstancesOfSpecificClassesSpecification | C
 public;ContentSpecificationBase 
 public;ContentSpecificationTypes
 alpha;ContentUpdateInfo = typeof UPDATE_FULL
-alpha;createContentFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey): ContentFormatter
 public;createFieldHierarchies(fields: Field[], ignoreCategories?: Boolean): FieldHierarchy[]
 public;CustomNodeSpecification 
 public;CustomQueryInstanceNodesSpecification 

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -47,6 +47,7 @@ public;Content
 public;ContentDescriptorRequestOptions
 public;ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions
 public;ContentFlags
+alpha;ContentFormatter
 public;ContentInstanceKeysRequestOptions
 public;ContentInstanceKeysRpcRequestOptions = PresentationRpcRequestOptions
 public;ContentInstancesOfSpecificClassesSpecification 
@@ -65,6 +66,7 @@ public;ContentSpecification = ContentInstancesOfSpecificClassesSpecification | C
 public;ContentSpecificationBase 
 public;ContentSpecificationTypes
 alpha;ContentUpdateInfo = typeof UPDATE_FULL
+alpha;createContentFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey): ContentFormatter
 public;createFieldHierarchies(fields: Field[], ignoreCategories?: Boolean): FieldHierarchy[]
 public;CustomNodeSpecification 
 public;CustomQueryInstanceNodesSpecification 
@@ -135,9 +137,6 @@ public;ElementPropertiesStructPropertyItem
 public;ElementSelectionScopeProps
 public;EnumerationChoice
 public;EnumerationInfo
-alpha;ExpandedNodeUpdateRecord
-alpha;ExpandedNodeUpdateRecord
-alpha;ExpandedNodeUpdateRecordJSON
 public;ExtendedDataRule 
 public;Field
 internal;FIELD_NAMES_SEPARATOR = "$"
@@ -174,12 +173,7 @@ beta;HierarchyLevelJSON
 deprecated;HierarchyLevelJSON
 public;HierarchyRequestOptions
 public;HierarchyRpcRequestOptions = PresentationRpcRequestOptions
-alpha;HierarchyUpdateInfo = typeof UPDATE_FULL | HierarchyUpdateRecord[]
-alpha;HierarchyUpdateInfo
-alpha;HierarchyUpdateInfoJSON = typeof UPDATE_FULL | HierarchyUpdateRecordJSON[]
-alpha;HierarchyUpdateRecord
-alpha;HierarchyUpdateRecord
-alpha;HierarchyUpdateRecordJSON
+alpha;HierarchyUpdateInfo = typeof UPDATE_FULL
 public;IContentVisitor
 public;Id64RulesetVariable 
 public;Id64RulesetVariableJSON 
@@ -230,6 +224,7 @@ public;Keys = ReadonlyArray
 public;KeySet
 public;KeySetJSON
 public;KindOfQuantityInfo
+alpha;KoqPropertyValueFormatter
 public;LabelCompositeValue
 public;LabelCompositeValue
 public;LabelCompositeValueJSON
@@ -254,6 +249,7 @@ public;NamedFieldDescriptor
 beta;NavigationPropertyInfo
 beta;NavigationPropertyInfo
 beta;NavigationPropertyInfoJSON
+public;NavigationPropertyValue
 public;NavigationRule = RootNodeRule | ChildNodeRule
 public;NavigationRuleBase 
 public;NestedContentField 
@@ -349,7 +345,6 @@ public;PropertyRangeGroupSpecification
 public;PropertySortingRule 
 public;PropertySpecification 
 public;PropertyValueFormat
-alpha;PropertyValueFormatter
 public;QuerySpecification = StringQuerySpecification | ECPropertyValueQuerySpecification
 public;QuerySpecificationBase
 public;QuerySpecificationTypes
@@ -438,14 +433,11 @@ public;traverseFieldHierarchy(hierarchy: FieldHierarchy, cb: (h: FieldHierarchy)
 public;TypeDescription = PrimitiveTypeDescription | ArrayTypeDescription | StructTypeDescription
 internal;UnsetRulesetVariableParams 
 alpha;UPDATE_FULL = "FULL"
-internal;UpdateHierarchyStateParams
 alpha;UpdateInfo
-alpha;UpdateInfo
-alpha;UpdateInfoJSON
-public;Value = string | number | boolean | undefined | ValuesMap | ValuesArray | NestedContentValue[]
+public;Value = string | number | boolean | undefined | ValuesMap | ValuesArray | NavigationPropertyValue | NestedContentValue[]
 public;Value
-public;ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NestedContentValueJSON[]
-deprecated;ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NestedContentValueJSON[]
+public;ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NavigationPropertyValue | NestedContentValueJSON[]
+deprecated;ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NavigationPropertyValue | NestedContentValueJSON[]
 public;ValuesArray 
 public;ValuesArrayJSON 
 deprecated;ValuesArrayJSON 

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -28,8 +28,6 @@ alpha;IModelContentChangeEventArgs
 alpha;IModelHierarchyChangeEventArgs
 internal;IMODELJS_PRESENTATION_SETTING_NAMESPACE = "imodeljs.presentation"
 public;ISelectionProvider
-internal;NodeIdentifier
-internal;NodeState
 internal;NoopFavoritePropertiesStorage 
 internal;OfflineCachingFavoritePropertiesStorage 
 internal;OfflineCachingFavoritePropertiesStorageProps
@@ -54,6 +52,5 @@ public;SelectionManager
 public;SelectionManagerProps
 public;SelectionScopesManager
 public;SelectionScopesManagerProps
-internal;StateTracker
 internal;ToolSelectionSyncHandler 
 internal;TRANSIENT_ELEMENT_CLASSNAME = "/TRANSIENT"

--- a/common/changes/@itwin/presentation-backend/presentation-values_formatting_2023-03-28-11-21.json
+++ b/common/changes/@itwin/presentation-backend/presentation-values_formatting_2023-03-28-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Added content values formatting to `PresentationManager.getContent`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-values_formatting_2023-03-28-11-21.json
+++ b/common/changes/@itwin/presentation-common/presentation-values_formatting_2023-03-28-11-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/presentation-common",
-      "comment": "Added ContentPropertyValuesFormatter for supporting content values formatting on the frontend",
+      "comment": "Added `ContentPropertyValuesFormatter` for content values' formatting on either frontend or backend",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/presentation-common/presentation-values_formatting_2023-03-28-11-21.json
+++ b/common/changes/@itwin/presentation-common/presentation-values_formatting_2023-03-28-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Added ContentPropertyValuesFormatter for supporting content values formatting on the frontend",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/presentation-values_formatting_2023-03-28-11-21.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-values_formatting_2023-03-28-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Added content valeus formatting to `PresentationManager`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/common/changes/@itwin/presentation-frontend/presentation-values_formatting_2023-03-28-11-21.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-values_formatting_2023-03-28-11-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/presentation-frontend",
-      "comment": "Added content valeus formatting to `PresentationManager`",
+      "comment": "Added content values formatting to `PresentationManager`",
       "type": "none"
     }
   ],

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -188,7 +188,7 @@
     },
     {
       "name": "@itwin/ecschema-metadata",
-      "allowedCategories": [ "backend", "common", "integration-testing", "internal", "tools" ]
+      "allowedCategories": [ "backend", "common", "frontend", "integration-testing", "internal", "tools" ]
     },
     {
       "name": "@itwin/ecschema-rpcinterface-common",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2166,6 +2166,7 @@ importers:
       '@itwin/core-bentley': workspace:*
       '@itwin/core-common': workspace:*
       '@itwin/core-quantity': workspace:*
+      '@itwin/ecschema-metadata': workspace:*
       '@itwin/eslint-plugin': ^4.0.0-dev.32
       '@itwin/presentation-common': workspace:*
       '@types/chai': 4.3.1
@@ -2209,6 +2210,7 @@ importers:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
       '@itwin/core-quantity': link:../../core/quantity
+      '@itwin/ecschema-metadata': link:../../core/ecschema-metadata
       '@itwin/eslint-plugin': 4.0.0-dev.32_eslint@7.32.0+typescript@5.0.2
       '@itwin/presentation-common': link:../common
       '@types/chai': 4.3.1
@@ -2324,6 +2326,7 @@ importers:
       '@itwin/core-frontend': workspace:*
       '@itwin/core-i18n': workspace:*
       '@itwin/core-quantity': workspace:*
+      '@itwin/ecschema-metadata': workspace:*
       '@itwin/eslint-plugin': ^4.0.0-dev.32
       '@itwin/presentation-common': workspace:*
       '@types/chai': 4.3.1
@@ -2360,6 +2363,7 @@ importers:
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-i18n': link:../../core/i18n
       '@itwin/core-quantity': link:../../core/quantity
+      '@itwin/ecschema-metadata': link:../../core/ecschema-metadata
       '@itwin/eslint-plugin': 4.0.0-dev.32_eslint@7.32.0+typescript@5.0.2
       '@itwin/presentation-common': link:../common
       '@types/chai': 4.3.1
@@ -7161,7 +7165,7 @@ packages:
   /@types/cpx/1.5.2:
     resolution: {integrity: sha512-CL9DbTAdf5NYcbYpBTli6JxVIpCAhJp1FeQiXd9SNjbC4o9k6McnHkU0FHgj9UYoN7TVX3poaaBrwFabTY7Skw==}
     dependencies:
-      '@types/node': 18.15.3
+      '@types/node': 18.11.5
     dev: false
 
   /@types/debug/4.1.7:
@@ -7356,6 +7360,10 @@ packages:
 
   /@types/node/16.18.16:
     resolution: {integrity: sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA==}
+
+  /@types/node/18.11.5:
+    resolution: {integrity: sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==}
+    dev: false
 
   /@types/node/18.15.3:
     resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -106,3 +106,4 @@ In addition to upgrading iTwin.js core dependencies to `4.0`, there are some oth
 
 - Support for React 18 (keep support of React 17 too).
 - Upgrade [iTwinUI](https://github.com/iTwin/iTwinUI) from v1 to v2.
+- `@itwin/presentation-backend`, `@itwin/presentation-common` and `@itwin/presentation-frontend` have new peer dependency `@itwin/ecschema-metadata`.

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -43,6 +43,7 @@
     "@itwin/core-bentley": "workspace:^4.0.0-dev.56",
     "@itwin/core-common": "workspace:^4.0.0-dev.56",
     "@itwin/core-quantity": "workspace:^4.0.0-dev.56",
+    "@itwin/ecschema-metadata": "workspace:^4.0.0-dev.56",
     "@itwin/presentation-common": "workspace:^4.0.0-dev.56"
   },
   "devDependencies": {
@@ -51,6 +52,7 @@
     "@itwin/core-bentley": "workspace:*",
     "@itwin/core-common": "workspace:*",
     "@itwin/core-quantity": "workspace:*",
+    "@itwin/ecschema-metadata": "workspace:*",
     "@itwin/eslint-plugin": "^4.0.0-dev.32",
     "@itwin/presentation-common": "workspace:*",
     "@types/chai": "4.3.1",

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -11,14 +11,14 @@ import { Id64String } from "@itwin/core-bentley";
 import { FormatProps, UnitSystemKey } from "@itwin/core-quantity";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import {
-  ComputeSelectionRequestOptions, Content, ContentDescriptorRequestOptions, ContentFlags, ContentRequestOptions, ContentSourcesRequestOptions,
-  createContentFormatter, DefaultContentDisplayTypes, Descriptor, DescriptorOverrides, DisplayLabelRequestOptions, DisplayLabelsRequestOptions,
-  DisplayValueGroup, DistinctValuesRequestOptions, ElementProperties, ElementPropertiesRequestOptions, FilterByInstancePathsHierarchyRequestOptions,
-  FilterByTextHierarchyRequestOptions, HierarchyCompareInfo, HierarchyCompareOptions, HierarchyLevelDescriptorRequestOptions, HierarchyLevelJSON,
-  HierarchyRequestOptions, InstanceKey, isComputeSelectionRequestOptions, isSingleElementPropertiesRequestOptions, KeySet, LabelDefinition,
-  LocalizationHelper, MultiElementPropertiesRequestOptions, Node, NodeKey, NodePathElement, Paged, PagedResponse, PresentationError,
-  PresentationStatus, Prioritized, Ruleset, RulesetVariable, SelectClassInfo, SelectionScope, SelectionScopeRequestOptions,
-  SingleElementPropertiesRequestOptions, WithCancelEvent,
+  ComputeSelectionRequestOptions, Content, ContentDescriptorRequestOptions, ContentFlags, ContentFormatter, ContentPropertyValueFormatter,
+  ContentRequestOptions, ContentSourcesRequestOptions, DefaultContentDisplayTypes, Descriptor, DescriptorOverrides, DisplayLabelRequestOptions,
+  DisplayLabelsRequestOptions, DisplayValueGroup, DistinctValuesRequestOptions, ElementProperties, ElementPropertiesRequestOptions,
+  FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions, HierarchyCompareInfo, HierarchyCompareOptions,
+  HierarchyLevelDescriptorRequestOptions, HierarchyLevelJSON, HierarchyRequestOptions, InstanceKey, isComputeSelectionRequestOptions,
+  isSingleElementPropertiesRequestOptions, KeySet, KoqPropertyValueFormatter, LabelDefinition, LocalizationHelper,
+  MultiElementPropertiesRequestOptions, Node, NodeKey, NodePathElement, Paged, PagedResponse, PresentationError, PresentationStatus, Prioritized,
+  Ruleset, RulesetVariable, SelectClassInfo, SelectionScope, SelectionScopeRequestOptions, SingleElementPropertiesRequestOptions, WithCancelEvent,
 } from "@itwin/presentation-common";
 import { buildElementsProperties, getElementsCount, iterateElementIds } from "./ElementPropertiesHelper";
 import { NativePlatformDefinition, NativePlatformRequestTypes } from "./NativePlatform";
@@ -527,14 +527,15 @@ export class PresentationManager {
   public async getContent(requestOptions: WithCancelEvent<Prioritized<Paged<ContentRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Content | undefined> {
     const content = await this._detail.getContent({
       ...requestOptions,
-      ...(!requestOptions.omitFormattedValues && this.props.schemaContextProvider !== undefined ? { omitFormattedValues: true } : undefined)
+      ...(!requestOptions.omitFormattedValues && this.props.schemaContextProvider !== undefined ? { omitFormattedValues: true } : undefined),
     });
 
     if (!content)
       return undefined;
 
     if (!requestOptions.omitFormattedValues && this.props.schemaContextProvider !== undefined) {
-      const formatter = createContentFormatter(this.props.schemaContextProvider(requestOptions.imodel), requestOptions.unitSystem);
+      const koqPropertyFormatter = new KoqPropertyValueFormatter(this.props.schemaContextProvider(requestOptions.imodel));
+      const formatter = new ContentFormatter(new ContentPropertyValueFormatter(koqPropertyFormatter), requestOptions.unitSystem);
       await formatter.formatContent(content);
     }
 

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -525,15 +525,15 @@ export class PresentationManager {
    * @public
    */
   public async getContent(requestOptions: WithCancelEvent<Prioritized<Paged<ContentRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Content | undefined> {
-    const shouldFormatValues = !requestOptions.omitFormattedValues;
     const content = await this._detail.getContent({
-      ...(shouldFormatValues && this.props.schemaContextProvider !== undefined ? { omitFormattedValues: true } : undefined),
       ...requestOptions,
+      ...(!requestOptions.omitFormattedValues && this.props.schemaContextProvider !== undefined ? { omitFormattedValues: true } : undefined)
     });
+
     if (!content)
       return undefined;
 
-    if (shouldFormatValues && this.props.schemaContextProvider !== undefined) {
+    if (!requestOptions.omitFormattedValues && this.props.schemaContextProvider !== undefined) {
       const formatter = createContentFormatter(this.props.schemaContextProvider(requestOptions.imodel), requestOptions.unitSystem);
       await formatter.formatContent(content);
     }

--- a/presentation/backend/src/test/PresentationManager.test.snap
+++ b/presentation/backend/src/test/PresentationManager.test.snap
@@ -282,6 +282,170 @@ Object {
 }
 `;
 
+exports[`PresentationManager addon results conversion to Presentation objects getContent returns content without formatting 1`] = `
+Object {
+  "contentSet": Array [
+    Object {
+      "classInfo": Object {
+        "id": "0x10f000000e465",
+        "label": "Cambridgeshire asymmetric SDD",
+        "name": "optimizing",
+      },
+      "displayValues": Object {},
+      "imageId": "bad90675-1cd6-4a1c-9a48-976928bf2c4c",
+      "labelDefinition": Object {
+        "displayValue": "Electronics",
+        "rawValue": "Intelligent Plastic Keyboard",
+        "typeName": "string",
+      },
+      "mergedFieldNames": Array [],
+      "primaryKeys": Array [
+        Object {
+          "className": "dot-com",
+          "id": "0x137ba0000004451",
+        },
+      ],
+      "values": Object {
+        "e-markets": 1.234,
+      },
+    },
+  ],
+  "descriptor": Object {
+    "categories": Array [
+      Object {
+        "description": "Test category description",
+        "expand": false,
+        "label": "Test Category",
+        "name": "test-category",
+        "priority": 0,
+      },
+    ],
+    "classesMap": Object {
+      "0x1": Object {
+        "label": "Class Label",
+        "name": "SchemaName:ClassName",
+      },
+    },
+    "connectionId": "",
+    "contentFlags": 0,
+    "displayType": "test",
+    "fields": Array [
+      Object {
+        "category": "test-category",
+        "editor": undefined,
+        "isReadonly": false,
+        "label": "Properties Field",
+        "name": "e-markets",
+        "priority": 0,
+        "properties": Array [
+          Object {
+            "property": Object {
+              "classInfo": "0x1",
+              "name": "PropertyName",
+              "type": "string",
+            },
+          },
+        ],
+        "renderer": undefined,
+        "type": Object {
+          "typeName": "double",
+          "valueFormat": "Primitive",
+        },
+      },
+    ],
+    "selectClasses": Array [
+      Object {
+        "isSelectPolymorphic": false,
+        "selectClassInfo": "0x1",
+      },
+    ],
+  },
+}
+`;
+
+exports[`PresentationManager addon results conversion to Presentation objects getContent returns formatted content 1`] = `
+Object {
+  "contentSet": Array [
+    Object {
+      "classInfo": Object {
+        "id": "0x14a1300000029c1",
+        "label": "generating IB back-end",
+        "name": "bypass",
+      },
+      "displayValues": Object {
+        "HTTP": "1.23",
+      },
+      "imageId": "9124abde-51a0-469c-83c9-93b31596571d",
+      "labelDefinition": Object {
+        "displayValue": "payment",
+        "rawValue": "mesh",
+        "typeName": "string",
+      },
+      "mergedFieldNames": Array [],
+      "primaryKeys": Array [
+        Object {
+          "className": "Legacy",
+          "id": "0x1119c00000171d2",
+        },
+      ],
+      "values": Object {
+        "HTTP": 1.234,
+      },
+    },
+  ],
+  "descriptor": Object {
+    "categories": Array [
+      Object {
+        "description": "Test category description",
+        "expand": false,
+        "label": "Test Category",
+        "name": "test-category",
+        "priority": 0,
+      },
+    ],
+    "classesMap": Object {
+      "0x1": Object {
+        "label": "Class Label",
+        "name": "SchemaName:ClassName",
+      },
+    },
+    "connectionId": "",
+    "contentFlags": 0,
+    "displayType": "test",
+    "fields": Array [
+      Object {
+        "category": "test-category",
+        "editor": undefined,
+        "isReadonly": false,
+        "label": "Properties Field",
+        "name": "HTTP",
+        "priority": 0,
+        "properties": Array [
+          Object {
+            "property": Object {
+              "classInfo": "0x1",
+              "name": "PropertyName",
+              "type": "string",
+            },
+          },
+        ],
+        "renderer": undefined,
+        "type": Object {
+          "typeName": "double",
+          "valueFormat": "Primitive",
+        },
+      },
+    ],
+    "selectClasses": Array [
+      Object {
+        "isSelectPolymorphic": false,
+        "selectClassInfo": "0x1",
+      },
+    ],
+  },
+}
+`;
+
 exports[`PresentationManager addon results conversion to Presentation objects getContent returns localized content 1`] = `
 Object {
   "contentSet": Array [

--- a/presentation/common/assets/locales/en/Presentation.json
+++ b/presentation/common/assets/locales/en/Presentation.json
@@ -11,5 +11,9 @@
   "selectedItems": {
     "categoryLabel": "Selected Item(s)",
     "categoryDescription": "Contains properties of selected item(s)"
+  },
+  "value": {
+    "true": "True",
+    "false": "False"
   }
 }

--- a/presentation/common/src/presentation-common.ts
+++ b/presentation/common/src/presentation-common.ts
@@ -23,7 +23,7 @@ export * from "./presentation-common/Utils";
 export * from "./presentation-common/PresentationIpcInterface";
 export * from "./presentation-common/LocalizationHelper";
 export * from "./presentation-common/InstanceFilterDefinition";
-export * from "./presentation-common/PropertyFormatter";
+export * from "./presentation-common/KoqPropertyValueFormatter";
 
 /**
  * @module RPC
@@ -62,6 +62,7 @@ export * from "./presentation-common/content/Renderer";
 export * from "./presentation-common/content/TypeDescription";
 export * from "./presentation-common/content/Value";
 export * from "./presentation-common/content/ContentTraverser";
+export * from "./presentation-common/content/PropertyValueFormatter";
 
 /**
  * @module Hierarchies

--- a/presentation/common/src/presentation-common/LocalizationHelper.ts
+++ b/presentation/common/src/presentation-common/LocalizationHelper.ts
@@ -87,6 +87,8 @@ export class LocalizationHelper {
   private translateContentItemValue(value: Value): Value {
     if (typeof value === "string") {
       value = this.getLocalizedString(value);
+    } else if (Value.isNavigationValue(value)) {
+      this.translateLabelDefinition(value.label);
     } else if (Value.isNestedContent(value)) {
       for (const nestedValue of value) {
         for (const key in nestedValue.values) {
@@ -132,5 +134,4 @@ export class LocalizationHelper {
       labelDefinition.displayValue = this.getLocalizedString(labelDefinition.displayValue);
     }
   }
-
 }

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -154,6 +154,12 @@ export interface ContentRequestOptions<TIModel, TDescriptor, TKeySet, TRulesetVa
   descriptor: TDescriptor;
   /** Input keys for getting the content */
   keys: TKeySet;
+  /**
+   * Flag that specifies whether value formatting should be emitted or not.
+   * Content is returned without `displayValues` when this is set to `true`.
+   * @alpha
+   */
+  omitFormattedValues?: boolean;
 }
 
 /**

--- a/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
+++ b/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
@@ -107,7 +107,7 @@ export class ContentPropertyValueFormatter {
     }
     if (type.typeName === "bool" || type.typeName === "boolean") {
       assert(typeof value === "boolean");
-      return value ? "True" : "False";
+      return value ? "@Presentation:value.true@" : "@Presentation:value.false@";
     }
     if (type.typeName === "int" || type.typeName === "long") {
       assert(isNumber(value));

--- a/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
+++ b/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Content
+ */
+
+import { assert } from "@itwin/core-bentley";
+import { UnitSystemKey } from "@itwin/core-quantity";
+import { SchemaContext } from "@itwin/ecschema-metadata";
+import { KindOfQuantityInfo, PropertyInfo } from "../EC";
+import { KoqPropertyValueFormatter } from "../KoqPropertyValueFormatter";
+import { ValuesDictionary } from "../Utils";
+import { Content } from "./Content";
+import { Field, PropertiesField } from "./Fields";
+import { ArrayTypeDescription, PrimitiveTypeDescription, PropertyValueFormat, StructTypeDescription, TypeDescription } from "./TypeDescription";
+import { DisplayValue, DisplayValuesMap, NestedContentValue, Value } from "./Value";
+
+/** @alpha */
+export function createContentFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey) {
+  const koqPropertyFormatter = new KoqPropertyValueFormatter(schemaContext);
+  const contentValueFormatter = new ContentPropertyValueFormatter(koqPropertyFormatter);
+  return new ContentFormatter(contentValueFormatter, unitSystem);
+}
+
+/** @alpha */
+export class ContentFormatter {
+  constructor(private _propertyValueFormatter: ContentPropertyValueFormatter, private _unitSystem?: UnitSystemKey) { }
+
+  public async formatContent(content: Content) {
+    const descriptor = content.descriptor;
+    for (const item of content.contentSet) {
+      await this.formatValues(item.values, item.displayValues, descriptor.fields, item.mergedFieldNames);
+    }
+    return content;
+  }
+
+  private async formatValues(values: ValuesDictionary<Value>, displayValues: ValuesDictionary<DisplayValue>, fields: Field[], mergedFields: string[]) {
+    for (const field of fields) {
+      const value = values[field.name];
+
+      // format display value of merged values
+      if (mergedFields.includes(field.name)) {
+        displayValues[field.name] = "@Presentation:label.varies@";
+        continue;
+      }
+
+      // format display values of nested content field
+      if (field.isNestedContentField()) {
+        assert(Value.isNestedContent(value));
+        await this.formatNestedContentDisplayValues(value, field.nestedFields);
+        continue;
+      }
+
+      displayValues[field.name] = await this._propertyValueFormatter.formatPropertyValue(field, value, this._unitSystem);
+    }
+  }
+
+  private async formatNestedContentDisplayValues(nestedValues: NestedContentValue[], fields: Field[]) {
+    for (const nestedValue of nestedValues) {
+      await this.formatValues(nestedValue.values, nestedValue.displayValues, fields, nestedValue.mergedFieldNames);
+    }
+  }
+
+}
+
+/** @alpha */
+export class ContentPropertyValueFormatter {
+  constructor(private _koqValueFormatter: KoqPropertyValueFormatter) { }
+
+  public async formatPropertyValue(field: Field, value: Value, unitSystem?: UnitSystemKey): Promise<DisplayValue> {
+    if (isFieldWithKoq(field) && typeof value === "number") {
+      const koq = field.properties[0].property.kindOfQuantity;
+      const formattedValue = await this._koqValueFormatter.format(value, { koqName: koq.name, unitSystem });
+      if (formattedValue !== undefined)
+        return formattedValue;
+    }
+
+    return this.formatValue(field.type, value);
+  }
+
+  public formatValue(type: TypeDescription, value: Value): DisplayValue {
+    switch (type.valueFormat) {
+      case PropertyValueFormat.Primitive:
+        return this.formatPrimitiveValue(type, value);
+      case PropertyValueFormat.Array:
+        return this.formatArrayValue(type, value);
+      case PropertyValueFormat.Struct:
+        return this.formatStructValue(type, value);
+    }
+  }
+
+  public formatPrimitiveValue(type: PrimitiveTypeDescription, value: Value) {
+    if (value === undefined)
+      return "";
+
+    if (type.typeName === "point2d" && isPoint2d(value)) {
+      return `X: ${formatDouble(value.x)} Y: ${formatDouble(value.y)}`;
+    }
+    if (type.typeName === "point3d" && isPoint3d(value)) {
+      return `X: ${formatDouble(value.x)} Y: ${formatDouble(value.y)} Z: ${formatDouble(value.z)}`;
+    }
+    if (type.typeName === "dateTime") {
+      assert(typeof value === "string");
+      return value;
+    }
+    if (type.typeName === "bool" || type.typeName === "boolean") {
+      assert(typeof value === "boolean");
+      return value ? "True" : "False";
+    }
+    if (type.typeName === "int" || type.typeName === "long") {
+      assert(isNumber(value));
+      return value.toFixed(0);
+    }
+    if (type.typeName === "double") {
+      assert(isNumber(value));
+      return formatDouble(value);
+    }
+    if (type.typeName === "navigation") {
+      assert(Value.isNavigationValue(value));
+      return value.label.displayValue;
+    }
+
+    return value.toString();
+  }
+
+  public formatStructValue(type: StructTypeDescription, value: Value) {
+    if (!Value.isMap(value))
+      return {};
+
+    const formattedMember: DisplayValuesMap = {};
+    for (const member of type.members) {
+      formattedMember[member.name] = this.formatValue(member.type, value[member.name]);
+    }
+    return formattedMember;
+  }
+
+  public formatArrayValue(type: ArrayTypeDescription, value: Value) {
+    if (!Value.isArray(value))
+      return [];
+
+    return value.map((arrayVal) => this.formatValue(type.memberType, arrayVal));
+  }
+}
+
+function formatDouble(value: number) {
+  return value.toFixed(2);
+}
+
+type FieldWithKoq = PropertiesField & {
+  properties: [{
+    property: PropertyInfo & {
+      kindOfQuantity: KindOfQuantityInfo;
+    };
+  }];
+};
+
+function isFieldWithKoq(field: Field): field is FieldWithKoq {
+  return field.isPropertiesField()
+    && field.properties.length > 0
+    && field.properties[0].property.kindOfQuantity !== undefined;
+}
+
+function isPoint2d(obj: Value): obj is { x: number, y: number } {
+  return obj !== undefined && isNumber((obj as any).x) && isNumber((obj as any).y);
+}
+
+function isPoint3d(obj: Value): obj is { x: number, y: number, z: number } {
+  return isPoint2d(obj) && isNumber((obj as any).z);
+}
+
+function isNumber(obj: Value): obj is number {
+  return !isNaN(Number(obj));
+}

--- a/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
+++ b/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
@@ -8,7 +8,6 @@
 
 import { assert } from "@itwin/core-bentley";
 import { UnitSystemKey } from "@itwin/core-quantity";
-import { SchemaContext } from "@itwin/ecschema-metadata";
 import { KindOfQuantityInfo, PropertyInfo } from "../EC";
 import { KoqPropertyValueFormatter } from "../KoqPropertyValueFormatter";
 import { ValuesDictionary } from "../Utils";
@@ -16,13 +15,6 @@ import { Content } from "./Content";
 import { Field, PropertiesField } from "./Fields";
 import { ArrayTypeDescription, PrimitiveTypeDescription, PropertyValueFormat, StructTypeDescription, TypeDescription } from "./TypeDescription";
 import { DisplayValue, DisplayValuesMap, NestedContentValue, Value } from "./Value";
-
-/** @alpha */
-export function createContentFormatter(schemaContext: SchemaContext, unitSystem?: UnitSystemKey) {
-  const koqPropertyFormatter = new KoqPropertyValueFormatter(schemaContext);
-  const contentValueFormatter = new ContentPropertyValueFormatter(koqPropertyFormatter);
-  return new ContentFormatter(contentValueFormatter, unitSystem);
-}
 
 /** @alpha */
 export class ContentFormatter {

--- a/presentation/common/src/presentation-common/content/Value.ts
+++ b/presentation/common/src/presentation-common/content/Value.ts
@@ -6,14 +6,15 @@
  * @module Content
  */
 
-import { InstanceKey } from "../EC";
+import { InstanceId, InstanceKey } from "../EC";
+import { LabelDefinition } from "../LabelDefinition";
 import { ValuesDictionary } from "../Utils";
 
 /**
  * Raw value type
  * @public
  */
-export type Value = string | number | boolean | undefined | ValuesMap | ValuesArray | NestedContentValue[];
+export type Value = string | number | boolean | undefined | ValuesMap | ValuesArray | NavigationPropertyValue | NestedContentValue[];
 
 /** @public */
 export namespace Value { // eslint-disable-line @typescript-eslint/no-redeclare
@@ -35,6 +36,13 @@ export namespace Value { // eslint-disable-line @typescript-eslint/no-redeclare
   /** Is the value a nested content value */
   export function isNestedContent(value: Value): value is NestedContentValue[] {
     return isNestedContentValue(value);
+  }
+
+  export function isNavigationValue(value: Value): value is NavigationPropertyValue {
+    return value !== undefined
+      && (value as NavigationPropertyValue).id !== undefined
+      && (value as NavigationPropertyValue).className !== undefined
+      && (value as NavigationPropertyValue).label !== undefined;
   }
 
   /**
@@ -167,6 +175,19 @@ export interface NestedContentValue {
   mergedFieldNames: string[];
 }
 
+/**
+ * Data structure that describes value of the navigation property.
+ * @alpha
+ */
+export interface NavigationPropertyValue {
+  /** Label of target instance. */
+  label: LabelDefinition;
+  /** Full class name of target instance in format `SchemaName:ClassName` */
+  className: string;
+  /** Id of target instance. */
+  id: InstanceId;
+}
+
 /** @public */
 export namespace NestedContentValue {
   /**
@@ -202,7 +223,7 @@ export namespace NestedContentValue {
  * @deprecated in 3.x. Use [[Value]]
  */
 // eslint-disable-next-line deprecation/deprecation
-export type ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NestedContentValueJSON[];
+export type ValueJSON = string | number | boolean | null | ValuesMapJSON | ValuesArrayJSON | NavigationPropertyValue | NestedContentValueJSON[];
 /**
  * JSON representation of [[ValuesMap]]
  * @public

--- a/presentation/common/src/presentation-common/content/Value.ts
+++ b/presentation/common/src/presentation-common/content/Value.ts
@@ -38,6 +38,7 @@ export namespace Value { // eslint-disable-line @typescript-eslint/no-redeclare
     return isNestedContentValue(value);
   }
 
+  /** Is the value a navigation value */
   export function isNavigationValue(value: Value): value is NavigationPropertyValue {
     return value !== undefined
       && (value as NavigationPropertyValue).id !== undefined
@@ -177,7 +178,7 @@ export interface NestedContentValue {
 
 /**
  * Data structure that describes value of the navigation property.
- * @alpha
+ * @public
  */
 export interface NavigationPropertyValue {
   /** Label of target instance. */

--- a/presentation/common/src/test/LocalizationHelper.test.ts
+++ b/presentation/common/src/test/LocalizationHelper.test.ts
@@ -4,8 +4,15 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { createRandomECInstancesNode, createRandomLabelCompositeValue, createRandomLabelDefinition, createTestCategoryDescription, createTestContentDescriptor, createTestContentItem, createTestECInstanceKey, createTestSimpleContentField } from "./_helpers";
-import { Content, Item, LabelDefinition, LocalizationHelper } from "../presentation-common";
+import { Content } from "../presentation-common/content/Content";
+import { Item } from "../presentation-common/content/Item";
+import { NavigationPropertyValue } from "../presentation-common/content/Value";
+import { LabelDefinition } from "../presentation-common/LabelDefinition";
+import { LocalizationHelper } from "../presentation-common/LocalizationHelper";
+import {
+  createRandomECInstancesNode, createRandomLabelCompositeValue, createRandomLabelDefinition, createTestCategoryDescription,
+  createTestContentDescriptor, createTestContentItem, createTestECInstanceKey, createTestSimpleContentField,
+} from "./_helpers";
 
 function getTestLocalizedString(key: string) {
   if (key.includes(":"))
@@ -145,6 +152,25 @@ describe("LocalizationHelper", () => {
       const content = new Content(createTestContentDescriptor({ fields: [field], categories: [testCategory] }), [contentItem]);
       localizationHelper.getLocalizedContent(content);
       expect(content.descriptor.categories[0].description).to.be.eq("LocalizedDescription");
+    });
+
+    it("translates navigation property value label", () => {
+      const navigationPropertyValue: NavigationPropertyValue = {
+        id: "0x1",
+        className: "Schema:Class",
+        label: createRandomLabelDefinition(),
+      };
+      navigationPropertyValue.label.rawValue = "@namespace:LocalizedValue@";
+      const contentItem = createTestContentItem({
+        values: {
+          navigationProperty: navigationPropertyValue,
+        },
+        displayValues: {},
+      });
+      const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
+      localizationHelper.getLocalizedContent(content);
+      const localizedValue = content.contentSet[0]!.values.navigationProperty as NavigationPropertyValue;
+      expect(localizedValue.label.rawValue).to.be.eq("LocalizedValue");
     });
 
     it("translates element properties label", () => {

--- a/presentation/common/src/test/content/PropertyFormatter.test.ts
+++ b/presentation/common/src/test/content/PropertyFormatter.test.ts
@@ -5,25 +5,13 @@
 
 import { expect } from "chai";
 import * as moq from "typemoq";
-import { SchemaContext } from "@itwin/ecschema-metadata";
 import { KoqPropertyValueFormatter, LabelDefinition, PropertyValueFormat, TypeDescription } from "../../presentation-common";
 import { Content } from "../../presentation-common/content/Content";
-import { ContentFormatter, ContentPropertyValueFormatter, createContentFormatter } from "../../presentation-common/content/PropertyValueFormatter";
+import { ContentFormatter, ContentPropertyValueFormatter } from "../../presentation-common/content/PropertyValueFormatter";
 import { DisplayValuesArray, DisplayValuesMap, NavigationPropertyValue, NestedContentValue } from "../../presentation-common/content/Value";
 import {
   createTestContentDescriptor, createTestContentItem, createTestNestedContentField, createTestPropertiesContentField, createTestPropertyInfo,
 } from "../_helpers";
-
-describe("createContentFormatter", () => {
-  it("creates formatter", async () => {
-    const formatter = createContentFormatter(new SchemaContext(), "metric");
-    const field = createTestPropertiesContentField({ name: "testField", properties: [], type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } });
-    const item = createTestContentItem({ displayValues: {}, values: { [field.name]: 1.5 } });
-    const content = new Content(createTestContentDescriptor({ fields: [field] }), [item]);
-    await formatter.formatContent(content);
-    expect(item.displayValues[field.name]).to.be.eq("1.50");
-  });
-});
 
 describe("ContentPropertyValueFormatter", () => {
   let formatter: ContentFormatter;

--- a/presentation/common/src/test/content/PropertyFormatter.test.ts
+++ b/presentation/common/src/test/content/PropertyFormatter.test.ts
@@ -152,8 +152,8 @@ describe("ContentPropertyValueFormatter", () => {
 
     it("'bool' value", async () => {
       const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "bool" });
-      expect(await formatter.formatPropertyValue(field, true)).to.be.eq("True");
-      expect(await formatter.formatPropertyValue(field, false)).to.be.eq("False");
+      expect(await formatter.formatPropertyValue(field, true)).to.be.eq("@Presentation:value.true@");
+      expect(await formatter.formatPropertyValue(field, false)).to.be.eq("@Presentation:value.false@");
     });
 
     it("'double' value", async () => {
@@ -223,7 +223,6 @@ describe("ContentPropertyValueFormatter", () => {
         members: [
           { name: "doubleProp", label: "Double Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } },
           { name: "intProp", label: "Int Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "int" } },
-          { name: "boolProp", label: "Bool Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "bool" } },
           { name: "pointProp", label: "Point Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "point2d" } },
         ],
       });
@@ -236,10 +235,9 @@ describe("ContentPropertyValueFormatter", () => {
       };
 
       const formattedValue = (await formatter.formatPropertyValue(field, structValue)) as DisplayValuesMap;
-      expect(Object.keys(formattedValue)).to.have.lengthOf(4);
+      expect(Object.keys(formattedValue)).to.have.lengthOf(3);
       expect(formattedValue.doubleProp).to.be.eq("1.50");
       expect(formattedValue.intProp).to.be.eq("1");
-      expect(formattedValue.boolProp).to.be.eq("False");
       expect(formattedValue.pointProp).to.be.eq("X: 1.23 Y: 4.57");
     });
 

--- a/presentation/common/src/test/content/PropertyFormatter.test.ts
+++ b/presentation/common/src/test/content/PropertyFormatter.test.ts
@@ -1,0 +1,337 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as moq from "typemoq";
+import { SchemaContext } from "@itwin/ecschema-metadata";
+import { KoqPropertyValueFormatter, LabelDefinition, PropertyValueFormat, TypeDescription } from "../../presentation-common";
+import { Content } from "../../presentation-common/content/Content";
+import { ContentFormatter, ContentPropertyValueFormatter, createContentFormatter } from "../../presentation-common/content/PropertyValueFormatter";
+import { DisplayValuesArray, DisplayValuesMap, NavigationPropertyValue, NestedContentValue } from "../../presentation-common/content/Value";
+import {
+  createTestContentDescriptor, createTestContentItem, createTestNestedContentField, createTestPropertiesContentField, createTestPropertyInfo,
+} from "../_helpers";
+
+describe("createContentFormatter", () => {
+  it("creates formatter", async () => {
+    const formatter = createContentFormatter(new SchemaContext(), "metric");
+    const field = createTestPropertiesContentField({ name: "testField", properties: [], type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } });
+    const item = createTestContentItem({ displayValues: {}, values: { [field.name]: 1.5 } });
+    const content = new Content(createTestContentDescriptor({ fields: [field] }), [item]);
+    await formatter.formatContent(content);
+    expect(item.displayValues[field.name]).to.be.eq("1.50");
+  });
+});
+
+describe("ContentPropertyValueFormatter", () => {
+  let formatter: ContentFormatter;
+  const propertyValueFormatterMock = moq.Mock.ofType<ContentPropertyValueFormatter>();
+  const koqField = createTestPropertiesContentField({
+    name: "koqFieldName",
+    properties: [{
+      property: createTestPropertyInfo({ name: "koqProperty", kindOfQuantity: { label: "Koq Props", name: "TestSchema:TestKoq", persistenceUnit: "Units:M" } }),
+    }],
+  });
+  const simplePropField = createTestPropertiesContentField({
+    name: "simpleFieldName",
+    properties: [{
+      property: createTestPropertyInfo({ name: "simpleProperty" }),
+    }],
+  });
+
+  beforeEach(() => {
+    propertyValueFormatterMock.setup(async (x) => x.formatPropertyValue(moq.It.isAny(), moq.It.isAny(), moq.It.isAny())).returns(async () => "FormattedValue");
+    formatter = new ContentFormatter(propertyValueFormatterMock.object);
+  });
+
+  afterEach(() => {
+    propertyValueFormatterMock.reset();
+  });
+
+  it("formats content item value", async () => {
+    const descriptor = createTestContentDescriptor({ fields: [koqField, simplePropField] });
+    const contentItem = createTestContentItem({
+      displayValues: {
+      },
+      values: {
+        [koqField.name]: 1.5,
+        [simplePropField.name]: "1.5",
+      },
+    });
+    const content = new Content(descriptor, [contentItem]);
+
+    const formattedContent = await formatter.formatContent(content);
+    expect(formattedContent.contentSet[0].displayValues[koqField.name]).to.be.eq("FormattedValue");
+    expect(formattedContent.contentSet[0].displayValues[simplePropField.name]).to.be.eq("FormattedValue");
+  });
+
+  it("formats nested content item value", async () => {
+    const nestedContentField = createTestNestedContentField({
+      name: "nestedContentFieldName",
+      nestedFields: [koqField, simplePropField],
+    });
+    const descriptor = createTestContentDescriptor({ fields: [nestedContentField] });
+    const contentItem = createTestContentItem({
+      displayValues: {
+      },
+      values: {
+        [nestedContentField.name]: [{
+          displayValues: {
+          },
+          values: {
+            [koqField.name]: 1.5,
+            [simplePropField.name]: "1.5",
+          },
+          primaryKeys: [],
+          mergedFieldNames: [],
+        }],
+      },
+    });
+    const content = new Content(descriptor, [contentItem]);
+
+    const formattedContent = await formatter.formatContent(content);
+    const nestedContentValue = formattedContent.contentSet[0].values[nestedContentField.name] as NestedContentValue[];
+    expect(nestedContentValue[0].displayValues[koqField.name]).to.be.eq("FormattedValue");
+    expect(nestedContentValue[0].displayValues[simplePropField.name]).to.be.eq("FormattedValue");
+  });
+
+  it("handles merged nested field", async () => {
+    const nestedContentField = createTestNestedContentField({
+      name: "nestedContentFieldName",
+      nestedFields: [simplePropField],
+    });
+    const descriptor = createTestContentDescriptor({ fields: [nestedContentField, koqField] });
+    const contentItem = createTestContentItem({
+      displayValues: {
+      },
+      values: {
+        [nestedContentField.name]: undefined,
+        [koqField.name]: 1.5,
+      },
+      mergedFieldNames: [nestedContentField.name],
+    });
+    const content = new Content(descriptor, [contentItem]);
+
+    const formattedContent = await formatter.formatContent(content);
+    expect(formattedContent.contentSet[0].displayValues[nestedContentField.name]).to.be.eq("@Presentation:label.varies@");
+    expect(formattedContent.contentSet[0].displayValues[koqField.name]).to.be.eq("FormattedValue");
+  });
+});
+
+describe("ContentPropertyValueFormatter", () => {
+  let formatter: ContentPropertyValueFormatter;
+  const koqFormatterMock = moq.Mock.ofType<KoqPropertyValueFormatter>();
+
+  beforeEach(() => {
+    formatter = new ContentPropertyValueFormatter(koqFormatterMock.object);
+  });
+
+  afterEach(() => {
+    koqFormatterMock.reset();
+  });
+
+  function createField(type: TypeDescription) {
+    return createTestPropertiesContentField({
+      properties: [],
+      type,
+    });
+  }
+
+  describe("formats primitive", () => {
+    it("'undefined' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "string" });
+      expect(await formatter.formatPropertyValue(field, undefined)).to.be.eq("");
+    });
+
+    it("'string' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "string" });
+      expect(await formatter.formatPropertyValue(field, "TestValue")).to.be.eq("TestValue");
+    });
+
+    it("'bool' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "bool" });
+      expect(await formatter.formatPropertyValue(field, true)).to.be.eq("True");
+      expect(await formatter.formatPropertyValue(field, false)).to.be.eq("False");
+    });
+
+    it("'double' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "double" });
+      expect(await formatter.formatPropertyValue(field, 1.5)).to.be.eq("1.50");
+      expect(await formatter.formatPropertyValue(field, 1.2345)).to.be.eq("1.23");
+    });
+
+    it("'int' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "int" });
+      expect(await formatter.formatPropertyValue(field, 5)).to.be.eq("5");
+    });
+
+    it("'dateTime' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "dateTime" });
+      expect(await formatter.formatPropertyValue(field, "2023-03-27:12:00:00")).to.be.eq("2023-03-27:12:00:00");
+    });
+
+    it("'point2d' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "point2d" });
+      expect(await formatter.formatPropertyValue(field, { x: 1.234, y: 5.678 })).to.be.eq("X: 1.23 Y: 5.68");
+    });
+
+    it("'point3d' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "point3d" });
+      expect(await formatter.formatPropertyValue(field, { x: 1.234, y: 5.678, z: 1.234 })).to.be.eq("X: 1.23 Y: 5.68 Z: 1.23");
+    });
+
+    it("'point3d' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "navigation" });
+      const value: NavigationPropertyValue = { id: "0x1", className: "Schema:Class", label: LabelDefinition.fromLabelString("Test Target Instance") };
+      expect(await formatter.formatPropertyValue(field, value)).to.be.eq("Test Target Instance");
+    });
+
+    it("KOQ property value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "double" });
+      field.properties = [{ property: createTestPropertyInfo({ kindOfQuantity: { label: "KOQ Lable", name: "KOQProp", persistenceUnit: "Unit" } }) }];
+      koqFormatterMock.setup(async (x) => x.format(1.5, moq.It.is((options) => options.unitSystem === "metric"))).returns(async () => "1.5 M");
+      expect(await formatter.formatPropertyValue(field, 1.5, "metric")).to.be.eq("1.5 M");
+    });
+
+    it("KOQ property value without KOQ metadata", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Primitive, typeName: "double" });
+      field.properties = [{ property: createTestPropertyInfo({ kindOfQuantity: { label: "KOQ Lable", name: "KOQProp", persistenceUnit: "Unit" } }) }];
+      koqFormatterMock.setup(async (x) => x.format(1.5, moq.It.isAny())).returns(async () => undefined);
+      expect(await formatter.formatPropertyValue(field, 1.5)).to.be.eq("1.50");
+    });
+  });
+
+  describe("formats struct", () => {
+    it("'undefined' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Struct, typeName: "struct", members: [{ name: "doubleProp", label: "Double Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } }] });
+      const formattedValue = (await formatter.formatPropertyValue(field, undefined)) as DisplayValuesMap;
+      expect(Object.keys(formattedValue)).to.be.empty;
+    });
+
+    it("value without members", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Struct, typeName: "struct", members: [] });
+      const formattedValue = (await formatter.formatPropertyValue(field, {})) as DisplayValuesMap;
+      expect(Object.keys(formattedValue)).to.be.empty;
+    });
+
+    it("value with different type members", async () => {
+      const field = createField({
+        valueFormat: PropertyValueFormat.Struct,
+        typeName: "struct",
+        members: [
+          { name: "doubleProp", label: "Double Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } },
+          { name: "intProp", label: "Int Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "int" } },
+          { name: "boolProp", label: "Bool Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "bool" } },
+          { name: "pointProp", label: "Point Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "point2d" } },
+        ],
+      });
+
+      const structValue = {
+        doubleProp: 1.5,
+        intProp: 1,
+        boolProp: false,
+        pointProp: { x: 1.234, y: 4.567 },
+      };
+
+      const formattedValue = (await formatter.formatPropertyValue(field, structValue)) as DisplayValuesMap;
+      expect(Object.keys(formattedValue)).to.have.lengthOf(4);
+      expect(formattedValue.doubleProp).to.be.eq("1.50");
+      expect(formattedValue.intProp).to.be.eq("1");
+      expect(formattedValue.boolProp).to.be.eq("False");
+      expect(formattedValue.pointProp).to.be.eq("X: 1.23 Y: 4.57");
+    });
+
+    it("value with struct members", async () => {
+      const field = createField({
+        valueFormat: PropertyValueFormat.Struct,
+        typeName: "struct",
+        members: [
+          { name: "doubleProp", label: "Double Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } },
+          {
+            name: "structProp", label: "Struct Property", type: {
+              valueFormat: PropertyValueFormat.Struct,
+              typeName: "struct",
+              members: [
+                { name: "nestedDoubleProp", label: "Nested Double Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } },
+                { name: "nestedIntProp", label: "Nested Int Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "int" } },
+              ],
+            },
+          },
+        ],
+      });
+
+      const structValue = {
+        doubleProp: 1.5,
+        structProp: {
+          nestedDoubleProp: 2.5,
+          nestedIntProp: 1,
+        },
+      };
+
+      const formattedValue = (await formatter.formatPropertyValue(field, structValue)) as DisplayValuesMap;
+      expect(Object.keys(formattedValue)).to.have.lengthOf(2);
+      expect(formattedValue.doubleProp).to.be.eq("1.50");
+      const structProp = formattedValue.structProp as DisplayValuesMap;
+      expect(Object.keys(structProp)).to.have.lengthOf(2);
+      expect(structProp.nestedDoubleProp).to.be.eq("2.50");
+      expect(structProp.nestedIntProp).to.be.eq("1");
+    });
+  });
+
+  describe("formats array", () => {
+    it("'undefined' value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Array, typeName: "array", memberType: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } });
+      const formattedValue = (await formatter.formatPropertyValue(field, undefined)) as DisplayValuesArray;
+      expect(formattedValue).to.be.empty;
+    });
+
+    it("empty value", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Array, typeName: "array", memberType: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } });
+      const formattedValue = (await formatter.formatPropertyValue(field, [])) as DisplayValuesArray;
+      expect(formattedValue).to.be.empty;
+    });
+
+    it("value with primitive items", async () => {
+      const field = createField({ valueFormat: PropertyValueFormat.Array, typeName: "array", memberType: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } });
+      const formattedValue = (await formatter.formatPropertyValue(field, [1.234, 5.678])) as DisplayValuesArray;
+      expect(formattedValue).to.have.lengthOf(2);
+      expect(formattedValue[0]).to.be.eq("1.23");
+      expect(formattedValue[1]).to.be.eq("5.68");
+    });
+
+    it("value with struct items", async () => {
+      const field = createField({
+        valueFormat: PropertyValueFormat.Array,
+        typeName: "array",
+        memberType: {
+          valueFormat: PropertyValueFormat.Struct,
+          typeName: "struct",
+          members: [
+            { name: "doubleProp", label: "Double Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" } },
+            { name: "pointProp", label: "Point Property", type: { valueFormat: PropertyValueFormat.Primitive, typeName: "point2d" } },
+          ],
+        },
+      });
+
+      const value = [{
+        doubleProp: 1.234,
+        pointProp: { x: 1.5, y: 5.678 },
+      }, {
+        doubleProp: 0.2,
+        pointProp: { x: 3, y: 4 },
+      }];
+
+      const formattedValue = (await formatter.formatPropertyValue(field, value)) as DisplayValuesArray;
+      expect(formattedValue).to.have.lengthOf(2);
+      const item1 = formattedValue[0] as DisplayValuesMap;
+      expect(item1.doubleProp).to.be.eq("1.23");
+      expect(item1.pointProp).to.be.eq("X: 1.50 Y: 5.68");
+      const item2 = formattedValue[1] as DisplayValuesMap;
+      expect(item2.doubleProp).to.be.eq("0.20");
+      expect(item2.pointProp).to.be.eq("X: 3.00 Y: 4.00");
+    });
+  });
+});
+

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -45,6 +45,7 @@
     "@itwin/core-common": "workspace:^4.0.0-dev.56",
     "@itwin/core-frontend": "workspace:^4.0.0-dev.56",
     "@itwin/core-quantity": "workspace:^4.0.0-dev.56",
+    "@itwin/ecschema-metadata": "workspace:^4.0.0-dev.56",
     "@itwin/presentation-common": "workspace:^4.0.0-dev.56"
   },
   "devDependencies": {
@@ -54,6 +55,7 @@
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-i18n": "workspace:*",
     "@itwin/core-quantity": "workspace:*",
+    "@itwin/ecschema-metadata": "workspace:*",
     "@itwin/eslint-plugin": "^4.0.0-dev.32",
     "@itwin/presentation-common": "workspace:*",
     "@types/chai": "4.3.1",

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -11,12 +11,13 @@ import { IModelApp, IModelConnection, IpcApp } from "@itwin/core-frontend";
 import { UnitSystemKey } from "@itwin/core-quantity";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import {
-  ClientDiagnosticsAttribute, Content, ContentDescriptorRequestOptions, ContentInstanceKeysRequestOptions, ContentRequestOptions,
-  ContentSourcesRequestOptions, ContentUpdateInfo, createContentFormatter, Descriptor, DescriptorOverrides, DisplayLabelRequestOptions,
-  DisplayLabelsRequestOptions, DisplayValueGroup, DistinctValuesRequestOptions, ElementProperties, FilterByInstancePathsHierarchyRequestOptions,
-  FilterByTextHierarchyRequestOptions, HierarchyLevelDescriptorRequestOptions, HierarchyRequestOptions, HierarchyUpdateInfo, InstanceKey, Item, Key,
-  KeySet, LabelDefinition, Node, NodeKey, NodePathElement, Paged, PagedResponse, PageOptions, PresentationIpcEvents, RpcRequestsHandler, Ruleset,
-  RulesetVariable, SelectClassInfo, SingleElementPropertiesRequestOptions, UpdateInfo, VariableValueTypes,
+  ClientDiagnosticsAttribute, Content, ContentDescriptorRequestOptions, ContentFormatter, ContentInstanceKeysRequestOptions,
+  ContentPropertyValueFormatter, ContentRequestOptions, ContentSourcesRequestOptions, ContentUpdateInfo, Descriptor, DescriptorOverrides,
+  DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DisplayValueGroup, DistinctValuesRequestOptions, ElementProperties,
+  FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions, HierarchyLevelDescriptorRequestOptions, HierarchyRequestOptions,
+  HierarchyUpdateInfo, InstanceKey, Item, Key, KeySet, KoqPropertyValueFormatter, LabelDefinition, Node, NodeKey, NodePathElement, Paged,
+  PagedResponse, PageOptions, PresentationIpcEvents, RpcRequestsHandler, Ruleset, RulesetVariable, SelectClassInfo,
+  SingleElementPropertiesRequestOptions, UpdateInfo, VariableValueTypes,
 } from "@itwin/presentation-common";
 import { IpcRequestsHandler } from "./IpcRequestsHandler";
 import { FrontendLocalizationHelper } from "./LocalizationHelper";
@@ -429,7 +430,8 @@ export class PresentationManager implements IDisposable {
     const items = result.items.map((itemJson) => Item.fromJSON(itemJson)).filter<Item>((item): item is Item => (item !== undefined));
     const resultContent = new Content(descriptor, items);
     if (!requestOptions.omitFormattedValues && this._schemaContextProvider) {
-      const contentFormatter = createContentFormatter(this._schemaContextProvider(requestOptions.imodel), IModelApp.quantityFormatter.activeUnitSystem);
+      const koqPropertyFormatter = new KoqPropertyValueFormatter(this._schemaContextProvider(requestOptions.imodel));
+      const contentFormatter = new ContentFormatter(new ContentPropertyValueFormatter(koqPropertyFormatter), IModelApp.quantityFormatter.activeUnitSystem);
       await contentFormatter.formatContent(resultContent);
     }
 


### PR DESCRIPTION
Added `ContentPropertyValuesFormatter` for getting display values for different type raw values in content. This is necessary for supporting Content formatting on the frontend.
Added ability to request Content without formatted values and format them on the frontend. 

imodel-native: https://github.com/iTwin/imodel-native/tree/presentation/values_formatting_rework
Native changes: https://github.com/iTwin/imodel-native/pull/220

Part of https://github.com/iTwin/itwinjs-core/issues/5029