### PR TITLE
Julio/fix custom attributes comparison

### DIFF
--- a/common/changes/@itwin/ecschema-editing/julio-fixCustomAttributesComparison_2023-12-04-21-54.json
+++ b/common/changes/@itwin/ecschema-editing/julio-fixCustomAttributesComparison_2023-12-04-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "Added full name comparison support for areItemsSameByName in SchemaComparer",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/core/ecschema-editing/src/Validation/SchemaComparer.ts
+++ b/core/ecschema-editing/src/Validation/SchemaComparer.ts
@@ -880,7 +880,7 @@ export class SchemaComparer {
     const schemaNameA = itemKeyA ? itemKeyA.schemaName : undefined;
     const schemaNameB = itemKeyB ? itemKeyB.schemaName : undefined;
 
-    return nameA === nameB && schemaNameA === topLevelSchemaNameA && schemaNameB === topLevelSchemaNameB;
+    return (nameA === nameB && schemaNameA === topLevelSchemaNameA && schemaNameB === topLevelSchemaNameB) || ( nameA === nameB && schemaNameA === schemaNameB );
   }
 
   /**
@@ -896,12 +896,10 @@ export class SchemaComparer {
         const classNameB = caB[0];
         const classItemKeyA = containerA.schema.getSchemaItemKey(classNameA);
         const classItemKeyB = containerB.schema.getSchemaItemKey(classNameB);
-        const areSameByName = this.areItemsSameByName(classItemKeyA, classItemKeyB, containerA.schema.name, containerB.schema.name);
-        if (areSameByName) {
-          return true;
-        }
+        return this.areItemsSameByName(classItemKeyA, classItemKeyB, containerA.schema.name, containerB.schema.name);
       }
     }
     return false;
   }
+  
 }

--- a/core/ecschema-editing/src/Validation/SchemaComparer.ts
+++ b/core/ecschema-editing/src/Validation/SchemaComparer.ts
@@ -880,7 +880,7 @@ export class SchemaComparer {
     const schemaNameA = itemKeyA ? itemKeyA.schemaName : undefined;
     const schemaNameB = itemKeyB ? itemKeyB.schemaName : undefined;
 
-    return (nameA === nameB && schemaNameA === topLevelSchemaNameA && schemaNameB === topLevelSchemaNameB) || ( nameA === nameB && schemaNameA === schemaNameB );
+    return (nameA === nameB && schemaNameA === topLevelSchemaNameA && schemaNameB === topLevelSchemaNameB) || (nameA === nameB && schemaNameA === schemaNameB);
   }
 
   /**
@@ -901,5 +901,4 @@ export class SchemaComparer {
     }
     return false;
   }
-  
 }

--- a/core/ecschema-editing/src/test/Validation/SchemaComparisonCustomAttributes.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaComparisonCustomAttributes.test.ts
@@ -185,5 +185,125 @@ describe("Custom attributes class comparison tests", () => {
       expect(findDiagnostic(reporter.changes[0].allDiagnostics, "SC-114", "DummyReference.customAttributeOne")).to.equal(true);
     });
 
+    it("should not report custom attribute instance class missing for top level referenced custom attribute if same full name", async ()=> {
+      const context = new SchemaContext();
+      const _dummyRefOne = await Schema.fromJson({
+        ...dummyRefJson,
+        items: {
+          customAttributeOne: {
+            schemaItemType: "CustomAttributeClass",
+            appliesTo: "AnyClass",
+          },
+          customAttributeTwo: {
+            schemaItemType: "CustomAttributeClass",
+            appliesTo: "AnyClass",
+          },
+        },
+      }, context);
+      
+      const schemaA = await Schema.fromJson({
+        ...schemaAJson,
+        references: [
+          {
+            name: "DummyReference",
+            version: "01.00.01",
+          },
+        ],
+        customAttributes: [
+          {
+            className: "DummyReference.customAttributeOne"
+          },
+          {
+            className: "DummyReference.customAttributeTwo"
+          }
+        ],
+      }, context);
+
+      const schemaB = await Schema.fromJson({
+        ...schemaBJson,
+        references: [
+          {
+            name: "DummyReference",
+            version: "01.00.01",
+          },
+        ],
+        customAttributes: [
+          {
+            className: "DummyReference.customAttributeOne"
+          }
+        ],
+      }, context);
+
+      const comparer = new SchemaComparer(reporter);
+      await comparer.compareSchemas(schemaA, schemaB);
+
+      expect(findDiagnostic(reporter.changes[0].allDiagnostics, "SC-114", "DummyReference.customAttributeOne")).to.equal(false);
+      expect(findDiagnostic(reporter.changes[0].allDiagnostics, "SC-114", "DummyReference.customAttributeTwo")).to.equal(true);
+    })
+
+    it("should not report custom attribute instance class missing for referenced class with same full name", async () => {
+      const context = new SchemaContext();
+      const _dummyRefOne = await Schema.fromJson({
+        ...dummyRefJson,
+        items: {
+          customAttributeOne: {
+            schemaItemType: "CustomAttributeClass",
+            appliesTo: "AnyClass",
+          },
+        },
+      }, context);
+
+      const schemaA = await Schema.fromJson({
+        ...schemaAJson,
+        references: [
+          {
+            name: "DummyReference",
+            version: "01.00.01",
+          },
+        ],
+        items: {
+          testClass: {
+            schemaItemType: "EntityClass",
+            customAttributes: [
+              {
+                className: "DummyReference.customAttributeOne",
+                showClasses: true,
+              },
+            ],
+          },
+        },
+      }, context);
+
+      const schemaB = await Schema.fromJson({
+        ...schemaBJson,
+        references: [
+          {
+            name: "DummyReference",
+            version: "01.00.01",
+          },
+        ],
+        items: {
+          testClass: {
+            schemaItemType: "EntityClass",
+            customAttributes: [
+              {
+                className: "DummyReference.customAttributeOne",
+                showClasses: true,
+              },
+            ],
+          },
+          customAttributeOne: {
+            schemaItemType: "CustomAttributeClass",
+            appliesTo: "AnyClass",
+          },
+        },
+      }, context);
+
+      const comparer = new SchemaComparer(reporter);
+      await comparer.compareSchemas(schemaA, schemaB);
+
+      expect(findDiagnostic(reporter.changes[0].allDiagnostics, "SC-114", "DummyReference.customAttributeOne")).to.equal(false);
+    });
+
   });
 });

--- a/core/ecschema-editing/src/test/Validation/SchemaComparisonCustomAttributes.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaComparisonCustomAttributes.test.ts
@@ -200,7 +200,7 @@ describe("Custom attributes class comparison tests", () => {
           },
         },
       }, context);
-      
+
       const schemaA = await Schema.fromJson({
         ...schemaAJson,
         references: [
@@ -211,11 +211,11 @@ describe("Custom attributes class comparison tests", () => {
         ],
         customAttributes: [
           {
-            className: "DummyReference.customAttributeOne"
+            className: "DummyReference.customAttributeOne",
           },
           {
-            className: "DummyReference.customAttributeTwo"
-          }
+            className: "DummyReference.customAttributeTwo",
+          },
         ],
       }, context);
 
@@ -229,8 +229,8 @@ describe("Custom attributes class comparison tests", () => {
         ],
         customAttributes: [
           {
-            className: "DummyReference.customAttributeOne"
-          }
+            className: "DummyReference.customAttributeOne",
+          },
         ],
       }, context);
 
@@ -239,7 +239,7 @@ describe("Custom attributes class comparison tests", () => {
 
       expect(findDiagnostic(reporter.changes[0].allDiagnostics, "SC-114", "DummyReference.customAttributeOne")).to.equal(false);
       expect(findDiagnostic(reporter.changes[0].allDiagnostics, "SC-114", "DummyReference.customAttributeTwo")).to.equal(true);
-    })
+    });
 
     it("should not report custom attribute instance class missing for referenced class with same full name", async () => {
       const context = new SchemaContext();


### PR DESCRIPTION
This PR adds full name comparison support to areItemsSameByName in SchemaComparer, this was needed for properties and classes where a fullName comparison is not the first check, such as CustomAttributes. 