### PR TITLE
Fix comparison of schemas with same name version

### DIFF
--- a/common/changes/@itwin/ecschema-editing/julio-fixComparisonOfSchemasWithSameNameVersion_2023-12-21-21-09.json
+++ b/common/changes/@itwin/ecschema-editing/julio-fixComparisonOfSchemasWithSameNameVersion_2023-12-21-21-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "Removed keyMismatch comparison in schemaDelegate so that two reports are created for each schemaA and schemaB",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/core/ecschema-editing/src/Validation/SchemaCompareResultDelegate.ts
+++ b/core/ecschema-editing/src/Validation/SchemaCompareResultDelegate.ts
@@ -24,7 +24,7 @@ import { ISchemaCompareReporter } from "./SchemaCompareReporter";
 export class SchemaCompareResultDelegate {
   private _schemaChangeReporters: ISchemaCompareReporter[];
   private _schemaAChanges: SchemaChanges;
-  private _schemaBChanges?: SchemaChanges;
+  private _schemaBChanges: SchemaChanges;
 
   /**
    * Initializes a new SchemaCompareResultDelegate instance.
@@ -32,9 +32,7 @@ export class SchemaCompareResultDelegate {
    */
   constructor(schemaA: Schema, schemaB: Schema, ...reporters: ISchemaCompareReporter[]) {
     this._schemaChangeReporters = reporters;
-    // const keyMismatch = !schemaA.schemaKey.matches(schemaB.schemaKey);
     this._schemaAChanges = new SchemaChanges(schemaA);
-    // if (keyMismatch)
     this._schemaBChanges = new SchemaChanges(schemaB);
   }
 
@@ -48,7 +46,7 @@ export class SchemaCompareResultDelegate {
   public compareComplete() {
     this.schemaChangeReporters.forEach((r) => r.report(this._schemaAChanges));
     if (this._schemaBChanges)
-      this.schemaChangeReporters.forEach((r) => r.report(this._schemaBChanges!));
+      this.schemaChangeReporters.forEach((r) => r.report(this._schemaBChanges));
   }
 
   /**
@@ -378,7 +376,7 @@ export class SchemaCompareResultDelegate {
   }
 
   private async reportDiagnostic(diagnostic: AnyDiagnostic): Promise<void> {
-    if (!this._schemaBChanges || this._schemaAChanges.schema === diagnostic.schema) {
+    if (this._schemaAChanges.schema === diagnostic.schema) {
       this._schemaAChanges.addDiagnostic(diagnostic);
       return;
     }

--- a/core/ecschema-editing/src/Validation/SchemaCompareResultDelegate.ts
+++ b/core/ecschema-editing/src/Validation/SchemaCompareResultDelegate.ts
@@ -32,10 +32,10 @@ export class SchemaCompareResultDelegate {
    */
   constructor(schemaA: Schema, schemaB: Schema, ...reporters: ISchemaCompareReporter[]) {
     this._schemaChangeReporters = reporters;
-    const keyMismatch = !schemaA.schemaKey.matches(schemaB.schemaKey);
+    // const keyMismatch = !schemaA.schemaKey.matches(schemaB.schemaKey);
     this._schemaAChanges = new SchemaChanges(schemaA);
-    if (keyMismatch)
-      this._schemaBChanges = new SchemaChanges(schemaB);
+    // if (keyMismatch)
+    this._schemaBChanges = new SchemaChanges(schemaB);
   }
 
   public get schemaChangeReporters(): ISchemaCompareReporter[] {

--- a/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
@@ -2,8 +2,8 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { Schema, SchemaContext } from "@itwin/ecschema-metadata";
-import { ISchemaChanges, ISchemaCompareReporter, SchemaChanges, SchemaComparer } from "../../ecschema-editing";
+import { Schema, SchemaContext, SchemaItem } from "@itwin/ecschema-metadata";
+import { AnyDiagnostic, ISchemaChanges, ISchemaCompareReporter, SchemaChanges, SchemaCompareCodes, SchemaComparer } from "../../ecschema-editing";
 import { expect } from "chai";
 
 class SchemaCompareReporter implements ISchemaCompareReporter {
@@ -13,7 +13,25 @@ class SchemaCompareReporter implements ISchemaCompareReporter {
   }
 }
 
-describe("Comparison tests for schemas with same name and version", () => {
+function findDiagnostic(diagnostics: AnyDiagnostic[], code: string, fullNameA: string, _fullNameB?: string, _propertyType?: string) {
+  let found = false;
+  for (const diagnostic of diagnostics) {
+    if (SchemaCompareCodes.SchemaItemMissing === code &&
+      (diagnostic.ecDefinition as SchemaItem).fullName === fullNameA) {
+      found = true;
+      break;
+    }
+
+    if (SchemaCompareCodes.CustomAttributeInstanceClassMissing === code &&
+      diagnostic.messageArgs?.at(0).className === fullNameA) {
+      found = true;
+      break;
+    }
+  }
+  return found;
+}
+
+describe.only("Comparison tests for schemas with same name and version", () => {
   let reporter: SchemaCompareReporter;
   let contextA: SchemaContext;
   let contextB: SchemaContext;
@@ -27,14 +45,62 @@ describe("Comparison tests for schemas with same name and version", () => {
     description: "descriptionA",
   };
 
+  const refOneJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "RefOne",
+    version: "1.0.1",
+    alias: "rOne",
+    label: "Ref One",
+    description: "Reference One",
+  };
+
+  const refTwoJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "RefTwo",
+    version: "1.0.1",
+    alias: "rTwo",
+    label: "Ref Two",
+    description: "Reference Two",
+  };
+
   beforeEach(async () => {
     reporter = new SchemaCompareReporter();
     contextA = new SchemaContext();
     contextB = new SchemaContext();
   });
 
-  describe("Compare same name, same version schemas with different contents", () => {
-    it.only("Writing basic tests", async () => {
+  describe("Compare same name, same version schemas that live in different context and with different contents", () => {
+    it("should generate a report for each schema that live in different context with same name and version", async () => {
+      const schemaA = await Schema.fromJson({
+        ...schemaAJson,
+        items: {
+          testClassOne: {
+            schemaItemType: "EntityClass",
+            description: "test class one for testing",
+            label: "test class one",
+          },
+        },
+      }, contextA);
+
+      const schemaA2 = await Schema.fromJson({
+        ...schemaAJson,
+        items: {
+          testClassOne: {
+            schemaItemType: "EntityClass",
+            description: "test class one for testing",
+            label: "test class one",
+          },
+        },
+      }, contextB);
+
+      const comparer = new SchemaComparer(reporter);
+      await comparer.compareSchemas(schemaA, schemaA2);
+      expect(reporter.changes.length).to.equal(2);
+      expect(reporter.changes[0]).not.be.undefined;
+      expect(reporter.changes[1]).not.be.undefined;
+    });
+
+    it("should return false to finding schemaItemMissing diagnostic from schemaB in schemaAChanges", async () => {
       const schemaA = await Schema.fromJson({
         ...schemaAJson,
         items: {
@@ -64,7 +130,125 @@ describe("Comparison tests for schemas with same name and version", () => {
 
       const comparer = new SchemaComparer(reporter);
       await comparer.compareSchemas(schemaA, schemaA2);
-      expect(comparer).not.be.undefined;
+
+      const schemaAChanges = reporter.changes[0].allDiagnostics;
+      const findTestClassTwoMissing = findDiagnostic(schemaAChanges, SchemaCompareCodes.SchemaItemMissing, "SchemaA.testClassTwo");
+      const findTestClassThreeMissing = findDiagnostic(schemaAChanges, SchemaCompareCodes.SchemaItemMissing, "SchemaA.testClassThree");
+
+      expect(findTestClassTwoMissing).to.be.false;
+      expect(findTestClassThreeMissing).to.be.false;
+
+    });
+
+    it("should return true to finding schemaItemMissing diagnostic from schemaB in schemaBChanges", async () => {
+      const schemaA = await Schema.fromJson({
+        ...schemaAJson,
+      }, contextA);
+
+      const schemaA2 = await Schema.fromJson({
+        ...schemaAJson,
+        items: {
+          testClassTwo: {
+            schemaItemType: "EntityClass",
+            description: "test class two for testing",
+            label: "test class two",
+          },
+          testClassThree: {
+            schemaItemType: "EntityClass",
+            description: "test class three for testing",
+            label: "test class three",
+          },
+        },
+      }, contextB);
+
+      const comparer = new SchemaComparer(reporter);
+      await comparer.compareSchemas(schemaA, schemaA2);
+
+      const schemaBChanges = reporter.changes[1].allDiagnostics;
+      const findTestClassTwoMissing = findDiagnostic(schemaBChanges, SchemaCompareCodes.SchemaItemMissing, "SchemaA.testClassTwo");
+      const findTestClassThreeMissing = findDiagnostic(schemaBChanges, SchemaCompareCodes.SchemaItemMissing, "SchemaA.testClassThree");
+
+      expect(findTestClassTwoMissing).to.be.true;
+      expect(findTestClassThreeMissing).to.be.true;
+    });
+
+    it("should test references", async () => {
+      await Schema.fromJson({
+        ...refOneJson,
+        items: {
+          testClassRefOne: {
+            schemaItemType: "EntityClass",
+            description: "test class one for ref one",
+            label: "test class one ref one",
+          },
+        },
+
+      }, contextA);
+
+      await Schema.fromJson({
+        ...refTwoJson,
+        items: {
+          testClassRefTwo: {
+            schemaItemType: "EntityClass",
+            description: "test class one for ref two",
+            label: "test class one ref two",
+          },
+        },
+      }, contextB);
+
+      const schemaA = await Schema.fromJson({
+        ...schemaAJson,
+        references: [
+          {
+            name: "RefOne",
+            version: "01.00.01",
+          },
+        ],
+        customAttributes: [
+          {
+            className: "RefOne.testClassRefOne",
+          },
+        ],
+        items: {
+          testClassOne: {
+            schemaItemType: "EntityClass",
+            description: "test class one for testing",
+            label: "test class one",
+          },
+        },
+      }, contextA);
+
+      const schemaA2 = await Schema.fromJson({
+        ...schemaAJson,
+        references: [
+          {
+            name: "RefTwo",
+            version: "01.00.01",
+          },
+        ],
+        customAttributes: [
+          {
+            className: "RefTwo.testClassRefTwo",
+          },
+        ],
+        items: {
+          testClassOne: {
+            schemaItemType: "EntityClass",
+            description: "test class one for testing",
+            label: "test class one",
+          },
+        },
+      }, contextB);
+
+      const comparer = new SchemaComparer(reporter);
+      await comparer.compareSchemas(schemaA, schemaA2);
+      const schemaAChanges = reporter.changes[0].allDiagnostics;
+      const schemaBChanges = reporter.changes[1].allDiagnostics;
+
+      expect(findDiagnostic(schemaAChanges, SchemaCompareCodes.CustomAttributeInstanceClassMissing, "RefOne.testClassRefOne")).to.be.true;
+      expect(findDiagnostic(schemaAChanges, SchemaCompareCodes.CustomAttributeInstanceClassMissing, "RefTwo.testClassRefTwo")).to.be.false;
+
+      expect(findDiagnostic(schemaBChanges, SchemaCompareCodes.CustomAttributeInstanceClassMissing, "RefTwo.testClassRefTwo")).to.be.true;
 
     });
   });

--- a/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Schema, SchemaContext } from "@itwin/ecschema-metadata";
+import { ISchemaChanges, ISchemaCompareReporter, SchemaChanges, SchemaComparer } from "../../ecschema-editing";
+import { expect } from "chai";
+
+class SchemaCompareReporter implements ISchemaCompareReporter {
+  public changes: SchemaChanges[] = [];
+  public report(schemaChanges: ISchemaChanges): void {
+    this.changes.push(schemaChanges as SchemaChanges);
+  }
+}
+
+describe("Comparison tests for schemas with same name and version", () => {
+  let reporter: SchemaCompareReporter;
+  let contextA: SchemaContext;
+  let contextB: SchemaContext;
+
+  const schemaAJson = {
+    $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+    name: "SchemaA",
+    version: "1.0.1",
+    alias: "a",
+    label: "labelA",
+    description: "descriptionA",
+  };
+
+  beforeEach(async () => {
+    reporter = new SchemaCompareReporter();
+    contextA = new SchemaContext();
+    contextB = new SchemaContext();
+  });
+
+  describe("Compare same name, same version schemas with different contents", () => {
+    it.only("Writing basic tests", async () => {
+      const schemaA = await Schema.fromJson({
+        ...schemaAJson,
+        items: {
+          testClassOne: {
+            schemaItemType: "EntityClass",
+            description: "test class one for testing",
+            label: "test class one",
+          },
+        },
+      }, contextA);
+
+      const schemaA2 = await Schema.fromJson({
+        ...schemaAJson,
+        items: {
+          testClassTwo: {
+            schemaItemType: "EntityClass",
+            description: "test class two for testing",
+            label: "test class two",
+          },
+          testClassThree: {
+            schemaItemType: "EntityClass",
+            description: "test class three for testing",
+            label: "test class three",
+          },
+        },
+      }, contextB);
+
+      const comparer = new SchemaComparer(reporter);
+      await comparer.compareSchemas(schemaA, schemaA2);
+      expect(comparer).not.be.undefined;
+
+    });
+  });
+});

--- a/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
@@ -13,7 +13,7 @@ class SchemaCompareReporter implements ISchemaCompareReporter {
   }
 }
 
-function findDiagnostic(diagnostics: AnyDiagnostic[], code: string, fullNameA: string, _fullNameB?: string, _propertyType?: string) {
+function findDiagnostic(diagnostics: AnyDiagnostic[], code: string, fullNameA: string) {
   let found = false;
   for (const diagnostic of diagnostics) {
     if (SchemaCompareCodes.SchemaItemMissing === code &&

--- a/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaComparisonSameNameVersion.test.ts
@@ -27,11 +27,17 @@ function findDiagnostic(diagnostics: AnyDiagnostic[], code: string, fullNameA: s
       found = true;
       break;
     }
+
+    if(SchemaCompareCodes.SchemaReferenceMissing === code && 
+      diagnostic.messageArgs?.at(0).fullName === fullNameA){
+      found = true;
+      break;
+    }
   }
   return found;
 }
 
-describe.only("Comparison tests for schemas with same name and version", () => {
+describe("Comparison tests for schemas with same name and version", () => {
   let reporter: SchemaCompareReporter;
   let contextA: SchemaContext;
   let contextB: SchemaContext;
@@ -172,7 +178,7 @@ describe.only("Comparison tests for schemas with same name and version", () => {
       expect(findTestClassThreeMissing).to.be.true;
     });
 
-    it("should test references", async () => {
+    it("should return false to finding references and custom attributes missing from schemaB in schemaAChanges report", async () => {
       await Schema.fromJson({
         ...refOneJson,
         items: {
@@ -245,11 +251,11 @@ describe.only("Comparison tests for schemas with same name and version", () => {
       const schemaAChanges = reporter.changes[0].allDiagnostics;
       const schemaBChanges = reporter.changes[1].allDiagnostics;
 
-      expect(findDiagnostic(schemaAChanges, SchemaCompareCodes.CustomAttributeInstanceClassMissing, "RefOne.testClassRefOne")).to.be.true;
       expect(findDiagnostic(schemaAChanges, SchemaCompareCodes.CustomAttributeInstanceClassMissing, "RefTwo.testClassRefTwo")).to.be.false;
+      expect(findDiagnostic(schemaAChanges, SchemaCompareCodes.SchemaReferenceMissing, "RefTwo")).to.be.false;
 
       expect(findDiagnostic(schemaBChanges, SchemaCompareCodes.CustomAttributeInstanceClassMissing, "RefTwo.testClassRefTwo")).to.be.true;
-
+      expect(findDiagnostic(schemaBChanges, SchemaCompareCodes.SchemaReferenceMissing, "RefTwo")).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This PR removes the keyMismatch comparison when comparing two schemas, this will allow the API to create two reports every time regardless of the schema names and version. 