### PR TITLE
Presentation: Fix mocha attempting to load irrelevant .js files

### DIFF
--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -103,7 +103,7 @@
       "mochaFile=lib/test/junit_results.xml"
     ],
     "spec": [
-      "./lib/**/*.js"
+      "./lib/**/*.test.js"
     ]
   }
 }


### PR DESCRIPTION
The first run causes `core-frontend` to copy some `.js` files to `/lib/public/scripts`. Then on the second run mocha attempted to load them and failed...