### PR TITLE
Batch table property access

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2295,6 +2295,8 @@ export enum ContextMode {
 export class ContextRealityModelState extends ContextRealityModel {
     // @internal
     constructor(props: ContextRealityModelProps, iModel: IModelConnection, displayStyle: DisplayStyleState);
+    // @beta
+    getFeatureProperties(featureId: Id64String): any;
     readonly iModel: IModelConnection;
     get isGlobal(): boolean;
     get modelId(): Id64String | undefined;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1719,8 +1719,6 @@ export class BatchedTileIdMap {
     getBatchProperties(id: Id64String): any;
     // (undocumented)
     getFeatureProperties(id: Id64String): Record<string, any> | undefined;
-    // (undocumented)
-    hasFeature(id: Id64String): boolean;
 }
 
 // @public
@@ -1734,9 +1732,8 @@ export interface BatchOptions {
 }
 
 // @beta
-export interface BatchTablePropertyMap {
+export interface BatchTableProperties {
     getFeatureProperties(id: Id64String): Record<string, any> | undefined;
-    hasFeature(id: Id64String): boolean;
 }
 
 // @public (undocumented)
@@ -3032,6 +3029,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     protected queryRenderTimelineProps(timelineId: Id64String): Promise<RenderTimelineProps | undefined>;
     // @internal (undocumented)
     protected _queryRenderTimelinePropsPromise?: Promise<RenderTimelineProps | undefined>;
+    get realityModels(): Iterable<ContextRealityModelState>;
     // @internal (undocumented)
     protected registerSettingsEventListeners(): void;
     get scheduleScript(): RenderSchedule.Script | undefined;
@@ -11411,7 +11409,7 @@ export class RealityTileTree extends TileTree {
     // @internal
     constructor(params: RealityTileTreeParams);
     // @beta
-    get batchTableProperties(): BatchTablePropertyMap | undefined;
+    get batchTableProperties(): BatchTableProperties | undefined;
     // @internal (undocumented)
     cartesianRange: Range3d;
     // @internal (undocumented)

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1716,7 +1716,6 @@ export abstract class BaseUnitFormattingSettingsProvider implements UnitFormatti
 export class BatchedTileIdMap {
     constructor(iModel: IModelConnection);
     getBatchId(properties: any): Id64String;
-    getBatchProperties(id: Id64String): any;
     // (undocumented)
     getFeatureProperties(id: Id64String): Record<string, any> | undefined;
 }

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1717,6 +1717,10 @@ export class BatchedTileIdMap {
     constructor(iModel: IModelConnection);
     getBatchId(properties: any): Id64String;
     getBatchProperties(id: Id64String): any;
+    // (undocumented)
+    getFeatureProperties(id: Id64String): Record<string, any> | undefined;
+    // (undocumented)
+    hasFeature(id: Id64String): boolean;
 }
 
 // @public
@@ -1727,6 +1731,12 @@ export interface BatchOptions {
     noHilite?: boolean;
     // @beta
     tileId?: string;
+}
+
+// @beta
+export interface BatchTablePropertyMap {
+    getFeatureProperties(id: Id64String): Record<string, any> | undefined;
+    hasFeature(id: Id64String): boolean;
 }
 
 // @public (undocumented)
@@ -11400,6 +11410,8 @@ export class RealityTileRegion {
 export class RealityTileTree extends TileTree {
     // @internal
     constructor(params: RealityTileTreeParams);
+    // @beta
+    get batchTableProperties(): BatchTablePropertyMap | undefined;
     // @internal (undocumented)
     cartesianRange: Range3d;
     // @internal (undocumented)

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2295,8 +2295,6 @@ export enum ContextMode {
 export class ContextRealityModelState extends ContextRealityModel {
     // @internal
     constructor(props: ContextRealityModelProps, iModel: IModelConnection, displayStyle: DisplayStyleState);
-    // @beta
-    getFeatureProperties(featureId: Id64String): any;
     readonly iModel: IModelConnection;
     get isGlobal(): boolean;
     get modelId(): Id64String | undefined;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -78,7 +78,7 @@ internal;BackgroundMapGeometry
 beta;class BaseUnitFormattingSettingsProvider 
 internal;BatchedTileIdMap
 public;BatchOptions
-beta;BatchTablePropertyMap
+beta;BatchTableProperties
 public;BeButton
 public;BeButtonEvent 
 public;BeButtonEventProps

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -78,6 +78,7 @@ internal;BackgroundMapGeometry
 beta;class BaseUnitFormattingSettingsProvider 
 internal;BatchedTileIdMap
 public;BatchOptions
+beta;BatchTablePropertyMap
 public;BeButton
 public;BeButtonEvent 
 public;BeButtonEventProps

--- a/common/changes/@itwin/core-frontend/pmc-query-batch-table_2024-01-27-01-05.json
+++ b/common/changes/@itwin/core-frontend/pmc-query-batch-table_2024-01-27-01-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add RealityTileTree.batchTableProperties for accessing per-feature properties from 3D Tiles 1.0 tilesets.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/pmc-query-batch-table_2024-01-27-02-16.json
+++ b/common/changes/@itwin/core-frontend/pmc-query-batch-table_2024-01-27-02-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add DisplayStyleState iterator over context reality models.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ContextRealityModelState.ts
+++ b/core/frontend/src/ContextRealityModelState.ts
@@ -12,7 +12,7 @@ import { DisplayStyleState } from "./DisplayStyleState";
 import { IModelConnection } from "./IModelConnection";
 import { PlanarClipMaskState } from "./PlanarClipMaskState";
 import { RealityDataSource } from "./RealityDataSource";
-import { createOrbitGtTileTreeReference, createRealityTileTreeReference, RealityModelTileTree, TileTreeReference } from "./tile/internal";
+import { createOrbitGtTileTreeReference, createRealityTileTreeReference, RealityModelTileTree, RealityTileTree, TileTreeReference } from "./tile/internal";
 
 /** A [ContextRealityModel]($common) attached to a [[DisplayStyleState]] supplying a [[TileTreeReference]] used to draw the
  * reality model in a [[Viewport]].
@@ -69,9 +69,32 @@ export class ContextRealityModelState extends ContextRealityModel {
   /** The tile tree reference responsible for drawing the reality model into a [[Viewport]]. */
   public get treeRef(): TileTreeReference { return this._treeRef; }
 
+  private get _realityTreeRef(): RealityModelTileTree.Reference | undefined {
+    return this._treeRef instanceof RealityModelTileTree.Reference ? this._treeRef : undefined;
+  }
+
   /** The transient Id assigned to this reality model at run-time. */
   public get modelId(): Id64String | undefined {
-    return (this._treeRef instanceof RealityModelTileTree.Reference) ? this._treeRef.modelId : undefined;
+    return this._realityTreeRef?.modelId;
+  }
+
+  /** Obtain the properties for a feature specified in this reality model's [batch table](https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/BatchTable).
+   * A ContextRealityModelState may refer to a tileset in one of the 3D Tiles 1.0 format (b3dm, i3dm, cmpt, or pnts).
+   * Tiles within such tilesets may include a "batch table" describing subcomponents ("features") within the tile. For example, a tileset representing a building
+   * may encode each door, window, and wall as separate features.
+   * The batch table may additionally contain metadata in JSON format describing each feature.
+   * During tile decoding, iTwin.js assigns unique, transient [Id64String]($bentley)s to each unique feature within the tileset.
+   * When interacting with tileset features (e.g., via the [][SelectionSet]] or a [[HitDetail]]), the features are identified by these transient Ids.
+   * getFeatureProperties takes the transient Id and returns the JSON properties of the corresponding feature, or `undefined` if no properties exist for the specified feature.
+   * @beta
+   */
+  public getFeatureProperties(featureId: Id64String): any {
+    const tree = this._realityTreeRef?.treeOwner.tileTree;
+    if (!tree || !(tree instanceof RealityTileTree))
+      return undefined;
+
+    const map = tree.loader.getBatchIdMap();
+    return map?.getBatchProperties(featureId);
   }
 
   /** Whether the reality model spans the entire globe ellipsoid. */

--- a/core/frontend/src/ContextRealityModelState.ts
+++ b/core/frontend/src/ContextRealityModelState.ts
@@ -12,7 +12,7 @@ import { DisplayStyleState } from "./DisplayStyleState";
 import { IModelConnection } from "./IModelConnection";
 import { PlanarClipMaskState } from "./PlanarClipMaskState";
 import { RealityDataSource } from "./RealityDataSource";
-import { createOrbitGtTileTreeReference, createRealityTileTreeReference, RealityModelTileTree, RealityTileTree, TileTreeReference } from "./tile/internal";
+import { createOrbitGtTileTreeReference, createRealityTileTreeReference, RealityModelTileTree, TileTreeReference } from "./tile/internal";
 
 /** A [ContextRealityModel]($common) attached to a [[DisplayStyleState]] supplying a [[TileTreeReference]] used to draw the
  * reality model in a [[Viewport]].
@@ -69,32 +69,9 @@ export class ContextRealityModelState extends ContextRealityModel {
   /** The tile tree reference responsible for drawing the reality model into a [[Viewport]]. */
   public get treeRef(): TileTreeReference { return this._treeRef; }
 
-  private get _realityTreeRef(): RealityModelTileTree.Reference | undefined {
-    return this._treeRef instanceof RealityModelTileTree.Reference ? this._treeRef : undefined;
-  }
-
   /** The transient Id assigned to this reality model at run-time. */
   public get modelId(): Id64String | undefined {
-    return this._realityTreeRef?.modelId;
-  }
-
-  /** Obtain the properties for a feature specified in this reality model's [batch table](https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/BatchTable).
-   * A ContextRealityModelState may refer to a tileset in one of the 3D Tiles 1.0 format (b3dm, i3dm, cmpt, or pnts).
-   * Tiles within such tilesets may include a "batch table" describing subcomponents ("features") within the tile. For example, a tileset representing a building
-   * may encode each door, window, and wall as separate features.
-   * The batch table may additionally contain metadata in JSON format describing each feature.
-   * During tile decoding, iTwin.js assigns unique, transient [Id64String]($bentley)s to each unique feature within the tileset.
-   * When interacting with tileset features (e.g., via the [][SelectionSet]] or a [[HitDetail]]), the features are identified by these transient Ids.
-   * getFeatureProperties takes the transient Id and returns the JSON properties of the corresponding feature, or `undefined` if no properties exist for the specified feature.
-   * @beta
-   */
-  public getFeatureProperties(featureId: Id64String): any {
-    const tree = this._realityTreeRef?.treeOwner.tileTree;
-    if (!tree || !(tree instanceof RealityTileTree))
-      return undefined;
-
-    const map = tree.loader.getBatchIdMap();
-    return map?.getBatchProperties(featureId);
+    return (this._treeRef instanceof RealityModelTileTree.Reference) ? this._treeRef.modelId : undefined;
   }
 
   /** Whether the reality model spans the entire globe ellipsoid. */

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -242,6 +242,18 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     }
   }
 
+  private * getRealityModels(): Iterable<ContextRealityModelState> {
+    for (const model of this.settings.contextRealityModels.models) {
+      assert(model instanceof ContextRealityModelState);
+      yield model;
+    }
+  }
+
+  /** Iterate over the reality models attached to this display style. */
+  public get realityModels(): Iterable<ContextRealityModelState> {
+    return this.getRealityModels();
+  }
+
   /** @internal */
   public forEachRealityTileTreeRef(func: (ref: TileTreeReference) => void): void {
     this.forEachRealityModel((model) => func(model.treeRef));

--- a/core/frontend/src/tile/BatchedTileIdMap.ts
+++ b/core/frontend/src/tile/BatchedTileIdMap.ts
@@ -48,10 +48,6 @@ export class BatchedTileIdMap {
     return undefined !== this._idMap ? this._idMap.get(id) : undefined;
   }
 
-  public hasFeature(id: Id64String): boolean {
-    return this._idMap !== undefined && this._idMap.has(id);
-  }
-
   public getFeatureProperties(id: Id64String): Record<string, any> | undefined {
     const props = this._idMap?.get(id);
     return typeof props === "object" ? props : undefined;

--- a/core/frontend/src/tile/BatchedTileIdMap.ts
+++ b/core/frontend/src/tile/BatchedTileIdMap.ts
@@ -43,11 +43,6 @@ export class BatchedTileIdMap {
     return entry.id;
   }
 
-  /** Obtain the JSON properties associated with the specified Id64String, or undefined if none exist. */
-  public getBatchProperties(id: Id64String): any {
-    return undefined !== this._idMap ? this._idMap.get(id) : undefined;
-  }
-
   public getFeatureProperties(id: Id64String): Record<string, any> | undefined {
     const props = this._idMap?.get(id);
     return typeof props === "object" ? props : undefined;

--- a/core/frontend/src/tile/BatchedTileIdMap.ts
+++ b/core/frontend/src/tile/BatchedTileIdMap.ts
@@ -47,4 +47,13 @@ export class BatchedTileIdMap {
   public getBatchProperties(id: Id64String): any {
     return undefined !== this._idMap ? this._idMap.get(id) : undefined;
   }
+
+  public hasFeature(id: Id64String): boolean {
+    return this._idMap !== undefined && this._idMap.has(id);
+  }
+
+  public getFeatureProperties(id: Id64String): Record<string, any> | undefined {
+    const props = this._idMap?.get(id);
+    return typeof props === "object" ? props : undefined;
+  }
 }

--- a/core/frontend/src/tile/RealityModelTileTree.ts
+++ b/core/frontend/src/tile/RealityModelTileTree.ts
@@ -876,11 +876,10 @@ export class RealityTreeReference extends RealityModelTileTree.Reference {
 
   public override async getToolTip(hit: HitDetail): Promise<HTMLElement | string | undefined> {
     const tree = this.treeOwner.tileTree;
-    if (undefined === tree || hit.iModel !== tree.iModel)
+    if (!(tree instanceof RealityTileTree) || hit.iModel !== tree.iModel)
       return undefined;
 
-    const map = (tree as RealityTileTree).loader.getBatchIdMap();
-    const batch = undefined !== map ? map.getBatchProperties(hit.sourceId) : undefined;
+    const batch = tree.batchTableProperties?.getFeatureProperties(hit.sourceId);
     if (undefined === batch && tree.modelId !== hit.sourceId)
       return undefined;
 

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -132,15 +132,21 @@ interface ChildReprojection {
  * Tiles within such tilesets may include a [batch table](https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/BatchTable) describing subcomponents ("features") within the tile.
  * For example, a tileset representing a building may encode each door, window, and wall as separate features.
  * The batch table may additionally contain metadata in JSON format describing each feature.
+ *
  * During tile decoding, iTwin.js assigns unique, transient [Id64String]($bentley)s to each unique feature within the tileset.
  * When interacting with tileset features (e.g., via a [[SelectionSet]] or [[HitDetail]]), the features are identified by these transient Ids.
- * @see [[RealityTileTree.batchTableProperties]] to obtain the property map for a TileTree.
+ * The tile tree's BatchTableProperties maintains the mapping between the transient Ids and the per-feature properties.
+ *
+ * The following example illustrates one way to obtain the properties of a specific feature within a reality model's batch table:
+ * ```ts
+ * [[include:GetBatchTableFeatureProperties]]
+ * ```
+ *
+ * @see [[RealityTileTree.batchTableProperties]] to obtain the batch table properties for a TileTree.
  * @beta
  */
-export interface BatchTablePropertyMap {
-  /** Returns true if the specified transient Id is mapped to a feature within this property map's [[TileTree]]. */
-  hasFeature(id: Id64String): boolean;
-  /** Obtain the JSON properties associated with the specified transient Id in this property map.
+export interface BatchTableProperties {
+  /** Obtain the JSON properties associated with the specified transient Id.
    * @param id The transient Id mapped to the feature of interest.
    * @returns A corresponding JSON object representing the feature's properties, or `undefined` if no such properties exist.
    * @note Treat the JSON properties as read-only - do not modify them.
@@ -203,7 +209,7 @@ export class RealityTileTree extends TileTree {
   /** The mapping of per-feature JSON properties from this tile tree's batch table, if one is defined.
    * @beta
    */
-  public get batchTableProperties(): BatchTablePropertyMap | undefined {
+  public get batchTableProperties(): BatchTableProperties | undefined {
     return this.loader.getBatchIdMap();
   }
 

--- a/core/frontend/src/tile/RealityTileTree.ts
+++ b/core/frontend/src/tile/RealityTileTree.ts
@@ -6,7 +6,7 @@
  * @module Tiles
  */
 
-import { assert, BeTimePoint, ProcessDetector } from "@itwin/core-bentley";
+import { assert, BeTimePoint, Id64String, ProcessDetector } from "@itwin/core-bentley";
 import {
   Matrix3d, Point3d, Range3d, Transform, Vector3d, XYZProps,
 } from "@itwin/core-geometry";
@@ -127,6 +127,27 @@ interface ChildReprojection {
   dbPoints: Point3d[];    // Center, xEnd, yEnd, zEnd
 }
 
+/** Provides access to per-feature properties within a [[RealityTileTree]].
+ * A [[RealityTileTree]] may refer to a tileset in one of the [3D Tiles 1.0](https://docs.ogc.org/cs/18-053r2/18-053r2.html).
+ * Tiles within such tilesets may include a [batch table](https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/BatchTable) describing subcomponents ("features") within the tile.
+ * For example, a tileset representing a building may encode each door, window, and wall as separate features.
+ * The batch table may additionally contain metadata in JSON format describing each feature.
+ * During tile decoding, iTwin.js assigns unique, transient [Id64String]($bentley)s to each unique feature within the tileset.
+ * When interacting with tileset features (e.g., via a [[SelectionSet]] or [[HitDetail]]), the features are identified by these transient Ids.
+ * @see [[RealityTileTree.batchTableProperties]] to obtain the property map for a TileTree.
+ * @beta
+ */
+export interface BatchTablePropertyMap {
+  /** Returns true if the specified transient Id is mapped to a feature within this property map's [[TileTree]]. */
+  hasFeature(id: Id64String): boolean;
+  /** Obtain the JSON properties associated with the specified transient Id in this property map.
+   * @param id The transient Id mapped to the feature of interest.
+   * @returns A corresponding JSON object representing the feature's properties, or `undefined` if no such properties exist.
+   * @note Treat the JSON properties as read-only - do not modify them.
+   */
+  getFeatureProperties(id: Id64String): Record<string, any> | undefined;
+}
+
 /** @internal */
 export interface RealityTileTreeParams extends TileTreeParams {
   readonly loader: RealityTileLoader;
@@ -177,6 +198,13 @@ export class RealityTileTree extends TileTree {
         this._ecefToDb = dbToEcef.inverse();
       }
     }
+  }
+
+  /** The mapping of per-feature JSON properties from this tile tree's batch table, if one is defined.
+   * @beta
+   */
+  public get batchTableProperties(): BatchTablePropertyMap | undefined {
+    return this.loader.getBatchIdMap();
   }
 
   /** @internal */

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -10,6 +10,7 @@ Table of contents:
 - [Batched tileset enhancements](#batched-tileset-enhancements)
   - [Per-model display settings](#per-model-display-settings)
   - [Support for excluded models](#support-for-excluded-models)
+  - [Batch table property access](#batch-table-property-access)
 - [Geometry](#geometry)
   - [Range tree search](#range-tree-search)
 
@@ -47,6 +48,19 @@ The [mesh export service](https://developer.bentley.com/apis/mesh-export/overvie
 - "Template" models containing geometry that serves as a template for placing 3d components.
 
 Previously, geometry from these models would fail to display. That has been [rectified](https://github.com/iTwin/itwinjs-core/pull/6270).
+
+### Batch table property access
+
+A [[RealityTileTree]] may refer to a tileset in one of the [3D Tiles 1.0](https://docs.ogc.org/cs/18-053r2/18-053r2.html). Tiles within such tilesets may include a [batch table](https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/BatchTable) describing subcomponents ("features") within the tile. For example, a tileset representing a building may encode each door, window, and wall as separate features. The batch table may additionally contain metadata in JSON format describing each feature.
+
+During tile decoding, iTwin.js assigns a unique, transient [Id64String]($bentley) to each unique feature within the tileset. When interacting with tileset features (e.g., via a [[SelectionSet]] or [[HitDetail]]), the features are identified by these transient Ids. The tile tree's [BatchTableProperties]($frontend) maintains the mapping between the transient Ids and the per-feature properties.
+
+To make use of the per-feature JSON properties, an application needs a way to look up the properties given the corresponding feature Id. The following example illustrates one way to obtain the properties of a specific feature within a reality model's batch table:
+```ts
+[[include:GetBatchTableFeatureProperties]]
+```
+
+See [[RealityTileTree.batchTableProperties]] to obtain the batch table properties for a TileTree.
 
 ## Geometry
 

--- a/example-code/snippets/src/frontend/BatchTableProperties.ts
+++ b/example-code/snippets/src/frontend/BatchTableProperties.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { Id64String } from "@itwin/core-bentley";
-import { RealityTileTree, TileTreeReference, Viewport } from "@itwin/core-frontend";
+import { RealityTileTree, Viewport } from "@itwin/core-frontend";
 
 // __PUBLISH_EXTRACT_START__ GetBatchTableFeatureProperties
 
@@ -13,23 +13,16 @@ import { RealityTileTree, TileTreeReference, Viewport } from "@itwin/core-fronte
  * @beta
  */
 export function getBatchTableFeatureProperties(featureId: Id64String, viewport: Viewport): Record<string, any> | undefined {
-  let featureProperties: Record<string, any> | undefined;
-
-  // Iterate the TileTreeReferences of the ContextRealityModels associated with the viewport to find the properties of the specified feature.
-  viewport.displayStyle.forEachRealityTileTreeRef((ref: TileTreeReference) => {
-    if (featureProperties) {
-      // We've already found the properties
-      return;
-    }
-
-    const tree = ref.treeOwner.tileTree;
-
+  for (const model of viewport.displayStyle.realityModels) {
     // Only RealityTileTrees have batch tables.
+    const tree = model.treeRef.treeOwner.tileTree;
     const batchTableProperties = tree instanceof RealityTileTree ? tree.batchTableProperties : undefined;
-    featureProperties = batchTableProperties?.getFeatureProperties(featureId);
-  });
+    const featureProperties = batchTableProperties?.getFeatureProperties(featureId);
+    if (featureProperties)
+      return featureProperties;
+  }
 
-  return featureProperties;
+  return undefined;
 }
 
 // __PUBLISH_EXTRACT_END__

--- a/example-code/snippets/src/frontend/BatchTableProperties.ts
+++ b/example-code/snippets/src/frontend/BatchTableProperties.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { Id64String } from "@itwin/core-bentley";
+import { RealityTileTree, TileTreeReference, Viewport } from "@itwin/core-frontend";
+
+// __PUBLISH_EXTRACT_START__ GetBatchTableFeatureProperties
+
+/** Given a viewport that is displaying one or more context reality models and the Id of a feature within one of those models' batch tables,
+ * return the JSON properties associated with that feature.
+ * @beta
+ */
+export function getBatchTableFeatureProperties(featureId: Id64String, viewport: Viewport): Record<string, any> | undefined {
+  let featureProperties: Record<string, any> | undefined;
+
+  // Iterate the TileTreeReferences of the ContextRealityModels associated with the viewport to find the properties of the specified feature.
+  viewport.displayStyle.forEachRealityTileTreeRef((ref: TileTreeReference) => {
+    if (featureProperties) {
+      // We've already found the properties
+      return;
+    }
+
+    const tree = ref.treeOwner.tileTree;
+
+    // Only RealityTileTrees have batch tables.
+    const batchTableProperties = tree instanceof RealityTileTree ? tree.batchTableProperties : undefined;
+    featureProperties = batchTableProperties?.getFeatureProperties(featureId);
+  });
+
+  return featureProperties;
+}
+
+// __PUBLISH_EXTRACT_END__

--- a/example-code/snippets/src/frontend/BatchTableProperties.ts
+++ b/example-code/snippets/src/frontend/BatchTableProperties.ts
@@ -13,15 +13,18 @@ import { RealityTileTree, Viewport } from "@itwin/core-frontend";
  * @beta
  */
 export function getBatchTableFeatureProperties(featureId: Id64String, viewport: Viewport): Record<string, any> | undefined {
+  // Iterate the viewport's context reality models to find the one to which the specified feature belongs.
   for (const model of viewport.displayStyle.realityModels) {
-    // Only RealityTileTrees have batch tables.
     const tree = model.treeRef.treeOwner.tileTree;
+
+    // Only RealityTileTrees have batch tables, hence the `instanceof` check.
     const batchTableProperties = tree instanceof RealityTileTree ? tree.batchTableProperties : undefined;
     const featureProperties = batchTableProperties?.getFeatureProperties(featureId);
     if (featureProperties)
       return featureProperties;
   }
 
+  // The specified feature was not found in any context reality model's batch table.
   return undefined;
 }
 


### PR DESCRIPTION
See NextVersion.md and example code in BatchTableProperties.ts.
I don't have a good way to automate testing of this.
I didn't want to make this API front-and-center because it's strictly relevant to a subset of 3D Tiles 1.0 tilesets. 3D Tiles 1.1 completely replaces the way per-feature properties are done, and we're also planning to migrate to viewer APIs based on "scene objects" instead of "tile trees".