### PR TITLE
Don't prefetch v2 checkpoints twice, check first if one is already ongoing.

### DIFF
--- a/common/changes/@itwin/core-backend/nick-numPrefetchesOnDatabase_2023-08-23-14-03.json
+++ b/common/changes/@itwin/core-backend/nick-numPrefetchesOnDatabase_2023-08-23-14-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -215,7 +215,7 @@ export class V2CheckpointManager {
         const maxRequests = getPrefetchConfig("maxRequests", 6);
         const timeout = getPrefetchConfig("timeout", 100);
         const maxBlocks = getPrefetchConfig("maxBlocks", 500); // default size of 2GB. Assumes a checkpoint block size of 4MB.
-        if (dbStats?.totalBlocks !== undefined && dbStats.totalBlocks <= maxBlocks) {
+        if (dbStats?.totalBlocks !== undefined && dbStats.totalBlocks <= maxBlocks && dbStats.nPrefetch === 0) {
           const logPrefetch = async (prefetch: CloudSqlite.CloudPrefetch) => {
             const stopwatch = new StopWatch(`[${container.containerId}/${dbName}]`, true);
             Logger.logInfo(loggerCategory, `Starting prefetch of ${stopwatch.description}`, { minRequests, maxRequests, timeout });
@@ -225,7 +225,7 @@ export class V2CheckpointManager {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           logPrefetch(CloudSqlite.startCloudPrefetch(container, dbName, { minRequests, nRequests: maxRequests, timeout }));
         } else {
-          Logger.logInfo(loggerCategory, `Skipping prefetch due to size limits.`, { maxBlocks, totalBlocksInDb: dbStats?.totalBlocks, v2props });
+          Logger.logInfo(loggerCategory, `Skipping prefetch due to size limits or ongoing prefetch.`, { maxBlocks, numPrefetches: dbStats?.nPrefetch, totalBlocksInDb: dbStats?.totalBlocks, v2props });
         }
       }
       return { dbName, container };

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -139,6 +139,10 @@ export namespace CloudSqlite {
     readonly transactions: boolean;
     /** the state of this database. Indicates whether the database is new or deleted since last upload */
     readonly state: "" | "copied" | "deleted";
+    /** current number of clients that have this database open. */
+    readonly nClient: number;
+    /** current number of ongoing prefetches on this database. */
+    readonly nPrefetch: number;
   }
 
   /** Filter options passed to CloudContainer.queryHttpLog

--- a/full-stack-tests/backend/src/integration/Checkpoints.test.ts
+++ b/full-stack-tests/backend/src/integration/Checkpoints.test.ts
@@ -8,7 +8,7 @@ import { ChildProcess } from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as sinon from "sinon";
-import { CloudSqlite, IModelDb, IModelHost, IModelJsFs, NativeCloudSqlite, SnapshotDb, V2CheckpointAccessProps, V2CheckpointManager } from "@itwin/core-backend";
+import { CheckpointManager, CloudSqlite, IModelDb, IModelHost, IModelJsFs, NativeCloudSqlite, SettingsPriority, SnapshotDb, V2CheckpointAccessProps, V2CheckpointManager } from "@itwin/core-backend";
 import { KnownTestLocations } from "@itwin/core-backend/lib/cjs/test/KnownTestLocations";
 import { AccessToken, GuidString } from "@itwin/core-bentley";
 import { ChangesetProps, IModelVersion } from "@itwin/core-common";
@@ -144,6 +144,38 @@ describe("Checkpoints", () => {
     }
   });
 
+  it("should only start one prefetch when same v2 checkpoint is opened twice", async () => {
+    IModelHost.appWorkspace.settings.addDictionary("prefetch", SettingsPriority.application, {
+      "Checkpoints/prefetch": true,
+      "Checkpoints/prefetch/maxBlocks": 5000,
+      "Checkpoints/prefetch/minRequests": 1,
+      "Checkpoints/prefetch/maxRequests": 3,
+    });
+    const prefetchSpy = sinon.spy(CloudSqlite, "startCloudPrefetch").withArgs(sinon.match.any, `${testChangeSet.id}.bim`, sinon.match.any); // Need matchers because GCS is also prefetched.
+    const iModel = await SnapshotDb.openCheckpointV2({
+      accessToken,
+      iTwinId: testITwinId,
+      iModelId: testIModelId,
+      changeset: testChangeSet,
+    });
+    expect(prefetchSpy.callCount).to.equal(1);
+    // stub openFile the second time around, we only need the attach call from openCheckpointV2 to take place to trigger a prefetch.
+    sinon.stub(SnapshotDb, "openFile").callsFake(() => {
+      return {} as SnapshotDb;
+    });
+    sinon.stub(CheckpointManager, "validateCheckpointGuids").callsFake(() => {});
+    const iModel2 = await SnapshotDb.openCheckpointV2({
+      accessToken,
+      iTwinId: testITwinId,
+      iModelId: testIModelId,
+      changeset: testChangeSet,
+    });
+    expect(prefetchSpy.callCount).to.equal(1);
+    iModel.close();
+    sinon.restore();
+    IModelHost.appWorkspace.settings.dropDictionary("prefetch");
+  });
+
   it("should be able to open and read V2 checkpoints without the daemon ", async () => {
     let iModel = await SnapshotDb.openCheckpointV2({
       accessToken,
@@ -218,6 +250,38 @@ describe("Checkpoints", () => {
 
     after(async () => {
       await shutdownDaemon();
+    });
+
+    it("should only start one prefetch when same v2 checkpoint is opened twice", async () => {
+      IModelHost.appWorkspace.settings.addDictionary("prefetch", SettingsPriority.application, {
+        "Checkpoints/prefetch": true,
+        "Checkpoints/prefetch/maxBlocks": 5000,
+        "Checkpoints/prefetch/minRequests": 1,
+        "Checkpoints/prefetch/maxRequests": 3,
+      });
+      const prefetchSpy = sinon.spy(CloudSqlite, "startCloudPrefetch").withArgs(sinon.match.any, `${testChangeSet.id}.bim`, sinon.match.any); // Need matchers because GCS is also prefetched.
+      const iModel = await SnapshotDb.openCheckpointV2({
+        accessToken,
+        iTwinId: testITwinId,
+        iModelId: testIModelId,
+        changeset: testChangeSet,
+      });
+      expect(prefetchSpy.callCount).to.equal(1);
+      // stub openFile the second time around, we only need the attach call from openCheckpointV2 to take place to trigger a prefetch.
+      sinon.stub(SnapshotDb, "openFile").callsFake(() => {
+        return {} as SnapshotDb;
+      });
+      sinon.stub(CheckpointManager, "validateCheckpointGuids").callsFake(() => {});
+      const iModel2 = await SnapshotDb.openCheckpointV2({
+        accessToken,
+        iTwinId: testITwinId,
+        iModelId: testIModelId,
+        changeset: testChangeSet,
+      });
+      expect(prefetchSpy.callCount).to.equal(1);
+      iModel.close();
+      sinon.restore();
+      IModelHost.appWorkspace.settings.dropDictionary("prefetch");
     });
 
     it("should be able to open and read V2 checkpoint with daemon running", async () => {

--- a/full-stack-tests/backend/src/integration/Checkpoints.test.ts
+++ b/full-stack-tests/backend/src/integration/Checkpoints.test.ts
@@ -152,6 +152,7 @@ describe("Checkpoints", () => {
       "Checkpoints/prefetch/maxRequests": 3,
     });
     const prefetchSpy = sinon.spy(CloudSqlite, "startCloudPrefetch").withArgs(sinon.match.any, `${testChangeSet.id}.bim`, sinon.match.any); // Need matchers because GCS is also prefetched.
+    const settingsSpy = sinon.spy(IModelHost.appWorkspace.settings, "getBoolean").withArgs("Checkpoints/prefetch");
     const iModel = await SnapshotDb.openCheckpointV2({
       accessToken,
       iTwinId: testITwinId,
@@ -159,6 +160,7 @@ describe("Checkpoints", () => {
       changeset: testChangeSet,
     });
     expect(prefetchSpy.callCount).to.equal(1);
+    expect(settingsSpy.callCount).to.equal(1);
     // stub openFile the second time around, we only need the attach call from openCheckpointV2 to take place to trigger a prefetch.
     sinon.stub(SnapshotDb, "openFile").callsFake(() => {
       return {} as SnapshotDb;
@@ -171,6 +173,7 @@ describe("Checkpoints", () => {
       changeset: testChangeSet,
     });
     expect(prefetchSpy.callCount).to.equal(1);
+    expect(settingsSpy.callCount).to.equal(2);
     iModel.close();
     sinon.restore();
     IModelHost.appWorkspace.settings.dropDictionary("prefetch");
@@ -260,6 +263,7 @@ describe("Checkpoints", () => {
         "Checkpoints/prefetch/maxRequests": 3,
       });
       const prefetchSpy = sinon.spy(CloudSqlite, "startCloudPrefetch").withArgs(sinon.match.any, `${testChangeSet.id}.bim`, sinon.match.any); // Need matchers because GCS is also prefetched.
+      const settingsSpy = sinon.spy(IModelHost.appWorkspace.settings, "getBoolean").withArgs("Checkpoints/prefetch");
       const iModel = await SnapshotDb.openCheckpointV2({
         accessToken,
         iTwinId: testITwinId,
@@ -267,6 +271,7 @@ describe("Checkpoints", () => {
         changeset: testChangeSet,
       });
       expect(prefetchSpy.callCount).to.equal(1);
+      expect(settingsSpy.callCount).to.equal(1);
       // stub openFile the second time around, we only need the attach call from openCheckpointV2 to take place to trigger a prefetch.
       sinon.stub(SnapshotDb, "openFile").callsFake(() => {
         return {} as SnapshotDb;
@@ -279,6 +284,7 @@ describe("Checkpoints", () => {
         changeset: testChangeSet,
       });
       expect(prefetchSpy.callCount).to.equal(1);
+      expect(settingsSpy.callCount).to.equal(2);
       iModel.close();
       sinon.restore();
       IModelHost.appWorkspace.settings.dropDictionary("prefetch");


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/tree/nick/prefetch-client-counts