### PR TITLE
Shift telemetry APIs to internal

### DIFF
--- a/common/changes/@itwin/core-backend/telemetry-manager_2023-07-09-16-49.json
+++ b/common/changes/@itwin/core-backend/telemetry-manager_2023-07-09-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-telemetry/telemetry-manager_2023-07-09-16-49.json
+++ b/common/changes/@itwin/core-telemetry/telemetry-manager_2023-07-09-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-telemetry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-telemetry"
+}

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -14,9 +14,8 @@ import {
 } from "@itwin/core-bentley";
 import {
   BriefcaseId, BriefcaseIdValue, BriefcaseProps, ChangesetFileProps, ChangesetIndex, ChangesetIndexOrId, ChangesetProps, ChangesetRange, ChangesetType, IModelError, IModelVersion, LocalBriefcaseProps,
-  LocalDirName, LocalFileName, RequestNewBriefcaseProps, RpcActivity,
+  LocalDirName, LocalFileName, RequestNewBriefcaseProps,
 } from "@itwin/core-common";
-import { TelemetryEvent } from "@itwin/core-telemetry";
 import { AcquireNewBriefcaseIdArg, IModelNameArg } from "./BackendHubAccess";
 import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { CheckpointManager, CheckpointProps, ProgressFunction } from "./CheckpointManager";
@@ -511,24 +510,4 @@ export class BriefcaseManager {
     }
   }
 
-  /** @internal */
-  public static logUsage(imodel: IModelDb, activity?: RpcActivity) { // eslint-disable-line deprecation/deprecation
-
-    const telemetryEvent = new TelemetryEvent(
-      "core-backend - Open iModel",
-      "7a6424d1-2114-4e89-b13b-43670a38ccd4", // Feature: "iModel Use"
-      imodel.iTwinId,
-      imodel.iModelId,
-      imodel.changeset?.id,
-    );
-    activity = activity ?? {
-      activityId: "",
-      applicationId: IModelHost.applicationId,
-      applicationVersion: IModelHost.applicationVersion,
-      sessionId: IModelHost.sessionId,
-      accessToken: "", // IModelHost.getAccessToken(); ACCESS_TOKEN_NEEDS_WORK
-    };
-
-    IModelHost.telemetry.postTelemetry(activity, telemetryEvent); // eslint-disable-line @typescript-eslint/no-floating-promises
-  }
 }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2508,7 +2508,6 @@ export class BriefcaseDb extends IModelDb {
       }
     }
 
-    BriefcaseManager.logUsage(briefcaseDb);
     this.onOpened.raiseEvent(briefcaseDb, args);
     return briefcaseDb;
   }

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -15,7 +15,6 @@ import { IModelJsNative, NativeLibrary } from "@bentley/imodeljs-native";
 import { DependenciesConfig, Types as ExtensionTypes } from "@itwin/cloud-agnostic-core";
 import { AccessToken, assert, BeEvent, DbResult, Guid, GuidString, IModelStatus, Logger, Mutable, ProcessDetector } from "@itwin/core-bentley";
 import { AuthorizationClient, BentleyStatus, IModelError, LocalDirName, SessionProps } from "@itwin/core-common";
-import { TelemetryManager } from "@itwin/core-telemetry";
 import { AzureServerStorageBindings } from "@itwin/object-storage-azure";
 import { ServerStorage } from "@itwin/object-storage-core";
 import { BackendHubAccess } from "./BackendHubAccess";
@@ -264,9 +263,6 @@ export class IModelHost {
 
   /** The AuthorizationClient used to obtain [AccessToken]($bentley)s. */
   public static authorizationClient?: AuthorizationClient;
-
-  /** @alpha */
-  public static readonly telemetry = new TelemetryManager();
 
   public static backendVersion = "";
   private static _profileName: string;

--- a/core/backend/src/rpc-impl/RpcBriefcaseUtility.ts
+++ b/core/backend/src/rpc-impl/RpcBriefcaseUtility.ts
@@ -156,7 +156,6 @@ export class RpcBriefcaseUtility {
     db = SnapshotDb.tryFindByKey(CheckpointManager.getKey(checkpoint));
     if (db) {
       Logger.logTrace(loggerCategory, "Checkpoint was already open", () => ({ ...tokenProps }));
-      BriefcaseManager.logUsage(db);
       return db;
     }
 
@@ -182,7 +181,6 @@ export class RpcBriefcaseUtility {
       Logger.logTrace(loggerCategory, "Opened V1 checkpoint", () => ({ ...tokenProps }));
     }
 
-    BriefcaseManager.logUsage(db, activity);
     return db;
   }
 

--- a/core/telemetry/src/TelemetryClient.ts
+++ b/core/telemetry/src/TelemetryClient.ts
@@ -11,9 +11,8 @@ import { BentleyError, GuidString, Logger } from "@itwin/core-bentley";
 import { RpcActivity } from "@itwin/core-common";
 import { TelemetryClientLoggerCategory } from "./TelemetryClientLoggerCategory";
 
-/**
- * @alpha
- * Represents a particular occurrence of an event that can be tracked through various telemetry services
+/** Represents a particular occurrence of an event that can be tracked through various telemetry services
+ * @internal
  */
 export class TelemetryEvent {
   public constructor(
@@ -55,12 +54,12 @@ export class TelemetryEvent {
   }
 }
 
-/** @alpha */
+/** @internal */
 export interface TelemetryClient {
   postTelemetry(requestContext: RpcActivity, telemetryEvent: TelemetryEvent): Promise<void>; // eslint-disable-line deprecation/deprecation
 }
 
-/** @alpha */
+/** @internal */
 export class TelemetryManager {
   protected readonly _clients: Set<TelemetryClient>;
 

--- a/core/telemetry/src/TelemetryClientLoggerCategory.ts
+++ b/core/telemetry/src/TelemetryClientLoggerCategory.ts
@@ -9,7 +9,7 @@
 /** Logger categories used by this package
  * @note All logger categories in this package start with the `telemetry-client` prefix.
  * @see [Logger]($bentley)
- * @alpha
+ * @internal
  */
 export enum TelemetryClientLoggerCategory {
   /** The logger category used for Telemetry */


### PR DESCRIPTION
The telemetry APIs in the `@itwin/core-telemetry` package were marked as `alpha` during the 3.0 release as the usage was sparse and inconsistent. At the time we were undecided on how to expose this API moving forward and marked the use in `IModelHost` and `IModelApp` as internal to discourage usage until we decided what to do.

The usage still existing today is used as feature tracking, specifically a few AppUI features and when an iModel was opened. However, feature tracking is more of an application level responsibility rather than something the library should do explicitly. Instead of having a set of APIs dedicated to it in the core libraries, the libraries focus on raising the appropriate events to enable applications to easily hook up their own feature tracking.

Given the above stance to stop supporting a telemetry API, we should remove the APIs completely since they are only `internal` and `alpha`. Unfortunately, the reliance of AppUI on them as of the 4.0 release would cause a cascading set of breaking changes that would require consumers to react.

Alternatively, we will mark all of the APIs as `internal` for the duration of 4.0 and remove the API entirely in the 5.0 release.

TODO:
- [ ] Create an Issue to track the appropriate removal in 5.0



