### PR TITLE
Enhance error termination for display-performance-test-app

### DIFF
--- a/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
+++ b/test-apps/display-performance-test-app/src/frontend/DisplayPerformanceTestApp.ts
@@ -116,13 +116,17 @@ export class DisplayPerfTestApp {
     IModelApp.animationInterval = undefined;
   }
 
-  public static async logException(ex: any, logFile?: { dir: string, name: string }): Promise<void> {
+  public static async logException(ex: any, logFile?: { dir: string, name: string }): Promise<boolean> {
     const errMsg = ex.stack ?? (ex.toString ? ex.toString() : "unknown error type");
     const msg = `DPTA_EXCEPTION\n${errMsg}\n`;
     const client = DisplayPerfRpcInterface.getClient();
     await client.consoleLog(msg);
     if (logFile)
       await client.writeExternalFile(logFile.dir, logFile.name, true, msg);
+    // test for exception messages that need to terminate app on and return true for any of those
+    return (msg.toLowerCase().includes("rendering context was lost") ||
+      msg.toLowerCase().includes("enospc") // ENOSPC no space left on device
+    );
   }
 }
 

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -1058,8 +1058,8 @@ export class TestRunner {
 
   private async onException(ex: any): Promise<void> {
     // We need to log here so it gets written to the file.
-    await DisplayPerfTestApp.logException(ex, { dir: this.curConfig.outputPath, name: this._logFileName });
-    if ("terminate" === this.curConfig.onException)
+    const terminateErr = await DisplayPerfTestApp.logException(ex, { dir: this.curConfig.outputPath, name: this._logFileName });
+    if (terminateErr || "terminate" === this.curConfig.onException)
       await DisplayPerfRpcInterface.getClient().terminate();
   }
 }


### PR DESCRIPTION
Display-performance-test-app traps and logs exceptions during tests, and by default keeps going to the next test (can be overridden by config).  However, certain exceptions cause DPTA to hang and are not recoverable, such as context loss.

Added test for known exceptions that are not recoverable and terminate DPTA on those.