### PR TITLE
Fix url prefix in reality data client base URL

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/RealityDataAccess.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/RealityDataAccess.test.ts
@@ -28,7 +28,7 @@ describe("RealityDataAccess (#integration)", () => {
     /** API Version. v1 by default */
     // version?: ApiVersion;
     /** API Url. Used to select environment. Defaults to "https://api.bentley.com/reality-management/reality-data */
-    baseUrl: `https://${process.env.IMJS_URL_PREFIX}api.bentley.com`,
+    baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com`,
   };
   let realityDataAccess: RealityDataAccessClient;
   before(async () => {

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -198,7 +198,7 @@ export class TestRunner {
         /** API Version. v1 by default */
         // version?: ApiVersion;
         /** API Url. Used to select environment. Defaults to "https://api.bentley.com/reality-management/reality-data" */
-        baseUrl: `https://${process.env.IMJS_URL_PREFIX}api.bentley.com`,
+        baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com`,
       };
       await DisplayPerfTestApp.startup({
         renderSys: renderOptions,
@@ -229,7 +229,7 @@ export class TestRunner {
       /** API Version. v1 by default */
       // version?: ApiVersion;
       /** API Url. Used to select environment. Defaults to "https://api.bentley.com/realitydata" */
-      baseUrl: `https://${process.env.IMJS_URL_PREFIX}api.bentley.com`,
+      baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com`,
     };
     // Perform all the tests for this iModel. If the iModel name contains an asterisk,
     // treat it as a wildcard and run tests for each iModel that matches the given wildcard.

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -232,7 +232,7 @@ export class DisplayTestApp {
       /** API Version. v1 by default */
       // version?: ApiVersion;
       /** API Url. Used to select environment. Defaults to "https://api.bentley.com/reality-management/reality-data" */
-      baseUrl: `https://${process.env.IMJS_URL_PREFIX}api.bentley.com`,
+      baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com`,
     };
     const opts: ElectronAppOpts | LocalHostIpcAppOpts = {
       iModelApp: {

--- a/test-apps/display-test-app/src/frontend/ClassificationsPanel.ts
+++ b/test-apps/display-test-app/src/frontend/ClassificationsPanel.ts
@@ -165,7 +165,7 @@ export class ClassificationsPanel extends ToolBarDropDown {
             /** API Version. v1 by default */
             // version?: ApiVersion;
             /** API Url. Used to select environment. Defaults to "https://api.bentley.com/realitydata" */
-            baseUrl: `https://${process.env.IMJS_URL_PREFIX}api.bentley.com`,
+            baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com`,
           };
           available = await new RealityDataAccessClient(realityDataClientOptions).getRealityDatas(accessToken, this._iTwinId, criteria);
         }


### PR DESCRIPTION
Fixes #6079.

If `process.env.WHATEVER` is not defined, it stringifies to `undefined`, not empty string.
Introduced in #6073.