### PR TITLE
`@itwin/map-layers-formats`: Add missing `core-frontend` peer dep

### DIFF
--- a/common/changes/@itwin/map-layers-formats/missing_peer_dep_2023-11-24-07-53.json
+++ b/common/changes/@itwin/map-layers-formats/missing_peer_dep_2023-11-24-07-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-formats",
+      "comment": "Added missing `@itwin/core-frontend` peer dependency",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-formats"
+}

--- a/extensions/map-layers-formats/package.json
+++ b/extensions/map-layers-formats/package.json
@@ -69,6 +69,7 @@
     "@itwin/appui-abstract": "workspace:*",
     "@itwin/core-bentley": "workspace:*",
     "@itwin/core-common": "workspace:*",
+    "@itwin/core-frontend": "workspace:*",
     "@itwin/core-geometry": "workspace:*"
   },
   "dependencies": {


### PR DESCRIPTION
`@itwin/map-layers-formats` package exposes types from `core-frontend` but does not have it as peer dependency.

https://github.com/iTwin/itwinjs-core/blob/ce0577203cc5ac67767871025e756566f937c933/common/api/map-layers-formats.api.md?plain=1#L62

https://github.com/iTwin/itwinjs-core/blob/ce0577203cc5ac67767871025e756566f937c933/common/api/map-layers-formats.api.md?plain=1#L94

This might lead to build failures in packages consuming `@itwin/map-layers-formats` if different `core-frontend` is resolved by package manager.