### PR TITLE
allow ExternalSourceAspect scope to be undefined

### DIFF
--- a/core/backend/src/ElementAspect.ts
+++ b/core/backend/src/ElementAspect.ts
@@ -147,7 +147,7 @@ export class ExternalSourceAspect extends ElementMultiAspect {
    * @note Warning: in a future major release the `scope` property will be optional, since the scope is intended to be potentially invalid.
    *       all references should treat it as potentially undefined, but we cannot change the type yet since that is a breaking change.
    */
-  public scope: RelatedElement;
+  public scope: RelatedElement | undefined;
   /** The identifier of the object in the source repository. */
   public identifier: string;
   /** The kind of object within the source repository. */


### PR DESCRIPTION
From issue: https://github.com/iTwin/itwinjs-core/issues/5587
Do not know if this change also requires the ExternalSourceAspectProps to be  `RelatedElementProps | undefined`