### PR TITLE
Fixes Webpack Backend Build Dependencies

### DIFF
--- a/common/changes/@itwin/backend-webpack-tools/BenPusey-FixDTABuildBackendWebpack_2023-09-12-20-41.json
+++ b/common/changes/@itwin/backend-webpack-tools/BenPusey-FixDTABuildBackendWebpack_2023-09-12-20-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/backend-webpack-tools",
-      "comment": "Fixes webpack tools dependencies.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/backend-webpack-tools/BenPusey-FixDTABuildBackendWebpack_2023-09-12-20-41.json
+++ b/common/changes/@itwin/backend-webpack-tools/BenPusey-FixDTABuildBackendWebpack_2023-09-12-20-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/backend-webpack-tools",
+      "comment": "Fixes webpack tools dependencies.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/backend-webpack-tools"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2834,6 +2834,7 @@ importers:
 
   ../../tools/backend-webpack:
     specifiers:
+      '@itwin/build-tools': workspace:*
       '@itwin/core-webpack-tools': workspace:*
       case-sensitive-paths-webpack-plugin: ^2.1.2
       chalk: ^3.0.0
@@ -2846,6 +2847,7 @@ importers:
       yargonaut: ^1.1.2
       yargs: ^17.4.0
     dependencies:
+      '@itwin/build-tools': link:../build
       '@itwin/core-webpack-tools': link:../webpack-core
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 3.0.0

--- a/tools/backend-webpack/package.json
+++ b/tools/backend-webpack/package.json
@@ -24,6 +24,7 @@
     "backend-webpack-tools": "./bin/backend-webpack-tools.js"
   },
   "dependencies": {
+    "@itwin/build-tools": "workspace:*",
     "@itwin/core-webpack-tools": "workspace:*",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "chalk": "^3.0.0",


### PR DESCRIPTION
Found this issue working with `display-test-app`, where the `npm run build:backend-webpack` command would fail with a module not found exception. This prevented devs from building the backend needed to run the `npm run start:electron-webpack` command. Probably caused issues for other backend webpack build commands as well.