### PR TITLE
Pass IModelHost.shutdown as the listener function instead of a lambda function 

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3262,7 +3262,7 @@ export class IModelHost {
     static setCrashReportProperty(name: string, value: string): void;
     // @internal (undocumented)
     static setHubAccess(hubAccess: BackendHubAccess | undefined): void;
-    static shutdown(): Promise<void>;
+    static shutdown(this: void): Promise<void>;
     static snapshotFileNameResolver?: FileNameResolver;
     static startup(options?: IModelHostOptions): Promise<void>;
     // @internal

--- a/common/changes/@itwin/core-backend/nick-removelistener_2023-11-01-20-07.json
+++ b/common/changes/@itwin/core-backend/nick-removelistener_2023-11-01-20-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -491,7 +491,7 @@ export class IModelHost {
     this.configuration = options;
     this.setupTileCache();
 
-    process.once("beforeExit", async () => IModelHost.shutdown());
+    process.once("beforeExit", IModelHost.shutdown);
     this.onAfterStartup.raiseEvent();
   }
 
@@ -504,13 +504,13 @@ export class IModelHost {
   }
 
   /** This method must be called when an iTwin.js host is shut down. Raises [[onBeforeShutdown]] */
-  public static async shutdown(): Promise<void> {
+  public static shutdown(this: void): void {
     // Note: This method is set as a node listener where `this` is unbound. Call private method to
     // ensure `this` is correct. Don't combine these methods.
     return IModelHost.doShutdown();
   }
 
-  private static async doShutdown() {
+  private static doShutdown() {
     if (!this._isValid)
       return;
 
@@ -522,7 +522,7 @@ export class IModelHost {
     this._appWorkspace = undefined;
 
     CloudSqlite.CloudCaches.destroy();
-    process.removeListener("beforeExit", async () => IModelHost.shutdown());
+    process.removeListener("beforeExit", IModelHost.shutdown);
   }
 
   /**

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -504,13 +504,13 @@ export class IModelHost {
   }
 
   /** This method must be called when an iTwin.js host is shut down. Raises [[onBeforeShutdown]] */
-  public static shutdown(this: void): void {
+  public static async shutdown(this: void): Promise<void> {
     // Note: This method is set as a node listener where `this` is unbound. Call private method to
     // ensure `this` is correct. Don't combine these methods.
     return IModelHost.doShutdown();
   }
 
-  private static doShutdown() {
+  private static async doShutdown() {
     if (!this._isValid)
       return;
 

--- a/core/backend/src/test/IModelHost.test.ts
+++ b/core/backend/src/test/IModelHost.test.ts
@@ -47,6 +47,17 @@ describe("IModelHost", () => {
     expect(Schemas.getRegisteredSchema("Functional")).to.exist;
   });
 
+  it("should properly cleanup beforeExit event listeners on shutdown", async () => {
+    const beforeCount = process.listenerCount("beforeExit");
+    for (let i = 0; i <= 15; i++) {
+      await IModelHost.startup();
+      await IModelHost.shutdown();
+
+    }
+    const afterCount = process.listenerCount("beforeExit");
+    expect(beforeCount).to.be.equal(afterCount);
+  });
+
   it("should call logger sync function", async () => {
     const logChanged = sinon.spy(IModelHost as any, "syncNativeLogLevels");
     await IModelHost.startup(opts);


### PR DESCRIPTION
removelistener can't find the listener to remove if an anonymous function is passed. 

Thanks to Carole for reporting this.

(node:22416) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 beforeExit listeners added to [process]. Use emitter.setMaxListeners() to increase limit 
Is seen in logs when running tests without this change.