### PR TITLE
Add support for Electron 27

### DIFF
--- a/common/changes/@itwin/certa/gytis-Electron-27-support_2023-10-13-10-54.json
+++ b/common/changes/@itwin/certa/gytis-Electron-27-support_2023-10-13-10-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "Add support for Electron 27.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/changes/@itwin/core-electron/gytis-Electron-27-support_2023-10-13-10-54.json
+++ b/common/changes/@itwin/core-electron/gytis-Electron-27-support_2023-10-13-10-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": " Add support for Electron 27.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
       '@itwin/core-bentley': link:../bentley
       '@itwin/core-geometry': link:../geometry
       '@itwin/eslint-plugin': 4.0.0-dev.44_5l66jx2oduai5ryf3y7wwu3np4
-      '@itwin/object-storage-core': 2.1.0
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@types/chai': 4.3.1
       '@types/flatbuffers': 1.10.1
       '@types/mocha': 8.2.3
@@ -452,7 +452,7 @@ importers:
       '@types/mocha': ^8.2.2
       '@types/node': 18.16.1
       chai: ^4.3.10
-      electron: ^26.2.1
+      electron: ^27.0.0
       eslint: ^8.44.0
       glob: ^7.1.2
       mocha: ^10.0.0
@@ -479,7 +479,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
       chai: 4.3.10
-      electron: 26.3.0
+      electron: 27.0.0
       eslint: 8.50.0
       glob: 7.2.3
       mocha: 10.2.0
@@ -598,10 +598,10 @@ importers:
       webpack: ^5.76.0
       wms-capabilities: 0.4.0
     dependencies:
-      '@itwin/cloud-agnostic-core': 2.1.0
+      '@itwin/cloud-agnostic-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/core-i18n': link:../i18n
       '@itwin/core-telemetry': link:../telemetry
-      '@itwin/object-storage-core': 2.1.0
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/webgl-compatibility': link:../webgl-compatibility
       '@loaders.gl/core': 3.4.14
       '@loaders.gl/draco': 3.4.14
@@ -1298,7 +1298,7 @@ importers:
       '@types/node': 18.16.1
       chai: ^4.3.10
       cpx2: ^3.0.0
-      electron: ^26.2.1
+      electron: ^27.0.0
       eslint: ^8.44.0
       mocha: ^10.0.0
       rimraf: ^3.0.2
@@ -1310,11 +1310,11 @@ importers:
       '@itwin/core-electron': link:../../core/electron
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-geometry': link:../../core/geometry
-      electron: 26.3.0
+      electron: 27.0.0
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/eslint-plugin': 4.0.0-dev.44_5l66jx2oduai5ryf3y7wwu3np4
-      '@itwin/oidc-signin-tool': 3.6.1_mw7ijh7naa3fttho2b5zv6acpm
+      '@itwin/oidc-signin-tool': 3.6.1_ucuw22jbeoimtubr2bfuzfadfa
       '@types/chai': 4.3.1
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
@@ -1366,7 +1366,7 @@ importers:
       '@itwin/ecschema-editing': link:../../core/ecschema-editing
       '@itwin/ecschema-locaters': link:../../core/ecschema-locaters
       '@itwin/ecschema-metadata': link:../../core/ecschema-metadata
-      '@itwin/imodel-transformer': 0.1.16_weqmipkhmjm5vfy37lv47aijmu
+      '@itwin/imodel-transformer': 0.1.16_ldn7mm7njkdg5fypcar6myqs34
       '@itwin/itwins-client': 1.2.0
       '@itwin/service-authorization': 0.6.3_mdtbcqczpmeuv6yjzfaigjndwi
       '@xmldom/xmldom': 0.8.10
@@ -1728,7 +1728,7 @@ importers:
       crypto-browserify: 3.12.0
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^26.2.1
+      electron: ^27.0.0
       eslint: ^8.44.0
       fs-extra: ^8.1.0
       glob: ^7.1.2
