### PR TITLE
Support plan projection priority for batched tilesets

### DIFF
--- a/core/frontend/src/common/imdl/ParseImdlDocument.ts
+++ b/core/frontend/src/common/imdl/ParseImdlDocument.ts
@@ -36,6 +36,15 @@ import { indexedEdgeParamsFromCompactEdges } from "./CompactEdges";
  */
 export type ImdlTimeline = RenderSchedule.ModelTimeline | RenderSchedule.Script;
 
+/** Describes one group of models within an iMdl tileset.
+ * @see [[ImdlParserOptions.modelGroups]].
+ * @internal
+ */
+export interface ImdlModelGroup {
+  models: Id64Set;
+  produceLayers: boolean;
+}
+ 
 /** Options provided to [[ImdlParser.parse]].
  * @internal
  */
@@ -48,7 +57,7 @@ export interface ImdlParserOptions {
   omitEdges?: boolean;
   createUntransformedRootNode?: boolean;
   /* see [[ImdlDecodeArgs.modelGroups]]. */
-  modelGroups?: Id64Set[];
+  modelGroups?: ImdlModelGroup[];
 }
 
 /** Arguments provided to [[parseImdlDocument]].
@@ -682,7 +691,7 @@ class Parser {
       featureTable.getModelIdPair(featureIndex, modelIdPair);
       const modelId = Id64.fromUint32PairObject(modelIdPair);
       for (let i = 0; i < modelGroups.length; i++) {
-        if (modelGroups[i].has(modelId))
+        if (modelGroups[i].models.has(modelId))
           return i;
       }
 

--- a/core/frontend/src/common/imdl/ParseImdlDocument.ts
+++ b/core/frontend/src/common/imdl/ParseImdlDocument.ts
@@ -49,6 +49,11 @@ export interface ImdlParserOptions {
   createUntransformedRootNode?: boolean;
   /* see [[ImdlDecodeArgs.modelGroups]]. */
   modelGroups?: Id64Set[];
+  /** If true, split up the contents of the tiles into [[Imdl.Layer]]s based on subcategory Id.
+   * V1 tiles already have this splitting applied on the backend.
+   * @see [PlanProjectionSettings.enforceDisplayPriority]($common).
+   */
+  produceLayers?: boolean;
 }
 
 /** Arguments provided to [[parseImdlDocument]].
@@ -411,6 +416,8 @@ class Parser {
             animationNodeId: AnimationNodeId.Untransformed,
             primitives: this.parseNodePrimitives(docPrimitives),
           });
+        } else if (this._options.produceLayers) {
+          this.parseLayers(nodes, docMesh, featureTable);
         } else {
           nodes.push({ primitives: this.parseNodePrimitives(docPrimitives) });
         }

--- a/core/frontend/src/common/imdl/ParseImdlDocument.ts
+++ b/core/frontend/src/common/imdl/ParseImdlDocument.ts
@@ -49,11 +49,6 @@ export interface ImdlParserOptions {
   createUntransformedRootNode?: boolean;
   /* see [[ImdlDecodeArgs.modelGroups]]. */
   modelGroups?: Id64Set[];
-  /** If true, split up the contents of the tiles into [[Imdl.Layer]]s based on subcategory Id.
-   * V1 tiles already have this splitting applied on the backend.
-   * @see [PlanProjectionSettings.enforceDisplayPriority]($common).
-   */
-  produceLayers?: boolean;
 }
 
 /** Arguments provided to [[parseImdlDocument]].
@@ -416,8 +411,6 @@ class Parser {
             animationNodeId: AnimationNodeId.Untransformed,
             primitives: this.parseNodePrimitives(docPrimitives),
           });
-        } else if (this._options.produceLayers) {
-          this.parseLayers(nodes, docMesh, featureTable);
         } else {
           nodes.push({ primitives: this.parseNodePrimitives(docPrimitives) });
         }

--- a/core/frontend/src/tile/ImdlDecoder.ts
+++ b/core/frontend/src/tile/ImdlDecoder.ts
@@ -11,7 +11,7 @@ import { BatchType } from "@itwin/core-common";
 import type { IModelConnection } from "../IModelConnection";
 import { BatchOptions } from "../render/GraphicBuilder";
 import { RenderSystem } from "../render/RenderSystem";
-import type { ImdlTimeline } from "../common/imdl/ParseImdlDocument";
+import type { ImdlModelGroup, ImdlTimeline } from "../common/imdl/ParseImdlDocument";
 import { acquireImdlParser, ImdlReaderResult, readImdlContent } from "./internal";
 
 /** Arguments supplied to [[ImdlDecoder.decode]].
@@ -29,7 +29,7 @@ export interface ImdlDecodeArgs {
   /** An array of model groups. If supplied, the graphics associated with each group of models will be decoded into a separate GraphciBranch
    * with [[GraphicBranch.groupNodeId]] set to the index of the group to which the model belongs.
    */
