### PR TITLE
CVE-2023-4863 - bump electron to 26.2.1

### DIFF
--- a/common/changes/@itwin/certa/bump-electron-26.2.1_2023-09-18-20-40.json
+++ b/common/changes/@itwin/certa/bump-electron-26.2.1_2023-09-18-20-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "Mitigate GHSA-j7hp-h8jx-5ppr by bumping electron to first patched version (26.2.1)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/changes/@itwin/core-electron/bump-electron-26.2.1_2023-09-18-20-40.json
+++ b/common/changes/@itwin/core-electron/bump-electron-26.2.1_2023-09-18-20-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Mitigate GHSA-j7hp-h8jx-5ppr by bumping electron to first patched version (26.2.1)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
       '@itwin/core-bentley': link:../bentley
       '@itwin/core-geometry': link:../geometry
       '@itwin/eslint-plugin': 4.0.0-dev.44_xaiy4vqh4w4prx7ej54h3ywmza
-      '@itwin/object-storage-core': 2.1.0
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@types/chai': 4.3.1
       '@types/flatbuffers': 1.10.0
       '@types/mocha': 8.2.3
@@ -452,7 +452,7 @@ importers:
       '@types/mocha': ^8.2.2
       '@types/node': 18.16.1
       chai: ^4.1.2
-      electron: ^26.0.0
+      electron: ^26.2.1
       eslint: ^8.44.0
       glob: ^7.1.2
       mocha: ^10.0.0
@@ -479,7 +479,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
       chai: 4.3.7
-      electron: 26.2.0
+      electron: 26.2.1
       eslint: 8.45.0
       glob: 7.2.3
       mocha: 10.2.0
@@ -597,10 +597,10 @@ importers:
       webpack: ^5.76.0
       wms-capabilities: 0.4.0
     dependencies:
-      '@itwin/cloud-agnostic-core': 2.1.0
+      '@itwin/cloud-agnostic-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/core-i18n': link:../i18n
       '@itwin/core-telemetry': link:../telemetry
-      '@itwin/object-storage-core': 2.1.0
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/webgl-compatibility': link:../webgl-compatibility
       '@loaders.gl/core': 3.4.7
       '@loaders.gl/draco': 3.4.7
@@ -1296,7 +1296,7 @@ importers:
       '@types/node': 18.16.1
       chai: ^4.1.2
       cpx2: ^3.0.0
-      electron: ^26.0.0
+      electron: ^26.2.1
       eslint: ^8.44.0
       mocha: ^10.0.0
       rimraf: ^3.0.2
@@ -1308,11 +1308,11 @@ importers:
       '@itwin/core-electron': link:../../core/electron
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-geometry': link:../../core/geometry
-      electron: 26.2.0
+      electron: 26.2.1
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/eslint-plugin': 4.0.0-dev.44_xaiy4vqh4w4prx7ej54h3ywmza
-      '@itwin/oidc-signin-tool': 3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e
+      '@itwin/oidc-signin-tool': 3.6.1_y7qbfqj25iik67jw2wovgyleam
       '@types/chai': 4.3.1
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
@@ -1362,7 +1362,7 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/ecschema-editing': link:../../core/ecschema-editing
       '@itwin/ecschema-metadata': link:../../core/ecschema-metadata
-      '@itwin/imodel-transformer': 0.1.16_weqmipkhmjm5vfy37lv47aijmu
+      '@itwin/imodel-transformer': 0.1.16_ldn7mm7njkdg5fypcar6myqs34
       '@itwin/itwins-client': 1.2.0
       '@itwin/service-authorization': 0.6.3_mdtbcqczpmeuv6yjzfaigjndwi
       '@xmldom/xmldom': 0.8.10
@@ -1722,7 +1722,7 @@ importers:
       crypto-browserify: 3.12.0
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^26.0.0
+      electron: ^26.2.1
       eslint: ^8.44.0
       fs-extra: ^8.1.0
       glob: ^7.1.2
@@ -1760,7 +1760,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_za7ctafeaxhew6k36pfsbotv7m
+      '@itwin/electron-authorization': 0.14.1_jyyqjsjn3zzjkls5batjdji7ni
       '@itwin/express-server': link:../../core/express-server
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.0_wj555zckjupkhkzyssqqpl4sei
@@ -1771,7 +1771,7 @@ importers:
       azurite: 3.24.0
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
-      electron: 26.2.0
+      electron: 26.2.1
       fs-extra: 8.1.0
       sinon: 15.2.0
       sinon-chai: 3.7.0_chai@4.3.7+sinon@15.2.0
