### PR TITLE
Enable display of all subcategories for non-scene decorations

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-ignore-subcategory-for-decorations_2023-11-28-21-11.json
+++ b/common/changes/@itwin/core-frontend/pmc-ignore-subcategory-for-decorations_2023-11-28-21-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Enable display of all subcategories for non-scene decorations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/render/webgl/BranchState.ts
+++ b/core/frontend/src/render/webgl/BranchState.ts
@@ -113,9 +113,16 @@ export class BranchState {
   }
 
   public static createForDecorations(): BranchState {
-    const vf = new ViewFlags({ renderMode: RenderMode.SmoothShade, lighting: false, whiteOnWhiteReversal: false });
-
-    return new BranchState({ viewFlags: vf, transform: Transform.createIdentity(), symbologyOverrides: new FeatureSymbology.Overrides(), edgeSettings: EdgeSettings.create(undefined), is3d: true });
+    const viewFlags = new ViewFlags({ renderMode: RenderMode.SmoothShade, lighting: false, whiteOnWhiteReversal: false });
+    const symbologyOverrides = new FeatureSymbology.Overrides();
+    symbologyOverrides.ignoreSubCategory = true;
+    return new BranchState({
+      viewFlags,
+      transform: Transform.createIdentity(),
+      symbologyOverrides,
+      edgeSettings: EdgeSettings.create(undefined),
+      is3d: true,
+    });
   }
 
   public withViewCoords(): BranchState {

--- a/core/frontend/src/render/webgl/Graphic.ts
+++ b/core/frontend/src/render/webgl/Graphic.ts
@@ -418,6 +418,8 @@ export class WorldDecorations extends Branch {
 
     // World decorations ignore all the symbology overrides for the "scene" geometry...
     this.branch.symbologyOverrides = new FeatureSymbology.Overrides();
+    // Make all subcategories visible.
+    this.branch.symbologyOverrides.ignoreSubCategory = true;
   }
 
   public init(decs: GraphicList): void {

--- a/core/frontend/src/test/TestDecorators.ts
+++ b/core/frontend/src/test/TestDecorators.ts
@@ -32,6 +32,7 @@ export class BoxDecorator extends TestDecorator {
   public points: Point3d[];
   public viewIndependentOrigin?: Point3d;
   public branchTransform?: Transform;
+  public graphicType: GraphicType;
 
   public constructor(options: {
     viewport: ScreenViewport;
@@ -41,6 +42,7 @@ export class BoxDecorator extends TestDecorator {
     points?: Point3d[];
     viewIndependentOrigin?: Point3d;
     branchTransform?: Transform;
+    graphicType?: GraphicType;
   }) {
     super();
     this.viewport = options.viewport;
@@ -49,6 +51,7 @@ export class BoxDecorator extends TestDecorator {
     this.placement = options.placement;
     this.viewIndependentOrigin = options.viewIndependentOrigin;
     this.branchTransform = options.branchTransform;
+    this.graphicType = options.graphicType ?? GraphicType.Scene;
 
     if (options.points) {
       this.points = options.points;
@@ -76,7 +79,7 @@ export class BoxDecorator extends TestDecorator {
   public decorate(context: DecorateContext): void {
     const builder = context.createGraphic({
       placement: this.placement,
-      type: GraphicType.Scene,
+      type: this.graphicType,
       pickable: this.pickable,
       viewIndependentOrigin: this.viewIndependentOrigin,
     });
@@ -91,7 +94,7 @@ export class BoxDecorator extends TestDecorator {
       graphic = context.createBranch(branch, this.branchTransform);
     }
 
-    context.addDecoration(GraphicType.Scene, graphic);
+    context.addDecoration(this.graphicType, graphic);
   }
 }
 

--- a/core/frontend/src/test/render/webgl/DecorationFeatures.test.ts
+++ b/core/frontend/src/test/render/webgl/DecorationFeatures.test.ts
@@ -38,7 +38,7 @@ describe("Decorations containing Features", () => {
       vp.addFeatureOverrideProvider({
         addFeatureOverrides: (ovrs) => {
           ovrs.setVisibleSubCategory("0x456");
-        }
+        },
       });
 
       expectColors(vp, bgAndDec);
@@ -71,5 +71,3 @@ describe("Decorations containing Features", () => {
     });
   });
 });
-
-

--- a/core/frontend/src/test/render/webgl/DecorationFeatures.test.ts
+++ b/core/frontend/src/test/render/webgl/DecorationFeatures.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { ColorDef, EmptyLocalization, RenderMode } from "@itwin/core-common";
+import { GraphicType, IModelApp, ScreenViewport } from "../../../core-frontend";
+import { expectColors } from "../../ExpectColors";
+import { testBlankViewport } from "../../openBlankViewport";
+import { BoxDecorator, TestDecorator } from "../../TestDecorators";
+
+describe.only("Decorations containing Features", () => {
+  before(async () => IModelApp.startup({ localization: new EmptyLocalization() }));
+  afterEach(() => TestDecorator.dropAll());
+  after(async () => IModelApp.shutdown());
+
+  function test(graphicType: GraphicType, subCategoryId: "0x456" | "0" | undefined, expectIgnoreSubCategory: boolean): void {
+    testBlankViewport((vp: ScreenViewport) => {
+      vp.viewFlags = vp.viewFlags.copy({
+        acsTriad: false,
+        grid: false,
+        lighting: false,
+        renderMode: RenderMode.SmoothShade,
+      });
+
+      const pickable = undefined !== subCategoryId ? { id: "0x123", subCategoryId } : undefined;
+      const decorator = new BoxDecorator({
+        viewport: vp,
+        color: ColorDef.red,
+        pickable,
+        graphicType,
+      });
+
+      const bg = [vp.view.displayStyle.backgroundColor];
+      const bgAndDec = [...bg, ColorDef.red];
+      expectColors(vp, expectIgnoreSubCategory ? bgAndDec : bg);
+
+      vp.addFeatureOverrideProvider({
+        addFeatureOverrides: (ovrs) => {
+          ovrs.setVisibleSubCategory("0x456");
+        }
+      });
+
+      expectColors(vp, bgAndDec);
+
+      decorator.drop();
+    });
+  }
+
+  describe("as scene graphics", () => {
+    it("only display if subcategory is invalid, missing, or enabled for the view", () => {
+      test(GraphicType.Scene, "0", true);
+      test(GraphicType.Scene, undefined, true);
+      test(GraphicType.Scene, "0x456", false);
+    });
+  });
+
+  describe("as world decorations", () => {
+    it("always display regardless of subcategory", () => {
+      test(GraphicType.WorldDecoration, "0", true);
+      test(GraphicType.WorldDecoration, undefined, true);
+      test(GraphicType.WorldDecoration, "0x456", true);
+    });
+  });
+
+  describe("as world overlays", () => {
+    it("always display regardless of subcategory", () => {
+      test(GraphicType.WorldOverlay, "0", true);
+      test(GraphicType.WorldOverlay, undefined, true);
+      test(GraphicType.WorldOverlay, "0x456", true);
+    });
+  });
+});
+
+

--- a/core/frontend/src/test/render/webgl/DecorationFeatures.test.ts
+++ b/core/frontend/src/test/render/webgl/DecorationFeatures.test.ts
@@ -9,7 +9,7 @@ import { expectColors } from "../../ExpectColors";
 import { testBlankViewport } from "../../openBlankViewport";
 import { BoxDecorator, TestDecorator } from "../../TestDecorators";
 
-describe.only("Decorations containing Features", () => {
+describe("Decorations containing Features", () => {
   before(async () => IModelApp.startup({ localization: new EmptyLocalization() }));
   afterEach(() => TestDecorator.dropAll());
   after(async () => IModelApp.shutdown());


### PR DESCRIPTION
Fixes #5876.
Non-scene graphics ignore the view's symbology overrides. That means no subcategories are visible, so only geometry that has an invalid subcategory gets displayed.
@Rock2000 is creating world decorations/overlays from element geometry, which contains valid subcategory Ids.
I changed it so that geometry of all subcategories is displayed for non-scene decorations, since disabling display of every subcategory is not useful.
In future, someone might want to create non-scene decorations that observe the symbology overrides applied to the view (e.g., subcategory visibility/appearance). If so we will need to provide a mechanism for that. For now, this is a sufficient improvement.

The third `test` in the "world decorations" and "world overlays" tests failed prior to my changes.