### PR TITLE
Add different decimal separator support to core-quantity's Parser

### DIFF
--- a/common/changes/@itwin/core-quantity/nam-parse-quantity-fix_2024-01-25-19-48.json
+++ b/common/changes/@itwin/core-quantity/nam-parse-quantity-fix_2024-01-25-19-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-quantity",
+      "comment": "Add parsing support for different decimal and thousand separators",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-quantity"
+}

--- a/core/quantity/src/Parser.ts
+++ b/core/quantity/src/Parser.ts
@@ -217,7 +217,9 @@ export class Parser {
           }
           processingNumber = true;
         }
-        wipToken = wipToken.concat(str[i]);
+        // Decimal separators must be replaced with '.' before converting to a number - parseFloat() only supports '.' as the decimal separator.
+        const charToAdd = charCode === format.decimalSeparator.charCodeAt(0) ? "." : str[i];
+        wipToken = wipToken.concat(charToAdd);
       } else {
         if (processingNumber) {
           if (charCode === QuantityConstants.CHAR_SLASH || charCode === QuantityConstants.CHAR_FRACTION_SLASH || charCode === QuantityConstants.CHAR_DIVISION_SLASH) {

--- a/core/quantity/src/test/Parsing.test.ts
+++ b/core/quantity/src/test/Parsing.test.ts
@@ -108,29 +108,17 @@ describe("Parsing tests:", () => {
   });
 
   it("Generate Parse Tokens given different decimal and thousand separators", async () => {
-    const testStrings = ["", "0/1", "1/0", "1/2", "-1/2", "+1/2", "2 /", "1,616252eggs", "1,616252E-35eggs", "-1,616252E-35eggs", "756345,345", "12.345,345", "3,6252e3 Miles", "-1 1/2 FT", "+1 1/2 FT", "-135°11'30,5\"", "-2FT 6IN", "135°11'30,5\"", "2FT 6IN", "1 1/2 FT"];
+    const testStrings = ["1,616252eggs", "1,616252E-35eggs", "-1,616252E-35eggs", "756345,345", "12.345,345", "3,6252e3 Miles", "-135°11'30,5\"", "135°11'30,5\""];
 
     const expectedTokens = [
-      [],
-      [{ value: 0 }],
-      [{ value: 1 }],
-      [{ value: 0.5 }],
-      [{ value: -0.5 }],
-      [{ value: 0.5 }],
-      [{ value: 2 }],
       [{ value: 1.616252 }, { value: "eggs" }],
       [{ value: 1.616252e-35 }, { value: "eggs" }],
       [{ value: -1.616252e-35 }, { value: "eggs" }],
       [{ value: 756345.345 }],
       [{ value: 12345.345 }],
       [{ value: 3625.2 }, { value: "Miles" }],
-      [{ value: -1.5 }, { value: "FT" }],
-      [{ value: 1.5 }, { value: "FT" }],
       [{ value: -135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
-      [{ value: -2 }, { value: "FT" }, { value: 6 }, { value: "IN" }],
       [{ value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
-      [{ value: 2 }, { value: "FT" }, { value: 6 }, { value: "IN" }],
-      [{ value: 1.5 }, { value: "FT" }],
     ];
 
     const formatData = {

--- a/core/quantity/src/test/Parsing.test.ts
+++ b/core/quantity/src/test/Parsing.test.ts
@@ -107,6 +107,55 @@ describe("Parsing tests:", () => {
     }
   });
 
+  it("Generate Parse Tokens given different decimal and thousand separators", async () => {
+    const testStrings = ["", "0/1", "1/0", "1/2", "-1/2", "+1/2", "2 /", "1,616252eggs", "1,616252E-35eggs", "-1,616252E-35eggs", "756345,345", "12.345,345", "3,6252e3 Miles", "-1 1/2 FT", "+1 1/2 FT", "-135°11'30,5\"", "-2FT 6IN", "135°11'30,5\"", "2FT 6IN", "1 1/2 FT"];
+
+    const expectedTokens = [
+      [],
+      [{ value: 0 }],
+      [{ value: 1 }],
+      [{ value: 0.5 }],
+      [{ value: -0.5 }],
+      [{ value: 0.5 }],
+      [{ value: 2 }],
+      [{ value: 1.616252 }, { value: "eggs" }],
+      [{ value: 1.616252e-35 }, { value: "eggs" }],
+      [{ value: -1.616252e-35 }, { value: "eggs" }],
+      [{ value: 756345.345 }],
+      [{ value: 12345.345 }],
+      [{ value: 3625.2 }, { value: "Miles" }],
+      [{ value: -1.5 }, { value: "FT" }],
+      [{ value: 1.5 }, { value: "FT" }],
+      [{ value: -135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
+      [{ value: -2 }, { value: "FT" }, { value: 6 }, { value: "IN" }],
+      [{ value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
+      [{ value: 2 }, { value: "FT" }, { value: 6 }, { value: "IN" }],
+      [{ value: 1.5 }, { value: "FT" }],
+    ];
+
+    const formatData = {
+      decimalSeparator: ",",
+      thousandSeparator: ".",
+      type: "Decimal",
+    };
+    const format = new Format("test");
+    const unitsProvider = new TestUnitsProvider();
+    await format.fromJSON(unitsProvider, formatData).catch(() => { });
+
+    let i = 0;
+    for (const strVal of testStrings) {
+      const tokens = Parser.parseQuantitySpecification(strVal, format);
+      assert.isTrue(tokens.length === expectedTokens[i].length);
+
+      // eslint-disable-next-line @typescript-eslint/prefer-for-of
+      for (let j = 0; j < tokens.length; j++) {
+        assert.isTrue(tokens[j].value === expectedTokens[i][j].value);
+      }
+
+      i = i + 1;
+    }
+  });
+
   it("Look up units", async () => {
     const expectedLookupResults = [
       { label: "FT", name: "Units.FT", unitContext: "" },


### PR DESCRIPTION
Addresses #6362 

Adds logic, plus test cases to core quantity's Parser, which supports parsing numeric strings that have decimal separators that don't use a period. 