### PR TITLE
Fix mobile backend to frontend communication

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -8054,7 +8054,7 @@ export class RpcManager {
 // @internal (undocumented)
 export class RpcMarshaling {
     static deserialize(protocol: RpcProtocol | undefined, value: RpcSerializedValue): any;
-    static serialize(protocol: RpcProtocol | undefined, value: any): Promise<RpcSerializedValue>;
+    static serialize(protocol: RpcProtocol | undefined, value: any): RpcSerializedValue;
 }
 
 // @internal

--- a/common/changes/@itwin/core-common/travis-send-to-frontend-not-async_2023-12-12-22-54.json
+++ b/common/changes/@itwin/core-common/travis-send-to-frontend-not-async_2023-12-12-22-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-electron/travis-send-to-frontend-not-async_2023-12-12-23-30.json
+++ b/common/changes/@itwin/core-electron/travis-send-to-frontend-not-async_2023-12-12-23-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/changes/@itwin/core-mobile/travis-send-to-frontend-not-async_2023-12-12-22-54.json
+++ b/common/changes/@itwin/core-mobile/travis-send-to-frontend-not-async_2023-12-12-22-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/common/src/rpc/core/RpcInvocation.ts
+++ b/core/common/src/rpc/core/RpcInvocation.ts
@@ -220,7 +220,7 @@ export class RpcInvocation {
   private async fulfillResolved(value: any): Promise<RpcRequestFulfillment> {
     this._timeOut = new Date().getTime();
     this.protocol.events.raiseEvent(RpcProtocolEvent.BackendResponseCreated, this);
-    const result = await RpcMarshaling.serialize(this.protocol, value);
+    const result = RpcMarshaling.serialize(this.protocol, value);
     return this.fulfill(result, value);
   }
 
@@ -229,7 +229,7 @@ export class RpcInvocation {
     if (!RpcConfiguration.developmentMode)
       reason.stack = undefined;
 
-    const result = await RpcMarshaling.serialize(this.protocol, reason);
+    const result = RpcMarshaling.serialize(this.protocol, reason);
 
     if (reason instanceof RpcPendingResponse) {
       this._pending = true;

--- a/core/common/src/rpc/core/RpcMarshaling.ts
+++ b/core/common/src/rpc/core/RpcMarshaling.ts
@@ -55,7 +55,7 @@ export class RpcMarshaling {
   private constructor() { }
 
   /** Serializes a value. */
-  public static async serialize(protocol: RpcProtocol | undefined, value: any): Promise<RpcSerializedValue> {
+  public static serialize(protocol: RpcProtocol | undefined, value: any): RpcSerializedValue {
     const serialized = RpcSerializedValue.create();
 
     if (typeof (value) === "undefined") {

--- a/core/common/src/rpc/core/RpcProtocol.ts
+++ b/core/common/src/rpc/core/RpcProtocol.ts
@@ -72,7 +72,7 @@ export interface RpcRequestFulfillment {
 /** @internal */
 export namespace RpcRequestFulfillment {
   export async function forUnknownError(request: SerializedRpcRequest, error: any): Promise<RpcRequestFulfillment> {
-    const result = await RpcMarshaling.serialize(undefined, error);
+    const result = RpcMarshaling.serialize(undefined, error);
 
     return {
       interfaceName: request.operation.interfaceDefinition,
@@ -202,7 +202,7 @@ export abstract class RpcProtocol {
       },
       method: request.method,
       path: request.path,
-      parameters: await RpcMarshaling.serialize(request.protocol, request.parameters),
+      parameters: RpcMarshaling.serialize(request.protocol, request.parameters),
       caching: RpcResponseCacheControl.None,
       protocolVersion: RpcProtocol.protocolVersion,
     };

--- a/core/electron/src/common/ElectronPush.ts
+++ b/core/electron/src/common/ElectronPush.ts
@@ -47,7 +47,7 @@ export class ElectronPushConnection<T> extends RpcPushConnection<T> {
   }
 
   public async send(messageData: any) {
-    const result = await RpcMarshaling.serialize(this._ipc.protocol, messageData);
+    const result = RpcMarshaling.serialize(this._ipc.protocol, messageData);
     const fulfillment: RpcRequestFulfillment = { result, rawResult: messageData, interfaceName: PUSH, id: this.channel.id, status: ++this._next };
     this._ipc.sendResponse(fulfillment, undefined);
   }

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -11,7 +11,6 @@ import { ProgressCallback } from "./Request";
 import { mobileAppStrings } from "../common/MobileAppChannel";
 import { BatteryState, DeviceEvents, MobileAppFunctions, MobileNotifications, Orientation } from "../common/MobileAppProps";
 import { MobileRpcManager } from "../common/MobileRpcManager";
-import { MobileRpcProtocol } from "../common/MobileRpcProtocol";
 import { MobileAuthorizationBackend } from "./MobileAuthorizationBackend";
 import { setupMobileRpc } from "./MobileRpcServer";
 

--- a/core/mobile/src/backend/MobileHost.ts
+++ b/core/mobile/src/backend/MobileHost.ts
@@ -200,16 +200,15 @@ export class MobileHost {
     if (!this.isValid) {
       this._device = opt?.mobileHost?.device ?? new (MobileDevice as any)();
       // set global device interface.
+      // NOTE: __iTwinJsNativeBridge is used by backend native code.
       (global as any).__iTwinJsNativeBridge = this._device;
       this.onMemoryWarning.addListener(() => {
         MobileHost.notifyMobileFrontend("notifyMemoryWarning");
       });
       this.onOrientationChanged.addListener(() => {
-        // If there is no connection to the frontend, MobileHost.notifyMobileFrontend will just
-        // crash the app. So only notify if there is a connection to the frontend.
-        if (MobileRpcProtocol.obtainInterop().connectionId !== 0) {
+        try {
           MobileHost.notifyMobileFrontend("notifyOrientationChanged");
-        }
+        } catch (_ex) { } // Ignore: frontend is not currently connected
       });
       this.onWillTerminate.addListener(() => {
         MobileHost.notifyMobileFrontend("notifyWillTerminate");

--- a/core/mobile/src/backend/MobileRpcServer.ts
+++ b/core/mobile/src/backend/MobileRpcServer.ts
@@ -189,6 +189,7 @@ export function setupMobileRpc() {
     server.dispose();
     usePendingSender();
     server = null;
+    (global as any).__iTwinJsRpcReady = false;
   });
 
   MobileHost.onEnterForeground.addListener(() => {

--- a/core/mobile/src/common/MobileIpc.ts
+++ b/core/mobile/src/common/MobileIpc.ts
@@ -39,7 +39,7 @@ export class MobileIpcTransport extends IpcWebSocketTransport {
     if (message.type === IpcWebSocketMessageType.Send || message.type === IpcWebSocketMessageType.Invoke) {
       this.sendToBackend(message); // eslint-disable-line @typescript-eslint/no-floating-promises
     } else if (message.type === IpcWebSocketMessageType.Push || message.type === IpcWebSocketMessageType.Response) {
-      this.sendToFrontend(message); // eslint-disable-line @typescript-eslint/no-floating-promises
+      this.sendToFrontend(message);
     }
   }
 
@@ -68,9 +68,9 @@ export class MobileIpcTransport extends IpcWebSocketTransport {
     request.dispose();
   }
 
-  private async sendToFrontend(message: IpcWebSocketMessage) {
+  private sendToFrontend(message: IpcWebSocketMessage) {
     MobileEventLoop.addTask();
-    const result = await RpcMarshaling.serialize(this._protocol, message);
+    const result = RpcMarshaling.serialize(this._protocol, message);
     MobileEventLoop.removeTask();
 
     const fulfillment: RpcRequestFulfillment = { result, rawResult: message, interfaceName: IPC, id: message.channel, status: 0 };

--- a/core/mobile/src/common/MobilePush.ts
+++ b/core/mobile/src/common/MobilePush.ts
@@ -54,7 +54,7 @@ export class MobilePushConnection<T> extends RpcPushConnection<T> {
 
   public async send(messageData: any) {
     MobileEventLoop.addTask();
-    const result = await RpcMarshaling.serialize(this._protocol, messageData);
+    const result = RpcMarshaling.serialize(this._protocol, messageData);
     MobileEventLoop.removeTask();
 
     const fulfillment: RpcRequestFulfillment = { result, rawResult: messageData, interfaceName: PUSH, id: this.channel.id, status: ++this._next };


### PR DESCRIPTION
The main fix is to make MobileIpc.sendToFrontend not be async so that if an error happens it does not crash the whole app. This required RpcMarshaling.serialize to also not be async.