### PR TITLE
Stabilize watchForChanges

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3052,6 +3052,8 @@ export abstract class IModelDb extends IModel {
     static validateSchemas(filePath: LocalFileName, forReadWrite: boolean): SchemaState;
     // (undocumented)
     readonly views: IModelDb.Views;
+    // @internal
+    get watchFilePathName(): LocalFileName;
     withPreparedSqliteStatement<T>(sql: string, callback: (stmt: SqliteStatement) => T, logErrors?: boolean): T;
     withPreparedStatement<T>(ecsql: string, callback: (stmt: ECSqlStatement) => T, logErrors?: boolean): T;
     withSqliteStatement<T>(sql: string, callback: (stmt: SqliteStatement) => T, logErrors?: boolean): T;

--- a/common/changes/@itwin/core-backend/pmc-stabilize-watch-for-changes_2023-09-08-18-32.json
+++ b/common/changes/@itwin/core-backend/pmc-stabilize-watch-for-changes_2023-09-08-18-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Make watching for briefcase changes more reliably.",
+      "comment": "Make watching for briefcase changes more reliable.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/pmc-stabilize-watch-for-changes_2023-09-08-18-32.json
+++ b/common/changes/@itwin/core-backend/pmc-stabilize-watch-for-changes_2023-09-08-18-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Make watching for briefcase changes more reliably.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -675,6 +675,10 @@
       "allowedCategories": [ "internal" ]
     },
     {
+      "name": "node-touch",
+      "allowedCategories": [ "backend" ]
+    },
+    {
       "name": "nodemon",
       "allowedCategories": [ "tools" ]
     },
