### PR TITLE
Add core-common to the list of packages for electron-auth and browser-auth to be marked as workspace:*

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -28,6 +28,9 @@ function readPackage(pkg) {
     ].includes(pkg.name)
   ) {
     pkg.dependencies["@itwin/core-bentley"] = "workspace:*";
+    if (pkg.name === "@itwin/browser-authorization" || pkg.name === "@itwin/electron-authorization") {
+      pkg.dependencies["@itwin/core-common"] = "workspace:*";
+    }
   }
 
   // https://github.com/iTwin/reality-data-client

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1731,7 +1731,7 @@ importers:
       webpack-cli: ^5.0.1
     dependencies:
       '@azure/storage-blob': 12.7.0
-      '@itwin/browser-authorization': 1.0.1_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/browser-authorization': 1.0.1_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/core-backend': link:../../core/backend
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
@@ -1746,7 +1746,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_n35ochjadrfvmsysax3symqq4m
+      '@itwin/electron-authorization': 0.14.1_uagso5jgyxmkqv2rrwzfnyka74
       '@itwin/express-server': link:../../core/express-server
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.0.0_wj555zckjupkhkzyssqqpl4sei
@@ -2475,7 +2475,7 @@ importers:
       webpack: ^5.76.0
     dependencies:
       '@itwin/appui-abstract': link:../../ui/appui-abstract
-      '@itwin/browser-authorization': 1.0.1_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/browser-authorization': 1.0.1_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/core-backend': link:../../core/backend
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
@@ -2484,7 +2484,7 @@ importers:
       '@itwin/core-geometry': link:../../core/geometry
       '@itwin/core-mobile': link:../../core/mobile
       '@itwin/core-quantity': link:../../core/quantity
-      '@itwin/electron-authorization': 0.14.1_n35ochjadrfvmsysax3symqq4m
+      '@itwin/electron-authorization': 0.14.1_uagso5jgyxmkqv2rrwzfnyka74
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
       '@itwin/imodels-access-backend': 3.0.0_wj555zckjupkhkzyssqqpl4sei
@@ -2599,7 +2599,7 @@ importers:
       '@bentley/icons-generic': 1.0.34
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/appui-abstract': link:../../ui/appui-abstract
-      '@itwin/browser-authorization': 1.0.1_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/browser-authorization': 1.0.1_mdtbcqczpmeuv6yjzfaigjndwi
       '@itwin/core-backend': link:../../core/backend
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
@@ -2613,7 +2613,7 @@ importers:
       '@itwin/editor-backend': link:../../editor/backend
       '@itwin/editor-common': link:../../editor/common
       '@itwin/editor-frontend': link:../../editor/frontend
-      '@itwin/electron-authorization': 0.14.1_n35ochjadrfvmsysax3symqq4m
+      '@itwin/electron-authorization': 0.14.1_uagso5jgyxmkqv2rrwzfnyka74
       '@itwin/frontend-devtools': link:../../core/frontend-devtools
       '@itwin/frontend-tiles': link:../../extensions/frontend-tiles
       '@itwin/hypermodeling-frontend': link:../../core/hypermodeling
