### PR TITLE
Presentation: Accept `Buffer` responses from addon

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-accept-buffer-responses-from-addon_2023-05-17-09-01.json
+++ b/common/changes/@itwin/presentation-backend/presentation-accept-buffer-responses-from-addon_2023-05-17-09-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -153,8 +153,7 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
       return this.createSuccessResponse(response);
     }
     private handleConvertedResult<TSource, TTarget>(response: IModelJsNative.ECPresentationManagerResponse<TSource>, conv: (s: TSource) => TTarget): NativePlatformResponse<TTarget> {
-      const { result, error, ...rest } = response;
-      return this.handleResult<TTarget>(result ? { ...rest, result: conv(result) } : { ...rest, error: error! });
+      return this.handleResult<TTarget>((response.result ? { ...response, result: conv(response.result) } : response) as IModelJsNative.ECPresentationManagerResponse<TTarget>);
     }
     private handleVoidResult(response: IModelJsNative.ECPresentationManagerResponse<void>): NativePlatformResponse<void> {
       if (response.error)

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -154,8 +154,8 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
     }
     private handleConvertedResult<TSource, TTarget>(response: IModelJsNative.ECPresentationManagerResponse<TSource>, conv: (s: TSource) => TTarget): NativePlatformResponse<TTarget> {
       return response.error
-        ? this.handleResult<TTarget>(response)
-        : this.handleResult<TTarget>({ ...response, result: conv(response.result) });
+        ? this.handleResult<TTarget>({ diagnostics: response.diagnostics, error: response.error })
+        : this.handleResult<TTarget>({ diagnostics: response.diagnostics, result: conv(response.result) });
     }
     private handleVoidResult(response: IModelJsNative.ECPresentationManagerResponse<void>): NativePlatformResponse<void> {
       if (response.error)

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -153,9 +153,8 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
       return this.createSuccessResponse(response);
     }
     private handleConvertedResult<TSource, TTarget>(response: IModelJsNative.ECPresentationManagerResponse<TSource>, conv: (s: TSource) => TTarget): NativePlatformResponse<TTarget> {
-      return response.error
-        ? this.handleResult<TTarget>({ diagnostics: response.diagnostics, error: response.error })
-        : this.handleResult<TTarget>({ diagnostics: response.diagnostics, result: conv(response.result) });
+      const { result, error, ...rest } = response;
+      return this.handleResult<TTarget>(result ? { ...rest, result: conv(result) } : { ...rest, error: error! });
     }
     private handleVoidResult(response: IModelJsNative.ECPresentationManagerResponse<void>): NativePlatformResponse<void> {
       if (response.error)

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -76,7 +76,7 @@ describe("default NativePlatform", () => {
     it("calls addon", async () => {
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: Promise.resolve({ result: "0" }), cancel: () => { } }))
+        .returns(() => ({ result: Promise.resolve({ result: Buffer.from("0") }), cancel: () => { } }))
         .verifiable();
       expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0" });
       addonMock.verifyAll();
@@ -118,7 +118,7 @@ describe("default NativePlatform", () => {
       const cancelEvent: BeEvent<() => void> = new BeEvent<() => void>();
       addonMock
         .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-        .returns(() => ({ result: Promise.resolve({ result: "0" }), cancel: cancelFunction }));
+        .returns(() => ({ result: Promise.resolve({ result: Buffer.from("0") }), cancel: cancelFunction }));
       expect(await nativePlatform.handleRequest(undefined, "", cancelEvent)).to.deep.equal({ result: "0" });
       addonMock.verifyAll();
       cancelEvent.raiseEvent();
@@ -134,7 +134,7 @@ describe("default NativePlatform", () => {
     };
     addonMock
       .setup((x) => x.handleRequest(moq.It.isAny(), ""))
-      .returns(() => ({ result: Promise.resolve({ result: "0", diagnostics }), cancel: () => { } }));
+      .returns(() => ({ result: Promise.resolve({ result: Buffer.from("0"), diagnostics }), cancel: () => { } }));
     expect(await nativePlatform.handleRequest(undefined, "")).to.deep.equal({ result: "0", diagnostics });
     addonMock.verifyAll();
   });


### PR DESCRIPTION
imodel-native PR: https://github.com/iTwin/imodel-native/pull/283
imodel-native: https://github.com/iTwin/imodel-native/tree/presentation/avoid-native-string-copy-to-napi-string