### PR TITLE
Fixes for iOS backend unit tests

### DIFF
--- a/common/changes/@itwin/core-backend/travis-ios-unit-tests-assets-fix_2023-10-13-22-47.json
+++ b/common/changes/@itwin/core-backend/travis-ios-unit-tests-assets-fix_2023-10-13-22-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "mocha",
     "ios:webpack:tests": "TESTS_GLOB=./lib/**/*.test.js webpack --config ../../tools/internal/ios/ios.webpack.config.js",
-    "ios:copy:assets": "cpx \"./src/test/assets/**/*\" ../../tools/internal/lib/ios/assets/assets",
+    "ios:copy:assets": "cpx \"./src/test/assets/**/*\" ../../tools/internal/lib/ios/assets/assets && cpx \"./src/assets/**/*\" ../../tools/internal/lib/ios/assets/assets",
     "ios:build:tests": "npm run -s build && npm run -s ios:webpack:tests && npm run -s ios:copy:assets"
   },
   "repository": {

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1FC349BF2AC5D86400A885C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D398E01427D82FB800575F47 /* core-test-runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "core-test-runner.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D398E01727D82FB800575F47 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		D398E01927D82FB800575F47 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -85,6 +86,7 @@
 		D398E01627D82FB800575F47 /* core-test-runner */ = {
 			isa = PBXGroup;
 			children = (
+				1FC349BF2AC5D86400A885C7 /* Info.plist */,
 				D398E07327D836D300575F47 /* ViewController.swift */,
 				D398E01727D82FB800575F47 /* App.swift */,
 				D398E01927D82FB800575F47 /* ContentView.swift */,
@@ -417,6 +419,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "core-test-runner/Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -450,6 +453,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "core-test-runner/Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "mobile-native-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/iTwin/mobile-native-ios",
+      "state" : {
+        "revision" : "a1a9b197430f336578b511153c1351c12b7e076c",
+        "version" : "4.2.5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/tools/internal/ios/core-test-runner/core-test-runner/Info.plist
+++ b/tools/internal/ios/core-test-runner/core-test-runner/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Fix assets copy for iOS backend unit tests
iOS test runner:
* Store results xmls in Documents
* Enable file sharing to extract results xmls
* Delete all but the most recent 10 results xmls 