### PR TITLE
Handle non-standard mimeType 'image/jpg'

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-mime-type-jpg_2023-05-31-11-49.json
+++ b/common/changes/@itwin/core-frontend/pmc-mime-type-jpg_2023-05-31-11-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Treat non-standard mimeType \"image/jpg\" as \"image/jpeg\".",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/common/ImageUtil.ts
+++ b/core/frontend/src/common/ImageUtil.ts
@@ -183,6 +183,8 @@ export function getImageSourceMimeType(format: ImageSourceFormat): string {
 export function getImageSourceFormatForMimeType(mimeType: string): ImageSourceFormat | undefined {
   switch (mimeType) {
     case "image/jpeg": return ImageSourceFormat.Jpeg;
+    // not standard, but people accidentally use it anyway.
+    case "image/jpg": return ImageSourceFormat.Jpeg;
     case "image/png": return ImageSourceFormat.Png;
     case "image/svg+xml;charset=utf-8": return ImageSourceFormat.Svg;
     default: return undefined;


### PR DESCRIPTION
The standard is `image/jpeg` but it's an easy mistake to make and real data sets make it.