### PR TITLE
Fix BriefcaseDb.closeAndReopen

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -493,6 +493,8 @@ export class BriefcaseDb extends IModelDb {
     readonly briefcaseId: BriefcaseId;
     // (undocumented)
     close(): void;
+    // @internal
+    executeWritable(func: () => Promise<void>): Promise<void>;
     // (undocumented)
     static findByKey(key: string): BriefcaseDb;
     get isBriefcase(): boolean;

--- a/common/changes/@itwin/core-backend/pmc-more-fun-with-file-watching_2023-09-13-18-20.json
+++ b/common/changes/@itwin/core-backend/pmc-more-fun-with-file-watching_2023-09-13-18-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fix two potential bugs when closing and reopening an iModel while pulling changes.\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2611,13 +2611,11 @@ export class BriefcaseDb extends IModelDb {
 
       // Restart default txn to trigger events when watch file is changed by some other process.
       const watcher = fs.watch(briefcaseDb.watchFilePathName, { persistent: false }, () => {
-        console.log("watch file changed");
         nativeDb.restartDefaultTxn();
       });
 
       // Stop the watcher when we close this connection.
       briefcaseDb.onBeforeClose.addOnce(() => {
-        console.log("closing file watcher");
         watcher.close();
       });
     }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2611,11 +2611,13 @@ export class BriefcaseDb extends IModelDb {
 
       // Restart default txn to trigger events when watch file is changed by some other process.
       const watcher = fs.watch(briefcaseDb.watchFilePathName, { persistent: false }, () => {
+        console.log("watch file changed");
         nativeDb.restartDefaultTxn();
       });
 
       // Stop the watcher when we close this connection.
       briefcaseDb.onBeforeClose.addOnce(() => {
+        console.log("closing file watcher");
         watcher.close();
       });
     }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2646,6 +2646,8 @@ export class BriefcaseDb extends IModelDb {
     const fileName = this.pathName;
 
     if (this.isReadonly) {
+      // Need to clear caches to avoid BUSY when attempting to close with unclosed statements.
+      this.clearCaches();
       this.nativeDb.closeIModel();
       this.nativeDb.openIModel(fileName, OpenMode.ReadWrite);
     }
@@ -2654,6 +2656,7 @@ export class BriefcaseDb extends IModelDb {
       await func();
     } finally {
       if (this.isReadonly) {
+        this.clearCaches();
         this.nativeDb.closeIModel();
         this.nativeDb.openIModel(fileName, OpenMode.Readonly);
       }

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -310,14 +310,12 @@ export class TxnManager {
 
   /** @internal */
   protected _onReplayExternalTxns() {
-    console.log("onReplay");
     this.onReplayExternalTxns.raiseEvent();
     IpcHost.notifyTxns(this._iModel, "notifyReplayExternalTxns");
   }
 
   /** @internal */
   protected _onReplayedExternalTxns() {
-    console.log("onReplayed");
     this.onReplayedExternalTxns.raiseEvent();
     IpcHost.notifyTxns(this._iModel, "notifyReplayedExternalTxns");
   }

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -310,12 +310,14 @@ export class TxnManager {
 
   /** @internal */
   protected _onReplayExternalTxns() {
+    console.log("onReplay");
     this.onReplayExternalTxns.raiseEvent();
     IpcHost.notifyTxns(this._iModel, "notifyReplayExternalTxns");
   }
 
   /** @internal */
   protected _onReplayedExternalTxns() {
+    console.log("onReplayed");
     this.onReplayedExternalTxns.raiseEvent();
     IpcHost.notifyTxns(this._iModel, "notifyReplayedExternalTxns");
   }

--- a/full-stack-tests/core/src/backend/backend.ts
+++ b/full-stack-tests/core/src/backend/backend.ts
@@ -9,7 +9,7 @@ import "@itwin/oidc-signin-tool/lib/cjs/certa/certaBackend";
 import * as fs from "fs";
 import * as path from "path";
 import {
-  FileNameResolver, IModelDb, IModelHost, IModelHostOptions, IpcHandler, IpcHost, LocalhostIpcHost, PhysicalModel, PhysicalPartition,
+  BriefcaseDb, FileNameResolver, IModelDb, IModelHost, IModelHostOptions, IpcHandler, IpcHost, LocalhostIpcHost, PhysicalModel, PhysicalPartition,
   SpatialCategory, SubjectOwnsPartitionElements,
 } from "@itwin/core-backend";
 import { Id64String, Logger, ProcessDetector } from "@itwin/core-bentley";
@@ -70,6 +70,11 @@ class FullStackTestIpcHandler extends IpcHandler implements FullStackTestIpc {
     const categoryId = category.insert();
     category.setDefaultAppearance(appearance);
     return categoryId;
+  }
+
+  public async closeAndReopenDb(key: string): Promise<void> {
+    const iModel = BriefcaseDb.findByKey(key);
+    return iModel.executeWritable(async () => undefined);
   }
 }
 

--- a/full-stack-tests/core/src/common/FullStackTestIpc.ts
+++ b/full-stack-tests/core/src/common/FullStackTestIpc.ts
@@ -10,4 +10,5 @@ export const fullstackIpcChannel = "full-stack-tests/fullStackIpc";
 export interface FullStackTestIpc {
   createAndInsertPhysicalModel(key: string, newModelCode: CodeProps): Promise<Id64String>;
   createAndInsertSpatialCategory(key: string, scopeModelId: Id64String, categoryName: string, appearance: SubCategoryAppearance.Props): Promise<Id64String>;
+  closeAndReopenDb(key: string): Promise<void>;
 }

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -211,14 +211,18 @@ describe("BriefcaseTxns", () => {
         await rwConn.close();
 
         // Reopen roConn as temporarily writable, then reopen as read-only.
+        console.log("Reopening read-only connection...");
         await coreFullStackTestIpc.closeAndReopenDb(roConn.key);
+        console.log("...reopened.");
 
         // Reopen rwConn
         await openRW();
 
         await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });
         await rwConn.saveChanges();
+        console.log("awaiting events...");
         await expectCommit("onElementsChanged", "onChangesApplied");
+        console.log("...events received.");
 
         await coreFullStackTestIpc.closeAndReopenDb(roConn.key);
         await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -193,6 +193,30 @@ describe("BriefcaseTxns", () => {
         await rwConn.saveChanges();
         await expectCommit("onElementsChanged", "onChangesApplied", "onModelGeometryChanged");
       });
+
+      it.only("continues to receive events after iModel is closed and reopened", async () => {
+        const expectEvents = installListeners(roConn);
+        const expectCommit = async (...evts: TxnEvent[]) => expectEvents(["onReplayExternalTxns", ...evts, "onReplayedExternalTxns"]);
+
+        const dictModelId = await rwConn.models.getDictionaryModel();
+        await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });
+        await rwConn.saveChanges();
+        await expectCommit("onElementsChanged", "onChangesApplied");
+
+        await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });
+        await rwConn.saveChanges();
+        await expectCommit("onElementsChanged", "onChangesApplied");
+
+        await coreFullStackTestIpc.closeAndReopenDb(roConn.key);
+        await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });
+        await rwConn.saveChanges();
+        await expectCommit("onElementsChanged", "onChangesApplied");
+
+        await coreFullStackTestIpc.closeAndReopenDb(roConn.key);
+        await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });
+        await rwConn.saveChanges();
+        await expectCommit("onElementsChanged", "onChangesApplied");
+      });
     });
   }
 });

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -26,7 +26,7 @@ describe("BriefcaseTxns", () => {
     const filePath = path.join(process.env.IMODELJS_CORE_DIRNAME!, "core/backend/lib/cjs/test/assets/planprojection.bim");
     async function openRW(): Promise<void> {
       rwConn = await BriefcaseConnection.openStandalone(filePath, OpenMode.ReadWrite);
-    };
+    }
 
     beforeEach(async () => openRW());
 

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -224,7 +224,11 @@ describe("BriefcaseTxns", () => {
         await expectCommit("onElementsChanged", "onChangesApplied");
         console.log("...events received.");
 
+        // Repeat.
+        await rwConn.close();
         await coreFullStackTestIpc.closeAndReopenDb(roConn.key);
+        await openRW();
+
         await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });
         await rwConn.saveChanges();
         await expectCommit("onElementsChanged", "onChangesApplied");

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -194,7 +194,7 @@ describe("BriefcaseTxns", () => {
         await expectCommit("onElementsChanged", "onChangesApplied", "onModelGeometryChanged");
       });
 
-      it.only("continues to receive events after iModel is closed and reopened", async () => {
+      it("continues to receive events after iModel is closed and reopened", async () => {
         const expectEvents = installListeners(roConn);
         const expectCommit = async (...evts: TxnEvent[]) => expectEvents(["onReplayExternalTxns", ...evts, "onReplayedExternalTxns"]);
 
@@ -211,18 +211,14 @@ describe("BriefcaseTxns", () => {
         await rwConn.close();
 
         // Reopen roConn as temporarily writable, then reopen as read-only.
-        console.log("Reopening read-only connection...");
         await coreFullStackTestIpc.closeAndReopenDb(roConn.key);
-        console.log("...reopened.");
 
         // Reopen rwConn
         await openRW();
 
         await coreFullStackTestIpc.createAndInsertSpatialCategory(rwConn.key, dictModelId, Guid.createValue(), { color: 0 });
         await rwConn.saveChanges();
-        console.log("awaiting events...");
         await expectCommit("onElementsChanged", "onChangesApplied");
-        console.log("...events received.");
 
         // Repeat.
         await rwConn.close();


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/845 (again).
- Before closing the db, you must close all open statements, or you will get BUSY error.
- After reopening the db, you must restore the native object's pointer to the JS IModelDb. It is reset to null when closing the db. If you don't restore it, native TxnManager won't be able to invoke functions on JS TxnManager, preventing events from being received in JS.