### PR TITLE
polyface silhouette edges

### DIFF
--- a/common/api/summary/core-geometry.exports.csv
+++ b/common/api/summary/core-geometry.exports.csv
@@ -14,6 +14,7 @@ public;AnnounceCurvePrimitive = (cp: CurvePrimitive) => void
 public;AnnounceDrapePanel = (linestring: GrowableXYZArray, segmentIndex: number, polyface: Polyface, facetIndex: number, points: Point3d[], indexAOnFacet: number, indexBOnFacet: number) => any
 public;AnnounceNumberNumber = (a0: number, a1: number) => void
 public;AnnounceNumberNumberCurvePrimitive = (a0: number, a1: number, cp: CurvePrimitive) => void
+public;AnyChain = CurvePrimitive | Path | BagOfCurves | Loop
 public;AnyCurve = CurvePrimitive | CurveCollection
 public;AnyCurvePrimitive = Arc3d | LineSegment3d | LineString3d | BSplineCurve3d | BezierCurve3d | DirectSpiral3d | IntegratedSpiral3d | CurveChainWithDistanceIndex | InterpolationCurve3d | AkimaCurve3d
 public;AnyGeometryQuery = Polyface | CurvePrimitive | CurveCollection | SolidPrimitive | CoordinateXYZ | PointString3d | BSpline2dNd
@@ -56,6 +57,7 @@ public;BSplineSurface3dH
 public;BSplineSurface3dQuery
 public;BSplineWrapMode
 public;ChainTypes = CurvePrimitive | Path | BagOfCurves | Loop | undefined
+deprecated;ChainTypes = CurvePrimitive | Path | BagOfCurves | Loop | undefined
 public;ClipMaskXYZRangePlanes
 public;ClippedPolyfaceBuilders
 public;Clipper

--- a/common/changes/@itwin/core-geometry/da4-polyface-silhouette_2023-11-02-03-47.json
+++ b/common/changes/@itwin/core-geometry/da4-polyface-silhouette_2023-11-02-03-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "polyface silhouettes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/curve/CurveOps.ts
+++ b/core/geometry/src/curve/CurveOps.ts
@@ -9,16 +9,15 @@
 
 import { Geometry } from "../Geometry";
 import { Range3d } from "../geometry3d/Range";
-import { AnyCurve } from "./CurveTypes";
 import { BagOfCurves, CurveCollection } from "./CurveCollection";
 import { CurvePrimitive } from "./CurvePrimitive";
+import { AnyChain, AnyCurve } from "./CurveTypes";
 import { MultiChainCollector } from "./internalContexts/MultiChainCollector";
 import { CurveChainWireOffsetContext } from "./internalContexts/PolygonOffsetContext";
 import { LineString3d } from "./LineString3d";
 import { Loop } from "./Loop";
 import { OffsetOptions } from "./OffsetOptions";
 import { Path } from "./Path";
-import { ChainTypes } from "./RegionOps";
 import { StrokeOptions } from "./StrokeOptions";
 
 /**
@@ -52,7 +51,7 @@ export class CurveOps {
   /**
    * Construct a separate xy-offset for each input curve.
    * * For best offset results, the inputs should be parallel to the xy-plane.
-   * @param curves input curve(s), z-coordinates ignored. Only [[ChainTypes]] are handled.
+   * @param curves input curve(s), z-coordinates ignored. Only curves of type [[AnyChain]] are handled.
    * @param offset offset distance (positive to left of curve, negative to right)
    * @param result array to collect offset curves
    * @returns summed length of offset curves
@@ -90,7 +89,7 @@ export class CurveOps {
    * @param gapTolerance distance to be treated as "effectively zero" when joining head-to-tail
    * @returns object with named chains, insideOffsets, outsideOffsets
    */
