### PR TITLE
Raise an event when mobile backend connects to frontend

### DIFF
--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -180,19 +180,12 @@ export class MobileHost {
     // (undocumented)
     static get isValid(): boolean;
     static notifyMobileFrontend<T extends keyof MobileNotifications>(methodName: T, ...args: Parameters<MobileNotifications[T]>): void;
-    // (undocumented)
     static readonly onAuthAccessTokenChanged: BeEvent<(accessToken: string | undefined, expirationDate: string | undefined) => void>;
-    // (undocumented)
     static readonly onConnected: BeEvent<Listener>;
-    // (undocumented)
     static readonly onEnterBackground: BeEvent<Listener>;
-    // (undocumented)
     static readonly onEnterForeground: BeEvent<Listener>;
-    // (undocumented)
     static readonly onMemoryWarning: BeEvent<Listener>;
-    // (undocumented)
     static readonly onOrientationChanged: BeEvent<Listener>;
-    // (undocumented)
     static readonly onWillTerminate: BeEvent<Listener>;
     // @internal (undocumented)
     static reconnect(connection: number): void;

--- a/common/api/core-mobile.api.md
+++ b/common/api/core-mobile.api.md
@@ -183,6 +183,8 @@ export class MobileHost {
     // (undocumented)
     static readonly onAuthAccessTokenChanged: BeEvent<(accessToken: string | undefined, expirationDate: string | undefined) => void>;
     // (undocumented)
+    static readonly onConnected: BeEvent<Listener>;
+    // (undocumented)
     static readonly onEnterBackground: BeEvent<Listener>;
     // (undocumented)
     static readonly onEnterForeground: BeEvent<Listener>;

--- a/common/changes/@itwin/core-mobile/travis-mobile-connect-event_2023-12-12-00-07.json
+++ b/common/changes/@itwin/core-mobile/travis-mobile-connect-event_2023-12-12-00-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "Add onConnected event to MobileHost.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -102,7 +102,7 @@ export class MobileHost {
   /**
    * Raised when the mobile OS informs a mobile app that it is running low on memory.
    *
-   * __Note:__ iOS and iPadOS send this warning so often as to make it not very useful.
+   * @note iOS and iPadOS send this warning so often as to make it not very useful.
    */
   public static readonly onMemoryWarning = new BeEvent();
   /**
@@ -120,7 +120,7 @@ export class MobileHost {
   /**
    * Raised after a mobile backend connects to the mobile frontend.
    *
-   * __Note:__ this will be raised at startup, and it will also be raised every time the app returns
+   * @note this will be raised at startup, and it will also be raised every time the app returns
    * to the foreground from the background.
    */
   public static readonly onConnected = new BeEvent();

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -99,12 +99,38 @@ export interface MobileHostOpts extends NativeHostOpts {
 export class MobileHost {
   private static _device?: MobileDevice;
   public static get device() { return this._device!; }
+  /**
+   * Raised when the mobile OS informs a mobile app that it is running low on memory.
+   *
+   * __Note:__ iOS and iPadOS send this warning so often as to make it not very useful.
+   */
   public static readonly onMemoryWarning = new BeEvent();
+  /**
+   * Raised when the device orientation changes on a device running a mobile app.
+   */
   public static readonly onOrientationChanged = new BeEvent();
+  /**
+   * Raised after a mobile app returns to the foreground.
+   */
   public static readonly onEnterForeground = new BeEvent();
+  /**
+   * Raised when a mobile app is about to enter the background.
+   */
   public static readonly onEnterBackground = new BeEvent();
+  /**
+   * Raised after a mobile backend connects to the mobile frontend.
+   *
+   * __Note:__ this will be raised at startup, and it will also be raised every time the app returns
+   * to the foreground from the background.
+   */
   public static readonly onConnected = new BeEvent();
+  /**
+   * Raised when a mobile app is about to be terminated by the mobile OS.
+   */
   public static readonly onWillTerminate = new BeEvent();
+  /**
+   * Raised when the native auth client informs the mobile host that the access token has changed.
+   */
   public static readonly onAuthAccessTokenChanged = new BeEvent<(accessToken: string | undefined, expirationDate: string | undefined) => void>();
 
   /** Send a notification to the MobileApp connected to this MobileHost. */

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -103,6 +103,7 @@ export class MobileHost {
   public static readonly onOrientationChanged = new BeEvent();
   public static readonly onEnterForeground = new BeEvent();
   public static readonly onEnterBackground = new BeEvent();
+  public static readonly onConnected = new BeEvent();
   public static readonly onWillTerminate = new BeEvent();
   public static readonly onAuthAccessTokenChanged = new BeEvent<(accessToken: string | undefined, expirationDate: string | undefined) => void>();
 

--- a/core/mobile/src/backend/MobileRpcServer.ts
+++ b/core/mobile/src/backend/MobileRpcServer.ts
@@ -83,6 +83,7 @@ export class MobileRpcServer {
       this._createSender();
       this._sendPending();
       (global as any).__iTwinJsRpcReady = true;
+      MobileHost.onConnected.raiseEvent();
     });
   }
 


### PR DESCRIPTION
This is a complement to a future PR that will cause IpcHost.send to throw an exception when the backend and frontend are not connected. (Right now it crashes the mobile app.) Any code that catches that exception can then record the fact somewhere and add an onConnect handler.