### PR TITLE
Fix unquantized feature index extraction

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-unquantized-feature-id-extraction_2023-11-21-19-46.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-unquantized-feature-id-extraction_2023-11-21-19-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/common/render/primitives/VertexTableSplitter.ts
+++ b/core/frontend/src/common/render/primitives/VertexTableSplitter.ts
@@ -336,8 +336,7 @@ class VertexTableSplitter {
       extractFeatureIndex = () => {
         return vertexBytes[3]
           | (vertexBytes[7] << 8)
-          | (vertexBytes[11] << 16)
-          | (vertexBytes[15] << 24);
+          | (vertexBytes[11] << 16);
       };
     } else {
       extractFeatureIndex = () => vertex[2] & 0x00ffffff;


### PR DESCRIPTION
#6220 fixed extraction of feature index from unquantized vertex tables but it was extracting 4 bytes. The 4th byte is the material index, not part of the feature index. If it is non-zero (i.e., the vertex table uses a material atlas), the extracted feature index will be incorrect.