### PR TITLE
Add public methods to BriefcaseManager to query changesets

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -539,6 +539,9 @@ export class BriefcaseManager {
     static getChangeSetsPath(iModelId: GuidString): LocalDirName;
     static getFileName(briefcase: BriefcaseProps): LocalFileName;
     static getIModelPath(iModelId: GuidString): LocalDirName;
+    static getLatestChangeset(arg: {
+        iModelId: GuidString;
+    }): Promise<ChangesetProps>;
     static initialize(cacheRootDir: LocalDirName): void;
     static isValidBriefcaseId(id: BriefcaseId): boolean;
     // @internal (undocumented)
@@ -547,6 +550,14 @@ export class BriefcaseManager {
     static pullAndApplyChangesets(db: IModelDb, arg: PullChangesArgs): Promise<void>;
     // @internal
     static pullMergePush(db: BriefcaseDb, arg: PushChangesArgs): Promise<void>;
+    static queryChangeset(arg: {
+        iModelId: GuidString;
+        changeset: ChangesetIndexOrId;
+    }): Promise<ChangesetProps>;
+    static queryChangesets(arg: {
+        iModelId: GuidString;
+        range: ChangesetRange;
+    }): Promise<ChangesetProps[]>;
     static releaseBriefcase(accessToken: AccessToken, briefcase: BriefcaseProps): Promise<void>;
 }
 

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -1085,7 +1085,7 @@ export enum ChangeOpCode {
     Update = 2
 }
 
-// @beta
+// @internal
 export interface ChangesetFileProps extends ChangesetProps {
     pathname: LocalFileName;
 }
@@ -1121,7 +1121,7 @@ export type ChangesetIndexOrId = ChangesetIndexAndId | {
     readonly index?: never;
 };
 
-// @beta
+// @public
 export interface ChangesetProps {
     briefcaseId: number;
     changesType: ChangesetType;
@@ -1130,7 +1130,7 @@ export interface ChangesetProps {
     index: ChangesetIndex;
     parentId: ChangesetId;
     pushDate: string;
-    size?: number;
+    size: number;
     userCreated: string;
 }
 

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -97,13 +97,13 @@ public;ChangedEntities
 internal;ChangedModels
 public;ChangedValueState
 public;ChangeOpCode
-beta;ChangesetFileProps 
+internal;ChangesetFileProps 
 public;ChangesetId = string
 public;ChangesetIdWithIndex
 public;ChangesetIndex = number
 public;ChangesetIndexAndId
 public;ChangesetIndexOrId = ChangesetIndexAndId |
-beta;ChangesetProps
+public;ChangesetProps
 public;ChangesetRange
 public;ChangesetType
 alpha;ChannelConstraintError 

--- a/common/changes/@itwin/core-backend/getlatestchangeset_2023-05-04-12-27.json
+++ b/common/changes/@itwin/core-backend/getlatestchangeset_2023-05-04-12-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "add public methods to BriefcaseManager to query the hub for changesets",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/getlatestchangeset_2023-05-04-12-27.json
+++ b/common/changes/@itwin/core-common/getlatestchangeset_2023-05-04-12-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/LocalHub.ts
+++ b/core/backend/src/LocalHub.ts
@@ -296,7 +296,7 @@ export class LocalHub {
   /** Get the properties of a changeset by its index */
   public getChangesetByIndex(index: ChangesetIndex): ChangesetProps {
     if (index <= 0)
-      return { id: "", changesType: 0, description: "version0", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0 };
+      return { id: "", changesType: 0, description: "version0", parentId: "", briefcaseId: 0, pushDate: "", userCreated: "", index: 0, size: 0 };
 
     return this.db.withPreparedSqliteStatement("SELECT description,size,type,pushDate,user,csId,briefcaseId FROM timeline WHERE csIndex=?", (stmt) => {
       stmt.bindInteger(1, index);

--- a/core/backend/src/test/changesets/ChangeMerging.test.ts
+++ b/core/backend/src/test/changesets/ChangeMerging.test.ts
@@ -13,13 +13,13 @@ import { KnownTestLocations } from "../KnownTestLocations";
 
 // Combine all local Txns and generate a changeset file. Then delete all local Txns.
 function createChangeset(imodel: IModelDb): ChangesetFileProps {
-  const changeset = imodel.nativeDb.startCreateChangeset();
+  const changeset = imodel.nativeDb.startCreateChangeset() as ChangesetFileProps;
 
-  // completeCreateChangeset deletes the file that startCreateChangeSet created.
-  // We make a copy of it now, before he does that.
+  // completeCreateChangeset deletes the changeset file. So make a copy of it now, before that happens.
   const csFileName = path.join(KnownTestLocations.outputDir, `${changeset.id}.changeset`);
   IModelJsFs.copySync(changeset.pathname, csFileName);
   changeset.pathname = csFileName;
+  changeset.size = IModelJsFs.lstatSync(csFileName)!.size;
 
   imodel.nativeDb.completeCreateChangeset({ index: 0 });
   return changeset;

--- a/core/common/src/ChangesetProps.ts
+++ b/core/common/src/ChangesetProps.ts
@@ -56,7 +56,7 @@ export enum ChangesetType {
 }
 
 /** Properties of a changeset
- * @beta
+ * @public
  */
 export interface ChangesetProps {
   /** The index (sequence number) from IModelHub for this changeset. Larger index values were pushed later. */
@@ -76,11 +76,11 @@ export interface ChangesetProps {
   /** The identity of the user that created this changeset */
   userCreated: string;
   /** The size, in bytes, of this changeset */
-  size?: number;
+  size: number;
 }
 
 /** Properties of a changeset file
- * @beta
+ * @internal
  */
 export interface ChangesetFileProps extends ChangesetProps {
   /** The full pathname of the local file holding this changeset. */


### PR DESCRIPTION
These public methods wrap the internal `BackendHubAccess` interface methods.