### PR TITLE
export SchemaFileUtility

### DIFF
--- a/common/api/ecschema-locaters.api.md
+++ b/common/api/ecschema-locaters.api.md
@@ -44,6 +44,12 @@ export abstract class SchemaFileLocater {
 }
 
 // @beta
+export class SchemaFileUtility {
+    static writeSchemaToXmlString(schema: Schema): Promise<string>;
+    static writeSchemaXmlFile(schema: Schema, outputPath: string): Promise<void>;
+}
+
+// @beta
 export class SchemaJsonFileLocater extends SchemaFileLocater implements ISchemaLocater {
     getSchema<T extends Schema>(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<T | undefined>;
     getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;

--- a/common/api/summary/ecschema-locaters.exports.csv
+++ b/common/api/summary/ecschema-locaters.exports.csv
@@ -2,6 +2,7 @@ sep=;
 Release Tag;API Item
 beta;FileSchemaKey 
 beta;class SchemaFileLocater
+beta;SchemaFileUtility
 beta;SchemaJsonFileLocater 
 beta;SchemaXmlFileLocater 
 beta;SchemaXmlStringLocater 

--- a/common/changes/@itwin/ecschema-locaters/export-file-utility_2023-09-07-18-34.json
+++ b/common/changes/@itwin/ecschema-locaters/export-file-utility_2023-09-07-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-locaters",
+      "comment": "Expose the SchemaFileUtility class to allow users to export in memory Schemas to xml files. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-locaters"
+}

--- a/core/ecschema-locaters/src/ecschema-locaters.ts
+++ b/core/ecschema-locaters/src/ecschema-locaters.ts
@@ -8,6 +8,7 @@ export * from "./SchemaJsonFileLocater";
 export * from "./SchemaXmlFileLocater";
 export * from "./StubSchemaXmlFileLocater";
 export * from "./SchemaXmlStringLocater";
+export * from "./SchemaFileUtility";
 
 /** @docs-package-description
  * The ecschema-locaters package contains classes for locating ECSchemas within a given


### PR DESCRIPTION
The SchemaFileUtility class allows writing in memory schemas to an xml file. It was requested to expose this class so that users can leverage this function. 