### PR TITLE
Add support for Electron 23 in iTwin.js 3.7

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -394,7 +394,7 @@ importers:
       '@types/mocha': ^8.2.2
       '@types/node': 18.11.5
       chai: ^4.1.2
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       mocha: ^10.0.0
       open: ^7.0.0
@@ -420,7 +420,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.11.5
       chai: 4.3.7
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       mocha: 10.2.0
       rimraf: 3.0.2
@@ -1325,7 +1325,7 @@ importers:
       '@types/node': 18.11.5
       chai: ^4.1.2
       cpx2: ^3.0.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       mocha: ^10.0.0
       rimraf: ^3.0.2
@@ -1337,11 +1337,11 @@ importers:
       '@itwin/core-electron': link:../../core/electron
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-geometry': link:../../core/geometry
-      electron: 22.3.1
+      electron: 23.2.0
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/eslint-plugin': link:../../tools/eslint-plugin
-      '@itwin/oidc-signin-tool': 3.6.1_electron@22.3.1
+      '@itwin/oidc-signin-tool': 3.6.1_electron@23.2.0
       '@types/chai': 4.3.1
       '@types/mocha': 8.2.3
       '@types/node': 18.11.5
@@ -1815,7 +1815,7 @@ importers:
       crypto-browserify: 3.12.0
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       fs-extra: ^8.1.0
       glob: ^7.1.2
@@ -1849,7 +1849,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.8.5_electron@22.3.1
+      '@itwin/electron-authorization': 0.8.5_electron@23.2.0
       '@itwin/express-server': link:../../core/express-server
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 2.3.0
@@ -1860,7 +1860,7 @@ importers:
       '@itwin/reality-data-client': 0.9.0
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
-      electron: 22.3.1
+      electron: 23.2.0
       fs-extra: 8.1.0
       sinon: 9.2.4
       sinon-chai: 3.7.0_chai@4.3.7+sinon@9.2.4
@@ -1868,7 +1868,7 @@ importers:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/certa': link:../../tools/certa
       '@itwin/eslint-plugin': link:../../tools/eslint-plugin
-      '@itwin/oidc-signin-tool': 3.6.1_electron@22.3.1
+      '@itwin/oidc-signin-tool': 3.6.1_electron@23.2.0
       '@itwin/projects-client': 0.6.0
       '@types/chai': 4.3.1
       '@types/chai-as-promised': 7.1.5
@@ -2150,7 +2150,7 @@ importers:
       browserify-zlib: ^0.2.0
       buffer: ^6.0.3
       chai: ^4.1.2
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       express: ^4.16.3
       glob: ^7.1.2
@@ -2171,7 +2171,7 @@ importers:
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/express-server': link:../../core/express-server
-      electron: 22.3.1
+      electron: 23.2.0
       express: 4.18.2
       semver: 7.3.8
       spdy: 4.0.2
@@ -2915,7 +2915,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       fs-extra: ^8.1.0
       internal-tools: workspace:*
@@ -2960,7 +2960,7 @@ importers:
       '@itwin/editor-backend': link:../../../editor/backend
       '@itwin/editor-common': link:../../../editor/common
       '@itwin/editor-frontend': link:../../../editor/frontend
-      '@itwin/electron-authorization': 0.8.5_electron@22.3.1
+      '@itwin/electron-authorization': 0.8.5_electron@23.2.0
       '@itwin/express-server': link:../../../core/express-server
       '@itwin/frontend-devtools': link:../../../core/frontend-devtools
       '@itwin/hypermodeling-frontend': link:../../../core/hypermodeling
@@ -3013,7 +3013,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       fs-extra: 8.1.0
       internal-tools: link:../../../tools/internal
@@ -3089,7 +3089,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       fs-extra: ^8.1.0
       internal-tools: workspace:*
@@ -3134,7 +3134,7 @@ importers:
       '@itwin/editor-backend': link:../../../editor/backend
       '@itwin/editor-common': link:../../../editor/common
       '@itwin/editor-frontend': link:../../../editor/frontend
-      '@itwin/electron-authorization': 0.8.5_electron@22.3.1
+      '@itwin/electron-authorization': 0.8.5_electron@23.2.0
       '@itwin/express-server': link:../../../core/express-server
       '@itwin/frontend-devtools': link:../../../core/frontend-devtools
       '@itwin/hypermodeling-frontend': link:../../../core/hypermodeling
@@ -3186,7 +3186,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       fs-extra: 8.1.0
       internal-tools: link:../../../tools/internal
@@ -3230,7 +3230,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       express: ^4.16.3
       internal-tools: workspace:*
