### PR TITLE
Add support for Electron 26

### DIFF
--- a/common/changes/@itwin/certa/gytis-Electron-26-support_2023-09-11-10-31.json
+++ b/common/changes/@itwin/certa/gytis-Electron-26-support_2023-09-11-10-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "Add support for Electron 26",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/changes/@itwin/core-electron/gytis-Electron-26-support_2023-09-11-10-31.json
+++ b/common/changes/@itwin/core-electron/gytis-Electron-26-support_2023-09-11-10-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Add support for Electron 26",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -452,7 +452,7 @@ importers:
       '@types/mocha': ^8.2.2
       '@types/node': 18.16.1
       chai: ^4.1.2
-      electron: ^25.0.0
+      electron: ^26.0.0
       eslint: ^8.44.0
       glob: ^7.1.2
       mocha: ^10.0.0
@@ -479,7 +479,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
       chai: 4.3.7
-      electron: 25.3.1
+      electron: 26.2.0
       eslint: 8.45.0
       glob: 7.2.3
       mocha: 10.2.0
@@ -1296,7 +1296,7 @@ importers:
       '@types/node': 18.16.1
       chai: ^4.1.2
       cpx2: ^3.0.0
-      electron: ^25.0.0
+      electron: ^26.0.0
       eslint: ^8.44.0
       mocha: ^10.0.0
       rimraf: ^3.0.2
@@ -1308,11 +1308,11 @@ importers:
       '@itwin/core-electron': link:../../core/electron
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-geometry': link:../../core/geometry
-      electron: 25.3.1
+      electron: 26.2.0
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/eslint-plugin': 4.0.0-dev.44_xaiy4vqh4w4prx7ej54h3ywmza
-      '@itwin/oidc-signin-tool': 3.6.1_jgafqqsuly2hjjpibxrcu56zma
+      '@itwin/oidc-signin-tool': 3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e
       '@types/chai': 4.3.1
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
@@ -1722,7 +1722,7 @@ importers:
       crypto-browserify: 3.12.0
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^25.0.0
+      electron: ^26.0.0
       eslint: ^8.44.0
       fs-extra: ^8.1.0
       glob: ^7.1.2
@@ -1760,7 +1760,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_vfbcftczlx5fy7lxoa3opanwwu
+      '@itwin/electron-authorization': 0.14.1_za7ctafeaxhew6k36pfsbotv7m
       '@itwin/express-server': link:../../core/express-server
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.0_wj555zckjupkhkzyssqqpl4sei
@@ -1771,7 +1771,7 @@ importers:
       azurite: 3.24.0
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
-      electron: 25.3.1
+      electron: 26.2.0
       fs-extra: 8.1.0
       sinon: 15.2.0
       sinon-chai: 3.7.0_chai@4.3.7+sinon@15.2.0
@@ -1781,7 +1781,7 @@ importers:
       '@itwin/eslint-plugin': 4.0.0-dev.44_xaiy4vqh4w4prx7ej54h3ywmza
       '@itwin/itwins-client': 1.2.0
       '@itwin/object-storage-core': 2.1.0
-      '@itwin/oidc-signin-tool': 3.6.1_jgafqqsuly2hjjpibxrcu56zma
+      '@itwin/oidc-signin-tool': 3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e
       '@types/chai': 4.3.1
       '@types/chai-as-promised': 7.1.5
       '@types/fs-extra': 4.0.12
@@ -2038,7 +2038,7 @@ importers:
       browserify-zlib: ^0.2.0
       buffer: ^6.0.3
       chai: ^4.1.2
-      electron: ^25.0.0
+      electron: ^26.0.0
       eslint: ^8.44.0
       express: ^4.16.3
       glob: ^7.1.2
@@ -2059,7 +2059,7 @@ importers:
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/express-server': link:../../core/express-server
-      electron: 25.3.1
+      electron: 26.2.0
       express: 4.18.2
       semver: 7.5.4
       spdy: 4.0.2
@@ -2454,7 +2454,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^25.0.0
+      electron: ^26.0.0
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2483,14 +2483,14 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/core-quantity': link:../../core/quantity
-      '@itwin/electron-authorization': 0.14.1_vfbcftczlx5fy7lxoa3opanwwu
+      '@itwin/electron-authorization': 0.14.1_za7ctafeaxhew6k36pfsbotv7m
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.0_wj555zckjupkhkzyssqqpl4sei
       '@itwin/imodels-access-frontend': 3.1.0_ueafa4slb6ohrhyf7kbp6egmha
       '@itwin/imodels-client-authoring': 3.1.0
       '@itwin/imodels-client-management': 3.1.0