@@ -1780,8 +1780,8 @@ importers:
       '@itwin/certa': link:../../tools/certa
       '@itwin/eslint-plugin': 4.0.0-dev.44_xaiy4vqh4w4prx7ej54h3ywmza
       '@itwin/itwins-client': 1.2.0
-      '@itwin/object-storage-core': 2.1.0
-      '@itwin/oidc-signin-tool': 3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
+      '@itwin/oidc-signin-tool': 3.6.1_y7qbfqj25iik67jw2wovgyleam
       '@types/chai': 4.3.1
       '@types/chai-as-promised': 7.1.5
       '@types/fs-extra': 4.0.12
@@ -2038,7 +2038,7 @@ importers:
       browserify-zlib: ^0.2.0
       buffer: ^6.0.3
       chai: ^4.1.2
-      electron: ^26.0.0
+      electron: ^26.2.1
       eslint: ^8.44.0
       express: ^4.16.3
       glob: ^7.1.2
@@ -2059,7 +2059,7 @@ importers:
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/express-server': link:../../core/express-server
-      electron: 26.2.0
+      electron: 26.2.1
       express: 4.18.2
       semver: 7.5.4
       spdy: 4.0.2
@@ -2454,7 +2454,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^26.0.0
+      electron: ^26.2.1
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2483,14 +2483,14 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/core-quantity': link:../../core/quantity
-      '@itwin/electron-authorization': 0.14.1_za7ctafeaxhew6k36pfsbotv7m
+      '@itwin/electron-authorization': 0.14.1_jyyqjsjn3zzjkls5batjdji7ni
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.0_wj555zckjupkhkzyssqqpl4sei
       '@itwin/imodels-access-frontend': 3.1.0_ueafa4slb6ohrhyf7kbp6egmha
       '@itwin/imodels-client-authoring': 3.1.0
       '@itwin/imodels-client-management': 3.1.0
-      '@itwin/oidc-signin-tool': 3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e
+      '@itwin/oidc-signin-tool': 3.6.1_y7qbfqj25iik67jw2wovgyleam
       '@itwin/reality-data-client': 0.9.0_mdtbcqczpmeuv6yjzfaigjndwi
       body-parser: 1.20.2
     devDependencies:
@@ -2507,7 +2507,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 26.2.0
+      electron: 26.2.1
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.45.0
       express: 4.18.2
@@ -2518,12 +2518,12 @@ importers:
       rimraf: 3.0.2
       rollup-plugin-copy: 3.4.0
       rollup-plugin-ignore: 1.0.10
-      rollup-plugin-visualizer: 5.9.2
-      rollup-plugin-webpack-stats: 0.2.0
+      rollup-plugin-visualizer: 5.9.2_rollup@3.28.0
+      rollup-plugin-webpack-stats: 0.2.0_rollup@3.28.0
       typescript: 5.0.4
       vite: 4.4.9_@types+node@18.16.1
       vite-plugin-env-compatible: 1.1.1
-      vite-plugin-inspect: 0.7.33_vite@4.4.9
+      vite-plugin-inspect: 0.7.33_rollup@3.28.0+vite@4.4.9
       webpack: 5.88.2
 
   ../../test-apps/display-test-app:
@@ -2571,7 +2571,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^26.0.0
+      electron: ^26.2.1
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2612,7 +2612,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_za7ctafeaxhew6k36pfsbotv7m
+      '@itwin/electron-authorization': 0.14.1_jyyqjsjn3zzjkls5batjdji7ni
       '@itwin/frontend-devtools': link:../../core/frontend-devtools
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
@@ -2621,7 +2621,7 @@ importers:
       '@itwin/imodels-client-authoring': 3.1.0
       '@itwin/imodels-client-management': 3.1.0
       '@itwin/map-layers-formats': link:../../extensions/map-layers-formats
-      '@itwin/object-storage-core': 2.1.0
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/reality-data-client': 0.9.0_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/webgl-compatibility': link:../../core/webgl-compatibility
       body-parser: 1.20.2
@@ -2640,7 +2640,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 26.2.0
+      electron: 26.2.1
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.45.0
       express: 4.18.2
@@ -2654,13 +2654,13 @@ importers:
       rimraf: 3.0.2
       rollup-plugin-copy: 3.4.0
       rollup-plugin-ignore: 1.0.10
-      rollup-plugin-visualizer: 5.9.2
-      rollup-plugin-webpack-stats: 0.2.0
+      rollup-plugin-visualizer: 5.9.2_rollup@3.28.0
+      rollup-plugin-webpack-stats: 0.2.0_rollup@3.28.0
       ts-node: 10.9.1_typescript@5.0.4
       typescript: 5.0.4
       vite: 4.4.9
       vite-plugin-env-compatible: 1.1.1
