### PR TITLE
Add support for Electron 28

### DIFF
--- a/common/changes/@itwin/certa/gytis-support-Electron-28_2023-12-05-08-14.json
+++ b/common/changes/@itwin/certa/gytis-support-Electron-28_2023-12-05-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "Add support for Electron 28",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/changes/@itwin/core-electron/gytis-support-Electron-28_2023-12-05-08-14.json
+++ b/common/changes/@itwin/core-electron/gytis-support-Electron-28_2023-12-05-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Add support for Electron 28",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -455,7 +455,7 @@ importers:
       '@types/mocha': ^8.2.2
       '@types/node': ~18.16.20
       chai: ^4.3.10
-      electron: ^27.0.0
+      electron: ^28.0.0
       eslint: ^8.44.0
       glob: ^7.1.2
       mocha: ^10.0.0
@@ -482,7 +482,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.20
       chai: 4.3.10
-      electron: 27.0.2
+      electron: 28.0.0
       eslint: 8.52.0
       glob: 7.2.3
       mocha: 10.2.0
@@ -1281,7 +1281,7 @@ importers:
       '@types/node': ~18.16.20
       chai: ^4.3.10
       cpx2: ^3.0.0
-      electron: ^27.0.0
+      electron: ^28.0.0
       eslint: ^8.44.0
       mocha: ^10.0.0
       rimraf: ^3.0.2
@@ -1293,11 +1293,11 @@ importers:
       '@itwin/core-electron': link:../../core/electron
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-geometry': link:../../core/geometry
-      electron: 27.0.2
+      electron: 28.0.0
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/eslint-plugin': 4.0.0-dev.44_tbd2sfde3bmfdyh2lekgkzvsmq
-      '@itwin/oidc-signin-tool': 3.6.1_ijhqvoftsy3b76kx6lhy7znwoq
+      '@itwin/oidc-signin-tool': 3.6.1_uagso5jgyxmkqv2rrwzfnyka74
       '@types/chai': 4.3.1
       '@types/mocha': 8.2.3
       '@types/node': 18.16.20
@@ -1711,7 +1711,7 @@ importers:
       crypto-browserify: 3.12.0
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^27.0.0
+      electron: ^28.0.0
       eslint: ^8.44.0
       fs-extra: ^8.1.0
       glob: ^7.1.2
@@ -1749,7 +1749,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_p77ba2kku4qr7amkn4zjjbxhyy
+      '@itwin/electron-authorization': 0.14.1_n35ochjadrfvmsysax3symqq4m
       '@itwin/express-server': link:../../core/express-server
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.1_wj555zckjupkhkzyssqqpl4sei
@@ -1760,7 +1760,7 @@ importers:
       azurite: 3.27.0
       chai: 4.3.10
       chai-as-promised: 7.1.1_chai@4.3.10
-      electron: 27.0.2
+      electron: 28.0.0
       fs-extra: 8.1.0
       sinon: 15.2.0
       sinon-chai: 3.7.0_chai@4.3.10+sinon@15.2.0
@@ -1770,7 +1770,7 @@ importers:
       '@itwin/eslint-plugin': 4.0.0-dev.44_tbd2sfde3bmfdyh2lekgkzvsmq
       '@itwin/itwins-client': 1.2.0
       '@itwin/object-storage-core': 2.1.1_wi4f5jl5k4hmcp6bi7ebuqypfm
-      '@itwin/oidc-signin-tool': 3.6.1_ijhqvoftsy3b76kx6lhy7znwoq
+      '@itwin/oidc-signin-tool': 3.6.1_uagso5jgyxmkqv2rrwzfnyka74
       '@types/chai': 4.3.1
       '@types/chai-as-promised': 7.1.7
       '@types/fs-extra': 4.0.14
@@ -2033,7 +2033,7 @@ importers:
       browserify-zlib: ^0.2.0
       buffer: ^6.0.3
       chai: ^4.3.10
-      electron: ^27.0.0
+      electron: ^28.0.0
       eslint: ^8.44.0
       express: ^4.16.3
       glob: ^7.1.2
@@ -2054,7 +2054,7 @@ importers:
       '@itwin/core-frontend': link:../../core/frontend
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/express-server': link:../../core/express-server
-      electron: 27.0.2
+      electron: 28.0.0
       express: 4.18.2
       semver: 7.5.4
       spdy: 4.0.2
@@ -2452,7 +2452,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^27.0.0
+      electron: ^28.0.0
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2481,14 +2481,14 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/core-quantity': link:../../core/quantity
-      '@itwin/electron-authorization': 0.14.1_p77ba2kku4qr7amkn4zjjbxhyy
+      '@itwin/electron-authorization': 0.14.1_n35ochjadrfvmsysax3symqq4m
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.1.1_wj555zckjupkhkzyssqqpl4sei
       '@itwin/imodels-access-frontend': 3.1.1_ueafa4slb6ohrhyf7kbp6egmha
       '@itwin/imodels-client-authoring': 3.1.0
       '@itwin/imodels-client-management': 3.1.0
