### PR TITLE
Add glyph data to TextString

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,9 @@
 {
   "debug.internalConsoleOptions": "openOnSessionStart",
   "editor.codeActionsOnSave": {
-    "editor.action.fixAll": true,
-    "source.fixAll.eslint": true,
-    "source.fixAll.markdownlint": true
+    "editor.action.fixAll": "explicit",
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.markdownlint": "explicit"
   },
   "editor.insertSpaces": true,
   "editor.formatOnSave": true,

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -9225,6 +9225,8 @@ export class TextString {
     constructor(props: TextStringProps);
     bold?: boolean;
     font: FontId;
+    glyphIds?: number[];
+    glyphOrigins?: Point2d[];
     // (undocumented)
     height: number;
     italic?: boolean;
@@ -9254,6 +9256,8 @@ export interface TextStringPrimitive {
 export interface TextStringProps {
     bold?: boolean;
     font: FontId;
+    glyphIds?: number[];
+    glyphOrigins?: Point2d[];
     // (undocumented)
     height: number;
     italic?: boolean;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2637,7 +2637,7 @@ export namespace ElementGeometry {
     export function fromGeometryQuery(geom: GeometryQuery, worldToLocal?: Transform): ElementGeometryDataEntry | undefined;
     export function fromImageGraphic(image: ImageGraphicProps, worldToLocal?: Transform): ElementGeometryDataEntry | undefined;
     export function fromSubGraphicRange(bbox: ElementAlignedBox3d): ElementGeometryDataEntry | undefined;
-    export function fromTextString(text: TextStringProps, worldToLocal?: Transform): ElementGeometryDataEntry | undefined;
+    export function fromTextString(text: TextStringProps, worldToLocal?: Transform, glyphs?: TextStringGlyphData): ElementGeometryDataEntry | undefined;
     export function getBRepEntityType(entry: ElementGeometryDataEntry): BRepEntity.Type | undefined;
     export function isAppearanceEntry(entry: ElementGeometryDataEntry): boolean;
     export function isCurve(entry: ElementGeometryDataEntry): boolean;
@@ -2690,6 +2690,7 @@ export namespace ElementGeometry {
     export function toImageGraphic(entry: ElementGeometryDataEntry, localToWorld?: Transform): ImageGraphicProps | undefined;
     export function toSubGraphicRange(entry: ElementGeometryDataEntry): ElementAlignedBox3d | undefined;
     export function toTextString(entry: ElementGeometryDataEntry, localToWorld?: Transform): TextStringProps | undefined;
+    export function toTextStringGlyphData(entry: ElementGeometryDataEntry): TextStringGlyphData | undefined;
     export function toTransform(sourceToWorld: Float64Array): Transform | undefined;
     export function transformBRep(entry: ElementGeometryDataEntry, inputTransform: Transform): boolean;
     export function updateGeometryParams(entry: ElementGeometryDataEntry, geomParams: GeometryParams, localToWorld?: Transform): boolean;
@@ -9225,8 +9226,6 @@ export class TextString {
     constructor(props: TextStringProps);
     bold?: boolean;
     font: FontId;
-    glyphIds?: number[];
-    glyphOrigins?: Point2d[];
     // (undocumented)
     height: number;
     italic?: boolean;
@@ -9245,6 +9244,16 @@ export class TextString {
 }
 
 // @public
+export interface TextStringGlyphData {
+    // (undocumented)
+    glyphIds: number[];
+    // (undocumented)
+    glyphOrigins: Point2d[];
+    // (undocumented)
+    range: Range2d;
+}
+
+// @public
 export interface TextStringPrimitive {
     // (undocumented)
     readonly textString: TextString;
@@ -9256,8 +9265,6 @@ export interface TextStringPrimitive {
 export interface TextStringProps {
     bold?: boolean;
     font: FontId;
-    glyphIds?: number[];
-    glyphOrigins?: Point2d[];
     // (undocumented)
     height: number;
     italic?: boolean;

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -775,6 +775,7 @@ deprecated;TerrainProviderName = string
 public;TerrainSettings
 internal;TestRpcManager
 public;TextString
+public;TextStringGlyphData
 public;TextStringPrimitive
 public;TextStringProps
 public;TextureData

--- a/common/changes/@itwin/core-backend/jf-glyph_2023-12-13-15-06.json
+++ b/common/changes/@itwin/core-backend/jf-glyph_2023-12-13-15-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/jf-glyph_2023-12-13-15-06.json
+++ b/common/changes/@itwin/core-common/jf-glyph_2023-12-13-15-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -1761,7 +1761,7 @@ describe("ElementGeometry", () => {
       glyphIds: [1, 2, 3],
       glyphOrigins: [new Point2d(0.0, 0.0), new Point2d(1000.0, 0.0), new Point2d(2000.0, 0.0)],
       range: new Range2d(0, 0, 10, 30),
-    }
+    };
 
     const entry = ElementGeometry.fromTextString(textProps, undefined, glyphData);
     assert.exists(entry);

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -192,11 +192,9 @@ function validateElementInfo(info: ElementGeometryInfo, expected: ExpectedElemen
           break;
         case ElementGeometryOpcode.TextString:
           const text = ElementGeometry.toTextString(entry);
-          const textGlyphData = ElementGeometry.toTextStringGlyphData(entry);
           assert.exists(text);
           if (!isWorld && undefined !== expected[i].originalEntry) {
             const other = ElementGeometry.toTextString(expected[i].originalEntry!);
-            const otherGlyphData = ElementGeometry.toTextStringGlyphData(expected[i].originalEntry!);
             assert.exists(other);
             assert.isTrue(text?.font === other?.font);
             assert.isTrue(text?.text === other?.text);
@@ -211,7 +209,6 @@ function validateElementInfo(info: ElementGeometryInfo, expected: ExpectedElemen
             const angles = YawPitchRollAngles.fromJSON(text?.rotation);
             const otherAngles = YawPitchRollAngles.fromJSON(other?.rotation);
             assert.isTrue(angles.isAlmostEqual(otherAngles));
-            assert.deepEqual(textGlyphData, otherGlyphData);
           }
           break;
         case ElementGeometryOpcode.Image:
@@ -1732,7 +1729,7 @@ describe("ElementGeometry", () => {
     assert(IModelStatus.Success === doElementGeometryValidate(imodel, newId, expectedFacet, false, undefined, 1));
   });
 
-  it.only("create GeometricElement3d from local coordinate text string flatbuffer data", async () => {
+  it("create GeometricElement3d from local coordinate text string flatbuffer data", async () => {
     // Set up element to be placed in iModel
     const seedElement = imodel.elements.getElement<GeometricElement>("0x1d");
     assert.exists(seedElement);
@@ -1769,6 +1766,9 @@ describe("ElementGeometry", () => {
     const entry = ElementGeometry.fromTextString(textProps, undefined, glyphData);
     assert.exists(entry);
     newEntries.push(entry!);
+    // We can't validate glyph data later from the TextString in the DB because the native TextString will re-compute them if the font isn't embedded.
+    // So, just verify that we are passing the correct flatbuffer here.
+    assert.deepEqual(entry ? ElementGeometry.toTextStringGlyphData(entry) : undefined, glyphData);
     expected.push({ opcode: ElementGeometryOpcode.TextString, originalEntry: entry });
 
     elementProps.elementGeometryBuilderParams = { entryArray: newEntries };

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -209,6 +209,8 @@ function validateElementInfo(info: ElementGeometryInfo, expected: ExpectedElemen
             const angles = YawPitchRollAngles.fromJSON(text?.rotation);
             const otherAngles = YawPitchRollAngles.fromJSON(other?.rotation);
             assert.isTrue(angles.isAlmostEqual(otherAngles));
+            assert.sameOrderedMembers(text?.glyphIds ?? [], other?.glyphIds ?? []);
+            assert.sameOrderedMembers(text?.glyphOrigins ?? [], other?.glyphOrigins ?? []);
           }
           break;
         case ElementGeometryOpcode.Image:
@@ -1755,6 +1757,8 @@ describe("ElementGeometry", () => {
       bold: true,
       origin: testOrigin,
       rotation: testAngles,
+      glyphIds: [1, 2, 3],
+      glyphOrigins: [new Point2d(0.0, 0.0), new Point2d(1000.0, 0.0), new Point2d(2000.0, 0.0)],
     };
 
     const entry = ElementGeometry.fromTextString(textProps);

--- a/core/common/src/geometry/ElementGeometry.ts
+++ b/core/common/src/geometry/ElementGeometry.ts
@@ -7,7 +7,7 @@
  */
 import { flatbuffers } from "flatbuffers";
 import { Id64, Id64String } from "@itwin/core-bentley";
-import { Angle, AngleSweep, Arc3d, BentleyGeometryFlatBuffer, CurveCollection, FrameBuilder, GeometryQuery, LineString3d, Loop, Matrix3d, Plane3dByOriginAndUnitNormal, Point2d, Point3d, Point3dArray, PointString3d, Polyface, PolyfaceQuery, Range2d, Range3d, SolidPrimitive, Transform, Vector3d, XYProps, YawPitchRollAngles } from "@itwin/core-geometry";
+import { Angle, AngleSweep, Arc3d, BentleyGeometryFlatBuffer, CurveCollection, FrameBuilder, GeometryQuery, LineString3d, Loop, Matrix3d, Plane3dByOriginAndUnitNormal, Point2d, Point3d, Point3dArray, PointString3d, Polyface, PolyfaceQuery, Range2d, Range3d, SolidPrimitive, Transform, Vector3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { EGFBAccessors } from "./ElementGeometryFB";
 import { Base64EncodedString } from "../Base64EncodedString";
 import { TextString, TextStringGlyphData, TextStringProps } from "./TextString";
@@ -1073,14 +1073,14 @@ export namespace ElementGeometry {
       if (!origin)
         throw new Error("Value cannot be null.");
       return new Point2d(origin.x(), origin.y());
-    }
-    const textStringRangeToRange2d = (range: EGFBAccessors.TextStringRange | null) => range ? new Range2d(range.lowx(), range.lowy(), range.highx(), range.highy()) : null;
+    };
+    const textStringRangeToRange2d = (r: EGFBAccessors.TextStringRange | null) => r ? new Range2d(r.lowx(), r.lowy(), r.highx(), r.highy()) : null;
     const range = textStringRangeToRange2d(ppfb.range());
     const glyphIds = Array.from({ length: ppfb.glyphIdsLength() }, (_, i) => ppfb.glyphIds(i) ?? 0);
     const glyphOrigins = Array.from({ length: ppfb.glyphOriginsLength() }, (_, i) => glyphOriginToPoint2d(ppfb.glyphOrigins(i)));
-    if (!range || range.isNull || glyphIds.length == 0 || glyphOrigins.length == 0)
+    if (!range || range.isNull || glyphIds.length === 0 || glyphOrigins.length === 0)
       return undefined;
-    return { glyphIds, glyphOrigins, range }
+    return { glyphIds, glyphOrigins, range };
   }
 
   /** Create entry from a [[TextString]] */

--- a/core/common/src/geometry/ElementGeometry.ts
+++ b/core/common/src/geometry/ElementGeometry.ts
@@ -1102,7 +1102,7 @@ export namespace ElementGeometry {
         return undefined;
       const glyphIdsOffset = builder.createGlyphIdsVector(fbb, glyphs.glyphIds);
       builder.startGlyphOriginsVector(fbb, glyphs.glyphOrigins.length);
-      for (const origin of glyphs.glyphOrigins) {
+      for (const origin of [...glyphs.glyphOrigins].reverse()) {
         EGFBAccessors.TextStringGlyphOrigin.createTextStringGlyphOrigin(fbb, origin.x, origin.y);
       }
       const glyphOriginsOffset = fbb.endVector();

--- a/core/common/src/geometry/TextString.ts
+++ b/core/common/src/geometry/TextString.ts
@@ -6,7 +6,7 @@
  * @module Geometry
  */
 
-import { Point2d, Point3d, Range2d, Transform, Vector3d, XYProps, XYZProps, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
+import { Point2d, Point3d, Range2d, Transform, Vector3d, XYZProps, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
 import { FontId } from "../Fonts";
 
 /**

--- a/core/common/src/geometry/TextString.ts
+++ b/core/common/src/geometry/TextString.ts
@@ -6,8 +6,17 @@
  * @module Geometry
  */
 
-import { Point2d, Point3d, Transform, Vector3d, XYZProps, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
+import { Point2d, Point3d, Range2d, Transform, Vector3d, XYProps, XYZProps, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
 import { FontId } from "../Fonts";
+
+/**
+ * Optional cached text layout information used to support legacy proxy graphics.
+ */
+export interface TextStringGlyphData {
+  glyphIds: number[];
+  glyphOrigins: Point2d[];
+  range: Range2d;
+}
 
 /** Properties for a TextString class.
  * @see [[GeometryStreamEntryProps]]
@@ -33,10 +42,6 @@ export interface TextStringProps {
   origin?: XYZProps;
   /** Optional rotation relative to element's placement. Default is identity matrix */
   rotation?: YawPitchRollProps;
-  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
-  glyphIds?: number[];
-  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
-  glyphOrigins?: Point2d[];
 }
 
 /** A single line of text, all with the same font, styles (underline, bold, italic), and size.
@@ -63,10 +68,6 @@ export class TextString {
   public readonly origin: Point3d;
   /** Rotation relative to element's placement */
   public readonly rotation: YawPitchRollAngles;
-  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
-  glyphIds?: number[];
-  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
-  glyphOrigins?: Point2d[];
   public get width() { return this.height * (this.widthFactor ? this.widthFactor : 1.0); }
 
   public constructor(props: TextStringProps) {
@@ -94,10 +95,6 @@ export class TextString {
       val.origin = this.origin;
     if (!this.rotation.isIdentity())
       val.rotation = this.rotation;
-    if (this.glyphIds)
-      val.glyphIds = this.glyphIds;
-    if (this.glyphOrigins)
-      val.glyphOrigins = this.glyphOrigins;
 
     return val;
   }

--- a/core/common/src/geometry/TextString.ts
+++ b/core/common/src/geometry/TextString.ts
@@ -6,7 +6,7 @@
  * @module Geometry
  */
 
-import { Point3d, Transform, Vector3d, XYZProps, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
+import { Point2d, Point3d, Transform, Vector3d, XYZProps, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
 import { FontId } from "../Fonts";
 
 /** Properties for a TextString class.
@@ -33,6 +33,10 @@ export interface TextStringProps {
   origin?: XYZProps;
   /** Optional rotation relative to element's placement. Default is identity matrix */
   rotation?: YawPitchRollProps;
+  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  glyphIds?: number[];
+  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  glyphOrigins?: Point2d[];
 }
 
 /** A single line of text, all with the same font, styles (underline, bold, italic), and size.
@@ -59,6 +63,10 @@ export class TextString {
   public readonly origin: Point3d;
   /** Rotation relative to element's placement */
   public readonly rotation: YawPitchRollAngles;
+  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  glyphIds?: number[];
+  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  glyphOrigins?: Point2d[];
   public get width() { return this.height * (this.widthFactor ? this.widthFactor : 1.0); }
 
   public constructor(props: TextStringProps) {
@@ -84,9 +92,12 @@ export class TextString {
     val.underline = this.underline;
     if (!this.origin.isAlmostZero)
       val.origin = this.origin;
-
     if (!this.rotation.isIdentity())
       val.rotation = this.rotation;
+    if (this.glyphIds)
+      val.glyphIds = this.glyphIds;
+    if (this.glyphOrigins)
+      val.glyphOrigins = this.glyphOrigins;
 
     return val;
   }

--- a/core/common/src/geometry/TextString.ts
+++ b/core/common/src/geometry/TextString.ts
@@ -33,9 +33,9 @@ export interface TextStringProps {
   origin?: XYZProps;
   /** Optional rotation relative to element's placement. Default is identity matrix */
   rotation?: YawPitchRollProps;
-  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
   glyphIds?: number[];
-  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
   glyphOrigins?: Point2d[];
 }
 
@@ -63,9 +63,9 @@ export class TextString {
   public readonly origin: Point3d;
   /** Rotation relative to element's placement */
   public readonly rotation: YawPitchRollAngles;
-  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
   glyphIds?: number[];
-  /** Optional cached text layout information. If undefined, it will be computed at display time. Default is undefined. */
+  /** Optional cached text layout information used to support legacy proxy graphics. If undefined, it will be computed at display time. Default is undefined. */
   glyphOrigins?: Point2d[];
   public get width() { return this.height * (this.widthFactor ? this.widthFactor : 1.0); }
 


### PR DESCRIPTION
There is the ability to include text layout data in the flatbuffer of TextString rather than computing them at display time. Batch connector (in C++) uses this to preserve visual fidelity between MicroStation and IModels. This PR adds the same data in the TypeScript library so that the live sync connector can do this as well.