### PR TITLE
Replace IModelApp.getAccessToken's usage of 'this' with 'IModelApp'

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-getaccesstoken_2023-04-18-13-34.json
+++ b/common/changes/@itwin/core-frontend/fix-getaccesstoken_2023-04-18-13-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "replace IModelApp.getAccessToken's implementation usage of 'this' with 'IModelApp'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -540,7 +540,7 @@ export class IModelApp {
    */
   public static async getAccessToken(): Promise<AccessToken> {
     try {
-      return (await this.authorizationClient?.getAccessToken()) ?? "";
+      return (await IModelApp.authorizationClient?.getAccessToken()) ?? "";
     } catch (e) {
       return "";
     }


### PR DESCRIPTION
In order to prevent needing to add a `.bind(IModelApp)` when using `IModelApp.getAccessToken` like this:
`const getAccessToken = props.getAccessToken ?? IModelApp.getAccessToken` 
Replace the `IModelApp.getAccessToken` implementation's usage of `this` with `IModelApp`
Since this is a static routine there is no reason to complicate its usage with the `this` keyword