### PR TITLE
Opt-in for batched tile edges

### DIFF
--- a/common/api/frontend-tiles.api.md
+++ b/common/api/frontend-tiles.api.md
@@ -17,11 +17,16 @@ export const createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeRefe
 // @beta
 export interface FrontendTilesOptions {
     computeSpatialTilesetBaseUrl?: ComputeSpatialTilesetBaseUrl;
+    // @internal
+    enableEdges?: boolean;
     maxLevelsToSkip?: number;
 }
 
-// @internal (undocumented)
-export function getMaxLevelsToSkip(): number;
+// @internal
+export const frontendTilesOptions: {
+    maxLevelsToSkip: number;
+    enableEdges: boolean;
+};
 
 // @beta
 export function initializeFrontendTiles(options: FrontendTilesOptions): void;

--- a/common/api/summary/frontend-tiles.exports.csv
+++ b/common/api/summary/frontend-tiles.exports.csv
@@ -3,7 +3,7 @@ Release Tag;API Item
 beta;ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise
 internal;createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeReferences.create
 beta;FrontendTilesOptions
-internal;getMaxLevelsToSkip(): number
+internal;frontendTilesOptions:
 beta;initializeFrontendTiles(options: FrontendTilesOptions): void
 beta;MeshExport
 internal;MeshExports

--- a/common/changes/@itwin/frontend-tiles/pmc-opt-in-batched-tile-edges_2023-09-22-11-23.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-opt-in-batched-tile-edges_2023-09-22-11-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/src/BatchedTile.ts
+++ b/extensions/frontend-tiles/src/BatchedTile.ts
@@ -11,7 +11,7 @@ import {
 } from "@itwin/core-frontend";
 import { loggerCategory } from "./LoggerCategory";
 import { BatchedTileTree } from "./BatchedTileTree";
-import { getMaxLevelsToSkip } from "./FrontendTiles";
+import { frontendTilesOptions } from "./FrontendTiles";
 
 /** @internal */
 export interface BatchedTileParams extends TileParams {
@@ -33,7 +33,7 @@ export class BatchedTile extends Tile {
     super(params, tree);
 
     // The root tile never has content, so it doesn't count toward max levels to skip.
-    this._unskippable = 0 === (this.depth % getMaxLevelsToSkip());
+    this._unskippable = 0 === (this.depth % frontendTilesOptions.maxLevelsToSkip);
 
     if (params.childrenProps?.length)
       this._childrenProps = params.childrenProps;

--- a/extensions/frontend-tiles/src/BatchedTileTree.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTree.ts
@@ -4,12 +4,18 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BeTimePoint } from "@itwin/core-bentley";
-import { BatchType, RenderSchedule, ViewFlagOverrides } from "@itwin/core-common";
+import { BatchType, RenderMode, RenderSchedule, ViewFlagOverrides } from "@itwin/core-common";
 import {
   acquireImdlDecoder, ImdlDecoder, IModelApp, Tile, TileDrawArgs, TileTree, TileTreeParams,
 } from "@itwin/core-frontend";
 import { BatchedTile, BatchedTileParams } from "./BatchedTile";
 import { BatchedTilesetReader } from "./BatchedTilesetReader";
+import { frontendTilesOptions } from "./FrontendTiles";
+
+const defaultViewFlags: ViewFlagOverrides = {
+  renderMode: RenderMode.SmoothShade,
+  visibleEdges: false,
+};
 
 /** @internal */
 export interface BatchedTileTreeParams extends TileTreeParams {
@@ -60,7 +66,7 @@ export class BatchedTileTree extends TileTree {
   }
 
   public override get viewFlagOverrides(): ViewFlagOverrides {
-    return { };
+    return frontendTilesOptions.enableEdges ?{ } : defaultViewFlags;
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/extensions/frontend-tiles/src/FrontendTiles.ts
+++ b/extensions/frontend-tiles/src/FrontendTiles.ts
@@ -191,24 +191,35 @@ export interface FrontendTilesOptions {
    * fill them. However, tiles close to the viewer (and therefore likely of most interest to them) will refine to an appropriate level of detail more quickly.
    */
   maxLevelsToSkip?: number;
+  /** Specifies whether to permit the user to enable visible edges or wireframe mode for batched tiles.
+   * The currently-deployed mesh export service does not produce edges, so this currently defaults to `false` to avoid user confusion.
+   * Set it to `true` if you are loading tiles created with a version of the exporter that does produce edges.
+   * ###TODO delete this option once we deploy an edge-producing version of the exporter to production.
+   * @internal
+   */
+  enableEdges?: boolean;
 }
 
 /** @internal */
 export const createFallbackSpatialTileTreeReferences = SpatialTileTreeReferences.create;
 
-let maxLevelsToSkip = 4;
-
-/** @internal */
-export function getMaxLevelsToSkip(): number {
-  return maxLevelsToSkip;
-}
+/** Global configuration initialized by [[initializeFrontendTiles]].
+ * @internal
+ */
+export const frontendTilesOptions = {
+  maxLevelsToSkip: 4,
+  enableEdges: false,
+};
 
 /** Initialize the frontend-tiles package to obtain tiles for spatial views.
  * @beta
  */
 export function initializeFrontendTiles(options: FrontendTilesOptions): void {
   if (undefined !== options.maxLevelsToSkip && options.maxLevelsToSkip >= 0)
-    maxLevelsToSkip = options.maxLevelsToSkip;
+    frontendTilesOptions.maxLevelsToSkip = options.maxLevelsToSkip;
+
+  if (options.enableEdges)
+    frontendTilesOptions.enableEdges = true;
 
   const computeUrl = options.computeSpatialTilesetBaseUrl ?? (
     async (iModel: IModelConnection) => obtainMeshExportTilesetUrl({ iModel, accessToken: await IModelApp.getAccessToken() })

--- a/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
+++ b/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
@@ -88,6 +88,7 @@ export class DisplayPerfTestApp {
     Object.assign(envConfiguration, config);
 
     initializeFrontendTiles({
+      enableEdges: true,
       computeSpatialTilesetBaseUrl: async (iModel) => {
         if (runner.curConfig.frontendTilesUrlTemplate === undefined)
           return undefined;

--- a/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
+++ b/test-apps/display-test-app/src/frontend/DisplayTestApp.ts
@@ -214,6 +214,7 @@ const dtaFrontendMain = async () => {
   // this needs to execute after all DisplayTestApp.startup executions so that env var will be current
   if (configuration.frontendTilesUrlTemplate) {
     initializeFrontendTiles({
+      enableEdges: true,
       computeSpatialTilesetBaseUrl: async (iModel) => {
         let urlStr = configuration.frontendTilesUrlTemplate!.replace("{iModel.key}", iModel.key);
         urlStr = urlStr.replace("{iModel.filename}", getFileName(iModel.key));


### PR DESCRIPTION
Amend #6022 to make the new behavior opt-in.
The currently deployed mesh export service does not produce edges. Users know this, but it's better to prevent any confusion by continuing to disallow turning on visible edges or wireframe when rendering those tiles, until the exporter is updated to support it.
display-test-app and display-performance-test-app opt in to the new behavior.