### PR TITLE
Only run iOS unit test once & update add-on

### DIFF
--- a/tools/internal/ios/core-test-runner/core-test-runner-xcuitest/CoreTestRunnerXCUITest.swift
+++ b/tools/internal/ios/core-test-runner/core-test-runner-xcuitest/CoreTestRunnerXCUITest.swift
@@ -7,10 +7,6 @@ import XCTest
 
 class CoreTestRunnerXCUITest: XCTestCase {
 
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
-        true
-    }
-
     override func setUpWithError() throws {
         continueAfterFailure = false
     }

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.2.5;
+				version = 4.2.10;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/iTwin/mobile-native-ios",
       "state" : {
-        "revision" : "a1a9b197430f336578b511153c1351c12b7e076c",
-        "version" : "4.2.5"
+        "revision" : "2f6675d9b997e3f8fdad1aec31c175e15a4f61b6",
+        "version" : "4.2.10"
       }
     }
   ],


### PR DESCRIPTION
Without this change, the backend unit tests were run in portrait and landscape in both light and dark mode, so they ran 4 times for no reason.
I don't know why the test runner project doesn't have the correct add-on version; I suspect that it is missing from the version update release instructions.