### PR TITLE
Fix test sensitive to order which is dependent on SQLite execution plan.

### DIFF
--- a/common/changes/@itwin/core-backend/affanK-fix-test-sensitive-to-order_2023-11-03-19-45.json
+++ b/common/changes/@itwin/core-backend/affanK-fix-test-sensitive-to-order_2023-11-03-19-45.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Fixed test broken by updating SQLite version.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/affanK-fix-test-sensitive-to-order_2023-11-03-19-45.json
+++ b/common/changes/@itwin/core-backend/affanK-fix-test-sensitive-to-order_2023-11-03-19-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fixed test broken by updating SQLite version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/ecdb/CTE.test.ts
+++ b/core/backend/src/test/ecdb/CTE.test.ts
@@ -40,10 +40,10 @@ describe("Common table expression support in ECSQL", () => {
                         JOIN base_classes  ON aId = cbc.TargetECInstanceId
                 ORDER BY 1
             )
-        SELECT group_concat( DISTINCT p.Name) prop from base_classes join meta.ECPropertyDef p on p.Class.id = aId`;
+        SELECT p.Name prop from base_classes join meta.ECPropertyDef p on p.Class.id = aId GROUP BY p.Name` ;
     const rows = await executeQuery(imodel1, query, ["Element"]);
-    const expected = ["CodeScope", "CodeSpec", "CodeValue", "FederationGuid", "JsonProperties", "LastMod", "Model", "Parent", "UserLabel", "BBoxHigh", "BBoxLow", "Category", "GeometryStream", "Origin", "Rotation", "TypeDefinition", "IsPrivate", "Description", "Rank", "Recipe", "Data", "Type", "Angle", "Pitch", "Roll", "Yaw", "CategorySelector", "DisplayStyle", "BaseModel", "Extents", "RotationAngle", "Properties", "Name", "InSpatialIndex", "Enabled", "EyePoint", "FocusDistance", "IsCameraOn", "LensAngle", "ModelSelector", "Url", "RepositoryGuid", "PaletteName", "Height", "Scale", "SheetTemplate", "Width", "Border", "BorderTemplate", "Flags", "Format", "View", "DrawingModel", "ViewAttachment"];
-    const actual = (rows[0].prop as string).split(",");
+    const expected = ["Angle", "BaseModel", "BBoxHigh", "BBoxLow", "Border", "BorderTemplate", "Category", "CategorySelector", "CodeScope", "CodeSpec", "CodeValue", "Data", "Description", "DisplayStyle", "DrawingModel", "Enabled", "Extents", "EyePoint", "FederationGuid", "Flags", "FocusDistance", "Format", "GeometryStream", "Height", "InSpatialIndex", "IsCameraOn", "IsPrivate", "JsonProperties", "LastMod", "LensAngle", "Model", "ModelSelector", "Name", "Origin", "PaletteName", "Parent", "Pitch", "Properties", "Rank", "Recipe", "RepositoryGuid", "Roll", "Rotation", "RotationAngle", "Scale", "SheetTemplate", "Type", "TypeDefinition", "Url", "UserLabel", "View", "ViewAttachment", "Width", "Yaw"];
+    const actual = rows.map((r) => r.prop);
     assert.sameOrderedMembers(actual, expected);
   });
 


### PR DESCRIPTION
_This test broke due to change execution plan in updated SQLite version._

imodel-native: https://github.com/iTwin/imodel-native/pull/542