### PR TITLE
Presentation: Diagnostic errors logged when using ContentModifier without a class attribute

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-fix-diagnostic-errors_2023-06-19-11-09.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix-diagnostic-errors_2023-06-19-11-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Update supplemental rules to not use unnecessary `class` attribute in content modifier. Update docs. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/docs/presentation/content/ContentModifier.md
+++ b/docs/presentation/content/ContentModifier.md
@@ -21,7 +21,8 @@ Content modifiers are used to modify how instances of specified ECClasses are di
 
 ### Attribute: `class`
 
-Specification of ECClass whose content should be modified. The modifier is applied to all content if this attribute is not specified.
+Specification of ECClass whose content should be modified. The modifier applies [property overrides](./PropertySpecification.md) and [property categories](./PropertyCategorySpecification.md) to all content if this attribute is not specified. This attribute must be specified in order to apply [related](./RelatedPropertiesSpecification.md) or [calculated](./CalculatedPropertiesSpecification.md) properties to the content.
+
 
 |                   |                                                                          |
 | ----------------- | ------------------------------------------------------------------------ |

--- a/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
+++ b/presentation/backend/assets/supplemental-presentation-rules/BisCore.PresentationRuleSet.json
@@ -267,10 +267,6 @@
     },
     {
       "ruleType": "ContentModifier",
-      "class": {
-        "schemaName": "BisCore",
-        "className": "Element"
-      },
       "propertyCategories": [
         {
           "id": "source_information",


### PR DESCRIPTION
Closes: https://github.com/iTwin/imodel-native/issues/318
imodel-native: https://github.com/iTwin/imodel-native/tree/presentation/fix-diagnostic-errors