### PR TITLE
Presentation: Fix Presentation RPC throwing on multiple repeated requests

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-fix-presentation-rpc-throw_2023-09-08-12-33.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix-presentation-rpc-throw_2023-09-08-12-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fixed Presentation RPC throwing on multiple repeated requests",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -123,19 +123,19 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
 
     Logger.logInfo(PresentationBackendLoggerCategory.Rpc, `Received '${requestId}' request. Params: ${requestKey}`);
 
+    let imodel: IModelDb;
+    try {
+      imodel = await this.getIModel(token);
+    } catch (e) {
+      assert(e instanceof Error);
+      return this.errorResponse(PresentationStatus.InvalidArgument, e.message);
+    }
+
     let resultPromise = this._pendingRequests.getValue(requestKey);
     if (resultPromise) {
       Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request already pending`);
     } else {
       Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request not found, creating a new one`);
-      let imodel: IModelDb;
-      try {
-        imodel = await this.getIModel(token);
-      } catch (e) {
-        assert(e instanceof Error);
-        return this.errorResponse(PresentationStatus.InvalidArgument, e.message);
-      }
-
       const { clientId: _, diagnostics: diagnosticsOptions, rulesetVariables, ...options } = requestOptions;
       const managerRequestOptions: any = {
         ...options,


### PR DESCRIPTION
The bug was introduced with https://github.com/iTwin/itwinjs-core/pull/5847, causing `PresentationRpcImpl` to throw in situations where multiple similar requests were sent one after another. Issue detected by regression tests in `presentation` repo:
```
Learning snippets
    Table
Error | core-backend.RpcInterface | Error in RPC operation {"ActivityId":"70d33fcd-31c9-4d6b-9df7-4c3ff762a9d7","SessionId":"1b615b62-d[99](https://github.com/iTwin/presentation/actions/runs/6120772963/job/16613712704?pr=258#step:8:100)3-4057-8648-3678b3b39d36","ApplicationId":"2686","ApplicationVersion":"1.0.0","rpcMethod":"getPagedContent","error":{"message":"InvalidArgument: A value with given ID \"{\"iModelKey\":\"51a00423-48e6-4fc7-bdcd-d6a56b60b04e\",\"requestId\":\"getPagedContent\",\"requestOptions\":{\"locale\":\"en-PSEUDO\",\"unitSystem\":\"imperial\",\"keys\":{\"instanceKeys\":[[\"BisCore:PhysicalModel\",\"+13\"]],\"nodeKeys\":[]},\"descriptor\":{\"displayType\":\"Grid\"},\"rulesetOrId\":{\"id\":\"my-table-rules\",\"rules\":[{\"ruleType\":\"Content\",\"condition\":\"SelectedNode.IsOfClass(\\\"Model\\\", \\\"BisCore\\\")\",\"specifications\":[{\"specType\":\"ContentRelatedInstances\",\"relationshipPaths\":[{\"relationship\":{\"schemaName\":\"BisCore\",\"className\":\"ModelContainsElements\"},\"direction\":\"Forward\"}]}]}]},\"paging\":{\"start\":0,\"size\":10},\"rulesetVariables\":[],\"clientId\":\"3dde9b79-f4fd-4908-95be-9d79af08784f\"}}\" already exists in this storage.","stack":"InvalidArgument: A value with given ID \"{\"iModelKey\":\"51a00423-48e6-4fc7-bdcd-d6a56b60b04e\",\"requestId\":\"getPagedContent\",\"requestOptions\":{\"locale\":\"en-PSEUDO\",\"unitSystem\":\"imperial\",\"keys\":{\"instanceKeys\":[[\"BisCore:PhysicalModel\",\"+13\"]],\"nodeKeys\":[]},\"descriptor\":{\"displayType\":\"Grid\"},\"rulesetOrId\":{\"id\":\"my-table-rules\",\"rules\":[{\"ruleType\":\"Content\",\"condition\":\"SelectedNode.IsOfClass(\\\"Model\\\", \\\"BisCore\\\")\",\"specifications\":[{\"specType\":\"ContentRelatedInstances\",\"relationshipPaths\":[{\"relationship\":{\"schemaName\":\"BisCore\",\"className\":\"ModelContainsElements\"},\"direction\":\"Forward\"}]}]}]},\"paging\":{\"start\":0,\"size\":10},\"rulesetVariables\":[],\"clientId\":\"3dde9b79-f4fd-4908-95be-9d79af08784f\"}}\" already exists in this storage.\n    at TemporaryStorage.addValue (/home/runner/work/presentation/presentation/node_modules/.pnpm/@itwin+presentation-backend@4.1.4_@itwin+core-backend@4.1.4_@itwin+core-bentley@4.1.4_@itwin+_2vanqballz7kejnyh2ilxjojfm/node_modules/@itwin/presentation-backend/src/presentation-backend/TemporaryStorage.ts:159:13)\n    at PresentationRpcImpl.makeRequest (/home/runner/work/presentation/presentation/node_modules/.pnpm/@itwin+presentation-backend@4.1.4_@itwin+core-backend@4.1.4_@itwin+core-bentley@4.1.4_@itwin+_2vanqballz7kejnyh2ilxjojfm/node_modules/@itwin/presentation-backend/src/presentation-backend/PresentationRpcImpl.ts:181:29)\n    at RpcInvocation.resolve (/home/runner/work/presentation/presentation/node_modules/.pnpm/@itwin+core-common@4.1.4_@itwin+core-bentley@4.1.4_@itwin+core-geometry@4.1.4/node_modules/@itwin/core-common/src/rpc/core/RpcInvocation.ts:172:14)\n    at /home/runner/work/presentation/presentation/node_modules/.pnpm/@itwin+core-common@4.1.4_@itwin+core-bentley@4.1.4_@itwin+core-geometry@4.1.4/node_modules/@itwin/core-common/src/rpc/core/RpcConfiguration.ts:212:28"}}
      1) handles errors
```