### PR TITLE
Presentation: Add hilite set iterator

### DIFF
--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -178,6 +178,7 @@ export interface HiliteSet {
 export class HiliteSetProvider {
     static create(props: HiliteSetProviderProps): HiliteSetProvider;
     getHiliteSet(selection: Readonly<KeySet>): Promise<HiliteSet>;
+    getHiliteSetIterator(selection: Readonly<KeySet>): AsyncIterableIterator<HiliteSet>;
 }
 
 // @public
@@ -500,6 +501,7 @@ export class SelectionManager implements ISelectionProvider {
     addToSelectionWithScope(source: string, imodel: IModelConnection, ids: Id64Arg, scope: SelectionScopeProps | SelectionScope | string, level?: number, rulesetId?: string): Promise<void>;
     clearSelection(source: string, imodel: IModelConnection, level?: number, rulesetId?: string): void;
     getHiliteSet(imodel: IModelConnection): Promise<HiliteSet>;
+    getHiliteSetIterator(imodel: IModelConnection): AsyncIterableIterator<HiliteSet>;
     getSelection(imodel: IModelConnection, level?: number): Readonly<KeySet>;
     getSelectionLevels(imodel: IModelConnection): number[];
     // @internal (undocumented)

--- a/common/changes/@itwin/presentation-frontend/presentation-hilite_set_iterator_2023-11-21-11-41.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-hilite_set_iterator_2023-11-21-11-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Added 'getHiliteSetIterator' method to `HiliteSetProvider`. It allows to handle hilite set in batches instead of waiting for whole set to be loaded. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -751,6 +751,14 @@
       "allowedCategories": [ "internal" ]
     },
     {
+      "name": "rxjs",
+      "allowedCategories": [ "frontend" ]
+    },
+    {
+      "name": "rxjs-for-await",
+      "allowedCategories": [ "frontend" ]
+    },
+    {
       "name": "sanitize-filename",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2386,11 +2386,16 @@ importers:
       mocha: ^10.0.0
       nyc: ^15.1.0
       rimraf: ^3.0.2
+      rxjs: ^7.8.1
+      rxjs-for-await: ^1.0.0
       sinon: ^15.0.4
       sinon-chai: ^3.2.0
       source-map-support: ^0.5.6
       typemoq: ^2.1.0
       typescript: ~5.0.2
+    dependencies:
+      rxjs: 7.8.1
+      rxjs-for-await: 1.0.0_rxjs@7.8.1
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/core-bentley': link:../../core/bentley
@@ -11105,6 +11110,20 @@ packages:
 
   /rx/2.3.24:
     resolution: {integrity: sha512-Ue4ZB7Dzbn2I9sIj8ws536nOP2S53uypyCkCz9q0vlYD5Kn6/pu4dE+wt2ZfFzd9m73hiYKnnCb1OyKqc+MRkg==}
+    dev: false
+
+  /rxjs-for-await/1.0.0_rxjs@7.8.1:
+    resolution: {integrity: sha512-MJhvf1vtQaljd5wlzsasvOjcohVogzkHkUI0gFE9nGhZ15/fT2vR1CjkLEh37oRqWwpv11vHo5D+sLM+Aw9Y8g==}
+    peerDependencies:
+      rxjs: ^7.0.0
+    dependencies:
+      rxjs: 7.8.1
+    dev: false
+
+  /rxjs/7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+    dependencies:
+      tslib: 2.6.2
     dev: false
 
   /safe-array-concat/1.0.1:

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -40,6 +40,10 @@
     "test": "mocha -r jsdom-global/register --config ../.mocharc.json \"./lib/cjs/test/**/*.test.js\"",
     "test:watch": "npm -s test -- --reporter min --watch-extensions ts --watch"
   },
+  "dependencies": {
+    "rxjs": "^7.8.1",
+    "rxjs-for-await": "^1.0.0"
+  },
   "peerDependencies": {
     "@itwin/core-bentley": "workspace:^4.3.0-dev.28",
     "@itwin/core-common": "workspace:^4.3.0-dev.28",

--- a/presentation/frontend/src/presentation-frontend/selection/HiliteSetProvider.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/HiliteSetProvider.ts
@@ -6,10 +6,12 @@
  * @module UnifiedSelection
  */
 
+import { from, Observable, shareReplay } from "rxjs";
+import { eachValueFrom } from "rxjs-for-await";
 import { Id64String } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
 import {
-  Content, ContentFlags, DEFAULT_KEYS_BATCH_SIZE, DefaultContentDisplayTypes, DescriptorOverrides, Item, Key, KeySet, Ruleset,
+  ContentFlags, DEFAULT_KEYS_BATCH_SIZE, DefaultContentDisplayTypes, DescriptorOverrides, Item, Key, KeySet, Ruleset,
 } from "@itwin/presentation-common";
 import { Presentation } from "../Presentation";
 import { TRANSIENT_ELEMENT_CLASSNAME } from "./SelectionManager";
@@ -47,7 +49,7 @@ export interface HiliteSetProviderProps {
  */
 export class HiliteSetProvider {
   private _imodel: IModelConnection;
-  private _cached: undefined | { keysGuid: string, result: HiliteSet };
+  private _cache: undefined | { keysGuid: string, observable: Observable<HiliteSet> };
 
   private constructor(props: HiliteSetProviderProps) {
     this._imodel = props.imodel;
@@ -58,34 +60,78 @@ export class HiliteSetProvider {
    */
   public static create(props: HiliteSetProviderProps) { return new HiliteSetProvider(props); }
 
-  private async getRecords(keys: KeySet): Promise<Item[]> {
-    const descriptor: DescriptorOverrides = {
-      displayType: DefaultContentDisplayTypes.Viewport,
-      contentFlags: ContentFlags.KeysOnly,
-    };
-    const options = {
-      imodel: this._imodel,
-      rulesetOrId: HILITE_RULESET,
-      descriptor,
-    };
-    const contentPromises = new Array<Promise<Content | undefined>>();
-    keys.forEachBatch(DEFAULT_KEYS_BATCH_SIZE, (batch: KeySet) => {
-      contentPromises.push(Presentation.presentation.getContent({ ...options, keys: batch }));
-    });
-    return (await Promise.all(contentPromises)).reduce((items, content) => {
-      if (content)
-        items.push(...content.contentSet);
-      return items;
-    }, new Array<Item>());
-  }
-
-  private createHiliteSet(records: Item[], transientIds: Id64String[]) {
-    if (!records.length)
-      return { elements: transientIds };
-
+  /**
+   * Get hilite set for instances and/or nodes whose keys are specified in the
+   * given KeySet.
+   *
+   * Note: The provider caches result of the last request, so subsequent requests
+   * for the same input doesn't cost.
+   */
+  public async getHiliteSet(selection: Readonly<KeySet>): Promise<HiliteSet> {
     const modelIds = new Array<Id64String>();
     const subCategoryIds = new Array<Id64String>();
-    const elementIds = transientIds; // note: not making a copy here since we're throwing away `transientIds` anyway
+    const elementIds = new Array<Id64String>();
+
+    const iterator = this.getHiliteSetIterator(selection);
+    for await (const set of iterator) {
+      modelIds.push(...set.models ?? []);
+      subCategoryIds.push(...set.subCategories ?? []);
+      elementIds.push(...set.elements ?? []);
+    }
+
+    return {
+      models: modelIds.length ? modelIds : undefined,
+      subCategories: subCategoryIds.length ? subCategoryIds : undefined,
+      elements: elementIds.length ? elementIds : undefined,
+    };
+  }
+
+  /**
+   * Get hilite set iterator for provided keys. It loads content in batches and
+   * yields hilite set created from each batch after it is loaded.
+   */
+  public getHiliteSetIterator(selection: Readonly<KeySet>) {
+    if (!this._cache || this._cache.keysGuid !== selection.guid) {
+      this._cache = {
+        keysGuid: selection.guid,
+        observable: from(this.createHiliteSetIterator(selection)).pipe(shareReplay({ refCount: true })),
+      };
+    }
+
+    return eachValueFrom(this._cache.observable);
+  }
+
+  private async * createHiliteSetIterator(selection: Readonly<KeySet>) {
+    const {keys, transientIds} = this.handleTransientKeys(selection);
+    const {options, keyBatches} = this.getContentOptions(keys);
+
+    if (transientIds.length !== 0) {
+      yield { elements: transientIds };
+    }
+
+    for (const batch of keyBatches) {
+      let loadedItems = 0;
+      while (true) {
+        const content = await Presentation.presentation.getContentAndSize({...options, paging: {start: loadedItems, size: CONTENT_SET_PAGE_SIZE}, keys: batch});
+        if (!content) {
+          break;
+        }
+
+        const result = this.createHiliteSet(content.content.contentSet);
+        yield result;
+
+        loadedItems += content.content.contentSet.length;
+        if (loadedItems >= content.size) {
+          break;
+        }
+      }
+    }
+  }
+
+  private createHiliteSet(records: Item[]): HiliteSet {
+    const modelIds = new Array<Id64String>();
+    const subCategoryIds = new Array<Id64String>();
+    const elementIds = new Array<Id64String>();
     records.forEach((rec) => {
       const ids = isModelRecord(rec) ? modelIds : isSubCategoryRecord(rec) ? subCategoryIds : elementIds;
       rec.primaryKeys.forEach((pk) => ids.push(pk.id));
@@ -97,33 +143,45 @@ export class HiliteSetProvider {
     };
   }
 
-  /**
-   * Get hilite set for instances and/or nodes whose keys are specified in the
-   * given KeySet.
-   *
-   * Note: The provider caches result of the last request, so subsequent requests
-   * for the same input doesn't cost.
-   */
-  public async getHiliteSet(selection: Readonly<KeySet>): Promise<HiliteSet> {
-    const selectionGuid = selection.guid;
-    if (!this._cached || this._cached.keysGuid !== selectionGuid) {
-      // need to create a new set without transients
-      const transientIds = new Array<Id64String>();
-      const keys = new KeySet();
-      keys.add(selection, (key: Key) => {
-        if (Key.isInstanceKey(key) && key.className === TRANSIENT_ELEMENT_CLASSNAME) {
-          transientIds.push(key.id);
-          return false;
-        }
-        return true;
-      });
-      const records = await this.getRecords(keys);
-      const result = this.createHiliteSet(records, transientIds);
-      this._cached = { keysGuid: selectionGuid, result };
-    }
-    return this._cached.result;
+  private getContentOptions(keys: KeySet) {
+    const descriptor: DescriptorOverrides = {
+      displayType: DefaultContentDisplayTypes.Viewport,
+      contentFlags: ContentFlags.KeysOnly,
+    };
+    const options = {
+      imodel: this._imodel,
+      rulesetOrId: HILITE_RULESET,
+      descriptor,
+    };
+    const keyBatches = new Array<KeySet>();
+    keys.forEachBatch(DEFAULT_KEYS_BATCH_SIZE, (batch: KeySet) => {
+      keyBatches.push(batch);
+    });
+    return {
+      options,
+      keyBatches,
+    };
+  }
+
+  private handleTransientKeys(selection: Readonly<KeySet>) {
+    // need to create a new set without transients
+    const transientIds = new Array<Id64String>();
+    const keys = new KeySet();
+    keys.add(selection, (key: Key) => {
+      if (Key.isInstanceKey(key) && key.className === TRANSIENT_ELEMENT_CLASSNAME) {
+        transientIds.push(key.id);
+        return false;
+      }
+      return true;
+    });
+    return {
+      transientIds,
+      keys,
+    };
   }
 }
+
+const CONTENT_SET_PAGE_SIZE = 1000;
 
 const isModelRecord = (rec: Item) => (rec.extendedData && rec.extendedData.isModel);
 

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -283,6 +283,19 @@ export class SelectionManager implements ISelectionProvider {
     }
     return provider.getHiliteSet(this.getSelection(imodel));
   }
+
+  /**
+   * Get the current hilite set iterator for the specified imodel.
+   * @public
+   */
+  public getHiliteSetIterator(imodel: IModelConnection) {
+    let provider = this._hiliteSetProviders.get(imodel);
+    if (!provider) {
+      provider = HiliteSetProvider.create({ imodel });
+      this._hiliteSetProviders.set(imodel, provider);
+    }
+    return provider.getHiliteSetIterator(this.getSelection(imodel));
+  }
 }
 
 /** @internal */

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -276,12 +276,7 @@ export class SelectionManager implements ISelectionProvider {
    * @public
    */
   public async getHiliteSet(imodel: IModelConnection): Promise<HiliteSet> {
-    let provider = this._hiliteSetProviders.get(imodel);
-    if (!provider) {
-      provider = HiliteSetProvider.create({ imodel });
-      this._hiliteSetProviders.set(imodel, provider);
-    }
-    return provider.getHiliteSet(this.getSelection(imodel));
+    return this.getHiliteSetProvider(imodel).getHiliteSet(this.getSelection(imodel));
   }
 
   /**
@@ -289,12 +284,16 @@ export class SelectionManager implements ISelectionProvider {
    * @public
    */
   public getHiliteSetIterator(imodel: IModelConnection) {
+    return this.getHiliteSetProvider(imodel).getHiliteSetIterator(this.getSelection(imodel));
+  }
+
+  private getHiliteSetProvider(imodel: IModelConnection) {
     let provider = this._hiliteSetProviders.get(imodel);
     if (!provider) {
       provider = HiliteSetProvider.create({ imodel });
       this._hiliteSetProviders.set(imodel, provider);
     }
-    return provider.getHiliteSetIterator(this.getSelection(imodel));
+    return provider;
   }
 }
 

--- a/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
+++ b/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Content, DEFAULT_KEYS_BATCH_SIZE, Item, KeySet } from "@itwin/presentation-common";
@@ -46,28 +45,34 @@ describe("HiliteSetProvider", () => {
     });
 
     it("memoizes result", async () => {
-      // note: listening on private method
-      const spy = sinon.stub(provider as any, "getRecords").returns(Promise.resolve([]));
-      const keys = new KeySet();
+      const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
+        new Item([createRandomECInstanceKey()], "", "", undefined, {}, {}, [], {}), // element
+      ]);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => ({ size: 1, content: resultContent }));
+      const keys = new KeySet([createRandomECInstanceKey()]);
 
       await provider.getHiliteSet(keys);
-      expect(spy).to.be.calledOnce; // records are fetched for the first request
+      // records are fetched for the first request
+      presentationManagerMock.verify(async (x) => x.getContentAndSize(moq.It.isAny()), moq.Times.once());
 
       await provider.getHiliteSet(keys);
-      expect(spy).to.be.calledOnce; // keys didn't change - result returned from cache
+      // keys didn't change - result returned from cache
+      presentationManagerMock.verify(async (x) => x.getContentAndSize(moq.It.isAny()), moq.Times.once());
 
       keys.add(createRandomECInstanceKey());
       await provider.getHiliteSet(keys);
-      expect(spy).to.be.calledTwice; // keys did change - result fetched again
+      // keys did change - result fetched again
+      presentationManagerMock.verify(async (x) => x.getContentAndSize(moq.It.isAny()), moq.Times.exactly(2));
 
       await provider.getHiliteSet(keys);
-      expect(spy).to.be.calledTwice; // keys didn't change - result returned from cache
+      // keys didn't change - result returned from cache
+      presentationManagerMock.verify(async (x) => x.getContentAndSize(moq.It.isAny()), moq.Times.exactly(2));
     });
 
     it("creates result for transient element keys", async () => {
       const transientKey = { className: TRANSIENT_ELEMENT_CLASSNAME, id: createRandomTransientId() };
 
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((opts) => opts.keys.isEmpty))).returns(async () => undefined);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((opts) => opts.keys.isEmpty))).returns(async () => undefined);
 
       const result = await provider.getHiliteSet(new KeySet([transientKey]));
       expect(result.models).to.be.undefined;
@@ -81,8 +86,8 @@ describe("HiliteSetProvider", () => {
       const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
         new Item([resultKey], "", "", undefined, {}, {}, [], {}), // element
       ]);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => resultContent);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => undefined);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => ({ size: 1, content: resultContent }));
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => undefined);
 
       const result = await provider.getHiliteSet(new KeySet([persistentKey]));
       expect(result.models).to.be.undefined;
