### PR TITLE
Harden computeFrustumPlanes() in FrustumPlanes.ts

### DIFF
--- a/common/changes/@itwin/core-common/markschlosser-fix-frustum-planes-front-too-small_2023-03-31-14-13.json
+++ b/common/changes/@itwin/core-common/markschlosser-fix-frustum-planes-front-too-small_2023-03-31-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/geometry/FrustumPlanes.ts
+++ b/core/common/src/geometry/FrustumPlanes.ts
@@ -75,7 +75,6 @@ function computeFrustumPlanes(frustum: Frustum): ClipPlane[] {
   } else
     return [];
 
-  assert(planes.length === 6);
   return planes;
 }
 

--- a/core/common/src/geometry/FrustumPlanes.ts
+++ b/core/common/src/geometry/FrustumPlanes.ts
@@ -168,7 +168,6 @@ export class FrustumPlanes {
    * @returns the degree to which all of the points are contained within the clipping planes.
    */
   public computeContainment(points: Point3d[], sphere?: BoundingSphere, tolerance: number = 1.0e-8): FrustumPlanes.Containment {
-    assert(this.isValid);
     if (undefined === this._planes)
       return FrustumPlanes.Containment.Outside;
 
@@ -213,7 +212,6 @@ export class FrustumPlanes {
    * @returns true if the ray extending from `origin` in the specified `direction` intersects at least one of the clipping planes.
    */
   public intersectsRay(origin: Point3d, direction: Vector3d): boolean {
-    assert(this.isValid);
     if (undefined === this._planes) {
       return false;
     }
@@ -257,4 +255,3 @@ export namespace FrustumPlanes { // eslint-disable-line no-redeclare
     Inside = 2,
   }
 }
-

--- a/core/common/src/geometry/FrustumPlanes.ts
+++ b/core/common/src/geometry/FrustumPlanes.ts
@@ -6,7 +6,6 @@
  * @module Geometry
  */
 
-import { assert } from "@itwin/core-bentley";
 import { ClipPlane, Point3d, Vector3d } from "@itwin/core-geometry";
 import { Frustum } from "../Frustum";
 import { BoundingSphere } from "./BoundingSphere";

--- a/core/common/src/geometry/FrustumPlanes.ts
+++ b/core/common/src/geometry/FrustumPlanes.ts
@@ -6,17 +6,42 @@
  * @module Geometry
  */
 
+import { assert } from "@itwin/core-bentley";
 import { ClipPlane, Point3d, Vector3d } from "@itwin/core-geometry";
 import { Frustum } from "../Frustum";
 import { BoundingSphere } from "./BoundingSphere";
 
+/*
+The following visualizes the contents of frustum.points, which is sent to computeFrustumPlanes().
+The below numbers are the indices into that array.
+
+   2----------3
+  /|         /|
+ / 0--------/-1
+6----------7  /
+| /        | /
+|/         |/
+4__________5
+
+0 = left bottom rear
+1 = right bottom rear
+2 = left top right
+3 = right top rear
+4 = left bottom front
+5 = right bottom front
+6 = left top front
+7 = right top front
+*/
+
+// Ordering of sub-arrays is: [origin, a, b]
 const planePointIndices = [
-  [1, 3, 5],  // right
-  [0, 4, 2],  // left
-  [2, 6, 3],  // top
-  [0, 1, 4],  // bottom
-  [0, 2, 1],  // back
-  [4, 5, 6],  // front
+  [1, 5, 3], // right
+  [0, 2, 4], // left
+  [2, 3, 6], // top
+  [0, 4, 1], // bottom
+  [0, 1, 2], // back
+  // Skip front plane because it can be too small. Instead derive it from back plane.
+  // Otherwise, it would be: [4, 6, 5]
 ];
 
 function computeFrustumPlanes(frustum: Frustum): ClipPlane[] {
@@ -24,9 +49,10 @@ function computeFrustumPlanes(frustum: Frustum): ClipPlane[] {
   const points = frustum.points;
   const expandPlaneDistance = 1e-6;
 
+  let normal: Vector3d | undefined;
   for (const indices of planePointIndices) {
     const i0 = indices[0], i1 = indices[1], i2 = indices[2];
-    const normal = Vector3d.createCrossProductToPoints(points[i2], points[i1], points[i0]);
+    normal = Vector3d.createCrossProductToPoints(points[i0], points[i1], points[i2]);
     normal.normalizeInPlace();
 
     const plane = ClipPlane.createNormalAndDistance(normal, normal.dotProduct(points[i0]) - expandPlaneDistance);
@@ -36,6 +62,20 @@ function computeFrustumPlanes(frustum: Frustum): ClipPlane[] {
     planes.push(plane);
   }
 
+  // Derive front plane from back plane due to fact that front plane can become very tiny and cause precision issues, resulting in zero frustum planes. Deriving the front plane from the rear rect resolves this problem.
+  // The back plane was the last plane processed above, so we can just consult the current value of `normal`.
+  if (undefined !== normal) {
+    normal.negate(normal); // negate the back plane
+    // NB: Below, we make sure we calculate the distance based on a point on the front rect, not the rear rect!
+    const plane = ClipPlane.createNormalAndDistance(normal, normal.dotProduct(points[4]) - expandPlaneDistance);
+    if (!plane)
+      return [];
+
+    planes.push(plane);
+  } else
+    return [];
+
+  assert(planes.length === 6);
   return planes;
 }
 
@@ -56,6 +96,7 @@ export class FrustumPlanes {
 
   /** Compute the six planes of the specified frustum.
    * If the frustum is degenerate - that is, its points do not represent a truncated pyramid - then the returned `FrustumPlanes` will contain zero planes.
+   * @note This method assumes that the front plane is parallel to the back plane.
    * @see [[isValid]] to test this condition.
    */
   public static fromFrustum(frustum: Frustum): FrustumPlanes {
@@ -86,6 +127,7 @@ export class FrustumPlanes {
 
   /** Recompute the planes from the specified frustum.
    * @returns true upon success, or false if the input frustum was degenerate, in which case [[isValid]] will be `false`.
+   * @note This method assumes that the front plane is parallel to the back plane.
    */
   public init(frustum: Frustum): boolean {
     this._planes = computeFrustumPlanes(frustum);
@@ -126,6 +168,7 @@ export class FrustumPlanes {
    * @returns the degree to which all of the points are contained within the clipping planes.
    */
   public computeContainment(points: Point3d[], sphere?: BoundingSphere, tolerance: number = 1.0e-8): FrustumPlanes.Containment {
+    assert(this.isValid);
     if (undefined === this._planes)
       return FrustumPlanes.Containment.Outside;
 
@@ -170,6 +213,7 @@ export class FrustumPlanes {
    * @returns true if the ray extending from `origin` in the specified `direction` intersects at least one of the clipping planes.
    */
   public intersectsRay(origin: Point3d, direction: Vector3d): boolean {
+    assert(this.isValid);
     if (undefined === this._planes) {
       return false;
     }
@@ -213,3 +257,4 @@ export namespace FrustumPlanes { // eslint-disable-line no-redeclare
     Inside = 2,
   }
 }
+

--- a/core/common/src/test/FrustumPlanes.test.ts
+++ b/core/common/src/test/FrustumPlanes.test.ts
@@ -23,7 +23,7 @@ describe("FrustumPlanes", () => {
       Point3d.fromJSON({ x: 22.838134428009578, y: -21.182090505813676, z: 2.248236463773556 }), // left bottom front
       Point3d.fromJSON({ x: 22.826687847036766, y: -21.3106221602675, z: 2.248236463773556 }),   // right bottom front
       Point3d.fromJSON({ x: 22.845184176795684, y: -21.18271833185903, z: 2.332414308846702 }),  // left top front
-      Point3d.fromJSON({ x: 22.833737595822875, y: -21.311249986312852, z: 2.332414308846702 })  // right top front
+      Point3d.fromJSON({ x: 22.833737595822875, y: -21.311249986312852, z: 2.332414308846702 }), // right top front
     ]);
 
     const frustumPlanes = FrustumPlanes.fromFrustum(frustum);
@@ -40,7 +40,7 @@ describe("FrustumPlanes", () => {
       Point3d.fromJSON({ x: 22.834416905993425, y: -21.302724625992933, z: 2.3314674264499287 }), // left bottom front
       Point3d.fromJSON({ x: 22.834298900004015, y: -21.304049694595548, z: 2.3314674264499287 }), // right bottom front
       Point3d.fromJSON({ x: 22.834425708266938, y: -21.30272540989272, z: 2.3315725303959707 }),  // left top front
-      Point3d.fromJSON({ x: 22.834307702277528, y: -21.304050478495334, z: 2.3315725303959707 })  // right top front
+      Point3d.fromJSON({ x: 22.834307702277528, y: -21.304050478495334, z: 2.3315725303959707 }), // right top front
     ]);
 
     /*
@@ -67,5 +67,22 @@ describe("FrustumPlanes", () => {
 
     const frustumPlanes = FrustumPlanes.fromFrustum(frustum);
     expect(frustumPlanes.planes.length).to.equal(6);
+  });
+
+  it("should properly handle a bad (zero-size) frustum", () => {
+    const frustum = new Frustum();
+    frustum.setFromCorners([
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // left bottom rear
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // right bottom rear
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // left top rear
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // right top rear
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // left bottom front
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // right bottom front
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // left top front
+      Point3d.fromJSON({ x: 0, y: 0, z: 0 }),  // right top front
+    ]);
+
+    const frustumPlanes = FrustumPlanes.fromFrustum(frustum);
+    expect(frustumPlanes.planes.length).to.equal(0);
   });
 });

--- a/core/common/src/test/FrustumPlanes.test.ts
+++ b/core/common/src/test/FrustumPlanes.test.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { FrustumPlanes } from "../geometry/FrustumPlanes";
+import { Frustum } from "../Frustum";
+import { Point3d } from "@itwin/core-geometry";
+
+describe("FrustumPlanes", () => {
+  it("should properly handle a default frustum", () => {
+    const frustumPlanes = FrustumPlanes.fromFrustum(new Frustum());
+    expect(frustumPlanes.planes.length).to.equal(6);
+  });
+
+  it("should properly handle a good frustum", () => {
+    const frustum = new Frustum();
+    frustum.setFromCorners([
+      Point3d.fromJSON({ x: 88.51459041033166, y: 0.7622479698565066, z: -21.27515944984108 }),  // left bottom rear
+      Point3d.fromJSON({ x: 83.59175566227866, y: -54.5154018605118, z: -21.275159449841123 }),  // right bottom rear
+      Point3d.fromJSON({ x: 91.54647813049287, y: 0.4922386212896158, z: 14.92723336305222 }),   // left top rear
+      Point3d.fromJSON({ x: 86.62364338243987, y: -54.78541120907869, z: 14.927233363052178 }),  // right top rear
+      Point3d.fromJSON({ x: 22.838134428009578, y: -21.182090505813676, z: 2.248236463773556 }), // left bottom front
+      Point3d.fromJSON({ x: 22.826687847036766, y: -21.3106221602675, z: 2.248236463773556 }),   // right bottom front
+      Point3d.fromJSON({ x: 22.845184176795684, y: -21.18271833185903, z: 2.332414308846702 }),  // left top front
+      Point3d.fromJSON({ x: 22.833737595822875, y: -21.311249986312852, z: 2.332414308846702 })  // right top front
+    ]);
+
+    const frustumPlanes = FrustumPlanes.fromFrustum(frustum);
+    expect(frustumPlanes.planes.length).to.equal(6);
+  });
+
+  it("should properly handle a frustum with very small front rect", () => {
+    const frustum = new Frustum();
+    frustum.setFromCorners([
+      Point3d.fromJSON({ x: 86.91579452523399, y: -51.11890676358028, z: 14.520007347159119 }),   // left bottom rear
+      Point3d.fromJSON({ x: 86.86504365154272, y: -51.68877944224387, z: 14.520007347159117 }),   // right bottom rear
+      Point3d.fromJSON({ x: 86.91958012182498, y: -51.11924389561279, z: 14.565209434923249 }),   // left top rear
+      Point3d.fromJSON({ x: 86.86882924813371, y: -51.68911657427638, z: 14.565209434923247 }),   // right top rear
+      Point3d.fromJSON({ x: 22.834416905993425, y: -21.302724625992933, z: 2.3314674264499287 }), // left bottom front
+      Point3d.fromJSON({ x: 22.834298900004015, y: -21.304049694595548, z: 2.3314674264499287 }), // right bottom front
+      Point3d.fromJSON({ x: 22.834425708266938, y: -21.30272540989272, z: 2.3315725303959707 }),  // left top front
+      Point3d.fromJSON({ x: 22.834307702277528, y: -21.304050478495334, z: 2.3315725303959707 })  // right top front
+    ]);
+
+    /*
+    Note the super small front rect. This previously caused issues in FrustumPlanes.fromFrustum().
+    So we will verify that that issue no longer occurs.
+
+       2----------3
+      /|         /|
+     / 0--------/-1
+    6----------7  /
+    | /        | /
+    |/         |/
+    4__________5
+
+    0 = LBR = { x: 86.91579452523399, y: -51.11890676358028, z: 14.520007347159119 }
+    1 = RBR = { x: 86.86504365154272, y: -51.68877944224387, z: 14.520007347159117 }
+    2 = LTR = { x: 86.91958012182498, y: -51.11924389561279, z: 14.565209434923249 }
+    3 = RTR = { x: 86.86882924813371, y: -51.68911657427638, z: 14.565209434923247 }
+    4 = LBF = { x: 22.834416905993425, y: -21.302724625992933, z: 2.3314674264499287 }
+    5 = RBF = { x: 22.834298900004015, y: -21.304049694595548, z: 2.3314674264499287 }
+    6 = LTF = { x: 22.834425708266938, y: -21.30272540989272, z: 2.3315725303959707 }
+    7 = RTF = { x: 22.834307702277528, y: -21.304050478495334, z: 2.3315725303959707 }
+    */
+
+    const frustumPlanes = FrustumPlanes.fromFrustum(frustum);
+    expect(frustumPlanes.planes.length).to.equal(6);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/670

In the case of the above bug, the front rect of a scaled-down frustum for readPixels() can become rather tiny because the source view frustum was already rather small. Deriving the front plane's normals from a small rect resulted in a near-zero plane normal, causing computeFrustumPlanes() to return an empty array of planes. This caused the rendering system to eventually assert.

To fix the problem, we now derive the front plane from the rear plane.

We also generally hardened the code in computeFrustumPlanes() by ensuring that the normals are only ever calculated from points of the frustum box that yield a 90 degree angle (this was not done previously).  We did this by reordering the point used for the cross product function. This reordering also makes it clearer what the values actually mean.

More documentation has been added to this source file in order to make it easier to debug and read in the future.

Furthermore, a test has been added (FrustumPlanes.test.ts) which exercises the particular bad frustum which prompted this work, verifying that it now processes properly. Some good frustums have been added to that test file as well.

- [x] Image Tests