### PR TITLE
fix git push

### DIFF
--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -67,7 +67,7 @@ await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-await $`git push`
+await $`git push origin HEAD:${targetBranch}`;
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -67,7 +67,7 @@ await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-await $`git push https://$(GITHUBTOKEN)@github.com/iTwin/itwinjs-core HEAD:${targetBranch}`
+await $`git push`
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {


### PR DESCRIPTION
remove extra parameters to push. The github token appears to not do anything, and the current branch is the branch that we want to push to anyway. Don't know why pushing to HEAD:origin/release/x.x.x doesn't work, but this should be fine. Only question I cannot answer is if this admin account is allowed to push to a protected branch without using some kind of token.

If anyone knows the expected behavior please let me know. I couldn't find anything online so I may be looking in the wrong place.