### PR TITLE
[@itwin/core-common] Removing dependency on semver

### DIFF
--- a/common/changes/@itwin/core-common/jake-common-remove-semver-depend_2023-05-04-19-51.json
+++ b/common/changes/@itwin/core-common/jake-common-remove-semver-depend_2023-05-04-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "removing dependency on semver",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -139,7 +139,6 @@ importers:
       '@types/flatbuffers': ~1.10.0
       '@types/mocha': ^8.2.2
       '@types/node': ^18.11.5
-      '@types/semver': 7.3.10
       chai: ^4.1.2
       eslint: ^8.36.0
       flatbuffers: ~1.12.0
@@ -147,13 +146,11 @@ importers:
       mocha: ^10.0.0
       nyc: ^15.1.0
       rimraf: ^3.0.2
-      semver: ^7.3.5
       typescript: ~5.0.2
     dependencies:
       '@itwin/object-storage-core': 1.6.0
       flatbuffers: 1.12.0
       js-base64: 3.7.5
-      semver: 7.5.0
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/core-bentley': link:../bentley
@@ -163,7 +160,6 @@ importers:
       '@types/flatbuffers': 1.10.0
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
-      '@types/semver': 7.3.10
       chai: 4.3.7
       eslint: 8.39.0
       mocha: 10.2.0

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@itwin/object-storage-core": "^1.5.0",
     "flatbuffers": "~1.12.0",
-    "semver": "^7.3.5",
     "js-base64": "^3.6.1"
   },
   "peerDependencies": {
@@ -53,7 +52,6 @@
     "@types/flatbuffers": "~1.10.0",
     "@types/mocha": "^8.2.2",
     "@types/node": "^18.11.5",
-    "@types/semver": "7.3.10",
     "chai": "^4.1.2",
     "eslint": "^8.36.0",
     "mocha": "^10.0.0",

--- a/core/common/src/RpcInterface.ts
+++ b/core/common/src/RpcInterface.ts
@@ -45,21 +45,8 @@ interface SemverType {
  */
 export abstract class RpcInterface {
 
-  private static findDiff(backend: SemverType, frontend: SemverType): string {
-    const isSame = backend.major === frontend.major && backend.minor === frontend.minor && backend.patch === frontend.patch && backend.prerelease === frontend.prerelease;
-    if (isSame) {
-      return "same";
-    }
-    if (backend.major !== frontend.major) {
-      return "major";
-    }
-    if (backend.minor !== frontend.minor) {
-      return "minor";
-    }
-    if (backend.patch !== frontend.patch) {
-      return "patch";
-    }
-    return "prerelease";
+  private static findDiff(backend: SemverType, frontend: SemverType) {
+    return backend.major !== frontend.major ? "major" : backend.minor !== frontend.minor ? "minor" : backend.patch !== frontend.patch ? "patch" : backend.prerelease !== frontend.prerelease ? "prerelease" : "same";
   }
 
   private static parseVer(version: string): SemverType {

--- a/core/common/src/RpcInterface.ts
+++ b/core/common/src/RpcInterface.ts
@@ -50,7 +50,9 @@ export abstract class RpcInterface {
   }
 
   private static parseVer(version: string): SemverType {
+    // Split the version string into major.minor.path and prerelease tag
     const split = version.split(/[:-]/);
+    // Split the major.minor.path into seperate components
     const prefix = split[0].split(".");
     if (split.length === 1) {
       return { major: Number(prefix[0]), minor: Number(prefix[1]), patch: Number(prefix[2]) };
@@ -64,11 +66,17 @@ export abstract class RpcInterface {
     const backendSemver = this.parseVer(backend);
     const frontendSemver = this.parseVer(frontend);
     const difference = this.findDiff(backendSemver, frontendSemver);
+
+    // If the major versions are different, the versions are not compatible
+    // In the case of prerelease tags, they are compatible if the whole version string matches, otherwise it fails
     if ((backendSemver.prerelease !== undefined || frontendSemver.prerelease !== undefined) || difference === "major") {
       return difference === "same";
     } else if (backendSemver.major === 0 || frontendSemver.major === 0) {
+      // If the major and minor versions match and major versions are 0, compatible as long as backend patch version is greater
       return difference === "same" || (difference === "patch" && frontendSemver.patch < backendSemver.patch);
     } else {
+      // If the strings match exactly, major and minor match but patch differs, versions are compatible
+      // If minor versions differ, compatible as long as backend patch versionn is greater
       return difference === "same" || difference === "patch" || (difference === "minor" && frontendSemver.minor < backendSemver.minor);
     }
   }

--- a/core/common/src/RpcInterface.ts
+++ b/core/common/src/RpcInterface.ts
@@ -82,7 +82,6 @@ export abstract class RpcInterface {
     } else if (backendSemver.major === 0 || frontendSemver.major === 0) {
       return difference === "same" || (difference === "patch" && frontendSemver.patch < backendSemver.patch);
     } else {
-      console.log()
       return difference === "same" || difference === "patch" || (difference === "minor" && frontendSemver.minor < backendSemver.minor);
     }
   }

--- a/core/common/src/test/VersionCompatible.test.ts
+++ b/core/common/src/test/VersionCompatible.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { RpcInterface } from "../RpcInterface";
+import { expect } from "chai";
+
+describe("isVersionCompatible", () => {
+  it("pass when versions match exactly with prerelease tags", () => {
+    expect(RpcInterface.isVersionCompatible("3.0.0-dev.0", "3.0.0-dev.0")).to.equal(true);
+  });
+  it("fail when versions with different prerelease tags", () => {
+    expect(RpcInterface.isVersionCompatible("3.0.0-dev.0", "3.0.0-dev.1")).to.equal(false);
+  });
+  it("fail when versions match but one has prerelease tags", () => {
+    expect(RpcInterface.isVersionCompatible("3.0.0", "3.0.0-dev.1")).to.equal(false);
+  });
+  it("pass when major versions are 0 and backend patch is greater", () => {
+    expect(RpcInterface.isVersionCompatible("0.11.1", "0.11.0")).to.equal(true);
+  });
+  it("fail when major versions are 0 and frontend patch is greater", () => {
+    expect(RpcInterface.isVersionCompatible("0.11.0", "0.11.1")).to.equal(false);
+  });
+  it("pass when versions match exactly without prerelease tags", () => {
+    expect(RpcInterface.isVersionCompatible("3.0.0", "3.0.0")).to.equal(true);
+  });
+  it("fail when major versions are different", () => {
+    expect(RpcInterface.isVersionCompatible("4.0.0", "3.0.0")).to.equal(false);
+  });
+  it("pass when major versions match, backend minor version is greater", () => {
+    expect(RpcInterface.isVersionCompatible("3.2.0", "3.1.0")).to.equal(true);
+  });
+  it("fail when major versions match, frontend minor version is greater", () => {
+    expect(RpcInterface.isVersionCompatible("3.1.0", "3.2.0")).to.equal(false);
+  });
+  it("fail when random string is passed in", () => {
+    expect(RpcInterface.isVersionCompatible("3.1.0", "kashfakfbjkafk")).to.equal(false);
+  });
+});


### PR DESCRIPTION
Removing semver dependency by implementing own way to compare versions. This is to help resolve an issue introduced when upgrading to semver@7.5.0 that caused failures when installing dependencies for the viewers. Removing our dependency on this should solve that issue.