### PR TITLE
Mobile RPC queue up pending messages until reconnected in foreground

### DIFF
--- a/common/changes/@itwin/core-mobile/mobile-rpc-server-pending_2023-05-03-22-13.json
+++ b/common/changes/@itwin/core-mobile/mobile-rpc-server-pending_2023-05-03-22-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "Queue up pending messages until reconnected in foreground.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/mobile/src/backend/MobileRpcServer.ts
+++ b/core/mobile/src/backend/MobileRpcServer.ts
@@ -36,7 +36,7 @@ export class MobileRpcServer {
   private _port: number;
   private _connectionId: number;
   private _pingTimer: NodeJS.Timeout;
-  public constructor() {
+  public constructor(private _pendingMessages: Array<string | Uint8Array> | undefined = undefined) {
     /* _pingTime is a fix for ios/mobile case where when the app moves into foreground from
      * background backend restart ws.Server and then notify frontend to reconnect. But ws.Server
      * listening event is not fired as node yield to kevent and wait for some io event to happen.
@@ -81,6 +81,7 @@ export class MobileRpcServer {
       this._connection = connection;
       this._connection.on("message", (data) => this._onConnectionMessage(data));
       this._createSender();
+      this._sendPending();
       (global as any).__iTwinJsRpcReady = true;
     });
   }
@@ -100,6 +101,20 @@ export class MobileRpcServer {
 
     MobileRpcServer.interop.sendString = sender;
     MobileRpcServer.interop.sendBinary = sender;
+  }
+
+  private _sendPending() {
+    if (this._pendingMessages === undefined)
+      return;
+
+    for (const message of this._pendingMessages) {
+      this._connection!.send(message, (err) => {
+        if (err) {
+          throw err;
+        }
+      });
+    }
+    this._pendingMessages.length = 0;
   }
 
   private _onConnectionMessage(data: ws.Data) {
@@ -152,6 +167,15 @@ export function setupMobileRpc() {
      Thus, we install a temporary timer on suspend to prevent the loop from exiting prematurely.
   */
   let retainUvLoop: NodeJS.Timer | undefined;
+  const pendingMessages: Array<string | Uint8Array> = [];
+
+  function usePendingSender() {
+    const sender = (message: string | Uint8Array, _connectionId: number) => {
+        pendingMessages.push(message);
+    };
+    MobileRpcServer.interop.sendString = sender;
+    MobileRpcServer.interop.sendBinary = sender;
+  }
 
   MobileHost.onEnterBackground.addListener(() => {
     hasSuspended = true;
@@ -162,6 +186,7 @@ export function setupMobileRpc() {
 
     retainUvLoop = setInterval(() => { }, 1000);
     server.dispose();
+    usePendingSender();
     server = null;
   });
 
@@ -170,7 +195,7 @@ export function setupMobileRpc() {
       return;
     }
 
-    server = new MobileRpcServer();
+    server = new MobileRpcServer(pendingMessages);
     clearInterval(retainUvLoop);
     retainUvLoop = undefined;
   });

--- a/core/mobile/src/backend/MobileRpcServer.ts
+++ b/core/mobile/src/backend/MobileRpcServer.ts
@@ -171,7 +171,7 @@ export function setupMobileRpc() {
 
   function usePendingSender() {
     const sender = (message: string | Uint8Array, _connectionId: number) => {
-        pendingMessages.push(message);
+      pendingMessages.push(message);
     };
     MobileRpcServer.interop.sendString = sender;
     MobileRpcServer.interop.sendBinary = sender;


### PR DESCRIPTION
This fixes a problem encountered when cancelling authentication in the Mobile SDK Android app. The native callback would happen before the RPC server had reconnected and the message would be lost.

Note: this was tested in the release/3.7.x branch as we're not able to run mobile on master yet.