-  modelGroups?: Id64Set[];
+  modelGroups?: ImdlModelGroup[];
 }
 
 /** An object that can decode graphics in iMdl format.

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -18,7 +18,7 @@ import { RenderGraphic } from "../render/RenderGraphic";
 import { BatchOptions } from "../render/GraphicBuilder";
 import { RenderSystem } from "../render/RenderSystem";
 import { ImdlModel } from "../common/imdl/ImdlModel";
-import { convertFeatureTable, ImdlParseError, ImdlParserOptions, ImdlTimeline, parseImdlDocument } from "../common/imdl/ParseImdlDocument";
+import { convertFeatureTable, ImdlModelGroup, ImdlParseError, ImdlParserOptions, ImdlTimeline, parseImdlDocument } from "../common/imdl/ParseImdlDocument";
 import { decodeImdlGraphics, IModelTileContent } from "./internal";
 
 /* eslint-disable no-restricted-syntax */
@@ -67,7 +67,7 @@ export interface ImdlReaderCreateArgs {
   containsTransformNodes?: boolean; // default false
   /** Supplied if the graphics in the tile are to be split up based on the nodes in the timeline. */
   timeline?: ImdlTimeline;
-  modelGroups?: Id64Set[];
+  modelGroups?: ImdlModelGroup[];
 }
 
 /** @internal */

--- a/extensions/frontend-tiles/src/BatchedModelGroups.ts
+++ b/extensions/frontend-tiles/src/BatchedModelGroups.ts
@@ -139,7 +139,7 @@ function encodeModelGroups(groups: ModelGroup[]): string {
   if (!groups.some((x) => x.planProjection?.enforceDisplayPriority))
     return start;
   
-  const end = groups.map((x) => x.planProjection?.enforceDisplayPriority ? "1" : "0");
+  const end = groups.map((x) => x.planProjection?.enforceDisplayPriority ? "1" : "0").join("");;
   return `${start}#${end}`;
 }
 
@@ -156,9 +156,10 @@ export function decodeImdlModelGroups(guid: string): ImdlModelGroup[] {
   if (undefined === parts[1])
     return groups;
 
-  assert(parts[1].length === groups.length);
+  const flags = parts[1];
+  assert(flags.length === groups.length);
   for (let i = 0; i < groups.length; i++)
-    groups[i].produceLayers = parts[i] === "1";
+    groups[i].produceLayers = flags[i] === "1";
 
   return groups;
 }

--- a/extensions/frontend-tiles/src/BatchedTileTree.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTree.ts
@@ -3,10 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { BeTimePoint, Id64Set, Id64String } from "@itwin/core-bentley";
+import { BeTimePoint, Id64String } from "@itwin/core-bentley";
 import { BatchType, RenderMode, RenderSchedule, ViewFlagOverrides } from "@itwin/core-common";
 import {
-  acquireImdlDecoder, ImdlDecoder, IModelApp, Tile, TileDrawArgs, TileTree, TileTreeParams,
+  acquireImdlDecoder, ImdlDecoder, ImdlModelGroup, IModelApp, Tile, TileDrawArgs, TileTree, TileTreeParams,
 } from "@itwin/core-frontend";
 import { BatchedTile, BatchedTileParams } from "./BatchedTile";
 import { BatchedTilesetReader, ModelMetadata } from "./BatchedTilesetReader";
@@ -23,7 +23,7 @@ export interface BatchedTileTreeParams extends TileTreeParams {
   reader: BatchedTilesetReader;
   script?: RenderSchedule.Script;
   models: Map<Id64String, ModelMetadata>;
-  modelGroups: Id64Set[] | undefined;
+  modelGroups: ImdlModelGroup[] | undefined;
 }
 
 /** @internal */
