### PR TITLE
Added support to enable experimental feature in concurrent queries

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -1842,6 +1842,8 @@ export interface DbQueryRequest extends DbRequest, QueryOptions {
     // (undocumented)
     args?: object;
     // (undocumented)
+    enableExperimentalFeatures?: boolean;
+    // (undocumented)
     query: string;
     // (undocumented)
     valueFormat?: DbValueFormat;
@@ -6963,6 +6965,7 @@ export interface QueryLimit {
 export interface QueryOptions extends BaseReaderOptions {
     abbreviateBlobs?: boolean;
     convertClassIdsToClassNames?: boolean;
+    experimentalFeatures?: boolean;
     includeMetaData?: boolean;
     limit?: QueryLimit;
     rowFormat?: QueryRowFormat;
@@ -6978,6 +6981,8 @@ export class QueryOptionsBuilder {
     setConvertClassIdsToNames(val: boolean): this;
     // @internal
     setDelay(val: number): this;
+    // @internal
+    setExperimentalFeatures(val: boolean): this;
     setLimit(val: QueryLimit): this;
     // @internal
     setPriority(val: number): this;

--- a/common/changes/@itwin/core-backend/enable-experimental-feature-concurrent-queries_2023-07-27-05-35.json
+++ b/common/changes/@itwin/core-backend/enable-experimental-feature-concurrent-queries_2023-07-27-05-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added support to enable experimental features on concurrent query and ecsqlreader",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/enable-experimental-feature-concurrent-queries_2023-07-27-05-35.json
+++ b/common/changes/@itwin/core-common/enable-experimental-feature-concurrent-queries_2023-07-27-05-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Added support to enable experimental features on concurrent query and ecsqlreader",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -131,7 +131,7 @@ export interface QueryOptions extends BaseReaderOptions {
   /**
    * Default to false. Enables experimental features to be used in the query
    */
-  experimentalFeatures?: boolean;
+  enableExperimentalFeatures?: boolean;
 }
 /** @beta */
 export type BlobRange = QueryLimit;
@@ -245,7 +245,7 @@ export class QueryOptionsBuilder {
    * @returns @type QueryOptionsBuilder for fluent interface.
    */
   public setExperimentalFeatures(val: boolean) {
-    this._options.experimentalFeatures = val;
+    this._options.enableExperimentalFeatures = val;
     return this;
   }
 }
@@ -686,7 +686,6 @@ export interface DbQueryRequest extends DbRequest, QueryOptions {
   valueFormat?: DbValueFormat;
   query: string;
   args?: object;
-  enableExperimentalFeatures?: boolean;
 }
 
 /** @internal */

--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -128,6 +128,10 @@ export interface QueryOptions extends BaseReaderOptions {
    * Determine row format.
    */
   rowFormat?: QueryRowFormat;
+  /**
+   * Default to false. Enables experimental features to be used in the query
+   */
+  experimentalFeatures?: boolean;
 }
 /** @beta */
 export type BlobRange = QueryLimit;
@@ -232,6 +236,16 @@ export class QueryOptionsBuilder {
    */
   public setDelay(val: number) {
     this._options.delay = val;
+    return this;
+  }
+  /**
+   * @internal
+   * Enables experimental features for the query. This parameter is treated as false by default.
+   * @param val A boolean value.
+   * @returns @type QueryOptionsBuilder for fluent interface.
+   */
+  public setExperimentalFeatures(val: boolean) {
+    this._options.experimentalFeatures = val;
     return this;
   }
 }
@@ -672,6 +686,7 @@ export interface DbQueryRequest extends DbRequest, QueryOptions {
   valueFormat?: DbValueFormat;
   query: string;
   args?: object;
+  enableExperimentalFeatures?: boolean;
 }
 
 /** @internal */

--- a/core/common/src/ECSqlReader.ts
+++ b/core/common/src/ECSqlReader.ts
@@ -349,7 +349,6 @@ export class ECSqlReader implements AsyncIterableIterator<QueryRowProxy> {
       valueFormat,
       query: this.query,
       args: this._param,
-      enableExperimentalFeatures: this._options?.experimentalFeatures,
     };
     request.includeMetaData = this._props.length > 0 ? false : true;
     request.limit = { offset: this._globalOffset, count: this._globalCount < 1 ? -1 : this._globalCount };

--- a/core/common/src/ECSqlReader.ts
+++ b/core/common/src/ECSqlReader.ts
@@ -349,6 +349,7 @@ export class ECSqlReader implements AsyncIterableIterator<QueryRowProxy> {
       valueFormat,
       query: this.query,
       args: this._param,
+      enableExperimentalFeatures: this._options?.experimentalFeatures,
     };
     request.includeMetaData = this._props.length > 0 ? false : true;
     request.limit = { offset: this._globalOffset, count: this._globalCount < 1 ? -1 : this._globalCount };


### PR DESCRIPTION
Added a new optional boolean parameter  "enableExperimentalFeatures" to QueryOptions and DbQueryRequest 
Setting this parameter to true from the QueryOptionsBuilder or adding this to the DBQueryRequest will enable experimental features to be used in the concurrent query.
Defaults to false if not specified.

imodel-native: https://github.com/iTwin/imodel-native/tree/enable-experimental-features-concurrent-queries