### PR TITLE
Update executeWritable to handle db busy errors

### DIFF
--- a/common/changes/@itwin/core-backend/ImVeryLost-handle-db-busy_2023-09-18-10-25.json
+++ b/common/changes/@itwin/core-backend/ImVeryLost-handle-db-busy_2023-09-18-10-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Update executeWritable to handle db busy errors",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/ImVeryLost-handle-db-busy_2023-09-18-10-25.json
+++ b/common/changes/@itwin/core-backend/ImVeryLost-handle-db-busy_2023-09-18-10-25.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Update executeWritable to handle db busy errors",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2654,20 +2654,20 @@ export class BriefcaseDb extends IModelDb {
    * @internal Exported strictly for tests.
    */
   public async executeWritable(func: () => Promise<void>): Promise<void> {
-    if (this.isReadonly)
-      this.closeAndReopen(OpenMode.ReadWrite);
+    const fileName = this.pathName;
 
     try {
+      if (this.isReadonly)
+        this.closeAndReopen(OpenMode.ReadWrite, fileName);
+
       await func();
     } finally {
       if (this.isReadonly)
-        this.closeAndReopen(OpenMode.Readonly);
+        this.closeAndReopen(OpenMode.Readonly, fileName);
     }
   }
 
-  private closeAndReopen(openMode: OpenMode) {
-    const fileName = this.pathName;
-
+  private closeAndReopen(openMode: OpenMode, fileName: string) {
     // Unclosed statements will produce BUSY error when attempting to close.
     this.clearCaches();
 


### PR DESCRIPTION
Follow up to #5980 

Previously, if db was locked, we ended up in corrupted state were `nativeDb` was closed, and any attempt to access it would kill the backend.
As such:
1. Move `closeAndReopen` into the try/finally block, to ensure briefcase is always reopened in read-only mode.
2. Move out the `const fileName = this.pathName;` line, as not to access `nativeDb` when its closed ( `pathName` is a wrapper around`this.nativeDb.getFilePath()`, which crashes the backend if `nativeDb` is closed.