### PR TITLE
Fix unit test output dirs to be writable on mobile

### DIFF
--- a/common/changes/@itwin/core-backend/travis-unit-tests-mobile-dirs_2023-09-28-16-50.json
+++ b/common/changes/@itwin/core-backend/travis-unit-tests-mobile-dirs_2023-09-28-16-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/IModelHost.test.ts
+++ b/core/backend/src/test/IModelHost.test.ts
@@ -18,7 +18,7 @@ import { IModelTestUtils } from "./IModelTestUtils";
 import { Logger, LogLevel } from "@itwin/core-bentley";
 
 describe("IModelHost", () => {
-  const opts = { cacheDir: path.join(__dirname, ".cache") };
+  const opts = { cacheDir: TestUtils.getCacheDir() };
   beforeEach(async () => {
     await TestUtils.shutdownBackend();
   });

--- a/core/backend/src/test/PropertyDb.test.ts
+++ b/core/backend/src/test/PropertyDb.test.ts
@@ -10,11 +10,12 @@ import { join } from "path";
 import { OpenMode } from "@itwin/core-bentley";
 import { IModelHost } from "../IModelHost";
 import { PropertyStore } from "../PropertyStore";
+import { KnownTestLocations } from "./KnownTestLocations";
 
 describe("PropertyDb", function (this: Suite) {
   this.timeout(0);
 
-  const outputDir = join(__dirname, "output");
+  const outputDir = KnownTestLocations.outputDir;
 
   before(async () => IModelHost.startup());
 

--- a/core/backend/src/test/TestUtils.ts
+++ b/core/backend/src/test/TestUtils.ts
@@ -50,7 +50,7 @@ export class DisableNativeAssertions implements IDisposable {
 
 export class TestUtils {
   public static getCacheDir(fallback: string | undefined = undefined) {
-    if (ProcessDetector.isIOSAppBackend) {
+    if (ProcessDetector.isMobileAppBackend) {
       return undefined; // Let the native side handle the cache.
     }
     return fallback ?? path.join(__dirname, ".cache"); // Set the cache dir to be under the lib directory.

--- a/core/backend/src/test/TestUtils.ts
+++ b/core/backend/src/test/TestUtils.ts
@@ -49,6 +49,13 @@ export class DisableNativeAssertions implements IDisposable {
 }
 
 export class TestUtils {
+  public static getCacheDir(fallback: string | undefined = undefined) {
+    if (ProcessDetector.isIOSAppBackend) {
+      return undefined; // Let the native side handle the cache.
+    }
+    return fallback ?? path.join(__dirname, ".cache"); // Set the cache dir to be under the lib directory.
+  }
+
   /** Handles the startup of IModelHost.
    * The provided config is used and will override any of the default values used in this method.
    *
@@ -58,11 +65,7 @@ export class TestUtils {
    */
   public static async startBackend(config?: IModelHostOptions): Promise<void> {
     const cfg = config ?? {};
-    if (ProcessDetector.isIOSAppBackend) {
-      cfg.cacheDir = undefined; // Let the native side handle the cache.
-    } else {
-      cfg.cacheDir = cfg.cacheDir ?? path.join(__dirname, ".cache");  // Set the cache dir to be under the lib directory.
-    }
+    cfg.cacheDir = TestUtils.getCacheDir(cfg.cacheDir);
     await IModelHost.startup(cfg);
   }
 

--- a/core/backend/src/test/standalone/TileCache.test.ts
+++ b/core/backend/src/test/standalone/TileCache.test.ts
@@ -103,7 +103,7 @@ describe("TileCache open v1", () => {
     // Shutdown IModelHost to allow this test to use it.
     await TestUtils.shutdownBackend();
     const config = {
-      cacheDir: path.join(__dirname, ".cache"),
+      cacheDir: TestUtils.getCacheDir(),
     };
     await TestUtils.startBackend(config);
 

--- a/core/backend/src/test/standalone/ViewDefinition.test.ts
+++ b/core/backend/src/test/standalone/ViewDefinition.test.ts
@@ -15,6 +15,7 @@ import {
   CategorySelector, DictionaryModel, DisplayStyle3d, IModelDb, ModelSelector, SpatialCategory, SpatialViewDefinition, StandaloneDb, ViewStore,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { KnownTestLocations } from "../KnownTestLocations";
 
 function createNewModelAndCategory(rwIModel: IModelDb) {
   const modelId = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(rwIModel, IModelTestUtils.getUniqueModelCode(rwIModel, "newPhysicalModel"))[1];
@@ -65,7 +66,7 @@ describe("ViewDefinition", () => {
       guid: Guid.createValue(),
     });
 
-    const dbName = join(__dirname, "output", "viewDefTest.db");
+    const dbName = join(KnownTestLocations.outputDir, "viewDefTest.db");
     ViewStore.ViewDb.createNewDb(dbName);
     vs1 = new ViewStore.ViewDb({ iModel, guidMap: new FakeGuids() });
     vs1.openDb(dbName, OpenMode.ReadWrite);

--- a/core/backend/src/test/standalone/ViewStoreDb.test.ts
+++ b/core/backend/src/test/standalone/ViewStoreDb.test.ts
@@ -9,6 +9,7 @@ import { join } from "path";
 import { Guid, GuidString, Logger, LogLevel, OpenMode } from "@itwin/core-bentley";
 import { ViewStore } from "../../ViewStore";
 import { ThumbnailFormatProps } from "@itwin/core-common";
+import { KnownTestLocations } from "../KnownTestLocations";
 
 describe("ViewStore", function (this: Suite) {
   this.timeout(0);
@@ -17,7 +18,7 @@ describe("ViewStore", function (this: Suite) {
 
   before(async () => {
     Logger.setLevel("SQLite", LogLevel.None); // we're expecting errors
-    const dbName = join(__dirname, "output", "viewStore.db");
+    const dbName = join(KnownTestLocations.outputDir, "viewStore.db");
     ViewStore.ViewDb.createNewDb(dbName);
     vs1 = new ViewStore.ViewDb({ guidMap: {} as any });
     vs1.openDb(dbName, OpenMode.ReadWrite);


### PR DESCRIPTION
Tests were failing because they were trying to write files to paths relative to `__dirname`, which does not work on mobile.