### PR TITLE
Temporarily ignore xml2js CVE until @azure/storage-blob is updated

### DIFF
--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -42,6 +42,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-9c47-m6qq-7p4h", // https://github.com/advisories/GHSA-9c47-m6qq-7p4h appui-test-app>@bentley/react-scripts>eslint-config-react-app>eslint-plugin-import>tsconfig-paths>json5
     "GHSA-27h2-hvpr-p74q", // https://github.com/advisories/GHSA-27h2-hvpr-p74q backend-integration-tests>azurite>jsonwebtoken
     "GHSA-8mwq-mj73-qv68", // https://github.com/advisories/GHSA-8mwq-mj73-qv68 full-stack-tests__backend>azurite>sequelize
+    "GHSA-776f-qx25-q3cc", // https://github.com/advisories/GHSA-776f-qx25-q3cc core__backend>@azure/storage-blob>@azure/core-http>xml2js
   ];
 
   let shouldFailBuild = false;


### PR DESCRIPTION
Revert when #5373 is complete.