### PR TITLE
Fix schedule simulation for unquantized tiles

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-split-unquantized-vertex-table_2023-11-21-10-26.json
+++ b/common/changes/@itwin/core-frontend/pmc-split-unquantized-vertex-table_2023-11-21-10-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/common/render/primitives/VertexTableSplitter.ts
+++ b/core/frontend/src/common/render/primitives/VertexTableSplitter.ts
@@ -330,6 +330,19 @@ class VertexTableSplitter {
     const vertex = new Uint32Array(vertSize);
     const vertexTable = new Uint32Array(this._input.vertices.data.buffer, this._input.vertices.data.byteOffset, this._input.vertices.numVertices * vertSize);
 
+    let extractFeatureIndex: () => number;
+    if (this._input.vertices.usesUnquantizedPositions) {
+      const vertexBytes = new Uint8Array(vertex.buffer);
+      extractFeatureIndex = () => {
+        return vertexBytes[3]
+          | (vertexBytes[7] << 8)
+          | (vertexBytes[11] << 16)
+          | (vertexBytes[15] << 24);
+      };
+    } else {
+      extractFeatureIndex = () => vertex[2] & 0x00ffffff;
+    }
+
     for (const index of this._input.indices) {
       // Extract the data for this vertex without allocating new typed arrays.
       const vertexOffset = index * vertSize;
@@ -337,7 +350,7 @@ class VertexTableSplitter {
         vertex[i] = vertexTable[vertexOffset + i];
 
       // Determine to which element the vertex belongs and find the corresponding Node.
-      const featureIndex = vertex[2] & 0x00ffffff;
+      const featureIndex = extractFeatureIndex();
       if (curState.featureIndex !== featureIndex) {
         curState.featureIndex = featureIndex;
         const nodeId = this._computeNodeId(featureIndex);

--- a/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
+++ b/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
@@ -169,7 +169,7 @@ function expectBaseVertices(vertexTable: VertexTable, expectedPts: Point[], hasC
       y: fpts[idx + 1],
       z: fpts[idx + 2],
       featureIndex: data[idx + 3],
-      colorIndex: (data[idx + 4] & 0x0000ffff) >>> 16,
+      colorIndex: (data[idx + 4] & 0x0000ffff),
     };
   } : (idx: number) => {
     const x = data[idx] & 0xffff;

--- a/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
+++ b/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
@@ -571,71 +571,70 @@ describe.only("VertexTableSplitter", () => {
           { x: 4, color: 0, feature: 1 },
         ]);
       });
-
-      it("produces rectangular vertex tables", () => {
-        setMaxTextureSize(6);
-
-        const expectDimensions = (p: PointStringParams, w: number, h: number) => {
-          expect(p.vertices.width).to.equal(w);
-          expect(p.vertices.height).to.equal(h);
-        };
-
-        const colors = [ ColorDef.red, ColorDef.green, ColorDef.blue ];
-        const featureTable = makePackedFeatureTable("0x2", "0x20", "0x200", "0x2000");
-        const points = [
-          { x: 0, color: 0, feature: 0 },
-          { x: 1, color: 1, feature: 0 },
-
-          { x: 2, color: 2, feature: 1 },
-
-          { x: 3, color: 1, feature: 2 },
-          { x: 4, color: 1, feature: 2 },
-          { x: 5, color: 1, feature: 2 },
-
-          { x: 6, color: 2, feature: 3 },
-          { x: 7, color: 0, feature: 3 },
-          { x: 8, color: 2, feature: 3 },
-        ];
-
-        const params = makePointStringParams(points, colors, unquantized);
-        expectPointStrings(params, colors, points);
-
-        const split = splitPointStringParams({
-          params, featureTable, maxDimension: 6,
-          computeNodeId: makeComputeNodeId(featureTable, (id) => id.lower),
-        });
-        expect(split.size).to.equal(4);
-
-        const p1 = split.get(0x2)!;
-        expectDimensions(p1, 3, 3);
-        expectPointStrings(p1, [ ColorDef.red, ColorDef.green ], [
-          { x: 0, color: 0, feature: 0 },
-          { x: 1, color: 1, feature: 0 },
-        ]);
-
-        const p2 = split.get(0x20)!;
-        expectDimensions(p2, 3, 1);
-        expectPointStrings(p2, ColorDef.blue, [{ x: 2, color: 0, feature: 1 }]);
-
-        const p3 = split.get(0x200)!;
-        expectDimensions(p3, 3, 3);
-        expectPointStrings(p3, ColorDef.green, [
-          { x: 3, color: 0, feature: 2 },
-          { x: 4, color: 0, feature: 2 },
-          { x: 5, color: 0, feature: 2 },
-        ]);
-
-        const p4 = split.get(0x2000)!;
-        expectDimensions(p4, 6, 2);
-        expectPointStrings(p4, [ColorDef.blue, ColorDef.red], [
-          { x: 6, color: 0, feature: 3 },
-          { x: 7, color: 1, feature: 3 },
-          { x: 8, color: 0, feature: 3 },
-        ]);
-      });
     });
   }
 
