### PR TITLE
Backend unit tests: copy mobile assets to tmp

### DIFF
--- a/common/changes/@itwin/core-backend/master_2023-09-27-20-33.json
+++ b/common/changes/@itwin/core-backend/master_2023-09-27-20-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/KnownTestLocations.ts
+++ b/core/backend/src/test/KnownTestLocations.ts
@@ -10,6 +10,12 @@ export class KnownTestLocations {
 
   /** The directory where test assets are stored. Keep in mind that the test is playing the role of the app. */
   public static get assetsDir(): string {
+    if (ProcessDetector.isMobileAppBackend) {
+      // Note: this relies on the native test runner copying its assets out of its app wrapper into
+      // its tmpdir before running the tests.
+      return join(tmpdir(), "assets");
+    }
+
     return join(__dirname, "assets");
   }
 

--- a/tools/internal/ios/core-test-runner/core-test-runner/ViewController.swift
+++ b/tools/internal/ios/core-test-runner/core-test-runner/ViewController.swift
@@ -12,8 +12,25 @@ class ViewController: ObservableObject {
     @Published var testStatus = "Tests not started."
     @Published var numFailed = -1
 
+    func copyAssetsToTemp() throws {
+        let srcPath = Bundle.main.bundlePath.appending("/Assets/assets")
+        let dstPath = NSString(string: NSTemporaryDirectory()).appendingPathComponent("assets")
+        let fm = FileManager.default
+        if fm.fileExists(atPath: dstPath) {
+            try fm.removeItem(atPath: dstPath)
+        }
+        try fm.copyItem(atPath: srcPath, toPath: dstPath)
+    }
+
     func runTests() {
         testStatus = "Starting tests..."
+        do {
+            try copyAssetsToTemp()
+        } catch {
+            NSLog("Error copying assets to tmp: \(error)")
+            self.testStatus = "Tests initialization error."
+            return
+        }
         // Environment variable is read in configureMocha.js and passed to BentleyMochaReporter.
         let testResultsUrl = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("mocha_test_results.xml")
         setenv("TEST_RESULTS_PATH", testResultsUrl.path, 1)


### PR DESCRIPTION
Otherwise the tests file due to a write attempt in a read-only directory tree