### PR TITLE
Allow pickable CanvasDecoration to forward motion event to active tool.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2041,6 +2041,7 @@ export interface CanvasDecoration {
     onWheel?(ev: BeWheelEvent): boolean;
     pick?(pt: XAndY): boolean;
     position?: XAndY;
+    propagateMouseMove?(ev: BeButtonEvent): boolean;
 }
 
 // @public

--- a/common/changes/@itwin/core-frontend/deco-propagate-mouse-motion_2023-07-18-14-42.json
+++ b/common/changes/@itwin/core-frontend/deco-propagate-mouse-motion_2023-07-18-14-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/CanvasDecoration.ts
+++ b/core/frontend/src/render/CanvasDecoration.ts
@@ -37,10 +37,14 @@ export interface CanvasDecoration {
   pick?(pt: XAndY): boolean;
   /** Optional method to be called whenever this decorator is picked and the mouse first enters this decoration. */
   onMouseEnter?(ev: BeButtonEvent): void;
-  /** Optional method to be called whenever when the mouse leaves this decoration. */
+  /** Optional method to be called whenever the mouse leaves this decoration. */
   onMouseLeave?(): void;
-  /** Optional method to be called whenever when the mouse moves inside this decoration. */
+  /** Optional method to be called whenever the mouse moves inside this decoration. */
   onMouseMove?(ev: BeButtonEvent): void;
+  /** Optional method to be called whenever the mouse moves inside this decoration that determines whether the event is forwarded to the active tool.
+   * @return true if the event was *not* handled by this decoration and should be forwarded to the active tool.
+   */
+  propagateMouseMove?(ev: BeButtonEvent): boolean;
   /**
    * Optional method to be called whenever this decorator is picked and a mouse button is pressed or released inside this decoration.
    * @return true if the event was handled by this decoration and should *not* be forwarded to the active tool.

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -1055,7 +1055,8 @@ export class ToolAdmin {
       if (overlayHit.onMouseMove)
         overlayHit.onMouseMove(ev);
 
-      return; // we're inside a pickable decoration, don't send event to tool
+      if (undefined === overlayHit.propagateMouseMove || !overlayHit.propagateMouseMove(ev))
+        return; // we're inside a pickable decoration that doesn't want event sent to tool
     }
 
     this._mouseMoveOverTimeout = setTimeout(async () => {


### PR DESCRIPTION
Part of iTwin/itwinjs-backlog#782. See that issue's description for details.