### PR TITLE
Increase timeout duration in mocha-reporter to fix flaky tests

### DIFF
--- a/common/changes/@itwin/build-tools/FlakyTestFix_2023-09-18-20-14.json
+++ b/common/changes/@itwin/build-tools/FlakyTestFix_2023-09-18-20-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Increase mocha reporter hang detection timeout duration to allow enough time for Chrome browsers during tests to close gracefully.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -90,7 +90,7 @@ class BentleyMochaReporter extends Spec {
     // Detect hangs caused by tests that leave timers/other handles open - not possible in electron frontends.
     if (!("electron" in process.versions)) {
       // NB: By calling unref() on this timer, we stop it from keeping the process alive, so it will only fire if _something else_ is still keeping
-      // the process alive after 5 seconds.  This also has the benefit of preventing the timer from showing up in wtfnode's dump of open handles.
+      // the process alive after 30 seconds.  This also has the benefit of preventing the timer from showing up in wtfnode's dump of open handles.
       setTimeout(() => {
         logBuildError(`Handle leak detected. Node was still running 5 seconds after tests completed.`);
         if (debugLeaks) {
@@ -114,7 +114,7 @@ class BentleyMochaReporter extends Spec {
 
         // Not sure why, but process.exit(1) wasn't working here...
         process.kill(process.pid);
-      }, 5000).unref();
+      }, 30000).unref();
     }
 
     if (!this.stats.pending)

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -114,7 +114,7 @@ class BentleyMochaReporter extends Spec {
 
         // Not sure why, but process.exit(1) wasn't working here...
         process.kill(process.pid);
-      }, 30000).unref();
+      }, 30 * 1000).unref();
     }
 
     if (!this.stats.pending)

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -92,7 +92,7 @@ class BentleyMochaReporter extends Spec {
       // NB: By calling unref() on this timer, we stop it from keeping the process alive, so it will only fire if _something else_ is still keeping
       // the process alive after 30 seconds.  This also has the benefit of preventing the timer from showing up in wtfnode's dump of open handles.
       setTimeout(() => {
-        logBuildError(`Handle leak detected. Node was still running 5 seconds after tests completed.`);
+        logBuildError(`Handle leak detected. Node was still running 30 seconds after tests completed.`);
         if (debugLeaks) {
           const wtf = require("wtfnode");
           wtf.setLogger("info", console.error);


### PR DESCRIPTION
- Increasing the timeout duration when detecting hangs in mocha-reporter index.ts to fix the handle leaks errors. 
- Most of the time, the browser only takes anywhere from 0.2s to a few seconds to close. However, sometimes, it can take the browser up to around 12s (based on some of the testing I've ran so far) to close successfully. Thus, having the timeout being only 5 seconds interrupts this process and forcefully kill the process, so the browser couldn't be cleaned up properly. Bumping this timeout duration to 30s would make sure that the browser have enough time to be closed gracefully by Playwright.

(Logs generated with DEBUG=pw:browser*)

With 5s of timeout: (gracefully close started but didn't end)
![image](https://github.com/iTwin/itwinjs-core/assets/116378951/d204db94-9c4d-4063-b04e-633d58d9dbb6)

With 30s of timeout:
![image](https://github.com/iTwin/itwinjs-core/assets/116378951/f88f182c-b92d-4581-bdcc-193f4ca2734d)
![image](https://github.com/iTwin/itwinjs-core/assets/116378951/7ed94905-4aa9-49c2-b19a-fa86c7860d17)

Related issues/discussion from playwright:
https://github.com/microsoft/playwright/discussions/21009
https://github.com/microsoft/playwright/issues/5327#issuecomment-1689798584