### PR TITLE
Fix for dynamic imports in Vite apps so tiles render

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-tiles-on-vite_2023-05-10-16-58.json
+++ b/common/changes/@itwin/core-frontend/fix-tiles-on-vite_2023-05-10-16-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Patch how dynamic import for packages are resolved in Vite based apps so tiles render\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -321,8 +321,9 @@ export class TileAdmin {
     // start dynamically loading default implementation and save the promise to avoid duplicate instances
     this._tileStoragePromise = (async () => {
       await import("reflect-metadata");
+      const objectStorage = await import(/* webpackChunkName: "object-storage-azure" */ "@itwin/object-storage-azure/lib/frontend");
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { AzureFrontendStorage, FrontendBlockBlobClientWrapperFactory } = await import(/* webpackChunkName: "object-storage" */ "@itwin/object-storage-azure/lib/frontend");
+      const { AzureFrontendStorage, FrontendBlockBlobClientWrapperFactory } = objectStorage.default ?? objectStorage;
       const azureStorage = new AzureFrontendStorage(new FrontendBlockBlobClientWrapperFactory());
       this._tileStorage = new TileStorage(azureStorage);
       return this._tileStorage;


### PR DESCRIPTION
There are long outstanding issues with [Vite](https://vitejs.dev/), [see](https://github.com/vitejs/vite/issues/5499), where dynamic imports behave differently between development and production builds.

See our users reporting issues: https://github.com/iTwin/itwinjs-core/discussions/5185