### PR TITLE
Code trim behaviors

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2905,6 +2905,9 @@ export abstract class IModelDb extends IModel {
     // @internal (undocumented)
     protected _codeService?: CodeService;
     get codeSpecs(): CodeSpecs;
+    // @beta
+    get codeValueBehavior(): "exact" | "trim-unicode-whitespace";
+    set codeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace");
     computeProjectExtents(options?: ComputeProjectExtentsOptions): ComputedProjectExtents;
     constructEntity<T extends Entity, P extends EntityProps = EntityProps>(props: P): T;
     containsClass(classFullName: string): boolean;

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1340,11 +1340,8 @@ export abstract class IModelDb extends IModel {
   }
 
   /**
-   * For cases where you need to preserve exact [[Code]]s between databases,
-   * you can set the codeValueBehavior to "exact". The default is "trim-unicode-whitespace".
-   * Code Values should be trimmed, this is primiarly for compatibility with iModels that
-   * failed to trim their codes.
-   * @beta
+   * Controls how [Code]($common)s are copied from this iModel into another iModel, to work around problems with iModels created by older connectors. The [imodel-transformer](https://github.com/iTwin/imodel-transformer) sets this appropriately on your behalf - you should never need to set or interrogate this property yourself.
+   * @public
    */
   public get codeValueBehavior(): "exact" | "trim-unicode-whitespace" {
     return this.nativeDb.getCodeValueBehavior();

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1338,6 +1338,21 @@ export abstract class IModelDb extends IModel {
       }
     });
   }
