### PR TITLE
Remove reserved SQLite keywords from tests

### DIFF
--- a/common/changes/@itwin/core-backend/remove_reserved_keywords_from_tests_2023-10-16-07-34.json
+++ b/common/changes/@itwin/core-backend/remove_reserved_keywords_from_tests_2023-10-16-07-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Change reserved ECSql keywords from tests.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/remove_reserved_keywords_from_tests_2023-10-16-07-34.json
+++ b/common/changes/@itwin/core-backend/remove_reserved_keywords_from_tests_2023-10-16-07-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Change reserved ECSql keywords from tests.",
+      "comment": "Change reserved SQLite keywords from tests.",
       "type": "none"
     }
   ],

--- a/core/backend/src/test/ecdb/ECSqlStatement.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlStatement.test.ts
@@ -1756,13 +1756,13 @@ describe("ECSqlStatement", () => {
     await using(ECDbTestHelper.createECDb(outDir, "bindrange3d.ecdb",
       `<ECSchema schemaName="Test" alias="test" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
         <ECEntityClass typeName="Foo" modifier="Sealed">
-          <ECProperty propertyName="Range" typeName="binary"/>
+          <ECProperty propertyName="Range3d" typeName="binary"/>
         </ECEntityClass>
        </ECSchema>`), async (ecdb) => {
 
       assert.isTrue(ecdb.isOpen);
 
-      const id: Id64String = ecdb.withPreparedStatement("INSERT INTO test.Foo(Range) VALUES(?)", (stmt: ECSqlStatement) => {
+      const id: Id64String = ecdb.withPreparedStatement("INSERT INTO test.Foo(Range3d) VALUES(?)", (stmt: ECSqlStatement) => {
         stmt.bindRange3d(1, testRange);
         const res: ECSqlInsertResult = stmt.stepForInsert();
         assert.equal(res.status, DbResult.BE_SQLITE_DONE);
@@ -1770,7 +1770,7 @@ describe("ECSqlStatement", () => {
         return res.id!;
       });
       ecdb.saveChanges();
-      ecdb.withPreparedStatement("SELECT Range FROM test.Foo WHERE ECInstanceId=?", (stmt: ECSqlStatement) => {
+      ecdb.withPreparedStatement("SELECT Range3d FROM test.Foo WHERE ECInstanceId=?", (stmt: ECSqlStatement) => {
         stmt.bindId(1, id);
         assert.equal(stmt.step(), DbResult.BE_SQLITE_ROW);
         const rangeBlob: Uint8Array = stmt.getValue(0).getBlob();

--- a/example-code/snippets/src/backend/ECSQL-queries.test.ts
+++ b/example-code/snippets/src/backend/ECSQL-queries.test.ts
@@ -32,12 +32,12 @@ describe("Useful ECSQL queries", () => {
     // and it is a child of a Subject named "Subject1".
     const partitionIds: Id64Set = iModel.withPreparedStatement(`
       select
-        physicalPartition.ecinstanceid
+        [partition].ecinstanceid
       from
-        ${PhysicalPartition.classFullName} as physicalPartition,
+        ${PhysicalPartition.classFullName} as [partition],
         (select ecinstanceid from ${Subject.classFullName} where CodeValue=:parentName) as parent
       where
-      physicalPartition.codevalue=:partitionName and physicalPartition.parent.id = parent.ecinstanceid;
+      [partition].codevalue=:partitionName and [partition].parent.id = parent.ecinstanceid;
     `, (stmt: ECSqlStatement) => {
       stmt.bindValue("parentName", "Subject1");
       stmt.bindValue("partitionName", "Physical");

--- a/example-code/snippets/src/backend/ECSQL-queries.test.ts
+++ b/example-code/snippets/src/backend/ECSQL-queries.test.ts
@@ -32,12 +32,12 @@ describe("Useful ECSQL queries", () => {
     // and it is a child of a Subject named "Subject1".
     const partitionIds: Id64Set = iModel.withPreparedStatement(`
       select
-        partition.ecinstanceid
+        physicalPartition.ecinstanceid
       from
-        ${PhysicalPartition.classFullName} as partition,
+        ${PhysicalPartition.classFullName} as physicalPartition,
         (select ecinstanceid from ${Subject.classFullName} where CodeValue=:parentName) as parent
       where
-        partition.codevalue=:partitionName and partition.parent.id = parent.ecinstanceid;
+      physicalPartition.codevalue=:partitionName and physicalPartition.parent.id = parent.ecinstanceid;
     `, (stmt: ECSqlStatement) => {
       stmt.bindValue("parentName", "Subject1");
       stmt.bindValue("partitionName", "Physical");


### PR DESCRIPTION
Some of the tests use reserved SQLite keywords, so those tests will fail when [ECSql starts using some of the reserved keywords that were not used before.](https://github.com/iTwin/imodel-native/pull/515)