### PR TITLE
Add querybcvstats to get some information about state of the cachefile

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -840,6 +840,20 @@ export namespace CloudSqlite {
         showOnlyFinished?: boolean;
         startFromId?: number;
     }
+    // @internal
+    export interface BcvStats {
+        readonly activeClients?: number;
+        readonly attachedContainers?: number;
+        readonly lockedCacheslots: number;
+        readonly ongoingPrefetches?: number;
+        readonly populatedCacheslots: number;
+        readonly totalCacheslots: number;
+        readonly totalClients?: number;
+    }
+    // @internal
+    export interface BcvStatsFilterOptions {
+        addClientInformation?: boolean;
+    }
     export interface CachedDbProps {
         readonly dirtyBlocks: number;
         readonly localBlocks: number;
@@ -911,6 +925,8 @@ export namespace CloudSqlite {
         onDisconnect?: (container: CloudContainer, detach: boolean) => void;
         // (undocumented)
         onDisconnected?: (container: CloudContainer, detach: boolean) => void;
+        // @internal
+        queryBcvStats(filterOptions?: BcvStatsFilterOptions): CloudSqlite.BcvStats;
         queryDatabase(dbName: string): CachedDbProps | undefined;
         queryDatabaseHash(dbName: string): string;
         queryDatabases(globArg?: string): string[];
@@ -1054,6 +1070,7 @@ export namespace CloudSqlite {
         busyHandler?: WriteLockBusyHandler;
     }, operation: () => Promise<T>): Promise<T>;
     export type WriteLockBusyHandler = (lockedBy: string, expires: string) => Promise<void | "stop">;
+        {};
 }
 
 // @alpha

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -43,6 +43,8 @@ public;CloudContainerArgs
 beta;CloudSqlite
 internal;BcvHttpLog
 internal;BcvHttpLogFilterOptions
+internal;BcvStats
+internal;BcvStatsFilterOptions
 internal;LockAndOpenArgs 
 internal;transferDb(direction: TransferDirection, container: CloudContainer, props: TransferDbProps): Promise
 alpha;CodeService

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -168,7 +168,7 @@ export class V2CheckpointManager {
         }
       }
 
-      this._cloudCache = CloudSqlite.CloudCaches.getCache({ cacheName: this.cloudCacheName, cacheDir });
+      this._cloudCache = CloudSqlite.CloudCaches.getCache({ cacheName: this.cloudCacheName, cacheDir, cacheSize: "50G" });
 
       // Its fine if its not a daemon, but lets log an info message
       if (!this._cloudCache.isDaemon)

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -178,6 +178,37 @@ export namespace CloudSqlite {
     readonly httpcode: number;
   }
 
