### PR TITLE
Ensure Ids are included in render timeline if needed

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-batched-tile-render-timeline_2023-06-13-17-13.json
+++ b/common/changes/@itwin/core-frontend/pmc-batched-tile-render-timeline_2023-06-13-17-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Ensure element Ids are loaded for RenderTimeline element when schedule scripts are applied on the frontend.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -166,7 +166,8 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
   /** @internal */
   protected async queryRenderTimelineProps(timelineId: Id64String): Promise<RenderTimelineProps | undefined> {
     try {
-      return await this.iModel.elements.loadProps(timelineId, { renderTimeline: { omitScriptElementIds: true } }) as RenderTimelineProps;
+      const omitScriptElementIds = !IModelApp.tileAdmin.enableFrontendScheduleScripts;
+      return await this.iModel.elements.loadProps(timelineId, { renderTimeline: { omitScriptElementIds } }) as RenderTimelineProps;
     } catch (_) {
       return undefined;
     }


### PR DESCRIPTION
If timeline is being applied on the frontend (i.e., `TileAdmin.enableFrontendScheduleScripts` is `true`), the element Ids need to be included.
This was the case for scripts stored in the display style's JSON properties, but not for those stored on RenderTimeline elements - they were always unconditionally omitted.