@@ -4103,16 +4103,14 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  /@itwin/browser-authorization/1.0.1_67wltvhdskk2oee2c3z2o4tfly:
+  /@itwin/browser-authorization/1.0.1_mdtbcqczpmeuv6yjzfaigjndwi:
     resolution: {integrity: sha512-UqPhiFuNrjhlDdPvUZXd3zULbmdGQ2GyMGOsLLdR+/DctRkEy6asxcaf10v/qBdEBhH7IF8TjA4vS0GWvbSVfg==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
     dependencies:
       '@itwin/core-bentley': link:../../core/bentley
-      '@itwin/core-common': 4.2.4_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/core-common': link:../../core/common
       oidc-client-ts: 2.4.0
-    transitivePeerDependencies:
-      - '@itwin/core-geometry'
     dev: false
 
   /@itwin/certa/3.7.17:
@@ -4207,32 +4205,19 @@ packages:
       reflect-metadata: 0.1.13
     dev: false
 
-  /@itwin/core-common/4.2.4_67wltvhdskk2oee2c3z2o4tfly:
-    resolution: {integrity: sha512-TH6H/Ke2290+JjEtQM8dEE3fZVcaZTrphZkCEBdi1Tyqts71DLyO0qA8uRvA8cS+aO/4MFVZU5TXcrKcnVMUPw==}
-    peerDependencies:
-      '@itwin/core-bentley': ^4.2.4
-      '@itwin/core-geometry': ^4.2.4
-    dependencies:
-      '@itwin/core-bentley': link:../../core/bentley
-      '@itwin/core-geometry': link:../../core/geometry
-      flatbuffers: 1.12.0
-      js-base64: 3.6.1
-    dev: false
-
-  /@itwin/electron-authorization/0.14.1_n35ochjadrfvmsysax3symqq4m:
+  /@itwin/electron-authorization/0.14.1_uagso5jgyxmkqv2rrwzfnyka74:
     resolution: {integrity: sha512-NslwCLw129obJHBRMcV/MdykqbD7d93SKTYOOBdaEab2T2niGCmCTJAOkjcWiZZMU0SwmjyxmY9iqdZjvvIqCA==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
       electron: '>=23.0.0 <25.0.0'
     dependencies:
       '@itwin/core-bentley': link:../../core/bentley
-      '@itwin/core-common': 4.2.4_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/core-common': link:../../core/common
       '@openid/appauth': 1.3.1
       electron: 28.0.0
       keytar: 7.9.0
       username: 5.1.0
     transitivePeerDependencies:
-      - '@itwin/core-geometry'
       - debug
     dev: false
 
@@ -12809,7 +12794,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.4.9_@types+node@18.16.20
+      vite: 4.4.9
     transitivePeerDependencies:
       - rollup
       - supports-color


### PR DESCRIPTION
After running rush update --full in the release branch a couple of days ago and a failing docs build: https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=2612229&view=logs&j=bf01bec3-f6e2-5983-bdff-93019feebaa1&t=8d110379-66a4-5f89-b46c-1a9b11ce4c18

I decided to debug into typedoc/typescript code and poke around. In a broken docs build (after running rush update --full), we were missing some exports from RpcManager. This was due to RpcManager now resolving to a path like `"D:/itwinjs-core2/common/temp/node_modules/.pnpm/@itwin+corecommon@4.3.3_67wltvhdskk2oee2c3z2o4tfly/node_modules/@itwin/core-common/lib/cjs/RpcManager.d.ts"` instead of `"D:/itwinjs-core/core/common/lib/cjs/RpcManager.d.ts"`. 

When running typedoc we intentionally exclude paths with node_modules (by passing an exclude regex) in the name which makes sense. Even when hovering over imports in vscode "import from @itwin/core-common" these incorrect paths would be shown which suggested that typescript module resolution was giving these paths to typedoc. I later confirmed that while stepping through typedoc and ending up in typescript code, but I didn't quite know why TS seemed to be getting confused.

The reason rush update --full caused this is due to the below
![image](https://github.com/iTwin/itwinjs-core/assets/22119573/b39a5b6a-baf5-4c72-9abc-39db83d414a4)
Because browser-auth was pulling in a version of @itwin/core-common... Since locally our package.json had 4.3.3 in it as well as in the pnpm-lock after rush update --full, this was confusing TS and it was no longer looking at the local copy of core-common but the installed version of core-common which was also 4.3.3. This lines up with why master works just fine, locally we had a dev version and installed we had some other officially released version. That also supports why release/4.3.x worked just fine before we had run rush update --full. Locally we had 4.3.3 and installed we had a 4.2.1 version.

Thanks Bill for noticing that we had an installed copy of core-common in the common/temp/.pnpm/node_modules and thanks Ben for general help with this.

**Open Questions**
1) Its confusing to me that I only had to change browser-auth in pnpmfile.cjs to get this to work again, when electron-auth should've been introducing the same problem (Note I did change both in the PR anyways).
1) Should this have caused more problems with docs than it did? Or does core-electron just have the perfect conditions to expose the problem. It feels like all that needs to happen is an import from core/common for it to have broken elsewhere.. but I don't know.
 