### PR TITLE
Add new appui packages location to NextVersion.md #5330

### DIFF
--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -152,7 +152,7 @@ The following previously-deprecated APIs have been removed:
 
 ### AppUI packages moved
 
-The source code for following packages was moved to the new [AppUi repository](https://github.com/iTwin/appui). The package names and published location have not changed.
+The source code for following packages was moved to the new [AppUi repository](https://github.com/iTwin/appui). The package names and published location have not changed, but the release schedule will be independent from that of the itwinjs-core packages.
 
 - @itwin/appui-react
 - @itwin/appui-layout-react

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -21,6 +21,7 @@ Table of contents:
   - [Handling of long-running requests](#handling-of-long-running-requests)
   - [Dependency updates](#dependency-updates)
 - [Deprecated API removals](#deprecated-api-removals)
+- [AppUI packages moved](#appui-packages-moved)
 
 ## Updated minimum requirements
 
@@ -148,4 +149,14 @@ The following previously-deprecated APIs have been removed:
 - `CloudStorageTileCache`
 - `IModelTileRpcInterface.getTileCacheContainerUrl`
 - `IModelTileRpcInterface.isUsingExternalTileCache`
+
+### AppUI packages moved
+
+The source code for following packages was moved to the new [AppUi repository](https://github.com/iTwin/appui). The package names and published location have not changed.
+
+- @itwin/appui-react
+- @itwin/appui-layout-react
+- @itwin/components-react
+- @itwin/core-react
+- @itwin/imodel-components-react
 


### PR DESCRIPTION
Document the source location for the appui packages that have been moved out of itwinjs-core in the 4.0 release