### PR TITLE
Make persistent reality models display with batched tiles

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-batched-tiles-reality-models_2023-10-19-16-58.json
+++ b/common/changes/@itwin/core-frontend/pmc-batched-tiles-reality-models_2023-10-19-16-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix SpatialModelState.isRealityModel returning false for reality models that don't store a tileset URL.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/frontend-tiles/pmc-batched-tiles-reality-models_2023-10-19-16-58.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-batched-tiles-reality-models_2023-10-19-16-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "Fix attached reality models not displaying with batched tiles.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/core/frontend/src/ModelState.ts
+++ b/core/frontend/src/ModelState.ts
@@ -278,6 +278,7 @@ export class SpatialModelState extends GeometricModel3dState {
   public readonly classifiers?: SpatialClassifiers;
 
   public static override get className() { return "SpatialModel"; }
+
   /** @internal */
   public override get asSpatialModel(): SpatialModelState { return this; }
 
@@ -286,9 +287,10 @@ export class SpatialModelState extends GeometricModel3dState {
     if (this.isRealityModel)
       this.classifiers = new SpatialClassifiers(this.jsonProperties);
   }
+
   /** Return true if this is a reality model (represented by a 3d tile set). */
   public get isRealityModel(): boolean {
-    return undefined !== this.jsonProperties.tilesetUrl;
+    return !!this.jsonProperties.tilesetUrl || !!this.jsonProperties.rdSourceKey || !!this.jsonProperties.orbitGtBlob;
   }
 }
 

--- a/extensions/frontend-tiles/src/BatchedModels.ts
+++ b/extensions/frontend-tiles/src/BatchedModels.ts
@@ -6,13 +6,19 @@
 import { Id64, Id64String } from "@itwin/core-bentley";
 import { Range3d } from "@itwin/core-geometry";
 import { ModelExtentsProps } from "@itwin/core-common";
-import { IModelConnection, SpatialViewState } from "@itwin/core-frontend";
+import { IModelConnection, SpatialModelState, SpatialViewState } from "@itwin/core-frontend";
+
+interface ModelMetadata {
+  extents?: Range3d;
+  isRealityModel: boolean;
+}
 
 export class BatchedModels {
   private readonly _iModel: IModelConnection;
   private _viewedModels!: Set<Id64String>;
+  private readonly _viewedExtents = new Range3d();
   private readonly _viewedModelIdPairs = new Id64.Uint32Set();
-  private readonly _modelRanges = new Map<Id64String, Range3d>();
+  private readonly _metadata = new Map<Id64String, ModelMetadata>();
   private _modelRangePromise?: Promise<void>;
 
   public constructor(view: SpatialViewState) {
@@ -20,24 +26,54 @@ export class BatchedModels {
     this.setViewedModels(view.modelSelector.models);
   }
 
-  public setViewedModels(models: Set<Id64String>): void {
+  public setViewedModels(models: Set<Id64String>): { realityModelIds?: Set<Id64String> } {
     this._viewedModels = models;
     this._viewedModelIdPairs.clear();
     this._viewedModelIdPairs.addIds(models);
+    this._viewedExtents.setNull();
 
     this._modelRangePromise = undefined;
-    const modelIds = Array.from(models).filter((modelId) => !this._modelRanges.has(modelId));
-    if (modelIds.length === 0)
-      return;
+    const rangeQueryModels: Id64String[] = [];
+    let realityModelIds: Set<Id64String> | undefined = undefined;
 
-    const modelRangePromise = this._modelRangePromise = this._iModel.models.queryExtents(modelIds).then((extents: ModelExtentsProps[]) => {
+    for (const modelId of models) {
+      let metadata = this._metadata.get(modelId);
+      if (!metadata) {
+        const model = this._iModel.models.getLoaded(modelId);
+        this._metadata.set(modelId, metadata = { isRealityModel: model instanceof SpatialModelState && model.isRealityModel });
+      }
+
+      if (metadata.isRealityModel) {
+        if (!realityModelIds)
+          realityModelIds = new Set<Id64String>();
+
+        realityModelIds.add(modelId);
+      }
+
+      if (undefined == metadata.extents)
+        rangeQueryModels.push(modelId);
+      else
+        this._viewedExtents.extendRange(metadata.extents);
+    }
+
+    if (rangeQueryModels.length === 0)
+      return { realityModelIds };
+
+    const modelRangePromise = this._modelRangePromise = this._iModel.models.queryExtents(rangeQueryModels).then((extents: ModelExtentsProps[]) => {
       if (modelRangePromise !== this._modelRangePromise)
         return;
 
       this._modelRangePromise = undefined;
-      for (const extent of extents)
-        this._modelRanges.set(extent.id, Range3d.fromJSON(extent.extents));
+      for (const extent of extents) {
+        const metadata = this._metadata.get(extent.id);
+        if (metadata) {
+          metadata.extents = Range3d.fromJSON(extent.extents);
+          this._viewedExtents.extendRange(metadata.extents);
+        }
+      }
     }).catch(() => { });
+
+    return { realityModelIds };
   }
 
   public views(modelId: Id64String): boolean {
@@ -49,10 +85,6 @@ export class BatchedModels {
   }
 
   public unionRange(range: Range3d): void {
-    for (const id of this._viewedModels) {
-      const extent = this._modelRanges.get(id);
-      if (extent)
-        range.extendRange(extent);
-    }
+    range.extendRange(this._viewedExtents);
   }
 }

--- a/extensions/frontend-tiles/src/BatchedModels.ts
+++ b/extensions/frontend-tiles/src/BatchedModels.ts
@@ -47,7 +47,7 @@ export class BatchedModels {
       if (metadata.isRealityModel)
         this.viewedRealityModelIds.add(modelId);
 
-      if (undefined == metadata.extents)
+      if (undefined === metadata.extents)
         rangeQueryModels.push(modelId);
       else
         this._viewedExtents.extendRange(metadata.extents);


### PR DESCRIPTION
Previously we assumed the geometry for all spatial models was included in the single batched tileset, but persistent reality models obtain their tiles from elsewhere, as specified in their JSON properties.
Tested locally with the big point cloud that wasn't showing up in ImageTests - it displays now.

Incidentally, compute the viewed extents only when they change, not every time `unionFitRange` is called.

Incidentally, fix a bug where `SpatialModelState.isRealityModel` was returning false incorrectly. It only checked for a `tilesetUrl` property, but the reality data can alternatively be specified by an `orbitGtBlob` or `rdSourceKey` property.

TODO:
- [ ] Evaluate ImageTests results