@@ -96,8 +101,8 @@ describe("HiliteSetProvider", () => {
       const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
         new Item([resultKey], "", "", undefined, {}, {}, [], { isModel: true }),
       ]);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => resultContent);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => undefined);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => ({ size: 1, content: resultContent }));
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => undefined);
 
       const result = await provider.getHiliteSet(new KeySet([persistentKey]));
       expect(result.models).to.deep.eq([resultKey.id]);
@@ -111,8 +116,8 @@ describe("HiliteSetProvider", () => {
       const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
         new Item([resultKey], "", "", undefined, {}, {}, [], { isSubCategory: true }),
       ]);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => resultContent);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => undefined);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => ({ size: 1, content: resultContent }));
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => undefined);
 
       const result = await provider.getHiliteSet(new KeySet([persistentKey]));
       expect(result.models).to.be.undefined;
@@ -132,8 +137,8 @@ describe("HiliteSetProvider", () => {
         new Item([resultSubCategoryKey], "", "", undefined, {}, {}, [], { isSubCategory: true }),
         new Item([resultElementKey], "", "", undefined, {}, {}, [], {}), // element
       ]);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => resultContent);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.isAny())).returns(async () => undefined);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => ({ size: 3, content: resultContent }));
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.isAny())).returns(async () => undefined);
 
       const result = await provider.getHiliteSet(new KeySet([transientKey, persistentKey]));
       expect(result.models).to.deep.eq([resultModelKey.id]);
