### PR TITLE
Fix leaks in map-layers-formats tests

### DIFF
--- a/common/changes/@itwin/map-layers-formats/geo-fix_maplayersformats_test_leak_2023-05-31-19-36.json
+++ b/common/changes/@itwin/map-layers-formats/geo-fix_maplayersformats_test_leak_2023-05-31-19-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-formats",
+      "comment": "Fix leaks in map-layers-formats tests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-formats"
+}

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
@@ -83,6 +83,7 @@ export abstract class ArcGISImageryProvider extends MapLayerImageryProvider {
    * Refer to fetch API for more details (https://developer.mozilla.org/en-US/docs/Web/API/fetch)
    */
   protected async fetch(url: URL, options?: RequestInit) {
+    console.log(" ArcGISImageryProvider.fetch");
 
     let errorCode: number | undefined;
     const urlObj = new URL(url);

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
@@ -83,7 +83,6 @@ export abstract class ArcGISImageryProvider extends MapLayerImageryProvider {
    * Refer to fetch API for more details (https://developer.mozilla.org/en-US/docs/Web/API/fetch)
    */
   protected async fetch(url: URL, options?: RequestInit) {
-    console.log(" ArcGISImageryProvider.fetch");
 
     let errorCode: number | undefined;
     const urlObj = new URL(url);

--- a/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureProvider.test.ts
+++ b/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureProvider.test.ts
@@ -27,6 +27,12 @@ const pngTransparent1x1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQ
 
 describe("ArcGisFeatureProvider", () => {
   const sandbox = sinon.createSandbox();
+  let fetchStub: any;
+
+  beforeEach(async () => {
+    // Make sure no call to fetch is made, other it creates leaks
+    fetchStub = sandbox.stub((ArcGISImageryProvider.prototype as any), "fetch");
+  });
 
   afterEach(async () => {
     sandbox.restore();
@@ -416,6 +422,7 @@ describe("ArcGisFeatureProvider", () => {
     sandbox.stub(ArcGisUtilities, "getServiceJson").callsFake(async function _(_url: string, _formatId: string, _userName?: string, _password?: string, _ignoreCache?: boolean, _requireToken?: boolean) {
       return {accessTokenRequired: false, content:{currentVersion: 11, capabilities: "Query"}};
     });
+    fetchStub.restore();  // fetch is always stubbed by default, restore and provide our own stub
     sandbox.stub((ArcGISImageryProvider.prototype as any), "fetch").callsFake(async  function _(_url: unknown, _options?: unknown) {
       const test = {
         headers: { "content-type" : "pbf"},
@@ -786,7 +793,6 @@ describe("ArcGisFeatureProvider", () => {
     sandbox.stub(ArcGisUtilities, "getServiceJson").callsFake(async function _(_url: string, _formatId: string, _userName?: string, _password?: string, _ignoreCache?: boolean, _requireToken?: boolean) {
       return {accessTokenRequired: false, content:{capabilities: "Query"}};
     });
-    const fetchStub = sandbox.stub((ArcGISImageryProvider.prototype as any), "fetch");
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "constructFeatureUrl").callsFake(function _(_row: number, _column: number, _zoomLevel: number, _format: ArcGisFeatureFormat, _geomOverride?: ArcGisGeometry, _outFields?: string, _tolerance?: number, _returnGeometry?: boolean) {
       return {url: settings.url};


### PR DESCRIPTION
@Jake-Screen was finally able to reproduce locally and we got:
![image](https://github.com/iTwin/itwinjs-core/assets/8309609/f78b1995-b4fa-4440-9d56-192260222e7a)

So I made sure the tests never reach 'fetch'