### PR TITLE
Mitigate quantization error for magnified tiles

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -1778,8 +1778,8 @@ export const CURRENT_REQUEST: unique symbol;
 
 // @internal
 export enum CurrentImdlVersion {
-    Combined = 2097152,
-    Major = 32,
+    Combined = 2162688,
+    Major = 33,
     Minor = 0
 }
 

--- a/common/changes/@itwin/core-frontend/pmc-v1-magnify-float_2023-12-28-20-20.json
+++ b/common/changes/@itwin/core-frontend/pmc-v1-magnify-float_2023-12-28-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/common/src/tile/IModelTileIO.ts
+++ b/core/common/src/tile/IModelTileIO.ts
@@ -35,7 +35,7 @@ export enum CurrentImdlVersion {
    * front-end is not capable of reading the tile content. Otherwise, this front-end can read the tile content even if the header specifies a
    * greater minor version than CurrentVersion.Minor, although some data may be skipped.
    */
-  Major = 32,
+  Major = 33,
   /** The unsigned 16-bit minor version number. If the major version in the tile header is equal to CurrentVersion.Major, then this package can
    * read the tile content even if the minor version in the tile header is greater than this value, although some data may be skipped.
    */

--- a/core/frontend/src/render/webgl/InstancedGeometry.ts
+++ b/core/frontend/src/render/webgl/InstancedGeometry.ts
@@ -284,6 +284,7 @@ export class InstancedGeometry extends CachedGeometry {
   public override get isLitSurface() { return this._repr.isLitSurface; }
   public override get hasBakedLighting() { return this._repr.hasBakedLighting; }
   public override get hasAnimation() { return this._repr.hasAnimation; }
+  public override get usesQuantizedPositions() { return this._repr.usesQuantizedPositions; }
   public get qOrigin() { return this._repr.qOrigin; }
   public get qScale() { return this._repr.qScale; }
   public override get materialInfo() { return this._repr.materialInfo; }


### PR DESCRIPTION
imodel-native-internal: https://github.com/iTwin/imodel-native-internal/pull/327

This PR just bumps tile format version to match native.
Older frontends will request an older tile format version; the mitigation is only applied for the new (v33) version.
This prevents older frontends from receiving unquantized tiles that they may not properly handle.

Also fixed `InstancedGeometry` failing to override `usesQuantizedPositions`, causing floating-point vertex tables to display incorrectly (jumbled into a plane).