-      vite-plugin-inspect: 0.7.33_vite@4.4.9
+      vite-plugin-inspect: 0.7.33_rollup@3.28.0+vite@4.4.9
       webpack: 5.88.2
 
   ../../test-apps/export-gltf:
@@ -2915,7 +2915,7 @@ importers:
       '@types/yargs': 17.0.19
       canonical-path: ^1.0.0
       detect-port: ~1.3.0
-      electron: ^26.0.0
+      electron: ^26.2.1
       eslint: ^8.44.0
       express: ^4.16.3
       jsonc-parser: ~2.0.3
@@ -2947,7 +2947,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
       '@types/yargs': 17.0.19
-      electron: 26.2.0
+      electron: 26.2.1
       eslint: 8.45.0
       nyc: 15.1.0
       rimraf: 3.0.2
@@ -4164,7 +4164,7 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/certa/3.7.11_electron@26.2.0:
+  /@itwin/certa/3.7.11_electron@26.2.1:
     resolution: {integrity: sha512-d5n/LtuL6hoeoZqO14O3fKYfpuW7IwMu99rxpO/P1a9xRj0Pes/VRwpA/74gJWROlQ38irm4Ywm4Tv5wcrSPfg==}
     hasBin: true
     peerDependencies:
@@ -4174,7 +4174,7 @@ packages:
         optional: true
     dependencies:
       detect-port: 1.3.0
-      electron: 26.2.0
+      electron: 26.2.1
       express: 4.18.2
       jsonc-parser: 2.0.3
       lodash: 4.17.21
@@ -4196,13 +4196,6 @@ packages:
       reflect-metadata: 0.1.13
     dev: false
 
-  /@itwin/cloud-agnostic-core/2.1.0:
-    resolution: {integrity: sha512-nVFJ55+sj3IExsXwPXJwtud2cK1+5gYsS1Q96Vz6pBQ1rn84i22JUwGmlBrvf3Em6obseBaDQ6GCRA4aUpAjgQ==}
-    engines: {node: '>=12.20 <19.0.0'}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-
   /@itwin/cloud-agnostic-core/2.1.0_scz6qrwecfbbxg4vskopkl3a7u:
     resolution: {integrity: sha512-nVFJ55+sj3IExsXwPXJwtud2cK1+5gYsS1Q96Vz6pBQ1rn84i22JUwGmlBrvf3Em6obseBaDQ6GCRA4aUpAjgQ==}
     engines: {node: '>=12.20 <19.0.0'}
@@ -4212,7 +4205,6 @@ packages:
     dependencies:
       inversify: 6.0.1
       reflect-metadata: 0.1.13
-    dev: false
 
   /@itwin/core-common/4.0.6_67wltvhdskk2oee2c3z2o4tfly:
     resolution: {integrity: sha512-1N92kv3bqY/01Mdto/GCKgO5dG6dli9d06lp1KpHTUuwPpWVob1oIF/w5ij+0C4QvHq54SZlCxDfNaC7FH6lKQ==}
@@ -4226,7 +4218,15 @@ packages:
       js-base64: 3.7.5
     dev: false
 