-      '@itwin/oidc-signin-tool': 3.6.1_jgafqqsuly2hjjpibxrcu56zma
+      '@itwin/oidc-signin-tool': 3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e
       '@itwin/reality-data-client': 0.9.0_mdtbcqczpmeuv6yjzfaigjndwi
       body-parser: 1.20.2
     devDependencies:
@@ -2507,7 +2507,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 25.3.1
+      electron: 26.2.0
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.45.0
       express: 4.18.2
@@ -2571,7 +2571,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^25.0.0
+      electron: ^26.0.0
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2612,7 +2612,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_vfbcftczlx5fy7lxoa3opanwwu
+      '@itwin/electron-authorization': 0.14.1_za7ctafeaxhew6k36pfsbotv7m
       '@itwin/frontend-devtools': link:../../core/frontend-devtools
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
@@ -2640,7 +2640,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 25.3.1
+      electron: 26.2.0
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.45.0
       express: 4.18.2
@@ -2913,7 +2913,7 @@ importers:
       '@types/yargs': 17.0.19
       canonical-path: ^1.0.0
       detect-port: ~1.3.0
-      electron: ^25.0.0
+      electron: ^26.0.0
       eslint: ^8.44.0
       express: ^4.16.3
       jsonc-parser: ~2.0.3
@@ -2945,7 +2945,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
       '@types/yargs': 17.0.19
-      electron: 25.3.1
+      electron: 26.2.0
       eslint: 8.45.0
       nyc: 15.1.0
       rimraf: 3.0.2
@@ -4162,7 +4162,7 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/certa/3.7.11_electron@25.3.1:
+  /@itwin/certa/3.7.11_electron@26.2.0:
     resolution: {integrity: sha512-d5n/LtuL6hoeoZqO14O3fKYfpuW7IwMu99rxpO/P1a9xRj0Pes/VRwpA/74gJWROlQ38irm4Ywm4Tv5wcrSPfg==}
     hasBin: true
     peerDependencies:
@@ -4172,7 +4172,7 @@ packages:
         optional: true
     dependencies:
       detect-port: 1.3.0
-      electron: 25.3.1
+      electron: 26.2.0
       express: 4.18.2
       jsonc-parser: 2.0.3
       lodash: 4.17.21
@@ -4224,7 +4224,7 @@ packages:
       js-base64: 3.7.5
     dev: false
 
