### PR TITLE
Fix flaky test that depended on order of changes in a changeset

### DIFF
--- a/common/changes/@itwin/core-backend/affanK-FixFlakyTest_2024-01-02-17-08.json
+++ b/common/changes/@itwin/core-backend/affanK-FixFlakyTest_2024-01-02-17-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fix flaky test caused by order of changes in changeset",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/affanK-FixFlakyTest_2024-01-02-17-08.json
+++ b/common/changes/@itwin/core-backend/affanK-FixFlakyTest_2024-01-02-17-08.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Fix flaky test caused by order of changes in changeset",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/core/backend/src/test/standalone/ChangesetReader.test.ts
+++ b/core/backend/src/test/standalone/ChangesetReader.test.ts
@@ -232,9 +232,9 @@ describe("Changeset Reader API", async () => {
       assert.equal(changes[0].ECInstanceId, "0x20000000004");
       assert.isUndefined(changes[0].ECClassId);
       assert.isDefined(changes[0].$meta?.fallbackClassId);
-      assert.equal(changes[0].$meta?.fallbackClassId, "0x3f");
+      assert.equal(changes[0].$meta?.fallbackClassId, "0x3d");
       assert.isUndefined(changes[0].s);
-      assert.equal(changes[0].$meta?.classFullName, "BisCore:Element");
+      assert.equal(changes[0].$meta?.classFullName, "BisCore:GeometricElement2d");
       assert.equal(changes[0].$meta?.op, "Updated");
       assert.equal(changes[0].$meta?.stage, "New");
 
@@ -242,9 +242,9 @@ describe("Changeset Reader API", async () => {
       assert.equal(changes[1].ECInstanceId, "0x20000000004");
       assert.isUndefined(changes[1].ECClassId);
       assert.isDefined(changes[1].$meta?.fallbackClassId);
-      assert.equal(changes[1].$meta?.fallbackClassId, "0x3f");
+      assert.equal(changes[1].$meta?.fallbackClassId, "0x3d");
       assert.isUndefined(changes[1].s);
-      assert.equal(changes[1].$meta?.classFullName, "BisCore:Element");
+      assert.equal(changes[1].$meta?.classFullName, "BisCore:GeometricElement2d");
       assert.equal(changes[1].$meta?.op, "Updated");
       assert.equal(changes[1].$meta?.stage, "Old");
     }


### PR DESCRIPTION
The fix is to choose the derived class id & name in meta data when the change is of type update and fallback classid is present for both changes.