### PR TITLE
Dan/fix finalize release

### DIFF
--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -27,7 +27,7 @@ let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x"
 let currentBranch = await $`git branch --show-current`;
 let commitMessage = await $`git log --format=%B -n 1`;
 
-
+// remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).slice(0, -1);
 currentBranch = String(currentBranch).slice(0, -1);
 commitMessage = String(commitMessage).slice(0, -2);
@@ -61,13 +61,15 @@ await $`rush publish --regenerate-changelogs`;
 // Uncomment For Manual runs and fix branch name to appropriate version
 // the version should match your incoming branch
 // await $`git checkout -b finalize-release-X.X.X`;
+// targetBranch = "finalize-release-X.X.X"
 /*********************************************************************/
+targetBranch = targetBranch.replace("origin/", "");
 await $`git add .`;
 await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-await $`git push https://$(GITHUBTOKEN)@github.com/iTwin/itwinjs-core HEAD:${targetBranch}`
+await $`git push HEAD:${targetBranch}`;
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -28,9 +28,9 @@ let currentBranch = await $`git branch --show-current`;
 let commitMessage = await $`git log --format=%B -n 1`;
 
 // remove extra null and new line characters from git cmds
-targetBranch = String(targetBranch).slice(0, -1);
-currentBranch = String(currentBranch).slice(0, -1);
-commitMessage = String(commitMessage).slice(0, -2);
+targetBranch = String(targetBranch).replace('\n', '');
+currentBranch = String(currentBranch).replace('\n', '');
+commitMessage = String(commitMessage).replace('\n', '');
 
 if (targetBranch === `origin/${currentBranch}`) {
   console.log("The current branch is the latest release, so the target will be master branch")
@@ -69,7 +69,7 @@ await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-await $`git push HEAD:${targetBranch}`;
+// await $`git push origin HEAD:${targetBranch}`;
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-// await $`git push origin HEAD:${targetBranch}`;
+await $`git push origin HEAD:${targetBranch}`;
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -44,8 +44,10 @@ if (targetBranch === `origin/${currentBranch}`) {
 }
 // copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
-// # copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
+
+targetBranch = targetBranch.replace("origin/", "");
 await $`git checkout ${targetBranch}`;
+// copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
 const currentFiles = getFilePaths(targetPath);
@@ -67,7 +69,6 @@ await $`rush publish --regenerate-changelogs`;
 // await $`git checkout -b finalize-release-X.X.X`;
 // targetBranch = "finalize-release-X.X.X"
 /*********************************************************************/
-targetBranch = targetBranch.replace("origin/", "");
 await $`git add .`;
 await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -32,6 +32,10 @@ targetBranch = String(targetBranch).replace('\n', '');
 currentBranch = String(currentBranch).replace('\n', '');
 commitMessage = String(commitMessage).replace('\n', '');
 
+console.log(`target branch: ${targetBranch}`);
+console.log(`current branch: ${currentBranch}`);
+console.log(`commit msg: ${commitMessage}`);
+
 if (targetBranch === `origin/${currentBranch}`) {
   console.log("The current branch is the latest release, so the target will be master branch")
   targetBranch = 'master'

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -28,9 +28,9 @@ let currentBranch = await $`git branch --show-current`;
 let commitMessage = await $`git log --format=%B -n 1`;
 
 // remove extra null and new line characters from git cmds
-targetBranch = String(targetBranch).replace('\n', '');
-currentBranch = String(currentBranch).replace('\n', '');
-commitMessage = String(commitMessage).replace('\n', '');
+targetBranch = String(targetBranch).replace(/\n/g, '');
+currentBranch = String(currentBranch).replace(/\n/g, '');
+commitMessage = String(commitMessage).replace(/\n/g, '');
 
 console.log(`target branch: ${targetBranch}`);
 console.log(`current branch: ${currentBranch}`);

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -16,8 +16,10 @@ jobs:
     name: Cherry-pick Changelogs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
+          ref: ${{ github.ref }} # checkouts the branch that triggered the workflow
           fetch-depth: 0
       - name: Set Git Config
         run: |

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -8,8 +8,10 @@ name: Finalize Release
 on:
   workflow_dispatch:
   push:
-    tags:
+    branches:
     - 'release/*'
+    paths:
+    - '**/CHANGELOG.md'
 
 jobs:
   finalize:


### PR DESCRIPTION
Fixes error wish push command by including `origin` in cmd.

Fixes the  removal of extra newline characters to be more readable.

Upgrades to action/checkoutV3

Add authtoken to checkout step. From testing in a dummy repo, this token also appears to be what authorizes the push later in the pipeline. Also tested pushing to a protected branch with an authorized user and it worked correctly.

Changes trigger from tag to on commits to branches with `release/*` and updates to files with the path `**/CHANGELOG.md`, this is because when the workflow is triggered by a tag, the default branch that gets checkout is in a detached head state, and checking out to a new branch doesn't correct this. I believe using git switch might work, however this is easier because I use the branch name to detect what the target branch for the change logs should be. The branch name when a tag is checked out is not the same name as the source branch, so it would require different logic to get the target branch. Switching to this was also makes it simpler for running the script locally.