### PR TITLE
Fixed DuplicateSchema error with multiple async getSchema calls

### DIFF
--- a/common/changes/@itwin/ecschema-metadata/fix-schema-locater-multiple-async-calls_2023-03-30-12-42.json
+++ b/common/changes/@itwin/ecschema-metadata/fix-schema-locater-multiple-async-calls_2023-03-30-12-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "Fixed scenario where in if the same schema was retrieved through multiple async calls, the schema was being re-added to cache with each call, leading to DuplicateSchema error",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-metadata/src/Deserialization/Helper.ts
+++ b/core/ecschema-metadata/src/Deserialization/Helper.ts
@@ -72,8 +72,9 @@ export class SchemaReadHelper<T = unknown> {
 
     this._schema = schema;
 
-    // Need to add this schema to the context to be able to locate schemaItems within the context.
-    await this._context.addSchema(schema);
+    // If this doesn't doesn't already exist in the cache, need to add this schema to the context to be able to locate schemaItems within the context.
+    if (this._context.getCachedSchemaSync(schema.schemaKey) === undefined)
+      await this._context.addSchema(schema);
 
     // Load schema references first
     // Need to figure out if other schemas are present.
@@ -118,8 +119,9 @@ export class SchemaReadHelper<T = unknown> {
 
     this._schema = schema;
 
-    // Need to add this schema to the context to be able to locate schemaItems within the context.
-    this._context.addSchemaSync(schema);
+    // If this doesn't doesn't already exist in the cache, need to add this schema to the context to be able to locate schemaItems within the context.
+    if (this._context.getCachedSchemaSync(schema.schemaKey) === undefined)
+      this._context.addSchemaSync(schema);
 
     // Load schema references first
     // Need to figure out if other schemas are present.

--- a/full-stack-tests/core/src/frontend/standalone/SchemaRPCLocater.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/SchemaRPCLocater.test.ts
@@ -3,13 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { expect, assert } from "chai";
+import { assert, expect } from "chai";
 
 import { TestUtility } from "../TestUtility";
 import { IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
-import { SchemaContext, SchemaMatchType, SchemaKey, ECObjectsStatus } from "@itwin/ecschema-metadata";
+import { SchemaContext, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
-
 
 describe("Schema RPC locater", () => {
   let imodel: IModelConnection;
@@ -40,8 +39,7 @@ describe("Schema RPC locater", () => {
 
       const secondCallSchema = await schemaLocater.getSchema(new SchemaKey("ECDbSchemaPolicies", 1, 0, 0), SchemaMatchType.LatestReadCompatible, context);
       expect(secondCallSchema).to.be.not.undefined;
-    }
-    catch (error: any) {
+    } catch (error: any) {
       // getSchema shouldn't fail with duplicate schema error when called more than once
       assert(false, error.toDebugString());
     }

--- a/full-stack-tests/core/src/frontend/standalone/SchemaRPCLocater.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/SchemaRPCLocater.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect, assert } from "chai";
+
+import { TestUtility } from "../TestUtility";
+import { IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
+import { SchemaContext, SchemaMatchType, SchemaKey, ECObjectsStatus } from "@itwin/ecschema-metadata";
+import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
+
+
+describe("Schema RPC locater", () => {
+  let imodel: IModelConnection;
+  let context: SchemaContext;
+
+  before(async () => {
+    await TestUtility.startFrontend();
+  });
+
+  after(async () => {
+    if (imodel !== undefined)
+      await imodel.close();
+
+    await TestUtility.shutdownFrontend();
+  });
+
+  it("getSchema shouldn't throw duplicate schema error when called by multiple calls", async () => {
+
+    imodel = await SnapshotConnection.openFile("testImodel.bim");
+    const schemaLocater = new ECSchemaRpcLocater(imodel);
+    context = new SchemaContext();
+    context.addLocater(schemaLocater);
+
+    try {
+      // Schema "ECDbSchemaPolicies" doesn't exist in the context, so it will be added as part of the first getSchema call
+      const firstCallSchema = await schemaLocater.getSchema(new SchemaKey("ECDbSchemaPolicies", 1, 0, 0), SchemaMatchType.LatestReadCompatible, context);
+      expect(firstCallSchema).to.be.not.undefined;
+
+      const secondCallSchema = await schemaLocater.getSchema(new SchemaKey("ECDbSchemaPolicies", 1, 0, 0), SchemaMatchType.LatestReadCompatible, context);
+      expect(secondCallSchema).to.be.not.undefined;
+    }
+    catch (error: any) {
+      // getSchema shouldn't fail with duplicate schema error when called more than once
+      assert(false, error.toDebugString());
+    }
+  });
+});


### PR DESCRIPTION
The getSchema() in ECSchemaRPCLocater internally calls the Schema.fromJSON().
When reading the schema, a call is made to context.addSchema() so as to be able to locate schemaItems within the context.
However, there is no check when calling addSchema() to see if the schema has already been loaded.

Hence, if multiple async calls are made to getSchema(), every getSchema() call after the first will throw a DuplicateSchema error as it tried to load the schema again.

I've added a check to see if the schema has already been cached.
addSchema() is only called if the schema is not present in the context.