### PR TITLE
Check that current tool still wants snap after promise is resolved.

### DIFF
--- a/common/changes/@itwin/core-frontend/accusnap-still-required_2023-05-15-12-56.json
+++ b/common/changes/@itwin/core-frontend/accusnap-still-required_2023-05-15-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -949,8 +949,12 @@ export class AccuSnap implements Decorator {
         this.aSnapHits.removeCurrentHit();
         hit = await this.getAccuSnapDetail(this.aSnapHits, out);
       }
+      if (!this._doSnapping)
+        hit = undefined; // Snap no longer requested...
     } else if (this.isLocateEnabled) {
       hit = await this.findLocatableHit(ev, false, out); // get next AccuSnap path (or undefined)
+      if (!this.isLocateEnabled)
+        hit = undefined; // Hit no longer requested...
     }
 
     // set the current hit
@@ -975,8 +979,12 @@ export class AccuSnap implements Decorator {
       if (this._doSnapping) {
         out.snapStatus = this.findHits(ev);
         hit = (SnapStatus.Success !== out.snapStatus) ? undefined : await this.getAccuSnapDetail(this.aSnapHits!, out);
+        if (!this._doSnapping)
+          hit = undefined; // Snap no longer requested...
       } else if (this.isLocateEnabled) {
         hit = await this.findLocatableHit(ev, true, out);
+        if (!this.isLocateEnabled)
+          hit = undefined; // Hit no longer requested...
       }
     }
 


### PR DESCRIPTION
For example, a primitive tool with AccuSnap enabled gets suspended by a viewing tool started from a drag event. Need to ignore snaps that are resolved after the view tool is started.