### PR TITLE
Address tile content disposal issues

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -1958,6 +1958,25 @@ export enum DbValueFormat {
     JsNames = 1
 }
 
+// @internal (undocumented)
+export function decodeTileContentDescription(args: DecodeTileContentDescriptionArgs): TileContentDescription;
+
+// @internal (undocumented)
+export interface DecodeTileContentDescriptionArgs {
+    // (undocumented)
+    is2d?: boolean;
+    // (undocumented)
+    isLeaf?: boolean;
+    // (undocumented)
+    isVolumeClassifier?: boolean;
+    // (undocumented)
+    options: TileOptions;
+    // (undocumented)
+    sizeMultiplier?: number;
+    // (undocumented)
+    stream: ByteStream;
+}
+
 // @internal
 export interface DecorationGeometryProps {
     // (undocumented)
@@ -7085,7 +7104,7 @@ export interface ReadableFormData extends BackendReadable {
 // @beta
 export function readElementMeshes(data: Uint8Array): IndexedPolyface[];
 
-// @internal
+// @internal @deprecated
 export function readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription;
 
 // @beta

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5191,6 +5191,7 @@ export interface ImdlReaderCreateArgs {
     is3d: boolean;
     // (undocumented)
     isCanceled?: ShouldAbortImdlReader;
+    isLeaf?: boolean;
     // (undocumented)
     loadEdges?: boolean;
     // (undocumented)
@@ -11577,7 +11578,7 @@ export class TileAdmin {
     addExternalTilesForUser(user: TileUser, statistics: ExternalTileStatistics): void;
     addLoadListener(callback: (imodel: IModelConnection) => void): () => void;
     // @internal
-    addTilesForUser(user: TileUser, selected: Tile[], ready: Set<Tile>): void;
+    addTilesForUser(user: TileUser, selected: Tile[], ready: Set<Tile>, touched: Set<Tile>): void;
     // @internal (undocumented)
     readonly alwaysRequestEdges: boolean;
     // @internal (undocumented)
@@ -11926,6 +11927,8 @@ export class TileDrawArgs {
     get secondaryClassifiers(): Map<number, RenderPlanarClassifier> | undefined;
     get symbologyOverrides(): FeatureSymbology.Overrides | undefined;
     get tileSizeModifier(): number;
+    // @internal
+    readonly touchedTiles: Set<Tile>;
     readonly tree: TileTree;
     readonly viewClip?: ClipVector;
     get viewFlagOverrides(): ViewFlagOverrides;

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -168,6 +168,8 @@ internal;DbResponseKind
 internal;DbResponseStatus
 beta;DbRuntimeStats
 internal;DbValueFormat
+internal;decodeTileContentDescription(args: DecodeTileContentDescriptionArgs): TileContentDescription
+internal;DecodeTileContentDescriptionArgs
 internal;DecorationGeometryProps
 beta;DefaultSupportedTypes
 internal;defaultTileOptions: TileOptions
@@ -600,6 +602,7 @@ public;Rank
 internal;ReadableFormData 
 beta;readElementMeshes(data: Uint8Array): IndexedPolyface[]
 internal;readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription
+deprecated;readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription
 beta;RealityData
 beta;RealityDataAccess
 beta;RealityDataFormat

--- a/common/changes/@itwin/core-common/pmc-preserve-tile-leafness_2023-04-25-15-09.json
+++ b/common/changes/@itwin/core-common/pmc-preserve-tile-leafness_2023-04-25-15-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/pmc-preserve-tile-leafness_2023-04-25-15-09.json
+++ b/common/changes/@itwin/core-frontend/pmc-preserve-tile-leafness_2023-04-25-15-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/frontend-tiles/pmc-preserve-tile-leafness_2023-04-25-15-09.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-preserve-tile-leafness_2023-04-25-15-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "Improve tile content disposal under memory pressure.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/core/common/src/tile/TileMetadata.ts
+++ b/core/common/src/tile/TileMetadata.ts
@@ -822,7 +822,7 @@ export interface TileContentDescription extends TileContentMetadata {
 /** Deserializes tile content metadata.
  * @throws [[TileReadError]]
  * @internal
- * @deprecated Use decodeTileContentDescription. I think tile agents (or their tests) are using this function.
+ * @deprecated in 4.0. Use decodeTileContentDescription. I think tile agents (or their tests) are using this function.
  */
 export function readTileContentDescription(stream: ByteStream, sizeMultiplier: number | undefined, is2d: boolean, options: TileOptions, isVolumeClassifier: boolean): TileContentDescription {
   return decodeTileContentDescription({ stream, sizeMultiplier, is2d, options, isVolumeClassifier });

--- a/core/common/src/tile/TileMetadata.ts
+++ b/core/common/src/tile/TileMetadata.ts
@@ -935,7 +935,14 @@ export class TileMetadataReader {
    * @throws [[TileReadError]]
    */
   public read(stream: ByteStream, props: TileProps): TileMetadata {
-    const content = readTileContentDescription(stream, props.sizeMultiplier, this._is2d, this._options, this._isVolumeClassifier);
+    const content = decodeTileContentDescription({
+      stream,
+      sizeMultiplier: props.sizeMultiplier,
+      is2d: this._is2d,
+      options: this._options,
+      isVolumeClassifier: this._isVolumeClassifier,
+    });
+
     return {
       contentRange: content.contentRange,
       isLeaf: content.isLeaf,

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -9,9 +9,9 @@
 import { assert, ByteStream, Id64String, JsonUtils, utf8ToString } from "@itwin/core-bentley";
 import { ClipVector, ClipVectorProps, Point2d, Point3d, Range2d, Range3d, Range3dProps, Transform, TransformProps, XYProps, XYZProps } from "@itwin/core-geometry";
 import {
-  BatchType, ColorDef, ColorDefProps, ComputeNodeId, ElementAlignedBox3d, FeatureIndexType, FeatureTableHeader, FillFlags, GltfV2ChunkTypes, GltfVersions, Gradient,
+  BatchType, ColorDef, ColorDefProps, ComputeNodeId, decodeTileContentDescription, ElementAlignedBox3d, FeatureIndexType, FeatureTableHeader, FillFlags, GltfV2ChunkTypes, GltfVersions, Gradient,
   ImageSource, ImageSourceFormat, ImdlFlags, ImdlHeader, LinePixels, MultiModelPackedFeatureTable, PackedFeatureTable, PolylineTypeFlags, QParams2d, QParams3d,
-  decodeTileContentDescription, RenderFeatureTable, RenderMaterial, RenderSchedule, RenderTexture, TextureMapping, TextureTransparency, TileFormat, TileHeader, TileReadError, TileReadStatus,
+  RenderFeatureTable, RenderMaterial, RenderSchedule, RenderTexture, TextureMapping, TextureTransparency, TileFormat, TileHeader, TileReadError, TileReadStatus,
 } from "@itwin/core-common";
 import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -11,7 +11,7 @@ import { ClipVector, ClipVectorProps, Point2d, Point3d, Range2d, Range3d, Range3
 import {
   BatchType, ColorDef, ColorDefProps, ComputeNodeId, ElementAlignedBox3d, FeatureIndexType, FeatureTableHeader, FillFlags, GltfV2ChunkTypes, GltfVersions, Gradient,
   ImageSource, ImageSourceFormat, ImdlFlags, ImdlHeader, LinePixels, MultiModelPackedFeatureTable, PackedFeatureTable, PolylineTypeFlags, QParams2d, QParams3d,
-  readTileContentDescription, RenderFeatureTable, RenderMaterial, RenderSchedule, RenderTexture, TextureMapping, TextureTransparency, TileFormat, TileHeader, TileReadError, TileReadStatus,
+  decodeTileContentDescription, RenderFeatureTable, RenderMaterial, RenderSchedule, RenderTexture, TextureMapping, TextureTransparency, TileFormat, TileHeader, TileReadError, TileReadStatus,
 } from "@itwin/core-common";
 import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";
@@ -474,6 +474,8 @@ export interface ImdlReaderCreateArgs {
   iModel: IModelConnection;
   modelId: Id64String;
   is3d: boolean;
+  /** If undefined, the tile's leafness will be deduced by decodeTileContentDescription. */
+  isLeaf?: boolean;
   system: RenderSystem;
   type?: BatchType; // default Primary
   loadEdges?: boolean; // default true
@@ -515,6 +517,7 @@ export class ImdlReader {
   private readonly _binaryData: Uint8Array;
   private readonly _iModel: IModelConnection;
   private readonly _is3d: boolean;
+  private readonly _isLeaf?: boolean;
   private readonly _modelId: Id64String;
   private readonly _system: RenderSystem;
   private readonly _type: BatchType;
@@ -592,6 +595,7 @@ export class ImdlReader {
     this._iModel = args.iModel;
     this._modelId = args.modelId;
     this._is3d = args.is3d;
+    this._isLeaf = args.isLeaf;
     this._system = args.system;
     this._type = args.type ?? BatchType.Primary;
     this._canceled = args.isCanceled;
@@ -607,7 +611,14 @@ export class ImdlReader {
   public async read(): Promise<ImdlReaderResult> {
     let content;
     try {
-      content = readTileContentDescription(this._buffer, this._sizeMultiplier, !this._is3d, IModelApp.tileAdmin, this._isVolumeClassifier);
+      content = decodeTileContentDescription({
+        stream: this._buffer,
+        sizeMultiplier: this._sizeMultiplier,
+        is2d: !this._is3d,
+        options: IModelApp.tileAdmin,
+        isVolumeClassifier: this._isVolumeClassifier,
+        isLeaf: this._isLeaf,
+      });
     } catch (e) {
       if (e instanceof TileReadError)
         return { isLeaf: true, readStatus: e.errorNumber };

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -465,7 +465,7 @@ export class RealityTileTree extends TileTree {
 
     this.reportTileVisibility(args, selected);
 
-    IModelApp.tileAdmin.addTilesForUser(args.context.viewport, selected, args.readyTiles);
+    IModelApp.tileAdmin.addTilesForUser(args.context.viewport, selected, args.readyTiles, args.touchedTiles);
     return selected;
   }
 

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -494,11 +494,13 @@ export class TileAdmin {
    * The TileAdmin takes ownership of the `ready` set - do not modify it after passing it in.
    * @internal
    */
-  public addTilesForUser(user: TileUser, selected: Tile[], ready: Set<Tile>): void {
+  public addTilesForUser(user: TileUser, selected: Tile[], ready: Set<Tile>, touched: Set<Tile>): void {
     // "selected" are tiles we are drawing.
     this._lruList.markUsed(user.tileUserId, selected);
     // "ready" are tiles we want to draw but can't yet because, for example, their siblings are not yet ready to be drawn.
     this._lruList.markUsed(user.tileUserId, ready);
+    // "touched" are tiles whose contents we want to keep in memory regardless of whether they are "selected" or "ready".
+    this._lruList.markUsed(user.tileUserId, touched);
 
     const entry = this.getTilesForUser(user);
     if (undefined === entry) {

--- a/core/frontend/src/tile/TileDrawArgs.ts
+++ b/core/frontend/src/tile/TileDrawArgs.ts
@@ -103,6 +103,10 @@ export class TileDrawArgs {
   public hiddenLineSettings?: HiddenLine.Settings;
   /** Tiles that we want to draw and that are ready to draw. May not actually be selected, e.g. if sibling tiles are not yet ready. */
   public readonly readyTiles = new Set<Tile>();
+  /** Tiles whose contents should be kept in memory regardless of whether or not they are selected for display.
+   * @internal
+   */
+  public readonly touchedTiles = new Set<Tile>();
   /** For perspective views, the view-Z of the near plane. */
   private readonly _nearFrontCenter?: Point3d;
   /** Overrides applied to the view's [ViewFlags]($common) when drawing the tiles. */

--- a/core/frontend/src/tile/TileTree.ts
+++ b/core/frontend/src/tile/TileTree.ts
@@ -133,7 +133,7 @@ export abstract class TileTree {
   public selectTiles(args: TileDrawArgs): Tile[] {
     this._lastSelected = BeTimePoint.now();
     const tiles = this._selectTiles(args);
-    IModelApp.tileAdmin.addTilesForUser(args.context.viewport, tiles, args.readyTiles);
+    IModelApp.tileAdmin.addTilesForUser(args.context.viewport, tiles, args.readyTiles, args.touchedTiles);
     args.processSelectedTiles(tiles);
     return tiles;
   }

--- a/extensions/frontend-tiles/src/BatchedTile.ts
+++ b/extensions/frontend-tiles/src/BatchedTile.ts
@@ -225,6 +225,7 @@ export class BatchedTile extends Tile {
       iModel: this.tree.iModel,
       modelId: this.tree.modelId,
       is3d: true,
+      isLeaf: this.isLeaf,
       system,
       isCanceled: shouldAbort,
       options: {

--- a/extensions/frontend-tiles/src/BatchedTile.ts
+++ b/extensions/frontend-tiles/src/BatchedTile.ts
@@ -183,8 +183,9 @@ export class BatchedTile extends Tile {
     if (TileVisibility.OutsideFrustum === vis)
       return;
 
+    const unskippable = 0 === (this.depth % getMaxLevelsToSkip());
     closestDisplayableAncestor = this.hasGraphics ? this : closestDisplayableAncestor;
-    if (TileVisibility.TooCoarse === vis) {
+    if (TileVisibility.TooCoarse === vis && (this.isReady || !unskippable)) {
       args.markUsed(this);
       const childrenLoadStatus = this.loadChildren();
       if (TileTreeLoadStatus.Loading === childrenLoadStatus)
@@ -199,7 +200,7 @@ export class BatchedTile extends Tile {
       }
     }
 
-    if (TileVisibility.Visible === vis && !this.isReady)
+    if ((TileVisibility.Visible === vis || unskippable) && !this.isReady)
         args.insertMissing(this);
 
     if (closestDisplayableAncestor)

--- a/extensions/frontend-tiles/src/BatchedTile.ts
+++ b/extensions/frontend-tiles/src/BatchedTile.ts
@@ -6,8 +6,8 @@
 import { assert, BeTimePoint, ByteStream, Logger } from "@itwin/core-bentley";
 import { ColorDef, Tileset3dSchema } from "@itwin/core-common";
 import {
-  GltfReaderProps, GraphicBuilder, ImdlReader, IModelApp, RealityTileLoader, RenderSystem, SelectParent, Tile, TileBoundingBoxes, TileContent,
-  TileDrawArgs, TileLoadStatus, TileParams, TileRequest, TileRequestChannel, TileTreeLoadStatus, TileUser, TileVisibility, Viewport,
+  GltfReaderProps, GraphicBuilder, ImdlReader, IModelApp, RealityTileLoader, RenderSystem, Tile, TileBoundingBoxes, TileContent,
+  TileDrawArgs, TileParams, TileRequest, TileRequestChannel, TileTreeLoadStatus, TileUser, TileVisibility, Viewport,
 } from "@itwin/core-frontend";
 import { loggerCategory } from "./LoggerCategory";
 import { BatchedTileTree } from "./BatchedTileTree";
@@ -50,135 +50,7 @@ export class BatchedTile extends Tile {
     return RealityTileLoader.computeTileLocationPriority(this, viewports, this.tree.iModelTransform);
   }
 
-  public selectTiles(selected: BatchedTile[], args: TileDrawArgs, numSkipped: number): SelectParent {
-    const vis = this.computeVisibility(args);
-    if (TileVisibility.OutsideFrustum === vis)
-      return SelectParent.No;
-
-    if (TileVisibility.Visible === vis) {
-      // This tile is of appropriate resolution to draw. If need loading or refinement, enqueue.
-      if (!this.isReady)
-        args.insertMissing(this);
-
-      if (this.hasGraphics) {
-        // It can be drawn - select it
-        args.markReady(this);
-        selected.push(this);
-      } else if (!this.isReady) {
-        // It can't be drawn. Try to draw children in its place; otherwise draw the parent.
-        // Do not load/request the children for this purpose.
-        const initialSize = selected.length;
-        const kids = this._batchedChildren;
-        if (undefined === kids)
-          return SelectParent.Yes;
-
-        // Find any descendant to draw, until we exceed max initial tiles to skip.
-        // if (this.depth < this.iModelTree.maxInitialTilesToSkip) {
-        //   for (const kid of kids) {
-        //     if (SelectParent.Yes === kid.selectTiles(selected, args, numSkipped)) {
-        //       selected.length = initialSize;
-        //       return SelectParent.Yes;
-        //     }
-
-        //     return SelectParent.No;
-        //   }
-        // }
-
-        // If all visible direct children can be drawn, draw them.
-        for (const kid of kids) {
-          if (TileVisibility.OutsideFrustum !== kid.computeVisibility(args)) {
-            if (!kid.hasGraphics) {
-              selected.length = initialSize;
-              return SelectParent.Yes;
-            } else {
-              selected.push(kid);
-            }
-          }
-        }
-
-        args.markUsed(this);
-      }
-
-      // We're drawing either this tile, or its direct children.
-      return SelectParent.No;
-    }
-
-    // This tile is too coarse to draw. Try to draw something more appropriate.
-    // If it is not ready to draw, we may want to skip loading in favor of loading its descendants.
-    // If we previously loaded and later unloaded content for this tile to free memory, don't force it to reload its content - proceed to children.
-    const maximumLevelsToSkip = getMaxLevelsToSkip();
-    let canSkipThisTile = (this._hadGraphics && !this.hasGraphics) /* || this.depth < this.iModelTree.maxInitialTilesToSkip */ ;
-    if (canSkipThisTile) {
-      numSkipped = 1;
-    } else {
-      canSkipThisTile = this.isReady || this.isParentDisplayable /* || this.depth < this.iModelTree.maxInitialTilesToSkip */ ;
-      if (canSkipThisTile && this.isDisplayable) { // skipping an undisplayable tile doesn't count toward the maximum
-        // Some tiles do not sub-divide - they only facet the same geometry to a higher resolution. We can skip directly to the correct resolution.
-        const isNotReady = !this.isReady && !this.hasGraphics /* && !this.hasSizeMultiplier */ ;
-        if (isNotReady) {
-          if (numSkipped >= maximumLevelsToSkip)
-            canSkipThisTile = false;
-          else
-            numSkipped += 1;
-        }
-      }
-    }
-
-    const childrenLoadStatus = this.loadChildren(); // NB: asynchronous
-    const children = canSkipThisTile ? this._batchedChildren : undefined;
-    if (canSkipThisTile && TileTreeLoadStatus.Loading === childrenLoadStatus) {
-      args.markChildrenLoading();
-      args.markUsed(this);
-    }
-
-    if (undefined !== children) {
-      // If we are the root tile and we are not displayable, then we want to draw *any* currently available children in our place, or else we would draw nothing.
-      // Otherwise, if we want to draw children in our place, we should wait for *all* of them to load, or else we would show missing chunks where not-yet-loaded children belong.
-      const isUndisplayableRootTile = this.isUndisplayableRootTile;
-      args.markUsed(this);
-      let drawChildren = true;
-      const initialSize = selected.length;
-      for (const child of children) {
-        // NB: We must continue iterating children so that they can be requested if missing.
-        if (SelectParent.Yes === child.selectTiles(selected, args, numSkipped)) {
-          if (child.loadStatus === TileLoadStatus.NotFound) {
-            // At least one child we want to draw failed to load. e.g., we reached max depth of map tile tree. Draw parent instead.
-            drawChildren = canSkipThisTile = false;
-          } else {
-            // At least one child we want to draw is not yet loaded. Wait for it to load before drawing it and its siblings, unless we have nothing to draw in their place.
-            drawChildren = isUndisplayableRootTile;
-          }
-        }
-      }
-
-      if (drawChildren)
-        return SelectParent.No;
-
-      // Some types of tiles (like maps) allow the ready children to be drawn on top of the parent while other children are not yet loaded.
-      if (args.parentsAndChildrenExclusive)
-        selected.length = initialSize;
-    }
-
-    if (this.isReady) {
-      if (this.hasGraphics) {
-        selected.push(this);
-        if (!canSkipThisTile) {
-          // This tile is too coarse, but we require loading it before we can start loading higher-res children.
-          args.markReady(this);
-        }
-      }
-
-      return SelectParent.No;
-    }
-
-    // This tile is not ready to be drawn. Request it *only* if we cannot skip it.
-    if (!canSkipThisTile)
-      args.insertMissing(this);
-
-    return this.isParentDisplayable ? SelectParent.Yes : SelectParent.No;
-  }
-
-  public altSelectTiles(selected: Set<BatchedTile>, args: TileDrawArgs, closestDisplayableAncestor: BatchedTile | undefined): void {
+  public selectTiles(selected: Set<BatchedTile>, args: TileDrawArgs, closestDisplayableAncestor: BatchedTile | undefined): void {
     const vis = this.computeVisibility(args);
     if (TileVisibility.OutsideFrustum === vis)
       return;
@@ -202,7 +74,7 @@ export class BatchedTile extends Tile {
       const children = this._batchedChildren;
       if (children) {
         for (const child of children)
-          child.altSelectTiles(selected, args, closestDisplayableAncestor);
+          child.selectTiles(selected, args, closestDisplayableAncestor);
 
         return;
       }

--- a/extensions/frontend-tiles/src/BatchedTile.ts
+++ b/extensions/frontend-tiles/src/BatchedTile.ts
@@ -210,7 +210,7 @@ export class BatchedTile extends Tile {
 
     // We want to display this tile. Request its content if not already loaded.
     if ((TileVisibility.Visible === vis || unskippable) && !this.isReady)
-        args.insertMissing(this);
+      args.insertMissing(this);
 
     if (closestDisplayableAncestor)
       selected.add(closestDisplayableAncestor);

--- a/extensions/frontend-tiles/src/BatchedTileTree.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTree.ts
@@ -51,9 +51,12 @@ export class BatchedTileTree extends TileTree {
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public override _selectTiles(args: TileDrawArgs): Tile[] {
-    const selected: BatchedTile[] = [];
-    this.rootTile.selectTiles(selected, args, 0);
-    return selected;
+    const selected = new Set<BatchedTile>();
+    this.rootTile.altSelectTiles(selected, args, undefined);
+    return Array.from(selected);
+    // const selected: BatchedTile[] = [];
+    // this.rootTile.selectTiles(selected, args, 0);
+    // return selected;
   }
 
   public override draw(args: TileDrawArgs): void {

--- a/extensions/frontend-tiles/src/BatchedTileTree.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTree.ts
@@ -52,11 +52,8 @@ export class BatchedTileTree extends TileTree {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public override _selectTiles(args: TileDrawArgs): Tile[] {
     const selected = new Set<BatchedTile>();
-    this.rootTile.altSelectTiles(selected, args, undefined);
+    this.rootTile.selectTiles(selected, args, undefined);
     return Array.from(selected);
-    // const selected: BatchedTile[] = [];
-    // this.rootTile.selectTiles(selected, args, 0);
-    // return selected;
   }
 
   public override draw(args: TileDrawArgs): void {

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -217,6 +217,8 @@ You can use these environment variables to alter the default behavior of various
   * If defined, the authorization client will not be initialized for the electron app, to work around a current bug that causes it to produce constant exceptions when attempting to obtain an access token.
 * IMJS_USE_FRONTEND_TILES
   * If defined, the @itwin/frontend-tiles package will be used to obtain tile trees for spatial views, served over localhost.
+* IMJS_GPU_MEMORY_LIMIT
+  * If defined, specifies the GpuMemoryLimit with which to initialize TileAdmin (none, relaxed, default, aggressive; or a specific number of bytes).
 
 ## Key-ins
 

--- a/test-apps/display-test-app/src/common/DtaConfiguration.ts
+++ b/test-apps/display-test-app/src/common/DtaConfiguration.ts
@@ -67,6 +67,7 @@ export interface DtaNumberConfiguration {
 
 export interface DtaOtherConfiguration {
   disabledExtensions?: string[]; // An array of names of WebGL extensions to be disabled
+  gpuMemoryLimit?:string | number; // see GpuMemoryLimit in core-frontend for supported string values
 }
 
 /** Parameters for starting display-test-app with a specified initial configuration */
@@ -155,6 +156,11 @@ export const getConfig = (): DtaConfiguration => {
   configuration.useProjectExtents = undefined === process.env.IMJS_NO_USE_PROJECT_EXTENTS;
   configuration.noElectronAuth = undefined !== process.env.IMJS_NO_ELECTRON_AUTH;
   configuration.useFrontendTiles = undefined !== process.env.IMJS_USE_FRONTEND_TILES;
+  const gpuMemoryLimit = process.env.IMJS_GPU_MEMORY_LIMIT;
+  if (undefined !== gpuMemoryLimit) {
+    const gpuByteLimit = Number.parseInt(gpuMemoryLimit, 10);
+    configuration.gpuMemoryLimit = Number.isNaN(gpuByteLimit) ? gpuMemoryLimit : gpuByteLimit;
+  }
 
   const parseSeconds = (key: string) => {
     const env = process.env[key];

--- a/test-apps/display-test-app/src/common/DtaConfiguration.ts
+++ b/test-apps/display-test-app/src/common/DtaConfiguration.ts
@@ -67,7 +67,7 @@ export interface DtaNumberConfiguration {
 
 export interface DtaOtherConfiguration {
   disabledExtensions?: string[]; // An array of names of WebGL extensions to be disabled
-  gpuMemoryLimit?:string | number; // see GpuMemoryLimit in core-frontend for supported string values
+  gpuMemoryLimit?: string | number; // see GpuMemoryLimit in core-frontend for supported string values
 }
 
 /** Parameters for starting display-test-app with a specified initial configuration */

--- a/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
+++ b/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
@@ -5,6 +5,7 @@
 import { Logger, LogLevel, ProcessDetector } from "@itwin/core-bentley";
 import { RpcConfiguration } from "@itwin/core-common";
 import {
+  GpuMemoryLimit,
   IModelApp, IModelConnection, RenderDiagnostics, RenderSystem, TileAdmin,
 } from "@itwin/core-frontend";
 import { initializeFrontendTiles } from "@itwin/frontend-tiles";
@@ -125,6 +126,9 @@ function setConfigurationResults(): [renderSystemOptions: RenderSystem.Options, 
 
   if (configuration.disableBRepCache)
     tileAdminProps.optimizeBRepProcessing = false;
+
+  if (undefined !== configuration.gpuMemoryLimit)
+    tileAdminProps.gpuMemoryLimits = configuration.gpuMemoryLimit as GpuMemoryLimit;
 
   tileAdminProps.enableExternalTextures = (configuration.enableExternalTextures !== false);
   tileAdminProps.enableFrontendScheduleScripts = (configuration.enableFrontendScheduleScripts !== false);


### PR DESCRIPTION
Users of the new @itwin/frontend-tiles package report that tiles sometimes disappear from the view, often failing to reload appropriately. This is particularly evident when setting a low GPU memory limit and using the look-and-move tool.

When a GPU memory limit is set, content for any tiles that are not considered "in use" are disposed of in LRU order until the total amount of GPU memory consumed (an estimate) is below the limit, or no unused tiles remain. This PR adds a config variable to display-test-app to specify the limit, to ease testing.

The reason unloaded tile contents were not reliably being reloaded: `Tile.setContent` was overriding the "is leaf" flag. Batched tiles know ahead of time whether or not they are leaves (have no children), but we were recomputing this from information in the tile content header. After we unloaded a "leaf" tile's content and then determined it was too coarse for the current view, we'd attempt to refine to its non-existent children because the leaf flag was unset, and end up drawing nothing. This is fixed.

Still, a low GPU memory limit causes lots of flickering and reloading when navigating the view. Part of this is due to the tile selection algorithm used by batched tiles, and part is due to our criteria for deciding whether or not a given tile is considered "in use". I've made some preliminary changes to improve (and simplify) both. In a subsequent PR I'd like to further improve things by potentially drawing descendant tiles and ancestor tiles simultaneously, clipping out regions of the ancestors as needed.