### PR TITLE
check for commit substring

### DIFF
--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -31,6 +31,9 @@ let commitMessage = await $`git log --format=%B -n 1`;
 targetBranch = String(targetBranch).replace(/\n/g, '');
 currentBranch = String(currentBranch).replace(/\n/g, '');
 commitMessage = String(commitMessage).replace(/\n/g, '');
+const substring = " Changelogs";
+if (commitMessage.includes(substring))
+  commitMessage = commitMessage.replace(substring, '');
 
 console.log(`target branch: ${targetBranch}`);
 console.log(`current branch: ${currentBranch}`);


### PR DESCRIPTION
fix the commit msg syntax error that occurs when a patch come from our previous Major version. This will need to get a bp to release/4.2.x