### PR TITLE
Handle trailing bytes after binary glTF chunk

### DIFF
--- a/common/changes/@itwin/core-common/bp-3.7.x-1b51f57c785c76dbb77068af253dc9295659af4f_2023-07-27-18-38.json
+++ b/common/changes/@itwin/core-common/bp-3.7.x-1b51f57c785c76dbb77068af253dc9295659af4f_2023-07-27-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix a failure to read some glTF data with extra padding bytes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/bp-3.7.x-1b51f57c785c76dbb77068af253dc9295659af4f_2023-07-27-18-38.json
+++ b/common/changes/@itwin/core-frontend/bp-3.7.x-1b51f57c785c76dbb77068af253dc9295659af4f_2023-07-27-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix a failure to read some glTF data with extra padding bytes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/common/src/tile/GltfTileIO.ts
+++ b/core/common/src/tile/GltfTileIO.ts
@@ -47,7 +47,11 @@ function consumeNextChunk(stream: ByteStream): TypedGltfChunk | undefined | fals
     return undefined;
 
   const offset = stream.curPos + 8;
+
   const length = stream.readUint32();
+  if (stream.isAtTheEnd)
+    return undefined;
+
   const type = stream.readUint32();
   stream.advance(length);
   return stream.isPastTheEnd ? false : { offset, length, type };

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -750,6 +750,9 @@ export abstract class GltfReader {
       }
       let componentCount = 1;
       switch (accessor.type) {
+        case "VEC4":
+          componentCount = 4;
+          break;
         case "VEC3":
           componentCount = 3;
           break;


### PR DESCRIPTION
Backport https://github.com/iTwin/itwinjs-core/pull/5737/commits/1b51f57c785c76dbb77068af253dc9295659af4f for reality data viewer.