### PR TITLE
Fix integration-test-steps yml to not use nonexistent script

### DIFF
--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -107,7 +107,7 @@ steps:
     condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
 
   # MacOS and Windows agents work without any virtual display
-  - script: npm run test:integration:frontend:ci
+  - script: npm run test:integration:frontend
     workingDirectory: "core/electron"
     env:
       NODE_ENV: development


### PR DESCRIPTION
iTwin.js Integration - Full build [failing on Windows and Mac](https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=2324541&view=logs&j=ed028be3-93cc-5810-b6af-4051bb99b75a&t=a2a85b14-6755-5bd8-5715-83dbe474dd87) because the script `test:integration:frontend:ci` no longer exists there. It was removed in #5037 . 

[Build run on this branch](https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=2324691&view=results)