### PR TITLE
Use Instance Query to get Aspects for abstract classes

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3088,10 +3088,14 @@ export namespace IModelDb {
         insertElement(elProps: ElementProps): Id64String;
         // @internal
         _queryAspects(elementId: Id64String, fromClassFullName: string, excludedClassFullNames?: Set<string>): ElementAspect[];
+        // @internal
+        _queryAspectsUsingInstanceQuery(elementId: Id64String, fromClassFullName?: string, excludedClassFullNames?: Set<string>): ElementAspect[];
         queryChildren(elementId: Id64String): Id64String[];
         queryElementIdByCode(code: Required<CodeProps>): Id64String | undefined;
         queryLastModifiedTime(elementId: Id64String): string;
         queryParent(elementId: Id64String): Id64String | undefined;
+        // @internal
+        _runInstanceQuery(sql: string, elementId: Id64String, excludedClassFullNames?: Set<string>): ElementAspect[];
         tryGetElement<T extends Element_2>(elementId: Id64String | GuidString | Code | ElementLoadProps, elementClass?: EntityClassType<Element_2>): T | undefined;
         tryGetElementProps<T extends ElementProps>(elementId: Id64String | GuidString | Code | ElementLoadProps): T | undefined;
         updateAspect(aspectProps: ElementAspectProps): void;

--- a/common/changes/@itwin/core-backend/rohitptnkr-use-instance-queries-in-getAspects_2023-09-11-10-56.json
+++ b/common/changes/@itwin/core-backend/rohitptnkr-use-instance-queries-in-getAspects_2023-09-11-10-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Use instance queries to get aspects for abstract classes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/element/ElementAspect.test.ts
+++ b/core/backend/src/test/element/ElementAspect.test.ts
@@ -4,12 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 import { assert, expect } from "chai";
 import { Id64, Id64String } from "@itwin/core-bentley";
-import { ElementAspectProps, ExternalSourceAspectProps, IModel, IModelError, SubCategoryAppearance } from "@itwin/core-common";
+import { ElementAspectProps, ExternalSourceAspectProps, IModel, SubCategoryAppearance } from "@itwin/core-common";
 import {
   Element, ElementAspect, ElementMultiAspect, ElementUniqueAspect, ExternalSourceAspect, PhysicalElement, SnapshotDb, SpatialCategory,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
-import { SequentialLogMatcher } from "../SequentialLogMatcher";
 
 describe("ElementAspect", () => {
 
@@ -122,12 +121,9 @@ describe("ElementAspect", () => {
     assert.equal(0, iModel.elements.getAspects(rootSubject.id).length, "Don't expect any aspects on the root Subject");
 
     // The 'Element' property is introduced by ElementUniqueAspect and ElementMultiAspect, but is not available at the ElementAspect base class.
-    // This is unfortunate, but is expected behavior and the reason why the getAllAspects method exists.
-
-    const slm = new SequentialLogMatcher();
-    slm.append().error().category("ECDb").message("No property or enumeration found for expression 'Element.Id'.");
-    assert.throws(() => iModel.elements.getAspects(element.id, ElementAspect.classFullName), IModelError);
-    assert.isTrue(slm.finishAndDispose());
+    // Since we're now using instance queries to query ElementUniqueAspect and ElementMultiAspect directly in getAspects(), we can provide ElementAspect to the function as well.
+    const aspects: ElementAspect[] = iModel.elements.getAspects(element.id, ElementAspect.classFullName);
+    assert.equal(aspects.length, 6);
 
     const allAspects: ElementAspect[] = iModel.elements.getAspects(element.id);
     assert.equal(allAspects.length, 6);


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/813.

There was a performance issue when calling getAspects() on an abstract class.
The function has been modified to use instance queries in order to get all aspects in a single go.