### PR TITLE
Add `NoChange` member to `TypeOfChange` flag enum for better support for TypeScript 5.x

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -10008,6 +10008,7 @@ export enum TypeOfChange {
     Geometry = 2,
     Hidden = 16,
     Indirect = 8,
+    NoChange = 0,
     Parent = 32,
     Placement = 4,
     Property = 1

--- a/common/changes/@itwin/core-common/master_2023-05-24-10-32.json
+++ b/common/changes/@itwin/core-common/master_2023-05-24-10-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Add `NoChange` member to `TypeOfChange` flag enum for better support for TypeScript 5.x.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/ChangedElements.ts
+++ b/core/common/src/ChangedElements.ts
@@ -16,6 +16,8 @@ import { AxisAlignedBox3dProps } from "./geometry/Placement";
  * @extensions
  */
 export enum TypeOfChange {
+  /** Element contains no changes */
+  NoChange = 0,
   /** A property in the element changed */
   Property = 0b1,
   /** The geometry stream of a [GeometricElement]($backend) changed */


### PR DESCRIPTION
After upgrading to TypeScript 5.0, users who have code like
```TypeScript
const changeType: TypeOfChange = 0; // Element contains no changes because it was deleted
```
will receive a type error: `Type '0' is not assignable to type 'TypeOfChange'.` because [all enums are now union enums](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#all-enums-are-union-enums).

With the change this PR makes, the code above no longer produces an error. [TypeScript playground](https://www.typescriptlang.org/play?#code/KYOwrgtgBAKgngB2AeQGYGEAWBDEBzYKAbwCgooB6CqAOQHstcCBnKAXigAYAaMqABQBOdJIIAucdlwBGARl7kA4sDoRgYwZI6c5PPvwA22AMbA1IMVJ2zOe8gEkQAEwCWg4McvbdthVAASLk5OoFY+vvrY7hZhNrYRAL4kJMAAHgh04lDGdCDMlsY4+MCy8EgAXLCIKBhFBFYA3CnpmQW5+dl1wABMZcCVfWiMxVKDtUzAAHRCIsDikgA+VUhDXZPKquqaDUA).