### PR TITLE
Loosen tolerance of Matrix3d.createRigidFromMatrix3d to allow near-rigid matrices

### DIFF
--- a/common/changes/@itwin/core-geometry/master_2024-01-11-23-07.json
+++ b/common/changes/@itwin/core-geometry/master_2024-01-11-23-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/geometry3d/Angle.ts
+++ b/core/geometry/src/geometry3d/Angle.ts
@@ -359,7 +359,7 @@ export class Angle implements BeJSONFunctions {
    */
   public static isAlmostEqualRadiansNoPeriodShift(radiansA: number, radiansB: number,
     radianTol: number = Geometry.smallAngleRadians): boolean {
-    return Math.abs(radiansA - radiansB) < radianTol;
+     return Math.abs(radiansA - radiansB) < radianTol;
   }
   /**
    * Test if two this angle and other are almost equal, NOT allowing shift by full circle (i.e., multiples of `2 * PI`).

--- a/core/geometry/src/geometry3d/Angle.ts
+++ b/core/geometry/src/geometry3d/Angle.ts
@@ -359,7 +359,7 @@ export class Angle implements BeJSONFunctions {
    */
   public static isAlmostEqualRadiansNoPeriodShift(radiansA: number, radiansB: number,
     radianTol: number = Geometry.smallAngleRadians): boolean {
-     return Math.abs(radiansA - radiansB) < radianTol;
+    return Math.abs(radiansA - radiansB) < radianTol;
   }
   /**
    * Test if two this angle and other are almost equal, NOT allowing shift by full circle (i.e., multiples of `2 * PI`).

--- a/core/geometry/src/geometry3d/YawPitchRollAngles.ts
+++ b/core/geometry/src/geometry3d/YawPitchRollAngles.ts
@@ -260,10 +260,11 @@ export class YawPitchRollAngles {
   }
   /**
    * Attempts to create a YawPitchRollAngles object from a Matrix3d
-   * * This conversion fails if the matrix is not rigid (unit rows and columns, and transpose is inverse)
+   * * This conversion fails if the matrix is not *sufficiently* rigid (unit rows and columns, and transpose is inverse)
    * * In the failure case the method's return value is `undefined`.
-   * * In the failure case, if the optional result was supplied, that result will nonetheless be filled with
-   * a set of angles.
+   * * In the failure case, if the optional `result` was supplied, that result will nonetheless be filled with a set
+   * of angles. You can use it with CAUTION. If your input is close to being rigid, then these angles will likely be
+   * sufficient; otherwise you can call `Matrix3d.createRigidFromMatrix3d` or `Matrix3d.makeRigid` and try again.
    */
   public static createFromMatrix3d(matrix: Matrix3d, result?: YawPitchRollAngles): YawPitchRollAngles | undefined {
     /**
@@ -337,6 +338,6 @@ export class YawPitchRollAngles {
     }
     // sanity check
     const matrix1 = angles.toMatrix3d();
-    return matrix.maxDiff(matrix1) < Geometry.smallAngleRadians ? angles : undefined;
+    return matrix.isAlmostEqual(matrix1) ? angles : undefined;
   }
 }

--- a/core/geometry/src/geometry3d/YawPitchRollAngles.ts
+++ b/core/geometry/src/geometry3d/YawPitchRollAngles.ts
@@ -259,12 +259,13 @@ export class YawPitchRollAngles {
     };
   }
   /**
-   * Attempts to create a YawPitchRollAngles object from a Matrix3d
-   * * This conversion fails if the matrix is not *sufficiently* rigid (unit rows and columns, and transpose is inverse)
-   * * In the failure case the method's return value is `undefined`.
-   * * In the failure case, if the optional `result` was supplied, that result will nonetheless be filled with a set
-   * of angles. You can use it with CAUTION. If your input is close to being rigid, then these angles will likely be
-   * sufficient; otherwise you can call `Matrix3d.createRigidFromMatrix3d` or `Matrix3d.makeRigid` and try again.
+   * Attempts to create a YawPitchRollAngles object from a Matrix3d.
+   * @param matrix rigid matrix to process. Caller can test for rigidity with [[Matrix3d.isRigid]] and
+   * ensure rigid input with [[Matrix3d.createRigidFromMatrix3d]] or [[Matrix3d.makeRigid]].
+   * @param result optional pre-allocated object to populate and return.
+   * @returns computed angles, or undefined if `matrix` is not rigid.
+   * * Even when undefined is returned, `result` (if supplied) is populated with angles that may be used with caution:
+   * their usefulness decreases the further `matrix` is from being rigid.
    */
   public static createFromMatrix3d(matrix: Matrix3d, result?: YawPitchRollAngles): YawPitchRollAngles | undefined {
     /**

--- a/core/geometry/src/test/geometry3d/YawPitchRollAngles.test.ts
+++ b/core/geometry/src/test/geometry3d/YawPitchRollAngles.test.ts
@@ -126,6 +126,7 @@ describe("YPR", () => {
     expect(ck.getNumErrors()).equals(0);
   });
 
+  // cspell:word Dovydas
   it("createFromMatrix3dNearRigidMatrices", () => {
     const ck = new bsiChecker.Checker();
     const matrix1 = Matrix3d.createRowValues(
@@ -137,59 +138,58 @@ describe("YPR", () => {
       0.707421, -0.415747, -0.571585,
       0, 0.808703, -0.588217,
       0.706792, 0.416117, 0.572094,
-    );
-    const matrices = [matrix1, matrix2]; // near-rigid matrices
+    ); // view matrix received from .css
+    const matrix3 = Matrix3d.createRowValues(
+      0.70742, -0.41574, -0.57158,
+      0, 0.80870, -0.58821,
+      0.70679, 0.41611, 0.57209,
+    ); // drop least significant digit from matrix2 (less rigid)
+    const matrix4 = Matrix3d.createRowValues(
+      0.7074, -0.4157, -0.5715,
+      0, 0.8087, -0.5882,
+      0.7067, 0.4161, 0.5720,
+    ); // drop least significant digit from matrix3 (less rigid)
+    const matrix5 = Matrix3d.createRowValues(
+      0.707, -0.415, -0.571,
+      0, 0.808, -0.588,
+      0.706, 0.416, 0.572,
+    ); // drop least significant digit from matrix3 (less rigid)
 
-    for (const matrix of matrices) {
-      GeometryCoreTestIO.consoleLog("original matrix", matrix.toJSON());
-      GeometryCoreTestIO.consoleLog("determinant", matrix.determinant());
-      GeometryCoreTestIO.consoleLog(
-        "column scales", matrix.columnXMagnitude(), matrix.columnYMagnitude(), matrix.columnZMagnitude(),
-      );
-      GeometryCoreTestIO.consoleLog(
-        "row scales", matrix.rowXMagnitude(), matrix.rowYMagnitude(), matrix.rowZMagnitude(),
-      );
-      // length of matrix rows and columns are within tolerance
-      const micrometerTol = 1e-6;
-      const unitVectorLength = 1;
-      ck.testLE(matrix.rowXMagnitude() - unitVectorLength, micrometerTol);
-      ck.testLE(matrix.rowYMagnitude() - unitVectorLength, micrometerTol);
-      ck.testLE(matrix.rowZMagnitude() - unitVectorLength, micrometerTol);
-      ck.testLE(matrix.columnXMagnitude() - unitVectorLength, micrometerTol);
-      ck.testLE(matrix.columnYMagnitude() - unitVectorLength, micrometerTol);
-      ck.testLE(matrix.columnZMagnitude() - unitVectorLength, micrometerTol);
-      // diff between matrix inverse and transpose is larger than tolerance but is small enough (matrix is close to rigid)
-      const inverse = matrix.inverse()!;
-      const transpose = matrix.transpose();
-      ck.testLE(Geometry.smallAngleRadians, inverse.maxDiff(transpose));
-      ck.testLE(inverse.maxDiff(transpose), micrometerTol);
-      // matrix is not rigid but is near-rigid so createFromMatrix3d does not return undefined
-      ck.testFalse(matrix.isRigid());
+    const matrices = [
+      {m: matrix1, nearRigid: true},
+      {m: matrix2, nearRigid: true},
+      {m: matrix3, nearRigid: false},
+      {m: matrix4, nearRigid: false},
+      {m: matrix5, nearRigid: false},
+    ];
+
+    for (const t of matrices) {
+      // confirm near-rigidity (or not)
+      ck.testFalse(t.m.isRigid(), "matrix is not rigid");
       const result: YawPitchRollAngles = new YawPitchRollAngles();
-      const yprA = YawPitchRollAngles.createFromMatrix3d(matrix, result);
-      ck.testPointer(yprA);
-      // make matrix rigid and verify again that the original matrix is close to rigid
-      const rigidMatrix = Matrix3d.createRigidFromMatrix3d(matrix)!;
-      ck.testTrue(matrix.isAlmostEqual(rigidMatrix));
-      ck.testLE(matrix.maxDiff(rigidMatrix), micrometerTol);
-      const yprB = YawPitchRollAngles.createFromMatrix3d(rigidMatrix)!;
-      ck.testPointer(yprB);
-      // verify that YPR angles from original matrix and rigid matrix are very close
-      ck.testTrue(result.yaw.isAlmostEqual(yprB.yaw, 1e-5));
-      ck.testTrue(result.pitch.isAlmostEqual(yprB.pitch, 1e-5));
-      ck.testTrue(result.roll.isAlmostEqual(yprB.roll, 1e-5));
-      // rigid matrix and near-rigid matrix YPR round trip vs original matrix
-      const maxDiff = matrix.maxDiff(rigidMatrix);
-      const matrixA = yprA!.toMatrix3d();
-      const matrixB = yprB.toMatrix3d();
-      const diffAB = matrix.maxDiff(matrixA);
-      const diffAC = matrix.maxDiff(matrixB);
-      ck.testLT(diffAB, micrometerTol);
-      ck.testLT(diffAC, micrometerTol);
-      GeometryCoreTestIO.consoleLog("original matrix ", matrix.toJSON());
-      GeometryCoreTestIO.consoleLog("maxDiff between matrix and rigid matrix", maxDiff);
-      GeometryCoreTestIO.consoleLog("ypr for rigid matrix", yprB);
-      GeometryCoreTestIO.consoleLog("maxDiff between ypr round trips", diffAB);
+      const ypr = YawPitchRollAngles.createFromMatrix3d(t.m, result);
+      ck.testBoolean(t.nearRigid, ypr !== undefined, "createFromMatrix3d returns as expected");
+
+      // create two rigid matrices derived from matrix
+      const rigidMatrix1 = result.toMatrix3d();
+      if (ck.testType(rigidMatrix1, Matrix3d))
+        ck.testTrue(rigidMatrix1.isRigid(), "roundtrip yields rigid matrix #1");
+      const rigidMatrix2 = Matrix3d.createRigidFromMatrix3d(t.m);
+      if (ck.testType(rigidMatrix2, Matrix3d))
+        ck.testTrue(rigidMatrix2.isRigid(), "makeRigid yields rigid matrix #2");
+
+      // near-rigid matrices are within smallCoordinateDistance of their derived rigid variants
+      ck.testBoolean(t.nearRigid, t.m.isAlmostEqual(rigidMatrix1), "matrix and rigidMatrix1 compare as expected");
+      ck.testBoolean(t.nearRigid, t.m.isAlmostEqual(rigidMatrix2!), "matrix and rigidMatrix2 compare as expected");
+
+      // near-rigid matrices' angles are within smallAngleRadians of their derived rigid variants' angles
+      const yprRigid1 = YawPitchRollAngles.createFromMatrix3d(rigidMatrix1);
+      ck.testType(yprRigid1, YawPitchRollAngles, "rigidMatrix1 yields ypr");
+      const yprRigid2 = YawPitchRollAngles.createFromMatrix3d(rigidMatrix2!);
+      ck.testType(yprRigid2, YawPitchRollAngles, "rigidMatrix2 yields ypr");
+      const yprSame1 = Geometry.isSmallAngleRadians(result.maxDiffRadians(yprRigid1!));
+      const yprSame2 = Geometry.isSmallAngleRadians(result.maxDiffRadians(yprRigid2!));
+      ck.testBoolean(t.nearRigid, yprSame1 && yprSame2, "ypr for matrix and rigid variants compare as expected");
     }
     expect(ck.getNumErrors()).equals(0);
   });

--- a/core/geometry/src/test/geometry3d/YawPitchRollAngles.test.ts
+++ b/core/geometry/src/test/geometry3d/YawPitchRollAngles.test.ts
@@ -153,7 +153,7 @@ describe("YPR", () => {
       0.707, -0.415, -0.571,
       0, 0.808, -0.588,
       0.706, 0.416, 0.572,
-    ); // drop least significant digit from matrix3 (less rigid)
+    ); // drop least significant digit from matrix4 (less rigid)
 
     const matrices = [
       {m: matrix1, nearRigid: true},
@@ -170,7 +170,7 @@ describe("YPR", () => {
       const ypr = YawPitchRollAngles.createFromMatrix3d(t.m, result);
       ck.testBoolean(t.nearRigid, ypr !== undefined, "createFromMatrix3d returns as expected");
 
-      // create two rigid matrices derived from matrix
+      // derive two rigid matrices
       const rigidMatrix1 = result.toMatrix3d();
       if (ck.testType(rigidMatrix1, Matrix3d))
         ck.testTrue(rigidMatrix1.isRigid(), "roundtrip yields rigid matrix #1");


### PR DESCRIPTION
Now if a near-rigid matrix is passed to Matrix3d.createRigidFromMatrix3d, the function does not return undefined.