### PR TITLE
fix finalize release 4.1.x

### DIFF
--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -28,9 +28,13 @@ let currentBranch = await $`git branch --show-current`;
 let commitMessage = await $`git log --format=%B -n 1`;
 
 // remove extra null and new line characters from git cmds
-targetBranch = String(targetBranch).slice(0, -1);
-currentBranch = String(currentBranch).slice(0, -1);
-commitMessage = String(commitMessage).slice(0, -2);
+targetBranch = String(targetBranch).replace(/\n/g, '');
+currentBranch = String(currentBranch).replace(/\n/g, '');
+commitMessage = String(commitMessage).replace(/\n/g, '');
+
+console.log(`target branch: ${targetBranch}`);
+console.log(`current branch: ${currentBranch}`);
+console.log(`commit msg: ${commitMessage}`);
 
 if (targetBranch === `origin/${currentBranch}`) {
   console.log("The current branch is the latest release, so the target will be master branch")
@@ -40,8 +44,10 @@ if (targetBranch === `origin/${currentBranch}`) {
 }
 // copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
-// # copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
+
+targetBranch = targetBranch.replace("origin/", "");
 await $`git checkout ${targetBranch}`;
+// copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
 const currentFiles = getFilePaths(targetPath);
@@ -63,13 +69,12 @@ await $`rush publish --regenerate-changelogs`;
 // await $`git checkout -b finalize-release-X.X.X`;
 // targetBranch = "finalize-release-X.X.X"
 /*********************************************************************/
-targetBranch = targetBranch.replace("origin/", "");
 await $`git add .`;
 await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-await $`git push HEAD:${targetBranch}`;
+await $`git push origin HEAD:${targetBranch}`;
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -46,7 +46,8 @@ if (targetBranch === `origin/${currentBranch}`) {
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
 targetBranch = targetBranch.replace("origin/", "");
-await $`git checkout ${targetBranch}`;
+// await $`git checkout ${targetBranch}`;
+await $`git checkout master`;
 // copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
@@ -66,15 +67,16 @@ await $`rush publish --regenerate-changelogs`;
 /*********************************************************************/
 // Uncomment For Manual runs and fix branch name to appropriate version
 // the version should match your incoming branch
-// await $`git checkout -b finalize-release-X.X.X`;
-// targetBranch = "finalize-release-X.X.X"
+await $`git checkout -b finalize-release-Test`;
+targetBranch = "finalize-release-Test"
 /*********************************************************************/
 await $`git add .`;
 await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-await $`git push origin HEAD:${targetBranch}`;
+// await $`git push origin HEAD:${targetBranch}`;
+await $`git push -u origin HEAD:${targetBranch}`;
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -46,8 +46,7 @@ if (targetBranch === `origin/${currentBranch}`) {
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
 targetBranch = targetBranch.replace("origin/", "");
-// await $`git checkout ${targetBranch}`;
-await $`git checkout master`;
+await $`git checkout ${targetBranch}`;
 // copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
@@ -67,16 +66,15 @@ await $`rush publish --regenerate-changelogs`;
 /*********************************************************************/
 // Uncomment For Manual runs and fix branch name to appropriate version
 // the version should match your incoming branch
-await $`git checkout -b finalize-release-Test`;
-targetBranch = "finalize-release-Test"
+// await $`git checkout -b finalize-release-X.X.X`;
+// targetBranch = "finalize-release-X.X.X"
 /*********************************************************************/
 await $`git add .`;
 await $`git commit -m "${commitMessage} Changelogs"`;
 await $`rush change --bulk --message "" --bump-type none`;
 await $`git add .`;
 await $`git commit --amend --no-edit`;
-// await $`git push origin HEAD:${targetBranch}`;
-await $`git push -u origin HEAD:${targetBranch}`;
+await $`git push origin HEAD:${targetBranch}`;
 
 // Read all files in the directory
 function getFilePaths(directoryPath) {

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -8,8 +8,10 @@ name: Finalize Release
 on:
   workflow_dispatch:
   push:
-    tags:
+    branches:
     - 'release/*'
+    paths:
+    - '**/CHANGELOG.md'
 
 jobs:
   finalize:


### PR DESCRIPTION
Fixes error with push command by including `origin` in cmd.

Fixes the removal of extra newline characters to be more readable.

Upgrades to action/checkoutV3

Add authtoken to checkout step. From testing in a dummy repo, this token also appears to be what authorizes the push later in the pipeline. Also tested pushing to a protected branch with an authorized user and it worked correctly.

Changes trigger from tag to on commits to branches with release/* and updates to files with the path **/CHANGELOG.md, this is because when the workflow is triggered by a tag, the default branch that gets checkout is in a detached head state, and checking out to a new branch doesn't correct this. I believe using git switch might work, however this is easier because I use the branch name to detect what the target branch for the change logs should be. The branch name when a tag is checked out is not the same name as the source branch, so it would require different logic to get the target branch. Switching to this was also makes it simpler for running the script locally.
