### PR TITLE
standardize package repo information

### DIFF
--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/backend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/backend"
   },
   "keywords": [
     "Bentley",

--- a/core/bentley/package.json
+++ b/core/bentley/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/bentley"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/bentley"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s build:esm",

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/common"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/common"
   },
   "keywords": [
     "Bentley",

--- a/core/ecschema-editing/package.json
+++ b/core/ecschema-editing/package.json
@@ -7,7 +7,8 @@
   "typings": "lib/cjs/ecschema-editing",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/ecschema-editing"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/ecschema-editing"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s createLocalization && npm run -s copy:test-assets",

--- a/core/ecschema-locaters/package.json
+++ b/core/ecschema-locaters/package.json
@@ -7,7 +7,8 @@
   "typings": "lib/cjs/ecschema-locaters",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/ecschema-locaters"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/ecschema-locators"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s copy:test-assets",

--- a/core/ecschema-metadata/package.json
+++ b/core/ecschema-metadata/package.json
@@ -7,7 +7,8 @@
   "typings": "lib/cjs/ecschema-metadata",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/ecschema-metadata"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/ecschema-metadata"
   },
   "scripts": {
     "build": "npm run -s build:cjs",

--- a/core/ecschema-rpc/common/package.json
+++ b/core/ecschema-rpc/common/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/ecschema-rpc/common"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/ecschema-rpc/common"
   },
   "scripts": {
     "build": "npm run -s build:cjs",

--- a/core/ecschema-rpc/impl/package.json
+++ b/core/ecschema-rpc/impl/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/ecschema-rpc/impl"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/ecschema-rpc/impl"
   },
   "scripts": {
     "build": "npm run -s build:cjs",

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/core-electron"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/electron"
   },
   "keywords": [
     "Bentley",

--- a/core/express-server/package.json
+++ b/core/express-server/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/express-server"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/express-server"
   },
   "keywords": [
     "Bentley",

--- a/core/extension/package.json
+++ b/core/extension/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/extension"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/extension"
   },
   "scripts": {
     "compile": "",

--- a/core/frontend-devtools/package.json
+++ b/core/frontend-devtools/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/frontend-devtools"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/frontend-devtools"
   },
   "keywords": [
     "Bentley",

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/frontend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/frontend"
   },
   "keywords": [
     "Bentley",

--- a/core/geometry/package.json
+++ b/core/geometry/package.json
@@ -24,7 +24,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/geometry"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/geometry"
   },
   "keywords": [
     "Bentley",

--- a/core/hypermodeling/package.json
+++ b/core/hypermodeling/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/hypermodeling-frontend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/hypermodeling"
   },
   "keywords": [
     "Bentley",

--- a/core/i18n/package.json
+++ b/core/i18n/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/i18n"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/i18n"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s build:esm && npm run -s webpack:test",

--- a/core/markup/package.json
+++ b/core/markup/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/markup"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/markup"
   },
   "keywords": [
     "Bentley",

--- a/core/mobile/package.json
+++ b/core/mobile/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/core-mobile"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/mobile"
   },
   "keywords": [
     "Bentley",

--- a/core/orbitgt/package.json
+++ b/core/orbitgt/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/orbitgt"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/orbitgt"
   },
   "keywords": [
     "Point Cloud"

--- a/core/quantity/package.json
+++ b/core/quantity/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/quantity"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/quantity"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s build:esm",

--- a/core/telemetry/package.json
+++ b/core/telemetry/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/telemetry"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/telemetry"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s build:esm",

--- a/core/transformer/package.json
+++ b/core/transformer/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/transformer"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/transformer"
   },
   "keywords": [
     "Bentley",

--- a/core/webgl-compatibility/package.json
+++ b/core/webgl-compatibility/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/core/webgl-compatibility"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "core/webgl-compatibility"
   },
   "keywords": [
     "Bentley",

--- a/domains/analytical/backend/package.json
+++ b/domains/analytical/backend/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/domains/analytical/backend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "domains/analytical/backend"
   },
   "keywords": [
     "Bentley",

--- a/domains/linear-referencing/backend/package.json
+++ b/domains/linear-referencing/backend/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/domains/linear-referencing/backend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "domains/linear-referencing/backend"
   },
   "keywords": [
     "Bentley",

--- a/domains/linear-referencing/common/package.json
+++ b/domains/linear-referencing/common/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/domains/linear-referencing/common"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "domains/linear-referencing/common"
   },
   "keywords": [
     "Bentley",

--- a/domains/physical-material/backend/package.json
+++ b/domains/physical-material/backend/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/domains/physical-material/backend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "domains/physical-material/backend"
   },
   "keywords": [
     "Bentley",

--- a/editor/backend/package.json
+++ b/editor/backend/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/editor/backend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "editor/backend"
   },
   "keywords": [
     "Bentley",

--- a/editor/common/package.json
+++ b/editor/common/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/editor/common"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "editor/common"
   },
   "keywords": [
     "Bentley",

--- a/editor/frontend/package.json
+++ b/editor/frontend/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/editor/frontend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "editor/frontend"
   },
   "keywords": [
     "Bentley",

--- a/extensions/frontend-tiles/package.json
+++ b/extensions/frontend-tiles/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/extensions/frontend-tiles"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "extensions/frontend-tiles"
   },
   "keywords": [
     "Bentley",

--- a/extensions/map-layers-auth/package.json
+++ b/extensions/map-layers-auth/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/extensions/map-layers-auth"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "extensions/map-layers-auth"
   },
   "keywords": [
     "iModel",

--- a/extensions/map-layers-formats/package.json
+++ b/extensions/map-layers-formats/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/extensions/map-layers-formats"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "extensions/map-layers-formats"
   },
   "keywords": [
     "iModel",

--- a/full-stack-tests/ecschema-rpc-interface/package.json
+++ b/full-stack-tests/ecschema-rpc-interface/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/full-stack-tests/ecschema-rpc-interface"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "full-stack-tests/ecschema-rpc-interface"
   },
   "scripts": {
     "build": "tsc 1>&2 && npm run -s webpack:test",

--- a/full-stack-tests/rpc-interface/package.json
+++ b/full-stack-tests/rpc-interface/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/full-stack-tests/rpc-interface"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "full-stack-tests/rpc-interface"
   },
   "keywords": [
     "Bentley",

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/presentation/backend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "presentation/backend"
   },
   "keywords": [
     "Bentley",

--- a/presentation/common/package.json
+++ b/presentation/common/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/presentation/common"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "presentation/common"
   },
   "keywords": [
     "Bentley",

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/presentation/frontend"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "presentation/frontend"
   },
   "keywords": [
     "Bentley",

--- a/presentation/opentelemetry/package.json
+++ b/presentation/opentelemetry/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/presentation/opentelemetry"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "presentation/opentelemetry"
   },
   "keywords": [
     "Bentley",

--- a/tools/backend-webpack/package.json
+++ b/tools/backend-webpack/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/tools/backend-webpack"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "tools/backend-webpack"
   },
   "author": {
     "name": "Bentley Systems, Inc.",

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/tools/build"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "tools/build"
   },
   "bin": {
     "betools": "bin/betools.js"

--- a/tools/build/scripts/utils/addPackageMetadata.js
+++ b/tools/build/scripts/utils/addPackageMetadata.js
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 const FS = require("fs-extra");
 const path = require("path");
@@ -10,7 +10,7 @@ const path = require("path");
 // so find the project root using rush env variable if available.
 const rootPackageJson = process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER
   ? path.join(process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER, "package.json")
-  : "../../../../package.json"
+  : "../../../../package.json";
 
 // Check if path to root package.json is valid.
 const rootPackageJsonPath = require.resolve(rootPackageJson);
@@ -20,9 +20,10 @@ const packageJsonPath = path.join(process.cwd(), "package.json");
 const packageJson = JSON.parse(FS.readFileSync(packageJsonPath));
 const version = packageJson.version;
 const repositoryUrl = packageJson.repository?.url;
+const repositoryDirectory = packageJson.repository?.directory;
 
-if (!version || !repositoryUrl) {
-  throw new Error('version or repositoryUrl not found in package.json');
+if (!version || !repositoryUrl || !repositoryDirectory) {
+  throw new Error("version or repository info not found in package.json");
 }
 
 // Appends the directory of the package root to the Typedoc JSON output
@@ -32,11 +33,14 @@ function addPackageMetadata(file, directory) {
     const pathToRootFolder = path.dirname(rootPackageJsonPath);
     const packageRoot = directory.substring(pathToRootFolder.length + 1);
     const jsonContents = JSON.parse(contents);
+
     jsonContents["packageRoot"] = packageRoot.endsWith("src")
       ? packageRoot
       : `${packageRoot}\\${"src"}`;
     jsonContents["version"] = version;
     jsonContents["repositoryUrl"] = repositoryUrl;
+    jsonContents["repositoryDirectory"] = repositoryDirectory;
+
     FS.writeFileSync(file, Buffer.from(JSON.stringify(jsonContents, null, 2)));
   }
 }

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -6,7 +6,8 @@
   "main": "bin/certa.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/tools/certa"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "tools/certa"
   },
   "bin": {
     "certa": "./bin/certa.js"

--- a/tools/ecschema2ts/package.json
+++ b/tools/ecschema2ts/package.json
@@ -9,7 +9,8 @@
   "main": "bin/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/tools/ecschema2ts"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "tools/ecschema2ts"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s copy:test-assets",

--- a/tools/perf-tools/package.json
+++ b/tools/perf-tools/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/tools/perf-tools"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "tools/perf-tools"
   },
   "scripts": {
     "build": "npm run -s build:cjs",

--- a/tools/webpack-core/package.json
+++ b/tools/webpack-core/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/tools/webpack-core"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "tools/webpack-core"
   },
   "author": {
     "name": "Bentley Systems, Inc.",

--- a/ui/appui-abstract/package.json
+++ b/ui/appui-abstract/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/ui/appui-abstract"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "ui/appui-abstract"
   },
   "scripts": {
     "build": "npm run -s build:cjs && npm run -s build:esm",

--- a/utils/workspace-editor/package.json
+++ b/utils/workspace-editor/package.json
@@ -19,7 +19,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iTwin/itwinjs-core/tree/master/utils/workspace-editor"
+    "url": "https://github.com/iTwin/itwinjs-core.git",
+    "directory": "utils/workspace-editor"
   },
   "dependencies": {
     "@itwin/core-bentley": "workspace:*",


### PR DESCRIPTION
Standardize how we reference our repo and package location in package.json files. A couple packages had incorrect urls. Now following npm monorepo guidance - https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository

Add repositoryDirectory field when extracting metadata for docs.