### PR TITLE
Presentation: Promote some `@alpha` apis to `@public`

### DIFF
--- a/common/api/appui-abstract.api.md
+++ b/common/api/appui-abstract.api.md
@@ -1519,7 +1519,6 @@ export interface PropertyDescription {
     displayLabel: string;
     editor?: PropertyEditorInfo;
     enum?: EnumerationChoicesInfo;
-    // @alpha
     hideCompositePropertyLabel?: boolean;
     name: string;
     // @alpha

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -2420,7 +2420,6 @@ export interface PropertyInfo {
     classInfo: ClassInfo;
     enumerationInfo?: EnumerationInfo;
     extendedType?: string;
-    // @alpha
     kindOfQuantity?: KindOfQuantityInfo;
     name: string;
     // @beta

--- a/common/changes/@itwin/appui-abstract/presentation-api-promotions_2023-03-28-11-39.json
+++ b/common/changes/@itwin/appui-abstract/presentation-api-promotions_2023-03-28-11-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-abstract",
+      "comment": "Promote `PropertyDescription.hideCompositePropertyLabel` to `@public`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-abstract"
+}

--- a/common/changes/@itwin/presentation-common/presentation-api-promotions_2023-03-28-11-39.json
+++ b/common/changes/@itwin/presentation-common/presentation-api-promotions_2023-03-28-11-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Promote `PropertyInfo.kindOfQuantity` to `@public`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/common/src/presentation-common/EC.ts
+++ b/presentation/common/src/presentation-common/EC.ts
@@ -260,10 +260,7 @@ export interface PropertyInfo {
   type: string;
   /** Enumeration info if the property is enumerable */
   enumerationInfo?: EnumerationInfo;
-  /**
-   * Kind of quantity information, if any.
-   * @alpha Still not entirely clear how kind of quantities will be handled and what data we'll need
-   */
+  /** Kind of quantity information, if any. */
   kindOfQuantity?: KindOfQuantityInfo;
   /** Extended type name of the ECProperty if it has one */
   extendedType?: string;

--- a/ui/appui-abstract/src/appui-abstract/properties/Description.ts
+++ b/ui/appui-abstract/src/appui-abstract/properties/Description.ts
@@ -7,7 +7,8 @@
  */
 
 import {
-  BasePropertyEditorParams, ColorEditorParams, ImageCheckBoxParams, PropertyEditorParams, PropertyEditorParamTypes, RangeEditorParams, SuppressLabelEditorParams,
+  BasePropertyEditorParams, ColorEditorParams, ImageCheckBoxParams, PropertyEditorParams, PropertyEditorParamTypes, RangeEditorParams,
+  SuppressLabelEditorParams,
 } from "./EditorParams";
 import { StandardEditorNames } from "./StandardEditorNames";
 import { StandardTypeNames } from "./StandardTypeNames";
@@ -89,10 +90,7 @@ export interface PropertyDescription {
   quantityType?: string;
   /** Get the custom DataController by this name and register it with the property editor */
   dataController?: string;
-  /**
-   * Should property label for composite (struct & array) properties be rendered.
-   * @alpha
-   */
+  /** Should property label for composite (struct & array) properties be rendered. */
   hideCompositePropertyLabel?: boolean;
 }
 


### PR DESCRIPTION
Based on https://github.com/iTwin/itwinjs-core/issues/4851.

**Promoted in this PR:**
```
presentation / quantity ALPHA: property "PropertyInfo.kindOfQuantity"
presentation ALPHA: property "PropertyDescription.hideCompositePropertyLabel"
```

**Couldn't find usage of this anywhere:**
```
presentation INTERNAL: method "RulesetVariablesManager.getAllVariables"
```

**Promoted in https://github.com/iTwin/itwinjs-core/pull/4954:**
```
presentation ALPHA: property "NestedContentField.actualPrimaryClassIds"
presentation ALPHA: property "NestedContentField.relationshipMeaning"
```  

**Made `@public` in https://github.com/iTwin/itwinjs-core/pull/5064 and https://github.com/iTwin/itwinjs-core/pull/5054:**
```
presentation INTERNAL: method "NestedContentField.rebuildParentship"
presentation INTERNAL: function "isCompositeDefinition"
```

**Not expected to be called by consumer code:**
```
presentation INTERNAL: class "AsyncTasksTracker"
presentation INTERNAL: method "PresentationManager.onNewiModelConnection"
```

