### PR TITLE
ViewCreator3d fits to the viewed models' extents

### DIFF
--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -48,7 +48,7 @@ jobs:
           if [ $(git status --porcelain | wc -l) -ne "0" ]; then
             echo "The following file(s) contain uncommitted changes:"
             git status --porcelain -u
-            echo "Please do the following:\n1. run extract-api in the core/extension dir \n2. commit the modified generated extension api files (found in the core/frontend and core/extension dirs) \n3. run rush change and commit the change files for core-frontend and core-extension"
+            echo -e 'Please do the following:\n1. run `rush extract-api` in the monorepo \n2. commit the modified generated extension api files (found in the core/frontend and core/extension dirs) \n3. run rush change and commit the change files for core-frontend and core-extension'
             exit 1
           fi
 

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2092,6 +2092,11 @@ export interface ComputeDisplayTransformArgs {
 }
 
 // @public
+export interface ComputeSpatialViewFitRangeOptions {
+    baseExtents?: Range3d;
+}
+
+// @public
 export function connectViewportFrusta(viewports: Iterable<Viewport>): () => void;
 
 // @public
@@ -7984,7 +7989,7 @@ export abstract class MapTilingScheme {
     readonly numberOfLevelZeroTilesX: number;
     readonly numberOfLevelZeroTilesY: number;
     // @alpha (undocumented)
-    get rootLevel(): 0 | -1;
+    get rootLevel(): -1 | 0;
     readonly rowZeroAtNorthPole: boolean;
     tileBordersNorthPole(row: number, level: number): boolean;
     tileBordersSouthPole(row: number, level: number): boolean;
@@ -11953,7 +11958,7 @@ export class SpatialViewState extends ViewState3d {
     static get className(): string;
     // (undocumented)
     clearViewedModels(): void;
-    computeFitRange(): AxisAlignedBox3d;
+    computeFitRange(options?: ComputeSpatialViewFitRangeOptions): AxisAlignedBox3d;
     // (undocumented)
     createAuxCoordSystem(acsName: string): AuxCoordSystemState;
     static createBlank(iModel: IModelConnection, origin: XYAndZ, extents: XYAndZ, rotation?: Matrix3d): SpatialViewState;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -7989,7 +7989,7 @@ export abstract class MapTilingScheme {
     readonly numberOfLevelZeroTilesX: number;
     readonly numberOfLevelZeroTilesY: number;
     // @alpha (undocumented)
-    get rootLevel(): -1 | 0;
+    get rootLevel(): 0 | -1;
     readonly rowZeroAtNorthPole: boolean;
     tileBordersNorthPole(row: number, level: number): boolean;
     tileBordersSouthPole(row: number, level: number): boolean;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -108,6 +108,7 @@ internal;ComputeAnimationNodeId = (featureIndex: number) => number
 public;ComputeChordToleranceArgs
 internal;computeDimensions(nEntries: number, nRgbaPerEntry: number, nExtraRgba: number, maxSize: number): Dimensions
 beta;ComputeDisplayTransformArgs
+public;ComputeSpatialViewFitRangeOptions
 public;connectViewportFrusta(viewports: Iterable
 public;connectViewports(viewports: Iterable
 public;connectViewportViews(viewports: Iterable

--- a/common/changes/@itwin/core-frontend/pmc-view-creator-fit_2023-06-12-19-31.json
+++ b/common/changes/@itwin/core-frontend/pmc-view-creator-fit_2023-06-12-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "ViewCreator3d fits to the extents of the viewed models. SpatialViewState.computeFitRange accepts an optional minimal fit range.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/SpatialViewState.ts
+++ b/core/frontend/src/SpatialViewState.ts
@@ -19,6 +19,10 @@ import { IModelConnection } from "./IModelConnection";
 import { AttachToViewportArgs, ViewState3d } from "./ViewState";
 import { SpatialTileTreeReferences, TileTreeReference } from "./tile/internal";
 
+export interface ComputeSpatialViewFitRangeOptions {
+  baseExtents?: Range3d;
+}
+
 /** Defines a view of one or more SpatialModels.
  * The list of viewed models is stored in the ModelSelector.
  * @public
@@ -136,9 +140,9 @@ export class SpatialViewState extends ViewState3d {
   }
 
   /** Compute world-space range appropriate for fitting the view. If that range is null, use the displayed extents. */
-  public computeFitRange(): AxisAlignedBox3d {
+  public computeFitRange(options?: ComputeSpatialViewFitRangeOptions): AxisAlignedBox3d {
     // Fit to the union of the ranges of all loaded tile trees.
-    const range = new Range3d();
+    const range = options?.baseExtents ?? new Range3d();
     this.forEachTileTreeRef((ref) => {
       ref.unionFitRange(range);
     });

--- a/core/frontend/src/SpatialViewState.ts
+++ b/core/frontend/src/SpatialViewState.ts
@@ -19,7 +19,11 @@ import { IModelConnection } from "./IModelConnection";
 import { AttachToViewportArgs, ViewState3d } from "./ViewState";
 import { SpatialTileTreeReferences, TileTreeReference } from "./tile/internal";
 
+/** Options supplied to [[SpatialViewState.computeFitRange]].
+ * @public
+ */
 export interface ComputeSpatialViewFitRangeOptions {
+  /** The minimal extents. The computed range will be unioned with this range if supplied. */
   baseExtents?: Range3d;
 }
 
@@ -139,7 +143,15 @@ export class SpatialViewState extends ViewState3d {
     return extents;
   }
 
-  /** Compute world-space range appropriate for fitting the view. If that range is null, use the displayed extents. */
+  /** Compute a volume in world coordinates tightly encompassing the contents of the view. The volume is computed from the union of the volumes of the
+   * view's viewed models, including [GeometricModel]($backend)s and reality models.
+   * Those volumes are obtained from the [[TileTree]]s used to render those models, so any tile tree that has not yet been loaded will not contribute to the computation.
+   * If `options.baseExtents` is defined, it will be unioned with the computed volume.
+   * If the computed volume is null (empty), a default volume will be computed from [IModel.projectExtents]($common), which may be a looser approximation of the
+   * models' volumes.
+   * @param options Options used to customize how the volume is computed.
+   * @returns A non-null volume in world coordinates encompassing the contents of the view.
+   */
   public computeFitRange(options?: ComputeSpatialViewFitRangeOptions): AxisAlignedBox3d {
     // Fit to the union of the ranges of all loaded tile trees.
     const range = options?.baseExtents ?? new Range3d();

--- a/core/frontend/src/SpatialViewState.ts
+++ b/core/frontend/src/SpatialViewState.ts
@@ -154,7 +154,7 @@ export class SpatialViewState extends ViewState3d {
    */
   public computeFitRange(options?: ComputeSpatialViewFitRangeOptions): AxisAlignedBox3d {
     // Fit to the union of the ranges of all loaded tile trees.
-    const range = options?.baseExtents ?? new Range3d();
+    const range = options?.baseExtents?.clone() ?? new Range3d();
     this.forEachTileTreeRef((ref) => {
       ref.unionFitRange(range);
     });

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -14,7 +14,7 @@ Either takes in a list of modelIds, or displays all 3D models by default.
 
 import { CompressedId64Set, Id64Array, Id64String } from "@itwin/core-bentley";
 import {
-  Camera, CategorySelectorProps, Code, CustomViewState3dProps, DisplayStyle3dProps, Environment, IModel, IModelReadRpcInterface, ModelSelectorProps,
+  Camera, CategorySelectorProps, Code, CustomViewState3dCreatorOptions, DisplayStyle3dProps, Environment, IModel, IModelReadRpcInterface, ModelSelectorProps,
   QueryRowFormat, RenderMode, ViewDefinition3dProps, ViewQueryParams, ViewStateProps,
 } from "@itwin/core-common";
 import { Range3d } from "@itwin/core-geometry";
@@ -79,13 +79,17 @@ export class ViewCreator3d {
    * @throws [IModelError]($common) If no 3d models are found in the iModel.
    */
   public async createDefaultView(options?: ViewCreator3dOptions, modelIds?: Id64String[]): Promise<ViewState> {
-    const serializedProps: CustomViewState3dProps = await IModelReadRpcInterface.getClientForRouting(this._imodel.routingContext.token).getCustomViewState3dData(this._imodel.getRpcProps(),
-      modelIds === undefined ? {} : { modelIds: CompressedId64Set.sortAndCompress(modelIds) });
+    const rpcOptions: CustomViewState3dCreatorOptions = modelIds ? { modelIds: CompressedId64Set.sortAndCompress(modelIds) } : { };
+    const rpc = IModelReadRpcInterface.getClientForRouting(this._imodel.routingContext.token);
+    const serializedProps = await rpc.getCustomViewState3dData(this._imodel.getRpcProps(), rpcOptions);
+
+    const baseExtents = Range3d.fromJSON(serializedProps.modelExtents);
     const props = await this._createViewStateProps(
       CompressedId64Set.decompressArray(serializedProps.modelIds),
       CompressedId64Set.decompressArray(serializedProps.categoryIds),
-      Range3d.fromJSON(serializedProps.modelExtents),
-      options);
+      baseExtents,
+      options
+    );
 
     const viewState = SpatialViewState.createFromProps(props, this._imodel);
     try {
@@ -99,7 +103,7 @@ export class ViewCreator3d {
     if (options?.allSubCategoriesVisible)
       viewState.displayStyle.enableAllLoadedSubCategories(viewState.categorySelector.categories);
 
-    const range = viewState.computeFitRange();
+    const range = viewState.computeFitRange({ baseExtents });
     viewState.lookAtVolume(range, options?.vpAspect);
 
     return viewState;

--- a/core/frontend/src/test/SpatialViewState.test.ts
+++ b/core/frontend/src/test/SpatialViewState.test.ts
@@ -85,5 +85,16 @@ describe("SpatialViewState", () => {
       expectFitRange(createView([]), baseExtents, baseExtents);
       expectFitRange(createView([new Range3d(-1, 2, 2, 2, 5, 7)]), new Range3d(-1, 1, 2, 3, 5, 7), baseExtents);
     });
+
+    it("does not modify input baseExtents", () => {
+      const baseExtents = new Range3d(0, 1, 2, 3, 4, 5);
+      expectFitRange(createView([new Range3d(-1, 2, 2, 2, 5, 7)]), new Range3d(-1, 1, 2, 3, 5, 7), baseExtents);
+      expect(baseExtents.low.x).to.equal(0);
+      expect(baseExtents.low.y).to.equal(1);
+      expect(baseExtents.low.z).to.equal(2);
+      expect(baseExtents.high.x).to.equal(3);
+      expect(baseExtents.high.y).to.equal(4);
+      expect(baseExtents.high.z).to.equal(5);
+    });
   });
 });

--- a/core/frontend/src/test/SpatialViewState.test.ts
+++ b/core/frontend/src/test/SpatialViewState.test.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { Range3d } from "@itwin/core-geometry";
+import { EmptyLocalization } from "@itwin/core-common";
+import { SpatialViewState } from "../SpatialViewState";
+import type { IModelConnection } from "../IModelConnection";
+import { IModelApp } from "../IModelApp";
+import { TileTreeLoadStatus, TileTreeReference } from "../tile/internal";
+import { createBlankConnection } from "./createBlankConnection";
+
+describe.only("SpatialViewState", () => {
+  const projectExtents = new Range3d(-100, -50, -25, 25, 50, 100);
+  let iModel: IModelConnection;
+
+  before(async () => {
+    await IModelApp.startup({ localization: new EmptyLocalization() });
+    iModel = createBlankConnection(undefined, undefined, projectExtents);
+  });
+
+  after(async () => IModelApp.shutdown());
+
+  class TreeRef extends TileTreeReference {
+    public constructor(private readonly _range: Range3d) {
+      super();
+    }
+
+    public override unionFitRange(union: Range3d): void {
+      union.extendRange(this._range);
+    }
+
+    public override get treeOwner() {
+      return {
+        iModel,
+        tileTree: undefined,
+        loadStatus: TileTreeLoadStatus.NotLoaded,
+        load: () => undefined,
+        dispose: () => undefined,
+        loadTree: async () => Promise.resolve(undefined),
+      };
+    }
+  }
+
+  function createView(ranges: Range3d[]): SpatialViewState {
+    const view = SpatialViewState.createBlank(iModel, { x: 0, y: 0, z: 0 }, { x: 1, y: 1, z: 1 });
+    const refs = ranges.map((range) => new TreeRef(range));
+    view.forEachModelTreeRef = (func: (ref: TileTreeReference) => void) => {
+      for (const ref of refs)
+        func(ref);
+    };
+
+    return view;
+  }
+
+  function expectFitRange(view: SpatialViewState, expected: Range3d): void {
+    const actual = view.computeFitRange();
+    expect(actual.low.x).to.equal(expected.low.x);
+    expect(actual.low.y).to.equal(expected.low.y);
+    expect(actual.low.z).to.equal(expected.low.z);
+    expect(actual.high.x).to.equal(expected.high.x);
+    expect(actual.high.y).to.equal(expected.high.y);
+    expect(actual.high.z).to.equal(expected.high.z);
+  }
+
+  describe("computeFitRange", () => {
+    it("unions ranges of all tile trees", () => {
+      expectFitRange(createView([new Range3d(0, 1, 2, 3, 4, 5)]), new Range3d(0, 1, 2, 3, 4, 5));
+    });
+
+    it("falls back to project extents upon null range", () => {
+    });
+
+    it("unions with base extents if provided", () => {
+    });
+  });
+});


### PR DESCRIPTION
Fixes #5619.
The `ViewCreator3d` knows the union of the extents of all of the models, but it calls `SpatialViewState.computeFitRange` which tries to (re-)compute it from the ranges of the models' tile trees, which are not yet loaded; therefore it would fall back to using the project extents.
Added an optional `baseExtents` to that method to permit it to provide its precomputed minimal extents.