### PR TITLE
Julio/merger phenomenon and constant

### DIFF
--- a/common/changes/@itwin/ecschema-editing/julio-mergerPhenomenonAndConstant_2023-09-22-21-06.json
+++ b/common/changes/@itwin/ecschema-editing/julio-mergerPhenomenonAndConstant_2023-09-22-21-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "Added schema merging support for phenomenon, constant, unit system and enumerators.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/core/ecschema-editing/src/Merging/ConstantMerger.ts
+++ b/core/ecschema-editing/src/Merging/ConstantMerger.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Constant, DelayedPromiseWithProps, LazyLoadedPhenomenon, Phenomenon, SchemaItemKey } from "@itwin/ecschema-metadata";
+import { SchemaItemChanges } from "../Validation/SchemaChanges";
+import { getItemNameAndSchemaRef, mergeSchemaItemProperties } from "./SchemaItemMerger";
+import { MutableConstant } from "../Editing/Mutable/MutableConstant";
+
+/**
+ * @internal
+ * @param target The constant the differences get merged into
+ * @param source The constant to compare
+ * @param changes Gets the @see SchemaItemChanges between the two constants.
+ * For example, if source constant has an attribute/property that it missing in
+ * target one, it would be listed in propertyValueChanges.
+ */
+export default async function mergeConstant(target: Constant, source: Constant, changes: SchemaItemChanges) {
+  const mutableConstant = target as MutableConstant;
+
+  // Get referenced higher level phenomenon
+  const [refSchema, itemName] = await getItemNameAndSchemaRef(source, source.phenomenon!.fullName);
+
+  await mergeSchemaItemProperties(mutableConstant, changes.propertyValueChanges, (item, propertyName, propertyValue) => {
+    switch (propertyName) {
+      case "definition": {
+        if (item.definition === "")
+          return item.setDefinition(propertyValue);
+        throw Error(`Failed to merged, constant definition conflict: ${propertyValue} -> ${item.definition}`);
+      }
+      case "numerator": {
+        if (!item.hasNumerator)
+          return item.setNumerator(propertyValue);
+        throw Error(`Failed to merged, constant numerator conflict: ${propertyValue} -> ${item.numerator}`);
+      }
+      case "denominator": {
+        if (!item.hasDenominator)
+          return item.setDenominator(propertyValue);
+        throw Error(`Failed to merged, constant denominator conflict: ${propertyValue} -> ${item.denominator}`);
+      }
+      case "phenomenon": {
+        if (item.phenomenon === undefined) {
+          // A lazy loaded phenomenon with the correct reference schema is needed, if reference schema is undefined then item schema.
+          const schemaItemKey = new SchemaItemKey(itemName, refSchema ? refSchema.schemaKey : target.schema.schemaKey);
+          const lazyTargetPhenomenon: LazyLoadedPhenomenon = new DelayedPromiseWithProps<SchemaItemKey, Phenomenon>(schemaItemKey, async () => {
+            const phenomenon = (await target.schema.context.getSchemaItem<Phenomenon>(schemaItemKey));
+            // At this point, higher level phenomenon item should not be undefined
+            if (phenomenon === undefined)
+              throw Error(`Unable to locate phenomenon item in schema ${schemaItemKey.schemaName}`);
+            return phenomenon;
+          });
+          return item.setPhenomenon(lazyTargetPhenomenon);
+        }
+      }
+    }
+  });
+}