@@ -152,10 +157,10 @@ describe("HiliteSetProvider", () => {
       const resultContent1 = new Content(createTestContentDescriptor({ fields: [] }), [
         new Item([elementKey], "", "", undefined, {}, {}, [], {}), // element
       ]);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((opts) => opts.keys.size === DEFAULT_KEYS_BATCH_SIZE))).returns(async () => resultContent1);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((opts) => opts.keys.size === DEFAULT_KEYS_BATCH_SIZE))).returns(async () => ({ size: 1, content: resultContent1 }));
 
       // second request returns no content
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((opts) => opts.keys.size === DEFAULT_KEYS_BATCH_SIZE))).returns(async () => undefined);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((opts) => opts.keys.size === DEFAULT_KEYS_BATCH_SIZE))).returns(async () => undefined);
 
       // third request returns content with subcategory and model keys
       const subCategoryKey = createRandomECInstanceKey();
@@ -164,12 +169,45 @@ describe("HiliteSetProvider", () => {
         new Item([subCategoryKey], "", "", undefined, {}, {}, [], { isSubCategory: true }),
         new Item([modelKey], "", "", undefined, {}, {}, [], { isModel: true }),
       ]);
-      presentationManagerMock.setup(async (x) => x.getContent(moq.It.is((opts) => opts.keys.size === 1))).returns(async () => resultContent2);
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((opts) => opts.keys.size === 1))).returns(async () => ({ size: 2, content: resultContent2 }));
 
       const result = await provider.getHiliteSet(new KeySet(inputKeys));
       expect(result.models).to.deep.eq([modelKey.id]);
       expect(result.subCategories).to.deep.eq([subCategoryKey.id]);
       expect(result.elements).to.deep.eq([elementKey.id]);
