### PR TITLE
Log metadata when uploading tiles

### DIFF
--- a/common/changes/@itwin/core-backend/log-tile-metadata_2023-05-02-10-40.json
+++ b/common/changes/@itwin/core-backend/log-tile-metadata_2023-05-02-10-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "log metadata when uploading tiles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/TileStorage.ts
+++ b/core/backend/src/TileStorage.ts
@@ -63,6 +63,7 @@ export class TileStorage {
         metadata,
         IModelHost.compressCachedTiles ? { contentEncoding: "gzip" } : undefined,
       );
+      Logger.logInfo(BackendLoggerCategory.IModelTileStorage, "Tile uploaded", { tileMetadata: metadata });
     } catch (err) {
       this.logException("Failed to upload tile", err);
       throw err;


### PR DESCRIPTION
This will help with optimizing the performance of tile analytics. Right now it has to query _all_ tiles for each tile tree to get their metadata because the blob storage API doesn't allow selecting only recent blobs. With this change the metadata can be extracted from Docker container logs.