### PR TITLE
Replaces rush env variable with require.main.filename call

### DIFF
--- a/common/changes/@itwin/build-tools/BenPusey-5796_2023-08-07-19-10.json
+++ b/common/changes/@itwin/build-tools/BenPusey-5796_2023-08-07-19-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Replaces rush env variable with require.main.filename for finding root",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/scripts/utils/addPackageMetadata.js
+++ b/tools/build/scripts/utils/addPackageMetadata.js
@@ -7,9 +7,9 @@ const FS = require("fs-extra");
 const path = require("path");
 
 // We cannot guarantee the folder structure of a project
-// so find the project root using rush env variable if available.
-const rootPackageJson = process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER
-  ? path.join(process.env.RUSHSTACK_FILE_ERROR_BASE_FOLDER, "package.json")
+// so find the project root using require.main if available.
+const rootPackageJson = require.main
+  ? path.join(path.dirname(require.main.filename), "package.json")
   : "../../../../package.json";
 
 // Check if path to root package.json is valid.


### PR DESCRIPTION
This change gives access to the root directory of the project by accessing the main node module. That directory contains the pacakge.json file that we need for this call. require.main documentation: [https://nodejs.org/api/modules.html#requiremain](https://nodejs.org/api/modules.html#requiremain)