+    });
+
+  });
+
+  describe("getHiliteSetIterator", () => {
+
+    let provider: HiliteSetProvider;
+
+    beforeEach(() => {
+      provider = HiliteSetProvider.create({ imodel: imodelMock.object });
+    });
+
+    it("iterates over content items in pages", async () => {
+      const elementKeys = new Array(1001).fill(0).map((_, i) => ({id: `0x${i}`, className: "TestElement"}));
+      const items = elementKeys.map((key) => new Item([key], "", "", undefined, {}, {}, [], {}));
+
+      const resultContent1 = new Content(createTestContentDescriptor({ fields: [] }), items.slice(0, 1000));
+      const resultContent2 = new Content(createTestContentDescriptor({ fields: [] }), items.slice(1000));
+
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((opts) => opts.paging?.start === 0))).returns(async () => ({ size: 1001, content: resultContent1 }));
+      presentationManagerMock.setup(async (x) => x.getContentAndSize(moq.It.is((opts) => (opts.paging?.start ?? 0) > 0))).returns(async () => ({ size: 1001, content: resultContent2 }));
+
+      const iterator = provider.getHiliteSetIterator(new KeySet([{ id: "0x1", className: "TestElement"}]));
+      let index = 0;
+      for await (const set of iterator) {
+        if (index === 0) {
+          expect(set.elements).to.deep.eq(elementKeys.slice(0, 1000).map((key) => key.id));
+        }
+        if (index === 1) {
+          expect(set.elements).to.deep.eq(elementKeys.slice(1000).map((key) => key.id));
+        }
+        index++;
+      }
     });
 
   });

