### PR TITLE
add `isPublic` member to `CloudContainer`

### DIFF
--- a/common/changes/@itwin/core-backend/container-ispublic_2023-05-03-09-39.json
+++ b/common/changes/@itwin/core-backend/container-ispublic_2023-05-03-09-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -14,6 +14,8 @@ import { LocalDirName, LocalFileName } from "@itwin/core-common";
 import { IModelHost } from "./IModelHost";
 import { IModelJsFs } from "./IModelJsFs";
 
+// spell:ignore logmsg httpcode
+
 /**
  * Types for using SQLite files stored in cloud containers.
  * @beta
@@ -48,11 +50,10 @@ export namespace CloudSqlite {
     writeable?: boolean;
     /** if true, container is attached in "secure" mode (blocks are encrypted). Only supported in daemon mode. */
     secure?: boolean;
-    /** An Id which enhances logging provided by CloudSQLite.
-     *  This Id will be used to identify, in log messages, all CloudSQLite client connections (also known as database connections) opened using this CloudContainer.
-     *  This Id is mostly only relevant to give more clarity to logs produced running in daemon mode, where there are usually many active CloudContainers and by extension, many ongoing HTTP requests.
-     */
-    cloudSqliteLogId?: string;
+    /** true if the container is public (doesn't require authorization) */
+    isPublic?: boolean;
+    /** string attached to log messages from CloudSQLite. This is most useful for identifying usage from daemon mode. */
+    logId?: string;
   }
 
   /** Returned from `CloudContainer.queryDatabase` describing one database in the container */
@@ -93,11 +94,8 @@ export namespace CloudSqlite {
     readonly endTime: string | undefined;
     /** "PUT", "GET", etc. */
     readonly method: string;
-    /** Name of the client that caused this request. Name will be "prefetch" if it is a request triggered by a prefetch.
-     *  Name of client can be configured by passing a 'cloudSqliteLogId' to a CloudContainer's ContainerProps.
-     *  Empty string otherwise.
-     */
-    readonly cloudSqliteLogId: string;
+    /** Name of the client that caused this request. Name will be "prefetch" if it is a request triggered by a prefetch. */
+    readonly logId: string;
     /** Log message associated with request */
     readonly logmsg: string;
     /** URI of request */
@@ -273,10 +271,14 @@ export namespace CloudSqlite {
     get containerId(): string;
     /** The *alias* to identify this CloudContainer in a CloudCache. Usually just the ContainerId. */
     get alias(): string;
+    /** The logId. */
+    get logId(): string;
     /** true if this CloudContainer is currently connected to a CloudCache via the `connect` method. */
     get isConnected(): boolean;
     /** true if this CloudContainer was created with the `writeable` flag (and its `accessToken` supplies write access). */
     get isWriteable(): boolean;
+    /** true if this container is public (doesn't require authorization ). */
+    get isPublic(): boolean;
     /** true if this CloudContainer currently holds the write lock for its container in the cloud. */
     get hasWriteLock(): boolean;
     /** true if this CloudContainer has local changes that have not be uploaded to its container in the cloud. */


### PR DESCRIPTION
Necessary to implement token refresh.

imodel-native: https://github.com/iTwin/imodel-native/tree/cloudsqlite-public-containers