### PR TITLE
Fix `RenderMaterialElement.onCloned` not remapping map texture ids

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4567,6 +4567,8 @@ export class RenderMaterialElement extends DefinitionElement {
     static createCode(iModel: IModelDb, scopeModelId: CodeScopeProps, name: string): Code;
     description?: string;
     static insert(iModelDb: IModelDb, definitionModelId: Id64String, materialName: string, params: RenderMaterialElementParams): Id64String;
+    // @internal (undocumented)
+    protected static onCloned(context: IModelElementCloneContext, sourceProps: ElementProps, targetProps: ElementProps): void;
     paletteName: string;
     // (undocumented)
     toJSON(): RenderMaterialProps;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -7327,8 +7327,17 @@ export namespace RenderMaterial {
 
 // @public
 export interface RenderMaterialAssetMapsProps {
+    Bump?: TextureMapProps;
+    Diffuse?: TextureMapProps;
+    Displacement?: TextureMapProps;
+    Finish?: TextureMapProps;
+    GlowColor?: TextureMapProps;
     Normal?: NormalMapProps;
     Pattern?: TextureMapProps;
+    Reflect?: TextureMapProps;
+    Specular?: TextureMapProps;
+    TranslucencyColor?: TextureMapProps;
+    TransparentColor?: TextureMapProps;
 }
 
 // @public

--- a/common/changes/@itwin/core-backend/fix-clone-materials_2024-01-10-19-10.json
+++ b/common/changes/@itwin/core-backend/fix-clone-materials_2024-01-10-19-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "fix texture remapping in RenderMaterialElement.onCloned",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/fix-clone-materials_2024-01-10-19-10.json
+++ b/common/changes/@itwin/core-common/fix-clone-materials_2024-01-10-19-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "add additional map types to RenderMaterialAssetMapsProps",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -6,12 +6,13 @@
  * @module Elements
  */
 
-import { Id64String } from "@itwin/core-bentley";
+import { Id64String, Id64 } from "@itwin/core-bentley";
 import {
-  BisCodeSpec, Code, CodeScopeProps, CodeSpec, DefinitionElementProps, NormalMapProps, RenderMaterialAssetMapsProps, RenderMaterialProps, RgbFactorProps, TextureMapProps,
+  BisCodeSpec, Code, CodeScopeProps, CodeSpec, DefinitionElementProps, ElementProps, NormalMapProps, RenderMaterialAssetMapsProps, RenderMaterialProps, RgbFactorProps, TextureMapProps,
 } from "@itwin/core-common";
 import { DefinitionElement } from "./Element";
 import { IModelDb } from "./IModelDb";
+import { IModelElementCloneContext } from "./IModelElementCloneContext";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -183,6 +184,18 @@ export class RenderMaterialElement extends DefinitionElement {
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, materialName: string, params: RenderMaterialElementParams): Id64String {
     const renderMaterial = this.create(iModelDb, definitionModelId, materialName, params);
     return iModelDb.elements.insertElement(renderMaterial.toJSON());
+  }
+
+  protected static override onCloned(context: IModelElementCloneContext, sourceProps: ElementProps, targetProps: ElementProps) {
+    super.onCloned(context, sourceProps, targetProps);
+    for (const mapName in sourceProps.jsonProperties?.materialAssets?.renderMaterial?.Map ?? {}) {
+      if (typeof mapName !== "string")
+        continue;
+      const sourceMap = sourceProps.jsonProperties.materialAssets.renderMaterial.Map[mapName];
+      if (!Id64.isValid(sourceMap.TextureId))
+        continue;
+      targetProps.jsonProperties.materialAssets.renderMaterial.Map[mapName].TextureId = context.findTargetElementId(sourceMap.TextureId);
+    }
   }
 }
 

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -192,9 +192,9 @@ export class RenderMaterialElement extends DefinitionElement {
       if (typeof mapName !== "string")
         continue;
       const sourceMap = sourceProps.jsonProperties.materialAssets.renderMaterial.Map[mapName];
-      if (!Id64.isValid(sourceMap.TextureId))
+      if (!Id64.isValid(sourceMap.TextureId) || sourceMap.TextureId === undefined)
         continue;
-      targetProps.jsonProperties.materialAssets.renderMaterial.Map[mapName].TextureId = context.findTargetElementId(sourceMap.TextureId);
+      targetProps.jsonProperties.materialAssets.renderMaterial.Map[mapName].TextureId = context.findTargetElementId(sourceMap.TextureId ?? Id64.invalid);
     }
   }
 }

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -6,7 +6,7 @@
  * @module Elements
  */
 
