### PR TITLE
Include model ranges in batched tilesets

### DIFF
--- a/common/changes/@itwin/frontend-tiles/pmc-include-model-ranges_2024-01-11-18-41.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-include-model-ranges_2024-01-11-18-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/package.json
+++ b/extensions/frontend-tiles/package.json
@@ -15,6 +15,7 @@
     "docs": "",
     "extract-api": "betools extract-api --entry=frontend-tiles",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",
+    "lint-fix": "eslint --fix -f visualstudio \"./src/**/*.ts\" 1>&2",
     "test": "npm run -s webpackTests && certa -r chrome",
     "webpackTests": "webpack --config ./src/test/utils/webpack-config.js 1>&2"
   },

--- a/extensions/frontend-tiles/src/BatchedModels.ts
+++ b/extensions/frontend-tiles/src/BatchedModels.ts
@@ -5,23 +5,16 @@
 
 import { Id64, Id64String } from "@itwin/core-bentley";
 import { Range3d } from "@itwin/core-geometry";
-import { ModelExtentsProps } from "@itwin/core-common";
-import { IModelConnection, SpatialViewState } from "@itwin/core-frontend";
-
-interface ModelMetadata {
-  extents?: Range3d;
-}
+import { SpatialViewState } from "@itwin/core-frontend";
 
 export class BatchedModels {
-  private readonly _iModel: IModelConnection;
   private _viewedModels!: Set<Id64String>;
   private readonly _viewedExtents = new Range3d();
   private readonly _viewedModelIdPairs = new Id64.Uint32Set();
-  private readonly _metadata = new Map<Id64String, ModelMetadata>();
-  private _modelRangePromise?: Promise<void>;
+  private readonly _ranges: Map<Id64String, Range3d>;
 
-  public constructor(view: SpatialViewState) {
-    this._iModel = view.iModel;
+  public constructor(view: SpatialViewState, ranges: Map<Id64String, Range3d>) {
+    this._ranges = ranges;
     this.setViewedModels(view.modelSelector.models);
   }
 
@@ -31,36 +24,11 @@ export class BatchedModels {
     this._viewedModelIdPairs.addIds(models);
     this._viewedExtents.setNull();
 
-    this._modelRangePromise = undefined;
-    const rangeQueryModels: Id64String[] = [];
-
     for (const modelId of models) {
-      let metadata = this._metadata.get(modelId);
-      if (!metadata)
-        this._metadata.set(modelId, metadata = { });
-
-      if (undefined === metadata.extents)
-        rangeQueryModels.push(modelId);
-      else
-        this._viewedExtents.extendRange(metadata.extents);
+      const range = this._ranges.get(modelId);
+      if (range)
+        this._viewedExtents.extendRange(range);
     }
-
-    if (rangeQueryModels.length === 0)
-      return;
-
-    const modelRangePromise = this._modelRangePromise = this._iModel.models.queryExtents(rangeQueryModels).then((extents: ModelExtentsProps[]) => {
-      if (modelRangePromise !== this._modelRangePromise)
-        return;
-
-      this._modelRangePromise = undefined;
-      for (const extent of extents) {
-        const metadata = this._metadata.get(extent.id);
-        if (metadata) {
-          metadata.extents = Range3d.fromJSON(extent.extents);
-          this._viewedExtents.extendRange(metadata.extents);
-        }
-      }
-    }).catch(() => { });
   }
 
   public views(modelId: Id64String): boolean {

--- a/extensions/frontend-tiles/src/BatchedSpatialTileTreeRefs.ts
+++ b/extensions/frontend-tiles/src/BatchedSpatialTileTreeRefs.ts
@@ -29,7 +29,7 @@ class BatchedSpatialTileTreeReferences implements SpatialTileTreeReferences {
 
   public constructor(spec: BatchedTilesetSpec, view: SpatialViewState) {
     this._view = view;
-    this._models = new BatchedModels(view);
+    this._models = new BatchedModels(view, spec.includedModels);
 
     const script = view.displayStyle.scheduleScript;
     this._currentScript = script?.requiresBatching ? script : undefined;

--- a/extensions/frontend-tiles/src/BatchedSpatialTileTreeRefs.ts
+++ b/extensions/frontend-tiles/src/BatchedSpatialTileTreeRefs.ts
@@ -34,20 +34,7 @@ class BatchedSpatialTileTreeReferences implements SpatialTileTreeReferences {
     const script = view.displayStyle.scheduleScript;
     this._currentScript = script?.requiresBatching ? script : undefined;
 
-    const includedModels = spec.props.extensions?.BENTLEY_BatchedTileSet?.includedModels;
-    this._excludedRefs = includedModels ? createSpatialTileTreeReferences(view, new Set(includedModels)) : {
-      update: () => { },
-      setDeactivated: () => { },
-      attachToViewport: () => { },
-      detachFromViewport: () => { },
-      [Symbol.iterator]: () => {
-        return {
-          next: () => {
-            return { done: true, value: undefined };
-          },
-        };
-      },
-    };
+    this._excludedRefs = createSpatialTileTreeReferences(view, new Set(spec.includedModels.keys()));
 
     this.load(spec, view.iModel);
 

--- a/extensions/frontend-tiles/src/BatchedTileTree.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTree.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BeTimePoint, Id64String } from "@itwin/core-bentley";
+import { Range3d } from "@itwin/core-geometry";
 import { BatchType, RenderMode, RenderSchedule, ViewFlagOverrides } from "@itwin/core-common";
 import {
   acquireImdlDecoder, ImdlDecoder, IModelApp, Tile, TileDrawArgs, TileTree, TileTreeParams,
@@ -22,7 +23,7 @@ export interface BatchedTileTreeParams extends TileTreeParams {
   rootTile: BatchedTileParams;
   reader: BatchedTilesetReader;
   script?: RenderSchedule.Script;
-  includedModels?: Set<Id64String>;
+  includedModels?: Map<Id64String, Range3d>;
 }
 
 /** @internal */

--- a/extensions/frontend-tiles/src/BatchedTilesetReader.ts
+++ b/extensions/frontend-tiles/src/BatchedTilesetReader.ts
@@ -3,9 +3,9 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Id64String } from "@itwin/core-bentley";
+import { assert, Id64String } from "@itwin/core-bentley";
 import {
-  Matrix3d, Point3d, Range3d, Transform, Vector3d,
+  Matrix3d, Point3d, Range3d, Range3dProps, Transform, Vector3d,
 } from "@itwin/core-geometry";
 import { Tileset3dSchema as schema } from "@itwin/core-common";
 import { IModelConnection, RealityModelTileUtils, TileLoadPriority } from "@itwin/core-frontend";
@@ -14,9 +14,12 @@ import { BatchedTile, BatchedTileParams } from "./BatchedTile";
 
 /** @internal */
 export interface BatchedTilesetProps extends schema.Tileset {
-  extensions?: {
-    BENTLEY_BatchedTileSet?: { // eslint-disable-line @typescript-eslint/naming-convention
-      includedModels: Id64String[];
+  extensions: {
+    BENTLEY_BatchedTileSet: { // eslint-disable-line @typescript-eslint/naming-convention
+      includedModels: Array<{
+        id: Id64String;
+        range: Range3dProps;
+      }>
     };
   };
 }
@@ -30,6 +33,14 @@ function isBatchedTileset(json: unknown): json is BatchedTilesetProps {
   if (!props.root || !props.asset)
     return false;
 
+  // The extension is required, and it must contain `id` and `range` fields.
+  const includedModels = props.extensions?.BENTLEY_BatchedTileSet?.includedModels;
+  if (!Array.isArray(includedModels))
+    return false;
+
+  if (includedModels.length > 0 && (!("id" in includedModels[0] || !("range" in includedModels[0]))))
+    return false;
+
   // ###TODO spec requires geometricError to be present on tileset and all tiles; exporter is omitting from tileset.
   if (undefined === props.geometricError)
     props.geometricError = props.root.geometricError;
@@ -41,15 +52,20 @@ function isBatchedTileset(json: unknown): json is BatchedTilesetProps {
 export interface BatchedTilesetSpec {
   baseUrl: URL;
   props: BatchedTilesetProps;
+  includedModels: Map<Id64String, Range3d>;
 }
 
 /** @internal */
 export namespace BatchedTilesetSpec {
-  export function create(baseUrl: URL, json: unknown) {
+  export function create(baseUrl: URL, json: unknown): BatchedTilesetSpec {
     if (!isBatchedTileset(json))
       throw new Error("Invalid tileset JSON");
 
-    return { baseUrl, props: json };
+    const includedModels = new Map<Id64String, Range3d>();
+    for (const entry of json.extensions.BENTLEY_BatchedTileSet.includedModels)
+      includedModels.set(entry.id, Range3d.fromJSON(entry.range));
+    
+    return { baseUrl, props: json, includedModels };
   }
 }
 
@@ -90,15 +106,15 @@ function transformFromJSON(json: schema.Transform): Transform {
 
 /** @internal */
 export class BatchedTilesetReader {
+  private readonly _spec: BatchedTilesetSpec;
   private readonly _iModel: IModelConnection;
-  private readonly _tileset: schema.Tileset;
-  public readonly baseUrl: URL;
 
   public constructor(spec: BatchedTilesetSpec, iModel: IModelConnection) {
     this._iModel = iModel;
-    this._tileset = spec.props;
-    this.baseUrl = spec.baseUrl;
+    this._spec = spec;
   }
+
+  public get baseUrl(): URL { return this._spec.baseUrl; }
 
   public readTileParams(json: schema.Tile, parent?: BatchedTile): BatchedTileParams {
     const content = json.content;
@@ -135,10 +151,8 @@ export class BatchedTilesetReader {
   }
 
   public async readTileTreeParams(): Promise<BatchedTileTreeParams> {
-    const root = this._tileset.root;
+    const root = this._spec.props.root;
     const location = root.transform ? transformFromJSON(root.transform) : Transform.createIdentity();
-    const extension = this._tileset.extensions?.BENTLEY_BatchedTileSet;
-    const includedModels = extension ? new Set<Id64String>(extension.includedModels) : undefined;
 
     return {
       id: "spatial-models",
@@ -148,7 +162,7 @@ export class BatchedTilesetReader {
       priority: TileLoadPriority.Primary,
       rootTile: this.readTileParams(root),
       reader: this,
-      includedModels,
+      includedModels: this._spec.includedModels,
     };
   }
 }

--- a/extensions/frontend-tiles/src/BatchedTilesetReader.ts
+++ b/extensions/frontend-tiles/src/BatchedTilesetReader.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { assert, Id64String } from "@itwin/core-bentley";
+import { Id64String } from "@itwin/core-bentley";
 import {
   Matrix3d, Point3d, Range3d, Range3dProps, Transform, Vector3d,
 } from "@itwin/core-geometry";
@@ -19,7 +19,7 @@ export interface BatchedTilesetProps extends schema.Tileset {
       includedModels: Array<{
         id: Id64String;
         range: Range3dProps;
-      }>
+      }>;
     };
   };
 }
@@ -64,7 +64,7 @@ export namespace BatchedTilesetSpec {
     const includedModels = new Map<Id64String, Range3d>();
     for (const entry of json.extensions.BENTLEY_BatchedTileSet.includedModels)
       includedModels.set(entry.id, Range3d.fromJSON(entry.range));
-    
+
     return { baseUrl, props: json, includedModels };
   }
 }


### PR DESCRIPTION
In reaction to https://github.com/iTwin/imodel-native-internal/pull/351.
Prerequisite for #6354.

The BENTLEY_BatchedTileset extension is now required, and must contain the parallel arrays of model Ids and model extents. Tilesets published prior to this change to tileset.json will fail to load. I do not want to have to maintain multiple alternate code paths to support pre-release versions of the tileset schema.