### PR TITLE
With DEBUG_LEAKS on: Print the initialize callstack of active async resources which may be preventing node from shutting down 

### DIFF
--- a/common/changes/@itwin/build-tools/nick-build-tools-change_2023-07-11-19-43.json
+++ b/common/changes/@itwin/build-tools/nick-build-tools-change_2023-07-11-19-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/common/changes/@itwin/build-tools/nick-build-tools-change_2023-07-11-19-45.json
+++ b/common/changes/@itwin/build-tools/nick-build-tools-change_2023-07-11-19-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "with DEBUG_LEAKS on: print the initialize callstack of active async resources which may be preventing node from shutting down",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/common/changes/@itwin/core-frontend/nick-build-tools-change_2023-07-11-19-43.json
+++ b/common/changes/@itwin/core-frontend/nick-build-tools-change_2023-07-11-19-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
@@ -113,7 +113,7 @@ export abstract class ArcGISImageryProvider extends MapLayerImageryProvider {
       response = await  fetch(tmpUrl.toString(), options);
     }
 
-    errorCode = await ArcGisUtilities.checkForResponseErrorCode(response.clone());
+    errorCode = await ArcGisUtilities.checkForResponseErrorCode(response);
 
     if (errorCode !== undefined &&
        (errorCode === ArcGisErrorCode.TokenRequired || errorCode === ArcGisErrorCode.InvalidToken) ) {
@@ -135,7 +135,7 @@ export abstract class ArcGISImageryProvider extends MapLayerImageryProvider {
 
         // Make a second attempt with refreshed token
         response = await fetch(urlObj2.toString(), options);
-        errorCode  = await ArcGisUtilities.checkForResponseErrorCode(response.clone());
+        errorCode  = await ArcGisUtilities.checkForResponseErrorCode(response);
       }
 
       if (errorCode === ArcGisErrorCode.TokenRequired || errorCode === ArcGisErrorCode.InvalidToken) {

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -19,23 +19,7 @@ function setupAsyncHooks() {
   const init = (asyncId: number, type: string, triggerAsyncId: number, _resource: any) => {
     const eid = async_hooks.executionAsyncId(); // (An executionAsyncId() of 0 means that it is being executed from C++ with no JavaScript stack above it.)
     const stack = new Error().stack;
-    asyncResourceStats.set(asyncId, {before: 0, after: 0, type, eid, triggerAsyncId, initStack: stack});
-  };
-  const before = (asyncId: number) => {
-    if (asyncResourceStats.get(asyncId) === undefined) {
-      return;
-    }
-    const entry = asyncResourceStats.get(asyncId);
-    entry.before = entry.before + 1;
-    asyncResourceStats.set(asyncId, entry);
-  };
-  const after = (asyncId: number) => {
-    if (asyncResourceStats.get(asyncId) === undefined) {
-      return;
-    }
-    const entry = asyncResourceStats.get(asyncId);
-    entry.after = entry.after + 1;
-    asyncResourceStats.set(asyncId, entry);
+    asyncResourceStats.set(asyncId, {type, eid, triggerAsyncId, initStack: stack});
   };
   const destroy = (asyncId: number) => {
     if (asyncResourceStats.get(asyncId) === undefined) {
@@ -44,7 +28,7 @@ function setupAsyncHooks() {
     asyncResourceStats.delete(asyncId);
   };
 
-  const asyncHook = async_hooks.createHook({init, before, after, destroy});
+  const asyncHook = async_hooks.createHook({init, destroy});
   asyncHook.enable();
 }
 const fs = require("fs-extra");
@@ -121,7 +105,7 @@ class BentleyMochaReporter extends Spec {
           // asyncResourceStats.set(asyncId, {before: 0, after: 0, type, eid, triggerAsyncId, initStack: stack});
           asyncResourceStats.forEach((value, key) => {
             if (activeResourcesInfo.includes(value.type.toLowerCase())) {
-              console.error(`asyncId: ${key}: before: ${value.before}, after: ${value.after}, type: ${value.type}, eid: ${value.eid},triggerAsyncId: ${value.triggerAsyncId}, initStack: ${value.initStack}`);
+              console.error(`asyncId: ${key}: type: ${value.type}, eid: ${value.eid},triggerAsyncId: ${value.triggerAsyncId}, initStack: ${value.initStack}`);
             }
           });
         } else {

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -32,7 +32,7 @@ function setupAsyncHooks() {
   asyncHook.enable();
 }
 const fs = require("fs-extra");
-import * as path from "path";
+const path = require("path");
 const { logBuildWarning, logBuildError, failBuild } = require("../scripts/utils/utils");
 
 const Base = require("mocha/lib/reporters/base");


### PR DESCRIPTION
Also removes unnecessary double clone from map-layers-format extension.
