### PR TITLE
Support civil use case that requires update be able to clear the geometry stream.

### DIFF
--- a/common/changes/@itwin/core-backend/clear-geometry-stream-2_2023-12-20-14-45.json
+++ b/common/changes/@itwin/core-backend/clear-geometry-stream-2_2023-12-20-14-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/clear-geometry-stream-2_2023-12-20-14-45.json
+++ b/common/changes/@itwin/core-common/clear-geometry-stream-2_2023-12-20-14-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -2294,6 +2294,28 @@ describe("ElementGeometry", () => {
     }
   });
 
+  it("create and update a GeometricElement3d to test clearing its geometry stream", async () => {
+    const seedElement = imodel.elements.getElement<GeometricElement>("0x1d");
+    assert.exists(seedElement);
+    assert.isTrue(seedElement.federationGuid! === "18eb4650-b074-414f-b961-d9cfaa6c8746");
+
+    const newId = createCircleElem(1.0, Point3d.create(5, 5, 0), YawPitchRollAngles.createDegrees(90, 0, 0), imodel, seedElement);
+    imodel.saveChanges();
+
+    const newElemProps = imodel.elements.getElementProps<GeometricElement3dProps>({ id: newId, wantGeometry: true });
+    assert.isDefined(newElemProps.geom);
+    assert.isTrue(newElemProps.placement !== undefined);
+
+    newElemProps.elementGeometryBuilderParams = { entryArray: [] };
+    imodel.elements.updateElement(newElemProps);
+    imodel.saveChanges();
+
+    const updateElemProps = imodel.elements.getElementProps<GeometricElement3dProps>({ id: newId, wantGeometry: true });
+    assert.isUndefined(updateElemProps.geom);
+    assert.isTrue(updateElemProps.placement !== undefined);
+    const updatedPlacement = Placement3d.fromJSON(updateElemProps.placement);
+    assert.isTrue(updatedPlacement.bbox.isNull);
+  });
 });
 
 describe("BRepGeometry", () => {

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -2223,9 +2223,6 @@ describe("ElementGeometry", () => {
     }
 
     //    Insert - various failure cases
-    elemProps.elementGeometryBuilderParams = { entryArray: [] };
-    expect(() => imodel.elements.insertElement(elemProps)).to.throw(); // TODO: check error message
-
     elemProps.elementGeometryBuilderParams = { entryArray: [{ opcode: 9999 } as unknown as ElementGeometryDataEntry] };
     expect(() => imodel.elements.insertElement(elemProps)).to.throw(); // TODO: check error message
 

--- a/core/common/src/geometry/ElementGeometry.ts
+++ b/core/common/src/geometry/ElementGeometry.ts
@@ -133,7 +133,7 @@ export interface ElementGeometryRequest {
  * @beta
  */
 export interface ElementGeometryBuilderParams {
-  /** The geometry stream data */
+  /** The geometry stream data. Calling update element with a zero length array will clear the geometry stream and invalidate the placement. */
   entryArray: ElementGeometryDataEntry[];
   /** If true, create geometry that displays oriented to face the camera */
   viewIndependent?: boolean;


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/580
