### PR TITLE
Fix bug in changesetECAdaptor

### DIFF
--- a/common/changes/@itwin/core-backend/nick-disableschemachecktrue_2023-12-05-18-03.json
+++ b/common/changes/@itwin/core-backend/nick-disableschemachecktrue_2023-12-05-18-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/ChangesetECAdaptor.ts
+++ b/core/backend/src/ChangesetECAdaptor.ts
@@ -72,7 +72,7 @@ class ECDbMap {
               AND ([cs].[Name] = :className))
     `;
     return this.db.withPreparedSqliteStatement(sql, (stmt) => {
-      const parts = classFullName.indexOf(".") ? classFullName.split(".") : classFullName.split(":");
+      const parts = classFullName.indexOf(".") !== -1 ? classFullName.split(".") : classFullName.split(":");
       stmt.bindString(":schemaNameOrAlias", parts[0]);
       stmt.bindString(":className", parts[1]);
       const classIds = [];


### PR DESCRIPTION
-1 is truthy, so when classFullName contains a : and not a ., it still splits on "." and then parts is an array of length 1.