### PR TITLE
use latest appui docs with hasDocs tag

### DIFF
--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -37,7 +37,7 @@ steps:
       stagingDir: ${{ parameters.stagingDir }}
       pipelineId: 8594 # iTwin AppUI/AppUI Docs CI
       artifactName: AppUI Docs
-      defaultBranch: refs/heads/release/4.0.x
+      buildTag: hasDocs
       useCurrentDocsArtifact: ${{ parameters.useCurrentAppUIDocsArtifact }}
 
   # Download BIS Docs artifact


### PR DESCRIPTION
For some reason, master is still gathering docs from AppUI's release/4.0.x branch. Switch this to the 'hasDocs' tag. 