### PR TITLE
Update recommended tools list

### DIFF
--- a/docs/learning/tutorials/development-prerequisites.md
+++ b/docs/learning/tutorials/development-prerequisites.md
@@ -19,7 +19,6 @@ The following tools are very helpful and highly suggested for working with iTwin
   - VS Code also supplies a graphical user interface for working with Git.
   - The following VS Code extensions can also be quite helpful:
     - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) (use the [@itwin/eslint-plugin](https://www.npmjs.com/package/@itwin/eslint-plugin) to enforce Bentley coding standards)
-    - [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
     - [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) (great tools for using Git inside VS Code)
     - [MarkdownLint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) (for editing documentation)
 


### PR DESCRIPTION
Debugger for Chrome is deprecated. The extension page has this message: This extension has been deprecated as Visual Studio Code now has a bundled JavaScript Debugger that covers the same functionality.