### PR TITLE
Presentation: Pass correct content options when loading multiple element properties

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-fix_multi_element_properties_request_2023-11-21-13-57.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix_multi_element_properties_request_2023-11-21-13-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fixed `getElementProperties` function to pass correct content options when loading properties.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -584,7 +584,7 @@ export class PresentationManager {
       const content = await this.getContent({
         ...optionsNoElementClasses,
         descriptor: {
-          displayType: DefaultContentDisplayTypes.PropertyPane,
+          displayType: DefaultContentDisplayTypes.Grid,
           contentFlags: ContentFlags.ShowLabels,
         },
         rulesetOrId: "ElementProperties",

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -2063,7 +2063,7 @@ describe("PresentationManager", () => {
           params: {
             keys: getKeysForContentRequest(new KeySet(elementKeys)),
             descriptorOverrides: {
-              displayType: DefaultContentDisplayTypes.PropertyPane,
+              displayType: DefaultContentDisplayTypes.Grid,
               contentFlags: ContentFlags.ShowLabels,
             },
             rulesetId: "ElementProperties",
@@ -2167,7 +2167,7 @@ describe("PresentationManager", () => {
           params: {
             keys: getKeysForContentRequest(new KeySet(elementKeys)),
             descriptorOverrides: {
-              displayType: DefaultContentDisplayTypes.PropertyPane,
+              displayType: DefaultContentDisplayTypes.Grid,
               contentFlags: ContentFlags.ShowLabels,
             },
             rulesetId: "ElementProperties",


### PR DESCRIPTION
Fixed bug uncovered by https://github.com/iTwin/imodel-native/pull/550

imodel-native: https://github.com/iTwin/imodel-native/pull/550