### PR TITLE
Expand AuthorizationClient with frequently-used types

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -405,6 +405,8 @@ export namespace Atmosphere {
 // @public
 export interface AuthorizationClient {
     getAccessToken(): Promise<AccessToken>;
+    isAuthorized?: boolean;
+    readonly onAccessTokenChanged?: BeEvent<(token: AccessToken) => void>;
 }
 
 // @public

--- a/common/changes/@itwin/core-common/expand-authorization-client_2023-09-28-18-28.json
+++ b/common/changes/@itwin/core-common/expand-authorization-client_2023-09-28-18-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Augment AuthorizationClient with optional isAuthorized property and optional onAccesTokenChanged BeEvent",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/AuthorizationClient.ts
+++ b/core/common/src/AuthorizationClient.ts
@@ -6,7 +6,7 @@
  * @module Authorization
  */
 
-import { AccessToken } from "@itwin/core-bentley";
+import { type AccessToken, BeEvent } from "@itwin/core-bentley";
 
 /** Provides authorization to access APIs.
  * Bentley's iTwin platform APIs [use OAuth 2.0](https://developer.bentley.com/apis/overview/authorization/) for authorization.
@@ -20,4 +20,10 @@ import { AccessToken } from "@itwin/core-bentley";
 export interface AuthorizationClient {
   /** Obtain an [[AccessToken]] for the currently authorized user, or blank string if no token is available. */
   getAccessToken(): Promise<AccessToken>;
+
+  /** [[BeEvent]] which fires when the client's [[AccessToken]] changes. */
+  readonly onAccessTokenChanged?: BeEvent<(token: AccessToken) => void>;
+
+  /** An [[AccessToken]] exists which is not expired */
+  isAuthorized?: boolean;
 }


### PR DESCRIPTION
Adds a couple of frequently-used and sensible types to the `AuthorizationClient` interface. An optional `isAuthorized` property used to determine if a token is present and not expired, and an optional `onAccessTokenChanged` BeEvent.

The types are optional for backwards compatibility.