### PR TITLE
Change config handling for display test app

### DIFF
--- a/test-apps/display-test-app/src/common/DtaConfiguration.ts
+++ b/test-apps/display-test-app/src/common/DtaConfiguration.ts
@@ -232,9 +232,16 @@ export const getConfig = (): DtaConfiguration => {
 
   configuration.iModelId = process.env.IMJS_IMODEL_ID;
   configuration.urlPrefix = process.env.IMJS_URL_PREFIX;
-  configuration.oidcClientId = process.env.IMJS_OIDC_CLIENT_ID;
-  configuration.oidcScope = process.env.IMJS_OIDC_SCOPE;
-  configuration.oidcRedirectUri = process.env.IMJS_OIDC_REDIRECT_URI;
+  if (ProcessDetector.isElectronAppFrontend) {
+    configuration.oidcClientId = process.env.IMJS_OIDC_ELECTRON_TEST_CLIENT_ID;
+    configuration.oidcScope = process.env.IMJS_OIDC_ELECTRON_TEST_SCOPES;
+    configuration.oidcRedirectUri = process.env.IMJS_OIDC_ELECTRON_TEST_REDIRECT_URI;
+  } else {
+    configuration.oidcClientId = process.env.IMJS_OIDC_CLIENT_ID;
+    configuration.oidcScope = process.env.IMJS_OIDC_SCOPE;
+    configuration.oidcRedirectUri = process.env.IMJS_OIDC_REDIRECT_URI;
+  }
+
   configuration.ignoreCache = undefined !== process.env.IMJS_IGNORE_CACHE;
 
   return configuration;

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -275,14 +275,14 @@ export class DisplayTestApp {
       // ###TODO fix that in the client and remove this
       if (!configuration.noElectronAuth)
         opts.iModelApp!.authorizationClient = new ElectronRendererAuthorization({
-          clientId: getConfigurationString("oidcClientId") ?? "imodeljs-spa-test",
+          clientId: getConfigurationString("oidcClientId") ?? "native-testId",
         });
 
       await ElectronApp.startup(opts);
     } else if (ProcessDetector.isMobileAppFrontend) {
       await MobileApp.startup(opts as MobileAppOpts);
     } else {
-      const redirectUri = "http://localhost:3000/signin-callback";
+      const redirectUri = getConfigurationString("oidcRedirectUri") ?? "http://localhost:3000/signin-callback";
       const urlObj = new URL(redirectUri);
       if (urlObj.pathname === window.location.pathname) {
         const client = new BrowserAuthorizationClient({


### PR DESCRIPTION
- Change default client id for electron renderer auth to a more appropriately named client id (electron client ids should follow `native-XX`)
- Fixes `dta signin` callback hanging after successful log in on the electron DTA, when `npm run start` script is used. Specifically, a different redirect url has to be used in this case, because the default, localhost:3000 is already used by the webserver. Added an if statement in DtaConfiguration to allow redirect urls to branch depending on the process.