-  /@itwin/electron-authorization/0.14.1_za7ctafeaxhew6k36pfsbotv7m:
+  /@itwin/core-quantity/4.0.7_mdtbcqczpmeuv6yjzfaigjndwi:
+    resolution: {integrity: sha512-2X+w5/w/Gx0KwKW61BwB2NM0t1NGbM/8F0UqW41jdG+t9IB9GEZiCpc86E8bmzfYRItB858rytgFWrNLtnWlWg==}
+    peerDependencies:
+      '@itwin/core-bentley': ^4.0.7
+    dependencies:
+      '@itwin/core-bentley': link:../../core/bentley
+    dev: false
+
+  /@itwin/electron-authorization/0.14.1_jyyqjsjn3zzjkls5batjdji7ni:
     resolution: {integrity: sha512-NslwCLw129obJHBRMcV/MdykqbD7d93SKTYOOBdaEab2T2niGCmCTJAOkjcWiZZMU0SwmjyxmY9iqdZjvvIqCA==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
@@ -4235,7 +4235,7 @@ packages:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': 4.0.6_67wltvhdskk2oee2c3z2o4tfly
       '@openid/appauth': 1.3.1
-      electron: 26.2.0
+      electron: 26.2.1
       keytar: 7.9.0
       username: 5.1.0
     transitivePeerDependencies:
@@ -4267,7 +4267,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@itwin/imodel-transformer/0.1.16_weqmipkhmjm5vfy37lv47aijmu:
+  /@itwin/imodel-transformer/0.1.16_ldn7mm7njkdg5fypcar6myqs34:
     resolution: {integrity: sha512-TVa1bZHSgE7nZ6UzXZq0zrDtR0va0rTA265GH7QmxgFD+sXZxUzODWd3SIp55NPNH+A7F9Bs/hLY4/HlB708vA==}
     engines: {node: ^18.0.0}
     peerDependencies:
@@ -4275,13 +4275,14 @@ packages:
       '@itwin/core-bentley': 3.6.0 - 4.0.999
       '@itwin/core-common': 3.6.0 - 4.0.999
       '@itwin/core-geometry': 3.6.0 - 4.0.999
+      '@itwin/core-quantity': 3.6.0 - 4.0.999
       '@itwin/ecschema-metadata': 3.6.0 - 4.0.999
     dependencies:
       '@itwin/core-backend': link:../../core/backend
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
       '@itwin/core-geometry': link:../../core/geometry
-      '@itwin/core-quantity': link:../../core/quantity
+      '@itwin/core-quantity': 4.0.7_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/ecschema-metadata': link:../../core/ecschema-metadata
       semver: 7.5.4
     dev: false
@@ -4391,18 +4392,6 @@ packages:
       - debug
     dev: false
 
-  /@itwin/object-storage-core/2.1.0:
-    resolution: {integrity: sha512-0zapV7KDn3NXeOAMoTUoiSiIuQQXUIn8IuLxLExEMoJ8xiG7JsFRWW1tm0Q9Lj095f/stT3V0TOvl4dw1G8pAA==}
-    engines: {node: '>=12.20 <19.0.0'}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-    dependencies:
-      '@itwin/cloud-agnostic-core': 2.1.0
-      axios: 0.27.2
-    transitivePeerDependencies:
-      - debug
-
   /@itwin/object-storage-core/2.1.0_scz6qrwecfbbxg4vskopkl3a7u:
     resolution: {integrity: sha512-0zapV7KDn3NXeOAMoTUoiSiIuQQXUIn8IuLxLExEMoJ8xiG7JsFRWW1tm0Q9Lj095f/stT3V0TOvl4dw1G8pAA==}
     engines: {node: '>=12.20 <19.0.0'}
@@ -4416,14 +4405,13 @@ packages:
       reflect-metadata: 0.1.13
     transitivePeerDependencies:
       - debug
-    dev: false
 
-  /@itwin/oidc-signin-tool/3.6.1_jxt7iwy7a2qrrfta2vadyi3t2e:
+  /@itwin/oidc-signin-tool/3.6.1_mdtbcqczpmeuv6yjzfaigjndwi:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/certa': 3.7.11_electron@26.2.0
+      '@itwin/certa': 3.7.11
       '@itwin/core-bentley': link:../../core/bentley
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -4436,12 +4424,12 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/oidc-signin-tool/3.6.1_mdtbcqczpmeuv6yjzfaigjndwi:
+  /@itwin/oidc-signin-tool/3.6.1_y7qbfqj25iik67jw2wovgyleam:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/certa': 3.7.11
+      '@itwin/certa': 3.7.11_electron@26.2.1
       '@itwin/core-bentley': link:../../core/bentley
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -4681,7 +4669,7 @@ packages:
       '@babel/runtime': 7.22.6
     dev: false
 
-  /@rollup/pluginutils/5.0.2:
+  /@rollup/pluginutils/5.0.2_rollup@3.28.0:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4693,6 +4681,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 3.28.0
     dev: true
 
   /@rushstack/node-core-library/3.59.7_@types+node@18.16.1:
@@ -5568,8 +5557,10 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.12.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -7003,8 +6994,8 @@ packages:
   /electron-to-chromium/1.4.467:
     resolution: {integrity: sha512-2qI70O+rR4poYeF2grcuS/bCps5KJh6y1jtZMDDEteyKJQrzLOEhFyXCLcHW6DTBjKjWkk26JhWoAi+Ux9A0fg==}
 
-  /electron/26.2.0:
-    resolution: {integrity: sha512-H6Z0sYTtLcybHCQT1yti/8BK+vN5/ZfoekKcdrfZMh5mVf2Z7psFVs6nBhXPzIOyRE/gdb6NcOppnUsGc3NJVQ==}
+  /electron/26.2.1:
+    resolution: {integrity: sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
@@ -8629,7 +8620,6 @@ packages:
 
   /inversify/6.0.1:
     resolution: {integrity: sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==}
-    dev: false
 
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10752,7 +10742,6 @@ packages:
 
   /reflect-metadata/0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
-    dev: false
 
   /regenerator-runtime/0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
@@ -10896,7 +10885,7 @@ packages:
     resolution: {integrity: sha512-VsbnfwwaTv2Dxl2onubetX/3RnSnplNnjdix0hvF8y2YpqdzlZrjIq6zkcuVJ08XysS8zqW3gt3ORBndFDgsrg==}
     dev: true
 
-  /rollup-plugin-visualizer/5.9.2:
+  /rollup-plugin-visualizer/5.9.2_rollup@3.28.0:
     resolution: {integrity: sha512-waHktD5mlWrYFrhOLbti4YgQCn1uR24nYsNuXxg7LkPH8KdTXVWR9DNY1WU0QqokyMixVXJS4J04HNrVTMP01A==}
     engines: {node: '>=14'}
     hasBin: true
@@ -10908,15 +10897,18 @@ packages:
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
+      rollup: 3.28.0
       source-map: 0.7.4
       yargs: 17.7.2
     dev: true
 
-  /rollup-plugin-webpack-stats/0.2.0:
+  /rollup-plugin-webpack-stats/0.2.0_rollup@3.28.0:
     resolution: {integrity: sha512-WDQ9ra6qWjeH/7D3q7lY/r5i9/HPt8OlZvvoQzS7Jdarh2v5+Fgw1BdAU2pBW0LB26J+vNYwdEdyJnkBhbQ2PQ==}
     engines: {node: '>=14'}
     peerDependencies:
       rollup: ^3.0.0
+    dependencies:
+      rollup: 3.28.0
     dev: true
 
   /rollup/3.28.0:
@@ -11012,7 +11004,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.12
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.12.0
       ajv-keywords: 5.1.0_ajv@8.12.0
     dev: false
 
@@ -12218,14 +12210,14 @@ packages:
     resolution: {integrity: sha512-4lqhBWhOzP+SaCPoCVdmpM5cXzjKQV5jgFauxea488oOeElXo/kw6bXkMIooZhrh9q7gclTl8en6N9NmnqUwRQ==}
     dev: true
 
-  /vite-plugin-inspect/0.7.33_vite@4.4.9:
+  /vite-plugin-inspect/0.7.33_rollup@3.28.0+vite@4.4.9:
     resolution: {integrity: sha512-cQRLQKa/+Ua++5hN0IZfqNn1JYXBg2eCQOSUatPTwhXMO7nwfSvhhSc45E1nXfBBEhzLLOxgr1OdbDu55PiDDA==}
     engines: {node: '>=14'}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
     dependencies:
       '@antfu/utils': 0.7.5
-      '@rollup/pluginutils': 5.0.2
+      '@rollup/pluginutils': 5.0.2_rollup@3.28.0
       debug: 4.3.4
       fs-extra: 11.1.1
       open: 9.1.0

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -53,7 +53,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.16.1",
     "chai": "^4.1.2",
-    "electron": "^26.0.0",
+    "electron": "^26.2.1",
     "eslint": "^8.44.0",
     "glob": "^7.1.2",
     "mocha": "^10.0.0",

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -23,7 +23,7 @@
     "@itwin/core-electron": "workspace:*",
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-geometry": "workspace:*",
-    "electron": "^26.0.0"
+    "electron": "^26.2.1"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -53,7 +53,7 @@
     "azurite": "^3.24.0",
     "chai-as-promised": "^7",
     "chai": "^4.1.2",
-    "electron": "^26.0.0",
+    "electron": "^26.2.1",
     "fs-extra": "^8.1.0",
     "sinon-chai": "^3.2.0",
     "sinon": "^15.0.4"

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -26,7 +26,7 @@
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-mobile": "workspace:*",
     "@itwin/express-server": "workspace:*",
-    "electron": "^26.0.0",
+    "electron": "^26.2.1",
     "express": "^4.16.3",
     "semver": "^7.3.5",
     "spdy": "^4.0.1"

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -72,7 +72,7 @@
     "cpx2": "^3.0.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^26.0.0",
+    "electron": "^26.2.1",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -89,7 +89,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^26.0.0",
+    "electron": "^26.2.1",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -52,7 +52,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.16.1",
     "@types/yargs": "17.0.19",
-    "electron": "^26.0.0",
+    "electron": "^26.2.1",
     "eslint": "^8.44.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Mitigate https://github.com/advisories/GHSA-j7hp-h8jx-5ppr by bumping electron to first patched version (26.2.1)