### PR TITLE
Presentation: Fix 'Source Element ID' property being assigned a wrong category

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-fix-source-element-id-invalid-category_2023-06-14-13-38.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix-source-element-id-invalid-category_2023-06-14-13-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fix \"Source Element ID\" property being assigned a wrong category",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/full-stack-tests/presentation/src/backend/DefaultSupplementalRules.test.ts
+++ b/full-stack-tests/presentation/src/backend/DefaultSupplementalRules.test.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
 import { IModelDb } from "@itwin/core-backend";
@@ -26,21 +26,18 @@ describe("Default supplemental rules", async () => {
       describe("Related properties", () => {
         it("loads `Element -> ExternalSourceAspect.Identifier` property into 'Source Information' group", async function () {
           let elementKey: InstanceKey | undefined;
-          const { db: imodel } = await buildTestIModelDb(
-            this.test!.fullTitle(),
-            async (db) => {
-              elementKey = insertPhysicalElement(db);
-              db.elements.insertAspect({
-                classFullName: "BisCore:ExternalSourceAspect",
-                element: {
-                  relClassName: "BisCore:ElementOwnsExternalSourceAspects",
-                  id: elementKey.id,
-                },
-                kind: "",
-                identifier: "test identifier",
-              } as ElementAspectProps);
-            }
-          );
+          const { db: imodel } = await buildTestIModelDb(this.test!.fullTitle(), async (db) => {
+            elementKey = insertPhysicalElement(db);
+            db.elements.insertAspect({
+              classFullName: "BisCore:ExternalSourceAspect",
+              element: {
+                relClassName: "BisCore:ElementOwnsExternalSourceAspects",
+                id: elementKey.id,
+              },
+              kind: "",
+              identifier: "test identifier",
+            } as ElementAspectProps);
+          });
           const rules: Ruleset = {
             id: "test",
             rules: [
@@ -61,15 +58,9 @@ describe("Default supplemental rules", async () => {
             keys: new KeySet([elementKey!]),
           });
           assert(!!content);
-          const externalSourceAspectField = getFieldByLabel(
-            content.descriptor.fields,
-            "External Source Aspect"
-          );
+          const externalSourceAspectField = getFieldByLabel(content.descriptor.fields, "External Source Aspect");
           assert(externalSourceAspectField.isNestedContentField());
-          const identifierField = getFieldByLabel(
-            externalSourceAspectField.nestedFields,
-            "Source Element ID"
-          );
+          const identifierField = getFieldByLabel(externalSourceAspectField.nestedFields, "Source Element ID");
           expect(identifierField.category.label).to.eq("Source Information");
           expect(content.contentSet[0]).to.containSubset({
             values: {
@@ -83,13 +74,11 @@ describe("Default supplemental rules", async () => {
             },
           });
         });
-        
+
         it("loads `Element -> ExternalSourceAspect -> ExternalSource -> RepositoryLink` properties into 'Source Information' group", async function () {
           let elementKey: InstanceKey | undefined;
-          const { db: imodel } = await buildTestIModelDb(
-            this.test!.fullTitle(),
-            async (db) => {
-              const schema = `<?xml version="1.0" encoding="UTF-8"?>
+          const { db: imodel } = await buildTestIModelDb(this.test!.fullTitle(), async (db) => {
+            const schema = `<?xml version="1.0" encoding="UTF-8"?>
                   <ECSchema schemaName="TestDomain" alias="td" version="01.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
                       <ECSchemaReference name="BisCore" version="01.00" alias="bis" />
                       <ECEntityClass typeName="MyRepositoryLink" displayLabel="My Repository Link">
@@ -97,42 +86,41 @@ describe("Default supplemental rules", async () => {
                           <ECProperty propertyName="MyProperty" displayLabel="My Property" typeName="string" />
                       </ECEntityClass>
                   </ECSchema>`;
-              await db.importSchemaStrings([schema]);
-              db.saveChanges();
+            await db.importSchemaStrings([schema]);
+            db.saveChanges();
 
-              elementKey = insertPhysicalElement(db);
-              const repositoryLinkId = db.elements.insertElement({
-                classFullName: "TestDomain:MyRepositoryLink",
-                model: IModel.repositoryModelId,
-                code: Code.createEmpty(),
-                userLabel: "test user label",
-                url: "test url",
-                myProperty: "test my property",
-              } as ElementProps);
-              const externalSourceId = db.elements.insertElement({
-                classFullName: "BisCore:ExternalSource",
-                model: IModel.dictionaryId,
-                code: Code.createEmpty(),
-                repository: {
-                  relClassName: "BisCore:ExternalSourceIsInRepository",
-                  id: repositoryLinkId,
-                },
-              } as ElementProps);
-              db.elements.insertAspect({
-                classFullName: "BisCore:ExternalSourceAspect",
-                element: {
-                  relClassName: "BisCore:ElementOwnsExternalSourceAspects",
-                  id: elementKey.id,
-                },
-                source: {
-                  relClassName: "BisCore:ElementIsFromSource",
-                  id: externalSourceId,
-                },
-                kind: "",
-                identifier: "test identifier",
-              } as ElementAspectProps);
-            }
-          );
+            elementKey = insertPhysicalElement(db);
+            const repositoryLinkId = db.elements.insertElement({
+              classFullName: "TestDomain:MyRepositoryLink",
+              model: IModel.repositoryModelId,
+              code: Code.createEmpty(),
+              userLabel: "test user label",
+              url: "test url",
+              myProperty: "test my property",
+            } as ElementProps);
+            const externalSourceId = db.elements.insertElement({
+              classFullName: "BisCore:ExternalSource",
+              model: IModel.dictionaryId,
+              code: Code.createEmpty(),
+              repository: {
+                relClassName: "BisCore:ExternalSourceIsInRepository",
+                id: repositoryLinkId,
+              },
+            } as ElementProps);
+            db.elements.insertAspect({
+              classFullName: "BisCore:ExternalSourceAspect",
+              element: {
+                relClassName: "BisCore:ElementOwnsExternalSourceAspects",
+                id: elementKey.id,
+              },
+              source: {
+                relClassName: "BisCore:ElementIsFromSource",
+                id: externalSourceId,
+              },
+              kind: "",
+              identifier: "test identifier",
+            } as ElementAspectProps);
+          });
           const rules: Ruleset = {
             id: "test",
             rules: [
@@ -146,14 +134,12 @@ describe("Default supplemental rules", async () => {
               },
             ],
           };
-          const content = await Presentation.getManager().getContent(
-            {
-              imodel,
-              rulesetOrId: rules,
-              descriptor: {},
-              keys: new KeySet([elementKey!]),
-            }
-          );
+          const content = await Presentation.getManager().getContent({
+            imodel,
+            rulesetOrId: rules,
+            descriptor: {},
+            keys: new KeySet([elementKey!]),
+          });
           assert(!!content);
           const externalSourceAspectField = getFieldByLabel(content.descriptor.fields, "External Source Aspect");
           assert(externalSourceAspectField.isNestedContentField());
@@ -166,41 +152,42 @@ describe("Default supplemental rules", async () => {
           });
           expect(content.contentSet[0]).to.containSubset({
             values: {
-              [externalSourceAspectField.name]: [{
-                values: {
-                  [repositoryLinkField.name]: [{
-                    values: {
-                      [getFieldByLabel(repositoryLinkField.nestedFields, "Code").name]: undefined,
-                      [getFieldByLabel(repositoryLinkField.nestedFields, "Name").name]: "test user label",
-                      [getFieldByLabel(repositoryLinkField.nestedFields, "Path").name]: "test url",
-                      [getFieldByLabel(repositoryLinkField.nestedFields, "Description").name]: undefined,
-                      [getFieldByLabel(repositoryLinkField.nestedFields, "Format").name]: undefined,
-                      [getFieldByLabel(repositoryLinkField.nestedFields, "My Property").name]: "test my property",
-                    },
-                  }],
+              [externalSourceAspectField.name]: [
+                {
+                  values: {
+                    [repositoryLinkField.name]: [
+                      {
+                        values: {
+                          [getFieldByLabel(repositoryLinkField.nestedFields, "Code").name]: undefined,
+                          [getFieldByLabel(repositoryLinkField.nestedFields, "Name").name]: "test user label",
+                          [getFieldByLabel(repositoryLinkField.nestedFields, "Path").name]: "test url",
+                          [getFieldByLabel(repositoryLinkField.nestedFields, "Description").name]: undefined,
+                          [getFieldByLabel(repositoryLinkField.nestedFields, "Format").name]: undefined,
+                          [getFieldByLabel(repositoryLinkField.nestedFields, "My Property").name]: "test my property",
+                        },
+                      },
+                    ],
+                  },
                 },
-              }],
+              ],
             },
           });
         });
 
         it("allows removing 'Source Element ID' property", async function () {
           let elementKey: InstanceKey | undefined;
-          const { db: imodel } = await buildTestIModelDb(
-            this.test!.fullTitle(),
-            async (db) => {
-              elementKey = insertPhysicalElement(db);
-              db.elements.insertAspect({
-                classFullName: "BisCore:ExternalSourceAspect",
-                element: {
-                  relClassName: "BisCore:ElementOwnsExternalSourceAspects",
-                  id: elementKey.id,
-                },
-                kind: "",
-                identifier: "test identifier",
-              } as ElementAspectProps);
-            }
-          );
+          const { db: imodel } = await buildTestIModelDb(this.test!.fullTitle(), async (db) => {
+            elementKey = insertPhysicalElement(db);
+            db.elements.insertAspect({
+              classFullName: "BisCore:ExternalSourceAspect",
+              element: {
+                relClassName: "BisCore:ElementOwnsExternalSourceAspects",
+                id: elementKey.id,
+              },
+              kind: "",
+              identifier: "test identifier",
+            } as ElementAspectProps);
+          });
           const rules: Ruleset = {
             id: "test",
             rules: [
@@ -236,64 +223,55 @@ describe("Default supplemental rules", async () => {
               },
             ],
           };
-          const descriptor = await Presentation.getManager().getContentDescriptor(
-            {
-              imodel,
-              rulesetOrId: rules,
-              displayType: DefaultContentDisplayTypes.PropertyPane,
-              keys: new KeySet([elementKey!]),
-            }
-          );
+          const descriptor = await Presentation.getManager().getContentDescriptor({
+            imodel,
+            rulesetOrId: rules,
+            displayType: DefaultContentDisplayTypes.PropertyPane,
+            keys: new KeySet([elementKey!]),
+          });
           assert(!!descriptor);
           expect(descriptor.categories).to.not.containSubset([
             {
               label: "Source Information",
             },
           ]);
-          expect(() =>
-            getFieldByLabel(descriptor.fields, "Source Element ID")
-          ).to.throw();
+          expect(() => getFieldByLabel(descriptor.fields, "Source Element ID")).to.throw();
         });
 
         it("allows removing 'Source Information -> Model Source' properties", async function () {
           let elementKey: InstanceKey | undefined;
-          const { db: imodel } = await buildTestIModelDb(
-            this.test!.fullTitle(),
-            async (db) => {
-              const partitionId = db.elements.insertElement({
-                classFullName: "BisCore:PhysicalPartition",
-                model: IModel.repositoryModelId,
-                parent: {
-                  relClassName: "BisCore:SubjectOwnsPartitionElements",
-                  id: IModel.rootSubjectId,
-                },
-                code: new Code({
-                  spec: db.codeSpecs.getByName(
-                    BisCodeSpec.informationPartitionElement
-                  ).id,
-                  scope: IModel.rootSubjectId,
-                  value: "physical model",
-                }),
-              });
-              const repositoryLinkId = db.elements.insertElement({
-                classFullName: "BisCore:RepositoryLink",
-                model: IModel.repositoryModelId,
-                code: Code.createEmpty(),
-                userLabel: "test user label",
-                url: "test url",
-              } as ElementProps);
-              db.relationships.insertInstance({
-                classFullName: "BisCore:ElementHasLinks",
-                sourceId: partitionId,
-                targetId: repositoryLinkId,
-              });
-              const modelId = db.models.insertModel({
-                classFullName: "BisCore:PhysicalModel",
-                modeledElement: { id: partitionId },
-              });
-              elementKey = insertPhysicalElement(db, modelId);
-            }
-          );
+          const { db: imodel } = await buildTestIModelDb(this.test!.fullTitle(), async (db) => {
+            const partitionId = db.elements.insertElement({
+              classFullName: "BisCore:PhysicalPartition",
+              model: IModel.repositoryModelId,
+              parent: {
+                relClassName: "BisCore:SubjectOwnsPartitionElements",
+                id: IModel.rootSubjectId,
+              },
+              code: new Code({
+                spec: db.codeSpecs.getByName(BisCodeSpec.informationPartitionElement).id,
+                scope: IModel.rootSubjectId,
+                value: "physical model",
+              }),
+            });
+            const repositoryLinkId = db.elements.insertElement({
+              classFullName: "BisCore:RepositoryLink",
+              model: IModel.repositoryModelId,
+              code: Code.createEmpty(),
+              userLabel: "test user label",
+              url: "test url",
+            } as ElementProps);
+            db.relationships.insertInstance({
+              classFullName: "BisCore:ElementHasLinks",
+              sourceId: partitionId,
+              targetId: repositoryLinkId,
+            });
+            const modelId = db.models.insertModel({
+              classFullName: "BisCore:PhysicalModel",
+              modeledElement: { id: partitionId },
+            });
+            elementKey = insertPhysicalElement(db, modelId);
+          });
           const rules: Ruleset = {
             id: "test",
             rules: [
@@ -343,14 +321,12 @@ describe("Default supplemental rules", async () => {
               },
             ],
           };
-          const descriptor = await Presentation.getManager().getContentDescriptor(
-            {
-              imodel,
-              rulesetOrId: rules,
-              displayType: DefaultContentDisplayTypes.PropertyPane,
-              keys: new KeySet([elementKey!]),
-            }
-          );
+          const descriptor = await Presentation.getManager().getContentDescriptor({
+            imodel,
+            rulesetOrId: rules,
+            displayType: DefaultContentDisplayTypes.PropertyPane,
+            keys: new KeySet([elementKey!]),
+          });
           assert(!!descriptor);
           expect(descriptor.categories).to.not.containSubset([
             {
@@ -368,41 +344,38 @@ describe("Default supplemental rules", async () => {
 
         it("allows removing 'Source Information' ExternalSource properties", async function () {
           let elementKey: InstanceKey | undefined;
-          const { db: imodel } = await buildTestIModelDb(
-            this.test!.fullTitle(),
-            async (db) => {
-              elementKey = insertPhysicalElement(db);
-              const repositoryLinkId = db.elements.insertElement({
-                classFullName: "BisCore:RepositoryLink",
-                model: IModel.repositoryModelId,
-                code: Code.createEmpty(),
-                userLabel: "test user label",
-                url: "test url",
-              } as ElementProps);
-              const externalSourceId = db.elements.insertElement({
-                classFullName: "BisCore:ExternalSource",
-                model: IModel.dictionaryId,
-                code: Code.createEmpty(),
-                repository: {
-                  relClassName: "BisCore:ExternalSourceIsInRepository",
-                  id: repositoryLinkId,
-                },
-              } as ElementProps);
-              db.elements.insertAspect({
-                classFullName: "BisCore:ExternalSourceAspect",
-                element: {
-                  relClassName: "BisCore:ElementOwnsExternalSourceAspects",
-                  id: elementKey.id,
-                },
-                source: {
-                  relClassName: "BisCore:ElementIsFromSource",
-                  id: externalSourceId,
-                },
-                kind: "",
-                identifier: "test identifier",
-              } as ElementAspectProps);
-            }
-          );
+          const { db: imodel } = await buildTestIModelDb(this.test!.fullTitle(), async (db) => {
+            elementKey = insertPhysicalElement(db);
+            const repositoryLinkId = db.elements.insertElement({
+              classFullName: "BisCore:RepositoryLink",
+              model: IModel.repositoryModelId,
+              code: Code.createEmpty(),
+              userLabel: "test user label",
+              url: "test url",
+            } as ElementProps);
+            const externalSourceId = db.elements.insertElement({
+              classFullName: "BisCore:ExternalSource",
+              model: IModel.dictionaryId,
+              code: Code.createEmpty(),
+              repository: {
+                relClassName: "BisCore:ExternalSourceIsInRepository",
+                id: repositoryLinkId,
+              },
+            } as ElementProps);
+            db.elements.insertAspect({
+              classFullName: "BisCore:ExternalSourceAspect",
+              element: {
+                relClassName: "BisCore:ElementOwnsExternalSourceAspects",
+                id: elementKey.id,
+              },
+              source: {
+                relClassName: "BisCore:ElementIsFromSource",
+                id: externalSourceId,
+              },
+              kind: "",
+              identifier: "test identifier",
+            } as ElementAspectProps);
+          });
           const rules: Ruleset = {
             id: "test",
             rules: [
@@ -459,14 +432,12 @@ describe("Default supplemental rules", async () => {
               },
             ],
           };
-          const descriptor = await Presentation.getManager().getContentDescriptor(
-            {
-              imodel,
-              rulesetOrId: rules,
-              displayType: DefaultContentDisplayTypes.PropertyPane,
-              keys: new KeySet([elementKey!]),
-            }
-          );
+          const descriptor = await Presentation.getManager().getContentDescriptor({
+            imodel,
+            rulesetOrId: rules,
+            displayType: DefaultContentDisplayTypes.PropertyPane,
+            keys: new KeySet([elementKey!]),
+          });
           assert(!!descriptor);
           expect(descriptor.categories).to.not.containSubset([
             {
@@ -479,51 +450,48 @@ describe("Default supplemental rules", async () => {
 
         it("allows removing 'Source Information -> Secondary Sources' properties", async function () {
           let elementKey: InstanceKey | undefined;
-          const { db: imodel } = await buildTestIModelDb(
-            this.test!.fullTitle(),
-            async (db) => {
-              elementKey = insertPhysicalElement(db);
-              const repositoryLinkId = db.elements.insertElement({
-                classFullName: "BisCore:RepositoryLink",
-                model: IModel.repositoryModelId,
-                code: Code.createEmpty(),
-                userLabel: "test user label",
-                url: "test url",
-              } as ElementProps);
-              const externalSourceId = db.elements.insertElement({
-                classFullName: "BisCore:ExternalSource",
-                model: IModel.dictionaryId,
-                code: Code.createEmpty(),
-                repository: {
-                  relClassName: "BisCore:ExternalSourceIsInRepository",
-                  id: repositoryLinkId,
-                },
-              } as ElementProps);
-              const externalSourceGroupId = db.elements.insertElement({
-                classFullName: "BisCore:ExternalSourceGroup",
-                model: IModel.dictionaryId,
-                code: Code.createEmpty(),
-              } as ElementProps);
-              db.relationships.insertInstance({
-                classFullName: "BisCore:ExternalSourceGroupGroupsSources",
-                sourceId: externalSourceGroupId,
-                targetId: externalSourceId,
-              });
-              db.elements.insertAspect({
-                classFullName: "BisCore:ExternalSourceAspect",
-                element: {
-                  relClassName: "BisCore:ElementOwnsExternalSourceAspects",
-                  id: elementKey.id,
-                },
-                source: {
-                  relClassName: "BisCore:ElementIsFromSource",
-                  id: externalSourceGroupId,
-                },
-                kind: "",
-                identifier: "test identifier",
-              } as ElementAspectProps);
-            }
-          );
+          const { db: imodel } = await buildTestIModelDb(this.test!.fullTitle(), async (db) => {
+            elementKey = insertPhysicalElement(db);
+            const repositoryLinkId = db.elements.insertElement({
+              classFullName: "BisCore:RepositoryLink",
+              model: IModel.repositoryModelId,
+              code: Code.createEmpty(),
+              userLabel: "test user label",
+              url: "test url",
+            } as ElementProps);
+            const externalSourceId = db.elements.insertElement({
+              classFullName: "BisCore:ExternalSource",
+              model: IModel.dictionaryId,
+              code: Code.createEmpty(),
+              repository: {
+                relClassName: "BisCore:ExternalSourceIsInRepository",
+                id: repositoryLinkId,
+              },
+            } as ElementProps);
+            const externalSourceGroupId = db.elements.insertElement({
+              classFullName: "BisCore:ExternalSourceGroup",
+              model: IModel.dictionaryId,
+              code: Code.createEmpty(),
+            } as ElementProps);
+            db.relationships.insertInstance({
+              classFullName: "BisCore:ExternalSourceGroupGroupsSources",
+              sourceId: externalSourceGroupId,
+              targetId: externalSourceId,
+            });
+            db.elements.insertAspect({
+              classFullName: "BisCore:ExternalSourceAspect",
+              element: {
+                relClassName: "BisCore:ElementOwnsExternalSourceAspects",
+                id: elementKey.id,
+              },
+              source: {
+                relClassName: "BisCore:ElementIsFromSource",
+                id: externalSourceGroupId,
+              },
+              kind: "",
+              identifier: "test identifier",
+            } as ElementAspectProps);
+          });
           const rules: Ruleset = {
             id: "test",
             rules: [
@@ -591,14 +559,12 @@ describe("Default supplemental rules", async () => {
               },
             ],
           };
-          const descriptor = await Presentation.getManager().getContentDescriptor(
-            {
-              imodel,
-              rulesetOrId: rules,
-              displayType: DefaultContentDisplayTypes.PropertyPane,
-              keys: new KeySet([elementKey!]),
-            }
-          );
+          const descriptor = await Presentation.getManager().getContentDescriptor({
+            imodel,
+            rulesetOrId: rules,
+            displayType: DefaultContentDisplayTypes.PropertyPane,
+            keys: new KeySet([elementKey!]),
+          });
           assert(!!descriptor);
           expect(descriptor.categories).to.not.containSubset([
             {
@@ -628,9 +594,7 @@ function insertPhysicalElement(db: IModelDb, modelId?: Id64String, categoryId?: 
         id: IModel.rootSubjectId,
       },
       code: new Code({
-        spec: db.codeSpecs.getByName(
-          BisCodeSpec.informationPartitionElement
-        ).id,
+        spec: db.codeSpecs.getByName(BisCodeSpec.informationPartitionElement).id,
         scope: IModel.rootSubjectId,
         value: "physical model",
       }),

--- a/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
+++ b/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
@@ -237,40 +237,6 @@
         "schemaName": "BisCore",
         "className": "Element"
       },
-      "relatedProperties": [
-        {
-          "propertiesSource": {
-            "relationship": {
-              "schemaName": "BisCore",
-              "className": "ElementOwnsUniqueAspect"
-            },
-            "direction": "Forward"
-          },
-          "handleTargetClassPolymorphically": true,
-          "relationshipMeaning": "SameInstance",
-          "skipIfDuplicate": true
-        },
-        {
-          "propertiesSource": {
-            "relationship": {
-              "schemaName": "BisCore",
-              "className": "ElementOwnsMultiAspects"
-            },
-            "direction": "Forward"
-          },
-          "handleTargetClassPolymorphically": true,
-          "relationshipMeaning": "SameInstance",
-          "skipIfDuplicate": true
-        }
-      ],
-      "applyOnNestedContent": true
-    },
-    {
-      "ruleType": "ContentModifier",
-      "class": {
-        "schemaName": "BisCore",
-        "className": "Element"
-      },
       "propertyCategories": [
         {
           "id": "source_information",
@@ -299,6 +265,57 @@
           "autoExpand": true
         }
       ]
+    },
+    {
+      "ruleType": "ContentModifier",
+      "class": {
+        "schemaName": "BisCore",
+        "className": "ElementAspect"
+      },
+      "propertyCategories": [
+        {
+          "id": "source_information",
+          "label": "Source Information",
+          "parentId": {
+            "type": "Root"
+          },
+          "autoExpand": true
+        }
+      ]
+    },
+    {
+      "ruleType": "ContentModifier",
+      "class": {
+        "schemaName": "BisCore",
+        "className": "Element"
+      },
+      "relatedProperties": [
+        {
+          "propertiesSource": {
+            "relationship": {
+              "schemaName": "BisCore",
+              "className": "ElementOwnsUniqueAspect"
+            },
+            "direction": "Forward"
+          },
+          "handleTargetClassPolymorphically": true,
+          "relationshipMeaning": "SameInstance",
+          "skipIfDuplicate": true
+        },
+        {
+          "propertiesSource": {
+            "relationship": {
+              "schemaName": "BisCore",
+              "className": "ElementOwnsMultiAspects"
+            },
+            "direction": "Forward"
+          },
+          "handleTargetClassPolymorphically": true,
+          "relationshipMeaning": "SameInstance",
+          "skipIfDuplicate": true
+        }
+      ],
+      "applyOnNestedContent": true
     },
     {
       "ruleType": "ContentModifier",


### PR DESCRIPTION
This is a quick fix to get past the regression [test failures](https://github.com/iTwin/presentation/actions/runs/5265017713/jobs/9517083564?pr=160#step:8:180) in [presentation](https://github.com/iTwin/presentation) repo:
```
ERR!   1) PropertyDataProvider
ERR!        with flat property categories
ERR!          finds nested property record keys:
ERR!      AssertionError: expected undefined not to be undefined
ERR!       at /home/runner/work/presentation/presentation/packages/full-stack-tests/src/components/properties/PropertyPaneDataProvider.test.ts:246:37
ERR! 
ERR!   2) PropertyDataProvider
ERR!        with nested property categories
ERR!          finds nested property record keys:
ERR!      TypeError: Cannot read properties of undefined (reading 'find')
ERR!       at /home/runner/work/presentation/presentation/packages/full-stack-tests/src/components/properties/PropertyPaneDataProvider.test.ts:248:61
```

They occur because the latest build of `presentation-backend` assigns a wrong category to "Source Element ID" property, which is used in one of the full stack tests in the `presentation` repo.

The real fix should be to just specify the content modifier without the `class` modifier, however in that case we're getting some diagnostic errors - that needs to be reviewed and fixed first (https://github.com/iTwin/imodel-native/issues/318). We can revisit this change when the fix is done.

Also, filed an issue to add full stack tests to cover all supplemental rules: https://github.com/iTwin/itwinjs-core/issues/5636. Not having those tests in `itwinjs-core` became a much larger problem after moving `presentation-components` into a separate repo.

