### PR TITLE
Update gather-docs.yaml for 3.8.0 release

### DIFF
--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -54,6 +54,6 @@ steps:
       project: 2c48216e-e72f-48b4-a4eb-40ff1c04e8e4
       pipeline: 7436 # iTwin.js/Docs/iTwin.js Docs - YAML
       buildVersionToDownload: latestFromBranch
-      branchName: refs/heads/master
+      branchName: refs/heads/release/3.7.x
       artifactName: .updated.json
       targetPath: ${{ parameters.stagingDir }}/config/


### PR DESCRIPTION
Looks like we never properly switched this to the correct branch on 3.7.0, so this was still labeled as master.
Once first patch for 3.8.0 is out we will set this to 3.8.x. 

Don't know if its worth changing 3.7.x branch since it will no longer be in use after next week. Thoughts @ben-polinsky @aruniverse ? It is a simple change, so for continuity purpose might as well right?