### PR TITLE
Add AuthorizationClient onAccessTokenChanged event

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -405,6 +405,7 @@ export namespace Atmosphere {
 // @public
 export interface AuthorizationClient {
     getAccessToken(): Promise<AccessToken>;
+    readonly onAccessTokenChanged?: BeEvent<(token: AccessToken) => void>;
 }
 
 // @public

--- a/common/changes/@itwin/core-common/add-auth-client-access-token-event_2023-10-19-17-57.json
+++ b/common/changes/@itwin/core-common/add-auth-client-access-token-event_2023-10-19-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Add optional onAccesTokenChanged BeEvent to AuthorizationClient",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-common/add-auth-client-access-token-event_2023-10-19-17-57.json
+++ b/common/changes/@itwin/core-common/add-auth-client-access-token-event_2023-10-19-17-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-common",
-      "comment": "Add optional onAccesTokenChanged BeEvent to AuthorizationClient",
+      "comment": "Add optional onAccessTokenChanged BeEvent to AuthorizationClient",
       "type": "none"
     }
   ],

--- a/core/common/src/AuthorizationClient.ts
+++ b/core/common/src/AuthorizationClient.ts
@@ -6,7 +6,7 @@
  * @module Authorization
  */
 
-import { AccessToken } from "@itwin/core-bentley";
+import { type AccessToken, BeEvent } from "@itwin/core-bentley";
 
 /** Provides authorization to access APIs.
  * Bentley's iTwin platform APIs [use OAuth 2.0](https://developer.bentley.com/apis/overview/authorization/) for authorization.
@@ -20,4 +20,7 @@ import { AccessToken } from "@itwin/core-bentley";
 export interface AuthorizationClient {
   /** Obtain an [[AccessToken]] for the currently authorized user, or blank string if no token is available. */
   getAccessToken(): Promise<AccessToken>;
+
+  /** [[BeEvent]] which fires when the client's [[AccessToken]] changes. */
+  readonly onAccessTokenChanged?: BeEvent<(token: AccessToken) => void>;
 }


### PR DESCRIPTION
Add an optional `onAccessTokenChanged` `BeEvent` to the `AuthorizationClient` interface.
We plan to make this property required in 5.0.