### PR TITLE
Remove render mode restrictions for batched tiles

### DIFF
--- a/common/changes/@itwin/frontend-tiles/pmc-batched-tile-edges_2023-09-21-20-44.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-batched-tile-edges_2023-09-21-20-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "Permit visible edges and wireframe mode to be used with batched tiles.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/src/BatchedTileTree.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTree.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BeTimePoint } from "@itwin/core-bentley";
-import { BatchType, RenderMode, RenderSchedule, ViewFlagOverrides } from "@itwin/core-common";
+import { BatchType, RenderSchedule, ViewFlagOverrides } from "@itwin/core-common";
 import {
   acquireImdlDecoder, ImdlDecoder, IModelApp, Tile, TileDrawArgs, TileTree, TileTreeParams,
 } from "@itwin/core-frontend";
@@ -17,11 +17,6 @@ export interface BatchedTileTreeParams extends TileTreeParams {
   reader: BatchedTilesetReader;
   script?: RenderSchedule.Script;
 }
-
-const viewFlagOverrides: ViewFlagOverrides = {
-  renderMode: RenderMode.SmoothShade,
-  visibleEdges: false,
-};
 
 /** @internal */
 export class BatchedTileTree extends TileTree {
@@ -65,7 +60,7 @@ export class BatchedTileTree extends TileTree {
   }
 
   public override get viewFlagOverrides(): ViewFlagOverrides {
-    return viewFlagOverrides;
+    return { };
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
Previously, batched tiles did not include edges, so we override the view flags to always use smooth shaded mode with visible edges disabled.
We now have a work-in-progress publisher that produces edges.
Folks who are using the currently-deployed version of the publisher have already been made aware that it does not yet support these display features, so presumably they will avoid trying to use them.