### PR TITLE
Mobile fixes for display-test-app

### DIFF
--- a/common/changes/@itwin/core-mobile/dta-mobile-fixes_2023-07-28-22-25.json
+++ b/common/changes/@itwin/core-mobile/dta-mobile-fixes_2023-07-28-22-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "Mobile fixes for display-test-app",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -11,6 +11,7 @@ import { ProgressCallback } from "./Request";
 import { mobileAppStrings } from "../common/MobileAppChannel";
 import { BatteryState, DeviceEvents, MobileAppFunctions, MobileNotifications, Orientation } from "../common/MobileAppProps";
 import { MobileRpcManager } from "../common/MobileRpcManager";
+import { MobileRpcProtocol } from "../common/MobileRpcProtocol";
 import { MobileAuthorizationBackend } from "./MobileAuthorizationBackend";
 import { setupMobileRpc } from "./MobileRpcServer";
 
@@ -177,7 +178,11 @@ export class MobileHost {
         MobileHost.notifyMobileFrontend("notifyMemoryWarning");
       });
       this.onOrientationChanged.addListener(() => {
-        MobileHost.notifyMobileFrontend("notifyOrientationChanged");
+        // If there is no connection to the frontend, MobileHost.notifyMobileFrontend will just
+        // crash the app. So only notify if there is a connection to the frontend.
+        if (MobileRpcProtocol.obtainInterop().connectionId !== 0) {
+          MobileHost.notifyMobileFrontend("notifyOrientationChanged");
+        }
       });
       this.onWillTerminate.addListener(() => {
         MobileHost.notifyMobileFrontend("notifyWillTerminate");

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -81,7 +81,7 @@ Debugging display-test-app can be accomplished using the following procedures to
 In addition, the configuration allows setting breakpoints in any dependent package that lives within this monorepo (i.e. core-frontend or core-backend).
 
 1. Make sure the backend is built `npm run build:backend`
-1. Run `npm run start:webserver`
+1. Run `npm run start:webserver` (`npm run start:mobile` for Android and iOS)
     * Launches the vite dev server, providing hot-module reloading of the frontend
 1. Launch the VSCode "display-test-app (electron)" or "display-test-app (chrome)" depending on which app type
 
@@ -90,7 +90,7 @@ A more advanced debug experience will give you more quick turn around time for b
 1. Initialize the backend build using `npm run build:backend -- --watch` in one terminal
     * The `--watch` command allows the Typescript compiler watch all of the source files and any time they change will automatically re-run the compilation
     * One caveat is you will have to restart the debugger (#3) each time you make a change. Note this is different from the frontend experience that live reloads the browser with the updated code, the backend doesn't support that currently.
-1. Run `npm run start:webserver` in a separate terminal
+1. Run `npm run start:webserver` in a separate terminal (`nmp run start:mobile` for Android and iOS)
     * Note: if the webserver and backend are run in the same terminal it will be hard to parse the output and attribute it to each one. This is why we recommend two different terminals instead of a single script to handle both.
 1. Launch the VSCode "display-test-app (electron)" or "display-test-app (chrome)" depending on which app type
 
@@ -210,7 +210,7 @@ You can use these environment variables to alter the default behavior of various
 * IMJS_IGNORE_CACHE
   * If defined, causes a locally cached copy of a a remote iModel to be deleted, forcing the iModel to always be downloaded.
 * IMJS_DEBUG_URL
-  * If defined on iOS, the URL used to open the frontend. (This is used in conjunction with `npm run start:webserver` and is the URL to the debug web server running on the developer's computer.)
+  * If defined on mobile, the URL used to open the frontend. (This is used in conjunction with `npm run start:mobile` and is the URL to the debug web server running on the developer's computer.)
 * IMJS_EXIT_AFTER_MODEL_OPENED
   * If defined on iOS, the app will exit after successfully opening an iModel. This is used for automated testing with the iOS Simulator.
 * IMJS_NO_ELECTRON_AUTH

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.bentley.imodeljs_test_app"
-        minSdk 24
+        minSdk 28
         targetSdk 32
         versionCode 1
         versionName "1.0"

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/copyAssets.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/copyAssets.gradle
@@ -23,11 +23,8 @@ task copyAssets {
         def assetsDir = "${rootDir}/app/src/main/assets"
 
         Map itemsToCopy = [
-            "${dtaDir}/lib/mobile/main.js": "${assetsDir}/backend",
-            "${dtaDir}/lib/mobile/assets": "${assetsDir}/backend/Assets",
-            "${dtaDir}/build": "${assetsDir}/frontend",
-            "${assetsDir}/frontend/locales/en": "${assetsDir}/frontend/locales/en-US",
-            "${dtaDir}/lib/mobile/env.json": "${assetsDir}"
+            "${dtaDir}/lib": "${assetsDir}/www",
+            "${assetsDir}/www/locales/en": "${assetsDir}/www/locales/en-US"
         ]
 
         for (def entry in itemsToCopy) {

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/src/main/java/com/bentley/imodeljs_test_app/MainActivity.kt
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/src/main/java/com/bentley/imodeljs_test_app/MainActivity.kt
@@ -132,8 +132,11 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         WebView.setWebContentsDebuggingEnabled(true)
         val alwaysExtractAssets = true // for debugging, otherwise the host will only extract when app version changes
-        host = IModelJsHost(this, alwaysExtractAssets, true)
-        host.startup()
+        host = IModelJsHost(this, alwaysExtractAssets, true).apply {
+            setBackendPath("www/mobile")
+            setHomePath("www/home")
+            startup()
+        }
 
         val webView = WebView(this)
         // using a WebViewAssetLoader so that the localization json files load properly
@@ -188,12 +191,12 @@ class MainActivity : AppCompatActivity() {
         if (env.has("IMJS_IGNORE_CACHE"))
             args += "&ignoreCache=true"
 
-        host.loadEntryPoint(env.optStringNotEmpty("IMJS_DEBUG_URL") ?: "https://${WebViewAssetLoader.DEFAULT_DOMAIN}/assets/frontend/index.html", args)
+        host.loadEntryPoint(env.optStringNotEmpty("IMJS_DEBUG_URL") ?: "https://${WebViewAssetLoader.DEFAULT_DOMAIN}/assets/www/index.html", args)
     }
 
     private fun loadEnvJson() {
         env = try {
-            JSONObject(assets.open("env.json").bufferedReader().use { it.readText() })
+            JSONObject(assets.open("www/mobile/env.json").bufferedReader().use { it.readText() })
         } catch (ex: Exception) {
             JSONObject()
         }

--- a/test-apps/display-test-app/android/imodeljs-test-app/gradle.properties
+++ b/test-apps/display-test-app/android/imodeljs-test-app/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "AppBundleRoot=\"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME\"\n\n# Remove existing assets\nrm -rf $AppBundleRoot/Assets\nmkdir $AppBundleRoot/Assets\n\n# Copy Frontend and Backend assets\nAssetRoot=\"$PROJECT_DIR/../..\"\ncp -L -R $AssetRoot/build/ $AppBundleRoot/Assets/www/\ncp -L -R $AssetRoot/lib/mobile/ $AppBundleRoot/Assets/\n";
+			shellScript = "AppBundleRoot=\"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME\"\n\n# Remove existing assets\nrm -rf $AppBundleRoot/Assets\nmkdir $AppBundleRoot/Assets\n\n# Copy Frontend and Backend assets\nAssetRoot=\"$PROJECT_DIR/../..\"\ncp -L -R $AssetRoot/lib/ $AppBundleRoot/Assets/www/\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app/ViewController.swift
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app/ViewController.swift
@@ -135,8 +135,8 @@ class ViewController: UIViewController, WKUIDelegate, UIDocumentPickerDelegate {
     }
     
     func setupBackend() {
-        let url = URL(fileURLWithPath: Bundle.main.bundlePath.appending("/Assets/main.js"))
-        if let envUrl = Bundle.main.url(forResource: "env", withExtension: "json", subdirectory: "Assets"),
+        let url = URL(fileURLWithPath: Bundle.main.bundlePath.appending("/Assets/www/mobile/main.js"))
+        if let envUrl = Bundle.main.url(forResource: "env", withExtension: "json", subdirectory: "Assets/www/mobile"),
            let envString = try? String(contentsOf: envUrl),
            let envData = JSON.fromString(envString) {
             configData = envData

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -26,6 +26,7 @@
     "start:electron": "electron ./lib/backend/DtaElectronMain.js",
     "start:electron-webpack": "electron ./lib/build/DtaElectronMain.js --trace-warnings --enable-logging",
     "start:webserver": "cross-env NODE_ENV=development vite",
+    "start:mobile": "cross-env NODE_ENV=development vite --host",
     "start:backend": "node --max-http-header-size=16000 lib/backend/WebMain.js",
     "start:servers": "run-p \"start:webserver\" \"start:backend\"",
     "test": "",


### PR DESCRIPTION
* Update Android minSdk to 28
* More memory for Android build with debug add-on
* Adjust for vite build being in `lib` instead of `build`
* Support vite debug server on mobile
* Fix iOS crash with orientation change event
