### PR TITLE
Update markdown files

### DIFF
--- a/docs/changehistory/2.18.0.md
+++ b/docs/changehistory/2.18.0.md
@@ -72,7 +72,7 @@ export class ExtensionUiItemsProvider implements UiItemsProvider {
 
 ### @itwin/appui-react package
 
-- The need for an IModelApp to explicitly call [ConfigurableUiManager.initialize]($appui-react) has been removed. This call is now made when processing [UiFramework.initialize]($appui-react). This will not break any existing applications as subsequent calls to `ConfigurableUiManager.initialize()` are ignored.
+- The need for an IModelApp to explicitly call `ConfigurableUiManager.initialize()` has been removed. This call is now made when processing [UiFramework.initialize]($appui-react). This will not break any existing applications as subsequent calls to `ConfigurableUiManager.initialize()` are ignored.
 
 - If an application calls [UiFramework.setIModelConnection]($appui-react) it will no longer need to explicitly call [SyncUiEventDispatcher.initializeConnectionEvents]($appui-react) as `UiFramework.setIModelConnection` will call that method as it update the redux store.
 

--- a/docs/changehistory/2.9.0.md
+++ b/docs/changehistory/2.9.0.md
@@ -252,4 +252,4 @@ If the returned type is certain (result of an ECSQL query, for example), then th
 
 ## UI Framework breaking change
 
-- The class `ToolUiManager` has been renamed to [ToolSettingsManager]($appui-react).
+- The class `ToolUiManager` has been renamed to `ToolSettingsManager`.

--- a/docs/changehistory/3.0.0.md
+++ b/docs/changehistory/3.0.0.md
@@ -1228,7 +1228,7 @@ The component `FrameworkVersion` has been updated so it no longer takes a versio
 
 #### Removed user change monitoring from @itwin/appui-react
 
-Previously `UiFramework` would monitor the state of an access token and would close all UI popups if the token was found to be empty. This feature has been removed. It is now the applications responsibility to enable this capability if they want it. The method [ConfigurableUiManager.closeUi]($appui-react) is now public and can be called by application to close the popup items.
+Previously `UiFramework` would monitor the state of an access token and would close all UI popups if the token was found to be empty. This feature has been removed. It is now the applications responsibility to enable this capability if they want it. The method `ConfigurableUiManager.closeUi` is now public and can be called by application to close the popup items.
 
 #### Deprecated components in favor of iTwinUI-react components
 

--- a/docs/learning/ui/appui-react/ChildWindows.md
+++ b/docs/learning/ui/appui-react/ChildWindows.md
@@ -58,6 +58,3 @@ Careful consideration must be taken when building components for use in a child 
 
 A Widget can specify set its `canPopout` property to true if its supports being in a child window. This allows a Widget to be "popped-out" to its own window and then re-docked in the Widget Panel when the child window is closed. See [Popout Widget Support](../../ui/appui-react/Widgets.md#popout-widget-support) for more details.
 
-## API Reference
-
-- [FrameworkChildWindows]($appui-react:FrameworkChildWindows)

--- a/docs/learning/ui/appui-react/ChildWindows.md
+++ b/docs/learning/ui/appui-react/ChildWindows.md
@@ -1,6 +1,6 @@
 # Child Window Manager
 
-The [ChildWindowManager]($appui-react) class, available via property `UiFramework.childWindowManager`, provides methods to display React components in additional browser windows. A child browser window shares the same javascript context as the single page IModelApp running in the main browser window. The ChildWindowManager maintains a list of all child windows and closes them when the page containing the IModelApp is unloaded.
+The [FrameworkChildWindows]($appui-react) interface, available via property `UiFramework.childWindows`, provides methods to display React components in additional browser windows. A child browser window shares the same javascript context as the single page IModelApp running in the main browser window. The ChildWindowManager maintains a list of all child windows and closes them when the page containing the IModelApp is unloaded.
 
 ## Popup URL
 
@@ -12,7 +12,7 @@ There are two options when opening a child popup window, the first is to allow a
   const content=(<div>Example Popout Widget</div>);
   const location={ height: 600, width: 400, left: 10, top: 50};
   const useDefaultPopoutUrl=false; // this is default if not specified
-  UiFramework.childWindowManager.openChildWindow(childWindowId, title, content, location, false);
+  UiFramework.childWindows.open(childWindowId, title, content, location, false);
 ```
 
 The second option is to pass true for the useDefaultPopoutUrl argument above. This will result in the use of the URL "/iTwinPopup.html". It is the responsibility of the application to ensure this HTML file is available at that location on the server. The minimum contents for this file is shown below. The div with `id=root` is required as it is the element that is used to host React components.
@@ -46,9 +46,9 @@ The second option is to pass true for the useDefaultPopoutUrl argument above. Th
 </html>
 ```
 
-When the ChildWindowManager opens a child window it immediately copies styles from the main application's document into the child window so the appearance of the child window matches that of the main window.
+When FrameworkChildWindows opens a child window it immediately copies styles from the main application's document into the child window so the appearance of the child window matches that of the main window.
 
-The ChildWindowManager does not try to save and restore child windows. The one exception is the child windows opened via the Widget "pop-out" icon. The widget system will maintain the state of the size and location of "popped-out" widgets and attempt to restore that position when the widget is subsequently popped out.
+FrameworkChildWindows does not try to save and restore child windows. The one exception is the child windows opened via the Widget "pop-out" icon. The widget system will maintain the state of the size and location of "popped-out" widgets and attempt to restore that position when the widget is subsequently popped out.
 
 ## Warning
 
@@ -60,4 +60,4 @@ A Widget can specify set its `canPopout` property to true if its supports being 
 
 ## API Reference
 
-- [ChildWindowManager]($appui-react:ChildWindowManager)
+- [FrameworkChildWindows]($appui-react:FrameworkChildWindows)

--- a/docs/learning/ui/appui-react/Dialogs.md
+++ b/docs/learning/ui/appui-react/Dialogs.md
@@ -3,8 +3,9 @@
 A **Dialog** is a small temporary window of options presented to the user.
 The `@itwin/appui-react` and `@itwin/core-react` packages contain several classes and components for displaying modal and modeless dialogs.
 
-* [ModalDialogManager]($appui-react) - displays and manages multiple modal dialogs
-* [ModelessDialogManager]($appui-react) - displays and manages multiple modeless dialogs
+* [FrameworkDialogs]($appui-react) - an interface accessed through `UiFramework.dialogs` manages dialogs open within the AppUI framework
+  * `UiFramework.dialogs.modal` - displays and manages multiple modal dialogs
+  * `UiFramework.dialogs.modeless` - displays and manages multiple modeless dialogs
 * [ModelessDialog]($appui-react) - Modeless Dialog React component uses the Dialog component with a modal={false} prop.
 It controls the z-index to keep the focused dialog above others.
 * [Dialog]($core-react) - Dialog React component with optional resizing and moving functionality.
@@ -79,10 +80,10 @@ export class SampleModalDialog extends React.Component<SampleModalDialogProps, S
 
 ### Opening a Modal Dialog
 
-The `ModalDialogManager.openDialog` function is called to open a modal dialog.
+The `UiFramework.dialogs.modal.open` function is called to open a modal dialog.
 
 ```tsx
-  ModalDialogManager.openDialog(
+  UiFramework.dialogs.modal.open(
     <SampleModalDialog
       onResult={(result) => this._handleModalResult(result)}
     />);
@@ -90,11 +91,11 @@ The `ModalDialogManager.openDialog` function is called to open a modal dialog.
 
 ### Handling Modal Dialog Close
 
-The `ModalDialogManager.closeDialog` function is called to close a modal dialog.
+The `UiFramework.dialogs.modal.close` function is called to close a modal dialog.
 
 ```tsx
   private _handleModalResult(result: DialogButtonType) {
-    ModalDialogManager.closeDialog();
+    UiFramework.dialogs.modal.close();
     IModelApp.notifications.outputMessage(
       new NotifyMessageDetails(OutputMessagePriority.Info, `Modal dialog result: ${result}`)
     );
@@ -168,12 +169,12 @@ export class SampleModelessDialog extends React.Component<SampleModelessDialogPr
 
 ### Opening a Modeless Dialog
 
-The `ModelessDialogManager.openDialog` function is called to open a modeless dialog.
+The `UiFramework.dialogs.modeless.open` function is called to open a modeless dialog.
 
 ```tsx
   const dialogId = "sample";
 
-  ModelessDialogManager.openDialog(
+  UiFramework.dialogs.modeless.open(
     <SampleModelessDialog
       opened={true}
       dialogId={dialogId}
@@ -183,11 +184,11 @@ The `ModelessDialogManager.openDialog` function is called to open a modeless dia
 
 ### Handling Modeless Dialog Close
 
-The `ModelessDialogManager.closeDialog` function is called to close a modeless dialog.
+The `UiFramework.dialogs.modeless.close` function is called to close a modeless dialog.
 
 ```tsx
   private _handleModelessClose = (dialogId: string) => {
-    ModelessDialogManager.closeDialog(dialogId);
+    UiFramework.dialogs.modeless.close(dialogId);
     IModelApp.notifications.outputMessage(
       new NotifyMessageDetails(OutputMessagePriority.Info, `Closed modeless dialog: ${dialogId}`)
     );

--- a/docs/learning/ui/appui-react/ModalFrontstage.md
+++ b/docs/learning/ui/appui-react/ModalFrontstage.md
@@ -46,5 +46,5 @@ FrontstageManager.openModalFrontstage(modalFrontstage);
 
 - [ModalFrontstage]($appui-react)
 - [ModalFrontstageInfo]($appui-react)
-- [FrontstageManager]($appui-react)
+- [FrameworkFrontstages]($appui-react)
 - [Frontstage]($appui-react:Frontstage)

--- a/docs/learning/ui/appui-react/NestedFrontstage.md
+++ b/docs/learning/ui/appui-react/NestedFrontstage.md
@@ -18,10 +18,10 @@ which will return to the previous frontstage when clicked/pressed.
 
 ## Code to Open Nested Frontstage
 
-The following code that instantiates a nested frontstage, initializes the [FrontstageDef]($appui-react), and calls [FrontstageManager.openNestedFrontstage]($appui-react) to open the nested frontstage.
+The following code that instantiates a nested frontstage, initializes the [FrontstageDef]($appui-react), and calls `UiFramework.frontstages.openNestedFrontstage` to open the nested frontstage.
 
 ```ts
 const frontstageProvider = new NestedFrontstage();
 const frontstageDef = await FrontstageDef.create(frontstageProvider);
-await FrontstageManager.openNestedFrontstage(frontstageDef);
+await UiFramework.fronstages.openNestedFrontstage(frontstageDef);
 ```

--- a/docs/learning/ui/imodel-components/Viewport.md
+++ b/docs/learning/ui/imodel-components/Viewport.md
@@ -16,7 +16,7 @@ The `viewState` is the [ViewState]($core-frontend) to use as a starting point.
 
 The `viewportRef` specifies a function that receives the [ScreenViewport]($core-frontend) created by the component and
 allows the component user a chance to save it. When using `@itwin/appui-react` and
-Frontstages, setting `ViewportContentControl.viewport` notifies the [FrontstageManager]($appui-react) that the
+Frontstages, setting `ViewportContentControl.viewport` notifies [FrameworkFrontstages]($appui-react), referenced through `UiFramework.frontstages`, that the
 content view is ready.
 
 ## Sample using Presentation Rules


### PR DESCRIPTION
AppUI 4.0 removes classes and interfaces that were deprecated in 3.x and earlier. Update the learning docs and release notes to removed links to the removed code.