### PR TITLE
Presentation: Update snapshot - filtered hierarchies don't support filtering on top

### DIFF
--- a/full-stack-tests/presentation/src/frontend/Hierarchies.test.snap
+++ b/full-stack-tests/presentation/src/frontend/Hierarchies.test.snap
@@ -191,7 +191,6 @@ Array [
             "rawValue": "filter ch1",
             "typeName": "string",
           },
-          "supportsFiltering": true,
         },
       },
       Object {
@@ -219,7 +218,6 @@ Array [
                 "rawValue": "filter ch4",
                 "typeName": "string",
               },
-              "supportsFiltering": true,
             },
           },
         ],
@@ -244,7 +242,6 @@ Array [
             "rawValue": "other ch3",
             "typeName": "string",
           },
-          "supportsFiltering": true,
         },
       },
     ],
@@ -268,7 +265,6 @@ Array [
         "rawValue": "filter r1",
         "typeName": "string",
       },
-      "supportsFiltering": true,
     },
   },
   Object {
@@ -295,7 +291,6 @@ Array [
             "rawValue": "filter ch6",
             "typeName": "string",
           },
-          "supportsFiltering": true,
         },
       },
     ],
@@ -319,7 +314,6 @@ Array [
         "rawValue": "other r3",
         "typeName": "string",
       },
-      "supportsFiltering": true,
     },
   },
 ]


### PR DESCRIPTION
imodel-native PR: https://github.com/iTwin/imodel-native/pull/365
imodel-native: https://github.com/iTwin/imodel-native/tree/presentation/hierarchy-filtering-perf-on-master