-      '@itwin/oidc-signin-tool': 3.6.1_ijhqvoftsy3b76kx6lhy7znwoq
+      '@itwin/oidc-signin-tool': 3.6.1_uagso5jgyxmkqv2rrwzfnyka74
       '@itwin/reality-data-client': 1.1.0_mdtbcqczpmeuv6yjzfaigjndwi
       body-parser: 1.20.2
     devDependencies:
@@ -2505,7 +2505,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 27.0.2
+      electron: 28.0.0
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.52.0
       express: 4.18.2
@@ -2569,7 +2569,7 @@ importers:
       cross-env: ^5.1.4
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
-      electron: ^27.0.0
+      electron: ^28.0.0
       esbuild-plugin-external-global: ^1.0.1
       eslint: ^8.44.0
       express: ^4.16.3
@@ -2610,7 +2610,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_p77ba2kku4qr7amkn4zjjbxhyy
+      '@itwin/electron-authorization': 0.14.1_n35ochjadrfvmsysax3symqq4m
       '@itwin/frontend-devtools': link:../../core/frontend-devtools
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
@@ -2638,7 +2638,7 @@ importers:
       cross-env: 5.2.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      electron: 27.0.2
+      electron: 28.0.0
       esbuild-plugin-external-global: 1.0.1
       eslint: 8.52.0
       express: 4.18.2
@@ -2913,7 +2913,7 @@ importers:
       '@types/yargs': 17.0.19
       canonical-path: ^1.0.0
       detect-port: ~1.3.0
-      electron: ^27.0.0
+      electron: ^28.0.0
       eslint: ^8.44.0
       express: ^4.16.3
       jsonc-parser: ~2.0.3
@@ -2945,7 +2945,7 @@ importers:
       '@types/mocha': 8.2.3
       '@types/node': 18.16.20
       '@types/yargs': 17.0.19
-      electron: 27.0.2
+      electron: 28.0.0
       eslint: 8.52.0
       nyc: 15.1.0
       rimraf: 3.0.2
@@ -4163,7 +4163,7 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/certa/3.7.16_electron@27.0.2:
+  /@itwin/certa/3.7.16_electron@28.0.0:
     resolution: {integrity: sha512-qcc29bliDOWZ84gtGyikH4mFGVUPlUkiMEmH5S443VYK9CvvhW2ClZBtgqQewBhk4Bxyg2qQnBTD+qEgIkmvqA==}
     hasBin: true
     peerDependencies:
@@ -4173,7 +4173,7 @@ packages:
         optional: true
     dependencies:
       detect-port: 1.3.0
-      electron: 27.0.2
+      electron: 28.0.0
       express: 4.18.2
       jsonc-parser: 2.0.3
       lodash: 4.17.21
@@ -4225,7 +4225,7 @@ packages:
       '@itwin/core-bentley': link:../../core/bentley
     dev: false
 
