### PR TITLE
Make Markup.selected and Markup.undo public.

### DIFF
--- a/common/api/core-markup.api.md
+++ b/common/api/core-markup.api.md
@@ -195,7 +195,6 @@ export class Markup {
     groupSelected(): void;
     // @internal (undocumented)
     readonly markupDiv: HTMLDivElement;
-    // @internal (undocumented)
     readonly selected: MarkupSelected;
     sendToBack(): void;
     setCursor(cursor: string): void;
@@ -207,7 +206,6 @@ export class Markup {
     readonly svgDynamics?: G;
     // @internal (undocumented)
     readonly svgMarkup?: G;
-    // @internal (undocumented)
     readonly undo: UndoManager;
     ungroupSelected(): void;
     // (undocumented)

--- a/common/changes/@itwin/core-markup/markup-api-promotions_2023-03-30-16-59.json
+++ b/common/changes/@itwin/core-markup/markup-api-promotions_2023-03-30-16-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-markup",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-markup"
+}

--- a/core/markup/src/Markup.ts
+++ b/core/markup/src/Markup.ts
@@ -385,9 +385,9 @@ const newSvgElement = (name: string) => adopt(create(name));
 export class Markup {
   /** @internal */
   public readonly markupDiv: HTMLDivElement;
-  /** @internal */
+  /** Support undo/redo of markup operations */
   public readonly undo = new UndoManager();
-  /** @internal */
+  /** The set of currently selected markup elements */
   public readonly selected!: MarkupSelected;
   /** @internal */
   public readonly svgContainer?: Svg;


### PR DESCRIPTION
Markup.undo to support undo/redo commands.
Markup.selected for writing tools or making changes to the selected markup elements.

Part of #4851 