### PR TITLE
add hasDocs tag; name docsBuild job

### DIFF
--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -44,7 +44,7 @@ parameters:
 
 
 jobs:
-  - job:
+  - job: docsBuild
     workspace:
       clean: all
     pool:

--- a/common/config/azure-pipelines/templates/copy-docs-artifact.yaml
+++ b/common/config/azure-pipelines/templates/copy-docs-artifact.yaml
@@ -17,6 +17,9 @@ parameters:
   - name: defaultBranch
     type: string
     default: refs/heads/master
+  - name: specificBuild
+    type: string
+    default: ""
 
   # If useCurrentDocsArtifact is set to true, attempt to pull artifact from the current run
   # rather than latest succesful run.
@@ -56,6 +59,9 @@ steps:
           ${{ if parameters.buildTag }}:
             buildVersionToDownload: latest
             tags: ${{parameters.buildTag}}
+          ${{ elseif parameters.specificBuild }}:
+            buildVersionToDownload: specific
+            buildId: ${{ parameters.specificBuild }}
           ${{ else }}:
             branchName: ${{ parameters.defaultBranch }}
             buildVersionToDownload: latestFromBranch

--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -76,7 +76,7 @@ steps:
       stagingDir: ${{ parameters.stagingDir }}
       pipelineId: 9056 # iTwin Transformer/Transformer Generate Docs
       artifactName: Transformer Docs
-      buildTag: hasDocs
+      defaultBranch: refs/heads/main
       useCurrentDocsArtifact: ${{ parameters.useCurrentTransformerDocsArtifact }}
 
   # Download Auth Clients artifact

--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -76,7 +76,7 @@ steps:
       stagingDir: ${{ parameters.stagingDir }}
       pipelineId: 9056 # iTwin Transformer/Transformer Generate Docs
       artifactName: Transformer Docs
-      defaultBranch: refs/heads/main
+      specificBuild: 2212281
       useCurrentDocsArtifact: ${{ parameters.useCurrentTransformerDocsArtifact }}
 
   # Download Auth Clients artifact

--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -66,6 +66,7 @@ steps:
       stagingDir: ${{ parameters.stagingDir }}
       pipelineId: 8602 # iTwin Presentation/iTwin Presentation Docs
       artifactName: Presentation Docs
+      buildTag: hasDocs
       useCurrentDocsArtifact: ${{ parameters.useCurrentPresentationDocsArtifact }}
 
   # Download Transformer Docs artifact
@@ -75,7 +76,7 @@ steps:
       stagingDir: ${{ parameters.stagingDir }}
       pipelineId: 9056 # iTwin Transformer/Transformer Generate Docs
       artifactName: Transformer Docs
-      defaultBranch: refs/heads/main
+      buildTag: hasDocs
       useCurrentDocsArtifact: ${{ parameters.useCurrentTransformerDocsArtifact }}
 
   # Download Auth Clients artifact


### PR DESCRIPTION
- use hasDocs tag when gathering from presentation
- name docsBuild job so imodel-transformer builds can tag appropriately. After changes are made in transformer repo, will double back and add hasDocs for transformer once again.