### PR TITLE
Updated getAspects to use instance queries

### DIFF
--- a/common/changes/@itwin/core-backend/rohitptnkr-update-tests-instance-query-getAspects_2023-09-13-08-49.json
+++ b/common/changes/@itwin/core-backend/rohitptnkr-update-tests-instance-query-getAspects_2023-09-13-08-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "As instance access no longer an experimental feature, removed experimental features option from relevant ecsql.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2065,7 +2065,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
         return this.runInstanceQuery(`SELECT $ FROM (
           SELECT ECInstanceId, ECClassId FROM Bis.ElementMultiAspect WHERE Element.Id = :elementId
             UNION ALL
-          SELECT ECInstanceId, ECClassId FROM Bis.ElementUniqueAspect WHERE Element.Id = :elementId) OPTIONS USE_JS_PROP_NAMES DO_NOT_TRUNCATE_BLOB ENABLE_EXPERIMENTAL_FEATURES`, elementId, excludedClassFullNames);
+          SELECT ECInstanceId, ECClassId FROM Bis.ElementUniqueAspect WHERE Element.Id = :elementId) OPTIONS USE_JS_PROP_NAMES DO_NOT_TRUNCATE_BLOB`, elementId, excludedClassFullNames);
 
       // Check if class is abstract
       const fullClassName = aspectClassFullName.split(":");
@@ -2092,7 +2092,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
         SELECT ECInstanceId, ECClassId FROM Bis.ElementMultiAspect WHERE Element.Id = :elementId AND ECClassId IN (${classIdList})
           UNION ALL
         SELECT ECInstanceId, ECClassId FROM Bis.ElementUniqueAspect WHERE Element.Id = :elementId AND ECClassId IN (${classIdList})
-        ) OPTIONS USE_JS_PROP_NAMES DO_NOT_TRUNCATE_BLOB ENABLE_EXPERIMENTAL_FEATURES`, elementId, excludedClassFullNames);
+        ) OPTIONS USE_JS_PROP_NAMES DO_NOT_TRUNCATE_BLOB`, elementId, excludedClassFullNames);
     }
 
     /** Insert a new ElementAspect into the iModel.

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2015,6 +2015,21 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       return this._iModel.constructEntity<ElementAspect>(aspect);
     }
 
+    /** Get a single ElementAspect by its instance Id.
+     * @throws [[IModelError]]
+     */
+    public getAspect(aspectInstanceId: Id64String): ElementAspect {
+      const sql = "SELECT ECClassId FROM BisCore:ElementAspect WHERE ECInstanceId=:aspectInstanceId";
+      const aspectClassFullName = this._iModel.withPreparedStatement(sql, (statement: ECSqlStatement): string | undefined => {
+        statement.bindId("aspectInstanceId", aspectInstanceId);
+        return (DbResult.BE_SQLITE_ROW === statement.step()) ? statement.getValue(0).getClassNameForClassId().replace(".", ":") : undefined;
+      });
+      if (undefined === aspectClassFullName) {
+        throw new IModelError(IModelStatus.NotFound, `ElementAspect not found ${aspectInstanceId}`);
+      }
+      return this._queryAspect(aspectInstanceId, aspectClassFullName);
+    }
+
     private static classMap = new Map<string, string>();
 
     private runInstanceQuery(sql: string, elementId: Id64String, excludedClassFullNames?: Set<string>): ElementAspect[] {
@@ -2039,21 +2054,6 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       });
     }
 
-    /** Get a single ElementAspect by its instance Id.
-     * @throws [[IModelError]]
-     */
-    public getAspect(aspectInstanceId: Id64String): ElementAspect {
-      const sql = "SELECT ECClassId FROM BisCore:ElementAspect WHERE ECInstanceId=:aspectInstanceId";
-      const aspectClassFullName = this._iModel.withPreparedStatement(sql, (statement: ECSqlStatement): string | undefined => {
-        statement.bindId("aspectInstanceId", aspectInstanceId);
-        return (DbResult.BE_SQLITE_ROW === statement.step()) ? statement.getValue(0).getClassNameForClassId().replace(".", ":") : undefined;
-      });
-      if (undefined === aspectClassFullName) {
-        throw new IModelError(IModelStatus.NotFound, `ElementAspect not found ${aspectInstanceId}`);
-      }
-      return this._queryAspect(aspectInstanceId, aspectClassFullName);
-    }
-
     /** Get the ElementAspect instances that are owned by the specified element.
      * @param elementId Get ElementAspects associated with this Element
      * @param aspectClassFullName Optionally filter ElementAspects polymorphically by this class name
@@ -2061,11 +2061,15 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @throws [[IModelError]]
      */
     public getAspects(elementId: Id64String, aspectClassFullName?: string, excludedClassFullNames?: Set<string>): ElementAspect[] {
-      if (aspectClassFullName === undefined)
-        return this.runInstanceQuery(`SELECT $ FROM (
+      if (aspectClassFullName === undefined) {
+        const allAspects: ElementAspect[] = this.runInstanceQuery(`SELECT $ FROM (
           SELECT ECInstanceId, ECClassId FROM Bis.ElementMultiAspect WHERE Element.Id = :elementId
             UNION ALL
           SELECT ECInstanceId, ECClassId FROM Bis.ElementUniqueAspect WHERE Element.Id = :elementId) OPTIONS USE_JS_PROP_NAMES DO_NOT_TRUNCATE_BLOB`, elementId, excludedClassFullNames);
+        if (allAspects.length === 0)
+          Logger.logError(BackendLoggerCategory.ECDb, `No aspects found for class ${aspectClassFullName} and element ${elementId}`);
+        return allAspects;
+      }
 
       // Check if class is abstract
       const fullClassName = aspectClassFullName.split(":");
@@ -2094,11 +2098,14 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
         return [];
       }
       // Execute an instance query to retrieve all aspects from all the derived classes
