### PR TITLE
Presentation: Optimizations for full iModel read

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -124,9 +124,9 @@ export interface MemoryHierarchyCacheConfig extends HierarchyCacheConfigBase {
 }
 
 // @public
-export interface MultiElementPropertiesResponse {
+export interface MultiElementPropertiesResponse<TParsedContent = ElementProperties> {
     // (undocumented)
-    iterator: () => AsyncGenerator<ElementProperties[]>;
+    iterator: () => AsyncGenerator<TParsedContent[]>;
     // (undocumented)
     total: number;
 }
@@ -248,7 +248,7 @@ export class PresentationManager {
     getDisplayLabelDefinition(requestOptions: WithCancelEvent<Prioritized<DisplayLabelRequestOptions<IModelDb, InstanceKey>>> & BackendDiagnosticsAttribute): Promise<LabelDefinition>;
     getDisplayLabelDefinitions(requestOptions: WithCancelEvent<Prioritized<Paged<DisplayLabelsRequestOptions<IModelDb, InstanceKey>>>> & BackendDiagnosticsAttribute): Promise<LabelDefinition[]>;
     getElementProperties(requestOptions: WithCancelEvent<Prioritized<SingleElementPropertiesRequestOptions<IModelDb>>> & BackendDiagnosticsAttribute): Promise<ElementProperties | undefined>;
-    getElementProperties(requestOptions: WithCancelEvent<Prioritized<MultiElementPropertiesRequestOptions<IModelDb>>> & BackendDiagnosticsAttribute): Promise<MultiElementPropertiesResponse>;
+    getElementProperties<TParsedContent = ElementProperties>(requestOptions: WithCancelEvent<Prioritized<MultiElementPropertiesRequestOptions<IModelDb, TParsedContent>>> & BackendDiagnosticsAttribute): Promise<MultiElementPropertiesResponse<TParsedContent>>;
     getFilteredNodePaths(requestOptions: WithCancelEvent<Prioritized<FilterByTextHierarchyRequestOptions<IModelDb, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<NodePathElement[]>;
     // @internal (undocumented)
     getNativePlatform: () => NativePlatformDefinition;

--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -32,6 +32,7 @@ import { Id64String } from '@itwin/core-bentley';
 import { IDisposable } from '@itwin/core-bentley';
 import { IModelDb } from '@itwin/core-backend';
 import { InstanceKey } from '@itwin/presentation-common';
+import { Item } from '@itwin/presentation-common';
 import { KeySet } from '@itwin/presentation-common';
 import { LabelDefinition } from '@itwin/presentation-common';
 import { MultiElementPropertiesRequestOptions } from '@itwin/presentation-common';
@@ -238,6 +239,8 @@ export class PresentationManager {
     dispose(): void;
     getContent(requestOptions: WithCancelEvent<Prioritized<Paged<ContentRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Content | undefined>;
     getContentDescriptor(requestOptions: WithCancelEvent<Prioritized<ContentDescriptorRequestOptions<IModelDb, KeySet, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<Descriptor | undefined>;
+    // @beta
+    getContentSet(requestOptions: WithCancelEvent<Prioritized<Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Item[]>;
     getContentSetSize(requestOptions: WithCancelEvent<Prioritized<ContentRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<number>;
     getContentSources(requestOptions: WithCancelEvent<Prioritized<ContentSourcesRequestOptions<IModelDb>>> & BackendDiagnosticsAttribute): Promise<SelectClassInfo[]>;
     // @internal (undocumented)

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -913,8 +913,8 @@ export interface ElementPropertiesPropertyItemBase extends ElementPropertiesItem
 // @public
 export type ElementPropertiesPropertyValueType = "primitive" | "array" | "struct";
 
-// @public
-export type ElementPropertiesRequestOptions<TIModel> = SingleElementPropertiesRequestOptions<TIModel> | MultiElementPropertiesRequestOptions<TIModel>;
+// @public @deprecated
+export type ElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> = SingleElementPropertiesRequestOptions<TIModel> | MultiElementPropertiesRequestOptions<TIModel, TParsedContent>;
 
 // @public
 export interface ElementPropertiesStructArrayPropertyItem extends ElementPropertiesArrayPropertyItemBase {
@@ -1468,7 +1468,7 @@ export interface IntsRulesetVariableJSON extends RulesetVariableBaseJSON {
 export function isComputeSelectionRequestOptions<TIModel>(options: ComputeSelectionRequestOptions<TIModel> | SelectionScopeRequestOptions<TIModel>): options is ComputeSelectionRequestOptions<TIModel>;
 
 // @internal
-export function isSingleElementPropertiesRequestOptions<TIModel>(options: ElementPropertiesRequestOptions<TIModel>): options is SingleElementPropertiesRequestOptions<TIModel>;
+export function isSingleElementPropertiesRequestOptions<TIModel, TParsedContent = any>(options: SingleElementPropertiesRequestOptions<TIModel> | MultiElementPropertiesRequestOptions<TIModel, TParsedContent>): options is SingleElementPropertiesRequestOptions<TIModel>;
 
 // @public
 export class Item {
@@ -1697,7 +1697,9 @@ export interface LocalizationHelperProps {
 }
 
 // @public
-export interface MultiElementPropertiesRequestOptions<TIModel> extends RequestOptions<TIModel> {
+export interface MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> extends RequestOptions<TIModel> {
+    // @beta
+    contentParser?: (descriptor: Descriptor, item: Item) => TParsedContent;
     elementClasses?: string[];
 }
 

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -312,6 +312,7 @@ export class Content {
 
 // @public
 export interface ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVariable = RulesetVariable> extends RequestOptionsWithRuleset<TIModel, TRulesetVariable> {
+    contentFlags?: number;
     displayType: string;
     keys: TKeySet;
     selection?: SelectionInfo;
@@ -339,6 +340,8 @@ export class ContentFormatter {
     constructor(_propertyValueFormatter: ContentPropertyValueFormatter, _unitSystem?: UnitSystemKey | undefined);
     // (undocumented)
     formatContent(content: Content): Promise<Content>;
+    // (undocumented)
+    formatContentItems(items: Item[], descriptor: Descriptor): Promise<Item[]>;
 }
 
 // @public
@@ -1483,6 +1486,10 @@ export class Item {
     inputKeys?: InstanceKey[];
     isFieldMerged(fieldName: string): boolean;
     label: LabelDefinition;
+    // @internal
+    static listFromJSON(json: ItemJSON[] | string): Item[];
+    // @internal
+    static listReviver(key: string, value: any): any;
     mergedFieldNames: string[];
     primaryKeys: InstanceKey[];
     // @internal
@@ -1667,6 +1674,10 @@ export class LocalizationHelper {
     constructor(props: LocalizationHelperProps);
     // (undocumented)
     getLocalizedContent(content: Content): Content;
+    // (undocumented)
+    getLocalizedContentDescriptor(descriptor: Descriptor): Descriptor;
+    // (undocumented)
+    getLocalizedContentItems(items: Item[]): Item[];
     // (undocumented)
     getLocalizedElementProperties(elem: ElementProperties): ElementProperties;
     // (undocumented)

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -131,6 +131,7 @@ public;ElementPropertiesPropertyItem = ElementPropertiesPrimitivePropertyItem | 
 public;ElementPropertiesPropertyItemBase 
 public;ElementPropertiesPropertyValueType = "primitive" | "array" | "struct"
 public;ElementPropertiesRequestOptions
+deprecated;ElementPropertiesRequestOptions
 public;ElementPropertiesStructArrayPropertyItem 
 public;ElementPropertiesStructPropertyItem 
 public;ElementSelectionScopeProps

--- a/common/changes/@itwin/presentation-backend/presentation-optimizations-for-full-imodel-read_2023-12-22-09-43.json
+++ b/common/changes/@itwin/presentation-backend/presentation-optimizations-for-full-imodel-read_2023-12-22-09-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Improve performance of `PresentationManager.getElementProperties` \"multi\" case by ~100%. Add a way to provide custom content parser.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-optimizations-for-full-imodel-read_2023-12-22-09-43.json
+++ b/common/changes/@itwin/presentation-common/presentation-optimizations-for-full-imodel-read_2023-12-22-09-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -752,11 +752,11 @@
     },
     {
       "name": "rxjs",
-      "allowedCategories": [ "frontend" ]
+      "allowedCategories": [ "backend", "frontend", "internal" ]
     },
     {
       "name": "rxjs-for-await",
-      "allowedCategories": [ "frontend" ]
+      "allowedCategories": [ "backend", "frontend" ]
     },
     {
       "name": "sanitize-filename",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1949,7 +1949,6 @@ importers:
       jsdom-global: 3.0.2
       mocha: ^10.0.0
       rimraf: ^3.0.2
-      rxjs: ^7.8.1
       sanitize-filename: ^1.6.3
       sinon: ^15.0.4
       sinon-chai: ^3.2.0
@@ -1993,7 +1992,6 @@ importers:
       fast-sort: 3.4.0
       mocha: 10.2.0
       rimraf: 3.0.2
-      rxjs: 7.8.1
       sinon: 15.2.0
       sinon-chai: 3.7.0_chai@4.3.10+sinon@15.2.0
       source-map-support: 0.5.21
@@ -12467,7 +12465,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.5.0
+      vite: 4.5.0_@types+node@18.16.20
     transitivePeerDependencies:
       - rollup
       - supports-color

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1949,6 +1949,7 @@ importers:
       jsdom-global: 3.0.2
       mocha: ^10.0.0
       rimraf: ^3.0.2
+      rxjs: ^7.8.1
       sanitize-filename: ^1.6.3
       sinon: ^15.0.4
       sinon-chai: ^3.2.0
@@ -1992,6 +1993,7 @@ importers:
       fast-sort: 3.4.0
       mocha: 10.2.0
       rimraf: 3.0.2
+      rxjs: 7.8.1
       sinon: 15.2.0
       sinon-chai: 3.7.0_chai@4.3.10+sinon@15.2.0
       source-map-support: 0.5.21
@@ -2216,6 +2218,8 @@ importers:
       nyc: ^15.1.0
       object-hash: ^1.3.1
       rimraf: ^3.0.2
+      rxjs: ^7.8.1
+      rxjs-for-await: ^1.0.0
       semver: ^7.3.5
       sinon: ^15.0.4
       sinon-chai: ^3.2.0
@@ -2223,6 +2227,8 @@ importers:
       typescript: ~5.0.2
     dependencies:
       object-hash: 1.3.1
+      rxjs: 7.8.1
+      rxjs-for-await: 1.0.0_rxjs@7.8.1
       semver: 7.5.4
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
@@ -4850,7 +4856,7 @@ packages:
   /@types/cpx/1.5.2:
     resolution: {integrity: sha512-CL9DbTAdf5NYcbYpBTli6JxVIpCAhJp1FeQiXd9SNjbC4o9k6McnHkU0FHgj9UYoN7TVX3poaaBrwFabTY7Skw==}
     dependencies:
-      '@types/node': 18.16.20
+      '@types/node': 18.16.1
     dev: false
 
   /@types/debug/4.1.10:
@@ -5026,6 +5032,10 @@ packages:
   /@types/node/16.18.59:
     resolution: {integrity: sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==}
     dev: true
+
+  /@types/node/18.16.1:
+    resolution: {integrity: sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==}
+    dev: false
 
   /@types/node/18.16.20:
     resolution: {integrity: sha512-nL54VfDjThdP2UXJXZao5wp76CDiDw4zSRO8d4Tk7UgDqNKGKVEQB0/t3ti63NS+YNNkIQDvwEAF04BO+WYu7Q==}
@@ -12457,7 +12467,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.5.0_@types+node@18.16.20
+      vite: 4.5.0
     transitivePeerDependencies:
       - rollup
       - supports-color

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -87,6 +87,8 @@
   },
   "dependencies": {
     "object-hash": "^1.3.1",
+    "rxjs": "^7.8.1",
+    "rxjs-for-await": "^1.0.0",
     "semver": "^7.3.5"
   },
   "nyc": {

--- a/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
+++ b/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
@@ -84,8 +84,7 @@ export function getClassesWithInstances(imodel: IModelDb, fullClassNames: string
       set.add(`${schemaName}.${className}`);
       return set;
     }, new Set()),
-    map((set) => [...set]),
-    mergeAll(),
+    mergeMap((set) => [...set]),
   );
 }
 

--- a/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
+++ b/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
@@ -10,17 +10,35 @@ import { from, map, mergeAll, mergeMap, Observable, reduce } from "rxjs";
 import { ECSqlStatement, IModelDb } from "@itwin/core-backend";
 import { assert, DbResult, Id64, Id64String } from "@itwin/core-bentley";
 import {
-  CategoryDescription, Content, Descriptor, ElementProperties, ElementPropertiesItem, ElementPropertiesPrimitiveArrayPropertyItem,
-  ElementPropertiesPropertyItem, ElementPropertiesStructArrayPropertyItem, IContentVisitor, Item, PresentationError, PresentationStatus,
-  ProcessFieldHierarchiesProps, ProcessMergedValueProps, ProcessPrimitiveValueProps, PropertyValueFormat, StartArrayProps, StartCategoryProps,
-  StartContentProps, StartFieldProps, StartItemProps, StartStructProps, traverseContent,
+  CategoryDescription,
+  Descriptor,
+  ElementProperties,
+  ElementPropertiesItem,
+  ElementPropertiesPrimitiveArrayPropertyItem,
+  ElementPropertiesPropertyItem,
+  ElementPropertiesStructArrayPropertyItem,
+  IContentVisitor,
+  Item,
+  PresentationError,
+  PresentationStatus,
+  ProcessFieldHierarchiesProps,
+  ProcessMergedValueProps,
+  ProcessPrimitiveValueProps,
+  PropertyValueFormat,
+  StartArrayProps,
+  StartCategoryProps,
+  StartContentProps,
+  StartFieldProps,
+  StartItemProps,
+  StartStructProps,
+  traverseContentItem,
 } from "@itwin/presentation-common";
 
 /** @internal */
-export const buildElementsProperties = (descriptor: Descriptor, items: Item[]): ElementProperties[] => {
+export const buildElementProperties = (descriptor: Descriptor, item: Item): ElementProperties => {
   const builder = new ElementPropertiesBuilder();
-  traverseContent(builder, new Content(descriptor, items));
-  return builder.items;
+  traverseContentItem(builder, descriptor, item);
+  return builder.items[0];
 };
 
 /** @internal */

--- a/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
+++ b/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { from, map, mergeAll, mergeMap, Observable, reduce } from "rxjs";
+import { from, mergeAll, mergeMap, Observable, reduce } from "rxjs";
 import { ECSqlStatement, IModelDb } from "@itwin/core-backend";
 import { assert, DbResult, Id64, Id64String } from "@itwin/core-bentley";
 import {

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -26,6 +26,7 @@ export enum NativePlatformRequestTypes {
   GetContentSources = "GetContentSources",
   GetContentDescriptor = "GetContentDescriptor",
   GetContentSetSize = "GetContentSetSize",
+  GetContentSet = "GetContentSet",
   GetContent = "GetContent",
   GetPagedDistinctValues = "GetPagedDistinctValues",
   GetDisplayLabel = "GetDisplayLabel",

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -512,7 +512,8 @@ export class PresentationManager {
   public async getContentDescriptor(requestOptions: WithCancelEvent<Prioritized<ContentDescriptorRequestOptions<IModelDb, KeySet, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<Descriptor | undefined> {
     const response = await this._detail.getContentDescriptor(requestOptions);
     const reviver = (key: string, value: any) => key === "" ? Descriptor.fromJSON(value) : value;
-    return JSON.parse(response, reviver);
+    const descriptor = JSON.parse(response, reviver);
+    return descriptor ? this._localizationHelper.getLocalizedContentDescriptor(descriptor) : undefined;
   }
 
   /**

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -279,7 +279,7 @@ export class PresentationManagerDetail implements IDisposable {
       rulesetOrId: "ElementProperties",
       keys: new KeySet([{ className: "BisCore:Element", id: elementId }]),
     });
-    if (!content) {
+    if (!content || content.contentSet.length === 0) {
       return undefined;
     }
     return buildElementProperties(content.descriptor, content.contentSet[0]);

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -200,6 +200,7 @@ export class PresentationManagerDetail implements IDisposable {
       keys: getKeysForContentRequest(requestOptions.keys, (map) => bisElementInstanceKeysProcessor(requestOptions.imodel, map)),
       descriptorOverrides: createContentDescriptorOverrides(descriptor),
     };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     return JSON.parse(await this.request(params), Item.listReviver);
   }
 

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -12,7 +12,7 @@ import {
   DescriptorOverrides, DiagnosticsOptions, DiagnosticsScopeLogs, DisplayLabelRequestOptions, DisplayLabelsRequestOptions, DisplayValueGroup,
   DistinctValuesRequestOptions, ElementProperties, FilterByInstancePathsHierarchyRequestOptions, FilterByTextHierarchyRequestOptions,
   FormatsMap,
-  HierarchyLevelDescriptorRequestOptions, HierarchyRequestOptions, InstanceKey, Key, KeySet, LabelDefinition, NodeKey, NodePathElement, Paged,
+  HierarchyLevelDescriptorRequestOptions, HierarchyRequestOptions, InstanceKey, Item, Key, KeySet, LabelDefinition, NodeKey, NodePathElement, Paged,
   PagedResponse, PresentationError, PresentationStatus, Prioritized, Ruleset, RulesetVariable, SelectClassInfo, SingleElementPropertiesRequestOptions,
   WithCancelEvent,
 } from "@itwin/presentation-common";
@@ -189,6 +189,18 @@ export class PresentationManagerDetail implements IDisposable {
       descriptorOverrides: createContentDescriptorOverrides(descriptor),
     };
     return JSON.parse(await this.request(params));
+  }
+
+  public async getContentSet(requestOptions: WithCancelEvent<Prioritized<Paged<ContentRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Item[]> {
+    const { rulesetOrId, descriptor, ...strippedOptions } = requestOptions;
+    const params = {
+      requestId: NativePlatformRequestTypes.GetContentSet,
+      rulesetId: this.registerRuleset(rulesetOrId),
+      ...strippedOptions,
+      keys: getKeysForContentRequest(requestOptions.keys, (map) => bisElementInstanceKeysProcessor(requestOptions.imodel, map)),
+      descriptorOverrides: createContentDescriptorOverrides(descriptor),
+    };
+    return JSON.parse(await this.request(params), Item.listReviver);
   }
 
   public async getContent(requestOptions: WithCancelEvent<Prioritized<Paged<ContentRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Content | undefined> {

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -278,8 +278,10 @@ export class PresentationManagerDetail implements IDisposable {
       rulesetOrId: "ElementProperties",
       keys: new KeySet([{ className: "BisCore:Element", id: elementId }]),
     });
-    const properties = buildElementsProperties(content);
-    return properties[0];
+    if (!content) {
+      return undefined;
+    }
+    return buildElementsProperties(content.descriptor, content.contentSet)[0];
   }
 
   /** Registers given ruleset and replaces the ruleset with its ID in the resulting object */

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -16,7 +16,7 @@ import {
   PagedResponse, PresentationError, PresentationStatus, Prioritized, Ruleset, RulesetVariable, SelectClassInfo, SingleElementPropertiesRequestOptions,
   WithCancelEvent,
 } from "@itwin/presentation-common";
-import { buildElementsProperties } from "./ElementPropertiesHelper";
+import { buildElementProperties } from "./ElementPropertiesHelper";
 import {
   createDefaultNativePlatform, NativePlatformDefinition, NativePlatformRequestTypes, NativePlatformResponse, NativePresentationDefaultUnitFormats,
   NativePresentationKeySetJSON, NativePresentationUnitSystem, PresentationNativePlatformResponseError,
@@ -282,7 +282,7 @@ export class PresentationManagerDetail implements IDisposable {
     if (!content) {
       return undefined;
     }
-    return buildElementsProperties(content.descriptor, content.contentSet)[0];
+    return buildElementProperties(content.descriptor, content.contentSet[0]);
   }
 
   /** Registers given ruleset and replaces the ruleset with its ID in the resulting object */

--- a/presentation/backend/src/test/ElementPropertiesHelper.test.ts
+++ b/presentation/backend/src/test/ElementPropertiesHelper.test.ts
@@ -16,67 +16,67 @@ import {
   createTestNestedContentField,
   createTestSimpleContentField,
 } from "@itwin/presentation-common/lib/cjs/test";
-import { buildElementsProperties, getBatchedClassElementIds, getClassesWithInstances, getElementsCount } from "../presentation-backend/ElementPropertiesHelper";
+import { buildElementProperties, getBatchedClassElementIds, getClassesWithInstances, getElementsCount } from "../presentation-backend/ElementPropertiesHelper";
 import { stubECSqlReader } from "./Helpers";
 
-describe("buildElementsProperties", () => {
-  it("returns empty array when given content with no items", () => {
-    expect(buildElementsProperties(createTestContentDescriptor({ fields: [] }), [])).to.be.empty;
-  });
-
+describe("buildElementProperties", () => {
   it("sets class label", () => {
     expect(
-      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
+      buildElementProperties(
+        createTestContentDescriptor({ fields: [] }),
         createTestContentItem({
           classInfo: createTestECClassInfo({ label: "Test label" }),
           values: {},
           displayValues: {},
         }),
-      ]),
-    ).to.containSubset([{ class: "Test label" }]);
+      ),
+    ).to.containSubset({ class: "Test label" });
   });
 
   it("sets element label", () => {
     expect(
-      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
+      buildElementProperties(
+        createTestContentDescriptor({ fields: [] }),
         createTestContentItem({
           label: "Test label",
           values: {},
           displayValues: {},
         }),
-      ]),
-    ).to.containSubset([{ label: "Test label" }]);
+      ),
+    ).to.containSubset({ label: "Test label" });
   });
 
   it("sets invalid element id when content item has not primary keys", () => {
     expect(
-      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
+      buildElementProperties(
+        createTestContentDescriptor({ fields: [] }),
         createTestContentItem({
           primaryKeys: [],
           values: {},
           displayValues: {},
         }),
-      ]),
-    ).to.containSubset([{ id: Id64.invalid }]);
+      ),
+    ).to.containSubset({ id: Id64.invalid });
   });
 
   it("sets element id", () => {
     expect(
-      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
+      buildElementProperties(
+        createTestContentDescriptor({ fields: [] }),
         createTestContentItem({
           primaryKeys: [createTestECInstanceKey({ id: "0x123" })],
           values: {},
           displayValues: {},
         }),
-      ]),
-    ).to.containSubset([{ id: "0x123" }]);
+      ),
+    ).to.containSubset({ id: "0x123" });
   });
 
   it("categorizes properties", () => {
     const parentCategory = createTestCategoryDescription({ name: "cat1", label: "Parent Category" });
     const childCategory = createTestCategoryDescription({ name: "cat2", label: "Child Category", parent: parentCategory });
     expect(
-      buildElementsProperties(
+      buildElementProperties(
         createTestContentDescriptor({
           categories: [parentCategory, childCategory],
           fields: [
@@ -84,52 +84,49 @@ describe("buildElementsProperties", () => {
             createTestSimpleContentField({ name: "prop2", label: "Prop Two", category: childCategory }),
           ],
         }),
-        [
-          createTestContentItem({
-            values: {
-              prop1: "value1",
-              prop2: "value2",
-            },
-            displayValues: {
-              prop1: "Value One",
-              prop2: "Value Two",
-            },
-          }),
-        ],
+
+        createTestContentItem({
+          values: {
+            prop1: "value1",
+            prop2: "value2",
+          },
+          displayValues: {
+            prop1: "Value One",
+            prop2: "Value Two",
+          },
+        }),
       ),
-    ).to.deep.eq([
-      {
-        class: "",
-        id: "0x1",
-        label: "",
-        items: {
-          ["Parent Category"]: {
-            type: "category",
-            items: {
-              ["Child Category"]: {
-                type: "category",
-                items: {
-                  ["Prop Two"]: {
-                    type: "primitive",
-                    value: "Value Two",
-                  },
+    ).to.deep.eq({
+      class: "",
+      id: "0x1",
+      label: "",
+      items: {
+        ["Parent Category"]: {
+          type: "category",
+          items: {
+            ["Child Category"]: {
+              type: "category",
+              items: {
+                ["Prop Two"]: {
+                  type: "primitive",
+                  value: "Value Two",
                 },
               },
-              ["Prop One"]: {
-                type: "primitive",
-                value: "Value One",
-              },
+            },
+            ["Prop One"]: {
+              type: "primitive",
+              value: "Value One",
             },
           },
         },
       },
-    ]);
+    });
   });
 
   it("sets primitive property value to empty string when it's not set", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
     expect(
-      buildElementsProperties(
+      buildElementProperties(
         createTestContentDescriptor({
           categories: [category],
           fields: [
@@ -138,122 +135,113 @@ describe("buildElementsProperties", () => {
             createTestSimpleContentField({ name: "prop", label: "Prop", category }),
           ],
         }),
-        [
-          createTestContentItem({
-            values: {
-              emptyProp: undefined,
-              undefinedProps: undefined,
-              prop: "valid value",
-            },
-            displayValues: {
-              emptyProp: "",
-              undefinedProps: undefined,
-              prop: "valid value",
-            },
-          }),
-        ],
+
+        createTestContentItem({
+          values: {
+            emptyProp: undefined,
+            undefinedProps: undefined,
+            prop: "valid value",
+          },
+          displayValues: {
+            emptyProp: "",
+            undefinedProps: undefined,
+            prop: "valid value",
+          },
+        }),
       ),
-    ).to.deep.eq([
-      {
-        class: "",
-        id: "0x1",
-        label: "",
-        items: {
-          ["Test Category"]: {
-            type: "category",
-            items: {
-              ["EmptyProp"]: {
-                type: "primitive",
-                value: "",
-              },
-              ["UndefinedProp"]: {
-                type: "primitive",
-                value: "",
-              },
-              ["Prop"]: {
-                type: "primitive",
-                value: "valid value",
-              },
+    ).to.deep.eq({
+      class: "",
+      id: "0x1",
+      label: "",
+      items: {
+        ["Test Category"]: {
+          type: "category",
+          items: {
+            ["EmptyProp"]: {
+              type: "primitive",
+              value: "",
+            },
+            ["UndefinedProp"]: {
+              type: "primitive",
+              value: "",
+            },
+            ["Prop"]: {
+              type: "primitive",
+              value: "valid value",
             },
           },
         },
       },
-    ]);
+    });
   });
 
   it("does not include category if it only has nested content field without values", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
     expect(
-      buildElementsProperties(
+      buildElementProperties(
         createTestContentDescriptor({
           categories: [category],
           fields: [createTestNestedContentField({ name: "nestedField", category, nestedFields: [createTestSimpleContentField({ name: "primitiveField" })] })],
         }),
-        [
-          createTestContentItem({
-            values: {
-              nestedField: [],
-            },
-            displayValues: {
-              nestedField: [],
-            },
-          }),
-        ],
+
+        createTestContentItem({
+          values: {
+            nestedField: [],
+          },
+          displayValues: {
+            nestedField: [],
+          },
+        }),
       ),
-    ).to.deep.eq([
-      {
-        class: "",
-        id: "0x1",
-        label: "",
-        items: {},
-      },
-    ]);
+    ).to.deep.eq({
+      class: "",
+      id: "0x1",
+      label: "",
+      items: {},
+    });
   });
 
   it("sets property value to empty string when it's merged", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
     expect(
-      buildElementsProperties(
+      buildElementProperties(
         createTestContentDescriptor({
           categories: [category],
           fields: [createTestSimpleContentField({ name: "prop", label: "Prop", category })],
         }),
-        [
-          createTestContentItem({
-            values: {
-              prop: "anything",
-            },
-            displayValues: {
-              prop: "anything",
-            },
-            mergedFieldNames: ["prop"],
-          }),
-        ],
+
+        createTestContentItem({
+          values: {
+            prop: "anything",
+          },
+          displayValues: {
+            prop: "anything",
+          },
+          mergedFieldNames: ["prop"],
+        }),
       ),
-    ).to.deep.eq([
-      {
-        class: "",
-        id: "0x1",
-        label: "",
-        items: {
-          ["Test Category"]: {
-            type: "category",
-            items: {
-              ["Prop"]: {
-                type: "primitive",
-                value: "",
-              },
+    ).to.deep.eq({
+      class: "",
+      id: "0x1",
+      label: "",
+      items: {
+        ["Test Category"]: {
+          type: "category",
+          items: {
+            ["Prop"]: {
+              type: "primitive",
+              value: "",
             },
           },
         },
       },
-    ]);
+    });
   });
 
   it("handles struct properties", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
     expect(
-      buildElementsProperties(
+      buildElementProperties(
         createTestContentDescriptor({
           categories: [category],
           fields: [
@@ -286,56 +274,53 @@ describe("buildElementsProperties", () => {
             }),
           ],
         }),
-        [
-          createTestContentItem({
-            values: {
-              prop: {
-                member1: "value1",
-                member2: "value2",
-              },
+
+        createTestContentItem({
+          values: {
+            prop: {
+              member1: "value1",
+              member2: "value2",
             },
-            displayValues: {
-              prop: {
-                member1: "Value One",
-                member2: "Value Two",
-              },
+          },
+          displayValues: {
+            prop: {
+              member1: "Value One",
+              member2: "Value Two",
             },
-          }),
-        ],
+          },
+        }),
       ),
-    ).to.deep.eq([
-      {
-        class: "",
-        id: "0x1",
-        label: "",
-        items: {
-          ["Test Category"]: {
-            type: "category",
-            items: {
-              ["Prop"]: {
-                type: "struct",
-                members: {
-                  ["Member One"]: {
-                    type: "primitive",
-                    value: "Value One",
-                  },
-                  ["Member Two"]: {
-                    type: "primitive",
-                    value: "Value Two",
-                  },
+    ).to.deep.eq({
+      class: "",
+      id: "0x1",
+      label: "",
+      items: {
+        ["Test Category"]: {
+          type: "category",
+          items: {
+            ["Prop"]: {
+              type: "struct",
+              members: {
+                ["Member One"]: {
+                  type: "primitive",
+                  value: "Value One",
+                },
+                ["Member Two"]: {
+                  type: "primitive",
+                  value: "Value Two",
                 },
               },
             },
           },
         },
       },
-    ]);
+    });
   });
 
   it("handles primitive array properties", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
     expect(
-      buildElementsProperties(
+      buildElementProperties(
         createTestContentDescriptor({
           categories: [category],
           fields: [
@@ -354,42 +339,39 @@ describe("buildElementsProperties", () => {
             }),
           ],
         }),
-        [
-          createTestContentItem({
-            values: {
-              prop: ["value1", "value2"],
-            },
-            displayValues: {
-              prop: ["Value One", "Value Two"],
-            },
-          }),
-        ],
+
+        createTestContentItem({
+          values: {
+            prop: ["value1", "value2"],
+          },
+          displayValues: {
+            prop: ["Value One", "Value Two"],
+          },
+        }),
       ),
-    ).to.deep.eq([
-      {
-        class: "",
-        id: "0x1",
-        label: "",
-        items: {
-          ["Test Category"]: {
-            type: "category",
-            items: {
-              ["Prop"]: {
-                type: "array",
-                valueType: "primitive",
-                values: ["Value One", "Value Two"],
-              },
+    ).to.deep.eq({
+      class: "",
+      id: "0x1",
+      label: "",
+      items: {
+        ["Test Category"]: {
+          type: "category",
+          items: {
+            ["Prop"]: {
+              type: "array",
+              valueType: "primitive",
+              values: ["Value One", "Value Two"],
             },
           },
         },
       },
-    ]);
+    });
   });
 
   it("handles struct array properties", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
     expect(
-      buildElementsProperties(
+      buildElementProperties(
         createTestContentDescriptor({
           categories: [category],
           fields: [
@@ -418,63 +400,59 @@ describe("buildElementsProperties", () => {
             }),
           ],
         }),
-        [
-          createTestContentItem({
-            values: {
-              prop: [
-                {
-                  member: "value1",
-                },
-                {
-                  member: "value2",
-                },
-              ],
-            },
-            displayValues: {
-              prop: [
-                {
-                  member: "Value One",
-                },
-                {
-                  member: "Value Two",
-                },
-              ],
-            },
-          }),
-        ],
-      ),
-    ).to.deep.eq([
-      {
-        class: "",
-        id: "0x1",
-        label: "",
-        items: {
-          ["Test Category"]: {
-            type: "category",
-            items: {
-              ["Prop"]: {
-                type: "array",
-                valueType: "struct",
-                values: [
-                  {
-                    ["Test Member"]: {
-                      type: "primitive",
-                      value: "Value One",
-                    },
-                  },
-                  {
-                    ["Test Member"]: {
-                      type: "primitive",
-                      value: "Value Two",
-                    },
-                  },
-                ],
+        createTestContentItem({
+          values: {
+            prop: [
+              {
+                member: "value1",
               },
+              {
+                member: "value2",
+              },
+            ],
+          },
+          displayValues: {
+            prop: [
+              {
+                member: "Value One",
+              },
+              {
+                member: "Value Two",
+              },
+            ],
+          },
+        }),
+      ),
+    ).to.deep.eq({
+      class: "",
+      id: "0x1",
+      label: "",
+      items: {
+        ["Test Category"]: {
+          type: "category",
+          items: {
+            ["Prop"]: {
+              type: "array",
+              valueType: "struct",
+              values: [
+                {
+                  ["Test Member"]: {
+                    type: "primitive",
+                    value: "Value One",
+                  },
+                },
+                {
+                  ["Test Member"]: {
+                    type: "primitive",
+                    value: "Value Two",
+                  },
+                },
+              ],
             },
           },
         },
       },
-    ]);
+    });
   });
 });
 

--- a/presentation/backend/src/test/ElementPropertiesHelper.test.ts
+++ b/presentation/backend/src/test/ElementPropertiesHelper.test.ts
@@ -1,450 +1,481 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import * as moq from "typemoq";
 import { ECSqlStatement, ECSqlValue, IModelDb } from "@itwin/core-backend";
 import { DbResult, Id64 } from "@itwin/core-bentley";
-import { Content, PresentationError, PropertyValueFormat } from "@itwin/presentation-common";
+import { PresentationError, PropertyValueFormat } from "@itwin/presentation-common";
 import {
-  createTestCategoryDescription, createTestContentDescriptor, createTestContentItem, createTestECClassInfo, createTestECInstanceKey,
-  createTestNestedContentField, createTestSimpleContentField,
+  createTestCategoryDescription,
+  createTestContentDescriptor,
+  createTestContentItem,
+  createTestECClassInfo,
+  createTestECInstanceKey,
+  createTestNestedContentField,
+  createTestSimpleContentField,
 } from "@itwin/presentation-common/lib/cjs/test";
-import { buildElementsProperties, getElementsCount, iterateElementIds } from "../presentation-backend/ElementPropertiesHelper";
+import { buildElementsProperties, getBatchedClassElementIds, getClassesWithInstances, getElementsCount } from "../presentation-backend/ElementPropertiesHelper";
+import { stubECSqlReader } from "./Helpers";
 
 describe("buildElementsProperties", () => {
-
-  it("returns empty array when given undefined content", () => {
-    expect(buildElementsProperties(undefined)).to.be.empty;
-  });
-
   it("returns empty array when given content with no items", () => {
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({ fields: [] }),
-      [],
-    ))).to.be.empty;
+    expect(buildElementsProperties(createTestContentDescriptor({ fields: [] }), [])).to.be.empty;
   });
 
   it("sets class label", () => {
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({ fields: [] }),
-      [
+    expect(
+      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
         createTestContentItem({
           classInfo: createTestECClassInfo({ label: "Test label" }),
           values: {},
           displayValues: {},
         }),
-      ],
-    ))).to.containSubset([{ class: "Test label" }]);
+      ]),
+    ).to.containSubset([{ class: "Test label" }]);
   });
 
   it("sets element label", () => {
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({ fields: [] }),
-      [
+    expect(
+      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
         createTestContentItem({
           label: "Test label",
           values: {},
           displayValues: {},
         }),
-      ],
-    ))).to.containSubset([{ label: "Test label" }]);
+      ]),
+    ).to.containSubset([{ label: "Test label" }]);
   });
 
   it("sets invalid element id when content item has not primary keys", () => {
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({ fields: [] }),
-      [
+    expect(
+      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
         createTestContentItem({
           primaryKeys: [],
           values: {},
           displayValues: {},
         }),
-      ],
-    ))).to.containSubset([{ id: Id64.invalid }]);
+      ]),
+    ).to.containSubset([{ id: Id64.invalid }]);
   });
 
   it("sets element id", () => {
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({ fields: [] }),
-      [
+    expect(
+      buildElementsProperties(createTestContentDescriptor({ fields: [] }), [
         createTestContentItem({
           primaryKeys: [createTestECInstanceKey({ id: "0x123" })],
           values: {},
           displayValues: {},
         }),
-      ],
-    ))).to.containSubset([{ id: "0x123" }]);
+      ]),
+    ).to.containSubset([{ id: "0x123" }]);
   });
 
   it("categorizes properties", () => {
     const parentCategory = createTestCategoryDescription({ name: "cat1", label: "Parent Category" });
     const childCategory = createTestCategoryDescription({ name: "cat2", label: "Child Category", parent: parentCategory });
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({
-        categories: [parentCategory, childCategory],
-        fields: [
-          createTestSimpleContentField({ name: "prop1", label: "Prop One", category: parentCategory }),
-          createTestSimpleContentField({ name: "prop2", label: "Prop Two", category: childCategory }),
-        ],
-      }),
-      [
-        createTestContentItem({
-          values: {
-            prop1: "value1",
-            prop2: "value2",
-          },
-          displayValues: {
-            prop1: "Value One",
-            prop2: "Value Two",
-          },
+    expect(
+      buildElementsProperties(
+        createTestContentDescriptor({
+          categories: [parentCategory, childCategory],
+          fields: [
+            createTestSimpleContentField({ name: "prop1", label: "Prop One", category: parentCategory }),
+            createTestSimpleContentField({ name: "prop2", label: "Prop Two", category: childCategory }),
+          ],
         }),
-      ],
-    ))).to.deep.eq([{
-      class: "",
-      id: "0x1",
-      label: "",
-      items: {
-        ["Parent Category"]: {
-          type: "category",
-          items: {
-            ["Child Category"]: {
-              type: "category",
-              items: {
-                ["Prop Two"]: {
-                  type: "primitive",
-                  value: "Value Two",
+        [
+          createTestContentItem({
+            values: {
+              prop1: "value1",
+              prop2: "value2",
+            },
+            displayValues: {
+              prop1: "Value One",
+              prop2: "Value Two",
+            },
+          }),
+        ],
+      ),
+    ).to.deep.eq([
+      {
+        class: "",
+        id: "0x1",
+        label: "",
+        items: {
+          ["Parent Category"]: {
+            type: "category",
+            items: {
+              ["Child Category"]: {
+                type: "category",
+                items: {
+                  ["Prop Two"]: {
+                    type: "primitive",
+                    value: "Value Two",
+                  },
                 },
               },
-            },
-            ["Prop One"]: {
-              type: "primitive",
-              value: "Value One",
+              ["Prop One"]: {
+                type: "primitive",
+                value: "Value One",
+              },
             },
           },
         },
       },
-    }]);
+    ]);
   });
 
   it("sets primitive property value to empty string when it's not set", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({
-        categories: [category],
-        fields: [
-          createTestSimpleContentField({ name: "emptyProp", label: "EmptyProp", category }),
-          createTestSimpleContentField({ name: "undefinedProps", label: "UndefinedProp", category }),
-          createTestSimpleContentField({ name: "prop", label: "Prop", category }),
-        ],
-      }),
-      [
-        createTestContentItem({
-          values: {
-            emptyProp: undefined,
-            undefinedProps: undefined,
-            prop: "valid value",
-          },
-          displayValues: {
-            emptyProp: "",
-            undefinedProps: undefined,
-            prop: "valid value",
-          },
+    expect(
+      buildElementsProperties(
+        createTestContentDescriptor({
+          categories: [category],
+          fields: [
+            createTestSimpleContentField({ name: "emptyProp", label: "EmptyProp", category }),
+            createTestSimpleContentField({ name: "undefinedProps", label: "UndefinedProp", category }),
+            createTestSimpleContentField({ name: "prop", label: "Prop", category }),
+          ],
         }),
-      ],
-    ))).to.deep.eq([{
-      class: "",
-      id: "0x1",
-      label: "",
-      items: {
-        ["Test Category"]: {
-          type: "category",
-          items: {
-            ["EmptyProp"]: {
-              type: "primitive",
-              value: "",
+        [
+          createTestContentItem({
+            values: {
+              emptyProp: undefined,
+              undefinedProps: undefined,
+              prop: "valid value",
             },
-            ["UndefinedProp"]: {
-              type: "primitive",
-              value: "",
+            displayValues: {
+              emptyProp: "",
+              undefinedProps: undefined,
+              prop: "valid value",
             },
-            ["Prop"]: {
-              type: "primitive",
-              value: "valid value",
+          }),
+        ],
+      ),
+    ).to.deep.eq([
+      {
+        class: "",
+        id: "0x1",
+        label: "",
+        items: {
+          ["Test Category"]: {
+            type: "category",
+            items: {
+              ["EmptyProp"]: {
+                type: "primitive",
+                value: "",
+              },
+              ["UndefinedProp"]: {
+                type: "primitive",
+                value: "",
+              },
+              ["Prop"]: {
+                type: "primitive",
+                value: "valid value",
+              },
             },
           },
         },
       },
-    }]);
+    ]);
   });
 
   it("does not include category if it only has nested content field without values", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({
-        categories: [category],
-        fields: [
-          createTestNestedContentField({ name: "nestedField", category, nestedFields: [createTestSimpleContentField({ name: "primitiveField" })] }),
-        ],
-      }),
-      [
-        createTestContentItem({
-          values: {
-            nestedField: [],
-          },
-          displayValues: {
-            nestedField: [],
-          },
+    expect(
+      buildElementsProperties(
+        createTestContentDescriptor({
+          categories: [category],
+          fields: [createTestNestedContentField({ name: "nestedField", category, nestedFields: [createTestSimpleContentField({ name: "primitiveField" })] })],
         }),
-      ],
-    ))).to.deep.eq([{
-      class: "",
-      id: "0x1",
-      label: "",
-      items: {},
-    }]);
+        [
+          createTestContentItem({
+            values: {
+              nestedField: [],
+            },
+            displayValues: {
+              nestedField: [],
+            },
+          }),
+        ],
+      ),
+    ).to.deep.eq([
+      {
+        class: "",
+        id: "0x1",
+        label: "",
+        items: {},
+      },
+    ]);
   });
 
   it("sets property value to empty string when it's merged", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({
-        categories: [category],
-        fields: [
-          createTestSimpleContentField({ name: "prop", label: "Prop", category }),
-        ],
-      }),
-      [
-        createTestContentItem({
-          values: {
-            prop: "anything",
-          },
-          displayValues: {
-            prop: "anything",
-          },
-          mergedFieldNames: ["prop"],
+    expect(
+      buildElementsProperties(
+        createTestContentDescriptor({
+          categories: [category],
+          fields: [createTestSimpleContentField({ name: "prop", label: "Prop", category })],
         }),
-      ],
-    ))).to.deep.eq([{
-      class: "",
-      id: "0x1",
-      label: "",
-      items: {
-        ["Test Category"]: {
-          type: "category",
-          items: {
-            ["Prop"]: {
-              type: "primitive",
-              value: "",
+        [
+          createTestContentItem({
+            values: {
+              prop: "anything",
+            },
+            displayValues: {
+              prop: "anything",
+            },
+            mergedFieldNames: ["prop"],
+          }),
+        ],
+      ),
+    ).to.deep.eq([
+      {
+        class: "",
+        id: "0x1",
+        label: "",
+        items: {
+          ["Test Category"]: {
+            type: "category",
+            items: {
+              ["Prop"]: {
+                type: "primitive",
+                value: "",
+              },
             },
           },
         },
       },
-    }]);
+    ]);
   });
 
   it("handles struct properties", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({
-        categories: [category],
-        fields: [
-          createTestSimpleContentField({
-            name: "prop",
-            label: "Prop",
-            category,
-            type: {
-              valueFormat: PropertyValueFormat.Struct,
-              typeName: "Test Struct",
-              members: [{
-                name: "member1",
-                label: "Member One",
-                type: {
-                  valueFormat: PropertyValueFormat.Primitive,
-                  typeName: "Primitive One",
-                },
-              }, {
-                name: "member2",
-                label: "Member Two",
-                type: {
-                  valueFormat: PropertyValueFormat.Primitive,
-                  typeName: "Primitive Two",
-                },
-              }],
+    expect(
+      buildElementsProperties(
+        createTestContentDescriptor({
+          categories: [category],
+          fields: [
+            createTestSimpleContentField({
+              name: "prop",
+              label: "Prop",
+              category,
+              type: {
+                valueFormat: PropertyValueFormat.Struct,
+                typeName: "Test Struct",
+                members: [
+                  {
+                    name: "member1",
+                    label: "Member One",
+                    type: {
+                      valueFormat: PropertyValueFormat.Primitive,
+                      typeName: "Primitive One",
+                    },
+                  },
+                  {
+                    name: "member2",
+                    label: "Member Two",
+                    type: {
+                      valueFormat: PropertyValueFormat.Primitive,
+                      typeName: "Primitive Two",
+                    },
+                  },
+                ],
+              },
+            }),
+          ],
+        }),
+        [
+          createTestContentItem({
+            values: {
+              prop: {
+                member1: "value1",
+                member2: "value2",
+              },
+            },
+            displayValues: {
+              prop: {
+                member1: "Value One",
+                member2: "Value Two",
+              },
             },
           }),
         ],
-      }),
-      [
-        createTestContentItem({
-          values: {
-            prop: {
-              member1: "value1",
-              member2: "value2",
-            },
-          },
-          displayValues: {
-            prop: {
-              member1: "Value One",
-              member2: "Value Two",
-            },
-          },
-        }),
-      ],
-    ))).to.deep.eq([{
-      class: "",
-      id: "0x1",
-      label: "",
-      items: {
-        ["Test Category"]: {
-          type: "category",
-          items: {
-            ["Prop"]: {
-              type: "struct",
-              members: {
-                ["Member One"]: {
-                  type: "primitive",
-                  value: "Value One",
-                },
-                ["Member Two"]: {
-                  type: "primitive",
-                  value: "Value Two",
+      ),
+    ).to.deep.eq([
+      {
+        class: "",
+        id: "0x1",
+        label: "",
+        items: {
+          ["Test Category"]: {
+            type: "category",
+            items: {
+              ["Prop"]: {
+                type: "struct",
+                members: {
+                  ["Member One"]: {
+                    type: "primitive",
+                    value: "Value One",
+                  },
+                  ["Member Two"]: {
+                    type: "primitive",
+                    value: "Value Two",
+                  },
                 },
               },
             },
           },
         },
       },
-    }]);
+    ]);
   });
 
   it("handles primitive array properties", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({
-        categories: [category],
-        fields: [
-          createTestSimpleContentField({
-            name: "prop",
-            label: "Prop",
-            category,
-            type: {
-              valueFormat: PropertyValueFormat.Array,
-              typeName: "Test Array",
-              memberType: {
-                valueFormat: PropertyValueFormat.Primitive,
-                typeName: "Test Primitive",
+    expect(
+      buildElementsProperties(
+        createTestContentDescriptor({
+          categories: [category],
+          fields: [
+            createTestSimpleContentField({
+              name: "prop",
+              label: "Prop",
+              category,
+              type: {
+                valueFormat: PropertyValueFormat.Array,
+                typeName: "Test Array",
+                memberType: {
+                  valueFormat: PropertyValueFormat.Primitive,
+                  typeName: "Test Primitive",
+                },
               },
+            }),
+          ],
+        }),
+        [
+          createTestContentItem({
+            values: {
+              prop: ["value1", "value2"],
+            },
+            displayValues: {
+              prop: ["Value One", "Value Two"],
             },
           }),
         ],
-      }),
-      [
-        createTestContentItem({
-          values: {
-            prop: ["value1", "value2"],
-          },
-          displayValues: {
-            prop: ["Value One", "Value Two"],
-          },
-        }),
-      ],
-    ))).to.deep.eq([{
-      class: "",
-      id: "0x1",
-      label: "",
-      items: {
-        ["Test Category"]: {
-          type: "category",
-          items: {
-            ["Prop"]: {
-              type: "array",
-              valueType: "primitive",
-              values: ["Value One", "Value Two"],
+      ),
+    ).to.deep.eq([
+      {
+        class: "",
+        id: "0x1",
+        label: "",
+        items: {
+          ["Test Category"]: {
+            type: "category",
+            items: {
+              ["Prop"]: {
+                type: "array",
+                valueType: "primitive",
+                values: ["Value One", "Value Two"],
+              },
             },
           },
         },
       },
-    }]);
+    ]);
   });
 
   it("handles struct array properties", () => {
     const category = createTestCategoryDescription({ label: "Test Category" });
-    expect(buildElementsProperties(new Content(
-      createTestContentDescriptor({
-        categories: [category],
-        fields: [
-          createTestSimpleContentField({
-            name: "prop",
-            label: "Prop",
-            category,
-            type: {
-              valueFormat: PropertyValueFormat.Array,
-              typeName: "Test Array",
-              memberType: {
-                valueFormat: PropertyValueFormat.Struct,
-                typeName: "Test Struct",
-                members: [{
-                  name: "member",
-                  label: "Test Member",
-                  type: {
-                    valueFormat: PropertyValueFormat.Primitive,
-                    typeName: "Test Primitive",
-                  },
-                }],
+    expect(
+      buildElementsProperties(
+        createTestContentDescriptor({
+          categories: [category],
+          fields: [
+            createTestSimpleContentField({
+              name: "prop",
+              label: "Prop",
+              category,
+              type: {
+                valueFormat: PropertyValueFormat.Array,
+                typeName: "Test Array",
+                memberType: {
+                  valueFormat: PropertyValueFormat.Struct,
+                  typeName: "Test Struct",
+                  members: [
+                    {
+                      name: "member",
+                      label: "Test Member",
+                      type: {
+                        valueFormat: PropertyValueFormat.Primitive,
+                        typeName: "Test Primitive",
+                      },
+                    },
+                  ],
+                },
               },
+            }),
+          ],
+        }),
+        [
+          createTestContentItem({
+            values: {
+              prop: [
+                {
+                  member: "value1",
+                },
+                {
+                  member: "value2",
+                },
+              ],
+            },
+            displayValues: {
+              prop: [
+                {
+                  member: "Value One",
+                },
+                {
+                  member: "Value Two",
+                },
+              ],
             },
           }),
         ],
-      }),
-      [
-        createTestContentItem({
-          values: {
-            prop: [{
-              member: "value1",
-            }, {
-              member: "value2",
-            }],
-          },
-          displayValues: {
-            prop: [{
-              member: "Value One",
-            }, {
-              member: "Value Two",
-            }],
-          },
-        }),
-      ],
-    ))).to.deep.eq([{
-      class: "",
-      id: "0x1",
-      label: "",
-      items: {
-        ["Test Category"]: {
-          type: "category",
-          items: {
-            ["Prop"]: {
-              type: "array",
-              valueType: "struct",
-              values: [{
-                ["Test Member"]: {
-                  type: "primitive",
-                  value: "Value One",
-                },
-              }, {
-                ["Test Member"]: {
-                  type: "primitive",
-                  value: "Value Two",
-                },
-              }],
+      ),
+    ).to.deep.eq([
+      {
+        class: "",
+        id: "0x1",
+        label: "",
+        items: {
+          ["Test Category"]: {
+            type: "category",
+            items: {
+              ["Prop"]: {
+                type: "array",
+                valueType: "struct",
+                values: [
+                  {
+                    ["Test Member"]: {
+                      type: "primitive",
+                      value: "Value One",
+                    },
+                  },
+                  {
+                    ["Test Member"]: {
+                      type: "primitive",
+                      value: "Value Two",
+                    },
+                  },
+                ],
+              },
             },
           },
         },
       },
-    }]);
+    ]);
   });
-
 });
 
 describe("getElementsCount", () => {
@@ -454,30 +485,41 @@ describe("getElementsCount", () => {
   });
 
   it("returns 0 when statement has no rows", () => {
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns((_q, cb) => {
-      const statementMock = moq.Mock.ofType<ECSqlStatement>();
-      statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
-      return cb(statementMock.object);
-    });
+    imodelMock
+      .setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny()))
+      .returns((_q, cb) => {
+        const statementMock = moq.Mock.ofType<ECSqlStatement>();
+        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
+        return cb(statementMock.object);
+      });
     expect(getElementsCount(imodelMock.object)).to.be.eq(0);
   });
 
   it("returns count when statement has row", () => {
     const elementCount = 3;
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns((_q, cb) => {
-      const valueMock = moq.Mock.ofType<ECSqlValue>();
-      valueMock.setup((x) => x.getInteger()).returns(() => elementCount);
-      const statementMock = moq.Mock.ofType<ECSqlStatement>();
-      statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_ROW);
-      statementMock.setup((x) => x.getValue(0)).returns(() => valueMock.object);
-      return cb(statementMock.object);
-    });
+    imodelMock
+      .setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny()))
+      .returns((_q, cb) => {
+        const valueMock = moq.Mock.ofType<ECSqlValue>();
+        valueMock.setup((x) => x.getInteger()).returns(() => elementCount);
+        const statementMock = moq.Mock.ofType<ECSqlStatement>();
+        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_ROW);
+        statementMock.setup((x) => x.getValue(0)).returns(() => valueMock.object);
+        return cb(statementMock.object);
+      });
     expect(getElementsCount(imodelMock.object)).to.be.eq(elementCount);
   });
 
   it("adds WHERE clause when class list is defined and not empty", () => {
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((query) => query.includes("WHERE")), moq.It.isAny()))
-      .returns(() => 0).verifiable();
+    imodelMock
+      .setup((x) =>
+        x.withPreparedStatement(
+          moq.It.is((query) => query.includes("WHERE")),
+          moq.It.isAny(),
+        ),
+      )
+      .returns(() => 0)
+      .verifiable();
     getElementsCount(imodelMock.object, ["TestSchema:TestClass"]);
     imodelMock.verifyAll();
   });
@@ -487,135 +529,49 @@ describe("getElementsCount", () => {
     expect(() => getElementsCount(imodelMock.object, ["%TestSchema:TestClass%"])).to.throw(PresentationError);
     expect(() => getElementsCount(imodelMock.object, ["TestSchema:TestClass  "])).to.throw(PresentationError);
   });
-
 });
 
-describe("iterateElementIds", () => {
+describe("getBatchedClassElementIds", () => {
   const imodelMock = moq.Mock.ofType<IModelDb>();
   beforeEach(() => {
     imodelMock.reset();
   });
 
-  function collectResults<T>(generator: Generator<T>) {
-    const results = [];
-    for (const entry of generator) {
-      results.push(entry);
-    }
-    return results;
-  }
-
-  it("returns empty map when statement has no rows", () => {
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns((_q, cb) => {
-      const statementMock = moq.Mock.ofType<ECSqlStatement>();
-      statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
-      return cb(statementMock.object);
-    });
-    expect(collectResults(iterateElementIds(imodelMock.object))).to.be.deep.eq([new Map<string, string[]>()]);
+  it("returns empty list when statement has no rows", async () => {
+    imodelMock.setup((x) => x.createQueryReader(moq.It.isAnyString())).returns(() => stubECSqlReader([]));
+    expect(await getBatchedClassElementIds(imodelMock.object, "x.y", 2)).to.be.deep.eq([]);
   });
 
-  it("returns ids grouped by class when statement has rows", () => {
-    const elements = [
-      { className: "TestSchema:TestClass", id: "0x1" },
-      { className: "TestSchema:TestClass", id: "0x2" },
-      { className: "TestSchema:TestClass2", id: "0x3" },
-      { className: "TestSchema:TestClass", id: "0x4" },
-    ];
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns((_q, cb) => {
-      const statementMock = moq.Mock.ofType<ECSqlStatement>();
-      for (const element of elements) {
-        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_ROW);
-        statementMock.setup((x) => x.getRow()).returns(() => ({ elId: element.id, elClassName: element.className }));
-      }
-      statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
-      return cb(statementMock.object);
-    });
-    const expectedResult = [new Map<string, string[]>([
-      ["TestSchema:TestClass", ["0x1", "0x2", "0x4"]],
-      ["TestSchema:TestClass2", ["0x3"]],
-    ])];
-    expect(collectResults(iterateElementIds(imodelMock.object))).to.be.deep.eq(expectedResult);
+  it("returns batches", async () => {
+    const elements = [{ id: "0x1" }, { id: "0x2" }, { id: "0x3" }, { id: "0x4" }, { id: "0x5" }];
+    imodelMock.setup((x) => x.createQueryReader(moq.It.isAnyString())).returns(() => stubECSqlReader(elements));
+    expect(await getBatchedClassElementIds(imodelMock.object, "x.y", 2)).to.be.deep.eq([
+      { from: "0x1", to: "0x2" },
+      { from: "0x3", to: "0x4" },
+      { from: "0x5", to: "0x5" },
+    ]);
+  });
+});
+
+describe("getClassesWithInstances", () => {
+  const imodelMock = moq.Mock.ofType<IModelDb>();
+  beforeEach(() => {
+    imodelMock.reset();
   });
 
-  it("skips rows without class name or id", () => {
-    const elements = [
-      { className: undefined, id: "0x1" },
-      { className: "TestSchema:TestClass", id: undefined },
-      { className: "TestSchema:TestClass", id: "0x2" },
-    ];
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns((_q, cb) => {
-      const statementMock = moq.Mock.ofType<ECSqlStatement>();
-      for (const element of elements) {
-        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_ROW);
-        statementMock.setup((x) => x.getRow()).returns(() => ({ elId: element.id, elClassName: element.className }));
-      }
-      statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
-      return cb(statementMock.object);
-    });
-    const expectedResult = [
-      new Map<string, string[]>([
-        ["TestSchema:TestClass", ["0x2"]],
-      ])];
-    expect(collectResults(iterateElementIds(imodelMock.object))).to.be.deep.eq(expectedResult);
+  it("returns unique class names by running a query", async () => {
+    imodelMock
+      .setup((x) => x.createQueryReader(moq.It.isAnyString()))
+      .returns(() =>
+        stubECSqlReader([
+          ["schema", "classA"],
+          ["schema", "classB"],
+          ["schema", "classA"],
+          ["schema", "classB"],
+        ]),
+      );
+    const result = new Array<string>();
+    await getClassesWithInstances(imodelMock.object, ["x"]).forEach((value) => result.push(value));
+    expect(result).to.deep.eq(["schema.classA", "schema.classB"]);
   });
-
-  it("adds WHERE clause when class list is defined and not empty", () => {
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((query) => query.includes("WHERE") && query.includes("IS (TestSchema:TestClass)")), moq.It.isAny()))
-      .returns((_q, cb) => {
-        const statementMock = moq.Mock.ofType<ECSqlStatement>();
-        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
-        return cb(statementMock.object);
-      })
-      .verifiable();
-    collectResults(iterateElementIds(imodelMock.object, ["TestSchema:TestClass"]));
-    imodelMock.verifyAll();
-  });
-
-  it("queries ids in pages", () => {
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((query) => !query.includes("WHERE")), moq.It.isAny()))
-      .returns((_q, cb) => {
-        const statementMock = moq.Mock.ofType<ECSqlStatement>();
-        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_ROW);
-        statementMock.setup((x) => x.getRow()).returns(() => ({ elId: "0x1", elClassName: "TestClass" }));
-        return cb(statementMock.object);
-      })
-      .verifiable();
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((query) => query.includes("ECInstanceId > ?")), moq.It.isAny()))
-      .returns((_q, cb) => {
-        const statementMock = moq.Mock.ofType<ECSqlStatement>();
-        statementMock.setup((x) => x.bindId(1, "0x1")).verifiable();
-        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
-        return cb(statementMock.object);
-      })
-      .verifiable();
-    collectResults(iterateElementIds(imodelMock.object, undefined, 1));
-    imodelMock.verifyAll();
-  });
-
-  it("queries ids in pages with class filter", () => {
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((query) => query.includes("IS (TestSchema:TestClass)") && !query.includes("ECInstanceId > ?")), moq.It.isAny()))
-      .returns((_q, cb) => {
-        const statementMock = moq.Mock.ofType<ECSqlStatement>();
-        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_ROW);
-        statementMock.setup((x) => x.getRow()).returns(() => ({ elId: "0x1", elClassName: "TestClass" }));
-        return cb(statementMock.object);
-      })
-      .verifiable();
-    imodelMock.setup((x) => x.withPreparedStatement(moq.It.is((query) => query.includes("IS (TestSchema:TestClass)") && query.includes("ECInstanceId > ?")), moq.It.isAny()))
-      .returns((_q, cb) => {
-        const statementMock = moq.Mock.ofType<ECSqlStatement>();
-        statementMock.setup((x) => x.bindId(1, "0x1")).verifiable();
-        statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
-        return cb(statementMock.object);
-      })
-      .verifiable();
-    collectResults(iterateElementIds(imodelMock.object, ["TestSchema:TestClass"], 1));
-    imodelMock.verifyAll();
-  });
-
-  it("throws if class list contains invalid class name", () => {
-    expect(() => collectResults(iterateElementIds(imodelMock.object, ["'TestSchema:TestClass'"]))).to.throw(PresentationError);
-    expect(() => collectResults(iterateElementIds(imodelMock.object, ["%TestSchema:TestClass%"]))).to.throw(PresentationError);
-    expect(() => collectResults(iterateElementIds(imodelMock.object, ["TestSchema:TestClass  "]))).to.throw(PresentationError);
-  });
-
 });

--- a/presentation/backend/src/test/Helpers.ts
+++ b/presentation/backend/src/test/Helpers.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ECSqlReader } from "@itwin/core-common";
+
+export function stubECSqlReader<TRow extends {}>(rows: TRow[]) {
+  let stepsCount = -1;
+  return {
+    async step() {
+      return ++stepsCount < rows.length;
+    },
+    get current() {
+      return stepsCount >= 0 && stepsCount < rows.length ? { toRow: () => rows[stepsCount] } : undefined;
+    },
+    async toArray() {
+      return rows;
+    },
+  } as unknown as ECSqlReader;
+}

--- a/presentation/backend/src/test/PresentationManager.test.snap
+++ b/presentation/backend/src/test/PresentationManager.test.snap
@@ -761,6 +761,190 @@ Object {
 }
 `;
 
+exports[`PresentationManager addon results conversion to Presentation objects getContentSet returns content set 1`] = `
+Array [
+  Object {
+    "classInfo": Object {
+      "id": "0xfef3000000b3cb",
+      "label": "Yuan Renminbi lime",
+      "name": "Multi-lateral",
+    },
+    "displayValues": Object {
+      "test field": "test display value",
+    },
+    "imageId": "image id",
+    "labelDefinition": Object {
+      "displayValue": "Argentine Peso",
+      "rawValue": "Functionality",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "District",
+        "id": "0x406e0000001bdf",
+      },
+    ],
+    "values": Object {
+      "test field": "test value",
+    },
+  },
+]
+`;
+
+exports[`PresentationManager addon results conversion to Presentation objects getContentSet returns content set for BisCore:Element instances when concrete key is found 1`] = `
+Array [
+  Object {
+    "classInfo": Object {
+      "id": "0x12f58000000306f",
+      "label": "lime Chips Centralized",
+      "name": "Regional",
+    },
+    "displayValues": Object {
+      "test field": "test display value",
+    },
+    "imageId": "test image id",
+    "labelDefinition": Object {
+      "displayValue": "Director",
+      "rawValue": "Refined",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "Armenian Dram",
+        "id": "0x13e25000000ea94",
+      },
+    ],
+    "values": Object {
+      "test field": "test value",
+    },
+  },
+]
+`;
+
+exports[`PresentationManager addon results conversion to Presentation objects getContentSet returns content set for BisCore:Element instances when concrete key is not found 1`] = `
+Array [
+  Object {
+    "classInfo": Object {
+      "id": "0x58d1000000eea3",
+      "label": "Corporate",
+      "name": "Money Market Account",
+    },
+    "displayValues": Object {
+      "test field": "test display value",
+    },
+    "imageId": "test image id",
+    "labelDefinition": Object {
+      "displayValue": "Nebraska",
+      "rawValue": "primary",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "Steel",
+        "id": "0x1450c0000017be8",
+      },
+    ],
+    "values": Object {
+      "test field": "test value",
+    },
+  },
+]
+`;
+
+exports[`PresentationManager addon results conversion to Presentation objects getContentSet returns content without formatting 1`] = `
+Array [
+  Object {
+    "classInfo": Object {
+      "id": "0x4c9d0000009d37",
+      "label": "e-tailers",
+      "name": "Seamless",
+    },
+    "displayValues": Object {},
+    "imageId": "test image id",
+    "labelDefinition": Object {
+      "displayValue": "neural",
+      "rawValue": "grey",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "ability",
+        "id": "0x4776000000b65d",
+      },
+    ],
+    "values": Object {
+      "test field": 1.234,
+    },
+  },
+]
+`;
+
+exports[`PresentationManager addon results conversion to Presentation objects getContentSet returns formatted content set 1`] = `
+Array [
+  Object {
+    "classInfo": Object {
+      "id": "0x185860000012371",
+      "label": "Human Optional Accounts",
+      "name": "holistic",
+    },
+    "displayValues": Object {
+      "test field": "1.23",
+    },
+    "imageId": "test image id",
+    "labelDefinition": Object {
+      "displayValue": "port",
+      "rawValue": "interactive",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "Chair",
+        "id": "0x306d00000118e0",
+      },
+    ],
+    "values": Object {
+      "test field": 1.234,
+    },
+  },
+]
+`;
+
+exports[`PresentationManager addon results conversion to Presentation objects getContentSet returns localized content set 1`] = `
+Array [
+  Object {
+    "classInfo": Object {
+      "id": "0x16d360000000546",
+      "label": "Personal Loan Account",
+      "name": "open-source",
+    },
+    "displayValues": Object {
+      "test field": "Not specified",
+    },
+    "imageId": "image id",
+    "labelDefinition": Object {
+      "displayValue": "Not specified",
+      "rawValue": "Not specified",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "empower",
+        "id": "0xf4e7000000fcfa",
+      },
+    ],
+    "values": Object {
+      "test field": "Not specified",
+    },
+  },
+]
+`;
+
 exports[`PresentationManager addon results conversion to Presentation objects getContentSources returns content sources 1`] = `
 Array [
   Object {

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -37,6 +37,7 @@ import { RulesetManagerImpl } from "../presentation-backend/RulesetManager";
 import { RulesetVariablesManagerImpl } from "../presentation-backend/RulesetVariablesManager";
 import { SelectionScopesHelper } from "../presentation-backend/SelectionScopesHelper";
 import { UpdatesTracker } from "../presentation-backend/UpdatesTracker";
+import { stubECSqlReader } from "./Helpers";
 
 const deepEqual = require("deep-equal"); // eslint-disable-line @typescript-eslint/no-var-requires
 
@@ -1466,6 +1467,315 @@ describe("PresentationManager", () => {
 
     });
 
+    describe("getContentSet", () => {
+
+      it("returns content set", async () => {
+        // what the addon receives
+        const keys = new KeySet([createRandomECInstancesNodeKey(), createRandomECInstanceKey()]);
+        const fieldName = "test field";
+        const category = createTestCategoryDescription();
+        const descriptor = createTestContentDescriptor({
+          categories: [category],
+          fields: [createTestSimpleContentField({
+            category,
+            name: fieldName,
+          })],
+        });
+        const expectedParams = {
+          requestId: NativePlatformRequestTypes.GetContentSet,
+          params: {
+            keys: getKeysForContentRequest(keys),
+            descriptorOverrides: descriptor.createDescriptorOverrides(),
+            paging: testData.pageOptions,
+            rulesetId: manager.getRulesetId(testData.rulesetOrId),
+          },
+        };
+
+        // what the addon returns
+        const addonResponse: ItemJSON[] = [{
+          primaryKeys: [createRandomECInstanceKey()],
+          classInfo: createRandomECClassInfo(),
+          labelDefinition: createRandomLabelDefinition(),
+          imageId: "image id",
+          values: {
+            [fieldName]: "test value",
+          },
+          displayValues: {
+            [fieldName]: "test display value",
+          },
+          mergedFieldNames: [],
+        }];
+        setup(addonResponse);
+
+        // test
+        const options: Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet>> = {
+          imodel: imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor,
+          keys,
+        };
+        const result = await manager.getContentSet(options);
+        verifyWithSnapshot(result, expectedParams);
+      });
+
+      it("returns localized content set", async () => {
+        // what the addon receives
+        const keys = new KeySet([createRandomECInstancesNodeKey(), createRandomECInstanceKey()]);
+        const fieldName = "test field";
+        const category = createTestCategoryDescription({ label: "@Presentation:label.notSpecified@" });
+        const descriptor = createTestContentDescriptor({
+          categories: [category],
+          fields: [createTestSimpleContentField({
+            label: "@Presentation:label.notSpecified@",
+            category,
+            name: fieldName,
+          })],
+        });
+        const expectedParams = {
+          requestId: NativePlatformRequestTypes.GetContentSet,
+          params: {
+            keys: getKeysForContentRequest(keys),
+            descriptorOverrides: descriptor.createDescriptorOverrides(),
+            paging: testData.pageOptions,
+            rulesetId: manager.getRulesetId(testData.rulesetOrId),
+          },
+        };
+
+        // what the addon returns
+        const addonResponse: ItemJSON[] = [{
+          primaryKeys: [createRandomECInstanceKey()],
+          classInfo: createRandomECClassInfo(),
+          labelDefinition: {
+            typeName: "string",
+            rawValue: "@Presentation:label.notSpecified@",
+            displayValue: "@Presentation:label.notSpecified@",
+          },
+          imageId: "image id",
+          values: {
+            [fieldName]: "@Presentation:label.notSpecified@",
+          },
+          displayValues: {
+            [fieldName]: "@Presentation:label.notSpecified@",
+          },
+          mergedFieldNames: [],
+        }];
+        setup(addonResponse);
+
+        // test
+        const options: Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet>> = {
+          imodel: imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor,
+          keys,
+        };
+        const result = await manager.getContentSet(options);
+        verifyWithSnapshot(result, expectedParams);
+      });
+
+      it("returns content set for BisCore:Element instances when concrete key is found", async () => {
+        // what the addon receives
+        const baseClassKey = { className: "BisCore:Element", id: "0x123" };
+        const concreteClassKey = { className: "concrete:class", id: baseClassKey.id };
+        setupIModelForElementKey(imodelMock, concreteClassKey);
+        const expectedParams = {
+          requestId: NativePlatformRequestTypes.GetContentSet,
+          params: {
+            keys: getKeysForContentRequest(new KeySet([concreteClassKey])),
+            descriptorOverrides: {},
+            paging: testData.pageOptions,
+            rulesetId: manager.getRulesetId(testData.rulesetOrId),
+          },
+        };
+
+        // what the addon returns
+        const fieldName = "test field";
+        const addonResponse: ItemJSON[] = [{
+          primaryKeys: [createRandomECInstanceKey()],
+          classInfo: createRandomECClassInfo(),
+          labelDefinition: createRandomLabelDefinition(),
+          imageId: "test image id",
+          values: {
+            [fieldName]: "test value",
+          },
+          displayValues: {
+            [fieldName]: "test display value",
+          },
+          mergedFieldNames: [],
+        }];
+        setup(addonResponse);
+
+        // test
+        const options: Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet>> = {
+          imodel: imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor: createTestContentDescriptor({ fields: [createTestSimpleContentField({ name: fieldName })] }),
+          keys: new KeySet([baseClassKey]),
+        };
+        const result = await manager.getContentSet(options);
+        verifyWithSnapshot(result, expectedParams);
+      });
+
+      it("returns content set for BisCore:Element instances when concrete key is not found", async () => {
+        // what the addon receives
+        const baseClassKey = { className: "BisCore:Element", id: "0x123" };
+        setupIModelForNoResultStatement(imodelMock);
+        const expectedParams = {
+          requestId: NativePlatformRequestTypes.GetContentSet,
+          params: {
+            keys: getKeysForContentRequest(new KeySet([baseClassKey])),
+            descriptorOverrides: {},
+            paging: testData.pageOptions,
+            rulesetId: manager.getRulesetId(testData.rulesetOrId),
+          },
+        };
+
+        // what the addon returns
+        const fieldName = "test field";
+        const addonResponse: ItemJSON[] = [{
+          primaryKeys: [createRandomECInstanceKey()],
+          classInfo: createRandomECClassInfo(),
+          labelDefinition: createRandomLabelDefinition(),
+          imageId: "test image id",
+          values: {
+            [fieldName]: "test value",
+          },
+          displayValues: {
+            [fieldName]: "test display value",
+          },
+          mergedFieldNames: [],
+        }];
+        setup(addonResponse);
+
+        // test
+        const options: Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet>> = {
+          imodel: imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor: createTestContentDescriptor({ fields: [createTestSimpleContentField({ name: fieldName })] }),
+          keys: new KeySet([baseClassKey]),
+        };
+        const result = await manager.getContentSet(options);
+        verifyWithSnapshot(result, expectedParams);
+      });
+
+      it("returns formatted content set", async () => {
+        // setup manager to support formatting
+        recreateManager({ schemaContextProvider: () => new SchemaContext() });
+
+        // what the addon receives
+        const keys = new KeySet([createRandomECInstancesNodeKey()]);
+        const fieldName = "test field";
+        const descriptor = createTestContentDescriptor({
+          fields: [
+            createTestPropertiesContentField({
+              name: fieldName,
+              properties: [{ property: createTestPropertyInfo() }],
+              type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" },
+            }),
+          ], displayType: "test",
+        });
+        const expectedParams = {
+          requestId: NativePlatformRequestTypes.GetContentSet,
+          params: {
+            keys: getKeysForContentRequest(keys),
+            descriptorOverrides: {
+              displayType: descriptor.displayType,
+            },
+            paging: testData.pageOptions,
+            rulesetId: manager.getRulesetId(testData.rulesetOrId),
+            omitFormattedValues: true,
+          },
+        };
+
+        // what the addon returns
+        const fieldValue = 1.234;
+        const addonResponse: ItemJSON[] = [{
+          primaryKeys: [createRandomECInstanceKey()],
+          classInfo: createRandomECClassInfo(),
+          labelDefinition: createRandomLabelDefinition(),
+          imageId: "test image id",
+          values: {
+            [fieldName]: fieldValue,
+          },
+          displayValues: {},
+          mergedFieldNames: [],
+        }];
+        setup(addonResponse);
+
+        // test
+        const options: Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet>> = {
+          imodel: imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor,
+          keys,
+        };
+        const result = await manager.getContentSet(options);
+        verifyWithSnapshot(result, expectedParams);
+      });
+
+      it("returns content without formatting", async () => {
+        // setup manager to support formatting
+        recreateManager({ schemaContextProvider: () => new SchemaContext() });
+
+        // what the addon receives
+        const keys = new KeySet([createRandomECInstancesNodeKey()]);
+        const fieldName = "test field";
+        const descriptor = createTestContentDescriptor({
+          fields: [
+            createTestPropertiesContentField({
+              name: fieldName,
+              properties: [{ property: createTestPropertyInfo() }],
+              type: { valueFormat: PropertyValueFormat.Primitive, typeName: "double" },
+            }),
+          ], displayType: "test",
+        });
+        const expectedParams = {
+          requestId: NativePlatformRequestTypes.GetContentSet,
+          params: {
+            keys: getKeysForContentRequest(keys),
+            descriptorOverrides: {
+              displayType: descriptor.displayType,
+            },
+            paging: testData.pageOptions,
+            rulesetId: manager.getRulesetId(testData.rulesetOrId),
+            omitFormattedValues: true,
+          },
+        };
+
+        // what the addon returns
+        const fieldValue = 1.234;
+        const addonResponse: ItemJSON[] = [{
+          primaryKeys: [createRandomECInstanceKey()],
+          classInfo: createRandomECClassInfo(),
+          labelDefinition: createRandomLabelDefinition(),
+          imageId: "test image id",
+          values: {
+            [fieldName]: fieldValue,
+          },
+          displayValues: {},
+          mergedFieldNames: [],
+        }];
+        setup(addonResponse);
+
+        // test
+        const options: Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet>> = {
+          imodel: imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          paging: testData.pageOptions,
+          descriptor,
+          keys,
+          omitFormattedValues: true,
+        };
+        const result = await manager.getContentSet(options);
+        verifyWithSnapshot(result, expectedParams);
+      });
+
+    });
+
     describe("getContent", () => {
 
       it("returns content", async () => {
@@ -1906,6 +2216,34 @@ describe("PresentationManager", () => {
     });
 
     describe("getElementProperties", () => {
+      it("returns no properties for invalid element id", async () => {
+        // what the addon receives
+        const elementKey = { className: "BisCore:Element", id: "0x123" };
+
+        const expectedContentParams = {
+          requestId: NativePlatformRequestTypes.GetContent,
+          params: {
+            keys: getKeysForContentRequest(new KeySet([elementKey])),
+            descriptorOverrides: {
+              displayType: DefaultContentDisplayTypes.PropertyPane,
+              contentFlags: ContentFlags.ShowLabels,
+            },
+            rulesetId: "ElementProperties",
+          },
+        };
+
+        // what the addon returns
+        setup({});
+
+        // test
+        const options: SingleElementPropertiesRequestOptions<IModelDb> = {
+          imodel: imodelMock.object,
+          elementId: elementKey.id,
+        };
+        const result = await manager.getElementProperties(options);
+        verifyMockRequest(expectedContentParams);
+        expect(result).to.be.undefined;
+      });
 
       it("returns single element properties", async () => {
         // what the addon receives
@@ -2047,66 +2385,82 @@ describe("PresentationManager", () => {
         expect(result).to.deep.eq(expectedResponse);
       });
 
-      function setupIModelForElementIds(imodel: moq.IMock<IModelDb>, idsByClass: Map<string, string[]>, idsCount: number) {
-        imodel.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns(() => idsCount);
-        imodel.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns(() => ({ ids: idsByClass, lastElementId: undefined }));
+      function setupIModelForElementIds(imodel: moq.IMock<IModelDb>, ids: string[]) {
+        imodel.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns(() => ids.length);
+        imodel.setup((x) => x.createQueryReader(moq.It.is((query) => query.startsWith("SELECT ECInstanceId")))).returns(() => stubECSqlReader(ids.map((id) => ({ id }))));
       }
 
       it("returns multiple elements properties", async () => {
         // what the addon receives
-        const elementKeys = [{ className: "TestSchema:TestClass", id: "0x123" }, { className: "TestSchema:TestClass", id: "0x124" }];
-        setupIModelForElementIds(imodelMock, new Map<string, string[]>([["TestSchema:TestClass", ["0x123", "0x124"]]]), 2);
-        elementKeys.forEach((key) => setupIModelForElementKey(imodelMock, key));
+        imodelMock.setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM [TestSchema].[TestClass]`)))).returns(() => stubECSqlReader([["TestSchema", "TestClass"]]));
+        setupIModelForElementIds(imodelMock, ["0x123", "0x124"]);
 
         const expectedContentParams = {
-          requestId: NativePlatformRequestTypes.GetContent,
+          requestId: NativePlatformRequestTypes.GetContentSet,
           params: {
-            keys: getKeysForContentRequest(new KeySet(elementKeys)),
+            rulesetId: manager.getRulesetId({
+              id: `content/TestSchema.TestClass`,
+              rules: [{
+                ruleType: "Content",
+                specifications: [{
+                  specType: "ContentInstancesOfSpecificClasses",
+                  classes: {
+                    schemaName: "TestSchema",
+                    classNames: ["TestClass"],
+                    arePolymorphic: false,
+                  },
+                  handlePropertiesPolymorphically: true,
+                }],
+              }],
+            }),
             descriptorOverrides: {
               displayType: DefaultContentDisplayTypes.Grid,
               contentFlags: ContentFlags.ShowLabels,
+              instanceFilter:{
+                selectClassName: `TestSchema.TestClass`,
+                expression: `this.ECInstanceId >= ${Number.parseInt("0x123", 16).toString(10)} AND this.ECInstanceId <= ${Number.parseInt("0x124", 16).toString(10)}`,
+              },
             },
-            rulesetId: "ElementProperties",
+            keys: new KeySet(),
           },
         };
 
         // what the addon returns
-        const addonContentResponse = new Content(
-          createTestContentDescriptor({
-            fields: [
-              createTestSimpleContentField({
-                name: "test",
-                label: "Test Field",
-                category: createTestCategoryDescription({ label: "Test Category" }),
-              }),
-            ],
-          }),
-          [
-            createTestContentItem({
-              label: "test label 1",
-              classInfo: createTestECClassInfo({ label: "Test Class" }),
-              primaryKeys: [{ className: "TestSchema:TestClass", id: "0x123" }],
-              values: {
-                test: "test value 1",
-              },
-              displayValues: {
-                test: "test display value 1",
-              },
-            }),
-            createTestContentItem({
-              label: "test label 2",
-              classInfo: createTestECClassInfo({ label: "Test Class" }),
-              primaryKeys: [{ className: "TestSchema:TestClass", id: "0x124" }],
-              values: {
-                test: "test value 2",
-              },
-              displayValues: {
-                test: "test display value 2",
-              },
+        setup(createTestContentDescriptor({
+          displayType: DefaultContentDisplayTypes.Grid,
+          contentFlags: ContentFlags.ShowLabels,
+          fields: [
+            createTestSimpleContentField({
+              name: "test",
+              label: "Test Field",
+              category: createTestCategoryDescription({ label: "Test Category" }),
             }),
           ],
-        ).toJSON();
-        setup(addonContentResponse);
+        }).toJSON());
+        setup([
+          createTestContentItem({
+            label: "test label 1",
+            classInfo: createTestECClassInfo({ label: "Test Class" }),
+            primaryKeys: [{ className: "TestSchema:TestClass", id: "0x123" }],
+            values: {
+              test: "test value 1",
+            },
+            displayValues: {
+              test: "test display value 1",
+            },
+          }),
+          createTestContentItem({
+            label: "test label 2",
+            classInfo: createTestECClassInfo({ label: "Test Class" }),
+            primaryKeys: [{ className: "TestSchema:TestClass", id: "0x124" }],
+            values: {
+              test: "test value 2",
+            },
+            displayValues: {
+              test: "test display value 2",
+            },
+          }),
+        ].map((item) => item.toJSON()));
 
         // test
         const options: MultiElementPropertiesRequestOptions<IModelDb> = {
@@ -2158,59 +2512,75 @@ describe("PresentationManager", () => {
 
       it("returns localized multiple elements properties", async () => {
         // what the addon receives
-        const elementKeys = [{ className: "TestSchema:TestClass", id: "0x123" }, { className: "TestSchema:TestClass", id: "0x124" }];
-        setupIModelForElementIds(imodelMock, new Map<string, string[]>([["TestSchema:TestClass", ["0x123", "0x124"]]]), 2);
-        elementKeys.forEach((key) => setupIModelForElementKey(imodelMock, key));
+        imodelMock.setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM [TestSchema].[TestClass]`)))).returns(() => stubECSqlReader([["TestSchema", "TestClass"]]));
+        setupIModelForElementIds(imodelMock, ["0x123", "0x124"]);
 
         const expectedContentParams = {
-          requestId: NativePlatformRequestTypes.GetContent,
+          requestId: NativePlatformRequestTypes.GetContentSet,
           params: {
-            keys: getKeysForContentRequest(new KeySet(elementKeys)),
+            rulesetId: manager.getRulesetId({
+              id: `content/TestSchema.TestClass`,
+              rules: [{
+                ruleType: "Content",
+                specifications: [{
+                  specType: "ContentInstancesOfSpecificClasses",
+                  classes: {
+                    schemaName: "TestSchema",
+                    classNames: ["TestClass"],
+                    arePolymorphic: false,
+                  },
+                  handlePropertiesPolymorphically: true,
+                }],
+              }],
+            }),
             descriptorOverrides: {
               displayType: DefaultContentDisplayTypes.Grid,
               contentFlags: ContentFlags.ShowLabels,
+              instanceFilter:{
+                selectClassName: `TestSchema.TestClass`,
+                expression: `this.ECInstanceId >= ${Number.parseInt("0x123", 16).toString(10)} AND this.ECInstanceId <= ${Number.parseInt("0x124", 16).toString(10)}`,
+              },
             },
-            rulesetId: "ElementProperties",
+            keys: new KeySet(),
           },
         };
 
         // what the addon returns
-        const addonContentResponse = new Content(
-          createTestContentDescriptor({
-            fields: [
-              createTestSimpleContentField({
-                name: "test",
-                label: "Test Field",
-                category: createTestCategoryDescription({ label: "Test Category" }),
-              }),
-            ],
-          }),
-          [
-            createTestContentItem({
-              label: "@Presentation:label.notSpecified@",
-              classInfo: createTestECClassInfo({ label: "Test Class" }),
-              primaryKeys: [{ className: "TestSchema:TestClass", id: "0x123" }],
-              values: {
-                test: "test value 1",
-              },
-              displayValues: {
-                test: "test display value 1",
-              },
-            }),
-            createTestContentItem({
-              label: "@Presentation:label.notSpecified@",
-              classInfo: createTestECClassInfo({ label: "Test Class" }),
-              primaryKeys: [{ className: "TestSchema:TestClass", id: "0x124" }],
-              values: {
-                test: "test value 2",
-              },
-              displayValues: {
-                test: "test display value 2",
-              },
+        setup(createTestContentDescriptor({
+          displayType: DefaultContentDisplayTypes.Grid,
+          contentFlags: ContentFlags.ShowLabels,
+          fields: [
+            createTestSimpleContentField({
+              name: "test",
+              label: "Test Field",
+              category: createTestCategoryDescription({ label: "Test Category" }),
             }),
           ],
-        ).toJSON();
-        setup(addonContentResponse);
+        }).toJSON());
+        setup([
+          createTestContentItem({
+            label: "@Presentation:label.notSpecified@",
+            classInfo: createTestECClassInfo({ label: "Test Class" }),
+            primaryKeys: [{ className: "TestSchema:TestClass", id: "0x123" }],
+            values: {
+              test: "test value 1",
+            },
+            displayValues: {
+              test: "test display value 1",
+            },
+          }),
+          createTestContentItem({
+            label: "@Presentation:label.notSpecified@",
+            classInfo: createTestECClassInfo({ label: "Test Class" }),
+            primaryKeys: [{ className: "TestSchema:TestClass", id: "0x124" }],
+            values: {
+              test: "test value 2",
+            },
+            displayValues: {
+              test: "test display value 2",
+            },
+          }),
+        ].map((item) => item.toJSON()));
 
         // test
         const options: MultiElementPropertiesRequestOptions<IModelDb> = {
@@ -2259,7 +2629,6 @@ describe("PresentationManager", () => {
           expect(items).to.deep.eq(expectedResponse);
         }
       });
-
     });
 
     describe("getDisplayLabelDefinition", () => {

--- a/presentation/common/src/presentation-common/LocalizationHelper.ts
+++ b/presentation/common/src/presentation-common/LocalizationHelper.ts
@@ -8,6 +8,7 @@
 
 import { CategoryDescription } from "./content/Category";
 import { Content } from "./content/Content";
+import { Descriptor } from "./content/Descriptor";
 import { Field } from "./content/Fields";
 import { Item } from "./content/Item";
 import { DisplayValue, Value } from "./content/Value";
@@ -50,15 +51,20 @@ export class LocalizationHelper {
     return labelDefinitions;
   }
 
+  public getLocalizedContentDescriptor(descriptor: Descriptor) {
+    descriptor.fields.forEach((field) => this.translateContentDescriptorField(field));
+    descriptor.categories.forEach((category) => this.translateContentDescriptorCategory(category));
+    return descriptor;
+  }
+
   public getLocalizedContentItems(items: Item[]) {
     items.forEach((item) => this.translateContentItem(item));
     return items;
   }
 
   public getLocalizedContent(content: Content) {
-    content.contentSet.forEach((item) => this.translateContentItem(item));
-    content.descriptor.fields.forEach((field) => this.translateContentDescriptorField(field));
-    content.descriptor.categories.forEach((category) => this.translateContentDescriptorCategory(category));
+    this.getLocalizedContentDescriptor(content.descriptor);
+    this.getLocalizedContentItems(content.contentSet);
     return content;
   }
 

--- a/presentation/common/src/presentation-common/LocalizationHelper.ts
+++ b/presentation/common/src/presentation-common/LocalizationHelper.ts
@@ -6,14 +6,14 @@
  * @module Core
  */
 
-import { Node } from "./hierarchy/Node";
-import { Content } from "./content/Content";
-import { Item } from "./content/Item";
-import { LabelCompositeValue, LabelDefinition } from "./LabelDefinition";
-import { DisplayValue, Value } from "./content/Value";
-import { Field } from "./content/Fields";
 import { CategoryDescription } from "./content/Category";
+import { Content } from "./content/Content";
+import { Field } from "./content/Fields";
+import { Item } from "./content/Item";
+import { DisplayValue, Value } from "./content/Value";
 import { ElementProperties } from "./ElementProperties";
+import { Node } from "./hierarchy/Node";
+import { LabelCompositeValue, LabelDefinition } from "./LabelDefinition";
 
 const KEY_PATTERN = /@[\w\d\-_]+:[\w\d\-\._]+?@/g;
 
@@ -48,6 +48,11 @@ export class LocalizationHelper {
   public getLocalizedLabelDefinitions(labelDefinitions: LabelDefinition[]) {
     labelDefinitions.forEach((labelDefinition) => this.translateLabelDefinition(labelDefinition));
     return labelDefinitions;
+  }
+
+  public getLocalizedContentItems(items: Item[]) {
+    items.forEach((item) => this.translateContentItem(item));
+    return items;
   }
 
   public getLocalizedContent(content: Content) {

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -139,6 +139,11 @@ export interface ContentDescriptorRequestOptions<TIModel, TKeySet, TRulesetVaria
    * @see [[DefaultContentDisplayTypes]]
    */
   displayType: string;
+  /**
+   * Content flags used for content customization.
+   * @see [[ContentFlags]]
+   */
+  contentFlags?: number;
   /** Input keys for getting the content */
   keys: TKeySet;
   /** Information about the selection event that was the cause of this content request */

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -8,13 +8,15 @@
 
 import { BeEvent, Id64String } from "@itwin/core-bentley";
 import { UnitSystemKey } from "@itwin/core-quantity";
-import { SelectionInfo } from "./content/Descriptor";
+import { Descriptor, SelectionInfo } from "./content/Descriptor";
 import { FieldDescriptor } from "./content/Fields";
 import { InstanceKey } from "./EC";
 import { InstanceFilterDefinition } from "./InstanceFilterDefinition";
 import { Ruleset } from "./rules/Ruleset";
 import { RulesetVariable } from "./RulesetVariables";
 import { SelectionScopeProps } from "./selection/SelectionScope";
+import { Item } from "./content/Item";
+import { ElementProperties } from "./ElementProperties";
 
 /**
  * A generic request options type used for both hierarchy and content requests.
@@ -183,8 +185,9 @@ export interface DistinctValuesRequestOptions<TIModel, TDescriptor, TKeySet, TRu
 /**
  * Request type for element properties requests
  * @public
+ * @deprecated in 4.x. Use [[SingleElementPropertiesRequestOptions]] or [[MultiElementPropertiesRequestOptions]] directly.
  */
-export type ElementPropertiesRequestOptions<TIModel> = SingleElementPropertiesRequestOptions<TIModel> | MultiElementPropertiesRequestOptions<TIModel>;
+export type ElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> = SingleElementPropertiesRequestOptions<TIModel> | MultiElementPropertiesRequestOptions<TIModel, TParsedContent>;
 
 /**
  * Request type for single element properties requests.
@@ -199,13 +202,20 @@ export interface SingleElementPropertiesRequestOptions<TIModel> extends RequestO
  * Request type for multiple elements properties requests.
  * @public
  */
-export interface MultiElementPropertiesRequestOptions<TIModel> extends RequestOptions<TIModel> {
+export interface MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> extends RequestOptions<TIModel> {
   /**
    * Classes of the elements to get properties for. If [[elementClasses]] is `undefined`, all classes
    * are used. Classes should be specified in one of these formats: "<schema name or alias>.<class_name>" or
    * "<schema name or alias>:<class_name>".
    */
   elementClasses?: string[];
+
+  /**
+   * Content parser that creates a result item based on given content descriptor and content item. Defaults
+   * to a parser that creates [[ElementProperties]] objects.
+   * @beta
+   */
+  contentParser?: (descriptor: Descriptor, item: Item) => TParsedContent;
 }
 
 /**
@@ -309,7 +319,7 @@ export type Prioritized<TOptions extends {}> = TOptions & {
  * Checks if supplied request options are for single or multiple element properties.
  * @internal
  */
-export function isSingleElementPropertiesRequestOptions<TIModel>(options: ElementPropertiesRequestOptions<TIModel>): options is SingleElementPropertiesRequestOptions<TIModel> {
+export function isSingleElementPropertiesRequestOptions<TIModel, TParsedContent = any>(options: SingleElementPropertiesRequestOptions<TIModel> | MultiElementPropertiesRequestOptions<TIModel, TParsedContent>): options is SingleElementPropertiesRequestOptions<TIModel> {
   return (options as SingleElementPropertiesRequestOptions<TIModel>).elementId !== undefined;
 }
 

--- a/presentation/common/src/presentation-common/content/Item.ts
+++ b/presentation/common/src/presentation-common/content/Item.ts
@@ -132,4 +132,28 @@ export class Item {
   public static reviver(key: string, value: any): any {
     return key === "" ? Item.fromJSON(value) : value;
   }
+
+  /**
+   * Deserialize items list from JSON
+   * @param json JSON or JSON serialized to string to deserialize from
+   * @returns Deserialized items list
+   * @internal
+   */
+  public static listFromJSON(json: ItemJSON[] | string): Item[] {
+    if (typeof json === "string") {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      return JSON.parse(json, Item.listReviver);
+    }
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    return json.map(Item.fromJSON).filter((item): item is Item => !!item);
+  }
+
+  /**
+   * Reviver function that can be used as a second argument for
+   * `JSON.parse` method when parsing [[Item]][] objects.
+   * @internal
+   */
+  public static listReviver(key: string, value: any): any {
+    return key === "" ? Item.listFromJSON(value) : value;
+  }
 }

--- a/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
+++ b/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
@@ -12,7 +12,9 @@ import { KindOfQuantityInfo, PropertyInfo } from "../EC";
 import { KoqPropertyValueFormatter } from "../KoqPropertyValueFormatter";
 import { ValuesDictionary } from "../Utils";
 import { Content } from "./Content";
+import { Descriptor } from "./Descriptor";
 import { Field, PropertiesField } from "./Fields";
+import { Item } from "./Item";
 import { ArrayTypeDescription, PrimitiveTypeDescription, PropertyValueFormat, StructTypeDescription, TypeDescription } from "./TypeDescription";
 import { DisplayValue, DisplayValuesMap, NestedContentValue, Value } from "./Value";
 
@@ -21,11 +23,15 @@ export class ContentFormatter {
   constructor(private _propertyValueFormatter: ContentPropertyValueFormatter, private _unitSystem?: UnitSystemKey) { }
 
   public async formatContent(content: Content) {
-    const descriptor = content.descriptor;
-    for (const item of content.contentSet) {
+    const formattedItems = await this.formatContentItems(content.contentSet, content.descriptor);
+    return new Content(content.descriptor, formattedItems);
+  }
+
+  public async formatContentItems(items: Item[], descriptor: Descriptor) {
+    return Promise.all(items.map(async (item) => {
       await this.formatValues(item.values, item.displayValues, descriptor.fields, item.mergedFieldNames);
-    }
-    return content;
+      return item;
+    }));
   }
 
   private async formatValues(values: ValuesDictionary<Value>, displayValues: ValuesDictionary<DisplayValue>, fields: Field[], mergedFields: string[]) {
@@ -54,7 +60,6 @@ export class ContentFormatter {
       await this.formatValues(nestedValue.values, nestedValue.displayValues, fields, nestedValue.mergedFieldNames);
     }
   }
-
 }
 
 /** @alpha */

--- a/presentation/common/src/test/content/Item.test.snap
+++ b/presentation/common/src/test/content/Item.test.snap
@@ -167,3 +167,101 @@ Object {
   },
 }
 `;
+
+exports[`Item listFromJSON parses items from JSON 1`] = `
+Array [
+  Object {
+    "classInfo": undefined,
+    "displayValues": Object {
+      "a": "B",
+    },
+    "extendedData": undefined,
+    "imageId": "",
+    "labelDefinition": Object {
+      "displayValue": "",
+      "rawValue": "",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "SchemaName:ClassName",
+        "id": "0x1",
+      },
+    ],
+    "values": Object {
+      "a": "b",
+    },
+  },
+  Object {
+    "classInfo": undefined,
+    "displayValues": Object {
+      "c": "D",
+    },
+    "extendedData": undefined,
+    "imageId": "",
+    "labelDefinition": Object {
+      "displayValue": "",
+      "rawValue": "",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "SchemaName:ClassName",
+        "id": "0x1",
+      },
+    ],
+    "values": Object {
+      "c": "d",
+    },
+  },
+]
+`;
+
+exports[`Item listFromJSON parses items from serialized JSON string 1`] = `
+Array [
+  Object {
+    "displayValues": Object {
+      "a": "B",
+    },
+    "imageId": "",
+    "labelDefinition": Object {
+      "displayValue": "",
+      "rawValue": "",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "SchemaName:ClassName",
+        "id": "0x1",
+      },
+    ],
+    "values": Object {
+      "a": "b",
+    },
+  },
+  Object {
+    "displayValues": Object {
+      "c": "D",
+    },
+    "imageId": "",
+    "labelDefinition": Object {
+      "displayValue": "",
+      "rawValue": "",
+      "typeName": "string",
+    },
+    "mergedFieldNames": Array [],
+    "primaryKeys": Array [
+      Object {
+        "className": "SchemaName:ClassName",
+        "id": "0x1",
+      },
+    ],
+    "values": Object {
+      "c": "d",
+    },
+  },
+]
+`;

--- a/presentation/common/src/test/content/Item.test.ts
+++ b/presentation/common/src/test/content/Item.test.ts
@@ -8,6 +8,7 @@ import { Item, ItemJSON } from "../../presentation-common/content/Item";
 import { NestedContentValueJSON } from "../../presentation-common/content/Value";
 import { createTestECInstanceKey } from "../_helpers/EC";
 import { createRandomECClassInfo, createRandomECInstanceKey, createRandomLabelDefinition } from "../_helpers/random";
+import { createTestContentItem } from "../_helpers";
 
 describe("Item", () => {
 
@@ -116,6 +117,25 @@ describe("Item", () => {
       expect(item).to.be.undefined;
     });
 
+  });
+
+  describe("listFromJSON", () => {
+    it("parses items from JSON", () => {
+      const items = [
+        createTestContentItem({ values: { a: "b" }, displayValues: { a: "B" } }),
+        createTestContentItem({ values: { c: "d" }, displayValues: { c: "D" } }),
+      ];
+      expect(Item.listFromJSON(items.map((i) => i.toJSON()))).to.matchSnapshot();
+    });
+
+    it("parses items from serialized JSON string", () => {
+      const items = [
+        createTestContentItem({ values: { a: "b" }, displayValues: { a: "B" } }),
+        createTestContentItem({ values: { c: "d" }, displayValues: { c: "D" } }),
+      ];
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(Item.listFromJSON(JSON.stringify(items))).to.matchSnapshot();
+    });
   });
 
   describe("isFieldMerged", () => {


### PR DESCRIPTION
Closes https://github.com/iTwin/itwinjs-backlog/issues/976.

imodel-native: https://github.com/iTwin/imodel-native/pull/582

Performance of reading all `bis.GeometricElement` elements' properties:

| iModel | Before the change | After the change |
| --- | --- | --- |
| https://construction.bentley.com/22845570-a681-423c-b107-d9d3445a77ec/4d132ce6-df69-441c-ac39-5edef761e42d/imodel-progress | > 4 hours | ~1:30 h |
| https://qa-connect-imodelhubwebsite.bentley.com/Context/892aa2c9-5be8-4865-9f37-7d4c7e75ebbf/iModel/90b6fa70-c130-40c0-8a76-969f57eaaea4 | ~190 s. | ~105 s. |

Also improved the `PresentationManager.getElementProperties` API for the multiple elements case to accept a custom content parser, in case the caller wants to get results in a format other than the simplified `ElementProperties`.