### PR TITLE
Add TileStorage to core-backend barrel file

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -5097,6 +5097,29 @@ export interface TextureCreateProps extends Omit<TextureProps, "data"> {
 // @internal
 export function throttleProgressCallback(func: ProgressFunction, checkAbort: () => ProgressStatus, progressInterval?: number): ProgressFunction;
 
+// @beta (undocumented)
+export class TileStorage {
+    constructor(storage: ServerStorage);
+    // (undocumented)
+    downloadTile(iModelId: string, changesetId: string, treeId: string, contentId: string, guid?: string): Promise<Uint8Array>;
+    // (undocumented)
+    getCachedTiles(iModelId: string): Promise<{
+        treeId: string;
+        contentId: string;
+        guid?: string;
+    }[]>;
+    // (undocumented)
+    getDownloadConfig(iModelId: string, expiresInSeconds?: number): Promise<TransferConfig>;
+    // (undocumented)
+    initialize(iModelId: string): Promise<void>;
+    // (undocumented)
+    isTileCached(iModelId: string, changesetId: string, treeId: string, contentId: string, guid?: string): Promise<boolean>;
+    // (undocumented)
+    readonly storage: ServerStorage;
+    // (undocumented)
+    uploadTile(iModelId: string, changesetId: string, treeId: string, contentId: string, content: Uint8Array, guid?: string, metadata?: Metadata): Promise<void>;
+}
+
 // @public
 export class TitleText extends DetailingSymbol {
     constructor(props: GeometricElement2dProps, iModel: IModelDb);

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -5097,26 +5097,19 @@ export interface TextureCreateProps extends Omit<TextureProps, "data"> {
 // @internal
 export function throttleProgressCallback(func: ProgressFunction, checkAbort: () => ProgressStatus, progressInterval?: number): ProgressFunction;
 
-// @beta (undocumented)
+// @beta
 export class TileStorage {
     constructor(storage: ServerStorage);
-    // (undocumented)
     downloadTile(iModelId: string, changesetId: string, treeId: string, contentId: string, guid?: string): Promise<Uint8Array>;
-    // (undocumented)
     getCachedTiles(iModelId: string): Promise<{
         treeId: string;
         contentId: string;
         guid?: string;
     }[]>;
-    // (undocumented)
     getDownloadConfig(iModelId: string, expiresInSeconds?: number): Promise<TransferConfig>;
-    // (undocumented)
     initialize(iModelId: string): Promise<void>;
-    // (undocumented)
     isTileCached(iModelId: string, changesetId: string, treeId: string, contentId: string, guid?: string): Promise<boolean>;
-    // (undocumented)
     readonly storage: ServerStorage;
-    // (undocumented)
     uploadTile(iModelId: string, changesetId: string, treeId: string, contentId: string, content: Uint8Array, guid?: string, metadata?: Metadata): Promise<void>;
 }
 

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -373,6 +373,7 @@ public;TextAnnotation3d
 public;Texture 
 internal;TextureCreateProps 
 internal;throttleProgressCallback(func: ProgressFunction, checkAbort: () => ProgressStatus, progressInterval?: number): ProgressFunction
+beta;TileStorage
 public;TitleText 
 public;ToChangesetArgs 
 public;TokenArg

--- a/common/changes/@itwin/core-backend/remove-prefix-param_2023-04-03-14-46.json
+++ b/common/changes/@itwin/core-backend/remove-prefix-param_2023-04-03-14-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/TileStorage.ts
+++ b/core/backend/src/TileStorage.ts
@@ -61,7 +61,7 @@ export class TileStorage {
     }
   }
 
-  public async getCachedTiles(iModelId: string, _prefix: string): Promise<{ treeId: string, contentId: string, guid?: string }[]> {
+  public async getCachedTiles(iModelId: string): Promise<{ treeId: string, contentId: string, guid?: string }[]> {
     return (await this.storage.listObjects({ baseDirectory: iModelId }))
       .map((objectReference) => ({
         parts: objectReference.relativeDirectory?.split("/") ?? [""],

--- a/core/backend/src/core-backend.ts
+++ b/core/backend/src/core-backend.ts
@@ -49,6 +49,7 @@ export * from "./domains/GenericElements";
 export { IModelJsNative, NativeCloudSqlite, NativeLoggerCategory } from "@bentley/imodeljs-native";
 export * from "./IModelElementCloneContext";
 export * from "./IModelCloneContext";
+export * from "./TileStorage";
 export * from "./IModelHost";
 export * from "./IpcHost";
 export * from "./NativeAppStorage";


### PR DESCRIPTION
This fixes a couple issues:
1. While an instance `TileStorage` coule be retrieved from `IModelHost`, there was no way to use it in a type annotation (or extend it, for whatever reason) without importing it directly from `TileStorage.ts`
2. The class had no documentation comments so it may have been unclear how to use it
3. `getCachedTiles` had a `_prefix` parameter that wasn't actually used. The original intention was to filter the list of tiles using the prefix to avoid downloading excessive information, but `ServerStorage` didn't have the relevant implementation (and still doesn't) so it was added as a placeholder and then slipped through the code review. In hindsight, I think it wasn't the best idea to begin with, because the whole purpose of this class is to abstract away the directory structure in which tiles are stored in cloud cache, and using a prefix requires knowing the structure of blob names you're looking for. So I decided to remove the parameter altogether, and if anyone needs this functionality, they can use `TileStorage.storage.listObjects` instead.