### PR TITLE
Deprecate default view Id

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3144,6 +3144,7 @@ export namespace IModelDb {
         // @beta (undocumented)
         saveDefaultViewStore(arg: CloudSqlite.ContainerProps): void;
         saveThumbnail(viewDefinitionId: Id64String, thumbnail: ThumbnailProps): number;
+        // @deprecated
         setDefaultViewId(viewId: Id64String): void;
         // @beta (undocumented)
         get viewStore(): ViewStore.CloudAccess;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -6936,6 +6936,7 @@ export namespace IModelConnection {
         getThumbnail(_viewId: Id64String): Promise<ThumbnailProps>;
         getViewList(queryParams: ViewQueryParams): Promise<ViewSpec[]>;
         load(viewDefinitionId: ViewIdString): Promise<ViewState>;
+        // @deprecated
         queryDefaultViewId(): Promise<Id64String>;
         queryProps(queryParams: ViewQueryParams): Promise<ViewDefinitionProps[]>;
         // (undocumented)

--- a/common/changes/@itwin/core-backend/pmc-default-view-doc_2023-09-07-01-02.json
+++ b/common/changes/@itwin/core-backend/pmc-default-view-doc_2023-09-07-01-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-frontend/pmc-default-view-doc_2023-09-07-00-18.json
+++ b/common/changes/@itwin/core-frontend/pmc-default-view-doc_2023-09-07-00-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2288,7 +2288,6 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
 
     /** Set the default view property the iModel.
      * @param viewId The Id of the ViewDefinition to use as the default
-     * @see [IModelConnection.queryDefaultViewId]($frontend) to query this property from the front-end.
      * @deprecated in 4.2.x. Avoid setting this property - it is not practical for one single view to serve the needs of the many applications
      * that might wish to view the contents of the iModel.
      */

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2286,8 +2286,11 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       return 0;
     }
 
-    /** Set the default view property the iModel
+    /** Set the default view property the iModel.
      * @param viewId The Id of the ViewDefinition to use as the default
+     * @see [IModelConnection.queryDefaultViewId]($frontend) to query this property from the front-end.
+     * @deprecated in 4.2.x. Avoid setting this property - it is not practical for one single view to serve the needs of the many applications
+     * that might wish to view the contents of the iModel.
      */
     public setDefaultViewId(viewId: Id64String): void {
       const spec = { namespace: "dgn_View", name: "DefaultView" };

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -1242,7 +1242,6 @@ export namespace IModelConnection { // eslint-disable-line no-redeclare
      * Most applications should ignore the default view and instead create a [[ViewState]] that fits their own requirements using APIs like [[ViewCreator3d]].
      * @returns the Id of the default view as defined in the iModel's property table, or an invalid ID if no default view is defined.
      * @deprecated in 4.2. Create a ViewState to your own specifications.
-     * @see [IModelDb.setDefaultViewId]($backend) to set this property.
      */
     public async queryDefaultViewId(): Promise<Id64String> {
       const iModel = this._iModel;

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -1238,9 +1238,11 @@ export namespace IModelConnection { // eslint-disable-line no-redeclare
 
     /** Query the Id of the default [ViewDefinition]($backend), if any, stored in this iModel's property table.
      * The default view is typically chosen by the application (such as a connector) that created the iModel.
-     * There is no guarantee that this view will be suitable for the purposes of any other application. Most applications should ignore the default view and
-     * instead create views that fit their own requirements, using APIs like [[ViewCreator3d]].
+     * There is no guarantee that this view will be suitable for the purposes of any other applications.
+     * Most applications should ignore the default view and instead create a [[ViewState]] that fits their own requirements using APIs like [[ViewCreator3d]].
      * @returns the Id of the default view as defined in the iModel's property table, or an invalid ID if no default view is defined.
+     * @deprecated in 4.2. Create a ViewState to your own specifications.
+     * @see [IModelDb.setDefaultViewId]($backend) to set this property.
      */
     public async queryDefaultViewId(): Promise<Id64String> {
       const iModel = this._iModel;

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -1236,9 +1236,11 @@ export namespace IModelConnection { // eslint-disable-line no-redeclare
       return views;
     }
 
-    /** Query the Id of the default view associated with this iModel. Applications can choose to use this as the default view to which to open a viewport upon startup, or the initial selection
-     * within a view selection dialog, or similar purposes.
-     * @returns the Id of the default view, or an invalid ID if no default view is defined.
+    /** Query the Id of the default [ViewDefinition]($backend), if any, stored in this iModel's property table.
+     * The default view is typically chosen by the application (such as a connector) that created the iModel.
+     * There is no guarantee that this view will be suitable for the purposes of any other application. Most applications should ignore the default view and
+     * instead create views that fit their own requirements, using APIs like [[ViewCreator3d]].
+     * @returns the Id of the default view as defined in the iModel's property table, or an invalid ID if no default view is defined.
      */
     public async queryDefaultViewId(): Promise<Id64String> {
       const iModel = this._iModel;

--- a/core/frontend/src/ViewCreator3d.ts
+++ b/core/frontend/src/ViewCreator3d.ts
@@ -241,6 +241,7 @@ export class ViewCreator3d {
    * Get the Id of the default view.
    */
   private async _getDefaultViewId(): Promise<Id64String | undefined> {
+    // eslint-disable-next-line deprecation/deprecation
     const viewId = await this._imodel.views.queryDefaultViewId();
     if (viewId !== Id64.invalid)
       return viewId;

--- a/test-apps/display-test-app/src/frontend/ViewPicker.ts
+++ b/test-apps/display-test-app/src/frontend/ViewPicker.ts
@@ -98,6 +98,7 @@ export class ViewList extends SortedArray<ViewSpec> {
 
     if (Id64.isInvalid(this._defaultViewId) && 0 < this._array.length) {
       this._defaultViewId = this._array[0].id;
+      // eslint-disable-next-line deprecation/deprecation
       const defaultViewId = await iModel.views.queryDefaultViewId();
       for (const spec of this) {
         if (spec.id === defaultViewId) {


### PR DESCRIPTION
This property was intended to provide a reasonable default view for an iModel, but in practice each viewing application will have its own definition of "reasonable" and most existing iModels' default views are far from reasonable choices for most applications. Besides, we expect future connectors to avoid embedding views in iModels at all.