@@ -3250,13 +3250,13 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/core-quantity': link:../../core/quantity
-      '@itwin/electron-authorization': 0.8.5_electron@22.3.1
+      '@itwin/electron-authorization': 0.8.5_electron@23.2.0
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 2.3.0
       '@itwin/imodels-access-frontend': 2.3.0
       '@itwin/imodels-client-authoring': 2.3.0
       '@itwin/imodels-client-management': 2.3.0
-      '@itwin/oidc-signin-tool': 3.6.1_electron@22.3.1
+      '@itwin/oidc-signin-tool': 3.6.1_electron@23.2.0
       '@itwin/reality-data-client': 0.9.0
       body-parser: 1.20.2
     devDependencies:
@@ -3273,7 +3273,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       express: 4.18.2
       internal-tools: link:../../tools/internal
@@ -3328,7 +3328,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       express: ^4.16.3
       express-ws: ^5.0.2
@@ -3361,7 +3361,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.8.5_electron@22.3.1
+      '@itwin/electron-authorization': 0.8.5_electron@23.2.0
       '@itwin/frontend-devtools': link:../../core/frontend-devtools
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
@@ -3389,7 +3389,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       express: 4.18.2
       express-ws: 5.0.2_express@4.18.2
@@ -3663,7 +3663,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       internal-tools: workspace:*
       npm-run-all: ^4.1.5
@@ -3688,7 +3688,7 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/core-quantity': link:../../core/quantity
       '@itwin/core-react': link:../../ui/core-react
-      '@itwin/electron-authorization': 0.8.5_electron@22.3.1
+      '@itwin/electron-authorization': 0.8.5_electron@23.2.0
       '@itwin/express-server': link:../../core/express-server
       '@itwin/imodel-components-react': link:../../ui/imodel-components-react
       '@itwin/itwinui-css': 0.63.1
@@ -3713,7 +3713,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       internal-tools: link:../../tools/internal
       npm-run-all: 4.1.5
@@ -3849,7 +3849,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       fs-extra: ^8.1.0
       internal-tools: workspace:*
@@ -3892,7 +3892,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.8.5_electron@22.3.1
+      '@itwin/electron-authorization': 0.8.5_electron@23.2.0
       '@itwin/express-server': link:../../core/express-server
       '@itwin/frontend-devtools': link:../../core/frontend-devtools
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
@@ -3943,7 +3943,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       fs-extra: 8.1.0
       internal-tools: link:../../tools/internal
@@ -4033,7 +4033,7 @@ importers:
       '@types/node': 18.11.5
       '@types/yargs': 17.0.19
       detect-port: ~1.3.0
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.11.0
       express: ^4.16.3
       jsonc-parser: ~2.0.3
@@ -4064,7 +4064,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.11.5
       '@types/yargs': 17.0.19
-      electron: 22.3.1
+      electron: 23.2.0
       eslint: 7.32.0
       nyc: 15.1.0
       rimraf: 3.0.2
@@ -7812,7 +7812,7 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/certa/3.6.0_electron@22.3.1:
+  /@itwin/certa/3.6.0_electron@23.2.0:
     resolution: {integrity: sha512-YrRKmOqheGPOWNDKtV7bm7iwpt5DKp8tpad3wu+4nyXWRSQ7U1npY93JDkXGWPs3TVmsNz4Y7uOoAyJHHHvyuA==}
     hasBin: true
     peerDependencies:
@@ -7822,7 +7822,7 @@ packages:
         optional: true
     dependencies:
       detect-port: 1.3.0
-      electron: 22.3.1
+      electron: 23.2.0
       express: 4.18.2
       jsonc-parser: 2.0.3
       lodash: 4.17.21
@@ -7861,14 +7861,14 @@ packages:
       webpack: 5.76.1
     dev: true
 
-  /@itwin/electron-authorization/0.8.5_electron@22.3.1:
+  /@itwin/electron-authorization/0.8.5_electron@23.2.0:
     resolution: {integrity: sha512-ynmZSEpyjrVl+Ro99jYL1GKFsVgb0MlHMrntdTxFjkbVOh9VtocX9gdw8oGrlrVuOYpy1jxd3+0uj36fRmv91w==}
     peerDependencies:
       electron: '>=14.0.0 <18.0.0'
     dependencies:
       '@itwin/core-bentley': link:../../core/bentley
       '@openid/appauth': 1.3.1
-      electron: 22.3.1
+      electron: 23.2.0
       keytar: 7.9.0
       open: 8.4.2
       username: 5.1.0