+
+  /**
+   * For cases where you need to preserve exact [[Code]]s between databases,
+   * you can set the codeValueBehavior to "exact". The default is "trim-unicode-whitespace".
+   * Code Values should be trimmed, this is primiarly for compatibility with iModels that
+   * failed to trim their codes.
+   * @beta
+   */
+  public get codeValueBehavior(): "exact" | "trim-unicode-whitespace" {
+    return this.nativeDb.getCodeValueBehavior();
+  }
+
+  public set codeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace") {
+    this.nativeDb.setCodeValueBehavior(newBehavior);
+  }
 }
 
 /** @public */

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -2786,29 +2786,36 @@ describe("iModel", () => {
     const imodelPath = IModelTestUtils.prepareOutputFile("IModel", "codeValueBehavior.bim");
     const imodel = SnapshotDb.createEmpty(imodelPath, { rootSubject: { name: "codeValueBehaviors" } });
     const spacesAndNbsp = "\xa0 \n\t\v";
-    const trimmedCodeValue = "CodeValue";
-    const badCodeValue = `${spacesAndNbsp}${trimmedCodeValue}${spacesAndNbsp}`;
-    const categoryProps: ElementProps = {
-      code: SpatialCategory.createCode(imodel, IModelDb.dictionaryId, badCodeValue),
-      model: IModelDb.dictionaryId,
-      classFullName: SpatialCategory.classFullName,
-    };
+
+    const getNumberedCodeValAndProps = (n: number) => {
+      const trimmedCodeVal = `CodeValue${n}`;
+      const untrimmedCodeVal = `${spacesAndNbsp}${trimmedCodeVal}${spacesAndNbsp}`;
+      const props: ElementProps = {
+        code: SpatialCategory.createCode(imodel, IModelDb.dictionaryId, untrimmedCodeVal),
+        model: IModelDb.dictionaryId,
+        classFullName: SpatialCategory.classFullName,
+      };
+      return { trimmedCodeVal, untrimmedCodeVal, props };
+    }
 
     expect(imodel.codeValueBehavior).to.equal("trim-unicode-whitespace");
 
-    const categ1Id = imodel.elements.createElement(categoryProps);
+    const code1 = getNumberedCodeValAndProps(1);
+    const categ1Id = imodel.elements.insertElement(code1.props);
     const categ1 = imodel.elements.getElement(categ1Id);
-    expect(categ1.code.value).to.equal(trimmedCodeValue);
+    expect(categ1.code.value).to.equal(code1.trimmedCodeVal);
 
     imodel.codeValueBehavior = "exact";
-    const categ2Id = imodel.elements.createElement(categoryProps);
+    const code2 = getNumberedCodeValAndProps(2);
+    const categ2Id = imodel.elements.insertElement(code2.props);
     const categ2 = imodel.elements.getElement(categ2Id);
-    expect(categ2.code.value).to.equal(badCodeValue);
+    expect(categ2.code.value).to.equal(code2.untrimmedCodeVal);
 
     imodel.codeValueBehavior = "trim-unicode-whitespace";
-    const categ3Id = imodel.elements.createElement(categoryProps);
+    const code3 = getNumberedCodeValAndProps(3);
+    const categ3Id = imodel.elements.insertElement(code3.props);
     const categ3 = imodel.elements.getElement(categ3Id);
-    expect(categ3.code.value).to.equal(trimmedCodeValue);
+    expect(categ3.code.value).to.equal(code3.trimmedCodeVal);
 
     imodel.close();
   });

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -2789,32 +2789,34 @@ describe("iModel", () => {
 
     const getNumberedCodeValAndProps = (n: number) => {
       const trimmedCodeVal = `CodeValue${n}`;
-      const untrimmedCodeVal = `${spacesAndNbsp}${trimmedCodeVal}${spacesAndNbsp}`;
+      const untrimmedCodeVal = `${trimmedCodeVal}\xa0`;
+      const spec = imodel.codeSpecs.getByName(SpatialCategory.getCodeSpecName()).id;
       const props: ElementProps = {
-        code: SpatialCategory.createCode(imodel, IModelDb.dictionaryId, untrimmedCodeVal),
+        // the [[Code]] class still (as it always has) trims unicode space, so avoid it
+        code: { spec, scope: IModelDb.dictionaryId, value: untrimmedCodeVal },
         model: IModelDb.dictionaryId,
         classFullName: SpatialCategory.classFullName,
       };
       return { trimmedCodeVal, untrimmedCodeVal, props };
-    }
+    };
 
     expect(imodel.codeValueBehavior).to.equal("trim-unicode-whitespace");
 
     const code1 = getNumberedCodeValAndProps(1);
     const categ1Id = imodel.elements.insertElement(code1.props);
-    const categ1 = imodel.elements.getElement(categ1Id);
+    const categ1 = imodel.elements.getElementJson({ id: categ1Id });
     expect(categ1.code.value).to.equal(code1.trimmedCodeVal);
 
     imodel.codeValueBehavior = "exact";
     const code2 = getNumberedCodeValAndProps(2);
     const categ2Id = imodel.elements.insertElement(code2.props);
-    const categ2 = imodel.elements.getElement(categ2Id);
+    const categ2 = imodel.elements.getElementJson({ id: categ2Id });
     expect(categ2.code.value).to.equal(code2.untrimmedCodeVal);
 
     imodel.codeValueBehavior = "trim-unicode-whitespace";
     const code3 = getNumberedCodeValAndProps(3);
     const categ3Id = imodel.elements.insertElement(code3.props);
-    const categ3 = imodel.elements.getElement(categ3Id);
+    const categ3 = imodel.elements.getElement({ id: categ3Id });
     expect(categ3.code.value).to.equal(code3.trimmedCodeVal);
 
     imodel.close();

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -2785,7 +2785,6 @@ describe("iModel", () => {
   it('should allow untrimmed codes when using "exact" codeValueBehavior', () => {
     const imodelPath = IModelTestUtils.prepareOutputFile("IModel", "codeValueBehavior.bim");
     const imodel = SnapshotDb.createEmpty(imodelPath, { rootSubject: { name: "codeValueBehaviors" } });
-    const spacesAndNbsp = "\xa0 \n\t\v";
 
     const getNumberedCodeValAndProps = (n: number) => {
       const trimmedCodeVal = `CodeValue${n}`;


### PR DESCRIPTION
Replaces this one https://github.com/iTwin/itwinjs-core/pull/5840 that originally also merged master. Description copied verbatim:

native PR: https://github.com/iTwin/imodel-native/pull/404
Description copied verbatim:

In https://github.com/iTwin/imodel-native/pull/180 we started unicode-aware (previously ascii) trimming of code values. Before that, several production iModels stored code values containing non-ascii whitespace. A couple transformer library users that are trying to move up to 4.x have reported failures when transforming these iModels since the codes are not preserved during db loads/stores.

Since the transformer wants to preserve the code values as they are stored in the Db, this PR introduces a per-dgndb `DgnCodeValue::Behavior m_codeValueBehavior`, and makes initialization of any DgnCodeValue tied to a dgndb context, e.g. FromJson, LoadFromDb. The default behavior is `TrimUnicodeWhiteSpace`, but now you can also set it to Exact, exposed to javascript as `nativeDb.get/setCodeValueBehavior(val: "exact" | "trim-unicode-whitespace")` and `IModelDb.codeValueBehavior`. The intention is for users like the transformer to change the handling during a transformation, and then turn it back.

Note that this PR does not change the behavior that has always existed of the JavaScript `Code` class, which performs unicode-aware whitespace trimming. The applications that managed to get non-ascii whitespace into the iModel in the first place were going around this class, and so is the transformer. This means `IModelDb.elements.getElement` will still trim codes in returned elements. If someone thinks that means we should remove the `IModelDb.codeValueBehavior` API I am introducing in this PR, I think that is reasonable, but I didn't want to rely on an internal API in the transformer.

Misc:
- I intend to backport this as a patch to the current release after this merges to master
- cherry-picked #5839 from master due to build failures