### PR TITLE
Remove max depth for reality tiles.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-rm-reality-tile-max-depth_2023-10-30-13-33.json
+++ b/common/changes/@itwin/core-frontend/pmc-rm-reality-tile-max-depth_2023-10-30-13-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Remove maximum depth constraint for reality tile trees.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -435,7 +435,7 @@ class RealityModelTileLoader extends RealityTileLoader {
   public get doDrapeBackgroundMap(): boolean { return this.tree.doDrapeBackgroundMap; }
   public override get wantDeduplicatedVertices() { return this._deduplicateVertices; }
 
-  public get maxDepth(): number { return 32; }  // Can be removed when element tile selector is working.
+  public get maxDepth(): number { return Number.MAX_SAFE_INTEGER; }
   public get minDepth(): number { return 0; }
   public get priority(): TileLoadPriority { return TileLoadPriority.Context; }
   public override getBatchIdMap(): BatchedTileIdMap | undefined { return this._batchedIdMap; }


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/901
Reverts "temporary" [five-year-old workaround](https://github.com/iTwin/itwinjs-core/commit/f85f06fb5f6f1499dc458a2edc992889cce66137).

#### TODO

- [ ] Run ImageTests