### PR TITLE
Two map-layers instances having different formatId or subLayers set should not share the same tile tree.

### DIFF
--- a/common/changes/@itwin/core-frontend/geo-fixImageryTileTreeSupplier_2023-06-03-01-29.json
+++ b/common/changes/@itwin/core-frontend/geo-fixImageryTileTreeSupplier_2023-06-03-01-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Two map-layers instances having different formatId or subLayers set should not share the same tile tree.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/tile/map/ImageryTileTree.test.ts
+++ b/core/frontend/src/test/tile/map/ImageryTileTree.test.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { ImageMapLayerProps, ImageMapLayerSettings } from "@itwin/core-common";
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { MockRender } from "../../../render/MockRender";
+import { createBlankConnection } from "../../createBlankConnection";
+import { ImageryMapLayerTreeReference } from "../../../tile/map/ImageryTileTree";
+import { IModelConnection } from "../../../IModelConnection";
+import { ImageryMapLayerFormat } from "../../../tile/map/MapLayerImageryFormats";
+import { MapLayerImageryProvider } from "../../../tile/map/MapLayerImageryProvider";
+import { IModelApp } from "../../../IModelApp";
+
+class CustomProvider extends MapLayerImageryProvider {
+  public override async constructUrl(_row: number, _column: number, _zoomLevel: number) { return this._settings.url;}
+  public override async  initialize(): Promise<void> {return;}
+}
+
+class BaseCustomFormat extends ImageryMapLayerFormat {
+  public static override createImageryProvider(settings: ImageMapLayerSettings): MapLayerImageryProvider | undefined {
+    return new CustomProvider(settings, true);
+  }
+}
+
+class CustomFormat1 extends BaseCustomFormat {
+  public static override formatId = "Custom1";
+  public static override createImageryProvider(settings: ImageMapLayerSettings): MapLayerImageryProvider | undefined {
+    return new CustomProvider(settings, true);
+  }
+}
+
+class CustomFormat2 extends BaseCustomFormat {
+  public static override formatId = "Custom2";
+  public static override createImageryProvider(settings: ImageMapLayerSettings): MapLayerImageryProvider | undefined {
+    return new CustomProvider(settings, true);
+  }
+}
+
+interface DatasetEntry {
+  lhs: ImageMapLayerProps;
+  rhs: ImageMapLayerProps;
+  expectSameTileTree: boolean;
+}
+
+describe.only("ImageryTileTree", () => {
+
+  let imodel: IModelConnection;
+
+  before(async () => {   // Create a ViewState to load into a Viewport
+    await MockRender.App.startup();
+    imodel = createBlankConnection();
+    IModelApp.mapLayerFormatRegistry.register(CustomFormat1);
+    IModelApp.mapLayerFormatRegistry.register(CustomFormat2);
+  });
+
+  const sandbox = sinon.createSandbox();
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  it("tree supplier", async () => {
+    const baseProps: ImageMapLayerProps = { formatId: "Custom1", url: "https://dummy.com", name: "CustomLayer", subLayers: [{name: "sub0", visible: true}]};
+    const dataset: DatasetEntry[] = [
+      {lhs: {...baseProps}, rhs: {...baseProps}, expectSameTileTree:true},
+      {lhs: {...baseProps, name: "someName"}, rhs: {...baseProps}, expectSameTileTree:true},
+      {lhs: {...baseProps, url: "https://someUrl.com"}, rhs: {...baseProps}, expectSameTileTree:false},
+      {lhs: {...baseProps, formatId:"Custom2"}, rhs: {...baseProps}, expectSameTileTree:false},
+      {lhs: {...baseProps, subLayers: [{name: "sub0", visible: false}]}, rhs: {...baseProps}, expectSameTileTree:false},
+      {lhs: {...baseProps, subLayers: [{name: "sub1", visible: true}]}, rhs: {...baseProps}, expectSameTileTree:false},
+    ];
+    for (const entry of dataset) {
+      const settingsLhs = ImageMapLayerSettings.fromJSON(entry.lhs);
+      const treeRefLhs = new ImageryMapLayerTreeReference(settingsLhs, 0, imodel);
+      const treeOwnerLhs = treeRefLhs.treeOwner;
+      const tileTreeLhs = await treeOwnerLhs.loadTree();
+      expect(tileTreeLhs).to.not.undefined;
+
+      const settingsRhs = ImageMapLayerSettings.fromJSON(entry.rhs);
+      const treeRefRhs = new ImageryMapLayerTreeReference(settingsRhs, 0, imodel);
+      const treeOwnerRhs = treeRefRhs.treeOwner;
+      const tileTreeRhs = await treeOwnerRhs.loadTree();
+      expect(tileTreeRhs).to.not.undefined;
+
+      if (entry.expectSameTileTree)
+        expect(tileTreeLhs!.modelId).to.equals(tileTreeRhs!.modelId);
+      else
+        expect(tileTreeLhs!.modelId).to.not.equals(tileTreeRhs!.modelId);
+    }
+  });
+});