@@ -1766,7 +1766,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_poazcgcl7ckg2qhuzm6ogbt57e
+      '@itwin/electron-authorization': 0.14.1_fownmjsf7c3noey7okp3qo7yzu
       '@itwin/express-server': link:../../core/express-server
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.1_wj555zckjupkhkzyssqqpl4sei
@@ -1777,7 +1777,7 @@ importers:
       azurite: 3.26.0
       chai: 4.3.10
       chai-as-promised: 7.1.1_chai@4.3.10
-      electron: 26.3.0
+      electron: 27.0.0
       fs-extra: 8.1.0
       sinon: 15.2.0
       sinon-chai: 3.7.0_chai@4.3.10+sinon@15.2.0
@@ -1786,8 +1786,8 @@ importers:
       '@itwin/certa': link:../../tools/certa
       '@itwin/eslint-plugin': 4.0.0-dev.44_5l66jx2oduai5ryf3y7wwu3np4
       '@itwin/itwins-client': 1.2.0
-      '@itwin/object-storage-core': 2.1.0
-      '@itwin/oidc-signin-tool': 3.6.1_mw7ijh7naa3fttho2b5zv6acpm
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
+      '@itwin/oidc-signin-tool': 3.6.1_ucuw22jbeoimtubr2bfuzfadfa
       '@types/chai': 4.3.1
       '@types/chai-as-promised': 7.1.6
       '@types/fs-extra': 4.0.13
@@ -2044,7 +2044,7 @@ importers:
       browserify-zlib: ^0.2.0
       buffer: ^6.0.3
       chai: ^4.3.10
-      electron: ^26.2.1
+      electron: ^27.0.0
       eslint: ^8.44.0
       express: ^4.16.3
       glob: ^7.1.2
@@ -2065,7 +2065,7 @@ importers:
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/express-server': link:../../core/express-server
-      electron: 26.3.0
+      electron: 27.0.0
       express: 4.18.2
       semver: 7.5.4
       spdy: 4.0.2
@@ -2460,7 +2460,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^26.2.1
+      electron: ^27.0.0
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2489,14 +2489,14 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/core-quantity': link:../../core/quantity
-      '@itwin/electron-authorization': 0.14.1_poazcgcl7ckg2qhuzm6ogbt57e
+      '@itwin/electron-authorization': 0.14.1_fownmjsf7c3noey7okp3qo7yzu
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.1_wj555zckjupkhkzyssqqpl4sei
       '@itwin/imodels-access-frontend': 3.1.1_ueafa4slb6ohrhyf7kbp6egmha
       '@itwin/imodels-client-authoring': 3.1.0
       '@itwin/imodels-client-management': 3.1.0
-      '@itwin/oidc-signin-tool': 3.6.1_mw7ijh7naa3fttho2b5zv6acpm
+      '@itwin/oidc-signin-tool': 3.6.1_ucuw22jbeoimtubr2bfuzfadfa
       '@itwin/reality-data-client': 1.1.0_mdtbcqczpmeuv6yjzfaigjndwi
       body-parser: 1.20.2
     devDependencies:
@@ -2513,7 +2513,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 26.3.0
+      electron: 27.0.0
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.50.0
       express: 4.18.2
@@ -2524,12 +2524,12 @@ importers:
       rimraf: 3.0.2
       rollup-plugin-copy: 3.5.0
       rollup-plugin-ignore: 1.0.10
-      rollup-plugin-visualizer: 5.9.2
-      rollup-plugin-webpack-stats: 0.2.1
+      rollup-plugin-visualizer: 5.9.2_rollup@3.29.4
+      rollup-plugin-webpack-stats: 0.2.1_rollup@3.29.4
       typescript: 5.0.4
       vite: 4.4.11_@types+node@18.16.1
       vite-plugin-env-compatible: 1.1.1
-      vite-plugin-inspect: 0.7.40_vite@4.4.11
+      vite-plugin-inspect: 0.7.40_rollup@3.29.4+vite@4.4.11
       webpack: 5.88.2
 
   ../../test-apps/display-test-app:
