### PR TITLE
Presentation: Include diagnostics in error responses

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-report-diagnostics-with-error-responses_2023-04-11-13-00.json
+++ b/common/changes/@itwin/presentation-backend/presentation-report-diagnostics-with-error-responses_2023-04-11-13-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fixed diagnostics not being included in error responses",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -318,14 +318,6 @@ async function withOptionalDiagnostics(
 ): Promise<NativePlatformResponse<string>> {
   const contexts = diagnosticsOptions.map((d) => d?.requestContextSupplier?.());
   const combinedOptions = combineDiagnosticsOptions(...diagnosticsOptions);
-  // const response = await nativePlatformRequestHandler(combinedOptions);
-  // if (response.diagnostics) {
-  //   const diagnostics = { logs: [response.diagnostics] };
-  //   diagnosticsOptions.forEach((options, i) => {
-  //     options && reportDiagnostics(diagnostics, options, contexts[i]);
-  //   });
-  // }
-  // return response;
   let responseDiagnostics: DiagnosticsScopeLogs | undefined;
   try {
     const response = await nativePlatformRequestHandler(combinedOptions);

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -105,8 +105,8 @@ describe("default NativePlatform", () => {
 
     it("throws with diagnostics", async () => {
       const diagnostics: DiagnosticsScopeLogs = {
-        scope: "x"
-      }
+        scope: "x",
+      };
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "" }, diagnostics }), cancel: () => { } }));

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -10,7 +10,7 @@ import * as moq from "typemoq";
 import { IModelDb, IModelHost, IModelJsNative } from "@itwin/core-backend";
 import { BeEvent } from "@itwin/core-bentley";
 import { DiagnosticsScopeLogs, PresentationError, PresentationStatus, UpdateInfo, VariableValueTypes } from "@itwin/presentation-common";
-import { createDefaultNativePlatform, NativePlatformDefinition } from "../presentation-backend/NativePlatform";
+import { createDefaultNativePlatform, NativePlatformDefinition, PresentationNativePlatformResponseError } from "../presentation-backend/NativePlatform";
 
 describe("default NativePlatform", () => {
 
@@ -86,21 +86,31 @@ describe("default NativePlatform", () => {
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Canceled, message: "test" } }), cancel: () => { } }));
-      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
+      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationNativePlatformResponseError, "test");
     });
 
     it("throws on error response", async () => {
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "test" } }), cancel: () => { } }));
-      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test");
+      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationNativePlatformResponseError, "test");
     });
 
     it("throws on `ResultSetTooLarge` error response", async () => {
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
         .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.ResultSetTooLarge, message: "test" } }), cancel: () => { } }));
-      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationError, "test").with.property("errorNumber", PresentationStatus.ResultSetTooLarge);
+      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationNativePlatformResponseError, "test").with.property("errorNumber", PresentationStatus.ResultSetTooLarge);
+    });
+
+    it("throws with diagnostics", async () => {
+      const diagnostics: DiagnosticsScopeLogs = {
+        scope: "x"
+      }
+      addonMock
+        .setup((x) => x.handleRequest(moq.It.isAny(), ""))
+        .returns(() => ({ result: Promise.resolve({ error: { status: IModelJsNative.ECPresentationStatus.Error, message: "" }, diagnostics }), cancel: () => { } }));
+      await expect(nativePlatform.handleRequest(undefined, "")).to.eventually.be.rejectedWith(PresentationNativePlatformResponseError).and.have.property("diagnostics", diagnostics);
     });
 
     it("adds listener to cancel event and calls it only after first invocation", async () => {


### PR DESCRIPTION
imodel-native PR: https://github.com/iTwin/imodel-native/pull/234
imodel-native: https://github.com/iTwin/imodel-native/tree/presentation/include-diagnostics-in-error-responses