### PR TITLE
Fix assertion for glTF containing a normal map.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-gltf-assert_2023-06-29-00-02.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-gltf-assert_2023-06-29-00-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix assertion when reading glTF containing a normal map.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -865,12 +865,16 @@ export abstract class GltfReader {
     const isTransparent = this.isMaterialTransparent(material);
     const textureId = this.extractTextureId(material);
     const normalMapId = this.extractNormalMapId(material);
-    const textureMapping = (undefined !== textureId || undefined !== normalMapId) ? this.findTextureMapping(textureId, isTransparent, normalMapId) : undefined;
+    let textureMapping = (undefined !== textureId || undefined !== normalMapId) ? this.findTextureMapping(textureId, isTransparent, normalMapId) : undefined;
     const color = colorFromMaterial(material, isTransparent);
     let renderMaterial: RenderMaterial | undefined;
     if (undefined !== textureMapping && undefined !== textureMapping.normalMapParams) {
       const args: CreateRenderMaterialArgs = { diffuse: { color }, specular: { color: ColorDef.white }, textureMapping };
       renderMaterial = IModelApp.renderSystem.createRenderMaterial(args);
+
+      // DisplayParams doesn't want a separate texture mapping if the material already has one.
+      textureMapping = undefined;
+
     }
     return new DisplayParams(DisplayParams.Type.Mesh, color, color, 1, LinePixels.Solid, FillFlags.Always, renderMaterial, undefined, hasBakedLighting, textureMapping);
   }


### PR DESCRIPTION
Introduced in #4679. Reported by @Ellord207.
`DisplayParams` will assert if the material has a texture mapping and a separate texture mapping is also displayed.
With assertions disabled, the glTF would display just fine regardless. Now it doesn't assert.