@@ -2577,7 +2577,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^26.2.1
+      electron: ^27.0.0
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2618,7 +2618,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_poazcgcl7ckg2qhuzm6ogbt57e
+      '@itwin/electron-authorization': 0.14.1_fownmjsf7c3noey7okp3qo7yzu
       '@itwin/frontend-devtools': link:../../core/frontend-devtools
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
@@ -2627,7 +2627,7 @@ importers:
       '@itwin/imodels-client-authoring': 3.1.0
       '@itwin/imodels-client-management': 3.1.0
       '@itwin/map-layers-formats': link:../../extensions/map-layers-formats
-      '@itwin/object-storage-core': 2.1.0
+      '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/reality-data-client': 1.1.0_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/webgl-compatibility': link:../../core/webgl-compatibility
       body-parser: 1.20.2
@@ -2646,7 +2646,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 26.3.0
+      electron: 27.0.0
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.50.0
       express: 4.18.2
@@ -2660,13 +2660,13 @@ importers:
       rimraf: 3.0.2
       rollup-plugin-copy: 3.5.0
       rollup-plugin-ignore: 1.0.10
-      rollup-plugin-visualizer: 5.9.2
-      rollup-plugin-webpack-stats: 0.2.1
+      rollup-plugin-visualizer: 5.9.2_rollup@3.29.4
+      rollup-plugin-webpack-stats: 0.2.1_rollup@3.29.4
       ts-node: 10.9.1_typescript@5.0.4
       typescript: 5.0.4
       vite: 4.4.11
       vite-plugin-env-compatible: 1.1.1
-      vite-plugin-inspect: 0.7.40_vite@4.4.11
+      vite-plugin-inspect: 0.7.40_rollup@3.29.4+vite@4.4.11
       webpack: 5.88.2
 
   ../../test-apps/export-gltf:
@@ -2921,7 +2921,7 @@ importers:
       '@types/yargs': 17.0.19
       canonical-path: ^1.0.0
       detect-port: ~1.3.0
-      electron: ^26.2.1
+      electron: ^27.0.0
       eslint: ^8.44.0
       express: ^4.16.3
       jsonc-parser: ~2.0.3
@@ -2953,7 +2953,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.1
       '@types/yargs': 17.0.19
-      electron: 26.3.0
+      electron: 27.0.0
       eslint: 8.50.0
       nyc: 15.1.0
       rimraf: 3.0.2
@@ -4168,7 +4168,7 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/certa/3.7.14_electron@26.3.0:
+  /@itwin/certa/3.7.14_electron@27.0.0:
     resolution: {integrity: sha512-6xelOyEuTQyJr3Nd5X/7dU7Zx8SllvkJpXF54mwHyvq3vL5XqRhHJP6a1IyCzZ+4ExnZm3dcEJXHNyKXf/75xQ==}
     hasBin: true
     peerDependencies:
@@ -4178,7 +4178,7 @@ packages:
         optional: true
     dependencies:
       detect-port: 1.3.0
-      electron: 26.3.0
+      electron: 27.0.0
       express: 4.18.2
       jsonc-parser: 2.0.3
       lodash: 4.17.21
@@ -4200,13 +4200,6 @@ packages:
       reflect-metadata: 0.1.13
     dev: false
 
-  /@itwin/cloud-agnostic-core/2.1.0:
-    resolution: {integrity: sha512-nVFJ55+sj3IExsXwPXJwtud2cK1+5gYsS1Q96Vz6pBQ1rn84i22JUwGmlBrvf3Em6obseBaDQ6GCRA4aUpAjgQ==}
-    engines: {node: '>=12.20 <19.0.0'}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-
   /@itwin/cloud-agnostic-core/2.1.0_scz6qrwecfbbxg4vskopkl3a7u:
     resolution: {integrity: sha512-nVFJ55+sj3IExsXwPXJwtud2cK1+5gYsS1Q96Vz6pBQ1rn84i22JUwGmlBrvf3Em6obseBaDQ6GCRA4aUpAjgQ==}
     engines: {node: '>=12.20 <19.0.0'}
