### PR TITLE
Modified getAspects to handle dot separator in full classname

### DIFF
--- a/common/changes/@itwin/core-backend/rohitptnkr-removed-breaking-change-from-getAspects_2023-11-16-10-01.json
+++ b/common/changes/@itwin/core-backend/rohitptnkr-removed-breaking-change-from-getAspects_2023-11-16-10-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "modified getAspects to handle dot separator in full class name",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2082,7 +2082,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       }
 
       // Check if class is abstract
-      const fullClassName = aspectClassFullName.split(":");
+      const fullClassName = aspectClassFullName.replace(".", ":").split(":");
       const val = this._iModel.nativeDb.getECClassMetaData(fullClassName[0], fullClassName[1]);
       if (val.result !== undefined) {
         const metaData = new EntityMetaData(JSON.parse(val.result));

--- a/core/backend/src/test/element/ElementAspect.test.ts
+++ b/core/backend/src/test/element/ElementAspect.test.ts
@@ -37,6 +37,16 @@ describe("ElementAspect", () => {
     assert.equal(aspect1.asAny.testUniqueAspectProperty, "Aspect1-Updated");
     assert.equal(aspect1.asAny.length, 1);
     assert.equal(JSON.stringify(aspect1), `{"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"Aspect1-Updated","length":1,"element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
+
+    // Test getAspects with dot separator
+    const aspect1DotSeparator: ElementAspect = iModel.elements.getAspects(element.id, "DgnPlatformTest.TestUniqueAspectNoHandler")[0];
+    assert.exists(aspect1DotSeparator);
+    assert.isTrue(aspect1DotSeparator instanceof ElementUniqueAspect);
+    assert.equal(aspect1DotSeparator.classFullName, "DgnPlatformTest:TestUniqueAspectNoHandler");
+    assert.equal(aspect1DotSeparator.asAny.testUniqueAspectProperty, "Aspect1-Updated");
+    assert.equal(aspect1DotSeparator.asAny.length, 1);
+    assert.equal(JSON.stringify(aspect1DotSeparator), `{"classFullName":"DgnPlatformTest:TestUniqueAspectNoHandler","id":"0x6","testUniqueAspectProperty":"Aspect1-Updated","length":1,"element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
+
     // cross-check getAspects against getAspect
     const aspect1X: ElementAspect = iModel.elements.getAspect(aspect1.id);
     assert.exists(aspect1X);
@@ -53,6 +63,16 @@ describe("ElementAspect", () => {
     assert.equal(aspect2.asAny.testUniqueAspectProperty, "Aspect2-Updated");
     assert.isUndefined(aspect2.asAny.length);
     assert.equal(JSON.stringify(aspect2), `{"classFullName":"DgnPlatformTest:TestUniqueAspect","id":"0x1","testUniqueAspectProperty":"Aspect2-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
+
+    // Test getAspects with dot separator
+    const aspect2DotSeparator: ElementAspect = iModel.elements.getAspects(element.id, "DgnPlatformTest.TestUniqueAspect")[0];
+    assert.exists(aspect2DotSeparator);
+    assert.isTrue(aspect2DotSeparator instanceof ElementUniqueAspect);
+    assert.equal(aspect2DotSeparator.classFullName, "DgnPlatformTest:TestUniqueAspect");
+    assert.equal(aspect2DotSeparator.asAny.testUniqueAspectProperty, "Aspect2-Updated");
+    assert.isUndefined(aspect2DotSeparator.asAny.length);
+    assert.equal(JSON.stringify(aspect2DotSeparator), `{"classFullName":"DgnPlatformTest:TestUniqueAspect","id":"0x1","testUniqueAspectProperty":"Aspect2-Updated","element":{"id":"0x17","relClassName":"BisCore.ElementOwnsUniqueAspect"}}`);
+
     // cross-check getAspects against getAspect
     const aspect2X: ElementAspect = iModel.elements.getAspect(aspect2.id);
     assert.exists(aspect2X);
@@ -93,6 +113,27 @@ describe("ElementAspect", () => {
       assert.equal(aspectX.asAny.testMultiAspectProperty, aspect.asAny.testMultiAspectProperty);
     });
     assert.equal(JSON.stringify(multiAspectsA), `[{"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
+    {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}}]`.replace(/\s+/g, ""));
+
+    // Test getAspects with dot separator
+    const multiAspectsADotSeparator: ElementAspect[] = iModel.elements.getAspects(element.id, "DgnPlatformTest.TestMultiAspectNoHandler");
+    assert.exists(multiAspectsADotSeparator);
+    assert.isArray(multiAspectsADotSeparator);
+    assert.equal(multiAspectsADotSeparator.length, 2);
+    multiAspectsADotSeparator.forEach((aspect) => {
+      assert.isTrue(aspect instanceof ElementMultiAspect);
+      assert.equal(aspect.schemaName, "DgnPlatformTest");
+      assert.equal(aspect.className, "TestMultiAspectNoHandler");
+      assert.exists(aspect.asAny.testMultiAspectProperty);
+      // cross-check against getting the aspects individually
+      const aspectX: ElementAspect = iModel.elements.getAspect(aspect.id);
+      assert.exists(aspectX);
+      assert.equal(aspectX.schemaName, aspect.schemaName);
+      assert.equal(aspectX.className, aspect.className);
+      assert.exists(aspectX.asAny.testMultiAspectProperty);
+      assert.equal(aspectX.asAny.testMultiAspectProperty, aspect.asAny.testMultiAspectProperty);
+    });
+    assert.equal(JSON.stringify(multiAspectsADotSeparator), `[{"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x4","testMultiAspectProperty":"Aspect3-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}},
     {"classFullName":"DgnPlatformTest:TestMultiAspectNoHandler","id":"0x5","testMultiAspectProperty":"Aspect4-Updated","element":{"id":"0x17","relClassName":"DgnPlatformTest.TestElement"}}]`.replace(/\s+/g, ""));
 
     const multiAspectsB: ElementAspect[] = iModel.elements.getAspects(element.id, "DgnPlatformTest:TestMultiAspect");

--- a/docs/bis/ec/ec-format.md
+++ b/docs/bis/ec/ec-format.md
@@ -101,6 +101,75 @@ Supported scientific type:
 
 **includeZero** determines whether to keep a segment of the composite even if its magnitude is zero. By default, this is true.
 
-## Sub-Elements
+**units (1..4)** an optional array of unit + label override objects.  A single units entry formats a value like `42.42 ft`.  If multiple units are specified they should be in decreasing magnitude and value split among the units like `42 ft 5.02 in`
 
-[Unit](./ec-unit.md) _(1..4)_
+## Examples
+
+This format will result in values split between feet and inches with a precision of 1/8th of an inch.  e.g. a value of 12.54166 feet would be formatted as `12'-6 1/2"`, a value of 1 meter would be formatted as `3'-3 3/8"`.
+
+```json
+    "AmerFI": {
+      "schemaItemType": "Format",
+      "label": "FeetInches",
+      "type": "Fractional",
+      "precision": 8,
+      "formatTraits": [
+        "KeepSingleZero",
+        "KeepDecimalPoint",
+        "ShowUnitLabel"
+      ],
+      "uomSeparator": "",
+      "composite": {
+        "spacer": "-",
+        "units": [
+          {
+            "name": "Units.FT",
+            "label": "'"
+          },
+          {
+            "name": "Units.IN",
+            "label": "\""
+          }
+        ]
+      }
+    }
+```
+
+This format specifies only one unit, decimal formatting and not label override.  So 12.5466 feet would be formatted as `3.8227 m` and a value of 1 meter would be formatted as `1.0 m`
+
+```json
+    "MyMetersFormat": {
+      "schemaItemType": "Format",
+      "label": "real",
+      "type": "Decimal",
+      "precision": 4,
+      "formatTraits": [
+        "KeepSingleZero",
+        "KeepDecimalPoint",
+        "ShowUnitLabel"
+      ]
+    },
+      "composite": {
+        "units": [
+          {
+            "name": "Units.M"
+          }
+        ]
+      }
+```
+
+This format does not specify any units so it may only be used in a [format override](./kindofquantity.md/#format-overrides).  Unitless formats and format overrides allow one base format to be used for any unit, see the [format override](./kindofquantity.md/#format-overrides) section for more details and examples.
+
+```json
+    "DefaultRealU": {
+      "schemaItemType": "Format",
+      "label": "realu",
+      "type": "Decimal",
+      "precision": 6,
+      "formatTraits": [
+        "KeepSingleZero",
+        "KeepDecimalPoint",
+        "ShowUnitLabel"
+      ]
+    }
+```


### PR DESCRIPTION
In the change made in the PR #5966, the function getAspects was modified to use instance queries.
As part of the change in which we are checking if the input class is abstract, I had assumed the input aspect class full name to only ever be colon-separated (as per the unit tests present at the time).
This constitutes a breaking change as we used to accept class full names that were dot-separated as well as colon-separated before the PR #5966 
This PR fixes the change to handle both inputs and makes the change made in #5966 non-breaking.

Fixes iTwin/itwinjs-backlog/issues/981