### PR TITLE
Improve behavior of Viewport.zoomToElements...

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -17685,6 +17685,7 @@ export type WorkerReturnType<T extends (...args: any) => any> = ReturnType<T> | 
 
 // @public
 export interface ZoomToOptions {
+    minimumDimension?: number;
     placementRelativeId?: StandardViewId;
     standardViewId?: StandardViewId;
     viewRotation?: Matrix3d;

--- a/common/changes/@itwin/core-frontend/zoom-to-elements-extents_2023-10-19-12-51.json
+++ b/common/changes/@itwin/core-frontend/zoom-to-elements-extents_2023-10-19-12-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -135,7 +135,7 @@ export interface DepthRangeNpc {
   maximum: number;
 }
 
-/** Options to allow changing the view rotation with zoomTo methods.
+/** Options to allow changing the view rotation with zoomTo methods and ensure minimum bounding box dimensions for zoomToElements.
  * @public
  */
 export interface ZoomToOptions {
@@ -145,6 +145,8 @@ export interface ZoomToOptions {
   placementRelativeId?: StandardViewId;
   /** Set view rotation from Matrix3d. */
   viewRotation?: Matrix3d;
+  /** Ensure minimum element-aligned bounding box dimensions in meters (3d only). */
+  minimumDimension?: number;
 }
 
 /** Options for changing the viewed Model of a 2d view via [[Viewport.changeViewedModel2d]]
@@ -2143,6 +2145,12 @@ export abstract class Viewport implements IDisposable, TileUser {
    */
   public async zoomToElements(ids: Id64Arg, options?: ViewChangeOptions & MarginOptions & ZoomToOptions): Promise<void> {
     const placements = await this.iModel.elements.getPlacements(ids, { type: this.view.is3d() ? "3d" : "2d" });
+    if (undefined !== options?.minimumDimension) {
+      for (const placement of placements) {
+        if (placement.isValid && placement instanceof Placement3d)
+          placement.bbox.ensureMinLengths(options.minimumDimension);
+      }
+    }
     this.zoomToPlacements(placements, options);
   }
 


### PR DESCRIPTION
...for lines and points in perspective views by adding the option to impose minimum element-aligned bounding box extents.

Team working on crack detection noticed that zoomToElements was not working well for them in perspective views as cracks would often be clipped by the front plane and the option to specify a margin isn't supported. Cracks are represented by geometric elements with a single line segment in their geometry stream. Added an option to ensure minimum element-aligned bounding box extents so that lines and points have a proper volume.