@@ -32,7 +32,7 @@ export class BatchedTileTree extends TileTree {
   public readonly reader: BatchedTilesetReader;
   public readonly scheduleScript?: RenderSchedule.Script;
   public readonly decoder: ImdlDecoder;
-  public readonly modelGroups: Id64Set[] | undefined;
+  public readonly modelGroups: ImdlModelGroup[] | undefined;
 
   public constructor(params: BatchedTileTreeParams) {
     super(params);

--- a/extensions/frontend-tiles/src/BatchedTileTreeReference.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTreeReference.ts
@@ -135,7 +135,16 @@ export class BatchedTileTreeReference extends TileTreeReference implements Featu
     const args = super.createDrawArgs(context);
 
     // ###TODO args.boundingRange = args.tree.getTransformNodeRange(this._animationTransformNodeId);
-    // ###TODO if PlanProjectionSettings.enforceDisplayPriority, createGraphicLayerContainer.
+
+    const proj = this._groupInfo.planProjection;
+    if (args && proj?.enforceDisplayPriority) {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      args.drawGraphics = () => {
+        const graphics = args.produceGraphics();
+        if (undefined !== graphics)
+          context.outputGraphic(context.target.renderSystem.createGraphicLayerContainer(graphics, proj.overlay, proj.transparency, proj.elevation));
+      };
+    }
 
     return args;
   }

--- a/extensions/frontend-tiles/src/BatchedTileTreeSupplier.ts
+++ b/extensions/frontend-tiles/src/BatchedTileTreeSupplier.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { comparePossiblyUndefined, compareStrings, CompressedId64Set, Logger } from "@itwin/core-bentley";
+import { comparePossiblyUndefined, compareStrings, Logger } from "@itwin/core-bentley";
 import { RenderSchedule } from "@itwin/core-common";
 import {
   IModelConnection, TileTree, TileTreeOwner, TileTreeSupplier,
@@ -11,6 +11,7 @@ import {
 import { loggerCategory } from "./LoggerCategory";
 import { BatchedTilesetReader, BatchedTilesetSpec } from "./BatchedTilesetReader";
 import { BatchedTileTree } from "./BatchedTileTree";
+import { decodeImdlModelGroups } from "./BatchedModelGroups";
 
 /** @internal */
 export interface BatchedTileTreeId {
@@ -33,7 +34,7 @@ class BatchedTileTreeSupplier implements TileTreeSupplier {
   public async createTileTree(treeId: BatchedTileTreeId, iModel: IModelConnection): Promise<TileTree | undefined> {
     const spec = treeId.spec;
     try {
-      const modelGroups = treeId.modelGroups ? treeId.modelGroups.split("_").map((x) => CompressedId64Set.decompressSet(x)) : undefined;
+      const modelGroups = treeId.modelGroups ? decodeImdlModelGroups(treeId.modelGroups) : undefined;
       const reader = new BatchedTilesetReader(spec, iModel, modelGroups);
       const params = await reader.readTileTreeParams();
 

--- a/extensions/frontend-tiles/src/BatchedTilesetReader.ts
+++ b/extensions/frontend-tiles/src/BatchedTilesetReader.ts
@@ -3,12 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { Id64, Id64Set, Id64String } from "@itwin/core-bentley";
+import { Id64, Id64String } from "@itwin/core-bentley";
 import {
   Matrix3d, Point3d, Range3d, Range3dProps, Transform, Vector3d,
 } from "@itwin/core-geometry";
 import { Tileset3dSchema as schema, ViewFlagOverrides } from "@itwin/core-common";
-import { IModelConnection, RealityModelTileUtils, TileLoadPriority } from "@itwin/core-frontend";
+import { IModelConnection, ImdlModelGroup, RealityModelTileUtils, TileLoadPriority } from "@itwin/core-frontend";
 import { BatchedTileTreeParams } from "./BatchedTileTree";
 import { BatchedTile, BatchedTileParams } from "./BatchedTile";
 
@@ -124,9 +124,9 @@ function transformFromJSON(json: schema.Transform): Transform {
 export class BatchedTilesetReader {
   private readonly _iModel: IModelConnection;
   private readonly _spec: BatchedTilesetSpec;
-  private readonly _modelGroups: Id64Set[] | undefined;
+  private readonly _modelGroups: ImdlModelGroup[] | undefined;
 
-  public constructor(spec: BatchedTilesetSpec, iModel: IModelConnection, modelGroups: Id64Set[] | undefined) {
+  public constructor(spec: BatchedTilesetSpec, iModel: IModelConnection, modelGroups: ImdlModelGroup[] | undefined) {
     this._iModel = iModel;
     this._spec = spec;
     this._modelGroups = modelGroups;

--- a/extensions/frontend-tiles/src/ModelGroup.ts
+++ b/extensions/frontend-tiles/src/ModelGroup.ts
@@ -18,6 +18,8 @@ export interface PlanProjectionInfo {
   transparency: number;
   /** If true, the graphics are drawn as overlays with no depth test. */
   overlay: boolean;
+  /** If true, the graphics should be split up into separate nodes based on subcategory Id so that draw order can be controlled by subcategory display priority. */
+  enforceDisplayPriority: boolean;
 }
 
 /** Display settings to be applied to a group of models.
@@ -60,11 +62,12 @@ function createPlanProjectionInfo(modelId: Id64String, context: ModelGroupingCon
     elevation: settings.elevation ?? context.getDefaultElevation(modelId),
     transparency: settings.transparency ?? 0,
     overlay: settings.overlay,
+    enforceDisplayPriority: !!settings.enforceDisplayPriority,
   };
 }
 
 function equalPlanProjections(a: PlanProjectionInfo, b: PlanProjectionInfo): boolean {
-  return a.elevation === b.elevation && a.overlay === b.overlay && a.transparency === b.transparency;
+  return a.enforceDisplayPriority === b.enforceDisplayPriority && a.elevation === b.elevation && a.overlay === b.overlay && a.transparency === b.transparency;
 }
 
 function createModelGroupInfo(context: ModelGroupingContext, modelId: Id64String): ModelGroupInfo {


### PR DESCRIPTION
Assertions in `LayerState.ts` because it expects: Container > Branch > Batch > Layer* and we're giving it nested branches.