-      return this.runInstanceQuery(`SELECT $ FROM (
+      const aspects: ElementAspect[] = this.runInstanceQuery(`SELECT $ FROM (
         SELECT ECInstanceId, ECClassId FROM Bis.ElementMultiAspect WHERE Element.Id = :elementId AND ECClassId IN (${classIdList})
           UNION ALL
         SELECT ECInstanceId, ECClassId FROM Bis.ElementUniqueAspect WHERE Element.Id = :elementId AND ECClassId IN (${classIdList})
         ) OPTIONS USE_JS_PROP_NAMES DO_NOT_TRUNCATE_BLOB`, elementId, excludedClassFullNames);
+      if (aspects.length === 0)
+        Logger.logError(BackendLoggerCategory.ECDb, `No aspects found for class ${aspectClassFullName} and element ${elementId}`);
+      return aspects;
     }
 
     /** Insert a new ElementAspect into the iModel.

--- a/core/backend/src/test/ecdb/ECSqlAst.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlAst.test.ts
@@ -470,20 +470,20 @@ describe("ECSql Abstract Syntax Tree", () => {
   it("parse $, $->prop", async () => {
     const tests = [
       {
-        orignalECSql: "SELECT $ FROM Meta.ECClassDef ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-        expectedECSql: "SELECT $ FROM [ECDbMeta].[ECClassDef] ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+        orignalECSql: "SELECT $ FROM Meta.ECClassDef",
+        expectedECSql: "SELECT $ FROM [ECDbMeta].[ECClassDef]",
       },
       {
-        orignalECSql: "SELECT $->[Name], $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-        expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef] ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+        orignalECSql: "SELECT $->[Name], $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef",
+        expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef]",
       },
       // {
-      //   orignalECSql: "SELECT $->Name, $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef WHERE $->Name LIKE '%Hellp' ORDER BY $->ECInstanceId DESC ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-      //   expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef] WHERE $->[Name] LIKE '%Hellp' ORDER BY $->[ECInstanceId] DESC ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+      //   orignalECSql: "SELECT $->Name, $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef WHERE $->Name LIKE '%Hellp' ORDER BY $->ECInstanceId DESC",
+      //   expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef] WHERE $->[Name] LIKE '%Hellp' ORDER BY $->[ECInstanceId] DESC",
       // },
       {
-        orignalECSql: "SELECT e.$->[Name], e.$-> DisplayLabel, e.$ -> Nothing FROM Meta.ECClassDef e ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-        expectedECSql: "SELECT [e].$->[Name], [e].$->[DisplayLabel], [e].$->[Nothing] FROM [ECDbMeta].[ECClassDef] [e] ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+        orignalECSql: "SELECT e.$->[Name], e.$-> DisplayLabel, e.$ -> Nothing FROM Meta.ECClassDef e",
+        expectedECSql: "SELECT [e].$->[Name], [e].$->[DisplayLabel], [e].$->[Nothing] FROM [ECDbMeta].[ECClassDef] [e]",
       },
     ];
     for (const test of tests) {

--- a/core/backend/src/test/element/ElementAspect.test.ts
+++ b/core/backend/src/test/element/ElementAspect.test.ts
@@ -36,6 +36,7 @@ describe("ElementAspect", () => {
     assert.equal(aspect1.classFullName, "DgnPlatformTest:TestUniqueAspectNoHandler");
     assert.equal(aspect1.asAny.testUniqueAspectProperty, "Aspect1-Updated");
     assert.equal(aspect1.asAny.length, 1);
+    assert.equal(JSON.stringify(aspect1), `{"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"Aspect1-Updated","length":1,"element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
     // cross-check getAspects against getAspect
     const aspect1X: ElementAspect = iModel.elements.getAspect(aspect1.id);
     assert.exists(aspect1X);
@@ -43,6 +44,7 @@ describe("ElementAspect", () => {
     assert.equal(aspect1X.classFullName, "DgnPlatformTest:TestUniqueAspectNoHandler");
     assert.equal(aspect1X.asAny.testUniqueAspectProperty, "Aspect1-Updated");
     assert.equal(aspect1X.asAny.length, 1);
+    assert.equal(JSON.stringify(aspect1X), `{"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"Aspect1-Updated","length":1,"element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
 
     const aspect2: ElementAspect = iModel.elements.getAspects(element.id, "DgnPlatformTest:TestUniqueAspect")[0];
     assert.exists(aspect2);
@@ -50,6 +52,7 @@ describe("ElementAspect", () => {
     assert.equal(aspect2.classFullName, "DgnPlatformTest:TestUniqueAspect");
     assert.equal(aspect2.asAny.testUniqueAspectProperty, "Aspect2-Updated");
     assert.isUndefined(aspect2.asAny.length);
+    assert.equal(JSON.stringify(aspect2), `{"classFullName":"DgnPlatformTest:TestUniqueAspect","id":"0x1","testUniqueAspectProperty":"Aspect2-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
     // cross-check getAspects against getAspect
     const aspect2X: ElementAspect = iModel.elements.getAspect(aspect2.id);
     assert.exists(aspect2X);
@@ -57,6 +60,7 @@ describe("ElementAspect", () => {
     assert.equal(aspect2X.classFullName, "DgnPlatformTest:TestUniqueAspect");
     assert.equal(aspect2X.asAny.testUniqueAspectProperty, "Aspect2-Updated");
     assert.isUndefined(aspect2X.asAny.length);
+    assert.equal(JSON.stringify(aspect2X), `{"classFullName":"DgnPlatformTest:TestUniqueAspect","id":"0x1","testUniqueAspectProperty":"Aspect2-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
 
     const uniqueAspects: ElementUniqueAspect[] = iModel.elements.getAspects(element.id, ElementUniqueAspect.classFullName);
     assert.equal(uniqueAspects.length, 2);
@@ -68,6 +72,8 @@ describe("ElementAspect", () => {
       assert.equal(aspectX.schemaName, aspect.schemaName);
       assert.equal(aspectX.className, aspect.className);
     });
+    assert.equal(JSON.stringify(uniqueAspects), `[{"classFullName":"DgnPlatformTest:TestUniqueAspect","id":"0x1","testUniqueAspectProperty":"Aspect2-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}},
+    {"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"Aspect1-Updated","length":1,"element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}]`.replace(/\s+/g, ""));
 
     const multiAspectsA: ElementAspect[] = iModel.elements.getAspects(element.id, "DgnPlatformTest:TestMultiAspectNoHandler");
     assert.exists(multiAspectsA);
@@ -86,6 +92,8 @@ describe("ElementAspect", () => {
       assert.exists(aspectX.asAny.testMultiAspectProperty);
       assert.equal(aspectX.asAny.testMultiAspectProperty, aspect.asAny.testMultiAspectProperty);
     });
+    assert.equal(JSON.stringify(multiAspectsA), `[{"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}}]`.replace(/\s+/g, ""));
 
     const multiAspectsB: ElementAspect[] = iModel.elements.getAspects(element.id, "DgnPlatformTest:TestMultiAspect");
     assert.exists(multiAspectsB);
@@ -103,6 +111,8 @@ describe("ElementAspect", () => {
       assert.equal(aspectX.className, "TestMultiAspect");
       assert.exists(aspectX.asAny.testMultiAspectProperty);
     });
+    assert.equal(JSON.stringify(multiAspectsB), `[{"classFullName":"DgnPlatformTest:TestMultiAspect","id":"0x2","testMultiAspectProperty":"Aspect5-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspect","id":"0x3","testMultiAspectProperty":"Aspect6-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}}]`.replace(/\s+/g, ""));
 
     const multiAspects: ElementAspect[] = iModel.elements.getAspects(element.id, ElementMultiAspect.classFullName);
     assert.equal(multiAspects.length, 4);
@@ -114,6 +124,10 @@ describe("ElementAspect", () => {
       assert.equal(aspectX.schemaName, aspect.schemaName);
       assert.equal(aspectX.className, aspect.className);
     });
+    assert.equal(JSON.stringify(multiAspects), `[{"classFullName":"DgnPlatformTest:TestMultiAspect","id":"0x2","testMultiAspectProperty":"Aspect5-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspect","id":"0x3","testMultiAspectProperty":"Aspect6-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}}]`.replace(/\s+/g, ""));
 
     const rootSubject = iModel.elements.getRootSubject();
     assert.equal(0, iModel.elements.getAspects(rootSubject.id, "DgnPlatformTest:TestUniqueAspect").length, "Don't expect DgnPlatformTest:TestUniqueAspect aspects on the root Subject");
@@ -122,11 +136,20 @@ describe("ElementAspect", () => {
 
     // The 'Element' property is introduced by ElementUniqueAspect and ElementMultiAspect, but is not available at the ElementAspect base class.
     // Since we're now using instance queries to query ElementUniqueAspect and ElementMultiAspect directly in getAspects(), we can provide ElementAspect to the function as well.
+    const aspectList = `[{"classFullName":"DgnPlatformTest:TestMultiAspect","id":"0x2","testMultiAspectProperty":"Aspect5-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspect","id":"0x3","testMultiAspectProperty":"Aspect6-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestUniqueAspect","id":"0x1","testUniqueAspectProperty":"Aspect2-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}},
+    {"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"Aspect1-Updated","length":1,"element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}]`.replace(/\s+/g, "");
+
     const aspects: ElementAspect[] = iModel.elements.getAspects(element.id, ElementAspect.classFullName);
     assert.equal(aspects.length, 6);
+    assert.equal(JSON.stringify(aspects), aspectList);
 
     const allAspects: ElementAspect[] = iModel.elements.getAspects(element.id);
     assert.equal(allAspects.length, 6);
+    assert.equal(JSON.stringify(allAspects), aspectList);
   });
 
   it("should be able to insert, update, and delete MultiAspects", () => {
@@ -143,6 +166,9 @@ describe("ElementAspect", () => {
     iModel.elements.insertAspect(aspectProps);
     let aspects: ElementAspect[] = iModel.elements.getAspects(element.id, aspectProps.classFullName);
     assert.isAtLeast(aspects.length, 1);
+    assert.equal(JSON.stringify(aspects), `[{"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x21","testMultiAspectProperty":"MultiAspectInsertTest1","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}}]`.replace(/\s+/g, ""));
     const numAspects = aspects.length;
 
     let found: boolean = false;
@@ -162,10 +188,17 @@ describe("ElementAspect", () => {
     const aspectsUpdated: ElementAspect[] = iModel.elements.getAspects(element.id, aspectProps.classFullName);
     assert.equal(aspectsUpdated.length, aspects.length);
     assert.equal(aspectsUpdated[foundIndex].asAny.testMultiAspectProperty, "MultiAspectInsertTest1-Updated");
+    // Check if aspect was updated
+    assert.equal(JSON.stringify(aspectsUpdated), `[{"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x21","testMultiAspectProperty":"MultiAspectInsertTest1-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsMultiAspects"}}]`.replace(/\s+/g, ""));
 
     iModel.elements.deleteAspect(aspects[foundIndex].id);
     aspects = iModel.elements.getAspects(element.id, aspectProps.classFullName);
     assert.equal(numAspects, aspects.length + 1);
+    // Check if aspect was deleted
+    assert.equal(JSON.stringify(aspects), `[{"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}}]`.replace(/\s+/g, ""));
   });
 
   it("should be able to insert, update, and delete UniqueAspects", () => {
@@ -182,16 +215,19 @@ describe("ElementAspect", () => {
     const aspects: ElementAspect[] = iModel.elements.getAspects(element.id, aspectProps.classFullName);
     assert.isTrue(aspects.length === 1);
     assert.equal(aspects[0].asAny.testUniqueAspectProperty, aspectProps.testUniqueAspectProperty);
+    assert.equal(JSON.stringify(aspects), `[{"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"UniqueAspectInsertTest1","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}]`);
 
     aspects[0].asAny.testUniqueAspectProperty = "UniqueAspectInsertTest1-Updated";
     iModel.elements.updateAspect(aspects[0].toJSON());
     const aspectsUpdated: ElementAspect[] = iModel.elements.getAspects(element.id, aspectProps.classFullName);
     assert.equal(aspectsUpdated.length, 1);
     assert.equal(aspectsUpdated[0].asAny.testUniqueAspectProperty, "UniqueAspectInsertTest1-Updated");
+    assert.equal(JSON.stringify(aspectsUpdated), `[{"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"UniqueAspectInsertTest1-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}]`);
 
     iModel.elements.deleteAspect(aspects[0].id);
     try {
-      iModel.elements.getAspects(element.id, aspectProps.classFullName);
+      const noAspects = iModel.elements.getAspects(element.id, aspectProps.classFullName);
+      assert.equal(noAspects.length, 0);
       assert.isTrue(false, "Expected this line to be skipped");
     } catch (error) {
       assert.isTrue(error instanceof Error);
@@ -224,6 +260,7 @@ describe("ElementAspect", () => {
 
     const aspects: ElementAspect[] = iModelDb.elements.getAspects(elementId, aspectProps.classFullName);
     assert.equal(aspects.length, 1);
+    assert.equal(JSON.stringify(aspects), `[{"classFullName":"BisCore:ExternalSourceAspect","id":"0x21","scope":{"id":"0x1","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"A","kind":"Letter","version":"1.0","checksum":"1","element":{"id":"0x11","relClassName":"BisCore.ElementOwnsMultiAspects"}}]`);
     expect(aspects[0]).to.deep.subsetEqual(aspectProps, { normalizeClassNameProps: true });
 
     expect(aspectJson).to.deep.subsetEqual(aspectProps, { normalizeClassNameProps: true });
@@ -295,12 +332,19 @@ describe("ElementAspect", () => {
     e1Aspects.forEach((x) => {
       assert.isTrue(findInProps(x, e1AspectProps));
     });
+    assert.equal(JSON.stringify(e1Aspects), `[{"classFullName":"BisCore:ExternalSourceAspect","id":"0x21","scope":{"id":"0x1","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"A","kind":"Letter","element":{"id":"0x11","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"BisCore:ExternalSourceAspect","id":"0x22","scope":{"id":"0x1","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"A","kind":"Letter","element":{"id":"0x11","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"BisCore:ExternalSourceAspect","id":"0x23","scope":{"id":"0x11","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"A","kind":"Letter","element":{"id":"0x11","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"BisCore:ExternalSourceAspect","id":"0x24","scope":{"id":"0x1","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"B","kind":"Letter","element":{"id":"0x11","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"BisCore:ExternalSourceAspect","id":"0x25","scope":{"id":"0x1","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"C","kind":"Kind2","element":{"id":"0x11","relClassName":"BisCore.ElementOwnsMultiAspects"}}]`.replace(/\s+/g, ""));
 
     const e2Aspects: ElementAspect[] = iModelDb.elements.getAspects(e2, aspectProps.classFullName);
     assert.equal(e2Aspects.length, e2AspectProps.length);
     e2Aspects.forEach((x) => {
       assert.isTrue(findInProps(x, e2AspectProps));
     });
+    assert.equal(JSON.stringify(e2Aspects), `[{"classFullName":"BisCore:ExternalSourceAspect","id":"0x26","scope":{"id":"0x1","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"A","kind":"Letter","element":{"id":"0x13","relClassName":"BisCore.ElementOwnsMultiAspects"}},
+    {"classFullName":"BisCore:ExternalSourceAspect","id":"0x27","scope":{"id":"0x1","relClassName":"BisCore.ElementScopesExternalSourceIdentifier"},"identifier":"C","kind":"Letter","element":{"id":"0x13","relClassName":"BisCore.ElementOwnsMultiAspects"}}]`.replace(/\s+/g, ""));
 
     const allA = ExternalSourceAspect.findAllBySource(iModelDb, scopeId1, kind, "A");
     assert.equal(allA.filter((x) => x.elementId === e1).length, 2, "there are two A's in scope 1 on e1");

--- a/full-stack-tests/core/src/frontend/standalone/ECSqlAst.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ECSqlAst.test.ts
@@ -460,20 +460,20 @@ describe("ECSql Abstract Syntax Tree", () => {
   it("parse $, $->prop", async () => {
     const tests = [
       {
-        orignalECSql: "SELECT $ FROM Meta.ECClassDef ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-        expectedECSql: "SELECT $ FROM [ECDbMeta].[ECClassDef] ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+        orignalECSql: "SELECT $ FROM Meta.ECClassDef",
+        expectedECSql: "SELECT $ FROM [ECDbMeta].[ECClassDef]",
       },
       {
-        orignalECSql: "SELECT $->[Name], $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-        expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef] ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+        orignalECSql: "SELECT $->[Name], $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef",
+        expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef]",
       },
       // {
-      //   orignalECSql: "SELECT $->Name, $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef WHERE $->Name LIKE '%Hellp' ORDER BY $->ECInstanceId DESC ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-      //   expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef] WHERE $->[Name] LIKE '%Hellp' ORDER BY $->[ECInstanceId] DESC ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+      //   orignalECSql: "SELECT $->Name, $-> DisplayLabel, $ -> Nothing FROM Meta.ECClassDef WHERE $->Name LIKE '%Hellp' ORDER BY $->ECInstanceId DESC",
+      //   expectedECSql: "SELECT $->[Name], $->[DisplayLabel], $->[Nothing] FROM [ECDbMeta].[ECClassDef] WHERE $->[Name] LIKE '%Hellp' ORDER BY $->[ECInstanceId] DESC",
       // },
       {
-        orignalECSql: "SELECT e.$->[Name], e.$-> DisplayLabel, e.$ -> Nothing FROM Meta.ECClassDef e ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
-        expectedECSql: "SELECT [e].$->[Name], [e].$->[DisplayLabel], [e].$->[Nothing] FROM [ECDbMeta].[ECClassDef] [e] ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES",
+        orignalECSql: "SELECT e.$->[Name], e.$-> DisplayLabel, e.$ -> Nothing FROM Meta.ECClassDef e",
+        expectedECSql: "SELECT [e].$->[Name], [e].$->[DisplayLabel], [e].$->[Nothing] FROM [ECDbMeta].[ECClassDef] [e]",
       },
     ];
     for (const test of tests) {


### PR DESCRIPTION
Updated getAspects() to cache all derived classes of an abstract class irrespective of whether they are instantiated at runtime.
getAspects now logs an error message when no aspects exists for the element Id and aspect class name supplied.

Updated tests to check the data and format of the aspects returned by getAspects() which is now using instance queries.
As instance access is no longer experimental, updated getAspects() and relevant tests to remove ENABLE_EXPERIMENTAL_FEATURES option for instance queries.

imodel-native: https://github.com/iTwin/imodel-native/tree/rohitptnkr/remove-instance-access-from-experimental-features