@@ -4216,7 +4209,6 @@ packages:
     dependencies:
       inversify: 6.0.1
       reflect-metadata: 0.1.13
-    dev: false
 
   /@itwin/core-common/4.1.7_67wltvhdskk2oee2c3z2o4tfly:
     resolution: {integrity: sha512-i352GmipU2ULbPQugYT1veICt3rTsXhysRfQurbIGd17sb2h/YOQp0cfm7e0lAJCtmieS19u/B2VEXKV64vGEg==}
@@ -4230,7 +4222,15 @@ packages:
       js-base64: 3.7.5
     dev: false
 
-  /@itwin/electron-authorization/0.14.1_poazcgcl7ckg2qhuzm6ogbt57e:
+  /@itwin/core-quantity/4.0.7_mdtbcqczpmeuv6yjzfaigjndwi:
+    resolution: {integrity: sha512-2X+w5/w/Gx0KwKW61BwB2NM0t1NGbM/8F0UqW41jdG+t9IB9GEZiCpc86E8bmzfYRItB858rytgFWrNLtnWlWg==}
+    peerDependencies:
+      '@itwin/core-bentley': ^4.0.7
+    dependencies:
+      '@itwin/core-bentley': link:../../core/bentley
+    dev: false
+
+  /@itwin/electron-authorization/0.14.1_fownmjsf7c3noey7okp3qo7yzu:
     resolution: {integrity: sha512-NslwCLw129obJHBRMcV/MdykqbD7d93SKTYOOBdaEab2T2niGCmCTJAOkjcWiZZMU0SwmjyxmY9iqdZjvvIqCA==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
@@ -4239,7 +4239,7 @@ packages:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': 4.1.7_67wltvhdskk2oee2c3z2o4tfly
       '@openid/appauth': 1.3.1
-      electron: 26.3.0
+      electron: 27.0.0
       keytar: 7.9.0
       username: 5.1.0
     transitivePeerDependencies:
@@ -4271,7 +4271,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@itwin/imodel-transformer/0.1.16_weqmipkhmjm5vfy37lv47aijmu:
+  /@itwin/imodel-transformer/0.1.16_ldn7mm7njkdg5fypcar6myqs34:
     resolution: {integrity: sha512-TVa1bZHSgE7nZ6UzXZq0zrDtR0va0rTA265GH7QmxgFD+sXZxUzODWd3SIp55NPNH+A7F9Bs/hLY4/HlB708vA==}
     engines: {node: ^18.0.0}
     peerDependencies:
@@ -4279,13 +4279,14 @@ packages:
       '@itwin/core-bentley': 3.6.0 - 4.0.999
       '@itwin/core-common': 3.6.0 - 4.0.999
       '@itwin/core-geometry': 3.6.0 - 4.0.999
+      '@itwin/core-quantity': 3.6.0 - 4.0.999
       '@itwin/ecschema-metadata': 3.6.0 - 4.0.999
     dependencies:
       '@itwin/core-backend': link:../../core/backend
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
       '@itwin/core-geometry': link:../../core/geometry
-      '@itwin/core-quantity': link:../../core/quantity
+      '@itwin/core-quantity': 4.0.7_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/ecschema-metadata': link:../../core/ecschema-metadata
       semver: 7.5.4
     dev: false
@@ -4395,18 +4396,6 @@ packages:
       - debug
     dev: false
 
-  /@itwin/object-storage-core/2.1.0:
-    resolution: {integrity: sha512-0zapV7KDn3NXeOAMoTUoiSiIuQQXUIn8IuLxLExEMoJ8xiG7JsFRWW1tm0Q9Lj095f/stT3V0TOvl4dw1G8pAA==}
-    engines: {node: '>=12.20 <19.0.0'}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-    dependencies:
-      '@itwin/cloud-agnostic-core': 2.1.0
-      axios: 0.27.2
-    transitivePeerDependencies:
-      - debug
-
   /@itwin/object-storage-core/2.1.0_scz6qrwecfbbxg4vskopkl3a7u:
     resolution: {integrity: sha512-0zapV7KDn3NXeOAMoTUoiSiIuQQXUIn8IuLxLExEMoJ8xiG7JsFRWW1tm0Q9Lj095f/stT3V0TOvl4dw1G8pAA==}
     engines: {node: '>=12.20 <19.0.0'}
@@ -4420,7 +4409,6 @@ packages:
       reflect-metadata: 0.1.13
     transitivePeerDependencies:
       - debug
-    dev: false
 
   /@itwin/oidc-signin-tool/3.6.1_mdtbcqczpmeuv6yjzfaigjndwi:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
@@ -4440,12 +4428,12 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/oidc-signin-tool/3.6.1_mw7ijh7naa3fttho2b5zv6acpm:
+  /@itwin/oidc-signin-tool/3.6.1_ucuw22jbeoimtubr2bfuzfadfa:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/certa': 3.7.14_electron@26.3.0
+      '@itwin/certa': 3.7.14_electron@27.0.0
       '@itwin/core-bentley': link:../../core/bentley
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -4677,7 +4665,7 @@ packages:
       '@babel/runtime': 7.23.1
     dev: false
 
-  /@rollup/pluginutils/5.0.5:
+  /@rollup/pluginutils/5.0.5_rollup@3.29.4:
     resolution: {integrity: sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4689,6 +4677,7 @@ packages:
       '@types/estree': 1.0.2
       estree-walker: 2.0.2
       picomatch: 2.3.1
+      rollup: 3.29.4
     dev: true
 
   /@rushstack/node-core-library/3.59.7_@types+node@18.16.1:
@@ -5563,8 +5552,10 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.12.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -7039,8 +7030,8 @@ packages:
   /electron-to-chromium/1.4.543:
     resolution: {integrity: sha512-t2ZP4AcGE0iKCCQCBx/K2426crYdxD3YU6l0uK2EO3FZH0pbC4pFz/sZm2ruZsND6hQBTcDWWlo/MLpiOdif5g==}
 
-  /electron/26.3.0:
-    resolution: {integrity: sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==}
+  /electron/27.0.0:
+    resolution: {integrity: sha512-mr3Zoy82l8XKK/TgguE5FeNeHZ9KHXIGIpUMjbjZWIREfAv+X2Q3vdX6RG0Pmi1K23AFAxANXQezIHBA2Eypwg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
@@ -8676,7 +8667,6 @@ packages:
 
   /inversify/6.0.1:
     resolution: {integrity: sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==}
-    dev: false
 
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10888,7 +10878,6 @@ packages:
 
   /reflect-metadata/0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
-    dev: false
 
   /reflect.getprototypeof/1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
@@ -11043,7 +11032,7 @@ packages:
     resolution: {integrity: sha512-VsbnfwwaTv2Dxl2onubetX/3RnSnplNnjdix0hvF8y2YpqdzlZrjIq6zkcuVJ08XysS8zqW3gt3ORBndFDgsrg==}
     dev: true
 
-  /rollup-plugin-visualizer/5.9.2:
+  /rollup-plugin-visualizer/5.9.2_rollup@3.29.4:
     resolution: {integrity: sha512-waHktD5mlWrYFrhOLbti4YgQCn1uR24nYsNuXxg7LkPH8KdTXVWR9DNY1WU0QqokyMixVXJS4J04HNrVTMP01A==}
     engines: {node: '>=14'}
     hasBin: true
@@ -11055,15 +11044,18 @@ packages:
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
+      rollup: 3.29.4
       source-map: 0.7.4
       yargs: 17.7.2
     dev: true
 
-  /rollup-plugin-webpack-stats/0.2.1:
+  /rollup-plugin-webpack-stats/0.2.1_rollup@3.29.4:
     resolution: {integrity: sha512-vKCIbX2DQMyxC7KFsrqgAwzk49I7Nt8b+4sHJ0Z3JT9FyPyb2OlcqxNykQshTGtMrx9H5dKNjZGuA4FaMs3Txw==}
     engines: {node: '>=14'}
     peerDependencies:
       rollup: ^3.0.0
+    dependencies:
+      rollup: 3.29.4
     dev: true
 
   /rollup/3.29.4:
@@ -11159,7 +11151,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.13
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.12.0
       ajv-keywords: 5.1.0_ajv@8.12.0
     dev: false
 
@@ -12374,7 +12366,7 @@ packages:
     resolution: {integrity: sha512-4lqhBWhOzP+SaCPoCVdmpM5cXzjKQV5jgFauxea488oOeElXo/kw6bXkMIooZhrh9q7gclTl8en6N9NmnqUwRQ==}
     dev: true
 
-  /vite-plugin-inspect/0.7.40_vite@4.4.11:
+  /vite-plugin-inspect/0.7.40_rollup@3.29.4+vite@4.4.11:
     resolution: {integrity: sha512-tsfva6MCg0ch6ckReWHvJ/9xf/zjTuJvakONf2qcMBB/iu9JqiRixfxMa/yLGrlNaBe6fUZHOVhtN2Me3Kthow==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -12385,7 +12377,7 @@ packages:
         optional: true
     dependencies:
       '@antfu/utils': 0.7.6
-      '@rollup/pluginutils': 5.0.5
+      '@rollup/pluginutils': 5.0.5_rollup@3.29.4
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.1.1

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -39,7 +39,7 @@
     "@itwin/core-bentley": "workspace:^4.3.0-dev.7",
     "@itwin/core-common": "workspace:^4.3.0-dev.7",
     "@itwin/core-frontend": "workspace:^4.3.0-dev.7",
-    "electron": ">=23.0.0 <27.0.0"
+    "electron": ">=23.0.0 <28.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",
@@ -53,7 +53,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.16.1",
     "chai": "^4.3.10",
-    "electron": "^26.2.1",
+    "electron": "^27.0.0",
     "eslint": "^8.44.0",
     "glob": "^7.1.2",
     "mocha": "^10.0.0",

--- a/core/electron/src/common/ElectronPush.ts
+++ b/core/electron/src/common/ElectronPush.ts
@@ -6,8 +6,6 @@
 import { RpcMarshaling, RpcPushChannel, RpcPushConnection, RpcPushTransport, RpcRequestFulfillment } from "@itwin/core-common";
 import { BackendIpcTransport, FrontendIpcTransport } from "./ElectronIpcTransport";
 
-/* eslint-disable deprecation/deprecation */
-
 const PUSH = "__push__";
 
 /** @internal */

--- a/core/electron/src/common/ElectronRpcManager.ts
+++ b/core/electron/src/common/ElectronRpcManager.ts
@@ -6,8 +6,6 @@
 import { IpcSocket, IpcSocketBackend, IpcSocketFrontend, RpcConfiguration, RpcInterfaceDefinition, RpcManager, RpcRegistry } from "@itwin/core-common";
 import { ElectronRpcProtocol } from "./ElectronRpcProtocol";
 
-/* eslint-disable deprecation/deprecation */
-
 /** RPC interface configuration for an Electron-based application.
  * @internal
  */

--- a/core/electron/src/common/ElectronRpcProtocol.ts
+++ b/core/electron/src/common/ElectronRpcProtocol.ts
@@ -12,8 +12,6 @@ import { ElectronIpcTransport, initializeIpc, IpcTransportMessage } from "./Elec
 import { ElectronRpcConfiguration } from "./ElectronRpcManager";
 import { ElectronRpcRequest } from "./ElectronRpcRequest";
 
-/* eslint-disable deprecation/deprecation */
-
 /** RPC interface protocol for an Electron-based application.
  * @internal
  */

--- a/core/electron/src/common/ElectronRpcRequest.ts
+++ b/core/electron/src/common/ElectronRpcRequest.ts
@@ -21,7 +21,7 @@ export class ElectronRpcRequest extends RpcRequest {
       const request = await this.protocol.serialize(this);
       this.protocol.transport.sendRequest(request);
     } catch (e) {
-      this.protocol.events.raiseEvent(RpcProtocolEvent.ConnectionErrorReceived, this);
+      this.protocol.events.raiseEvent(RpcProtocolEvent.ConnectionErrorReceived, this); // eslint-disable-line deprecation/deprecation
     }
 
     return new Promise<number>((resolve) => {

--- a/core/electron/src/common/ElectronRpcRequest.ts
+++ b/core/electron/src/common/ElectronRpcRequest.ts
@@ -6,8 +6,6 @@
 import { RpcProtocolEvent, RpcRequest, RpcRequestFulfillment } from "@itwin/core-common";
 import { ElectronRpcProtocol } from "./ElectronRpcProtocol";
 
-/* eslint-disable deprecation/deprecation */
-
 /** @internal */
 export class ElectronRpcRequest extends RpcRequest {
   private _res: (value: number) => void = () => undefined;

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -91,7 +91,7 @@ async function testRegisterIpcHandler() {
 }
 
 async function testInitializeProvidedRpcInterface() {
-  abstract class TestRpcInterface extends RpcInterface { // eslint-disable-line deprecation/deprecation
+  abstract class TestRpcInterface extends RpcInterface {
     public static readonly interfaceName = "TestRpcInterface";
     public static interfaceVersion = "0.0.0";
   }

--- a/core/electron/src/test/frontend/ElectronApp.test.ts
+++ b/core/electron/src/test/frontend/ElectronApp.test.ts
@@ -28,7 +28,7 @@ describe("ElectronApp tests.", () => {
   });
 
   it("Should initialize and terminate provided RPC interfaces.", async () => {
-    abstract class TestRpcInterface extends RpcInterface { // eslint-disable-line deprecation/deprecation
+    abstract class TestRpcInterface extends RpcInterface {
       public static readonly interfaceName = "TestRpcInterface";
       public static interfaceVersion = "0.0.0";
     }

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,3 +3,11 @@ publish: false
 ---
 # NextVersion
 
+Table of contents:
+
+- [Electron 27 support](#electron-27-support)
+
+
+## Electron 27 support
+
+In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 27](https://www.electronjs.org/blog/electron-27-0).

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -23,7 +23,7 @@
     "@itwin/core-electron": "workspace:*",
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-geometry": "workspace:*",
-    "electron": "^26.2.1"
+    "electron": "^27.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -53,7 +53,7 @@
     "azurite": "^3.24.0",
     "chai-as-promised": "^7",
     "chai": "^4.3.10",
-    "electron": "^26.2.1",
+    "electron": "^27.0.0",
     "fs-extra": "^8.1.0",
     "sinon-chai": "^3.2.0",
     "sinon": "^15.0.4"

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -26,7 +26,7 @@
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-mobile": "workspace:*",
     "@itwin/express-server": "workspace:*",
-    "electron": "^26.2.1",
+    "electron": "^27.0.0",
     "express": "^4.16.3",
     "semver": "^7.3.5",
     "spdy": "^4.0.1"

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -72,7 +72,7 @@
     "cpx2": "^3.0.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^26.2.1",
+    "electron": "^27.0.0",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -89,7 +89,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^26.2.1",
+    "electron": "^27.0.0",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -52,14 +52,14 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "18.16.1",
     "@types/yargs": "17.0.19",
-    "electron": "^26.2.1",
+    "electron": "^27.0.0",
     "eslint": "^8.44.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
     "typescript": "~5.0.2"
   },
   "peerDependencies": {
-    "electron": ">=23.0.0 <27.0.0"
+    "electron": ">=23.0.0 <28.0.0"
   },
   "peerDependenciesMeta": {
     "electron": {


### PR DESCRIPTION
#### Changes:
- Extend supported Electron version range with Electron 27.
- Increase Electron dev dependency version to `^27.0.0`.

No code changes required since core doesn't use [APIs changed in 27](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#planned-breaking-api-changes-270).