--- a/presentation/frontend/src/test/selection/SelectionManager.test.ts
+++ b/presentation/frontend/src/test/selection/SelectionManager.test.ts
@@ -818,4 +818,43 @@ describe("SelectionManager", () => {
 
   });
 
+  describe("getHiliteSetIterator", () => {
+
+    let factory: sinon.SinonStub<[{ imodel: IModelConnection }], HiliteSetProvider>;
+
+    beforeEach(() => {
+      const providerMock = moq.Mock.ofType<HiliteSetProvider>();
+      providerMock.setup(async (x) => x.getHiliteSet(moq.It.isAny())).returns(async () => ({}));
+      factory = sinon.stub(HiliteSetProvider, "create").returns(providerMock.object);
+    });
+
+    afterEach(() => {
+      factory.restore();
+    });
+
+    it("creates provider once for imodel", () => {
+      const imodelMock1 = moq.Mock.ofType<IModelConnection>();
+      const imodelMock2 = moq.Mock.ofType<IModelConnection>();
+
+      // call for the first with an imodel should create a provider
+      selectionManager.getHiliteSetIterator(imodelMock1.object);
+      expect(factory).to.be.calledOnceWith({ imodel: imodelMock1.object });
+      factory.resetHistory();
+
+      // second call with same imodel shouldn't create a new provider
+      selectionManager.getHiliteSetIterator(imodelMock1.object);
+      expect(factory).to.not.be.called;
+
+      // another imodel - new provider
+      selectionManager.getHiliteSetIterator(imodelMock2.object);
+      expect(factory).to.be.calledOnceWith({ imodel: imodelMock2.object });
+      factory.resetHistory();
+
+      // make sure we still have provider for the first imodel
+      selectionManager.getHiliteSetIterator(imodelMock1.object);
+      expect(factory).to.not.be.called;
+    });
+
+  });
+
 });


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/329

Added `getHiliteSetIterator` method to `HiliteSetProvider`. This allows to handle hilite set in batches instead of waiting for whole set to be loaded. It also makes to possible to cancel hilite set loading if selection changes.
