### PR TITLE
Enhance display-performance-test-app output.

### DIFF
--- a/test-apps/display-performance-test-app/README.md
+++ b/test-apps/display-performance-test-app/README.md
@@ -299,7 +299,7 @@ Below is an example json config file:
 
 ## Performance file output
 
-The performance data output is in csv format (and is intended to be saved as a csv file, though you may specify otherwise), and you should be able to open the performance file in Excel as well, for easier viewing. The string "End of Tests-----------" will be appended to the end of the csv file once the entire performance test run has been completed.
+The performance data output is in csv format (and is intended to be saved as a csv file, though you may specify otherwise), and you should be able to open the performance file in Excel as well, for easier viewing. The string "End of Tests-----------" will be appended to the end of the csv file once the entire performance test run has been completed.  Note that you will only get performance data for tests which have the 'testType' set to 'timings' or 'both'.
 
 The performance data file should always contain the following column headers:
 
@@ -320,6 +320,10 @@ The performance data file should always contain the following column headers:
 
 * ReadPixels Selector - a string representation of the Pixel.Selector used in the readPixels call; this will be blank if readPixels is not called
 * Tile Loading Time - the time it takes to load all of the tiles for this model (in ms)
+* Num Selected Tiles - the number of tiles used to draw the view
+* Selected Tile GPU MB - the amount of memory requested from the GPU for the graphics of the tiles selected for display
+* Tile Tree GPU MB - the amount of memory requested from the GPU for the graphics of the tiles selected for display plus any recently used or parent tiles which are still on the GPU
+* Total GPU MB - the total amount of memory requested (and not yet relinquished) from the GPU by the render system, including frame buffers, textures, graphics, etc.
 * Scene Time - the time it takes to load the scene, i.e. the time it takes to do everything in the renderFrame() function except for the drawFrame() call (in ms)
 * Begin Paint - the time it takes to call the _beginPaint() function (in ms)
 * Planar Classifiers - the time it takes to call the drawPlanarClassifiers() function (in ms)
@@ -352,6 +356,15 @@ The performance data file may also contain any or all of the below column header
 * Effective FPS - the effective total time converted to fps (frames per second); this is an estimate of what the actual fps would be if it wasn’t throttled down to a maximum of 60 fps
 * Actual Total Time - the total time it takes to get from starting to render a frame to starting to render the next frame (i.e. the time it takes to get from point A until you hit point A again)
 * Actual FPS - the actual total time converted into fps (frames per second); this should be a fairly accurate reflection of the fps value gathered when running in display-test-app
+
+The 'renderCmdStats' flag when set to true will also output the following columns whether or not the 'minimize' flag is set to true:
+
+* Primitives - a count of the number of primitives in the command lists used to draw the view
+* Batches - a count of the number of batches in the command lists used to draw the view
+* Branches - a count of the number of branches in the command lists used to draw the view
+* Primitives Per Tile - the average number of primitives per selected tile used to draw the view
+
+Note that setting the 'renderCmdStats' flag to true while also setting the 'minimize' flag to true will also output the 'Num Selected Tiles' and 'Tile Tree GPU MB' columns described earlier.
 
 The 'View Flags' column contains a string representation of view flag specifications that differ from those defaults found in the ViewFlags class. This string representation may consist of any or all of the following:
 

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -874,9 +874,14 @@ export class TestRunner {
       const dbgCtl = test.viewport.target.debugControl;
       if (undefined !== dbgCtl) {
         const cmdCounts = dbgCtl.getRenderCommands();
+        let numPrimitives = 0;
         if (undefined !== cmdCounts) {
-          for (const cc of cmdCounts)
+          for (const cc of cmdCounts) {
             rowData.set(cc.name, cc.count);
+            if ("Primitives" === cc.name)
+              numPrimitives = cc.count;
+          }
+          rowData.set("Primitives Per Tile", 0 === numPrimitives ? -1 : numPrimitives / test.numSelectedTiles);
         }
       }
     }

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -34,6 +34,7 @@ export interface TestSetProps extends TestConfigProps {
 export interface TestSetsProps extends TestConfigProps {
   signIn?: boolean;
   minimize?: boolean;
+  renderCmdStats?: boolean;
   testSet: TestSetProps[];
 }
 
@@ -141,6 +142,7 @@ class OverrideProvider {
 export class TestRunner {
   private readonly _config: TestConfigStack;
   private readonly _minimizeOutput: boolean;
+  private readonly _outputRenderCmdStats: boolean;
   private readonly _testSets: TestSetProps[];
   private readonly _logFileName: string;
   private readonly _testNamesImages = new Map<string, number>();
@@ -171,6 +173,7 @@ export class TestRunner {
     this._lastRestartConfig = this.curConfig;
     this._testSets = props.testSet;
     this._minimizeOutput = true === props.minimize;
+    this._outputRenderCmdStats = true === props.renderCmdStats;
     this._logFileName = "_DispPerfTestAppViewLog.txt";
     this._savedViewsFetcher = savedViewsFetcher;
 
@@ -861,6 +864,21 @@ export class TestRunner {
       rowData.set("Selected Tile GPU MB", test.selectedTileGpuBytes / (1024 * 1024));
       rowData.set("Tile Tree GPU MB", test.viewedTileTreeGpuBytes / (1024 * 1024));
       rowData.set("Total GPU MB", test.totalGpuBytes / (1024 * 1024));
+    }
+
+    if (this._outputRenderCmdStats) {
+      if (this._minimizeOutput) {
+        rowData.set("Num Selected Tiles", test.numSelectedTiles);
+        rowData.set("Selected Tile GPU MB", test.selectedTileGpuBytes / (1024 * 1024));
+      }
+      const dbgCtl = test.viewport.target.debugControl;
+      if (undefined !== dbgCtl) {
+        const cmdCounts = dbgCtl.getRenderCommands();
+        if (undefined !== cmdCounts) {
+          for (const cc of cmdCounts)
+            rowData.set(cc.name, cc.count);
+        }
+      }
     }
 
     const setGpuData = (name: string) => {


### PR DESCRIPTION
Enhance the .csv output of timings tests in display-performance-test-app so that when the 'renderCmdStats' flag is set to true it will output columns for the number of Primitives, Batches, and Branches used by the command lists to render the scene.

I also added this new option and comumns explanations to the README file and added information for some comumns which were missing from the README file.