@@ -8042,10 +8042,10 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/oidc-signin-tool/3.6.1_electron@22.3.1:
+  /@itwin/oidc-signin-tool/3.6.1_electron@23.2.0:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
     dependencies:
-      '@itwin/certa': 3.6.0_electron@22.3.1
+      '@itwin/certa': 3.6.0_electron@23.2.0
       '@itwin/core-bentley': link:../../core/bentley
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -12883,8 +12883,8 @@ packages:
   /electron-to-chromium/1.4.310:
     resolution: {integrity: sha512-/xlATgfwkm5uDDwLw5nt/MNEf7c1oazLURMZLy39vOioGYyYzLWIDT8fZMJak6qTiAJ7udFTy7JG7ziyjNutiA==}
 
-  /electron/22.3.1:
-    resolution: {integrity: sha512-iDltL9j12bINK3aOp8ZoGq4NFBFjJhw1AYHelbWj93XUCAIT4fdA+PRsq0aaTHg3bthLLlLRvIZVgNsZPqWcqg==}
+  /electron/23.2.0:
+    resolution: {integrity: sha512-De9e21cri0QYct/w6tTNOnKyCt9RVKUw5F8PEN4FPzGR9tr6IT53uyt42uH754uJWrZeLMCAdoXy6/0GmMmYZA==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -41,7 +41,7 @@
     "@itwin/core-common": "workspace:^3.7.0-dev.7",
     "@itwin/core-frontend": "workspace:^3.7.0-dev.7",
     "@itwin/presentation-common": "workspace:^3.7.0-dev.7",
-    "electron": ">=14.0.0 <18.0.0 || >=22.0.0 <23.0.0"
+    "electron": ">=14.0.0 <18.0.0 || >=22.0.0 <24.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",
@@ -56,7 +56,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.11.5",
     "chai": "^4.1.2",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "mocha": "^10.0.0",
     "rimraf": "^3.0.2",

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -24,7 +24,7 @@
     "@itwin/core-electron": "workspace:*",
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-geometry": "workspace:*",
-    "electron": "^22.0.0"
+    "electron": "^23.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -50,7 +50,7 @@
     "sinon": "^9.0.2",
     "sinon-chai": "^3.2.0",
     "fs-extra": "^8.1.0",
-    "electron": "^22.0.0"
+    "electron": "^23.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -27,7 +27,7 @@
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-mobile": "workspace:*",
     "@itwin/express-server": "workspace:*",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "express": "^4.16.3",
     "semver": "^7.3.5",
     "spdy": "^4.0.1"

--- a/test-apps/appui-test-app/connected/package.json
+++ b/test-apps/appui-test-app/connected/package.json
@@ -63,7 +63,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "fs-extra": "^8.1.0",
     "internal-tools": "workspace:*",

--- a/test-apps/appui-test-app/standalone/package.json
+++ b/test-apps/appui-test-app/standalone/package.json
@@ -64,7 +64,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "fs-extra": "^8.1.0",
     "internal-tools": "workspace:*",

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -71,7 +71,7 @@
     "cpx2": "^3.0.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "express": "^4.16.3",
     "internal-tools": "workspace:*",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -88,7 +88,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "express": "^4.16.3",
     "express-ws": "^5.0.2",

--- a/test-apps/presentation-test-app/package.json
+++ b/test-apps/presentation-test-app/package.json
@@ -68,7 +68,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "internal-tools": "workspace:*",
     "npm-run-all": "^4.1.5",

--- a/test-apps/ui-test-app/package.json
+++ b/test-apps/ui-test-app/package.json
@@ -62,7 +62,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "fs-extra": "^8.1.0",
     "internal-tools": "workspace:*",

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -50,14 +50,14 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.11.5",
     "@types/yargs": "17.0.19",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "eslint": "^7.11.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
     "typescript": "~4.4.0"
   },
   "peerDependencies": {
-    "electron": ">=14.0.0 <18.0.0 || >=22.0.0 <23.0.0"
+    "electron": ">=14.0.0 <18.0.0 || >=22.0.0 <24.0.0"
   },
   "peerDependenciesMeta": {
     "electron": {


### PR DESCRIPTION
At the moment, iTwin.js 3.6 core only supports Electron 22 and lower while `@itwin/electron-authorization` only supports Electron 23. As a result, latest `@itwin/electron-authorization` version can't be used with latest `@itwin/core-electron` version. This PR fixes that by adding support for Electron 23 in upcoming iTwin.js 3.7. 

No code changes required since none of the [Electron breaking changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#planned-breaking-api-changes-230) should affect us.

cc: @GintV 