### PR TITLE
Save changes before closing ReadWrite IModels

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2991,7 +2991,7 @@ export abstract class IModelDb extends IModel {
     clearCaches(): void;
     // @internal (undocumented)
     clearFontMap(): void;
-    close(): void;
+    close(description?: string): void;
     // @alpha (undocumented)
     get codeService(): CodeService | undefined;
     // @internal (undocumented)

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2991,7 +2991,7 @@ export abstract class IModelDb extends IModel {
     clearCaches(): void;
     // @internal (undocumented)
     clearFontMap(): void;
-    close(description?: string): void;
+    close(): void;
     // @alpha (undocumented)
     get codeService(): CodeService | undefined;
     // @internal (undocumented)

--- a/common/changes/@itwin/core-backend/aks-save-changes-on-IModelDb-close_2023-11-29-08-12.json
+++ b/common/changes/@itwin/core-backend/aks-save-changes-on-IModelDb-close_2023-11-29-08-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Save changes before closing IModels opened in ReadWrite mode",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -154,7 +154,7 @@ export class BriefcaseManager {
             const fileSize = IModelJsFs.lstatSync(fileName)?.size ?? 0;
             const db = IModelDb.openDgnDb({ path: fileName }, OpenMode.Readonly);
             briefcaseList.push({ fileName, iTwinId: db.getITwinId(), iModelId: db.getIModelId(), briefcaseId: db.getBriefcaseId(), changeset: db.getCurrentChangeset(), fileSize });
-            db.closeIModel();
+            db.closeFile();
           } catch (_err) {
           }
         }
@@ -246,7 +246,7 @@ export class BriefcaseManager {
         throw new IModelError(IModelStatus.InvalidId, `Downloaded briefcase has wrong changesetId: ${fileName}`);
     } finally {
       nativeDb.saveChanges();
-      nativeDb.closeIModel();
+      nativeDb.closeFile();
     }
     return response;
   }
@@ -282,7 +282,7 @@ export class BriefcaseManager {
         iModelId: db.getIModelId(),
         briefcaseId: db.getBriefcaseId(),
       };
