### PR TITLE
fix webpack import of named core version

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-webpack-core-ver-import_2023-10-02-17-32.json
+++ b/common/changes/@itwin/core-frontend/fix-webpack-core-ver-import_2023-10-02-17-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -8,10 +8,10 @@
 
 // @ts-expect-error package.json will resolve from the lib/{cjs,esm} dir without copying it into the build output we deliver
 // eslint-disable-next-line @itwin/import-within-package
-import { version } from "../../package.json";
+import packageJson from "../../package.json";
 /** @public */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-export const ITWINJS_CORE_VERSION = version as string;
+export const ITWINJS_CORE_VERSION = packageJson.version as string;
 const COPYRIGHT_NOTICE = 'Copyright © 2017-2023 <a href="https://www.bentley.com" target="_blank" rel="noopener noreferrer">Bentley Systems, Inc.</a>';
 
 import { UiAdmin } from "@itwin/appui-abstract";

--- a/core/frontend/tsconfig.json
+++ b/core/frontend/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "./node_modules/@itwin/build-tools/tsconfig-base.json",
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "./src/**/*.ts"
-  ]
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
<img width="1073" alt="image" src="https://github.com/iTwin/itwinjs-core/assets/11051042/c734235e-08f1-4f2d-a447-fb0545faf5e1">

Fixes the above webpack issue by enabling  [allowSyntheticDefaultImports](https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports) and switching from named to default import

thx @simnorm for reporting the issue