--- a/core/ecschema-editing/src/Merging/EnumerationMerger.ts
+++ b/core/ecschema-editing/src/Merging/EnumerationMerger.ts
@@ -2,16 +2,40 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { Enumeration, parsePrimitiveType, primitiveTypeToString } from "@itwin/ecschema-metadata";
-import { ChangeType, EnumerationChanges } from "../Validation/SchemaChanges";
+import { AnyEnumerator, Enumeration, parsePrimitiveType, primitiveTypeToString } from "@itwin/ecschema-metadata";
+import { ChangeType, EnumerationChanges, EnumeratorDelta } from "../Validation/SchemaChanges";
 import { mergeSchemaItemProperties } from "./SchemaItemMerger";
 import { MutableEnumeration } from "../Editing/Mutable/MutableEnumeration";
 
 /**
  * @internal
+ * @param item Type Enumerator, the Enumerator the differences get merged into.
+ * @param attributeName Name of the Enumerator attribute that changed.
+ * @param deltaChange Provides information about the changes in Enumerator attributes.
+ * @param attributeValue The value that gets merged into the Enumerator attribute.
+ */
+type EnumeratorAttributeChanged<TEnumerator extends AnyEnumerator> = (item: TEnumerator, attributeName: string, deltaChange: string, attributeValue: any) => void | boolean;
+
+/**
+ * Simple interface to extend access Enumerator attributes
+ * and allow editing.
+ */
+interface MutableEnumerator extends AnyEnumerator {
+  label?: string;
+  description?: string;
+}
+
+/**
+ * @param target The Enumeration the differences get merged into
+ * @param source The Enumeration to compare
+ * @param changes Gets the @see EnumerationChanges between the two Enumerations.
+ * For example, if source Enumeration has an attribute that is undefined in
+ * target one, it would be listed in propertyValueChanges.
+ * @internal
  */
 export default async function mergeEnumeration(target: Enumeration, source: Enumeration, changes: EnumerationChanges) {
   const mutableEnumeration = target as MutableEnumeration;
+
   await mergeSchemaItemProperties(mutableEnumeration, changes.propertyValueChanges, (item, propertyName, propertyValue) => {
     switch (propertyName) {
       case "isStrict": return item.setIsStrict(propertyValue);
@@ -25,17 +49,53 @@ export default async function mergeEnumeration(target: Enumeration, source: Enum
   });
 
   for (const enumeratorChange of changes.enumeratorChanges.values()) {
-    // Handle each case:
-    // If missing, add source enumerator to target
     if (enumeratorChange.enumeratorMissing?.changeType === ChangeType.Missing) {
-
       const enumerator = source.getEnumeratorByName(enumeratorChange.ecTypeName);
       if (enumerator === undefined) {
-        throw Error(`Enumerator '${enumeratorChange.ecTypeName}' not found in class ${source.fullName}`);
+        throw Error(`Enumerator '${enumeratorChange.ecTypeName}' not found in Enumeration ${source.fullName}`);
       }
-
       const result = mutableEnumeration.createEnumerator(enumerator.name, enumerator.value, enumerator.label, enumerator.description);
       mutableEnumeration.addEnumerator(result);
+    } else {
+      const targetEnumerator = target.getEnumeratorByName(enumeratorChange.ecTypeName);
+      if (targetEnumerator === undefined) {
+        throw Error(`Enumerator '${enumeratorChange.ecTypeName}' not found in Enumeration ${target.fullName}`);
+      }
+      const mutableEnumerator = targetEnumerator as MutableEnumerator;
+      await mergeEnumeratorAttributes(mutableEnumerator, enumeratorChange.enumeratorDeltas, (enumerator, attributeName, deltaChange, attributeValue) => {
+        switch (attributeName) {
+          case "label": {
+            enumerator.label = attributeValue;
+            return;
+          }
+          case "description": {
+            enumerator.description = attributeValue;
+            return;
+          }
+          case "value": {
+            throw Error(`Failed to merge enumerator attribute, ${deltaChange} in ${enumerator.name}`);
+          }
+        }
+      });
+    }
+  }
+}
+
+/**
+ * Similar logic to mergeSchemaItemProperties but for EnumeratorDelta, which has the differences starting at index 1,
+ * hence the .slice(1), this is the main difference between mergeSchemaItemProperties.
+ * @param targetEnumerator The enumerator the differences get merged into.
+ * @param changes Gets the @see EnumeratorDelta, the Enumerator delta array holds information about changes between two Enumerators.
+ * @param handler Defines the information needed to merge the attributes.
+ * @internal
+ */
+async function mergeEnumeratorAttributes<T extends AnyEnumerator>(targetEnumerator: T, changes: EnumeratorDelta[], handler: EnumeratorAttributeChanged<T>) {
+  for (let index = 0, stepUp = true; index < changes.length; stepUp && index++, stepUp = true) {
+    const deltaChange = changes[index].toString(); // this will be useful for error message.
+    const [attributeName, attributeValue] = changes[index].diagnostic.messageArgs!.slice(1); // messageArgs[0] seems to be an object, need to get to the next one, slice to start at index 1
+    if (handler(targetEnumerator, attributeName, deltaChange, attributeValue) === true) {
+      changes.splice(index, 1);
+      stepUp = false;
     }
   }
 }

--- a/core/ecschema-editing/src/Merging/PhenomenonMerger.ts
+++ b/core/ecschema-editing/src/Merging/PhenomenonMerger.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Phenomenon } from "@itwin/ecschema-metadata";
+import { SchemaItemChanges } from "../Validation/SchemaChanges";
+import { MutablePhenomenon } from "../Editing/Mutable/MutablePhenomenon";
+
+/**
+ * @internal
+ */
+export default async function mergePhenomenon(target: Phenomenon, source: Phenomenon, _changes?: SchemaItemChanges) {
+  const mutablePhenomenon = target as MutablePhenomenon;
+
+  if(mutablePhenomenon.definition === ""){
+    await mutablePhenomenon.setDefinition(source.definition);
+  }else{
+    throw Error(`Failed to merge schemas, definition attribute conflict: ${source.definition} -> ${target.definition}`);
+  }
+}

--- a/core/ecschema-editing/src/Merging/SchemaItemFactory.ts
+++ b/core/ecschema-editing/src/Merging/SchemaItemFactory.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { CustomAttributeClass, EntityClass, Enumeration, Phenomenon, PropertyCategory, Schema, SchemaItem, StructClass } from "@itwin/ecschema-metadata";
+import { CustomAttributeClass, EntityClass, Enumeration, Phenomenon, PropertyCategory, Schema, SchemaItem, StructClass, UnitSystem } from "@itwin/ecschema-metadata";
 
 /**
  * @internal
@@ -22,6 +22,8 @@ export namespace SchemaItemFactory {
       return new PropertyCategory(targetSchema, template.name);
     if (is(template, Phenomenon))
       return new Phenomenon(targetSchema, template.name);
+    if (is(template, UnitSystem))
+      return new UnitSystem(targetSchema, template.name);
 
     throw new Error(`Unsupported Schema Item Type: ${template.constructor.name}`);
 

--- a/core/ecschema-editing/src/Merging/SchemaItemFactory.ts
+++ b/core/ecschema-editing/src/Merging/SchemaItemFactory.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { CustomAttributeClass, EntityClass, Enumeration, PropertyCategory, Schema, SchemaItem, StructClass } from "@itwin/ecschema-metadata";
+import { CustomAttributeClass, EntityClass, Enumeration, Phenomenon, PropertyCategory, Schema, SchemaItem, StructClass } from "@itwin/ecschema-metadata";
 
 /**
  * @internal
@@ -20,6 +20,8 @@ export namespace SchemaItemFactory {
       return new CustomAttributeClass(targetSchema, template.name, template.modifier);
     if(is(template, PropertyCategory))
       return new PropertyCategory(targetSchema, template.name);
+    if (is(template, Phenomenon))
+      return new Phenomenon(targetSchema, template.name);
 
     throw new Error(`Unsupported Schema Item Type: ${template.constructor.name}`);
 

--- a/core/ecschema-editing/src/Merging/SchemaItemFactory.ts
+++ b/core/ecschema-editing/src/Merging/SchemaItemFactory.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { CustomAttributeClass, EntityClass, Enumeration, Phenomenon, PropertyCategory, Schema, SchemaItem, StructClass, UnitSystem } from "@itwin/ecschema-metadata";
+import { Constant, CustomAttributeClass, EntityClass, Enumeration, Phenomenon, PropertyCategory, Schema, SchemaItem, StructClass, UnitSystem } from "@itwin/ecschema-metadata";
 
 /**
  * @internal
@@ -22,6 +22,8 @@ export namespace SchemaItemFactory {
       return new PropertyCategory(targetSchema, template.name);
     if (is(template, Phenomenon))
       return new Phenomenon(targetSchema, template.name);
+    if (is(template, Constant))
+      return new Constant(targetSchema, template.name);
     if (is(template, UnitSystem))
       return new UnitSystem(targetSchema, template.name);
 

--- a/core/ecschema-editing/src/Merging/SchemaItemMerger.ts
+++ b/core/ecschema-editing/src/Merging/SchemaItemMerger.ts
@@ -24,7 +24,7 @@ abstract class MutableSchemaItem extends SchemaItem{
  * @param mergeFn           Merge function for complex merging.
  * @internal
  */
-export default async function mergeSchemaItems<TChange extends SchemaItemChanges, TItem extends SchemaItem>(context: SchemaMergeContext, schemaItemChanges: Iterable<TChange>, mergeFn: SchemaItemMergeFn<TChange, TItem>) {
+export default async function mergeSchemaItems<TChange extends SchemaItemChanges, TItem extends SchemaItem>(context: SchemaMergeContext, schemaItemChanges: Iterable<TChange>, mergeFn?: SchemaItemMergeFn<TChange, TItem>) {
   for(const change of schemaItemChanges) {
 
     // Gets the source and the target item. The target item could be undefined at that point.
@@ -66,7 +66,8 @@ export default async function mergeSchemaItems<TChange extends SchemaItemChanges
       return;
     });
 
-    await mergeFn(targetItem, sourceItem, change, context);
+    if (mergeFn)
+      await mergeFn(targetItem, sourceItem, change, context);
   }
 }
 

