### PR TITLE
Allow creation of cross-origin workers

### DIFF
--- a/common/changes/@itwin/core-frontend/wkb-cross-origin-worker_2023-09-05-17-04.json
+++ b/common/changes/@itwin/core-frontend/wkb-cross-origin-worker_2023-09-05-17-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Allow creation of cross-origin web workers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/common/WorkerProxy.ts
+++ b/core/frontend/src/common/WorkerProxy.ts
@@ -99,7 +99,16 @@ export function createWorkerProxy<T>(workerJsPath: string): WorkerProxy<T> {
   let curMsgId = 0;
   let terminated = false;
 
-  const worker = new Worker(workerJsPath);
+  let worker: Worker;
+  const sameOrigin = workerJsPath.substring(0, globalThis.origin.length) === globalThis.origin;
+  if (sameOrigin) {
+    worker = new Worker(workerJsPath);
+  } else {
+    const workerBlob = new Blob([`importScripts("${workerJsPath}");`]);
+    const workerBlobUrl = URL.createObjectURL(workerBlob);
+    worker = new Worker(workerBlobUrl);
+  }
+
   worker.onmessage = (e: MessageEvent) => {
     const response = e.data as WorkerResponse;
     assert(typeof response === "object");


### PR DESCRIPTION
Cross-origin web workers are not allowed by default. This PR detects if the worker .js file is cross-origin and, if so, will create a worker using a `Blob` and `importScripts`. This seems to be a generally accepted workaround for the cross-origin worker problem.