### PR TITLE
Presentation: Remove a link to a missing sample

### DIFF
--- a/docs/presentation/content/index.md
+++ b/docs/presentation/content/index.md
@@ -36,5 +36,4 @@ Modifiers can be specified as part of [content specifications](#specifications) 
 
 ## External resources
 
-- [Retrieving properties in different ways](https://www.itwinjs.org/sample-showcase/?group=Viewer+Features&sample=property-formatting-sample)
 - [Using element properties API to display properties in custom component](https://www.itwinjs.org/sandboxes/grigas/Element%20Properties%20Loader)


### PR DESCRIPTION
Remove the broken link as the sample is now gone and I couldn't find anything similar to what it used to contain.