### PR TITLE
Allow RC on older Maj version

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -26,6 +26,7 @@ parameters:
     - minor
     - patch
     - releaseCandidate
+    - releaseCandidatePrevMaj
 
 trigger: none
 pr: none
@@ -157,11 +158,11 @@ jobs:
     - bash: 'git push --follow-tags https://$(GITHUBTOKEN)@github.com/iTwin/itwinjs-core HEAD:$(Build.SourceBranch)'
       displayName: Push version bump
 
-  - ${{ if eq(parameters.BumpType, 'releaseCandidate') }}:
+  - ${{ if or(eq(parameters.BumpType, 'releaseCandidate') eq(parameters.BumpType, 'releaseCandidatePrevMaj')) }}:
     - job: CreateBranch
       displayName: Create branch for next release
       dependsOn: Bump
-      condition: and(in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'), eq(dependencies.Bump.result, 'Succeeded'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'), eq(dependencies.Bump.result, 'Succeeded'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq('${{ parameters.BumpType }}', 'releaseCandidatePrevMaj')))
       variables:
         version: $[ dependencies.Bump.outputs['getVersion.version'] ]
 


### PR DESCRIPTION
Add new parameter called `releaseCandidatePrevMaj` which runs the the create branch step job.

Skips other RC tasks as I believe they are unnecessary/unwanted in this circumstance.

Once branch is created I believe we can run `minor` bump once the new "RC" clears all its checks

Need to figure out what steps are needed in the updateMaster job because I believe some of them are necessary but not sure about all of them. 