### PR TITLE
Fix Nightly's getting skipped

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -48,9 +48,11 @@ jobs:
 
       - bash: |
           prevAuthor=$(git log -1 --pretty=format:'%an')
-          echo $prevAuthor
-          if [ "$prevAuthor" = "imodeljs-admin" ]; then
-            echo "Previous commit appears to be from imodeljs-admin. Skipping current nightly bump."
+          prevCommit=$(git log -1 --pretty=format:'%B')
+          authorCheck='imodeljs-admin'
+          commitCheck='^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$'
+          if [[ $prevAuthor = $authorCheck ]] && [[ $prevCommit =~ $commitCheck ]]; then
+            echo "Previous commit appears to be from a prior nightly build. Skipping current nightly bump."
             exit 1
           fi
         continueOnError: true


### PR DESCRIPTION
only skip nightly's when prior commit is from imodeljs-admin and prior commit msg has the format X.X.X-dex.X