### PR TITLE
move ecsql/common generated-docs up one folder level

### DIFF
--- a/common/changes/@itwin/ecsql-common/fix-ecsql-common-docs-location_2023-11-02-13-14.json
+++ b/common/changes/@itwin/ecsql-common/fix-ecsql-common-docs-location_2023-11-02-13-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecsql-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecsql-common"
+}

--- a/core/ecsql/common/package.json
+++ b/core/ecsql/common/package.json
@@ -11,7 +11,7 @@
     "build:cjs": "tsc 1>&2 --outDir lib/cjs",
     "build:esm": "tsc 1>&2 --module ES2020 --outDir lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
-    "docs": "betools docs --includes=../../generated-docs/extract --json=../../generated-docs/core/ecsql-common/file.json --tsIndexFile=./ecsql-common.ts --onlyJson",
+    "docs": "betools docs --includes=../../../generated-docs/extract --json=../../../generated-docs/core/ecsql-common/file.json --tsIndexFile=./ecsql-common.ts --onlyJson",
     "extract-api": "betools extract-api --entry=ecsql-common",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "mocha",


### PR DESCRIPTION
The `docs` script for `ecsql-common` outputs to an incorrect location. This fixes that so the generated docs sit alongside other packages' generated docs in the repo.