+  /** Filter options passed to 'CloudContainer.queryBcvStats'
+   *  @internal
+  */
+  interface BcvStatsFilterOptions {
+    /** if true, adds activeClients, totalClients, ongoingPrefetches, and attachedContainers to the result. */
+    addClientInformation?: boolean;
+  }
+
+  /** Returned from 'CloudContainer.queryBcvStats' describing the rows in the bcv_stat table.
+   *  Also gathers additional statistics using the other virtual tables bcv_container, bcv_database such as totalClients, ongoingPrefetches, activeClients and attachedContainers.
+   *  @internal
+   */
+  export interface BcvStats {
+    /** The total number of cache slots that are currently in use or 'locked' by ongoing client read transactions. In daemonless mode, this value is always 0.
+     *  A locked cache slot implies that it is not eligible for eviction in the event of a full cachefile.
+    */
+    readonly lockedCacheslots: number;
+    /** The current number of slots with data in them in the cache. */
+    readonly populatedCacheslots: number;
+    /** The configured size of the cache, in number of slots. */
+    readonly totalCacheslots: number;
+    /** The total number of clients opened on this cache */
+    readonly totalClients?: number;
+    /** The total number of ongoing prefetches on this cache */
+    readonly ongoingPrefetches?: number;
+    /** The total number of active clients on this cache. An active client is one which has an open read txn. */
+    readonly activeClients?: number;
+    /** The total number of attached containers on this cache. */
+    readonly attachedContainers?: number;
+  }
+
   /** The name of a CloudSqlite database within a CloudContainer. */
   export interface DbNameProp {
     /** the name of the database within the CloudContainer.
@@ -490,6 +521,12 @@ export namespace CloudSqlite {
      * @internal
      */
     queryHttpLog(filterOptions?: BcvHttpLogFilterOptions): CloudSqlite.BcvHttpLog[];
+
+    /**
+     * query the bcv_stat table.
+     * @internal
+     */
+    queryBcvStats(filterOptions?: BcvStatsFilterOptions): CloudSqlite.BcvStats;
 
     /**
      * Get the SHA1 hash of the content of a database.

--- a/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
+++ b/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
@@ -163,6 +163,7 @@ describe("CloudSqlite", () => {
     db.close();
     container.disconnect({ detach: true });
   });
+
   it("Should refresh write lock expiry time if withWriteLock called twice with same user", async () => {
     const container = testContainers[0];
     container.connect(caches[1]);
@@ -184,6 +185,59 @@ describe("CloudSqlite", () => {
     });
     writeLockExpiryTimeNoWriteLock = container.writeLockExpires; // Should be empty string when no write lock.
     expect(writeLockExpiryTimeNoWriteLock).to.equal("");
+    container.disconnect({detach: true});
+  });
+
+  it("should query bcv stat table", async () => {
+    const cache = azSqlite.makeCache("bcv-stat-cache");
+    const container = testContainers[0];
+    container.connect(cache);
+
+    const checkOptionalReturnValues = (bcvStats: CloudSqlite.BcvStats, expectDefined: boolean) => {
+      if (expectDefined) {
+        expect(bcvStats.activeClients).to.not.be.undefined;
+        expect(bcvStats.attachedContainers).to.not.be.undefined;
+        expect(bcvStats.ongoingPrefetches).to.not.be.undefined;
+        expect(bcvStats.totalClients).to.not.be.undefined;
+      } else {
+        expect(bcvStats.activeClients).to.be.undefined;
+        expect(bcvStats.attachedContainers).to.be.undefined;
+        expect(bcvStats.ongoingPrefetches).to.be.undefined;
+        expect(bcvStats.totalClients).to.be.undefined;
+      }
+    };
+    let stats = container.queryBcvStats();
+    checkOptionalReturnValues(stats, false);
+    stats = container.queryBcvStats({addClientInformation: false});
+    checkOptionalReturnValues(stats, false);
+    expect(cache.isDaemon).to.be.false;
+    // daemonless is always 0 locked blocks.
+    expect(stats.lockedCacheslots).to.equal(0);
+    // we haven't opened any databases yet, so have 0 entries in the cache.
+    expect(stats.populatedCacheslots).to.equal(0);
+    // 10 gb in bytes, current cache size defined by this test suite.
+    const tenGb = 10 * (1024 * 1024 * 1024);
+    // 64 kb, current block size defined by this test suite.
+    const blockSize = 64 * 1024;
+    // totalCacheslots is the number of entries allowed in the cachefile.
+    expect(stats.totalCacheslots).to.equal(tenGb / blockSize);
+
+    const dbs = container.queryDatabases();
+    expect(dbs.length).to.be.greaterThanOrEqual(1);
+    let db = container.queryDatabase(dbs[0]);
+    expect(db !== undefined).to.be.true;
+    expect(db!.localBlocks).to.equal(0);
+    const prefetch = CloudSqlite.startCloudPrefetch(container, dbs[0]);
+    await prefetch.promise;
+    // Check bcv stats again after prefetching a database.
+    db = container.queryDatabase(dbs[0]);
+    expect(db!.localBlocks).to.equal(db!.totalBlocks);
+    stats = container.queryBcvStats({addClientInformation: true});
+    checkOptionalReturnValues(stats, true);
+    expect(stats.lockedCacheslots).to.equal(0);
+    expect(stats.populatedCacheslots).to.equal(db!.totalBlocks);
+    expect(stats.totalCacheslots).to.equal(tenGb / blockSize);
+    container.disconnect({detach: true});
   });
 
   it("cloud containers", async () => {


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/tree/nick/cachefilemetrics

This will be used in the daemon prometheus client.