### PR TITLE
add 4.3.0 changelogs to left nav

### DIFF
--- a/docs/changehistory/leftNav.md
+++ b/docs/changehistory/leftNav.md
@@ -10,6 +10,7 @@ closedPanels: ["Previous Versions", "Changelogs"]
 
 ### Versions
 
+- [4.3.0](./4.3.0.md)
 - [4.2.0](./4.2.0.md)
 - [4.1.0](./4.1.0.md)
 - [4.0.0](./4.0.0.md)


### PR DESCRIPTION
Adds the missing 4.3.0 changelogs to our change history. We should also consider a eslint rule for formatting `leftNav.md` files as extra spaces cause paragraphs to be inserted which breaks the nav.