### PR TITLE
Bugfix/window area with aspect ratio skew

### DIFF
--- a/common/changes/@itwin/core-frontend/bugfix-window-area-with-aspectRatioSkew_2023-06-23-01-41.json
+++ b/common/changes/@itwin/core-frontend/bugfix-window-area-with-aspectRatioSkew_2023-06-23-01-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Take into account the aspectRatioSkew of the view inside the window area tool.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -3559,7 +3559,8 @@ export class WindowAreaTool extends ViewTool {
     if (currentDelta.x === 0 || delta.x === 0)
       return undefined;
 
-    const viewAspect = currentDelta.y / currentDelta.x;
+    const skew = vp.view.getAspectRatioSkew();
+    const viewAspect = skew * currentDelta.y / currentDelta.x;
     const aspectRatio = Math.abs(delta.y / delta.x);
 
     let halfDeltaX;


### PR DESCRIPTION
This fixes an issue with the window area tool that previously ignored the aspectRatioSkew.

Please refer to the 'before' and 'after' videos that show the behavior with aspectRatioSkew = 1 and aspectRatioSkew = 5.

https://github.com/iTwin/itwinjs-core/assets/3418768/658c7810-5da1-42e5-b377-f1ffd543260e


https://github.com/iTwin/itwinjs-core/assets/3418768/5242e2ad-45ee-4173-a39c-6b0014c4b87b

