### PR TITLE
Fix Display Test App's production electron build

### DIFF
--- a/common/changes/@itwin/core-frontend/nam-dta-electron-fix_2023-07-26-19-35.json
+++ b/common/changes/@itwin/core-frontend/nam-dta-electron-fix_2023-07-26-19-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Use import instead of require",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/nam-dta-electron-fix_2023-07-26-19-35.json
+++ b/common/changes/@itwin/core-frontend/nam-dta-electron-fix_2023-07-26-19-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Use import instead of require",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2477,7 +2477,6 @@ importers:
     specifiers:
       '@bentley/icons-generic': ^1.0.34
       '@bentley/icons-generic-webfont': ^1.0.34
-      '@esbuild-plugins/node-modules-polyfill': ^0.2.2
       '@itwin/appui-abstract': workspace:*
       '@itwin/backend-webpack-tools': workspace:*
       '@itwin/browser-authorization': ^0.5.1
@@ -2575,7 +2574,6 @@ importers:
       body-parser: 1.20.2
       vhacd-js: 0.0.1
     devDependencies:
-      '@esbuild-plugins/node-modules-polyfill': 0.2.2
       '@itwin/backend-webpack-tools': link:../../tools/backend-webpack
       '@itwin/build-tools': link:../../tools/build
       '@itwin/core-webpack-tools': link:../../tools/webpack-core
@@ -5599,15 +5597,6 @@ packages:
       comment-parser: 1.3.1
       esquery: 1.5.0
       jsdoc-type-pratt-parser: 4.0.0
-
-  /@esbuild-plugins/node-modules-polyfill/0.2.2:
-    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
-    peerDependencies:
-      esbuild: '*'
-    dependencies:
-      escape-string-regexp: 4.0.0
-      rollup-plugin-node-polyfills: 0.2.1
-    dev: true
 
   /@esbuild/android-arm/0.18.15:
     resolution: {integrity: sha512-wlkQBWb79/jeEEoRmrxt/yhn5T1lU236OCNpnfRzaCJHZ/5gf82uYx1qmADTBWE0AR/v7FiozE1auk2riyQd3w==}
@@ -11255,10 +11244,6 @@ packages:
   /estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-
-  /estree-walker/0.6.1:
-    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
-    dev: true
 
   /estree-walker/1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
@@ -17045,21 +17030,6 @@ packages:
     resolution: {integrity: sha512-VsbnfwwaTv2Dxl2onubetX/3RnSnplNnjdix0hvF8y2YpqdzlZrjIq6zkcuVJ08XysS8zqW3gt3ORBndFDgsrg==}
     dev: true
 
-  /rollup-plugin-inject/3.0.2:
-    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
-    dependencies:
-      estree-walker: 0.6.1
-      magic-string: 0.25.9
-      rollup-pluginutils: 2.8.2
-    dev: true
-
-  /rollup-plugin-node-polyfills/0.2.1:
-    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
-    dependencies:
-      rollup-plugin-inject: 3.0.2
-    dev: true
-
   /rollup-plugin-terser/7.0.2_rollup@2.79.1:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
@@ -17094,12 +17064,6 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       rollup: ^3.0.0
-    dev: true
-
-  /rollup-pluginutils/2.8.2:
-    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
-    dependencies:
-      estree-walker: 0.6.1
     dev: true
 
   /rollup/2.79.1:

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -52,9 +52,7 @@ import * as viewTool from "./tools/ViewTool";
 import { UserPreferencesAccess } from "./UserPreferences";
 import { ViewManager } from "./ViewManager";
 import * as viewState from "./ViewState";
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require("./IModeljs-css");
+import "./IModeljs-css";
 
 // cSpell:ignore noopener noreferrer gprid forin nbsp csrf xsrf
 

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -75,7 +75,6 @@
     "vhacd-js": "^0.0.1"
   },
   "devDependencies": {
-    "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@itwin/backend-webpack-tools": "workspace:*",
     "@itwin/build-tools": "workspace:*",
     "@itwin/core-webpack-tools": "workspace:*",

--- a/test-apps/display-test-app/vite.config.ts
+++ b/test-apps/display-test-app/vite.config.ts
@@ -6,7 +6,6 @@ import { defineConfig, loadEnv, searchForWorkspaceRoot } from "vite";
 import envCompatible from "vite-plugin-env-compatible";
 import browserslistToEsbuild from "browserslist-to-esbuild";
 import viteInspect from "vite-plugin-inspect";
-import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import { externalGlobalPlugin } from "esbuild-plugin-external-global";
 import copy from "rollup-plugin-copy";
 import ignore from "rollup-plugin-ignore";
@@ -59,7 +58,9 @@ export default defineConfig(() => {
           /core\/electron/, // prevent error in ElectronApp
           /core\/mobile/, // prevent error in MobileApp
           /node_modules/, // prevent errors for modules
+          /core\/frontend/, // prevent errors with require in IModelApp
         ],
+        transformMixedEsModules: true // transforms require statements
       },
       rollupOptions: {
         input: "./index.html",
@@ -102,11 +103,12 @@ export default defineConfig(() => {
         prefix: "IMJS_",
       }),
     ],
+    define: {
+      "process.env" : process.env // injects process.env into the frontend
+    },
     optimizeDeps: {
       esbuildOptions: {
         plugins: [
-          // Node.js modules not available to bundler by default
-          NodeModulesPolyfillPlugin(),
           externalGlobalPlugin({
             // allow global `window` object to access electron as external global
             electron: "window['electron']",


### PR DESCRIPTION
When `npm run start:electron` is run by itself in `test-apps/display-test-app`, the frontend would raise errors in the console, stating `require is not defined`. This comes from Vite, by default, not properly transforming `require` statements used in CommonJS into `import` used by ES6.

`vite.config.js` was edited to explicitly transform files that use `require`, such as that found in `core-frontend`.

In addition, `process.env` is used in many places in DTA, but wasn't being picked up within vite's build process, raising a `process is not defined` at DTA's runtime. To address that, we inject `process.env`.
Steps to reproduce and test:
Run `rushx build`, then run `npm run start:electron`. If you get a localhost:3000 - CONNECTION REFUSED error, it means `NODE_ENV` was set to `development`. You can fix that by going into `package.json` and replace line 26 with
`"start:electron": "cross-env NODE_ENV=production electron ./lib/backend/DtaElectronMain.js"`.