### PR TITLE
Fixes issues with debuggers on display-test-app

### DIFF
--- a/test-apps/display-test-app/vite.config.ts
+++ b/test-apps/display-test-app/vite.config.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import { defineConfig, loadEnv, searchForWorkspaceRoot } from "vite";
 import envCompatible from "vite-plugin-env-compatible";
 import browserslistToEsbuild from "browserslist-to-esbuild";
@@ -122,6 +122,7 @@ export default defineConfig(() => {
           }),
         ],
       },
+      force: true, // forces cache dumps on each rebuild. should be turned off once the issue in vite with monorepos not being correctly optimized is fixed.
       // overoptimized dependencies in the same monorepo (vite converts all cjs to esm)
       include: [
         "@itwin/core-common", // for opening iModel error

--- a/test-apps/display-test-app/vite.config.ts
+++ b/test-apps/display-test-app/vite.config.ts
@@ -54,7 +54,7 @@ export default defineConfig(() => {
     logLevel: process.env.VITE_CI ? "error" : "warn",
     build: {
       outDir: "./lib",
-      sourcemap: !!process.env.VITE_CI, // append to the resulting output file if not running in CI.
+      sourcemap: !process.env.VITE_CI, // append to the resulting output file if not running in CI.
       minify: false, // disable compaction of source code
       target: browserslistToEsbuild(), // for browserslist in package.json
       commonjsOptions: {

--- a/test-apps/display-test-app/vite.config.ts
+++ b/test-apps/display-test-app/vite.config.ts
@@ -122,7 +122,7 @@ export default defineConfig(() => {
           }),
         ],
       },
-      force: true, // forces cache dumps on each rebuild. should be turned off once the issue in vite with monorepos not being correctly optimized is fixed.
+      force: true, // forces cache dumps on each rebuild. should be turned off once the issue in vite with monorepos not being correctly optimized is fixed. Issue link: https://github.com/vitejs/vite/issues/14099
       // overoptimized dependencies in the same monorepo (vite converts all cjs to esm)
       include: [
         "@itwin/core-common", // for opening iModel error


### PR DESCRIPTION
Fixes a couple of issues in the vite config file for the display-test-app that were causing the debugger to not display correctly. First, the `build.sourcemap` value has been updated so that changed files can be seen in the debugger source. Second, the `optimizeDeps.force` value has been set, so that changes to those files are properly displayed in the debugger. Note that setting the force value is not a perfect solution, as this change causes the vite cache to be rebuilt entirely on each rebuild, which has a negative effect on performance. However, there is a known issue with vite where `optimizeDeps.include` does not work as intended on monorepos, [here](https://github.com/vitejs/vite/issues/14099). As a result, this is our best solution for known. Once the issue in vite is resolved, we should update to remove the force flag. Closes #5929. 