### PR TITLE
set nodeVersion back to 18.x

### DIFF
--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -55,11 +55,11 @@ jobs:
         clean: true
       - template: ../templates/core-build.yaml
         parameters:
-          nodeVersion: 18.16.0 #TODO Change back to 18.x once segfault on 18.16.1? is resolved.
+          nodeVersion: 18.x
           buildIos: true
       # Will run if even there is a failure somewhere else in the pipeline.
       - template: ../templates/publish-test-results.yaml
         parameters:
-          nodeVersion: 18.16.0 #TODO Change back to 18.x once segfault on 18.16.1? is resolved.
+          nodeVersion: 18.x
       # The publish script identifies any new packages not previously published and tags the build
       - template: ../templates/publish.yaml


### PR DESCRIPTION
We never switched back our node version to be 18.x. Assuming we want to revert back to this.