@@ -788,6 +792,10 @@
     },
     {
       "name": "supertest",
+      "allowedCategories": [ "backend" ]
+    },
+    {
+      "name": "touch",
       "allowedCategories": [ "backend" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -49,6 +49,7 @@ importers:
       semver: ^7.3.5
       sinon: ^15.0.4
       source-map-loader: ^4.0.0
+      touch: ^3.1.0
       typescript: ~5.0.2
       webpack: ^5.76.0
       ws: ^7.5.3
@@ -65,6 +66,7 @@ importers:
       multiparty: 4.2.3
       reflect-metadata: 0.1.13
       semver: 7.5.4
+      touch: 3.1.0
       ws: 7.5.9
     devDependencies:
       '@itwin/build-tools': link:../../tools/build

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -28,6 +28,7 @@ importers:
       '@types/node': 18.16.1
       '@types/semver': 7.3.10
       '@types/sinon': ^10.0.15
+      '@types/touch': ^3.1.2
       '@types/ws': ^7.0.0
       chai: ^4.1.2
       chai-as-promised: ^7
@@ -85,6 +86,7 @@ importers:
       '@types/node': 18.16.1
       '@types/semver': 7.3.10
       '@types/sinon': 10.0.15
+      '@types/touch': 3.1.2
       '@types/ws': 7.4.7
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
@@ -5118,6 +5120,12 @@ packages:
     resolution: {integrity: sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==}
     dependencies:
       '@types/superagent': 4.1.18
+    dev: true
+
+  /@types/touch/3.1.2:
+    resolution: {integrity: sha512-6YYYfTc90glAZBvyjpmz6JFLtBRyLWXckmlNgK4R2czsWg63cRCI9Rb3aKJ6LPbw8jpHf7nZdVvMd6gUg4hVsw==}
+    dependencies:
+      '@types/node': 18.16.1
     dev: true
 
   /@types/triple-beam/1.3.2:

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -72,6 +72,7 @@
     "@types/node": "18.16.1",
     "@types/semver": "7.3.10",
     "@types/sinon": "^10.0.15",
+    "@types/touch": "^3.1.2",
     "@types/ws": "^7.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7",
@@ -101,9 +102,9 @@
     "inversify": "~6.0.1",
     "json5": "^2.2.3",
     "multiparty": "^4.2.1",
-    "touch": "^3.1.0",
     "reflect-metadata": "^0.1.13",
     "semver": "^7.3.5",
+    "touch": "^3.1.0",
     "ws": "^7.5.3"
   },
   "nyc": {

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -101,6 +101,7 @@
     "inversify": "~6.0.1",
     "json5": "^2.2.3",
     "multiparty": "^4.2.1",
+    "touch": "^3.1.0",
     "reflect-metadata": "^0.1.13",
     "semver": "^7.3.5",
     "ws": "^7.5.3"

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -8,6 +8,7 @@
 
 import * as fs from "fs";
 import { join } from "path";
+import * as touch from "touch";
 import { IModelJsNative } from "@bentley/imodeljs-native";
 import {
   AccessToken, assert, BeEvent, BentleyStatus, ChangeSetStatus, DbResult, Guid, GuidString, Id64, Id64Arg, Id64Array, Id64Set, Id64String,
@@ -329,6 +330,15 @@ export abstract class IModelDb extends IModel {
    * @note this member is only valid while the iModel is opened.
    */
   public get pathName(): LocalFileName { return this.nativeDb.getFilePath(); }
+
+  /** Get the full path to this iModel's "watch file".
+   * A read-only briefcase opened with `watchForChanges: true` creates this file next to the briefcase file on open, if it doesn't already exist.
+   * A writable briefcase "touches" this file if it exists whenever it commits changes to the briefcase.
+   * The read-only briefcase can use a file watcher to react when the writable briefcase makes changes to the briefcase.
+   * This is more reliable than watching the sqlite WAL file.
+   * @internal
+   */
+  public get watchFilePathName(): LocalFileName { return `${this.pathName}-watch`; }
 
   /** @internal */
   protected constructor(args: { nativeDb: IModelJsNative.DgnDb, key: string, changeset?: ChangesetIdWithIndex }) {
@@ -2542,11 +2552,13 @@ export class BriefcaseDb extends IModelDb {
     const nativeDb = this.openDgnDb(file, openMode, undefined, args);
     const briefcaseDb = new BriefcaseDb({ nativeDb, key: file.key ?? Guid.createValue(), openMode, briefcaseId: nativeDb.getBriefcaseId() });
 
-    // If they asked to watch for changes, set an fs.watch on the "-wal" file (only it is modified while we hold this connection.)
+    // If they asked to watch for changes, set an fs.watch on the "-watch" file (only it is modified while we hold this connection.)
     // Whenever there are changes, restart our defaultTxn. That loads the changes from the other connection and sends
     // notifications as if they happened on this connection. Note: the watcher is called only when the backend event loop cycles.
     if (args.watchForChanges && undefined === args.container) {
-      const watcher = fs.watch(`${file.path}-wal`, { persistent: false }, () => nativeDb.restartDefaultTxn());
+      // Must touch the file synchronously - cannot watch a file until it exists.
+      touch.sync(briefcaseDb.watchFilePathName);
+      const watcher = fs.watch(briefcaseDb.watchFilePathName, { persistent: false }, () => nativeDb.restartDefaultTxn());
       briefcaseDb.onBeforeClose.addOnce(() => watcher.close()); // Stop the watcher when we close this connection.
     }
 

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -251,6 +251,7 @@ export class TxnManager {
    */
   private touchWatchFile(): void {
     // This is an async call. We don't have any reason to await it.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     touch(this._iModel.watchFilePathName, { nocreate: true });
   }
 

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -6,6 +6,7 @@
  * @module iModels
  */
 
+import * as touch from "touch";
 import {
   assert, BeEvent, BentleyError, compareStrings, CompressedId64Set, DbResult, Id64Array, Id64String, IModelStatus, IndexMap, Logger, OrderedId64Array,
 } from "@itwin/core-bentley";
@@ -244,6 +245,15 @@ export class TxnManager {
   private _getRelationshipClass(relClassName: string): typeof Relationship {
     return this._iModel.getJsClass<typeof Relationship>(relClassName);
   }
+
+  /** If a -watch file exists for this iModel, update its timestamp so watching processes can be
+   * notified that we've modified the briefcase.
+   */
+  private touchWatchFile(): void {
+    // This is an async call. We don't have any reason to await it.
+    touch(this._iModel.watchFilePathName, { nocreate: true });
+  }
+
   /** @internal */
   protected _onBeforeOutputsHandled(elClassName: string, elId: Id64String): void {
     (this._getElementClass(elClassName) as any).onBeforeOutputsHandled(elId, this._iModel);
@@ -292,6 +302,7 @@ export class TxnManager {
 
   /** @internal */
   protected _onCommitted() {
+    this.touchWatchFile();
     this.onCommitted.raiseEvent();
     IpcHost.notifyTxns(this._iModel, "notifyCommitted", this.hasPendingTxns, Date.now());
   }
@@ -323,6 +334,7 @@ export class TxnManager {
 
   /** @internal */
   protected _onAfterUndoRedo(isUndo: boolean) {
+    this.touchWatchFile();
     this.onAfterUndoRedo.raiseEvent(isUndo);
     IpcHost.notifyTxns(this._iModel, "notifyAfterUndoRedo", isUndo);
   }


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/845 (the geometry synchronization problem, not the project extents synchronization problem).
Previously, a reader process would watch sqlite's WAL file to detect when a writer process modified the briefcase.
This is unreliable - we may be notified of the change to the file before the changes can be read.
Instead:
- When opening a read-only briefcase /path/to/my.bim with `watchForChanges=true`, create /path/to/my.bim-watch if it does not exist, and watch it for changes. I call this the briefcase's "watch file".
- After committing to a briefcase, modify the timestamp on my.bim-watch if it exists, to signal that the changes are ready to be read by a reader process.

I could delete the watch file when closing the read-only briefcase, but that would break a hypothetical second briefcase that is also watching the file.
I could record the number of current watchers into the watch file, and delete it only when closing the only remaining watcher, but that would be prone to all sorts of fun race conditions, and if a watcher process terminated without closing the briefcase the watcher count would become inaccurate.
Instead, I just leave the empty file in perpetuity once created.