-  /@itwin/electron-authorization/0.14.1_vfbcftczlx5fy7lxoa3opanwwu:
+  /@itwin/electron-authorization/0.14.1_za7ctafeaxhew6k36pfsbotv7m:
     resolution: {integrity: sha512-NslwCLw129obJHBRMcV/MdykqbD7d93SKTYOOBdaEab2T2niGCmCTJAOkjcWiZZMU0SwmjyxmY9iqdZjvvIqCA==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
@@ -4233,7 +4233,7 @@ packages:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': 4.0.6_67wltvhdskk2oee2c3z2o4tfly
       '@openid/appauth': 1.3.1
-      electron: 25.3.1
+      electron: 26.2.0
       keytar: 7.9.0
       username: 5.1.0
     transitivePeerDependencies:
@@ -4416,12 +4416,12 @@ packages:
       - debug
     dev: false
 
-  /@itwin/oidc-signin-tool/3.6.1_jgafqqsuly2hjjpibxrcu56zma:
+  /@itwin/oidc-signin-tool/3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/certa': 3.7.11_electron@25.3.1
+      '@itwin/certa': 3.7.11_electron@26.2.0
       '@itwin/core-bentley': link:../../core/bentley
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -7001,8 +7001,8 @@ packages:
   /electron-to-chromium/1.4.467:
     resolution: {integrity: sha512-2qI70O+rR4poYeF2grcuS/bCps5KJh6y1jtZMDDEteyKJQrzLOEhFyXCLcHW6DTBjKjWkk26JhWoAi+Ux9A0fg==}
 
-  /electron/25.3.1:
-    resolution: {integrity: sha512-t0QXXqgf0/P0OJ9LU3qpcBMK+wL0FRwTQfooBaaG08v5hywPzc1yplfb3l4tS1xC0Ttw8IBaKLBeEoRgxBRHjg==}
+  /electron/26.2.0:
+    resolution: {integrity: sha512-H6Z0sYTtLcybHCQT1yti/8BK+vN5/ZfoekKcdrfZMh5mVf2Z7psFVs6nBhXPzIOyRE/gdb6NcOppnUsGc3NJVQ==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -39,7 +39,7 @@
     "@itwin/core-bentley": "workspace:^4.2.0-dev.18",
     "@itwin/core-common": "workspace:^4.2.0-dev.18",
     "@itwin/core-frontend": "workspace:^4.2.0-dev.18",
-    "electron": ">=23.0.0 <26.0.0"
+    "electron": ">=23.0.0 <27.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",
@@ -53,7 +53,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.16.1",
     "chai": "^4.1.2",
-    "electron": "^25.0.0",
+    "electron": "^26.0.0",
     "eslint": "^8.44.0",
     "glob": "^7.1.2",
     "mocha": "^10.0.0",

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,7 @@ Table of contents:
 
 - [Geometry](#geometry)
   - [Clip any curve](#clip-any-curve)
+- [Electron 26 support](#electron-26-support)
 
 
 ## Geometry
@@ -14,3 +15,7 @@ Table of contents:
 ### Clip any curve
 
 The new [ClipUtils.clipAnyCurve] clips any `CurvePrimitive`, `Path`, or `BagOfCurves` and any region including any `Loop`, `ParityRegion`, or `UnionRegion`. One just needs to pass `AnyCurve` and a `Clipper` and the functions collect portions of any curve that are within the clipper into an array of any curves and returns the array.
+
+## Electron 26 support
+
+In addition to already supported Electron versions, iTwin.js now supports [Electron 26](https://www.electronjs.org/blog/electron-26-0).

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,4 +18,4 @@ The new [ClipUtils.clipAnyCurve] clips any `CurvePrimitive`, `Path`, or `BagOfCu
 
 ## Electron 26 support
 
-In addition to [already supported Electron versions](../learning/SupportedPlatforms.md), iTwin.js now supports [Electron 26](https://www.electronjs.org/blog/electron-26-0).
+In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 26](https://www.electronjs.org/blog/electron-26-0).

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,4 +18,4 @@ The new [ClipUtils.clipAnyCurve] clips any `CurvePrimitive`, `Path`, or `BagOfCu
 
 ## Electron 26 support
 
-In addition to already supported Electron versions, iTwin.js now supports [Electron 26](https://www.electronjs.org/blog/electron-26-0).
+In addition to [already supported Electron versions](../learning/SupportedPlatforms.md), iTwin.js now supports [Electron 26](https://www.electronjs.org/blog/electron-26-0).

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -23,7 +23,7 @@
     "@itwin/core-electron": "workspace:*",
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-geometry": "workspace:*",
-    "electron": "^25.0.0"
+    "electron": "^26.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -53,7 +53,7 @@
     "azurite": "^3.24.0",
     "chai-as-promised": "^7",
     "chai": "^4.1.2",
-    "electron": "^25.0.0",
+    "electron": "^26.0.0",
     "fs-extra": "^8.1.0",
     "sinon-chai": "^3.2.0",
     "sinon": "^15.0.4"

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -26,7 +26,7 @@
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-mobile": "workspace:*",
     "@itwin/express-server": "workspace:*",
-    "electron": "^25.0.0",
+    "electron": "^26.0.0",
     "express": "^4.16.3",
     "semver": "^7.3.5",
     "spdy": "^4.0.1"

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -72,7 +72,7 @@
     "cpx2": "^3.0.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^25.0.0",
+    "electron": "^26.0.0",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -89,7 +89,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^25.0.0",
+    "electron": "^26.0.0",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -59,7 +59,7 @@
     "typescript": "~5.0.2"
   },
   "peerDependencies": {
-    "electron": ">=23.0.0 <26.0.0"
+    "electron": ">=23.0.0 <27.0.0"
   },
   "peerDependenciesMeta": {
     "electron": {

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -52,7 +52,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.16.1",
     "@types/yargs": "17.0.19",
-    "electron": "^25.0.0",
+    "electron": "^26.0.0",
     "eslint": "^8.44.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
#### Changes:
- Extend supported Electron version range with Electron 26.
- Increase Electron dev dependency version to `^26.0.0`.

No code changes required since core doesn't use [APIs changed in 26](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#planned-breaking-api-changes-260).