### PR TITLE
Fix Map Feature Info for ArcGIS map services when reprojection is needed

### DIFF
--- a/common/changes/@itwin/core-frontend/fix_maplayers_identify_2023-11-17-21-03.json
+++ b/common/changes/@itwin/core-frontend/fix_maplayers_identify_2023-11-17-21-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix Map Feature Info for ArcGIS map services when reprojection is needed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/tile/map/ArcGISMapLayerImageryProvider.test.ts
+++ b/core/frontend/src/test/tile/map/ArcGISMapLayerImageryProvider.test.ts
@@ -163,12 +163,13 @@ describe("ArcGISMapLayerImageryProvider", () => {
       geometry: { x: 5, y: 6 },
       geometryType: "esriGeometryPoint",
       tolerance: 0.1,
+      sr: 3857,
       mapExtent: {
         low: { x: 1, y: 3 },
         high: { x: 2, y: 4 },
       },
       imageDisplay: { width: 256, height: 256, dpi: 96 },
-      layers: { prefix: "visible", layerIds: [ "2", "3" ] },
+      layers: { prefix: "top", layerIds: [ "2", "3" ] },
       returnGeometry: true,
       maxAllowableOffset,
     };

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
@@ -333,6 +333,7 @@ export class ArcGISMapLayerImageryProvider extends ArcGISImageryProvider {
       geometryType: "esriGeometryPoint",
       tolerance,
       mapExtent: {low: {x: bbox.left, y: bbox.bottom}, high: {x: bbox.right, y: bbox.top}},
+      sr: 3857,
       imageDisplay: {width: this.tileSize, height: this.tileSize, dpi: 96},
       layers: {prefix: "top", layerIds},
       returnGeometry,

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
@@ -94,7 +94,7 @@ export class ArcGISIdentifyRequestUrl {
     newUrl.searchParams.append("geometryType", json.geometryType);
 
     if (json.sr) {
-      newUrl.searchParams.append("sr", `${json.geometryType}`);
+      newUrl.searchParams.append("sr", `${json.sr}`);
     }
 
     if (json.layers) {
@@ -334,7 +334,7 @@ export class ArcGISMapLayerImageryProvider extends ArcGISImageryProvider {
       tolerance,
       mapExtent: {low: {x: bbox.left, y: bbox.bottom}, high: {x: bbox.right, y: bbox.top}},
       imageDisplay: {width: this.tileSize, height: this.tileSize, dpi: 96},
-      layers: {prefix: "visible", layerIds},
+      layers: {prefix: "top", layerIds},
       returnGeometry,
       maxAllowableOffset}, 3 /* 1mm accuracy*/);
 


### PR DESCRIPTION
Very small fix to correctly set the spatial reference id in the 'Identify' query parameters.  
Also use the default 'top' mode instead of all `visible` layers.