### PR TITLE
Test watchForChanges from frontend

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -10,130 +10,135 @@ import { BriefcaseConnection } from "@itwin/core-frontend";
 import { coreFullStackTestIpc, deleteElements, initializeEditTools, insertLineElement, makeModelCode, transformElements } from "../Editing";
 import { TestUtility } from "../TestUtility";
 
-describe("BriefcaseTxns", () => {
-  if (!ProcessDetector.isMobileAppFrontend) {
-    let imodel: BriefcaseConnection;
+describe.only("BriefcaseTxns", () => {
+  if (ProcessDetector.isMobileAppFrontend)
+    return;
 
-    before(async () => {
-      await TestUtility.startFrontend(undefined, undefined, true);
-      await initializeEditTools();
-    });
+  let writableConn: BriefcaseConnection;
 
-    after(async () => {
-      await TestUtility.shutdownFrontend();
-    });
+  before(async () => {
+    await TestUtility.startFrontend(undefined, undefined, true);
+    await initializeEditTools();
+  });
 
-    beforeEach(async () => {
-      const filePath = path.join(process.env.IMODELJS_CORE_DIRNAME!, "core/backend/lib/cjs/test/assets/planprojection.bim");
-      imodel = await BriefcaseConnection.openStandalone(filePath, OpenMode.ReadWrite);
-    });
+  after(async () => {
+    await TestUtility.shutdownFrontend();
+  });
 
-    afterEach(async () => {
-      await imodel.close();
-    });
+  beforeEach(async () => {
+    const filePath = path.join(process.env.IMODELJS_CORE_DIRNAME!, "core/backend/lib/cjs/test/assets/planprojection.bim");
+    writableConn = await BriefcaseConnection.openStandalone(filePath, OpenMode.ReadWrite);
+  });
 
-    it("receives events from TxnManager", async () => {
-      type TxnEventName = "onElementsChanged" | "onModelsChanged" | "onModelGeometryChanged" | "onCommit" | "onCommitted" | "onChangesApplied";
-      type TxnEvent = TxnEventName | "beforeUndo" | "beforeRedo" | "afterUndo" | "afterRedo";
+  afterEach(async () => {
+    await writableConn.close();
+  });
 
-      const received: TxnEvent[] = [];
-      imodel.txns.onBeforeUndoRedo.addListener((isUndo) => received.push(isUndo ? "beforeUndo" : "beforeRedo"));
-      imodel.txns.onAfterUndoRedo.addListener((isUndo) => received.push(isUndo ? "afterUndo" : "afterRedo"));
+  async function test(readableConn: BriefcaseConnection): Promise<void> {
+    type TxnEventName = "onElementsChanged" | "onModelsChanged" | "onModelGeometryChanged" | "onCommit" | "onCommitted" | "onChangesApplied";
+    type TxnEvent = TxnEventName | "beforeUndo" | "beforeRedo" | "afterUndo" | "afterRedo";
 
-      const txnEventNames: TxnEventName[] = ["onElementsChanged", "onModelsChanged", "onModelGeometryChanged", "onCommit", "onCommitted", "onChangesApplied"];
-      for (const event of txnEventNames)
-        imodel.txns[event].addListener(() => received.push(event));
+    const received: TxnEvent[] = [];
+    readableConn.txns.onBeforeUndoRedo.addListener((isUndo) => received.push(isUndo ? "beforeUndo" : "beforeRedo"));
+    readableConn.txns.onAfterUndoRedo.addListener((isUndo) => received.push(isUndo ? "afterUndo" : "afterRedo"));
 
-      const expected: TxnEvent[] = [];
-      const expectEvents = async (additionalEvents: TxnEvent[]): Promise<void> => {
-        // The backend sends the events synchronously but the frontend receives them asynchronously relative to this test.
-        // So we must wait until all expected events are received. If our expectations are wrong, we may end up waiting forever.
-        for (const additionalEvent of additionalEvents)
-          expected.push(additionalEvent);
+    const txnEventNames: TxnEventName[] = ["onElementsChanged", "onModelsChanged", "onModelGeometryChanged", "onCommit", "onCommitted", "onChangesApplied"];
+    for (const event of txnEventNames)
+      readableConn.txns[event].addListener(() => received.push(event));
 
-        const wait = async (): Promise<void> => {
-          if (received.length >= expected.length)
-            return;
+    const expected: TxnEvent[] = [];
+    const expectEvents = async (additionalEvents: TxnEvent[]): Promise<void> => {
+      // The backend sends the events synchronously but the frontend receives them asynchronously relative to this test.
+      // So we must wait until all expected events are received. If our expectations are wrong, we may end up waiting forever.
+      for (const additionalEvent of additionalEvents)
+        expected.push(additionalEvent);
 
-          await new Promise<void>((resolve: any) => setTimeout(resolve, 100));
-          return wait();
-        };
+      const wait = async (): Promise<void> => {
+        if (received.length >= expected.length)
+          return;
 
-        await wait();
-        expect(received).to.deep.equal(expected);
-        received.length = expected.length = 0;
+        await new Promise<void>((resolve: any) => setTimeout(resolve, 100));
+        return wait();
       };
 
-      const expectCommit = async (...evts: TxnEvent[]) => expectEvents(["onCommit", ...evts, "onCommitted"]);
+      await wait();
+      expect(received).to.deep.equal(expected);
+      received.length = expected.length = 0;
+    };
 
-      const dictModelId = await imodel.models.getDictionaryModel();
-      const category = await coreFullStackTestIpc.createAndInsertSpatialCategory(imodel.key, dictModelId, Guid.createValue(), { color: 0 });
-      await imodel.saveChanges();
-      await expectCommit("onElementsChanged");
+    const expectCommit = async (...evts: TxnEvent[]) => expectEvents(["onCommit", ...evts, "onCommitted"]);
 
-      const code = await makeModelCode(imodel, imodel.models.repositoryModelId, Guid.createValue());
-      const model = await coreFullStackTestIpc.createAndInsertPhysicalModel(imodel.key, code);
-      await imodel.saveChanges();
-      await expectCommit("onElementsChanged", "onModelsChanged");
+    const dictModelId = await readableConn.models.getDictionaryModel();
+    const category = await coreFullStackTestIpc.createAndInsertSpatialCategory(writableConn.key, dictModelId, Guid.createValue(), { color: 0 });
+    await writableConn.saveChanges();
+    await expectCommit("onElementsChanged");
 
-      // NB: onCommit is produced *after* we process all changes. onModelGeometryChanged is produced *during* change processing.
-      const elem1 = await insertLineElement(imodel, model, category);
-      await imodel.saveChanges();
+    const code = await makeModelCode(readableConn, readableConn.models.repositoryModelId, Guid.createValue());
+    const model = await coreFullStackTestIpc.createAndInsertPhysicalModel(writableConn.key, code);
+    await writableConn.saveChanges();
+    await expectCommit("onElementsChanged", "onModelsChanged");
 
-      await expectCommit("onModelGeometryChanged", "onElementsChanged");
+    // NB: onCommit is produced *after* we process all changes. onModelGeometryChanged is produced *during* change processing.
+    const elem1 = await insertLineElement(writableConn, model, category);
+    await writableConn.saveChanges();
 
-      await transformElements(imodel, [elem1], Transform.createTranslationXYZ(1, 0, 0));
-      await imodel.saveChanges();
-      await expectCommit("onModelGeometryChanged", "onElementsChanged");
+    await expectCommit("onModelGeometryChanged", "onElementsChanged");
 
-      await deleteElements(imodel, [elem1]);
-      await imodel.saveChanges();
-      await expectCommit("onModelGeometryChanged", "onElementsChanged");
+    await transformElements(writableConn, [elem1], Transform.createTranslationXYZ(1, 0, 0));
+    await writableConn.saveChanges();
+    await expectCommit("onModelGeometryChanged", "onElementsChanged");
 
-      const undo = async () => imodel.txns.reverseSingleTxn();
-      const expectUndo = async (evts: TxnEvent[]) => expectEvents(["beforeUndo", ...evts, "afterUndo"]);
+    await deleteElements(writableConn, [elem1]);
+    await writableConn.saveChanges();
+    await expectCommit("onModelGeometryChanged", "onElementsChanged");
 
-      await undo();
-      await expectUndo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
-      await undo();
-      await expectUndo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
-      await undo();
-      await expectUndo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
-      await undo();
-      await expectUndo(["onElementsChanged", "onModelsChanged", "onChangesApplied"]);
-      await undo();
-      await expectUndo(["onElementsChanged", "onChangesApplied"]);
+    const undo = async () => writableConn.txns.reverseSingleTxn();
+    const expectUndo = async (evts: TxnEvent[]) => expectEvents(["beforeUndo", ...evts, "afterUndo"]);
 
-      const redo = async () => imodel.txns.reinstateTxn();
-      const expectRedo = async (evts: TxnEvent[]) => expectEvents(["beforeRedo", ...evts, "afterRedo"]);
-      await redo();
-      await expectRedo(["onElementsChanged", "onChangesApplied"]);
-      await redo();
-      await expectRedo(["onElementsChanged", "onModelsChanged", "onChangesApplied"]);
-      await redo();
-      await expectRedo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
-      await redo();
-      await expectRedo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
-      await redo();
-      await expectRedo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
+    await undo();
+    await expectUndo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
+    await undo();
+    await expectUndo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
+    await undo();
+    await expectUndo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
+    await undo();
+    await expectUndo(["onElementsChanged", "onModelsChanged", "onChangesApplied"]);
+    await undo();
+    await expectUndo(["onElementsChanged", "onChangesApplied"]);
 
-      await imodel.txns.reverseAll();
-      await expectUndo([
-        "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
-        "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
-        "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
-        "onElementsChanged", "onModelsChanged", "onChangesApplied",
-        "onElementsChanged", "onChangesApplied",
-      ]);
+    const redo = async () => writableConn.txns.reinstateTxn();
+    const expectRedo = async (evts: TxnEvent[]) => expectEvents(["beforeRedo", ...evts, "afterRedo"]);
+    await redo();
+    await expectRedo(["onElementsChanged", "onChangesApplied"]);
+    await redo();
+    await expectRedo(["onElementsChanged", "onModelsChanged", "onChangesApplied"]);
+    await redo();
+    await expectRedo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
+    await redo();
+    await expectRedo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
+    await redo();
+    await expectRedo(["onElementsChanged", "onChangesApplied", "onModelGeometryChanged"]);
 
-      await imodel.txns.reinstateTxn();
-      await expectRedo([
-        "onElementsChanged", "onChangesApplied",
-        "onElementsChanged", "onModelsChanged", "onChangesApplied",
-        "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
-        "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
-        "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
-      ]);
-    });
+    await writableConn.txns.reverseAll();
+    await expectUndo([
+      "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
+      "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
+      "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
+      "onElementsChanged", "onModelsChanged", "onChangesApplied",
+      "onElementsChanged", "onChangesApplied",
+    ]);
+
+    await writableConn.txns.reinstateTxn();
+    await expectRedo([
+      "onElementsChanged", "onChangesApplied",
+      "onElementsChanged", "onModelsChanged", "onChangesApplied",
+      "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
+      "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
+      "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
+    ]);
   }
+
+  it("receives events from TxnManager", async () => {
+    await test(writableConn);
+  });
 });

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -10,7 +10,7 @@ import { BriefcaseConnection } from "@itwin/core-frontend";
 import { coreFullStackTestIpc, deleteElements, initializeEditTools, insertLineElement, makeModelCode, transformElements } from "../Editing";
 import { TestUtility } from "../TestUtility";
 
-describe.only("BriefcaseTxns", () => {
+describe("BriefcaseTxns", () => {
   if (ProcessDetector.isMobileAppFrontend)
     return;
 
@@ -25,8 +25,8 @@ describe.only("BriefcaseTxns", () => {
     await TestUtility.shutdownFrontend();
   });
 
+  const filePath = path.join(process.env.IMODELJS_CORE_DIRNAME!, "core/backend/lib/cjs/test/assets/planprojection.bim");
   beforeEach(async () => {
-    const filePath = path.join(process.env.IMODELJS_CORE_DIRNAME!, "core/backend/lib/cjs/test/assets/planprojection.bim");
     writableConn = await BriefcaseConnection.openStandalone(filePath, OpenMode.ReadWrite);
   });
 
@@ -138,7 +138,19 @@ describe.only("BriefcaseTxns", () => {
     ]);
   }
 
-  it("receives events from TxnManager", async () => {
+  it("receives events for writable connection", async () => {
     await test(writableConn);
+  });
+
+  it.only("receives events for read-only connection when watchForChanges is enabled", async () => {
+    const readableConn = await BriefcaseConnection.openFile({
+      fileName: filePath,
+      key: Guid.createValue(),
+      readonly: true,
+      watchForChanges: true,
+    });
+
+    await test(readableConn);
+    await readableConn.close();
   });
 });


### PR DESCRIPTION
Don't look at this. If you do, make sure to hide whitespace changes in the diff.
Relevant to https://github.com/iTwin/itwinjs-backlog/issues/845.

The test that exercises the writable connection directly passes.
The one that exercises a read-only connection with `watchForChanges` enabled hangs indefinitely awaiting events that never come.
Debugger is busted in VS Code, so I'm debugging by throwing exceptions at the points in the code where I'd like to set breakpoints.

The file watcher is installed, and is invoked when saving changes.
TxnManager.notifyCommitted is being invoked.
ChangedEntitiesProc.processChanges is not dispatching an element changed event when inserting a category.

The writable connection gets (for the first operation - inserting a category): onCommit, onElementsChanged, onCommitted.
The read-only connection gets onElementsChanged, onChangesApplied.
The test may need to be adjusted to account for this, since it doesn't make sense for a read-only connection to receive events about commit. The display logic that is supposed to be updating the view may not be taking that into consideration either.