-  /@itwin/electron-authorization/0.14.1_p77ba2kku4qr7amkn4zjjbxhyy:
+  /@itwin/electron-authorization/0.14.1_n35ochjadrfvmsysax3symqq4m:
     resolution: {integrity: sha512-NslwCLw129obJHBRMcV/MdykqbD7d93SKTYOOBdaEab2T2niGCmCTJAOkjcWiZZMU0SwmjyxmY9iqdZjvvIqCA==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
@@ -4234,7 +4234,7 @@ packages:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': 4.2.1_67wltvhdskk2oee2c3z2o4tfly
       '@openid/appauth': 1.3.1
-      electron: 27.0.2
+      electron: 28.0.0
       keytar: 7.9.0
       username: 5.1.0
     transitivePeerDependencies:
@@ -4405,12 +4405,12 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@itwin/oidc-signin-tool/3.6.1_ijhqvoftsy3b76kx6lhy7znwoq:
+  /@itwin/oidc-signin-tool/3.6.1_mdtbcqczpmeuv6yjzfaigjndwi:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/certa': 3.7.16_electron@27.0.2
+      '@itwin/certa': 3.7.16
       '@itwin/core-bentley': link:../../core/bentley
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -4423,12 +4423,12 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/oidc-signin-tool/3.6.1_mdtbcqczpmeuv6yjzfaigjndwi:
+  /@itwin/oidc-signin-tool/3.6.1_uagso5jgyxmkqv2rrwzfnyka74:
     resolution: {integrity: sha512-4M391FMMwPuRVZSC8DAtLlWlWMDwAVigI8ZY5gvPkHTOOHSAKPxFxZD/zXsySJ3Rn+tFNpP6DctU6OVxrYolRQ==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0
     dependencies:
-      '@itwin/certa': 3.7.16
+      '@itwin/certa': 3.7.16_electron@28.0.0
       '@itwin/core-bentley': link:../../core/bentley
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -7030,8 +7030,8 @@ packages:
   /electron-to-chromium/1.4.568:
     resolution: {integrity: sha512-3TCOv8+BY6Ltpt1/CmGBMups2IdKOyfEmz4J8yIS4xLSeMm0Rf+psSaxLuswG9qMKt+XbNbmADybtXGpTFlbDg==}
 
-  /electron/27.0.2:
-    resolution: {integrity: sha512-4fbcHQ40ZDlqhr5Pamm+M5BF7ry2lGqjFTWTJ/mrBwuiPWu6xhV/RWgUhKBaLqKNfAaNl3eMxV3Jc82gv6JauQ==}
+  /electron/28.0.0:
+    resolution: {integrity: sha512-eDhnCFBvG0PGFVEpNIEdBvyuGUBsFdlokd+CtuCe2ER3P+17qxaRfWRxMmksCOKgDHb5Wif5UxqOkZSlA4snlw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -39,7 +39,7 @@
     "@itwin/core-bentley": "workspace:^4.3.0-dev.35",
     "@itwin/core-common": "workspace:^4.3.0-dev.35",
     "@itwin/core-frontend": "workspace:^4.3.0-dev.35",
-    "electron": ">=23.0.0 <28.0.0"
+    "electron": ">=23.0.0 <29.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",
@@ -53,7 +53,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "~18.16.20",
     "chai": "^4.3.10",
-    "electron": "^27.0.0",
+    "electron": "^28.0.0",
     "eslint": "^8.44.0",
     "glob": "^7.1.2",
     "mocha": "^10.0.0",

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -9,7 +9,7 @@ Table of contents:
   - [Clip any curve](#clip-any-curve)
 - [ECSQL instance properties](#ecsql-instance-properties)
 - [Node 20 support](#node-20-support)
-- [Electron 27 support](#electron-27-support)
+- [Electron 27 and Electron 28 support](#electron-27-and-electron-28-support)
 - [Element aspects require locking](#element-aspects-require-locking)
 - [Display](#display)
   - [Colorizing clip intersections](#colorizing-clip-intersections)
@@ -32,9 +32,9 @@ ECSQL supports querying instance properties, which are any property in a class s
 
 iTwin.js now officially supports Node 20 starting with LTS version of 20.9.0. Node 20 support is in addition to Node 18, not a replacement.
 
-## Electron 27 support
+## Electron 27 and Electron 28 support
 
-In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 27](https://www.electronjs.org/blog/electron-27-0).
+In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 27](https://www.electronjs.org/blog/electron-27-0) and [Electron 28](https://releases.electronjs.org/release/v28.0.0).
 
 ## Element aspects require locking
 

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -23,7 +23,7 @@
     "@itwin/core-electron": "workspace:*",
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-geometry": "workspace:*",
-    "electron": "^27.0.0"
+    "electron": "^28.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -53,7 +53,7 @@
     "azurite": "^3.24.0",
     "chai-as-promised": "^7",
     "chai": "^4.3.10",
-    "electron": "^27.0.0",
+    "electron": "^28.0.0",
     "fs-extra": "^8.1.0",
     "sinon-chai": "^3.2.0",
     "sinon": "^15.0.4"

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -26,7 +26,7 @@
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-mobile": "workspace:*",
     "@itwin/express-server": "workspace:*",
-    "electron": "^27.0.0",
+    "electron": "^28.0.0",
     "express": "^4.16.3",
     "semver": "^7.3.5",
     "spdy": "^4.0.1"

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -72,7 +72,7 @@
     "cpx2": "^3.0.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^27.0.0",
+    "electron": "^28.0.0",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -91,7 +91,7 @@
     "cross-env": "^5.1.4",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^27.0.0",
+    "electron": "^28.0.0",
     "esbuild-plugin-external-global": "^1.0.1",
     "eslint": "^8.44.0",
     "express": "^4.16.3",

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -52,14 +52,14 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "~18.16.20",
     "@types/yargs": "17.0.19",
-    "electron": "^27.0.0",
+    "electron": "^28.0.0",
     "eslint": "^8.44.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
     "typescript": "~5.0.2"
   },
   "peerDependencies": {
-    "electron": ">=23.0.0 <28.0.0"
+    "electron": ">=23.0.0 <29.0.0"
   },
   "peerDependenciesMeta": {
     "electron": {


### PR DESCRIPTION
#### Changes:
- Extend range of supported Electron versions with Electron 28.
- Increase Electron dev dependency version to `^28.0.0`.

No code changes required since core doesn't use [APIs changed in 28](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#planned-breaking-api-changes-280).