### PR TITLE
Retry concurrent query if timeout occurs

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2463,6 +2463,8 @@ export class ECSqlReader implements AsyncIterableIterator<QueryRowProxy> {
     // (undocumented)
     reset(options?: QueryOptions): void;
     resetBindings(): void;
+    // @internal (undocumented)
+    protected runWithRetry(request: DbQueryRequest): Promise<DbQueryResponse>;
     // (undocumented)
     setParams(param: QueryBinder): void;
     get stats(): QueryStats;

--- a/common/changes/@itwin/core-backend/concurrent-query-retry_2023-07-11-07-14.json
+++ b/common/changes/@itwin/core-backend/concurrent-query-retry_2023-07-11-07-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added unit test to check if retry was triggered when concurrent query faces a timeout",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/concurrent-query-retry_2023-07-11-07-14.json
+++ b/common/changes/@itwin/core-common/concurrent-query-retry_2023-07-11-07-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Added check to trigger retry if concurrent query faces a timeout",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/ECSqlReader.ts
+++ b/core/common/src/ECSqlReader.ts
@@ -366,13 +366,13 @@ export class ECSqlReader implements AsyncIterableIterator<QueryRowProxy> {
   /**
    *
    */
-  private async runWithRetry(request: DbQueryRequest) {
-    const needRetry = (rs: DbQueryResponse) => (rs.status === DbResponseStatus.Partial || rs.status === DbResponseStatus.QueueFull || rs.status === DbResponseStatus.Timeout) && (rs.data.length === 0);
+  protected async runWithRetry(request: DbQueryRequest) {
+    const needRetry = (rs: DbQueryResponse) => (rs.status === DbResponseStatus.Partial || rs.status === DbResponseStatus.QueueFull || rs.status === DbResponseStatus.Timeout) && (typeof(rs.data) === "undefined" || rs.data.length === 0);
     const updateStats = (rs: DbQueryResponse) => {
       this._stats.backendCpuTime += rs.stats.cpuTime;
       this._stats.backendTotalTime += rs.stats.totalTime;
       this._stats.backendMemUsed += rs.stats.memUsed;
-      this._stats.backendRowsReturned += rs.data.length;
+      this._stats.backendRowsReturned += (typeof(rs.data) === "undefined") ? 0 : rs.data.length;
     };
     const execQuery = async (req: DbQueryRequest) => {
       const startTime = Date.now();

--- a/core/common/src/ECSqlReader.ts
+++ b/core/common/src/ECSqlReader.ts
@@ -367,12 +367,12 @@ export class ECSqlReader implements AsyncIterableIterator<QueryRowProxy> {
    * @internal
    */
   protected async runWithRetry(request: DbQueryRequest) {
-    const needRetry = (rs: DbQueryResponse) => (rs.status === DbResponseStatus.Partial || rs.status === DbResponseStatus.QueueFull || rs.status === DbResponseStatus.Timeout) && (typeof(rs.data) === "undefined" || rs.data.length === 0);
+    const needRetry = (rs: DbQueryResponse) => (rs.status === DbResponseStatus.Partial || rs.status === DbResponseStatus.QueueFull || rs.status === DbResponseStatus.Timeout) && (rs.data === undefined || rs.data.length === 0);
     const updateStats = (rs: DbQueryResponse) => {
       this._stats.backendCpuTime += rs.stats.cpuTime;
       this._stats.backendTotalTime += rs.stats.totalTime;
       this._stats.backendMemUsed += rs.stats.memUsed;
-      this._stats.backendRowsReturned += (typeof(rs.data) === "undefined") ? 0 : rs.data.length;
+      this._stats.backendRowsReturned += (rs.data === undefined) ? 0 : rs.data.length;
     };
     const execQuery = async (req: DbQueryRequest) => {
       const startTime = Date.now();

--- a/core/common/src/ECSqlReader.ts
+++ b/core/common/src/ECSqlReader.ts
@@ -364,7 +364,7 @@ export class ECSqlReader implements AsyncIterableIterator<QueryRowProxy> {
   }
 
   /**
-   *
+   * @internal
    */
   protected async runWithRetry(request: DbQueryRequest) {
     const needRetry = (rs: DbQueryResponse) => (rs.status === DbResponseStatus.Partial || rs.status === DbResponseStatus.QueueFull || rs.status === DbResponseStatus.Timeout) && (typeof(rs.data) === "undefined" || rs.data.length === 0);


### PR DESCRIPTION
If a timeout occurs during the execution of a concurrent query, the data returned in the response remains undefined.
The current code wasn't validating this and was trying to read the length of the data array returned, which ended up causing a typerror "Cannot read properties of undefined".
I've added a check to continue with the retries if the timeout scenario occurs.