### PR TITLE
temporarily export internal class MultiChainCollector

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -3795,6 +3795,15 @@ export class MomentData {
     toJSON(): any;
 }
 
+// @internal
+export class MultiChainCollector {
+    constructor(endPointShiftTolerance?: number, planeTolerance?: number | undefined);
+    announceChainsAsLineString3d(announceChain: (ls: LineString3d) => void): void;
+    captureCurve(candidate: GeometryQuery): void;
+    captureCurvePrimitive(candidate: CurvePrimitive): void;
+    grabResult(makeLoopIfClosed?: boolean): ChainTypes;
+}
+
 // @public
 export type MultiLineStringDataVariant = LineStringDataVariant | LineStringDataVariant[];
 

--- a/common/api/summary/core-geometry.exports.csv
+++ b/common/api/summary/core-geometry.exports.csv
@@ -180,6 +180,7 @@ public;Matrix3dProps = number[][] | number[]
 public;Matrix4d 
 public;Matrix4dProps = Point4dProps[]
 public;MomentData
+internal;MultiChainCollector
 public;MultiLineStringDataVariant = LineStringDataVariant | LineStringDataVariant[]
 internal;Newton1dUnbounded 
 internal;Newton1dUnboundedApproximateDerivative 

--- a/common/changes/@itwin/core-geometry/da4-export-multichaincollector-expedient_2023-06-15-17-20.json
+++ b/common/changes/@itwin/core-geometry/da4-export-multichaincollector-expedient_2023-06-15-17-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "temporarily export internal class MultiChainCollector",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/core-geometry.ts
+++ b/core/geometry/src/core-geometry.ts
@@ -255,3 +255,6 @@ export * from "./serialization/IModelJsonSchema";
 export * from "./serialization/DeepCompare";
 export * from "./serialization/GeometrySamples";
 export { BentleyGeometryFlatBuffer } from "./serialization/BentleyGeometryFlatBuffer";
+
+// temporary export for internal access pending exposure of this functionality via public API
+export { MultiChainCollector } from "./curve/internalContexts/MultiChainCollector";

--- a/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
+++ b/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
@@ -292,7 +292,11 @@ public announceChainsAsLineString3d(announceChain: (ls: LineString3d) => void): 
     }
   }
 }
-// static methods to assist offset sequences ....
+
+/**
+ * Static methods to assist offset sequences.
+ * @internal
+ */
 export class OffsetHelpers {
   // recursively sum lengths, allowing CurvePrimitive, CurveCollection, or array of such at any level.
   public static sumLengths(data: any): number {
@@ -400,7 +404,7 @@ export class OffsetHelpers {
     }
     return false;
   }
-  // Try to move move head (end) of g0 and tail (beginning) of g1 together.
+  // Try to move move tail (end) of g0 and/or head (beginning) of g1 to a common point.
   public static moveHeadOrTail(g0: CurvePrimitive, g1: CurvePrimitive, maxShift: number): boolean {
     const xyz0 = g0.endPoint();
     const xyz1 = g1.startPoint();


### PR DESCRIPTION
So as to not hold up iTwin Studio project.

When new API exposing this class's functionality is created for #5505, this temporary export will be reverted.