### PR TITLE
[docs] update min glibc ver

### DIFF
--- a/docs/learning/SupportedPlatforms.md
+++ b/docs/learning/SupportedPlatforms.md
@@ -4,7 +4,7 @@
 
 iTwin.js **backends** are built and tested on the following:
 
-- Debian 10 "Buster" and Debian 11 "Bullseye"
+- Debian 11 "Bullseye"
 - Windows 10 version 1803 (or greater)
 - MacOS 10.15 (or greater)
 
@@ -18,17 +18,17 @@ The following Node.js versions are officially supported by the iTwin.js backend 
 
 | iTwin.js - Node Support | iTwin.js 1.x | iTwin.js 2.x | iTwin.js 3.x | iTwin.js 4.x |
 | ----------------------- | ------------ | ------------ | ------------ | ------------ |
-| Node 18                 | ❌           | ❌           | ✅ (>= 3.5) | ✅          |
-| Node 16 (>=16.13)       | ❌           | ❌           | ✅          | ❌          |
-| Node 14 (>=14.17)       | ❌           | ✅ (>= 2.13) | ✅          | ❌          |
-| Node 12 (>=12.22)       | ✅           | ✅           | ✅          | ❌          |
-| Node 10                 | ❌           | ❌           | ❌          | ❌          |
+| Node 18 (>=18.12)       | ❌           | ❌           | ✅ (>= 3.5)  | ✅           |
+| Node 16 (>=16.13)       | ❌           | ❌           | ✅           | ❌           |
+| Node 14 (>=14.17)       | ❌           | ✅ (>= 2.13) | ✅           | ❌           |
+| Node 12 (>=12.22)       | ✅           | ✅           | ✅           | ❌           |
+| Node 10                 | ❌           | ❌           | ❌           | ❌           |
 
 ### Backend Prerequisites
 
 | Operating System | Architectures | Versions                                                                                                           | Notes           |
 | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------ | --------------- |
-| Linux            | all           | GLIBC >= 2.24, GLIBCXX >= 3.4.22                                                                                   |                 |
+| Linux            | all           | GLIBC >= 2.27, GLIBCXX >= 3.4.22                                                                                   |                 |
 | Windows          | all           | [Visual Studio 2017 C Runtime](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads) |                 |
 | macOS            | x64           | >= 10.15                                                                                                           |                 |
 | macOS            | arm64         | >= 11                                                                                                              | >= iTwin.js 3.3 |

--- a/docs/learning/SupportedPlatforms.md
+++ b/docs/learning/SupportedPlatforms.md
@@ -4,6 +4,7 @@
 
 iTwin.js **backends** are built and tested on the following:
 
+- Arch Linux
 - Debian 11 "Bullseye"
 - Windows 10 version 1803 (or greater)
 - MacOS 10.15 (or greater)
@@ -28,7 +29,7 @@ The following Node.js versions are officially supported by the iTwin.js backend 
 
 | Operating System | Architectures | Versions                                                                                                           | Notes           |
 | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------ | --------------- |
-| Linux            | all           | GLIBC >= 2.27, GLIBCXX >= 3.4.22                                                                                   |                 |
+| Linux            | all           | GLIBC >= 2.31, GLIBCXX >= 3.4.28                                                                                   |                 |
 | Windows          | all           | [Visual Studio 2017 C Runtime](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads) |                 |
 | macOS            | x64           | >= 10.15                                                                                                           |                 |
 | macOS            | arm64         | >= 11                                                                                                              | >= iTwin.js 3.3 |


### PR DESCRIPTION
Update minimum support to debian 11
- based on this min glibc ver will be 2.31, [see](https://en.wikipedia.org/wiki/Glibc)
- glibcxx ver obtained from https://github.com/nodejs/node/blob/4eec3626f2c2898ec00734e4b0ab70de8c24704c/BUILDING.md?plain=1#L180