### PR TITLE
Model Display Transform Provider provides 'base transform'

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -9476,7 +9476,7 @@ export interface ModalReturn {
 
 // @beta
 export interface ModelDisplayTransformProvider {
-    getModelDisplayTransform(modelId: Id64String): Transform | undefined;
+    getModelDisplayTransform(modelId: Id64String, baseTransform?: Transform): Transform | undefined;
 }
 
 // @internal (undocumented)

--- a/common/changes/@itwin/core-frontend/model-transform-provider-issues847_2023-08-28-18-42.json
+++ b/common/changes/@itwin/core-frontend/model-transform-provider-issues847_2023-08-28-18-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "ModelDisplayTransformProvider can now provide the base transform",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -68,7 +68,7 @@ export interface ModelDisplayTransformProvider {
    * ```typescript
    * // BaseTf^-1 X ModelFt X BaseTf
    * baseTransform = baseTransform ?? Transform.createIdentity();
-   * let transform = baseTranform.inverse()!.multiplyTransformTransform(modelTransform);
+   * let transform = baseTransform.inverse()!.multiplyTransformTransform(modelTransform);
    * transform = transform.multiplyTransformTransform(baseTranform);
    * return transform;
    * ```

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -69,7 +69,7 @@ export interface ModelDisplayTransformProvider {
    * // BaseTf^-1 X ModelFt X BaseTf
    * baseTransform = baseTransform ?? Transform.createIdentity();
    * let transform = baseTransform.inverse()!.multiplyTransformTransform(modelTransform);
-   * transform = transform.multiplyTransformTransform(baseTranform);
+   * transform = transform.multiplyTransformTransform(baseTransform);
    * return transform;
    * ```
    */

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -68,8 +68,8 @@ export interface ModelDisplayTransformProvider {
    * ```typescript
    * // BaseTf^-1 X ModelFt X BaseTf
    * baseTransform = baseTransform ?? Transform.createIdentity();
-   * let transform = baseTranfrom.inverse()!.multiplyTransformTransform(modelTransform);
-   * transform = transform.multiplyTransformTransform(baseTranfrom);
+   * let transform = baseTranform.inverse()!.multiplyTransformTransform(modelTransform);
+   * transform = transform.multiplyTransformTransform(baseTranform);
    * return transform;
    * ```
    */

--- a/core/frontend/src/ViewState.ts
+++ b/core/frontend/src/ViewState.ts
@@ -64,9 +64,10 @@ export interface ExtentLimits {
 export interface ModelDisplayTransformProvider {
   /** Given the Id of a model, return the transform to be applied to it at display time, or `undefined` to apply no display transform.
    * @note Callers typically want to modify the returned Transform - make sure to return a new, mutable Transform, e.g. by using [Transform.clone]($core-geometry).
-   * @argument baseTransform is a shallow clone of the transform the returned transform will be multiplied with (BaseTf X ModelTf).  It is intended to be used if you need the transform you return to be the first matrix in the multiplication (ModelTf X BaseTf).  You can achieve this with the following code:
+   * @argument baseTransform is a shallow clone of the transform the returned transform will be multiplied with (BaseTf X ModelTf).  If baseTransform is undefined, an identity matrix can be assumed.  It is intended to be used if you need the transform you return to be the first matrix in the multiplication (ModelTf X BaseTf).  You can achieve this with the following code:
    * ```typescript
    * // BaseTf^-1 X ModelFt X BaseTf
+   * baseTransform = baseTransform ?? Transform.createIdentity();
    * let transform = baseTranfrom.inverse()!.multiplyTransformTransform(modelTransform);
    * transform = transform.multiplyTransformTransform(baseTranfrom);
    * return transform;

--- a/core/frontend/src/tile/PrimaryTileTree.ts
+++ b/core/frontend/src/tile/PrimaryTileTree.ts
@@ -256,7 +256,7 @@ class PrimaryTreeReference extends TileTreeReference {
 
   protected override computeTransform(tree: TileTree): Transform {
     const baseTf = this.computeBaseTransform(tree);
-    const displayTf = this.view.modelDisplayTransformProvider?.getModelDisplayTransform(this.model.id);
+    const displayTf = this.view.modelDisplayTransformProvider?.getModelDisplayTransform(this.model.id, baseTf.clone());
     return displayTf ? baseTf.multiplyTransformTransform(displayTf, displayTf) : baseTf;
   }
 }


### PR DESCRIPTION
This change is prompt by investigations for model alignment workflows.

The transform describing changes to a model's spatial location will be called the "model transform (`modelTf`)."  The original transform describing its location in the iModel will be called, "base transform (`baseTf`)."  The transform describing the world location the model is displayed at is "display transform (`displayTf`)."  The modelTf will be applied to the model's elements after editing.  To accurately create this effect the when calculating the displayTf, the modelTf should be the first matrix during multiplication with the baseTf (`displayTf = modelTf X baseTf`).

The changes extend [ModelDisplayTransformProvider](https://www.itwinjs.org/reference/core-frontend/views/viewstate/modeldisplaytransformprovider/)'s interface to allow the system to provider this baseTf when relevant.

Fixes: https://github.com/iTwin/itwinjs-backlog/issues/847