### PR TITLE
refresh write lock expiry time when calling acquireWriteLock as the same user

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -836,6 +836,8 @@ export namespace CloudSqlite {
     export interface CachedDbProps {
         readonly dirtyBlocks: number;
         readonly localBlocks: number;
+        readonly nClient: number;
+        readonly nPrefetch: number;
         readonly state: "" | "copied" | "deleted";
         readonly totalBlocks: number;
         readonly transactions: boolean;
@@ -910,6 +912,7 @@ export namespace CloudSqlite {
         releaseWriteLock(): void;
         get storageType(): string;
         uploadChanges(): Promise<void>;
+        get writeLockExpires(): string;
     }
     // (undocumented)
     export interface CloudHttpProps {

--- a/full-stack-tests/backend/src/integration/Checkpoints.test.ts
+++ b/full-stack-tests/backend/src/integration/Checkpoints.test.ts
@@ -166,7 +166,7 @@ describe("Checkpoints", () => {
       return {} as SnapshotDb;
     });
     sinon.stub(CheckpointManager, "validateCheckpointGuids").callsFake(() => {});
-    const iModel2 = await SnapshotDb.openCheckpointV2({
+    await SnapshotDb.openCheckpointV2({
       accessToken,
       iTwinId: testITwinId,
       iModelId: testIModelId,
@@ -277,7 +277,7 @@ describe("Checkpoints", () => {
         return {} as SnapshotDb;
       });
       sinon.stub(CheckpointManager, "validateCheckpointGuids").callsFake(() => {});
-      const iModel2 = await SnapshotDb.openCheckpointV2({
+      await SnapshotDb.openCheckpointV2({
         accessToken,
         iTwinId: testITwinId,
         iModelId: testIModelId,


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/tree/nick/exposebcvkvtime

Removed the writeLockExpires on ContainerInternal object and instead added it as a getter to the container object in imodel-native. This lets us actually read the expiry time from the bcv_kv table which is a more accurate test that the containerinternal timestamp.