### PR TITLE
rm require in core-frontend

### DIFF
--- a/common/changes/@itwin/core-frontend/arun-rm-frontend-require_2023-09-25-15-16.json
+++ b/common/changes/@itwin/core-frontend/arun-rm-frontend-require_2023-09-25-15-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "remove `require` call preventing pure ESM usage",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -11,7 +11,7 @@
 import { version } from "../../package.json";
 /** @public */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-export const ITWINJS_CORE_VERSION = version;
+export const ITWINJS_CORE_VERSION = version as string;
 const COPYRIGHT_NOTICE = 'Copyright © 2017-2023 <a href="https://www.bentley.com" target="_blank" rel="noopener noreferrer">Bentley Systems, Inc.</a>';
 
 import { UiAdmin } from "@itwin/appui-abstract";

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -6,7 +6,7 @@
  * @module IModelApp
  */
 
-// @ts-expect-error resolves from the lib/{cjs,esm} dir
+// @ts-expect-error package.json will resolve from the lib/{cjs,esm} dir without copying it into the build output we deliver
 // eslint-disable-next-line @itwin/import-within-package
 import { version } from "../../package.json";
 /** @public */

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -6,9 +6,12 @@
  * @module IModelApp
  */
 
+// @ts-expect-error resolves from the lib/{cjs,esm} dir
+// eslint-disable-next-line @itwin/import-within-package
+import { version } from "../../package.json";
 /** @public */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-export const ITWINJS_CORE_VERSION = require("../../package.json").version as string; // require resolves from the lib/{cjs,esm} dir
+export const ITWINJS_CORE_VERSION = version;
 const COPYRIGHT_NOTICE = 'Copyright © 2017-2023 <a href="https://www.bentley.com" target="_blank" rel="noopener noreferrer">Bentley Systems, Inc.</a>';
 
 import { UiAdmin } from "@itwin/appui-abstract";