-      db.closeIModel();
+      db.closeFile();
 
       if (accessToken) {
         if (this.isValidBriefcaseId(briefcase.briefcaseId)) {

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -434,7 +434,7 @@ export class CheckpointManager {
     }
 
     const isValid = checkpoint.iModelId === nativeDb.getIModelId() && checkpoint.changeset.id === nativeDb.getCurrentChangeset().id;
-    nativeDb.closeIModel();
+    nativeDb.closeFile();
     if (!isValid)
       IModelJsFs.removeSync(fileName);
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -364,7 +364,7 @@ export abstract class IModelDb extends IModel {
     }
   }
 
-  /** Close this IModel, if it is currently open. */
+  /** Close this IModel, if it is currently open, and save changes if it was opened in ReadWrite mode. */
   public close(description?: string): void {
     if (!this.isOpen)
       return; // don't continue if already closed

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -3003,8 +3003,10 @@ export class StandaloneDb extends BriefcaseDb {
    */
   public static upgradeStandaloneSchemas(filePath: LocalFileName) {
     let nativeDb = this.openDgnDb({ path: filePath }, OpenMode.ReadWrite, { profile: ProfileOptions.Upgrade, schemaLockHeld: true });
+    nativeDb.saveChanges();
     nativeDb.closeFile();
     nativeDb = this.openDgnDb({ path: filePath }, OpenMode.ReadWrite, { domain: DomainOptions.Upgrade, schemaLockHeld: true });
+    nativeDb.saveChanges();
     nativeDb.closeFile();
   }
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -365,7 +365,7 @@ export abstract class IModelDb extends IModel {
   }
 
   /** Close this IModel, if it is currently open, and save changes if it was opened in ReadWrite mode. */
-  public close(description?: string): void {
+  public close(): void {
     if (!this.isOpen)
       return; // don't continue if already closed
 
@@ -377,7 +377,7 @@ export abstract class IModelDb extends IModel {
     this._codeService?.close();
     this._codeService = undefined;
     if (!this.isReadonly)
-      this.saveChanges(description);
+      this.saveChanges();
     this.nativeDb.closeFile();
   }
 

--- a/core/backend/src/LocalHub.ts
+++ b/core/backend/src/LocalHub.ts
@@ -130,7 +130,7 @@ export class LocalHub {
       nativeDb.saveLocalValue(BriefcaseLocalValue.NoLocking, arg.noLocks ? "true" : undefined);
       nativeDb.saveChanges();
     } finally {
-      nativeDb.closeIModel();
+      nativeDb.closeFile();
     }
   }
 

--- a/core/backend/src/test/SchemaUtils.test.ts
+++ b/core/backend/src/test/SchemaUtils.test.ts
@@ -70,6 +70,7 @@ describe("convertEC2Schemas", () => {
       const row = stmt.getRow();
       propNamesInEntityClass.push(row.name);
     }
+    stmt.dispose();
     assert.equal(rowCount, 9);
 
     assert.isFalse(propNamesInEntityClass.includes("Id"));  // The Id property is a reserved keyword and should have been renamed
@@ -93,6 +94,7 @@ describe("convertEC2Schemas", () => {
       const row = stmt.getRow();
       propNamesInStructClass.push(row.name);
     }
+    stmt.dispose();
     assert.equal(rowCount, 3);
 
     assert.isTrue(propNamesInStructClass.includes("Id")); // The Id property is not a reserved keyword for Struct classes and should not be renamed

--- a/core/backend/src/test/element/ElementDependencyGraph.test.ts
+++ b/core/backend/src/test/element/ElementDependencyGraph.test.ts
@@ -147,7 +147,7 @@ describe("ElementDependencyGraph", () => {
     };
     nativeDb.openIModel(pathname, OpenMode.ReadWrite, upgradeOptions);
     nativeDb.deleteAllTxns();
-    nativeDb.closeIModel();
+    nativeDb.closeFile();
   };
 
   before(async () => {

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -2182,7 +2182,7 @@ describe("iModel", () => {
       getITwinId: () => iTwinId,
       getCurrentChangeset: () => changeset,
       setIModelDb: () => { },
-      closeIModel: () => { },
+      closeFile: () => { },
     };
 
     const errorLogStub = sinon.stub(Logger, "logError").callsFake(() => { });

--- a/core/backend/src/test/standalone/TxnManager.test.ts
+++ b/core/backend/src/test/standalone/TxnManager.test.ts
@@ -31,7 +31,7 @@ describe("TxnManager", () => {
     };
     nativeDb.openIModel(pathname, OpenMode.ReadWrite, upgradeOptions);
     nativeDb.deleteAllTxns();
-    nativeDb.closeIModel();
+    nativeDb.closeFile();
   };
 
   beforeEach(async () => {

--- a/full-stack-tests/backend/src/HubUtility.ts
+++ b/full-stack-tests/backend/src/HubUtility.ts
@@ -227,7 +227,7 @@ export class HubUtility {
     }
 
     perfLogger.dispose();
-    nativeDb.closeIModel();
+    nativeDb.closeFile();
 
     return results;
   }
@@ -282,7 +282,7 @@ export class HubUtility {
     if (nativeDb.queryLocalValue("StandaloneEdit"))
       nativeDb.deleteLocalValue("StandaloneEdit");
     nativeDb.saveChanges();
-    nativeDb.closeIModel();
+    nativeDb.closeFile();
 
     return iModelPathname;
   }

--- a/full-stack-tests/backend/src/integration/ApplyChangeSets.test.ts
+++ b/full-stack-tests/backend/src/integration/ApplyChangeSets.test.ts
@@ -82,7 +82,7 @@ async function validateAllChangesetOperationsOnDisk(iModelDir: string) {
     status = applyChangesetsToNativeDb(nativeDb, filteredChangesets);
   }
 
-  nativeDb.closeIModel();
+  nativeDb.closeFile();
   assert.isTrue(status === ChangeSetStatus.Success, "Error applying changesets");
 }
 

--- a/full-stack-tests/backend/src/integration/ChangedElements.test.ts
+++ b/full-stack-tests/backend/src/integration/ChangedElements.test.ts
@@ -226,7 +226,7 @@ describe("ChangedElements", () => {
 
     ChangedElementsManager.cleanUp();
 
-    newIModel.closeIModel();
+    newIModel.closeFile();
   });
 
   it("Create ChangedElements Cache and process changesets while rolling Db without caching", async () => {
@@ -295,6 +295,6 @@ describe("ChangedElements", () => {
 
     ChangedElementsManager.cleanUp();
 
-    newIModel.closeIModel();
+    newIModel.closeFile();
   });
 });

--- a/test-apps/display-test-app/src/backend/SetToStandalone.ts
+++ b/test-apps/display-test-app/src/backend/SetToStandalone.ts
@@ -54,7 +54,7 @@ function setToStandalone(iModelName: string) {
     nativeDb.deleteAllTxns(); // necessary before resetting briefcaseId
     nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned); // standalone iModels should always have BriefcaseId unassigned
     nativeDb.saveChanges(); // save change to briefcaseId
-    nativeDb.closeIModel();
+    nativeDb.closeFile();
   } catch (err: any) {
     log(err.message);
   }


### PR DESCRIPTION
With this pull request, changes made to the iModel will now be automatically saved before closing.

imodel-native: https://github.com/iTwin/imodel-native/pull/558