-  public static collectInsideAndOutsideXYOffsets(fragments: AnyCurve[], offsetDistance: number, gapTolerance: number): { insideOffsets: AnyCurve[], outsideOffsets: AnyCurve[], chains: ChainTypes } {
+  public static collectInsideAndOutsideXYOffsets(fragments: AnyCurve[], offsetDistance: number, gapTolerance: number): { insideOffsets: AnyCurve[], outsideOffsets: AnyCurve[], chains?: AnyChain } {
     const collector = new MultiChainCollector(gapTolerance);
     for (const s of fragments) {
       collector.captureCurve(s);
@@ -131,7 +130,7 @@ export class CurveOps {
    * @param planeTolerance tolerance for considering a closed chain to be planar. If undefined, only create Path. If defined, create Loops for closed chains within tolerance of a plane.
    * @returns chains, possibly wrapped in a [[BagOfCurves]].
    */
-  public static collectChains(fragments: AnyCurve[], gapTolerance: number = Geometry.smallMetricDistance, planeTolerance: number | undefined = Geometry.smallMetricDistance): ChainTypes {
+  public static collectChains(fragments: AnyCurve[], gapTolerance: number = Geometry.smallMetricDistance, planeTolerance: number | undefined = Geometry.smallMetricDistance): AnyChain | undefined {
     const collector = new MultiChainCollector(gapTolerance, planeTolerance);
     for (const s of fragments) {
       collector.captureCurve(s);

--- a/core/geometry/src/curve/CurveTypes.ts
+++ b/core/geometry/src/curve/CurveTypes.ts
@@ -7,14 +7,15 @@
  * @module Curve
  */
 
-import type { CurveCollection } from "./CurveCollection";
+import type { BagOfCurves, CurveCollection } from "./CurveCollection";
 import type { CurvePrimitive } from "./CurvePrimitive";
 import type { Loop } from "./Loop";
+import type { Path } from "./Path";
 import type { ParityRegion } from "./ParityRegion";
 import type { UnionRegion } from "./UnionRegion";
 
 /**
- * Union type for `GeometryQuery` classes that have contain curves, either as individual parameter space or as collections
+ * Union type for `GeometryQuery` classes that have contain curves, either as individual parameter space or as collections.
  * @public
  */
 export type AnyCurve = CurvePrimitive | CurveCollection;
@@ -24,3 +25,16 @@ export type AnyCurve = CurvePrimitive | CurveCollection;
  * @public
  */
 export type AnyRegion = Loop | ParityRegion | UnionRegion;
+
+/**
+ * Union type for a general curve chain, or a `BagOfCurves` understood to be a collection of unrelated chains.
+ * @public
+ * @deprecated in 4.x. Use AnyChain | undefined.
+ */
+export type ChainTypes = CurvePrimitive | Path | BagOfCurves | Loop | undefined;
+
+/**
+ * Union type for a general curve chain, or a `BagOfCurves` understood to be a collection of unrelated chains.
+ * @public
+ */
+export type AnyChain = CurvePrimitive | Path | BagOfCurves | Loop;

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -25,11 +25,11 @@ import { HalfEdge, HalfEdgeGraph, HalfEdgeMask } from "../topology/Graph";
 import { HalfEdgeGraphSearch } from "../topology/HalfEdgeGraphSearch";
 import { HalfEdgeGraphOps } from "../topology/Merging";
 import { LineStringDataVariant, MultiLineStringDataVariant, Triangulator } from "../topology/Triangulation";
-import { AnyCurve, AnyRegion } from "./CurveTypes";
 import { BagOfCurves, CurveChain, CurveCollection } from "./CurveCollection";
 import { CurveCurve } from "./CurveCurve";
 import { CurveOps } from "./CurveOps";
 import { CurvePrimitive } from "./CurvePrimitive";
+import { AnyChain, AnyCurve, AnyRegion } from "./CurveTypes";
 import { CurveWireMomentsXYZ } from "./CurveWireMomentsXYZ";
 import { GeometryQuery } from "./GeometryQuery";
 import { ChainCollectorContext } from "./internalContexts/ChainCollectorContext";
@@ -47,13 +47,6 @@ import { RegionMomentsXY } from "./RegionMomentsXY";
 import { RegionBooleanContext, RegionGroupOpType, RegionOpsFaceToFaceSearch } from "./RegionOpsClassificationSweeps";
 import { StrokeOptions } from "./StrokeOptions";
 import { UnionRegion } from "./UnionRegion";
-
-/**
- * Possible return types from [[splitToPathsBetweenBreaks]], [[collectInsideAndOutsideOffsets]] and
- * [[collectChains]].
- * @public
- */
-export type ChainTypes = CurvePrimitive | Path | BagOfCurves | Loop | undefined;
 
 /**
  * * `properties` is a string with special characters indicating
@@ -492,7 +485,7 @@ export class RegionOps {
    * [[cloneCurvesWithXYSplits]].
    * * Return simplest form -- single primitive, single path, or bag of curves.
    */
-  public static splitToPathsBetweenBreaks(source: AnyCurve | undefined, makeClones: boolean): ChainTypes {
+  public static splitToPathsBetweenBreaks(source: AnyCurve | undefined, makeClones: boolean): AnyChain | undefined {
     if (source === undefined)
       return undefined;
     if (source instanceof CurvePrimitive)
@@ -516,7 +509,7 @@ export class RegionOps {
    */
   public static collectInsideAndOutsideOffsets(
     fragments: AnyCurve[], offsetDistance: number, gapTolerance: number,
-  ): { insideOffsets: AnyCurve[], outsideOffsets: AnyCurve[], chains: ChainTypes } {
+  ): { insideOffsets: AnyCurve[], outsideOffsets: AnyCurve[], chains?: AnyChain } {
     return CurveOps.collectInsideAndOutsideXYOffsets(fragments, offsetDistance, gapTolerance);
   }
   /**
@@ -525,7 +518,7 @@ export class RegionOps {
    * @param gapTolerance distance to be treated as "effectively zero" when assembling fragments head-to-tail
    * @returns chains, possibly wrapped in a [[BagOfCurves]].
    */
-  public static collectChains(fragments: AnyCurve[], gapTolerance: number = Geometry.smallMetricDistance): ChainTypes {
+  public static collectChains(fragments: AnyCurve[], gapTolerance: number = Geometry.smallMetricDistance): AnyChain | undefined {
     return CurveOps.collectChains(fragments, gapTolerance);
   }
   /**

--- a/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
+++ b/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
@@ -12,15 +12,15 @@ import { FrameBuilder } from "../../geometry3d/FrameBuilder";
 import { Point3d } from "../../geometry3d/Point3dVector3d";
 import { XYAndZ } from "../../geometry3d/XYZProps";
 import { Arc3d } from "../Arc3d";
-import { AnyCurve } from "../CurveTypes";
 import { BagOfCurves, CurveCollection } from "../CurveCollection";
 import { CurveCurve } from "../CurveCurve";
 import { CurvePrimitive } from "../CurvePrimitive";
+import { AnyChain, AnyCurve } from "../CurveTypes";
 import { LineSegment3d } from "../LineSegment3d";
 import { LineString3d } from "../LineString3d";
 import { Loop } from "../Loop";
 import { Path } from "../Path";
-import { ChainTypes, RegionOps } from "../RegionOps";
+import { RegionOps } from "../RegionOps";
 import { StrokeOptions } from "../StrokeOptions";
 
 /**
@@ -316,7 +316,7 @@ export class MultiChainCollector {
     return linestring;
   }
   /** Return the collected results, structured as the simplest possible type. */
-  public grabResult(makeLoopIfClosed: boolean = false): ChainTypes {
+  public grabResult(makeLoopIfClosed: boolean = false): AnyChain | undefined {
     const chains = this._chains;
     if (chains.length === 0)
       return undefined;

--- a/core/geometry/src/geometry3d/Point3dVector3d.ts
+++ b/core/geometry/src/geometry3d/Point3dVector3d.ts
@@ -1469,6 +1469,16 @@ export class Vector3d extends XYZ {
     return Angle.createAtan2(this.dotProduct(planeNormal), this.crossProductMagnitude(planeNormal));
   }
   /**
+   * Return the angle in radians (not as strongly typed Angle) from this vector to the plane perpendicular to planeNormal.
+   * * The returned angle is between -PI/2 and PI/2.
+   * * The returned angle is measured in the plane containing the two vectors.
+   * * The function returns PI/2 - radiansTo(planeNormal).
+   * @param planeNormal a normal vector to the plane.
+   */
+  public radiansFromPerpendicular(planeNormal: Vector3d): number {
+    return Math.atan2(this.dotProduct(planeNormal), this.crossProductMagnitude(planeNormal));
+  }
+  /**
    * Return the (strongly-typed) angle from this vector to vectorB, using only the xy parts.
    * * The returned angle is between -180 and 180 degrees.
    * * Use `planarAngleTo` and `signedAngleTo` to return an angle measured in a specific plane.


### PR DESCRIPTION
In support of https://github.com/iTwin/itwinjs-core/issues/5833.

Includes:
* new method `PolyfaceQuery.collectSilhouetteEdges` often yields better results than `PolyfaceQuery.boundaryOfVisibleSubset` with selector === 2 because it focuses on edges whose adjacent facet normals bracket the eye vector perpendicular, instead of focusing on the boundary of side facets with perpendicular normal.
* new convenience method `PolyfaceQuery.collectBoundaryEdges` does the same for boundary edges
* deprecate `ChainTypes` in favor of `AnyChain | undefined`
* `PolygonWireOffsetContext.constructPolygonWireXYOffset` now works on non-planar input, such as computed mesh silhouettes.
* `PolyfaceBuilder.addTorusPipe` honors the builder's `StrokeOptions` to define mesh resolution.
* `PolyfaceBuilder.addFacetsFromVisitor` adds _all_ facets from a visitor.
* test for mesh silhouette functionality now computes and verifies the complete silhouette+boundary "loop" (non-planar closed linestring in general). This serves as POC for part of the proposed computation of restricted Hausdorff "max" distance.