--- a/test-apps/display-performance-test-app/vite.config.ts
+++ b/test-apps/display-performance-test-app/vite.config.ts
@@ -60,7 +60,7 @@ export default defineConfig(() => {
       target: browserslistToEsbuild(), // for browserslist in package.json
       logLevel: process.env.VITE_CI ? "error" : "warn",
       commonjsOptions: {
-        // plugin to convert CommonJS modules to ES6, so they can be included in bundle
+        // plugin to convert CommonJS modules to ESM, so they can be included in bundle
         include: [
           /core\/electron/, // prevent error in ElectronApp
           /core\/mobile/, // prevent error in MobileApp
@@ -126,8 +126,9 @@ export default defineConfig(() => {
       force: true, // forces cache dumps on each rebuild. should be turned off once the issue in vite with monorepos not being correctly optimized is fixed. Issue link: https://github.com/vitejs/vite/issues/14099
       // overoptimized dependencies in the same monorepo (vite converts all cjs to esm)
       include: [
-        "@itwin/core-common", // for opening iModel error
+        "@itwin/core-common", // to prevent error when opening iModel from undefined rpc policy
         "@itwin/core-electron/lib/cjs/ElectronFrontend", // import from module error
+        "@itwin/core-frontend", // to prevent multiple core-frontends (cjs & esm) from being imported
         "@itwin/core-mobile/lib/cjs/MobileFrontend", // import from module error
       ],
     },

--- a/test-apps/display-performance-test-app/vite.config.ts
+++ b/test-apps/display-performance-test-app/vite.config.ts
@@ -64,8 +64,7 @@ export default defineConfig(() => {
         include: [
           /core\/electron/, // prevent error in ElectronApp
           /core\/mobile/, // prevent error in MobileApp
-          /node_modules/, // prevent errors for modules
-          /core\/frontend/, // prevent errors with require in IModelApp
+          /node_modules/, // prevent errors from dependencies
         ],
         transformMixedEsModules: true, // transforms require statements
       },
@@ -129,7 +128,6 @@ export default defineConfig(() => {
       include: [
         "@itwin/core-common", // for opening iModel error
         "@itwin/core-electron/lib/cjs/ElectronFrontend", // import from module error
-        "@itwin/core-frontend", // file in repository uses require (cjs)
         "@itwin/core-mobile/lib/cjs/MobileFrontend", // import from module error
       ],
     },

--- a/test-apps/display-test-app/vite.config.ts
+++ b/test-apps/display-test-app/vite.config.ts
@@ -14,7 +14,8 @@ import { webpackStats } from "rollup-plugin-webpack-stats";
 import * as packageJson from "./package.json";
 import path from "path";
 
-const mode = process.env.NODE_ENV === "development" ? "development" : "production";
+const mode =
+  process.env.NODE_ENV === "development" ? "development" : "production";
 
 // array of public directories static assets from dependencies to copy
 const assets = ["./public/*"]; // assets for test-app
@@ -27,7 +28,8 @@ Object.keys(packageJson.dependencies).forEach((pkgName) => {
         .replace(/([\/\\]lib[\/\\]).*/, "$1public/*");
 
       const assetsPath = path.relative(process.cwd(), pkg).replace(/\\/g, "/"); // use relative path with forward slashes
-      if (assetsPath.endsWith("lib/public/*")) { // filter out pkgs that actually dont have assets
+      if (assetsPath.endsWith("lib/public/*")) {
+        // filter out pkgs that actually dont have assets
         assets.push(assetsPath);
       }
     } catch {}
@@ -58,7 +60,7 @@ export default defineConfig(() => {
       minify: false, // disable compaction of source code
       target: browserslistToEsbuild(), // for browserslist in package.json
       commonjsOptions: {
-        // plugin to convert CommonJS modules to ES6, so they can be included in bundle
+        // plugin to convert CommonJS modules to ESM, so they can be included in bundle
         include: [
           /core\/electron/, // prevent error in ElectronApp
           /core\/mobile/, // prevent error in MobileApp
@@ -101,7 +103,7 @@ export default defineConfig(() => {
         ],
         overwrite: true,
         copyOnce: true, // only during initial build or on change
-        hook: "buildStart"
+        hook: "buildStart",
       }),
       // open http://localhost:3000/__inspect/ to debug vite plugins
       ...(mode === "development" ? [viteInspect({ build: true })] : []),
@@ -124,8 +126,9 @@ export default defineConfig(() => {
       force: true, // forces cache dumps on each rebuild. should be turned off once the issue in vite with monorepos not being correctly optimized is fixed. Issue link: https://github.com/vitejs/vite/issues/14099
       // overoptimized dependencies in the same monorepo (vite converts all cjs to esm)
       include: [
-        "@itwin/core-common", // for opening iModel error
+        "@itwin/core-common", // to prevent error when opening iModel from undefined rpc policy
         "@itwin/core-electron/lib/cjs/ElectronFrontend", // import from module error
+        "@itwin/core-frontend", // to prevent multiple core-frontends (cjs & esm) from being imported
         "@itwin/core-mobile/lib/cjs/MobileFrontend", // import from module error
       ],
     },

--- a/test-apps/display-test-app/vite.config.ts
+++ b/test-apps/display-test-app/vite.config.ts
@@ -62,8 +62,7 @@ export default defineConfig(() => {
         include: [
           /core\/electron/, // prevent error in ElectronApp
           /core\/mobile/, // prevent error in MobileApp
-          /node_modules/, // prevent errors for modules
-          /core\/frontend/, // prevent errors with require in IModelApp
+          /node_modules/, // prevent errors from dependencies
         ],
         transformMixedEsModules: true, // transforms require statements
       },
@@ -127,7 +126,6 @@ export default defineConfig(() => {
       include: [
         "@itwin/core-common", // for opening iModel error
         "@itwin/core-electron/lib/cjs/ElectronFrontend", // import from module error
-        "@itwin/core-frontend", // file in repository uses require (cjs)
         "@itwin/core-mobile/lib/cjs/MobileFrontend", // import from module error
       ],
     },


### PR DESCRIPTION
Remove `require` call in core-frontend preventing pure esm usage of the pkg
Like we do with the cjs require, in esm we import a file (package.json) at runtime which doesnt exist at compile time, so we suppress the ts compiler error.
If we import the file where it actually is, it will copy the json file into the lib folder, and the paths of our output will be different (lib/esm/src instead of just lib/esm)

ToDo later:
investigate what other libraries are doing to expose the version
possibilities:
- [ ] have a txt file that has the version string, and do some pre-processing (like we do w/ imodel-native) (personally not a huge fan of this approach)
- [ ] look into [rootDirs](https://www.typescriptlang.org/tsconfig#rootDirs)