+  it("produces rectangular vertex tables", () => {
+    setMaxTextureSize(6);
+
+    const expectDimensions = (p: PointStringParams, w: number, h: number) => {
+      expect(p.vertices.width).to.equal(w);
+      expect(p.vertices.height).to.equal(h);
+    };
+
+    const colors = [ ColorDef.red, ColorDef.green, ColorDef.blue ];
+    const featureTable = makePackedFeatureTable("0x2", "0x20", "0x200", "0x2000");
+    const points = [
+      { x: 0, color: 0, feature: 0 },
+      { x: 1, color: 1, feature: 0 },
+
+      { x: 2, color: 2, feature: 1 },
+
+      { x: 3, color: 1, feature: 2 },
+      { x: 4, color: 1, feature: 2 },
+      { x: 5, color: 1, feature: 2 },
+
+      { x: 6, color: 2, feature: 3 },
+      { x: 7, color: 0, feature: 3 },
+      { x: 8, color: 2, feature: 3 },
+    ];
+
+    const params = makePointStringParams(points, colors, false);
+    expectPointStrings(params, colors, points);
+
+    const split = splitPointStringParams({
+      params, featureTable, maxDimension: 6,
+      computeNodeId: makeComputeNodeId(featureTable, (id) => id.lower),
+    });
+    expect(split.size).to.equal(4);
+
+    const p1 = split.get(0x2)!;
+    expectDimensions(p1, 3, 3);
+    expectPointStrings(p1, [ ColorDef.red, ColorDef.green ], [
+      { x: 0, color: 0, feature: 0 },
+      { x: 1, color: 1, feature: 0 },
+    ]);
+
+    const p2 = split.get(0x20)!;
+    expectDimensions(p2, 3, 1);
+    expectPointStrings(p2, ColorDef.blue, [{ x: 2, color: 0, feature: 1 }]);
+
+    const p3 = split.get(0x200)!;
+    expectDimensions(p3, 3, 3);
+    expectPointStrings(p3, ColorDef.green, [
+      { x: 3, color: 0, feature: 2 },
+      { x: 4, color: 0, feature: 2 },
+      { x: 5, color: 0, feature: 2 },
+    ]);
+
+    const p4 = split.get(0x2000)!;
+    expectDimensions(p4, 6, 2);
+    expectPointStrings(p4, [ColorDef.blue, ColorDef.red], [
+      { x: 6, color: 0, feature: 3 },
+      { x: 7, color: 1, feature: 3 },
+      { x: 8, color: 0, feature: 3 },
+    ]);
+  });
   function makeSurface(adjustPt?: (pt: TriMeshPoint) => TriMeshPoint): { params: MeshParams, colors: ColorDef | ColorDef[], featureTable: PackedFeatureTable, mesh: TriMesh } {
     let colors: ColorDef | ColorDef[] = [ ColorDef.red, ColorDef.green, ColorDef.blue ];
     const featureTable = makePackedFeatureTable("0x1", "0x2", "0x3");

--- a/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
+++ b/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
@@ -88,7 +88,7 @@ function makePointList(pts: Point[], quantized: boolean): QPoint3dList | (Array<
   return points;
 }
 
-function makePointStringParams(pts: Point[], colors: ColorDef | ColorDef[], unquantized?: boolean): PointStringParams {
+function makePointStringParams(pts: Point[], colors: ColorDef | ColorDef[], unquantized: boolean): PointStringParams {
   const colorIndex = makeColorIndex(pts, colors);
   const featureIndex = makeFeatureIndex(pts);
 
@@ -105,6 +105,9 @@ function makePointStringParams(pts: Point[], colors: ColorDef | ColorDef[], unqu
 
   const params = createPointStringParams(args)!;
   expect(params).not.to.be.undefined;
+  expect(params.vertices.usesUnquantizedPositions).to.equal(unquantized);
+  expectBaseVertices(params.vertices, pts);
+
   return params;
 }
 
@@ -173,7 +176,7 @@ function expectBaseVertices(vertexTable: VertexTable, expectedPts: Point[], hasC
 
 function expectPointStrings(params: PointStringParams, expectedColors: ColorDef | ColorDef[], expectedPts: Point[]): void {
   const vertexTable = params.vertices;
-  expect(vertexTable.numRgbaPerVertex).to.equal(3);
+  expect(vertexTable.numRgbaPerVertex).to.equal(vertexTable.usesUnquantizedPositions ? 5 : 3);
   expect(vertexTable.numVertices).to.equal(expectedPts.length);
   expectColors(vertexTable, expectedColors);
 
@@ -476,131 +479,136 @@ describe.only("VertexTableSplitter", () => {
     };
   }
 
-  it("splits point string params based on node Id", () => {
-    const featureTable = makePackedFeatureTable("0x1", "0x2", "0x10000000002");
+  for (let iUnquantized = 0; iUnquantized < 2; iUnquantized++) {
+    const unquantized = iUnquantized > 0;
+    describe(unquantized ? "Unquantized" : "Quantized", () => {
+      it("splits point string params based on node Id", () => {
+        const featureTable = makePackedFeatureTable("0x1", "0x2", "0x10000000002");
 
-    const points: Point[] = [
-      { x: 1, color: 0, feature: 0 },
-      { x: 0, color: 0, feature: 1 },
-      { x: 5, color: 0, feature: 2 },
-      { x: 4, color: 0, feature: 1 },
-      { x: 2, color: 0, feature: 2 },
-    ];
+        const points: Point[] = [
+          { x: 1, color: 0, feature: 0 },
+          { x: 0, color: 0, feature: 1 },
+          { x: 5, color: 0, feature: 2 },
+          { x: 4, color: 0, feature: 1 },
+          { x: 2, color: 0, feature: 2 },
+        ];
 
-    const params = makePointStringParams(points, ColorDef.red);
-    expectPointStrings(params, ColorDef.red, points);
+        const params = makePointStringParams(points, ColorDef.red, unquantized);
+        expectPointStrings(params, ColorDef.red, points);
 
-    const split = splitPointStringParams({
-      params, featureTable, maxDimension: 2048,
-      computeNodeId: makeComputeNodeId(featureTable, (id) => id.upper > 0 ? 1 : 0),
+        const split = splitPointStringParams({
+          params, featureTable, maxDimension: 2048,
+          computeNodeId: makeComputeNodeId(featureTable, (id) => id.upper > 0 ? 1 : 0),
+        });
+        expect(split.size).to.equal(2);
+
+        expectPointStrings(split.get(0)!, ColorDef.red, [
+          { x: 1, color: 0, feature: 0 },
+          { x: 0, color: 0, feature: 1 },
+          { x: 4, color: 0, feature: 1 },
+        ]);
+
+        expectPointStrings(split.get(1)!, ColorDef.red, [
+          { x: 5, color: 0, feature: 2 },
+          { x: 2, color: 0, feature: 2 },
+        ]);
+      });
+
+      it("reconstructs or collapses color tables and remaps color indices", () => {
+        const featureTable = makePackedFeatureTable("0x1", "0x2");
+
+        const colors = [ ColorDef.red, ColorDef.green, ColorDef.blue ];
+
+        const points = [
+          { x: 1, color: 2, feature: 0 },
+          { x: 2, color: 0, feature: 0 },
+          { x: 3, color: 1, feature: 1 },
+          { x: 4, color: 1, feature: 1 },
+        ];
+
+        const params = makePointStringParams(points, colors, unquantized);
+        expectPointStrings(params, colors, points);
+
+        const split = splitPointStringParams({
+          params, featureTable, maxDimension: 2048,
+          computeNodeId: makeComputeNodeId(featureTable, (id) => id.lower),
+        });
+        expect(split.size).to.equal(2);
+
+        expectPointStrings(split.get(1)!, [ ColorDef.blue, ColorDef.red ], [
+          { x: 1, color: 0, feature: 0 },
+          { x: 2, color: 1, feature: 0 },
+        ]);
+
+        expectPointStrings(split.get(2)!, ColorDef.green, [
+          { x: 3, color: 0, feature: 1 },
+          { x: 4, color: 0, feature: 1 },
+        ]);
+      });
+
+      it("produces rectangular vertex tables", () => {
+        setMaxTextureSize(6);
+
+        const expectDimensions = (p: PointStringParams, w: number, h: number) => {
+          expect(p.vertices.width).to.equal(w);
+          expect(p.vertices.height).to.equal(h);
+        };
+
+        const colors = [ ColorDef.red, ColorDef.green, ColorDef.blue ];
+        const featureTable = makePackedFeatureTable("0x2", "0x20", "0x200", "0x2000");
+        const points = [
+          { x: 0, color: 0, feature: 0 },
+          { x: 1, color: 1, feature: 0 },
+
+          { x: 2, color: 2, feature: 1 },
+
+          { x: 3, color: 1, feature: 2 },
+          { x: 4, color: 1, feature: 2 },
+          { x: 5, color: 1, feature: 2 },
+
+          { x: 6, color: 2, feature: 3 },
+          { x: 7, color: 0, feature: 3 },
+          { x: 8, color: 2, feature: 3 },
+        ];
+
+        const params = makePointStringParams(points, colors, unquantized);
+        expectPointStrings(params, colors, points);
+
+        const split = splitPointStringParams({
+          params, featureTable, maxDimension: 6,
+          computeNodeId: makeComputeNodeId(featureTable, (id) => id.lower),
+        });
+        expect(split.size).to.equal(4);
+
+        const p1 = split.get(0x2)!;
+        expectDimensions(p1, 3, 3);
+        expectPointStrings(p1, [ ColorDef.red, ColorDef.green ], [
+          { x: 0, color: 0, feature: 0 },
+          { x: 1, color: 1, feature: 0 },
+        ]);
+
+        const p2 = split.get(0x20)!;
+        expectDimensions(p2, 3, 1);
+        expectPointStrings(p2, ColorDef.blue, [{ x: 2, color: 0, feature: 1 }]);
+
+        const p3 = split.get(0x200)!;
+        expectDimensions(p3, 3, 3);
+        expectPointStrings(p3, ColorDef.green, [
+          { x: 3, color: 0, feature: 2 },
+          { x: 4, color: 0, feature: 2 },
+          { x: 5, color: 0, feature: 2 },
+        ]);
+
+        const p4 = split.get(0x2000)!;
+        expectDimensions(p4, 6, 2);
+        expectPointStrings(p4, [ColorDef.blue, ColorDef.red], [
+          { x: 6, color: 0, feature: 3 },
+          { x: 7, color: 1, feature: 3 },
+          { x: 8, color: 0, feature: 3 },
+        ]);
+      });
     });
-    expect(split.size).to.equal(2);
-
-    expectPointStrings(split.get(0)!, ColorDef.red, [
-      { x: 1, color: 0, feature: 0 },
-      { x: 0, color: 0, feature: 1 },
-      { x: 4, color: 0, feature: 1 },
-    ]);
-
-    expectPointStrings(split.get(1)!, ColorDef.red, [
-      { x: 5, color: 0, feature: 2 },
-      { x: 2, color: 0, feature: 2 },
-    ]);
-  });
-
-  it("reconstructs or collapses color tables and remaps color indices", () => {
-    const featureTable = makePackedFeatureTable("0x1", "0x2");
-
-    const colors = [ ColorDef.red, ColorDef.green, ColorDef.blue ];
-
-    const points = [
-      { x: 1, color: 2, feature: 0 },
-      { x: 2, color: 0, feature: 0 },
-      { x: 3, color: 1, feature: 1 },
-      { x: 4, color: 1, feature: 1 },
-    ];
-
-    const params = makePointStringParams(points, colors);
-    expectPointStrings(params, colors, points);
-
-    const split = splitPointStringParams({
-      params, featureTable, maxDimension: 2048,
-      computeNodeId: makeComputeNodeId(featureTable, (id) => id.lower),
-    });
-    expect(split.size).to.equal(2);
-
-    expectPointStrings(split.get(1)!, [ ColorDef.blue, ColorDef.red ], [
-      { x: 1, color: 0, feature: 0 },
-      { x: 2, color: 1, feature: 0 },
-    ]);
-
-    expectPointStrings(split.get(2)!, ColorDef.green, [
-      { x: 3, color: 0, feature: 1 },
-      { x: 4, color: 0, feature: 1 },
-    ]);
-  });
-
-  it("produces rectangular vertex tables", () => {
-    setMaxTextureSize(6);
-
-    const expectDimensions = (p: PointStringParams, w: number, h: number) => {
-      expect(p.vertices.width).to.equal(w);
-      expect(p.vertices.height).to.equal(h);
-    };
-
-    const colors = [ ColorDef.red, ColorDef.green, ColorDef.blue ];
-    const featureTable = makePackedFeatureTable("0x2", "0x20", "0x200", "0x2000");
-    const points = [
-      { x: 0, color: 0, feature: 0 },
-      { x: 1, color: 1, feature: 0 },
-
-      { x: 2, color: 2, feature: 1 },
-
-      { x: 3, color: 1, feature: 2 },
-      { x: 4, color: 1, feature: 2 },
-      { x: 5, color: 1, feature: 2 },
-
-      { x: 6, color: 2, feature: 3 },
-      { x: 7, color: 0, feature: 3 },
-      { x: 8, color: 2, feature: 3 },
-    ];
-
-    const params = makePointStringParams(points, colors);
-    expectPointStrings(params, colors, points);
-
-    const split = splitPointStringParams({
-      params, featureTable, maxDimension: 6,
-      computeNodeId: makeComputeNodeId(featureTable, (id) => id.lower),
-    });
-    expect(split.size).to.equal(4);
-
-    const p1 = split.get(0x2)!;
-    expectDimensions(p1, 3, 3);
-    expectPointStrings(p1, [ ColorDef.red, ColorDef.green ], [
-      { x: 0, color: 0, feature: 0 },
-      { x: 1, color: 1, feature: 0 },
-    ]);
-
-    const p2 = split.get(0x20)!;
-    expectDimensions(p2, 3, 1);
-    expectPointStrings(p2, ColorDef.blue, [{ x: 2, color: 0, feature: 1 }]);
-
-    const p3 = split.get(0x200)!;
-    expectDimensions(p3, 3, 3);
-    expectPointStrings(p3, ColorDef.green, [
-      { x: 3, color: 0, feature: 2 },
-      { x: 4, color: 0, feature: 2 },
-      { x: 5, color: 0, feature: 2 },
-    ]);
-
-    const p4 = split.get(0x2000)!;
-    expectDimensions(p4, 6, 2);
-    expectPointStrings(p4, [ColorDef.blue, ColorDef.red], [
-      { x: 6, color: 0, feature: 3 },
-      { x: 7, color: 1, feature: 3 },
-      { x: 8, color: 0, feature: 3 },
-    ]);
-  });
+  }
 
   function makeSurface(adjustPt?: (pt: TriMeshPoint) => TriMeshPoint): { params: MeshParams, colors: ColorDef | ColorDef[], featureTable: PackedFeatureTable, mesh: TriMesh } {
     let colors: ColorDef | ColorDef[] = [ ColorDef.red, ColorDef.green, ColorDef.blue ];

--- a/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
+++ b/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
@@ -182,7 +182,6 @@ function expectBaseVertices(vertexTable: VertexTable, expectedPts: Point[], hasC
     };
   };
 
-
   for (let i = 0; i < vertexTable.numVertices; i++) {
     const idx = i * vertexTable.numRgbaPerVertex;
     const vert = getVertex(idx);

--- a/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
+++ b/core/frontend/src/test/render/primitives/VertexTableSplitter.test.ts
@@ -469,7 +469,7 @@ function expectEdges(params: EdgeParams | undefined, expected: Edges | undefined
     expectPolyline(params.polylines, expected.polylines!);
 }
 
-describe.only("VertexTableSplitter", () => {
+describe("VertexTableSplitter", () => {
   class MockSystem extends MockRender.System {
     public static maxTextureSize = 2048;
     public override get maxTextureSize() { return MockSystem.maxTextureSize; }


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native-internal/pull/251

The bytes representing the positions and feature indices are transposed in unquantized tiles for more efficient access on the GPU. When splitting vertex tables, we need to invert the transpose when extracting the feature index.