--- a/core/frontend/src/test/tile/map/ImageryTileTree.test.ts
+++ b/core/frontend/src/test/tile/map/ImageryTileTree.test.ts
@@ -45,7 +45,7 @@ interface DatasetEntry {
   expectSameTileTree: boolean;
 }
 
-describe.only("ImageryTileTree", () => {
+describe("ImageryTileTree", () => {
 
   let imodel: IModelConnection;
 

--- a/core/frontend/src/tile/map/ImageryTileTree.ts
+++ b/core/frontend/src/tile/map/ImageryTileTree.ts
@@ -320,18 +320,25 @@ class ImageryMapLayerTreeSupplier implements TileTreeSupplier {
    * This allows the ID to serve as a lookup key to find the corresponding TileTree.
    */
   public compareTileTreeIds(lhs: ImageryMapLayerTreeId, rhs: ImageryMapLayerTreeId): number {
-    let cmp = compareStrings(lhs.settings.url, rhs.settings.url);
+    let cmp = compareStrings(lhs.settings.formatId, rhs.settings.formatId);
     if (0 === cmp) {
-      cmp = compareStringsOrUndefined(lhs.settings.userName, rhs.settings.userName);
+      cmp = compareStrings(lhs.settings.url, rhs.settings.url);
       if (0 === cmp) {
-        cmp = compareStringsOrUndefined(lhs.settings.password, rhs.settings.password);
+        cmp = compareStringsOrUndefined(lhs.settings.userName, rhs.settings.userName);
         if (0 === cmp) {
-          cmp = compareBooleans(lhs.settings.transparentBackground, rhs.settings.transparentBackground);
+          cmp = compareStringsOrUndefined(lhs.settings.password, rhs.settings.password);
           if (0 === cmp) {
-            cmp = compareNumbers(lhs.settings.subLayers.length, rhs.settings.subLayers.length);
+            cmp = compareBooleans(lhs.settings.transparentBackground, rhs.settings.transparentBackground);
             if (0 === cmp) {
-              for (let i = 0; i < lhs.settings.subLayers.length && 0 === cmp; i++)
-                cmp = compareBooleans(lhs.settings.subLayers[i].visible, rhs.settings.subLayers[i].visible);
+              cmp = compareNumbers(lhs.settings.subLayers.length, rhs.settings.subLayers.length);
+              if (0 === cmp) {
+                for (let i = 0; i < lhs.settings.subLayers.length && 0 === cmp; i++) {
+                  cmp = compareStringsOrUndefined(lhs.settings.subLayers[i].name, rhs.settings.subLayers[i].name);
+                  if (0 === cmp) {
+                    cmp = compareBooleans(lhs.settings.subLayers[i].visible, rhs.settings.subLayers[i].visible);
+                  }
+                }
+              }
             }
           }
         }

--- a/core/frontend/src/tile/map/ImageryTileTree.ts
+++ b/core/frontend/src/tile/map/ImageryTileTree.ts
@@ -333,7 +333,7 @@ class ImageryMapLayerTreeSupplier implements TileTreeSupplier {
               cmp = compareNumbers(lhs.settings.subLayers.length, rhs.settings.subLayers.length);
               if (0 === cmp) {
                 for (let i = 0; i < lhs.settings.subLayers.length && 0 === cmp; i++) {
-                  cmp = compareStringsOrUndefined(lhs.settings.subLayers[i].name, rhs.settings.subLayers[i].name);
+                  cmp = compareStrings(lhs.settings.subLayers[i].name, rhs.settings.subLayers[i].name);
                   if (0 === cmp) {
                     cmp = compareBooleans(lhs.settings.subLayers[i].visible, rhs.settings.subLayers[i].visible);
                   }


### PR DESCRIPTION
Two map layers instance having two different set of sub-layers, such as:
```
{ formatId: "ArcGIS", url: "https://server.com", name: "Layer1", subLayers: [{name: "sub_layer1", visible: true}]};
{ formatId: "ArcGIS", url: "https://server.com", name: "Layer1", subLayers: [{name: "sub_layer2", visible: true}]};
```
should not share the same tile tree since it define different datasets.

Also I think the same apply for two map-layers having two differents formatId, but same URL, although unlikely:
```
{ formatId: "ArcGIS", url: "https://server.com", name: "Layer1",};
{ formatId: "WMS", url: "https://server.com", name: "Layer2"};
```