-import { Id64String, Id64 } from "@itwin/core-bentley";
+import { Id64, Id64String } from "@itwin/core-bentley";
 import {
   BisCodeSpec, Code, CodeScopeProps, CodeSpec, DefinitionElementProps, ElementProps, NormalMapProps, RenderMaterialAssetMapsProps, RenderMaterialProps, RgbFactorProps, TextureMapProps,
 } from "@itwin/core-common";

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -186,6 +186,7 @@ export class RenderMaterialElement extends DefinitionElement {
     return iModelDb.elements.insertElement(renderMaterial.toJSON());
   }
 
+  /** @internal */
   protected static override onCloned(context: IModelElementCloneContext, sourceProps: ElementProps, targetProps: ElementProps) {
     super.onCloned(context, sourceProps, targetProps);
     for (const mapName in sourceProps.jsonProperties?.materialAssets?.renderMaterial?.Map ?? {}) {

--- a/core/backend/src/test/standalone/RenderMaterialElement.test.ts
+++ b/core/backend/src/test/standalone/RenderMaterialElement.test.ts
@@ -318,17 +318,19 @@ describe("RenderMaterialElement", () => {
         ["Unknown" as any]: { TextureId: textureId },
         ["InvalidTexture" as any]: { TextureId: Id64.invalid },
         ["UnknownTexture" as any]: { TextureId: unknownTextureId },
+        ["NoTextureId" as any]: { OtherProp: 1 },
       };
 
       const material = test({});
       const jsonProps = material.jsonProperties as RenderMaterialProps["jsonProperties"];
-      assert(jsonProps?.materialAssets?.renderMaterial?.Map);
+      assert(jsonProps?.materialAssets?.renderMaterial && jsonProps.materialAssets.renderMaterial.Map === undefined);
       jsonProps.materialAssets.renderMaterial.Map = maps;
       material.update();
 
       const context = {
         findTargetElementId: (sourceId: Id64String) => {
-          expect(Id64.isId64(sourceId)).to.be.true;
+          expect(typeof sourceId, `bad id: ${sourceId}`).to.equal("string");
+          expect(Id64.isId64(sourceId), `bad id: ${sourceId}`).to.be.true;
           return "CLONED";
         },
       } as any as IModelElementCloneContext;
@@ -337,10 +339,9 @@ describe("RenderMaterialElement", () => {
       const targetProps = structuredClone(sourceProps);
 
       // eslint-disable-next-line @typescript-eslint/dot-notation
-      RenderMaterialElement["onCloned"](context, material.toJSON(), targetProps);
-      expect(targetProps)
+      RenderMaterialElement["onCloned"](context, sourceProps, targetProps);
 
-      expect(jsonProps?.materialAssets?.renderMaterial.Map).to.deep.equal({
+      expect(targetProps.jsonProperties?.materialAssets?.renderMaterial?.Map).to.deep.equal({
         Pattern: { TextureId: "CLONED" },
         Normal: { TextureId: "CLONED" },
         Bump: { TextureId: "CLONED" },
@@ -353,8 +354,9 @@ describe("RenderMaterialElement", () => {
         TransparentColor: { TextureId: "CLONED" },
         Displacement: { TextureId: "CLONED" },
         Unknown: { TextureId: "CLONED" },
-        InvalidTexture: { TextureId: "CLONED" },
+        InvalidTexture: { TextureId: Id64.invalid },
         UnknownTexture: { TextureId: "CLONED" },
+        NoTextureId: { OtherProp: 1 },
       });
     });
   });

--- a/core/common/src/MaterialProps.ts
+++ b/core/common/src/MaterialProps.ts
@@ -112,7 +112,7 @@ export interface RenderMaterialAssetMapsProps {
    * present in the surface's geometry.
    */
   Normal?: NormalMapProps;
-  /** Maps an image describing detailed minor height variation of the geometry surface. */
+  /** Maps an image describing detailed minor height variation of the surface geometry. */
   Bump?: TextureMapProps;
   /** Maps an image describing the diffuse color of the surface, replacing or mixing with the surface's own color. */
   Diffuse?: TextureMapProps;
@@ -122,11 +122,11 @@ export interface RenderMaterialAssetMapsProps {
   GlowColor?: TextureMapProps;
   /** Maps an image describing the reflectiveness of the surface */
   Reflect?: TextureMapProps;
-  /** Maps an image describing the specular of the surface */
+  /** Maps an image describing the specular component of the surface */
   Specular?: TextureMapProps;
   /** Maps an image describing the translucency of the surface, how much light comes out the back of the surface */
   TranslucencyColor?: TextureMapProps;
-  /** Maps an image describing the transparency of the surface, how visible objects should be through this */
+  /** Maps an image describing the transparency of the surface, how visible objects behind this object are */
   TransparentColor?: TextureMapProps;
   /** Maps an image describing the displacement of the surface geometry */
   Displacement?: TextureMapProps;

--- a/core/common/src/MaterialProps.ts
+++ b/core/common/src/MaterialProps.ts
@@ -112,6 +112,24 @@ export interface RenderMaterialAssetMapsProps {
    * present in the surface's geometry.
    */
   Normal?: NormalMapProps;
+  /** Maps an image describing detailed minor height variation of the geometry surface. */
+  Bump?: TextureMapProps;
+  /** Maps an image describing the diffuse color of the surface, replacing or mixing with the surface's own color. */
+  Diffuse?: TextureMapProps;
+  /** Maps an image describing the glossiness of the surface's finish */
+  Finish?: TextureMapProps;
+  /** Maps an image describing glowing parts of the surface */
+  GlowColor?: TextureMapProps;
+  /** Maps an image describing the reflectiveness of the surface */
+  Reflect?: TextureMapProps;
+  /** Maps an image describing the specular of the surface */
+  Specular?: TextureMapProps;
+  /** Maps an image describing the translucency of the surface, how much light comes out the back of the surface */
+  TranslucencyColor?: TextureMapProps;
+  /** Maps an image describing the transparency of the surface, how visible objects should be through this */
+  TransparentColor?: TextureMapProps;
+  /** Maps an image describing the displacement of the surface geometry */
+  Displacement?: TextureMapProps;
 }
 
 /** Describes the graphical properties of a [RenderMaterialElement]($backend) as part of a [[RenderMaterialProps]].


### PR DESCRIPTION
### Why

Transformations can lose data or cause strange behavior if they do not remap ids in json properties, and the ids are attempted to be reused by another application. In this case, transformations can just lose textured materials.

### What

- fix not remapping texture ids in `RenderMaterial` json properties
- add a test over a mock clone context
  - move some test utilities up in the file to reuse in a new `describe` test block
- add optional types for possible maps in iModel data, see below for questions

### Questions

I am seeking review of the documentation I added for possible maps as observed in the house model sample. I see a potential list of really supported maps [here in the native code](https://github.com/iTwin/imodel-native/blob/116fc61ff5d19c08c0d5296295b44a71c5e2cf71/iModelCore/iModelPlatform/PublicAPI/DgnPlatform/RenderMaterial.h#L89), but the house model had some not listed there iirc.

It seems connectors are generating others not listed. Would it be preferable to specify an index signature in the type instead of adding these new optional explicit ones as I did?