### PR TITLE
Azurite 3.24.0

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -24,7 +24,6 @@
     "pnpm": {
       "auditConfig": {
         "ignoreCves": [
-          "CVE-2023-0842" // https://github.com/advisories/GHSA-776f-qx25-q3cc full-stack-tests__backend>azurite>xml2js
         ]
       }
     }

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -24,6 +24,7 @@
     "pnpm": {
       "auditConfig": {
         "ignoreCves": [
+          "CVE-2023-26132" // https://github.com/advisories/GHSA-4gxf-g5gf-22h4 full-stack-tests__backend>azurite>sequelize>dottie
         ]
       }
     }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1542,7 +1542,7 @@ importers:
       '@types/fs-extra': ^4.0.7
       '@types/mocha': ^8.2.2
       '@types/sinon': ^9.0.0
-      azurite: ^3.22.0
+      azurite: ^3.24.0
       chai: ^4.1.2
       chai-as-promised: ^7
       cpx2: ^3.0.0
@@ -1587,7 +1587,7 @@ importers:
       '@itwin/oidc-signin-tool': 3.6.1_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/perf-tools': link:../../tools/perf-tools
       '@itwin/projects-client': 0.6.0
-      azurite: 3.23.0
+      azurite: 3.24.0
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
       cpx2: 3.0.2
@@ -8112,8 +8112,8 @@ packages:
     dependencies:
       deep-equal: 2.2.0
 
-  /azurite/3.23.0:
-    resolution: {integrity: sha512-dj99VB4f5v81W/ibNpPX7hZHr0qFxlOd7NQxZVozCNMohQcFKifR99gKvXSTzlUhmg+OiAQTpAteBpb4/tKrtQ==}
+  /azurite/3.24.0:
+    resolution: {integrity: sha512-QJ3OXUW+5JH1JN1XdEOkOgm7WBGS8uKYtWcEdvNX6/srm0UbOXduIxbz7xts0pJfpw5aPslfEzxEl65FTHjL1A==}
     engines: {node: '>=10.0.0', vscode: ^1.39.0}
     hasBin: true
     dependencies:
@@ -8130,15 +8130,15 @@ packages:
       multistream: 2.1.1
       mysql2: 3.2.4
       rimraf: 3.0.2
-      sequelize: 6.31.0_6xc3bxijh4e4vva3gzuchr5vbu
+      sequelize: 6.31.0_sqlip2vm27ve5wztqdoue3ualq
       stoppable: 1.1.0
-      tedious: 15.1.3
+      tedious: 16.1.0
       to-readable-stream: 2.1.0
       tslib: 2.5.0
       uri-templates: 0.2.0
       uuid: 3.4.0
       winston: 3.8.2
-      xml2js: 0.4.23
+      xml2js: 0.6.0
     transitivePeerDependencies:
       - debug
       - ibm_db
@@ -16805,7 +16805,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: false
 
-  /sequelize/6.31.0_6xc3bxijh4e4vva3gzuchr5vbu:
+  /sequelize/6.31.0_sqlip2vm27ve5wztqdoue3ualq:
     resolution: {integrity: sha512-nCPVtv+QydBmb3Us2jCNAr1Dx3gST83VZxxrUQn/JAVFCOrmYOgUaPUz5bevummyNf30zfHsZhIKYAOD3ULfTA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -16851,7 +16851,7 @@ packages:
       retry-as-promised: 7.0.4
       semver: 7.5.0
       sequelize-pool: 7.1.0
-      tedious: 15.1.3
+      tedious: 16.1.0
       toposort-class: 1.0.1
       uuid: 8.3.2
       validator: 13.9.0
@@ -17737,9 +17737,9 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  /tedious/15.1.3:
-    resolution: {integrity: sha512-166EpRm5qknwhEisjZqz/mF7k14fXKJYHRg6XiAXVovd/YkyHJ3SG4Ppy89caPaNFfRr7PVYe+s4dAvKaCMFvw==}
-    engines: {node: '>=14'}
+  /tedious/16.1.0:
+    resolution: {integrity: sha512-5W+shTkUoAyrB/Bbx89k6Q8Cb400OHzS6XDXQdsTp/obe1cFyOhNc1KI4FI6TOzklDGJWyLnEEfUSBVMpugnjA==}
+    engines: {node: '>=16'}
     dependencies:
       '@azure/identity': 2.1.0
       '@azure/keyvault-keys': 4.7.0
@@ -19215,6 +19215,14 @@ packages:
 
   /xml2js/0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: false
+
+  /xml2js/0.6.0:
+    resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
     engines: {node: '>=4.0.0'}
     dependencies:
       sax: 1.2.4

--- a/full-stack-tests/backend/package.json
+++ b/full-stack-tests/backend/package.json
@@ -55,7 +55,7 @@
     "@itwin/perf-tools": "workspace:*",
     "@itwin/projects-client": "^0.6.0",
     "sinon": "^9.0.2",
-    "azurite": "^3.22.0",
+    "azurite": "^3.24.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7",
     "cpx2": "^3.0.0",


### PR DESCRIPTION
Resolves previously-ignored CVE in xml2js.
Does not resolve [new dottie CVE](https://github.com/advisories/GHSA-4gxf-g5gf-22h4). sequelize is patched, azurite is not.
@aruniverse 