### PR TITLE
Add code value trimming "behaviors" for compatibility with old iModels

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2905,6 +2905,9 @@ export abstract class IModelDb extends IModel {
     // @internal (undocumented)
     protected _codeService?: CodeService;
     get codeSpecs(): CodeSpecs;
+    // @beta
+    get codeValueBehavior(): "exact" | "trim-unicode-whitespace";
+    set codeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace");
     computeProjectExtents(options?: ComputeProjectExtentsOptions): ComputedProjectExtents;
     constructEntity<T extends Entity, P extends EntityProps = EntityProps>(props: P): T;
     containsClass(classFullName: string): boolean;

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1338,6 +1338,21 @@ export abstract class IModelDb extends IModel {
       }
     });
   }
+
+  /**
+   * For cases where you need to preserve exact [[Code]]s between databases,
+   * you can set the codeValueBehavior to "exact". The default is "trim-unicode-whitespace".
+   * Code Values should be trimmed, this is primiarly for compatibility with iModels that
+   * failed to trim their codes.
+   * @beta
+   */
+  public get codeValueBehavior(): "exact" | "trim-unicode-whitespace" {
+    return this.nativeDb.getCodeValueBehavior();
+  }
+
+  public set codeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace") {
+    this.nativeDb.setCodeValueBehavior(newBehavior);
+  }
 }
 
 /** @public */


### PR DESCRIPTION
native PR: https://github.com/iTwin/imodel-native/pull/404
Description copied verbatim:

In https://github.com/iTwin/imodel-native/pull/180 we started unicode-aware (previously ascii) trimming of code values. Before that, several production iModels stored code values containing non-ascii whitespace. A couple transformer library users that are trying to move up to 4.x have reported failures when transforming these iModels since the codes are not preserved during db loads/stores.

Since the transformer wants to preserve the code values as they are stored in the Db, this PR introduces a per-dgndb DgnCodeValue::Behavior m_codeValueBehavior, and makes initialization of any DgnCodeValue tied to a dgndb context, e.g. FromJson, LoadFromDb. The default behavior is TrimUnicodeWhiteSpace, but now you can also set it to Exact, exposed to javascript as nativeDb.get/setCodeValueBehavior(val: "exact" | "trim-unicode-whitespace"). The intention is for users like the transformer to change the handling during a transformation, and then turn it back.

Misc:
- I intend to backport this as a patch to the current release after this merges to master
