### PR TITLE
Fix classification for glTF point clouds.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -14079,6 +14079,8 @@ export enum TileBoundingBoxes {
 
 // @public
 export interface TileContent {
+    // @internal
+    containsPointCloud?: boolean;
     contentRange?: ElementAlignedBox3d;
     graphic?: RenderGraphic;
     isLeaf?: boolean;

--- a/common/changes/@itwin/core-frontend/master_2023-07-14-17-42.json
+++ b/common/changes/@itwin/core-frontend/master_2023-07-14-17-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -416,6 +416,7 @@ export abstract class GltfReader {
   protected _computedContentRange?: ElementAlignedBox3d;
   private readonly _resolvedTextures = new Dictionary<TextureKey, RenderTexture | false>((lhs, rhs) => compareTextureKeys(lhs, rhs));
   private readonly _dracoMeshes = new Map<DracoMeshCompression, DracoMesh>();
+  private _containsPointCloud = false;
 
   protected get _nodes(): GltfDictionary<GltfNode> { return this._glTF.nodes ?? emptyDict; }
   protected get _meshes(): GltfDictionary<GltfMesh> { return this._glTF.meshes ?? emptyDict; }
@@ -524,6 +525,7 @@ export abstract class GltfReader {
       contentRange,
       range,
       graphic: renderGraphic,
+      containsPointCloud: this._containsPointCloud,
     };
   }
 
@@ -1102,6 +1104,7 @@ export abstract class GltfReader {
     if (hasFeatures)
       features.type = FeatureIndexType.Uniform;
 
+    this._containsPointCloud = true;
     return {
       type: "pointcloud",
       positions: posData.buffer,

--- a/core/frontend/src/tile/RealityTileLoader.ts
+++ b/core/frontend/src/tile/RealityTileLoader.ts
@@ -131,6 +131,13 @@ export abstract class RealityTileLoader {
         return { graphic };
       case TileFormat.B3dm:
         reader = B3dmReader.create(streamBuffer, iModel, modelId, is3d, tile.contentRange, system, yAxisUp, tile.isLeaf, tile.center, tile.transformToRoot, isCanceled, this.getBatchIdMap(), this.wantDeduplicatedVertices);
+        if (reader) {
+          // glTF spec defaults wrap mode to "repeat" but many reality tiles omit the wrap mode and should not repeat.
+          // The render system also currently only produces mip-maps for repeating textures, and we don't want mip-maps for reality tile textures.
+          assert(reader instanceof GltfReader);
+          reader.defaultWrapMode = GltfWrapMode.ClampToEdge;
+        }
+
         break;
       case TileFormat.I3dm:
         reader = I3dmReader.create(streamBuffer, iModel, modelId, is3d, tile.contentRange, system, yAxisUp, tile.isLeaf, isCanceled, undefined, this.wantDeduplicatedVertices);
@@ -174,12 +181,10 @@ export abstract class RealityTileLoader {
 
     let content: TileContent = {};
     if (undefined !== reader) {
-      // glTF spec defaults wrap mode to "repeat" but many reality tiles omit the wrap mode and should not repeat.
-      // The render system also currently only produces mip-maps for repeating textures, and we don't want mip-maps for reality tile textures.
-      if (reader instanceof GltfReader)
-        reader.defaultWrapMode = GltfWrapMode.ClampToEdge;
       try {
         content = await reader.read();
+        if (content.containsPointCloud)
+          this._containsPointClouds = true;
       } catch (_err) {
         // Failure to load should prevent us from trying to load children
         content.isLeaf = true;

--- a/core/frontend/src/tile/TileContent.ts
+++ b/core/frontend/src/tile/TileContent.ts
@@ -22,4 +22,10 @@ export interface TileContent {
   contentRange?: ElementAlignedBox3d;
   /** True if this tile requires no subdivision or refinement - i.e., has no child tiles. */
   isLeaf?: boolean;
+  /** Whether the content includes one or more point clouds.
+   * Generally, if this is true, it contains exactly one point cloud and no other geometry.
+   * We need to know this for the classification shaders.
+   * @internal
+   */
+  containsPointCloud?: boolean;
 }


### PR DESCRIPTION
#5737 overlooked the need to set `RealityTileLoader.containsPointClouds`, so that we will select the correct classification shaders.
Incidentally, move special case for b3dm reality tiles that don't conform to 3D tiles spec for default wrap mode to only apply to b3dm tilesets.