### PR TITLE
Fix for timing issue in core tests

### DIFF
--- a/common/changes/@itwin/core-backend/test-fix_2023-04-19-16-13.json
+++ b/common/changes/@itwin/core-backend/test-fix_2023-04-19-16-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fix for timing issue in core tests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
@@ -198,6 +198,10 @@ export class IModelTileRpcImpl extends RpcInterface implements IModelTileRpcInte
       modelIds = undefined;
 
     const db = await RpcBriefcaseUtility.findOpenIModel(currentActivity().accessToken, tokenProps);
+    if (!db.isOpen) {
+      return;
+    }
+
     return db.nativeDb.purgeTileTrees(modelIds);
   }
 


### PR DESCRIPTION
BriefcaseConnection purges the tile trees in response to various events (such as undo/redo). However, this is requested asynchronously on the frontend (via IPC/RPC).

If the briefcase is closed immediately after (in our core tests, for example), the purge can fail (even though it was requested first on the frontend).

This PR fixes the intermittent crash by checking if the briefcase is still open after the async call to RpcBriefcaseUtility.findOpenIModel returns.

The overall scheme is still vulnerable to similar future crashes since nothing is "awaiting" the asynchronous operations that may be kicked off in the briefcase event handlers.