### PR TITLE
update docsites metadata with repo versioning info

### DIFF
--- a/docs/config/docSites.json
+++ b/docs/config/docSites.json
@@ -54,7 +54,7 @@
         "archivedPath": "/v2"
       },
       {
-        "version": "v3.6.1",
+        "version": "v3.7.0",
         "archivedPath": "/v3"
       }
     ],
@@ -105,6 +105,15 @@
         "\\columnXYZ": "{\\begin{bmatrix}#1\\\\#2\\\\#3\\end{bmatrix}}",
         "\\rowXYZ": "{\\begin{bmatrix} #1 & #2 & #3\\end{bmatrix}}"
       }
+    },
+    "repoVersioningInLockstep": {
+      "appui": true,
+      "auth-clients": false,
+      "connector-framework": true,
+      "itwinjs-core": true,
+      "object-storage": true,
+      "presentation": true,
+      "transformer": true
     }
   }
 }


### PR DESCRIPTION
To help docs link to release notes, we need to know if a repository keeps its packages in lockstep. 