### PR TITLE
Fix world decorations issues

### DIFF
--- a/core/frontend/src/render/primitives/mesh/MeshBuilder.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshBuilder.ts
@@ -242,8 +242,10 @@ export class MeshBuilder {
   }
 
   public addTriangle(triangle: Triangle): void {
-    // Prefer to avoid adding vertices originating from degenerate triangles before we get here...
-    assert(!triangle.isDegenerate);
+    // Attempt to avoid adding vertices originating from degenerate triangles before we get here.
+    // Removed assert and just return if degenerate at this point because uncommon cases (not worth testing for) can still occur.
+    if (triangle.isDegenerate)
+      return;
 
     const onInsert = (_vk: TriangleKey) => this.mesh.addTriangle(triangle);
     this.triangleSet.insertKey(triangle, onInsert);

--- a/core/frontend/src/render/primitives/mesh/MeshBuilderMap.ts
+++ b/core/frontend/src/render/primitives/mesh/MeshBuilderMap.ts
@@ -43,7 +43,7 @@ export class MeshBuilderMap extends Dictionary<MeshBuilderMap.Key, MeshBuilder> 
       this.features = new FeatureTable(2048 * 1024, pickable.modelId);
   }
 
-  public static createFromGeometries(geometries: GeometryList, tolerance: number, range: Range3d, is2d: boolean, options: GeometryOptions, pickable: { modelId?: Id64String} | undefined): MeshBuilderMap {
+  public static createFromGeometries(geometries: GeometryList, tolerance: number, range: Range3d, is2d: boolean, options: GeometryOptions, pickable: { modelId?: Id64String } | undefined): MeshBuilderMap {
     const map = new MeshBuilderMap(tolerance, range, is2d, options, pickable);
 
     for (const geom of geometries)
@@ -54,9 +54,10 @@ export class MeshBuilderMap extends Dictionary<MeshBuilderMap.Key, MeshBuilder> 
 
   public toMeshes(): MeshList {
     const meshes = new MeshList(this.features, this.range);
-    for (const builder of this._values)
-      meshes.push(builder.mesh);
-
+    for (const builder of this._values) {
+      if (builder.mesh.points.length > 0)
+        meshes.push(builder.mesh);
+    }
     return meshes;
   }
 


### PR DESCRIPTION
World decorations would disappear in certain data cases after zooming out past a certain level.  This was due to case of a single triangle mesh as the first mesh, turning degenerate after zooming out, would cause the transformOrigin to corrupt from calculating it twice.

Also, although degenerate triangles in meshes were getting thrown out early, an assert could still occur from a degenerate triangle later in MeshBuilder.addTriangle.  Tracked this down to some uncommon cases that caused duplicate indexes even when the early degenerate vertex check passed.  Removed the assert and just return now if degenerate at that point because the uncommon cases are not worth spending time checking for.

Fixes #5467


- [x] ImageTests