--- a/core/ecschema-editing/src/Merging/SchemaItemMerger.ts
+++ b/core/ecschema-editing/src/Merging/SchemaItemMerger.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { SchemaItem } from "@itwin/ecschema-metadata";
+import { Schema, SchemaItem } from "@itwin/ecschema-metadata";
 import { ChangeType, PropertyValueChange, SchemaItemChanges } from "../Validation/SchemaChanges";
 import { MutableSchema } from "../Editing/Mutable/MutableSchema";
 import { SchemaItemFactory } from "./SchemaItemFactory";
@@ -86,4 +86,16 @@ export async function mergeSchemaItemProperties<T extends SchemaItem>(targetItem
       increment = false;
     }
   }
+}
+
+/**
+ * @param source The schema item the reference gets copied from
+ * @param itemFullName Parsing through item full name give us the schema reference name and the item name, these values are needed to create a new schema item key.
+ * @returns Item referenced schema and item name.
+ * @internal
+ */
+export async function getItemNameAndSchemaRef(source: SchemaItem, itemFullName: string): Promise<[Schema | undefined, string]> {
+  const [schemaName, itemName] = SchemaItem.parseFullName(itemFullName);
+  const refSchema = await source.schema.getReference(schemaName);
+  return [refSchema, itemName];
 }

