### PR TITLE
Add a ViewCreator3d option to make all subcategories visible

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2574,6 +2574,8 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     // @internal (undocumented)
     get displayTerrain(): boolean;
     dropSubCategoryOverride(id: Id64String): void;
+    // @internal
+    enableAllLoadedSubCategories(categoryIds: Id64Arg): boolean;
     equalState(other: DisplayStyleState): boolean;
     findMapLayerIndexByNameAndSource(name: string, source: string, isOverlay: boolean): number;
     forEachRealityModel(func: (model: ContextRealityModelState) => void): void;
@@ -2634,6 +2636,8 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     // @deprecated
     get scheduleScriptReference(): RenderSchedule.ScriptReference | undefined;
     setOSMBuildingDisplay(options: OsmBuildingDisplayOptions): boolean;
+    // @internal
+    setSubCategoryVisible(subCategoryId: Id64String, visible: boolean): boolean;
     abstract get settings(): DisplayStyleSettings;
     get viewFlags(): ViewFlags;
     set viewFlags(flags: ViewFlags);
@@ -6950,7 +6954,7 @@ export abstract class MapTilingScheme {
     readonly numberOfLevelZeroTilesX: number;
     readonly numberOfLevelZeroTilesY: number;
     // @alpha (undocumented)
-    get rootLevel(): 0 | -1;
+    get rootLevel(): -1 | 0;
     readonly rowZeroAtNorthPole: boolean;
     tileBordersNorthPole(row: number, level: number): boolean;
     tileBordersSouthPole(row: number, level: number): boolean;
@@ -13413,6 +13417,7 @@ export class ViewCreator3d {
 
 // @public
 export interface ViewCreator3dOptions {
+    allSubCategoriesVisible?: boolean;
     cameraOn?: boolean;
     skyboxOn?: boolean;
     standardViewId?: StandardViewId;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -10932,6 +10932,7 @@ export { Storage_2 as Storage }
 // @internal
 export class SubCategoriesCache {
     constructor(imodel: IModelConnection);
+    add(categoryId: string, subCategoryId: string, appearance: SubCategoryAppearance): void;
     // (undocumented)
     clear(): void;
     // (undocumented)

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -6954,7 +6954,7 @@ export abstract class MapTilingScheme {
     readonly numberOfLevelZeroTilesX: number;
     readonly numberOfLevelZeroTilesY: number;
     // @alpha (undocumented)
-    get rootLevel(): -1 | 0;
+    get rootLevel(): 0 | -1;
     readonly rowZeroAtNorthPole: boolean;
     tileBordersNorthPole(row: number, level: number): boolean;
     tileBordersSouthPole(row: number, level: number): boolean;

--- a/common/changes/@itwin/core-frontend/pmc-view-creator-all-subcategories_2023-03-29-11-55.json
+++ b/common/changes/@itwin/core-frontend/pmc-view-creator-all-subcategories_2023-03-29-11-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add an option for ViewCreator3d to make all subcategories visible.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -798,7 +798,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
   /** For each subcategory belonging to any of the specified categories, make it visible by turning off the "invisible" flag in its subcategory appearance.
    * This requires that the categories and subcategories have been previously loaded by, e.g., a call to IModelConnection.querySubCategories.
    * @see Viewport.changeCategoryDisplay
-   * @see ViewCreator3dOptions.enableAllSubCategories
+   * @see ViewCreator3dOptions.allSubCategoriesVisible
    * @internal
    */
   public enableAllLoadedSubCategories(categoryIds: Id64Arg): boolean {

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -818,7 +818,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
   /** Change the "invisible" flag for the given subcategory's appearance.
    * This requires that the subcategory appearance has been previously loaded by, e.g., a call to IModelConnection.Categories.getSubCategoryInfo.
    * @returns true if the visibility of any subcategory was modified.
-   * @see [[enableAllLoadedSubCategories]].
+   * @see [[enableAllLoadedSubCategories]]
    * @internal
    */
   public setSubCategoryVisible(subCategoryId: Id64String, visible: boolean): boolean {

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -797,6 +797,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
 
   /** For each subcategory belonging to any of the specified categories, make it visible by turning off the "invisible" flag in its subcategory appearance.
    * This requires that the categories and subcategories have been previously loaded by, e.g., a call to IModelConnection.querySubCategories.
+   * @returns true if the visibility of any subcategory was modified.
    * @see Viewport.changeCategoryDisplay
    * @see ViewCreator3dOptions.allSubCategoriesVisible
    * @internal
@@ -816,6 +817,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
 
   /** Change the "invisible" flag for the given subcategory's appearance.
    * This requires that the subcategory appearance has been previously loaded by, e.g., a call to IModelConnection.Categories.getSubCategoryInfo.
+   * @returns true if the visibility of any subcategory was modified.
    * @see [[enableAllLoadedSubCategories]].
    * @internal
    */

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -5,7 +5,7 @@
 /** @packageDocumentation
  * @module Views
  */
-import { assert, BeEvent, Id64, Id64String } from "@itwin/core-bentley";
+import { assert, BeEvent, Id64, Id64Arg, Id64String } from "@itwin/core-bentley";
 import { Angle, Range1d, Vector3d } from "@itwin/core-geometry";
 import {
   BackgroundMapProps, BackgroundMapProvider, BackgroundMapProviderProps, BackgroundMapSettings,
@@ -794,6 +794,47 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
    * @see [[overrideSubCategory]]
    */
   public getSubCategoryOverride(id: Id64String): SubCategoryOverride | undefined { return this.settings.getSubCategoryOverride(id); }
+
+  /** For each subcategory belonging to any of the specified categories, make it visible by turning off the "invisible" flag in its subcategory appearance.
+   * This requires that the categories and subcategories have been previously loaded by, e.g., a call to IModelConnection.querySubCategories.
+   * @see Viewport.changeCategoryDisplay
+   * @see ViewCreator3dOptions.enableAllSubCategories
+   * @internal
+   */
+  public enableAllLoadedSubCategories(categoryIds: Id64Arg): boolean {
+    let anyChanged = false;
+    for (const categoryId of Id64.iterable(categoryIds)) {
+      const subCategoryIds = this.iModel.subcategories.getSubCategories(categoryId);
+      if (undefined !== subCategoryIds)
+        for (const subCategoryId of subCategoryIds)
+          if (this.setSubCategoryVisible(subCategoryId, true))
+            anyChanged = true;
+    }
+
+    return anyChanged;
+  }
+
+  /** Change the "invisible" flag for the given subcategory's appearance.
+   * This requires that the subcategory appearance has been previously loaded by, e.g., a call to IModelConnection.Categories.getSubCategoryInfo.
+   * @see [[enableAllLoadedSubCategories]].
+   * @internal
+   */
+  public setSubCategoryVisible(subCategoryId: Id64String, visible: boolean): boolean {
+    const app = this.iModel.subcategories.getSubCategoryAppearance(subCategoryId);
+    if (undefined === app)
+      return false; // category not enabled or subcategory not found
+
+    const curOvr = this.getSubCategoryOverride(subCategoryId);
+    const isAlreadyVisible = undefined !== curOvr && undefined !== curOvr.invisible ? !curOvr.invisible : !app.invisible;
+    if (isAlreadyVisible === visible)
+      return false;
+
+    // Preserve existing overrides - just flip the visibility flag.
+    const json = undefined !== curOvr ? curOvr.toJSON() : {};
+    json.invisible = !visible;
+    this.overrideSubCategory(subCategoryId, SubCategoryOverride.fromJSON(json));
+    return true;
+  }
 
   /** Returns true if solar shadow display is enabled by this display style. */
   public get wantShadows(): boolean {

--- a/core/frontend/src/SubCategoriesCache.ts
+++ b/core/frontend/src/SubCategoriesCache.ts
@@ -108,7 +108,10 @@ export class SubCategoriesCache {
         this._byCategoryId.set(id, invalidCategoryIdEntry);
   }
 
-  private add(categoryId: string, subCategoryId: string, appearance: SubCategoryAppearance) {
+  /** Exposed strictly for tests.
+   * @internal
+   */
+  public add(categoryId: string, subCategoryId: string, appearance: SubCategoryAppearance) {
     let set = this._byCategoryId.get(categoryId);
     if (undefined === set)
       this._byCategoryId.set(categoryId, set = new Set<string>());

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -28,16 +28,31 @@ import { SpatialViewState } from "./SpatialViewState";
  * @extensions
 */
 export interface ViewCreator3dOptions {
-  /** Turn [[Camera]] on when generating the view. Defaults to true (on) */
+  /** Turn the [[Camera]] on to produce a perspective view.
+   * Default: true
+   */
   cameraOn?: boolean;
-  /** Turn [[SkyBox]] on when generating the view. */
+  /** Enables display of a [[SkyBox]] in the view. */
   skyboxOn?: boolean;
-  /** [[StandardViewId]] for the view state. */
+  /** Orients the view to one of the standard view rotations. */
   standardViewId?: StandardViewId;
-  /** Merge in props from the seed view (default spatial view) of the iModel.  */
+  /** Merge in props from a persistent "seed" view obtained from the iModel.
+   * @note The selection of the seed view is somewhat arbitrary, and the contents and styling of that view are unpredictable, so this option is not recommended.
+   */
   useSeedView?: boolean;
-  /** Aspect ratio of [[Viewport]]. Required to fit contents of the model(s) in the initial state of the view. */
+  /** The desired aspect ratio of the [[Viewport]] in which the view is to be displayed.
+   * This is used to adjust the view's frustum so that the viewed models are better centered within the viewport.
+   */
   vpAspect?: number;
+  /** Indicates that geometry belonging to every [SubCategory]($backend) should be visible within the view.
+   * Each subcategory has a [SubCategoryAppearance]($common) that specifies how its geometry is displayed. This includes a [SubCategoryAppearance.invisible]($common) property that,
+   * when set to `true`, indicates the geometry should not be displayed at all. A view can override the appearances of any subcategories using a [SubCategoryOverride]($common).
+   * If `allSubCategoriesVisible` is `true`, [[ViewCreator3d]] will apply such an override to every viewed subcategory to change [SubCategoryOverride.invisible]($common) to `false`, making
+   * every subcategory visible.
+   * @note Subcategories are typically set to invisible by default for a reason.
+   * Forcing them all to be visible may produce undesirable results, such as z-fighting between geometry on different subcategories that are not intended to be viewed together.
+   */
+  allSubCategoriesVisible?: boolean;
 }
 
 /**
@@ -51,7 +66,6 @@ export interface ViewCreator3dOptions {
  * @extensions
  */
 export class ViewCreator3d {
-
   /**
    * Constructs a ViewCreator3d using an [[IModelConnection]].
    * @param _imodel [[IModelConnection]] to query for categories and/or models.
@@ -81,6 +95,9 @@ export class ViewCreator3d {
 
     if (options?.standardViewId)
       viewState.setStandardRotation(options.standardViewId);
+
+    if (options?.allSubCategoriesVisible)
+      viewState.displayStyle.enableAllLoadedSubCategories(viewState.categorySelector.categories);
 
     const range = viewState.computeFitRange();
     viewState.lookAtVolume(range, options?.vpAspect);

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -754,13 +754,8 @@ export abstract class Viewport implements IDisposable, TileUser {
   }
 
   private enableAllSubCategories(categoryIds: Id64Arg): void {
-    for (const categoryId of Id64.iterable(categoryIds)) {
-      const subCategoryIds = this.iModel.subcategories.getSubCategories(categoryId);
-      if (undefined !== subCategoryIds) {
-        for (const subCategoryId of subCategoryIds)
-          this.changeSubCategoryDisplay(subCategoryId, true);
-      }
-    }
+    if (this.displayStyle.enableAllLoadedSubCategories(categoryIds))
+      this.maybeInvalidateScene();
   }
 
   /** @internal */
@@ -771,20 +766,8 @@ export abstract class Viewport implements IDisposable, TileUser {
    * @param display: True to make geometry belonging to the subcategory visible within this viewport, false to make it invisible.
    */
   public changeSubCategoryDisplay(subCategoryId: Id64String, display: boolean): void {
-    const app = this.iModel.subcategories.getSubCategoryAppearance(subCategoryId);
-    if (undefined === app)
-      return; // category not enabled or subcategory not found
-
-    const curOvr = this.getSubCategoryOverride(subCategoryId);
-    const isAlreadyVisible = undefined !== curOvr && undefined !== curOvr.invisible ? !curOvr.invisible : !app.invisible;
-    if (isAlreadyVisible === display)
-      return;
-
-    // Preserve existing overrides - just flip the visibility flag.
-    const json = undefined !== curOvr ? curOvr.toJSON() : {};
-    json.invisible = !display;
-    this.overrideSubCategory(subCategoryId, SubCategoryOverride.fromJSON(json)); // will set the ChangeFlag appropriately
-    this.maybeInvalidateScene();
+    if (this.displayStyle.setSubCategoryVisible(subCategoryId, display))
+      this.maybeInvalidateScene();
   }
 
   /** The settings controlling how a background map is displayed within a view.

--- a/full-stack-tests/core/src/frontend/standalone/ViewCreator3d.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewCreator3d.test.ts
@@ -66,7 +66,7 @@ describe("ViewCreator3d", async () => {
     view = await creator.createDefaultView({ allSubCategoriesVisible: true });
     expectVisible(true, true);
 
-    imodel.subcategories.add("0x19", "0x20", invisibleAppearance);
+    imodel.subcategories.add("0x17", "0x20", invisibleAppearance);
     view = await creator.createDefaultView({ allSubCategoriesVisible: true });
     expectVisible(true, true);
 

--- a/full-stack-tests/core/src/frontend/standalone/ViewCreator3d.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewCreator3d.test.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
+import { SubCategoryAppearance } from "@itwin/core-common";
 import { IModelConnection, ScreenViewport, SnapshotConnection, ViewCreator3d} from "@itwin/core-frontend";
 import { TestUtility } from "../TestUtility";
 
@@ -33,6 +34,44 @@ describe("ViewCreator3d", async () => {
 
     expect(testVp.numReadyTiles).to.equal(1);
     expect(testVp.numSelectedTiles).to.equal(1);
+  });
+
+  it("should optionally enable display of all subcategories", async () => {
+    // This test works by replacing subcategory appearances in the iModel's SubCategoriesCache to change the default visibility of a subcategory.
+    // In a real scenario the visibility would be obtained from the persistent subcategory appearance - our test iModels don't contain any
+    // invisible subcategories to test with.
+    // The iModel contains one spatial category 0x17 with one subcategory 0x18. We're adding a second pretend subcategory 0x20.
+    imodel.subcategories.add("0x17", "0x18", new SubCategoryAppearance());
+    imodel.subcategories.add("0x17", "0x20", new SubCategoryAppearance());
+
+    const creator = new ViewCreator3d(imodel);
+    let view = await creator.createDefaultView();
+    function expectVisible(subcat18Vis: boolean, subcat20Vis: boolean): void {
+      expect(view.isSubCategoryVisible("0x18")).to.equal(subcat18Vis);
+      expect(view.isSubCategoryVisible("0x20")).to.equal(subcat20Vis);
+    }
+
+    expect(Array.from(view.categorySelector.categories)).to.deep.equal(["0x17"]);
+    expectVisible(true, true);
+
+    const invisibleAppearance = new SubCategoryAppearance({ invisible: true });
+    imodel.subcategories.add("0x17", "0x18", invisibleAppearance);
+
+    view = await creator.createDefaultView();
+    expectVisible(false, true);
+
+    view = await creator.createDefaultView({ allSubCategoriesVisible: false });
+    expectVisible(false, true);
+
+    view = await creator.createDefaultView({ allSubCategoriesVisible: true });
+    expectVisible(true, true);
+
+    imodel.subcategories.add("0x19", "0x20", invisibleAppearance);
+    view = await creator.createDefaultView({ allSubCategoriesVisible: true });
+    expectVisible(true, true);
+
+    view = await creator.createDefaultView();
+    expectVisible(false, false);
   });
 });
 


### PR DESCRIPTION
Fixes #5153.
As usual, the hard part is writing a test.
Incidentally, cleaned up `ViewCreator3dOptions` documentation.