--- a/core/ecschema-editing/src/Merging/SchemaMerger.ts
+++ b/core/ecschema-editing/src/Merging/SchemaMerger.ts
@@ -74,6 +74,9 @@ export class SchemaMerger {
     const propertyCategoryChanges = filterChangesByItemType(schemaChanges.schemaItemChanges, SchemaItemType.PropertyCategory);
     await mergeSchemaItems(mergeContext, propertyCategoryChanges, mergePropertyCategory);
 
+    const unitSystemChanges = filterChangesByItemType(schemaChanges.schemaItemChanges, SchemaItemType.UnitSystem);
+    await mergeSchemaItems(mergeContext, unitSystemChanges);
+
     const phenomenonChanges = filterChangesByItemType(schemaChanges.schemaItemChanges, SchemaItemType.Phenomenon);
     await mergeSchemaItems(mergeContext, phenomenonChanges, mergePhenomenon);
 

--- a/core/ecschema-editing/src/Merging/SchemaMerger.ts
+++ b/core/ecschema-editing/src/Merging/SchemaMerger.ts
@@ -17,6 +17,7 @@ import mergeSchemaItems from "./SchemaItemMerger";
 import mergeSchemaReferences from "./SchemaReferenceMerger";
 import mergeCAClasses from "./CAClassMerger";
 import mergePhenomenon from "./PhenomenonMerger";
+import mergeConstant from "./ConstantMerger";
 
 /**
  * Defines the context of a Schema merging run.
@@ -79,6 +80,9 @@ export class SchemaMerger {
 
     const phenomenonChanges = filterChangesByItemType(schemaChanges.schemaItemChanges, SchemaItemType.Phenomenon);
     await mergeSchemaItems(mergeContext, phenomenonChanges, mergePhenomenon);
+
+    const constantChanges = filterChangesByItemType(schemaChanges.schemaItemChanges, SchemaItemType.Constant);
+    await mergeSchemaItems(mergeContext, constantChanges, mergeConstant);
 
     // TODO: For now we just do simple copy and merging of properties and classes. For more complex types
     //       with bases classes or relationships, this might need to get extended.

--- a/core/ecschema-editing/src/Merging/SchemaMerger.ts
+++ b/core/ecschema-editing/src/Merging/SchemaMerger.ts
@@ -16,6 +16,7 @@ import mergePropertyCategory from "./PropertyCategoryMerger";
 import mergeSchemaItems from "./SchemaItemMerger";
 import mergeSchemaReferences from "./SchemaReferenceMerger";
 import mergeCAClasses from "./CAClassMerger";
+import mergePhenomenon from "./PhenomenonMerger";
 
 /**
  * Defines the context of a Schema merging run.
@@ -72,6 +73,9 @@ export class SchemaMerger {
 
     const propertyCategoryChanges = filterChangesByItemType(schemaChanges.schemaItemChanges, SchemaItemType.PropertyCategory);
     await mergeSchemaItems(mergeContext, propertyCategoryChanges, mergePropertyCategory);
+
+    const phenomenonChanges = filterChangesByItemType(schemaChanges.schemaItemChanges, SchemaItemType.Phenomenon);
+    await mergeSchemaItems(mergeContext, phenomenonChanges, mergePhenomenon);
 
     // TODO: For now we just do simple copy and merging of properties and classes. For more complex types
     //       with bases classes or relationships, this might need to get extended.

--- a/core/ecschema-editing/src/test/Merging/ConstantMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/ConstantMerger.test.ts
@@ -1,0 +1,284 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Constant, Schema, SchemaContext } from "@itwin/ecschema-metadata";
+import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { expect } from "chai";
+
+describe("Constant merger tests", () => {
+  let targetContext: SchemaContext;
+  let sourceContext: SchemaContext;
+
+  const sourceJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "SourceSchema",
+    version: "1.2.3",
+    alias: "source",
+  };
+  const targetJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "TargetSchema",
+    version: "1.0.0",
+    alias: "target",
+  };
+  const referenceJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "ReferenceSchema",
+    version: "1.2.0",
+    alias: "reference",
+  };
+
+  beforeEach(() => {
+    targetContext = new SchemaContext();
+    sourceContext = new SchemaContext();
+  });
+
+  describe("Constant missing tests", () => {
+    it("should merge missing constant", async () => {
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            phenomenon: "SourceSchema.testPhenomenon",
+            definition: "PI",
+            numerator: 5.5,
+            denominator: 5.1,
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+        },
+      }, targetContext);
+
+      const testConstant = {
+        schemaItemType: "Constant",
+        label: "Test Constant",
+        description: "testing a constant",
+        phenomenon: "TargetSchema.testPhenomenon",
+        definition: "PI",
+        numerator: 5.5,
+        denominator: 5.1,
+      };
+
+      const merger = new SchemaMerger();
+      const mergedSchema = await merger.merge(targetSchema, sourceSchema);
+      const mergedConstant = await mergedSchema.getItem<Constant>("testConstant");
+      const mergedConstantToJSON = mergedConstant!.toJSON(false, false);
+
+      expect(mergedConstantToJSON).deep.eq(testConstant);
+
+    });
+
+    it("it should merge missing constant with referenced phenomenon", async () => {
+      const _referenceSchema = await Schema.fromJson({
+        ...referenceJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+        },
+      }, sourceContext);
+
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        references: [
+          {
+            name: "ReferenceSchema",
+            version: "1.2.0",
+          },
+        ],
+        items: {
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            definition: "PI",
+            phenomenon: "ReferenceSchema.testPhenomenon",
+            numerator: 5,
+            denominator: 5.1,
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+      }, targetContext);
+
+      const merger = new SchemaMerger();
+      const mergedSchema = await merger.merge(targetSchema, sourceSchema);
+      const mergedConstant = await mergedSchema.getItem<Constant>("testConstant");
+      expect((mergedConstant?.phenomenon)?.fullName).to.be.equals("ReferenceSchema.testPhenomenon");
+    });
+  });
+
+  describe("Constant delta tests", () => {
+    it("it should throw error if definition conflict exist", async () => {
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            definition: "PI",
+            phenomenon: "SourceSchema.testPhenomenon",
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            definition: "PII",
+            phenomenon: "TargetSchema.testPhenomenon",
+          },
+        },
+      }, targetContext);
+
+      const merger = new SchemaMerger();
+      await expect(merger.merge(targetSchema, sourceSchema)).to.be.rejectedWith(Error, "Failed to merged, constant definition conflict: PI -> PII");
+
+    });
+
+    it("it should throw error if numerator conflict exist", async () => {
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            definition: "PI",
+            phenomenon: "SourceSchema.testPhenomenon",
+            numerator: 5.5,
+            denominator: 5.1,
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            definition: "PI",
+            phenomenon: "TargetSchema.testPhenomenon",
+            numerator: 4.5,
+            denominator: 5.1,
+          },
+        },
+      }, targetContext);
+
+      const merger = new SchemaMerger();
+      await expect(merger.merge(targetSchema, sourceSchema)).to.be.rejectedWith(Error, "Failed to merged, constant numerator conflict: 5.5 -> 4.5");
+    });
+
+    it("it should throw error if denominator conflict exist", async () => {
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            definition: "PI",
+            phenomenon: "SourceSchema.testPhenomenon",
+            numerator: 5,
+            denominator: 5.1,
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+          testConstant: {
+            schemaItemType: "Constant",
+            label: "Test Constant",
+            description: "testing a constant",
+            definition: "PI",
+            phenomenon: "TargetSchema.testPhenomenon",
+            numerator: 5,
+            denominator: 4.2,
+          },
+        },
+      }, targetContext);
+
+      const merger = new SchemaMerger();
+      await expect(merger.merge(targetSchema, sourceSchema)).to.be.rejectedWith(Error, "Failed to merged, constant denominator conflict: 5.1 -> 4.2");
+    });
+  });
+});

--- a/core/ecschema-editing/src/test/Merging/PhenomenonMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/PhenomenonMerger.test.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Phenomenon, Schema, SchemaContext } from "@itwin/ecschema-metadata";
+import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { expect } from "chai";
+
+describe("Phenomenon merger tests", () => {
+  let targetContext: SchemaContext;
+  let sourceContext: SchemaContext;
+
+  const sourceJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "SourceSchema",
+    version: "1.2.3",
+    alias: "source",
+  };
+  const targetJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "TargetSchema",
+    version: "1.0.0",
+    alias: "target",
+  };
+
+  beforeEach(() => {
+    targetContext = new SchemaContext();
+    sourceContext = new SchemaContext();
+  });
+
+  describe("Phenomenon missing test", () => {
+    it("should merge missing phenomenon item", async () => {
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+      }, targetContext);
+
+      const merger = new SchemaMerger();
+      const mergedSchema = await merger.merge(targetSchema, sourceSchema);
+
+      const sourcePhenomenon = await sourceSchema.getItem<Phenomenon>("testPhenomenon");
+      const mergedPhenomenon = await mergedSchema.getItem<Phenomenon>("testPhenomenon");
+
+      expect(sourcePhenomenon!.toJSON()).deep.eq(mergedPhenomenon!.toJSON());
+
+    });
+  });
+
+  describe("Phenomenon attribute conflict tests", () => {
+    it("should throw error for definition conflict", async () => {
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(2)",
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+        items: {
+          testPhenomenon: {
+            schemaItemType: "Phenomenon",
+            name: "AREA",
+            label: "Area",
+            description: "Area description",
+            definition: "Units.LENGTH(4)",
+          },
+        },
+      }, targetContext);
+
+      const merger = new SchemaMerger();
+      await expect(merger.merge(targetSchema, sourceSchema)).to.be.rejectedWith(Error, "definition attribute conflict: Units.LENGTH(2) -> Units.LENGTH(4)");
+    });
+  });
+});

--- a/core/ecschema-editing/src/test/Merging/UnitSystemMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/UnitSystemMerger.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Schema, SchemaContext, UnitSystem } from "@itwin/ecschema-metadata";
+import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { expect } from "chai";
+
+describe("Unit system merger tests", () => {
+  let sourceContext: SchemaContext;
+  let targetContext: SchemaContext;
+
+  const sourceJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "SourceSchema",
+    version: "1.2.3",
+    alias: "source",
+  };
+  const targetJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "TargetSchema",
+    version: "1.0.0",
+    alias: "target",
+  };
+
+  beforeEach(() => {
+    targetContext = new SchemaContext();
+    sourceContext = new SchemaContext();
+  });
+
+  describe("Unit system missing tests", () => {
+    it("should merge missing unit system", async () => {
+      const sourceSchema = await Schema.fromJson({
+        ...sourceJson,
+        items: {
+          testUnitSystem: {
+            schemaItemType: "UnitSystem",
+            name: "IMPERIAL",
+            label: "Imperial",
+          },
+        },
+      }, sourceContext);
+
+      const targetSchema = await Schema.fromJson({
+        ...targetJson,
+      }, targetContext);
+
+      const merger = new SchemaMerger();
+      const mergedSchema = await merger.merge(targetSchema, sourceSchema);
+      const mergedUnitSystem = await mergedSchema.getItem<UnitSystem>("testUnitSystem");
+      const sourceUnitSystem = await sourceSchema.getItem<UnitSystem>("testUnitSystem");
+      expect(mergedUnitSystem!.toJSON()).to.deep.equal(sourceUnitSystem!.toJSON());
+    });
+
+  });
+});


### PR DESCRIPTION
This PR adds schema merging support for Constant, Phenomenon, Unit System schema items and Enumeration enumerators.
It only handles the case when those items are missing when merging two schemas, complex conflict resolution will be handled in future iterations, for the time being it throws an error if such conflicts exists.

Fixes https://github.com/iTwin/itwinjs-core/issues/5993 https://github.com/iTwin/itwinjs-core/issues/5992 https://github.com/iTwin/itwinjs-core/issues/5991