### PR TITLE
Presentation: Fix descriptor, node path and distinct value responses not being localized

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1679,11 +1679,15 @@ export class LocalizationHelper {
     // (undocumented)
     getLocalizedContentItems(items: Item[]): Item[];
     // (undocumented)
+    getLocalizedDisplayValueGroup(group: DisplayValueGroup): DisplayValueGroup;
+    // (undocumented)
     getLocalizedElementProperties(elem: ElementProperties): ElementProperties;
     // (undocumented)
     getLocalizedLabelDefinition(labelDefinition: LabelDefinition): LabelDefinition;
     // (undocumented)
     getLocalizedLabelDefinitions(labelDefinitions: LabelDefinition[]): LabelDefinition[];
+    // (undocumented)
+    getLocalizedNodePathElement(npe: NodePathElement): NodePathElement;
     // (undocumented)
     getLocalizedNodes(nodes: Node_2[]): Node_2[];
     // (undocumented)

--- a/common/changes/@itwin/presentation-backend/presentation-fix-missing-localization_2024-01-29-12-21.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix-missing-localization_2024-01-29-12-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fix descriptor, node path and distinct value responses not being localized",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-fix-missing-localization_2024-01-29-12-21.json
+++ b/common/changes/@itwin/presentation-common/presentation-fix-missing-localization_2024-01-29-12-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/presentation-fix-missing-localization_2024-01-29-12-21.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-fix-missing-localization_2024-01-29-12-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Fix descriptor, node path and distinct value responses not being localized",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/docs/presentation/advanced/Localization.md
+++ b/docs/presentation/advanced/Localization.md
@@ -8,36 +8,49 @@ format](https://www.i18next.com/misc/json-format#i-18-next-json-v3) - it
 only supports simple key-value pairs (including nesting) without plurals or
 interpolation.
 
-Localization happens on the **frontend**.
-In the case of only using the backend, you must provide a localization function [PresentationManagerProps.getLocalizedString]($presentation-backend) when initializing the presentation backend.
-The localization function should translate:
-<details>
-  <summary>List of translatable strings</summary>
+## On the frontend
 
-  * @Presentation:label.notSpecified@,
-  * @Presentation:label.other@,
-  * @Presentation:label.varies@,
-  * @Presentation:label.multipleInstances@,
-  * @Presentation:field.label@,
-  * @Presentation:selectedItems.categoryLabel@,
-  * @Presentation:selectedItems.categoryDescription@,
+All responses to requests made through the frontend's [PresentationManager]($presentation-frontend) are automatically localized, assuming all required assets are properly set up.
+`@itwin/presentation-frontend` relies on [IModelApp.localization]($frontend) to do the translations. All Presentation localized strings are defined in locale files located at
+the `public` folder from `@itwin/presentation-common` - consumers must ensure these locale files are placed at a location known to [IModelApp.localization]($frontend). See
+[Localization in iTwin.js](..\..\learning\frontend\Localization.md) page for more details.
+
+## On the backend
+
+In the case of only using the backend, consumers must provide a localization function [PresentationManagerProps.getLocalizedString]($presentation-backend) when initializing the presentation backend.
+
+The localization function should translate the following strings:
+
+<details>
+
+<summary>List of translatable strings</summary>
+
+* @Presentation:label.notSpecified@
+* @Presentation:label.other@
+* @Presentation:label.varies@
+* @Presentation:label.multipleInstances@
+* @Presentation:field.label@
+* @Presentation:selectedItems.categoryLabel@
+* @Presentation:selectedItems.categoryDescription@
 
 </details>
 
+Example for providing the localization function:
+
 ```typescript
-  function getLocalizedStringExample(key: string) {
-    // implementation...
-  }
+function getLocalizedStringExample(key: string) {
+  // implementation...
+}
 
 const presentationBackendProps: PresentationProps = {
   getLocalizedString: (key) => getLocalizedStringExample(key),
 };
 
 Presentation.initialize(presentationBackendProps);
-
 ```
+
 ## Localization in presentation rulesets
 
-The strings in presentation rule sets can be localized by using the following
-format: `@LocalizationNamespace:StringId@`. Additionally, you can use multiple
-localized pieces in one string, e.g. `Concat_@Namespace:String1@_and_@Namespace:String2@`.
+The strings in presentation rule sets can be localized by using the following format: `@LocalizationNamespace:StringId@`. Additionally, you can use
+multiple localized pieces in one string, e.g. `Concat_@Namespace:String1@_and_@Namespace:String2@`. Such strings are then localized using [IModelApp.localization]($frontend)
+API using identifier specified between the `@` characters, e.g. `LocalizationNamespace:StringId` for `@LocalizationNamespace:StringId@`.

--- a/full-stack-tests/presentation/src/frontend/Localization.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Localization.test.ts
@@ -242,11 +242,11 @@ describe("Localization", async () => {
       keys: new KeySet(),
     }))!;
 
-    expect(content!.descriptor.categories[0].label).to.eq("_test_ string");
-    expect(content!.descriptor.categories[0].description).to.eq("_test_ nested string");
+    expect(content.descriptor.categories[0].label).to.eq("_test_ string");
+    expect(content.descriptor.categories[0].description).to.eq("_test_ nested string");
 
-    const field = getFieldByLabel(content!.descriptor.fields, "_test_ string");
-    expect(content!.contentSet[0].displayValues[field.name]).to.eq("_test_ nested string");
+    const field = getFieldByLabel(content.descriptor.fields, "_test_ string");
+    expect(content.contentSet[0].displayValues[field.name]).to.eq("_test_ nested string");
   });
 
   it("localizes distinct values", async () => {

--- a/full-stack-tests/presentation/src/frontend/Localization.test.ts
+++ b/full-stack-tests/presentation/src/frontend/Localization.test.ts
@@ -1,34 +1,21 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { IModelApp, IModelConnection, SnapshotConnection } from "@itwin/core-frontend";
-import { ChildNodeSpecificationTypes, Ruleset, RuleTypes } from "@itwin/presentation-common";
+import { ChildNodeSpecificationTypes, DefaultContentDisplayTypes, KeySet, Ruleset, RuleTypes } from "@itwin/presentation-common";
 import { Presentation, PresentationManager } from "@itwin/presentation-frontend";
 import { initialize, terminate, testLocalization } from "../IntegrationTests";
-
-const RULESET: Ruleset = {
-  id: "localization test",
-  rules: [{
-    ruleType: RuleTypes.RootNodes,
-    specifications: [{
-      specType: ChildNodeSpecificationTypes.CustomNode,
-      type: "root",
-      label: "@Test:string@",
-      description: "@Test:nested.string@",
-    }],
-  }],
-};
+import { getFieldByLabel } from "../Utils";
 
 describe("Localization", async () => {
-
   let imodel: IModelConnection;
 
   before(async () => {
     await initialize({ localization: testLocalization });
     await IModelApp.localization.registerNamespace("Test");
-    Presentation.presentation.activeLocale = "en";
+    Presentation.presentation.activeLocale = "test";
     const testIModelName: string = "assets/datasets/Properties_60InstancesWithUrl2.ibim";
     imodel = await SnapshotConnection.openFile(testIModelName);
     expect(imodel).is.not.null;
@@ -39,15 +26,268 @@ describe("Localization", async () => {
     await terminate();
   });
 
-  it("localizes using app/test supplied localized strings", async () => {
-    const nodes = await Presentation.presentation.getNodes({ imodel, rulesetOrId: RULESET });
+  it("localizes nodes", async () => {
+    const nodes = await Presentation.presentation.getNodes({ imodel, rulesetOrId: CUSTOM_NODES_RULESET });
     expect(nodes.length).to.eq(1);
-    expect(nodes[0].label.displayValue).to.eq("test value");
-    expect(nodes[0].description).to.eq("test nested value");
+    expect(nodes[0].label.displayValue).to.eq("_test_ string");
+    expect(nodes[0].description).to.eq("_test_ nested string");
+  });
+
+  it("localizes nodes when requesting with count", async () => {
+    const { nodes } = await Presentation.presentation.getNodesAndCount({ imodel, rulesetOrId: CUSTOM_NODES_RULESET });
+    expect(nodes.length).to.eq(1);
+    expect(nodes[0].label.displayValue).to.eq("_test_ string");
+    expect(nodes[0].description).to.eq("_test_ nested string");
+  });
+
+  it("localizes nodes descriptor", async () => {
+    const descriptor = await Presentation.presentation.getNodesDescriptor({
+      imodel,
+      rulesetOrId: {
+        id: "nodes descriptor",
+        rules: [
+          {
+            ruleType: "RootNodes",
+            specifications: [
+              {
+                specType: "InstanceNodesOfSpecificClasses",
+                classes: { schemaName: "BisCore", classNames: ["Subject"] },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(descriptor!.categories[0].label).to.eq("Selected Item(s)");
+  });
+
+  it("localizes node paths", async () => {
+    const paths = await Presentation.presentation.getNodePaths({
+      imodel,
+      rulesetOrId: {
+        id: "nodes descriptor",
+        rules: [
+          {
+            ruleType: "RootNodes",
+            specifications: [
+              {
+                specType: "InstanceNodesOfSpecificClasses",
+                classes: { schemaName: "BisCore", classNames: ["Subject"] },
+                groupByClass: false,
+                groupByLabel: false,
+              },
+            ],
+          },
+          {
+            ruleType: "InstanceLabelOverride",
+            class: { schemaName: "BisCore", className: "Subject" },
+            values: [
+              {
+                specType: "String",
+                value: "@Test:string@",
+              },
+            ],
+          },
+        ],
+      },
+      instancePaths: [[{ className: "BisCore:Subject", id: "0x1" }]],
+    });
+    expect(paths[0].node.label.displayValue).to.eq("_test_ string");
+  });
+
+  it("localizes filtered node paths", async () => {
+    const paths = await Presentation.presentation.getFilteredNodePaths({
+      imodel,
+      rulesetOrId: {
+        id: "nodes descriptor",
+        rules: [
+          {
+            ruleType: "RootNodes",
+            specifications: [
+              {
+                specType: "InstanceNodesOfSpecificClasses",
+                classes: { schemaName: "BisCore", classNames: ["Subject"] },
+                groupByClass: false,
+                groupByLabel: false,
+              },
+            ],
+          },
+          {
+            ruleType: "InstanceLabelOverride",
+            class: { schemaName: "BisCore", className: "Subject" },
+            values: [
+              {
+                specType: "String",
+                value: "@Test:string@",
+              },
+            ],
+          },
+        ],
+      },
+      filterText: "str",
+    });
+    expect(paths[0].node.label.displayValue).to.eq("_test_ string");
+  });
+
+  it("localizes content descriptor", async () => {
+    const descriptor = await Presentation.presentation.getContentDescriptor({
+      imodel,
+      rulesetOrId: {
+        id: "content descriptor",
+        rules: [
+          {
+            ruleType: "Content",
+            specifications: [
+              {
+                specType: "ContentInstancesOfSpecificClasses",
+                classes: { schemaName: "BisCore", classNames: ["Subject"] },
+              },
+            ],
+          },
+          {
+            ruleType: "DefaultPropertyCategoryOverride",
+            specification: {
+              id: "default",
+              label: "@Test:string@",
+              description: "@Test:nested.string@",
+            },
+          },
+        ],
+      },
+      displayType: DefaultContentDisplayTypes.PropertyPane,
+      keys: new KeySet(),
+    });
+    expect(descriptor!.categories[0].label).to.eq("_test_ string");
+    expect(descriptor!.categories[0].description).to.eq("_test_ nested string");
+  });
+
+  it("localizes content", async () => {
+    const content = await Presentation.presentation.getContent({
+      imodel,
+      rulesetOrId: {
+        id: "content",
+        rules: [
+          {
+            ruleType: "Content",
+            specifications: [
+              {
+                specType: "ContentInstancesOfSpecificClasses",
+                classes: { schemaName: "BisCore", classNames: ["Subject"] },
+                calculatedProperties: [
+                  {
+                    label: "@Test:string@",
+                    value: `"@Test:nested.string@"`,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            ruleType: "DefaultPropertyCategoryOverride",
+            specification: {
+              id: "default",
+              label: "@Test:string@",
+              description: "@Test:nested.string@",
+            },
+          },
+        ],
+      },
+      descriptor: {
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+      },
+      keys: new KeySet(),
+    });
+
+    expect(content!.descriptor.categories[0].label).to.eq("_test_ string");
+    expect(content!.descriptor.categories[0].description).to.eq("_test_ nested string");
+
+    const field = getFieldByLabel(content!.descriptor.fields, "_test_ string");
+    expect(content!.contentSet[0].displayValues[field.name]).to.eq("_test_ nested string");
+  });
+
+  it("localizes content when requesting with size", async () => {
+    const { content } = (await Presentation.presentation.getContentAndSize({
+      imodel,
+      rulesetOrId: {
+        id: "content",
+        rules: [
+          {
+            ruleType: "Content",
+            specifications: [
+              {
+                specType: "ContentInstancesOfSpecificClasses",
+                classes: { schemaName: "BisCore", classNames: ["Subject"] },
+                calculatedProperties: [
+                  {
+                    label: "@Test:string@",
+                    value: `"@Test:nested.string@"`,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            ruleType: "DefaultPropertyCategoryOverride",
+            specification: {
+              id: "default",
+              label: "@Test:string@",
+              description: "@Test:nested.string@",
+            },
+          },
+        ],
+      },
+      descriptor: {
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+      },
+      keys: new KeySet(),
+    }))!;
+
+    expect(content!.descriptor.categories[0].label).to.eq("_test_ string");
+    expect(content!.descriptor.categories[0].description).to.eq("_test_ nested string");
+
+    const field = getFieldByLabel(content!.descriptor.fields, "_test_ string");
+    expect(content!.contentSet[0].displayValues[field.name]).to.eq("_test_ nested string");
+  });
+
+  it("localizes distinct values", async () => {
+    const ruleset: Ruleset = {
+      id: "content",
+      rules: [
+        {
+          ruleType: "Content",
+          specifications: [
+            {
+              specType: "ContentInstancesOfSpecificClasses",
+              classes: { schemaName: "BisCore", classNames: ["Subject"] },
+              calculatedProperties: [
+                {
+                  label: "@Test:string@",
+                  value: `"@Test:nested.string@"`,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const descriptor = await Presentation.presentation.getContentDescriptor({
+      imodel,
+      rulesetOrId: ruleset,
+      displayType: DefaultContentDisplayTypes.Grid,
+      keys: new KeySet(),
+    });
+    const field = getFieldByLabel(descriptor!.fields, "_test_ string");
+    const distinctValues = await Presentation.presentation.getPagedDistinctValues({
+      imodel,
+      rulesetOrId: ruleset,
+      descriptor: descriptor!,
+      keys: new KeySet(),
+      fieldDescriptor: field.getFieldDescriptor(),
+    });
+    expect(distinctValues.items[0].displayValue).to.eq("_test_ nested string");
   });
 
   describe("Multiple frontends for one backend", async () => {
-
     let frontends: PresentationManager[];
 
     beforeEach(async () => {
@@ -59,20 +299,37 @@ describe("Localization", async () => {
     });
 
     it("handles multiple simultaneous requests from different frontends with different locales", async () => {
-      for (let i = 0; i < 100; ++i) {
-        const nodes = {
-          en: await frontends[0].getNodes({ imodel, rulesetOrId: RULESET }),
-          test: await frontends[1].getNodes({ imodel, rulesetOrId: RULESET }),
-        };
+      await Promise.all(
+        Array.from({ length: 100 }).map(async () => {
+          const [en, test] = await Promise.all([
+            await frontends[0].getNodes({ imodel, rulesetOrId: CUSTOM_NODES_RULESET }),
+            await frontends[1].getNodes({ imodel, rulesetOrId: CUSTOM_NODES_RULESET }),
+          ]);
 
-        expect(nodes.en[0].label.displayValue).to.eq("test value");
-        expect(nodes.en[0].description).to.eq("test nested value");
+          expect(en[0].label.displayValue).to.eq("test value");
+          expect(en[0].description).to.eq("test nested value");
 
-        expect(nodes.test[0].label.displayValue).to.eq("_test_ string");
-        expect(nodes.test[0].description).to.eq("_test_ nested string");
-      }
+          expect(test[0].label.displayValue).to.eq("_test_ string");
+          expect(test[0].description).to.eq("_test_ nested string");
+        }),
+      );
     });
-
   });
-
 });
+
+const CUSTOM_NODES_RULESET: Ruleset = {
+  id: "localization test",
+  rules: [
+    {
+      ruleType: RuleTypes.RootNodes,
+      specifications: [
+        {
+          specType: ChildNodeSpecificationTypes.CustomNode,
+          type: "root",
+          label: "@Test:string@",
+          description: "@Test:nested.string@",
+        },
+      ],
+    },
+  ],
+};

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -474,8 +474,8 @@ export class PresentationManager {
    */
   public async getNodesDescriptor(requestOptions: WithCancelEvent<Prioritized<HierarchyLevelDescriptorRequestOptions<IModelDb, NodeKey, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<Descriptor | undefined> {
     const response = await this._detail.getNodesDescriptor(requestOptions);
-    const reviver = (key: string, value: any) => key === "" ? Descriptor.fromJSON(value) : value;
-    return JSON.parse(response, reviver);
+    const descriptor = Descriptor.fromJSON(JSON.parse(response));
+    return descriptor ? this._localizationHelper.getLocalizedContentDescriptor(descriptor) : undefined;
   }
 
   /**
@@ -484,7 +484,8 @@ export class PresentationManager {
    * @public
    */
   public async getNodePaths(requestOptions: WithCancelEvent<Prioritized<FilterByInstancePathsHierarchyRequestOptions<IModelDb, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<NodePathElement[]> {
-    return this._detail.getNodePaths(requestOptions);
+    const result = await this._detail.getNodePaths(requestOptions);
+    return result.map((npe) => this._localizationHelper.getLocalizedNodePathElement(npe));
   }
 
   /**
@@ -493,7 +494,8 @@ export class PresentationManager {
    * @public
    */
   public async getFilteredNodePaths(requestOptions: WithCancelEvent<Prioritized<FilterByTextHierarchyRequestOptions<IModelDb, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<NodePathElement[]> {
-    return this._detail.getFilteredNodePaths(requestOptions);
+    const result = await this._detail.getFilteredNodePaths(requestOptions);
+    return result.map((npe) => this._localizationHelper.getLocalizedNodePathElement(npe));
   }
 
   /**
@@ -511,8 +513,7 @@ export class PresentationManager {
    */
   public async getContentDescriptor(requestOptions: WithCancelEvent<Prioritized<ContentDescriptorRequestOptions<IModelDb, KeySet, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<Descriptor | undefined> {
     const response = await this._detail.getContentDescriptor(requestOptions);
-    const reviver = (key: string, value: any) => key === "" ? Descriptor.fromJSON(value) : value;
-    const descriptor = JSON.parse(response, reviver);
+    const descriptor = Descriptor.fromJSON(JSON.parse(response));
     return descriptor ? this._localizationHelper.getLocalizedContentDescriptor(descriptor) : undefined;
   }
 
@@ -578,7 +579,12 @@ export class PresentationManager {
    * @public
    */
   public async getPagedDistinctValues(requestOptions: WithCancelEvent<Prioritized<DistinctValuesRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<PagedResponse<DisplayValueGroup>> {
-    return this._detail.getPagedDistinctValues(requestOptions);
+    const result = await this._detail.getPagedDistinctValues(requestOptions);
+    return {
+      ...result,
+      // eslint-disable-next-line deprecation/deprecation
+      items: result.items.map((g) => this._localizationHelper.getLocalizedDisplayValueGroup(g)),
+    };
   }
 
   /**

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -261,7 +261,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
   // eslint-disable-next-line deprecation/deprecation
   public override async getNodePaths(token: IModelRpcProps, requestOptions: FilterByInstancePathsHierarchyRpcRequestOptions): PresentationRpcResponse<NodePathElementJSON[]> {
     return this.makeRequest(token, "getNodePaths", requestOptions, async (options) => {
-      const result = await this.getManager(requestOptions.clientId).getNodePaths(options);
+      const result = await this.getManager(requestOptions.clientId).getDetail().getNodePaths(options);
       // eslint-disable-next-line deprecation/deprecation
       return result.map(NodePathElement.toJSON);
     });
@@ -270,7 +270,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
   // eslint-disable-next-line deprecation/deprecation
   public override async getFilteredNodePaths(token: IModelRpcProps, requestOptions: FilterByTextHierarchyRpcRequestOptions): PresentationRpcResponse<NodePathElementJSON[]> {
     return this.makeRequest(token, "getFilteredNodePaths", requestOptions, async (options) => {
-      const result = await this.getManager(requestOptions.clientId).getFilteredNodePaths(options);
+      const result = await this.getManager(requestOptions.clientId).getDetail().getFilteredNodePaths(options);
       // eslint-disable-next-line deprecation/deprecation
       return result.map(NodePathElement.toJSON);
     });
@@ -356,7 +356,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
         ...options,
         keys: KeySet.fromJSON(options.keys),
       });
-      const response = await this.getManager(requestOptions.clientId).getPagedDistinctValues(options);
+      const response = await this.getManager(requestOptions.clientId).getDetail().getPagedDistinctValues(options);
       return {
         ...response,
         // eslint-disable-next-line deprecation/deprecation

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -695,9 +695,15 @@ describe("PresentationManager", () => {
     });
 
     const setup = (addonResponse: any) => {
+      if (addonResponse === undefined) {
+        nativePlatformMock
+          .setup(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAnyString(), undefined))
+          .returns(async () => ({ result: "null" }));
+        return undefined;
+      }
       const serialized = JSON.stringify(addonResponse);
       nativePlatformMock.setup(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAnyString(), undefined))
-        .returns(async () => ({ result: JSON.stringify(addonResponse) }));
+        .returns(async () => ({ result: serialized }));
       return JSON.parse(serialized);
     };
     const verifyMockRequest = (expectedParams: any) => {
@@ -975,6 +981,30 @@ describe("PresentationManager", () => {
         };
         const result = await manager.getNodesDescriptor(options);
         verifyWithSnapshot(result, expectedParams);
+      });
+
+      it("handles undefined descriptor", async () => {
+        // what the addon receives
+        const parentNodeKey = createRandomECInstancesNodeKey();
+        const expectedParams = {
+          requestId: NativePlatformRequestTypes.GetNodesDescriptor,
+          params: {
+            nodeKey: parentNodeKey,
+            rulesetId: manager.getRulesetId(testData.rulesetOrId),
+          },
+        };
+
+        // what the addon returns
+        setup(undefined);
+
+        // test
+        const options: HierarchyLevelDescriptorRequestOptions<IModelDb, NodeKey> = {
+          imodel: imodelMock.object,
+          rulesetOrId: testData.rulesetOrId,
+          parentKey: parentNodeKey,
+        };
+        const result = await manager.getNodesDescriptor(options);
+        verifyWithExpectedResult(result, undefined, expectedParams);
       });
 
     });

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -695,20 +695,23 @@ describe("PresentationRpcImpl", () => {
 
       it("calls manager", async () => {
         const result = [createRandomNodePathElement(0), createRandomNodePathElement(0)];
-        const rpcOptions: PresentationRpcRequestOptions<FilterByTextHierarchyRequestOptions<never, RulesetVariableJSON>> = {
-          ...defaultRpcParams,
-          rulesetOrId: testData.rulesetOrId,
-          filterText: "filter",
-        };
         const managerOptions: WithCancelEvent<FilterByTextHierarchyRequestOptions<IModelDb>> = {
           imodel: testData.imodelMock.object,
           rulesetOrId: testData.rulesetOrId,
           filterText: "filter",
           cancelEvent: new BeEvent<() => void>(),
         };
-        presentationManagerMock.setup(async (x) => x.getFilteredNodePaths(managerOptions))
-          .returns(async () => result)
-          .verifiable();
+        const rpcOptions: PresentationRpcRequestOptions<FilterByTextHierarchyRequestOptions<never, RulesetVariableJSON>> = {
+          ...defaultRpcParams,
+          rulesetOrId: managerOptions.rulesetOrId,
+          filterText: managerOptions.filterText,
+        };
+        const presentationManagerDetailStub = {
+          getFilteredNodePaths: sinon.spy(async () => result),
+        };
+        presentationManagerMock
+          .setup((x) => x.getDetail())
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getFilteredNodePaths(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         // eslint-disable-next-line deprecation/deprecation
@@ -722,12 +725,6 @@ describe("PresentationRpcImpl", () => {
       it("calls manager", async () => {
         const result = [createRandomNodePathElement(0), createRandomNodePathElement(0)];
         const keyArray: InstanceKey[][] = [[createRandomECInstanceKey(), createRandomECInstanceKey()]];
-        const rpcOptions: PresentationRpcRequestOptions<FilterByInstancePathsHierarchyRequestOptions<never, RulesetVariableJSON>> = {
-          ...defaultRpcParams,
-          rulesetOrId: testData.rulesetOrId,
-          instancePaths: keyArray,
-          markedIndex: 1,
-        };
         const managerOptions: WithCancelEvent<FilterByInstancePathsHierarchyRequestOptions<IModelDb>> = {
           imodel: testData.imodelMock.object,
           rulesetOrId: testData.rulesetOrId,
@@ -735,9 +732,18 @@ describe("PresentationRpcImpl", () => {
           markedIndex: 1,
           cancelEvent: new BeEvent<() => void>(),
         };
-        presentationManagerMock.setup(async (x) => x.getNodePaths(managerOptions))
-          .returns(async () => result)
-          .verifiable();
+        const rpcOptions: PresentationRpcRequestOptions<FilterByInstancePathsHierarchyRequestOptions<never, RulesetVariableJSON>> = {
+          ...defaultRpcParams,
+          rulesetOrId: managerOptions.rulesetOrId,
+          instancePaths: managerOptions.instancePaths,
+          markedIndex: managerOptions.markedIndex,
+        };
+        const presentationManagerDetailStub = {
+          getNodePaths: sinon.spy(async () => result),
+        };
+        presentationManagerMock
+          .setup((x) => x.getDetail())
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getNodePaths(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         // eslint-disable-next-line deprecation/deprecation
@@ -1367,9 +1373,12 @@ describe("PresentationRpcImpl", () => {
           fieldDescriptor: managerOptions.fieldDescriptor,
           paging: testData.pageOptions,
         };
-        presentationManagerMock.setup(async (x) => x.getPagedDistinctValues(managerOptions))
-          .returns(async () => distinctValues)
-          .verifiable();
+        const presentationManagerDetailStub = {
+          getPagedDistinctValues: sinon.spy(async () => distinctValues),
+        };
+        presentationManagerMock
+          .setup((x) => x.getDetail())
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);
@@ -1406,9 +1415,12 @@ describe("PresentationRpcImpl", () => {
           fieldDescriptor: managerOptions.fieldDescriptor,
           paging: { start: 0, size: MAX_ALLOWED_PAGE_SIZE + 1 },
         };
-        presentationManagerMock.setup(async (x) => x.getPagedDistinctValues(managerOptions))
-          .returns(async () => distinctValues)
-          .verifiable();
+        const presentationManagerDetailStub = {
+          getPagedDistinctValues: sinon.spy(async () => distinctValues),
+        };
+        presentationManagerMock
+          .setup((x) => x.getDetail())
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);
@@ -1446,9 +1458,12 @@ describe("PresentationRpcImpl", () => {
           paging: { start: 5 },
           cancelEvent: new BeEvent<() => void>(),
         };
-        presentationManagerMock.setup(async (x) => x.getPagedDistinctValues(managerOptions))
-          .returns(async () => distinctValues)
-          .verifiable();
+        const presentationManagerDetailStub = {
+          getPagedDistinctValues: sinon.spy(async () => distinctValues),
+        };
+        presentationManagerMock
+          .setup((x) => x.getDetail())
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);
@@ -1485,9 +1500,12 @@ describe("PresentationRpcImpl", () => {
           fieldDescriptor: managerOptions.fieldDescriptor,
           paging: undefined,
         };
-        presentationManagerMock.setup(async (x) => x.getPagedDistinctValues(managerOptions))
-          .returns(async () => distinctValues)
-          .verifiable();
+        const presentationManagerDetailStub = {
+          getPagedDistinctValues: sinon.spy(async () => distinctValues),
+        };
+        presentationManagerMock
+          .setup((x) => x.getDetail())
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);

--- a/presentation/common/src/presentation-common/LocalizationHelper.ts
+++ b/presentation/common/src/presentation-common/LocalizationHelper.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 /** @packageDocumentation
  * @module Core
  */
@@ -11,9 +11,10 @@ import { Content } from "./content/Content";
 import { Descriptor } from "./content/Descriptor";
 import { Field } from "./content/Fields";
 import { Item } from "./content/Item";
-import { DisplayValue, Value } from "./content/Value";
+import { DisplayValue, DisplayValueGroup, Value } from "./content/Value";
 import { ElementProperties } from "./ElementProperties";
 import { Node } from "./hierarchy/Node";
+import { NodePathElement } from "./hierarchy/NodePathElement";
 import { LabelCompositeValue, LabelDefinition } from "./LabelDefinition";
 
 const KEY_PATTERN = /@[\w\d\-_]+:[\w\d\-\._]+?@/g;
@@ -36,113 +37,131 @@ export class LocalizationHelper {
   }
 
   public getLocalizedNodes(nodes: Node[]): Node[] {
-    for (const node of nodes)
-      this.translateNode(node);
-    return nodes;
+    return nodes.map((n) => this.getLocalizedNode(n));
+  }
+
+  public getLocalizedNodePathElement(npe: NodePathElement): NodePathElement {
+    return {
+      ...npe,
+      node: this.getLocalizedNode(npe.node),
+      children: npe.children.map((c) => this.getLocalizedNodePathElement(c)),
+    };
+  }
+
+  public getLocalizedDisplayValueGroup(group: DisplayValueGroup): DisplayValueGroup {
+    return {
+      ...group,
+      displayValue: this.getLocalizedDisplayValue(group.displayValue),
+    };
   }
 
   public getLocalizedLabelDefinition(labelDefinition: LabelDefinition): LabelDefinition {
-    this.translateLabelDefinition(labelDefinition);
+    const getLocalizedComposite = (compositeValue: LabelCompositeValue) => ({
+      ...compositeValue,
+      values: compositeValue.values.map((value) => this.getLocalizedLabelDefinition(value)),
+    });
+
+    if (labelDefinition.typeName === LabelDefinition.COMPOSITE_DEFINITION_TYPENAME) {
+      return {
+        ...labelDefinition,
+        rawValue: getLocalizedComposite(labelDefinition.rawValue as LabelCompositeValue),
+      };
+    }
+    if (labelDefinition.typeName === "string") {
+      return {
+        ...labelDefinition,
+        rawValue: this.getLocalizedString(labelDefinition.rawValue as string),
+        displayValue: this.getLocalizedString(labelDefinition.displayValue),
+      };
+    }
     return labelDefinition;
   }
 
   public getLocalizedLabelDefinitions(labelDefinitions: LabelDefinition[]) {
-    labelDefinitions.forEach((labelDefinition) => this.translateLabelDefinition(labelDefinition));
-    return labelDefinitions;
+    return labelDefinitions.map((labelDefinition) => this.getLocalizedLabelDefinition(labelDefinition));
   }
 
   public getLocalizedContentDescriptor(descriptor: Descriptor) {
-    descriptor.fields.forEach((field) => this.translateContentDescriptorField(field));
-    descriptor.categories.forEach((category) => this.translateContentDescriptorCategory(category));
-    return descriptor;
+    const clone = new Descriptor(descriptor);
+    clone.fields.forEach((field) => this.getLocalizedContentField(field));
+    clone.categories.forEach((category) => this.getLocalizedCategoryDescription(category));
+    return clone;
   }
 
-  public getLocalizedContentItems(items: Item[]) {
-    items.forEach((item) => this.translateContentItem(item));
-    return items;
+  public getLocalizedContentItems(items: Item[]): Item[] {
+    return items.map((item) => this.getLocalizedContentItem(item));
   }
 
-  public getLocalizedContent(content: Content) {
-    this.getLocalizedContentDescriptor(content.descriptor);
-    this.getLocalizedContentItems(content.contentSet);
-    return content;
+  public getLocalizedContent(content: Content): Content {
+    return new Content(this.getLocalizedContentDescriptor(content.descriptor), this.getLocalizedContentItems(content.contentSet));
   }
 
-  public getLocalizedElementProperties(elem: ElementProperties) {
-    elem.label = this.getLocalizedString(elem.label);
-    return elem;
+  public getLocalizedElementProperties(elem: ElementProperties): ElementProperties {
+    return {
+      ...elem,
+      label: this.getLocalizedString(elem.label),
+    };
   }
 
-  private translateContentItem(item: Item) {
-    for (const key in item.displayValues) {
-      // istanbul ignore else
-      if (key)
-        item.displayValues[key] = this.translateContentItemDisplayValue(item.displayValues[key]);
-    }
-    for (const key in item.values) {
-      // istanbul ignore else
-      if (key)
-        item.values[key] = this.translateContentItemValue(item.values[key]);
-    }
-    this.translateLabelDefinition(item.label);
+  // warning: this function mutates the item
+  private getLocalizedContentItem(item: Item): Item {
+    item.label = this.getLocalizedLabelDefinition(item.label);
+    item.values = Object.entries(item.values).reduce((o, [k, v]) => ({ ...o, [k]: this.getLocalizedRawValue(v) }), {});
+    item.displayValues = Object.entries(item.displayValues).reduce((o, [k, v]) => ({ ...o, [k]: this.getLocalizedDisplayValue(v) }), {});
+    return item;
   }
 
-  private translateContentItemDisplayValue(value: DisplayValue): DisplayValue {
-    // istanbul ignore else
+  private getLocalizedRawValue(value: Value): Value {
     if (typeof value === "string") {
-      value = this.getLocalizedString(value);
+      return this.getLocalizedString(value);
+    }
+    if (Value.isNavigationValue(value)) {
+      return {
+        ...value,
+        label: this.getLocalizedLabelDefinition(value.label),
+      };
+    }
+    if (Value.isNestedContent(value)) {
+      return value.map((item) => ({
+        ...item,
+        values: Object.entries(item.values).reduce((o, [k, v]) => ({ ...o, [k]: this.getLocalizedRawValue(v) }), {}),
+        displayValues: Object.entries(item.displayValues).reduce((o, [k, v]) => ({ ...o, [k]: this.getLocalizedDisplayValue(v) }), {}),
+      }));
     }
     return value;
   }
 
-  private translateContentItemValue(value: Value): Value {
-    if (typeof value === "string") {
-      value = this.getLocalizedString(value);
-    } else if (Value.isNavigationValue(value)) {
-      this.translateLabelDefinition(value.label);
-    } else if (Value.isNestedContent(value)) {
-      for (const nestedValue of value) {
-        for (const key in nestedValue.values) {
-          // istanbul ignore else
-          if (key)
-            nestedValue.values[key] = this.translateContentItemValue(nestedValue.values[key]);
-        }
-        for (const key in nestedValue.displayValues) {
-          // istanbul ignore else
-          if (key)
-            nestedValue.displayValues[key] = this.translateContentItemDisplayValue(nestedValue.displayValues[key]);
-        }
-      }
-    }
-    return value;
-  }
-
-  private translateContentDescriptorField(field: Field) {
+  // warning: this function mutates the field
+  private getLocalizedContentField(field: Field) {
     field.label = this.getLocalizedString(field.label);
+    return field;
   }
 
-  private translateContentDescriptorCategory(category: CategoryDescription) {
+  // warning: this function mutates the category
+  private getLocalizedCategoryDescription(category: CategoryDescription) {
     category.label = this.getLocalizedString(category.label);
     category.description = this.getLocalizedString(category.description);
+    return category;
   }
 
-  private translateNode(node: Node) {
-    this.translateLabelDefinition(node.label);
-    // istanbul ignore else
-    if (node.description)
-      node.description = this.getLocalizedString(node.description);
-  }
-
-  private translateLabelDefinition(labelDefinition: LabelDefinition) {
-    const translateComposite = (compositeValue: LabelCompositeValue) => {
-      compositeValue.values.map((value) => this.translateLabelDefinition(value));
+  private getLocalizedNode(node: Node) {
+    return {
+      ...node,
+      label: this.getLocalizedLabelDefinition(node.label),
+      ...(node.description ? { description: this.getLocalizedString(node.description) } : undefined),
     };
+  }
 
-    if (labelDefinition.typeName === LabelDefinition.COMPOSITE_DEFINITION_TYPENAME)
-      translateComposite(labelDefinition.rawValue as LabelCompositeValue);
-    else if (labelDefinition.typeName === "string") {
-      labelDefinition.rawValue = this.getLocalizedString(labelDefinition.rawValue as string);
-      labelDefinition.displayValue = this.getLocalizedString(labelDefinition.displayValue);
+  private getLocalizedDisplayValue(value: DisplayValue): DisplayValue {
+    if (typeof value === "undefined") {
+      return undefined;
     }
+    if (typeof value === "string") {
+      return this.getLocalizedString(value);
+    }
+    if (Array.isArray(value)) {
+      return value.map((v) => this.getLocalizedDisplayValue(v));
+    }
+    return Object.entries(value).reduce((o, [k, v]) => ({ ...o, [k]: this.getLocalizedDisplayValue(v) }), {});
   }
 }

--- a/presentation/common/src/test/LocalizationHelper.test.ts
+++ b/presentation/common/src/test/LocalizationHelper.test.ts
@@ -1,22 +1,30 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
+import { NodePathElement } from "../presentation-common";
 import { Content } from "../presentation-common/content/Content";
 import { Item } from "../presentation-common/content/Item";
-import { NavigationPropertyValue } from "../presentation-common/content/Value";
-import { LabelDefinition } from "../presentation-common/LabelDefinition";
+import { DisplayValueGroup, NavigationPropertyValue } from "../presentation-common/content/Value";
+import { LabelCompositeValue, LabelDefinition } from "../presentation-common/LabelDefinition";
 import { LocalizationHelper } from "../presentation-common/LocalizationHelper";
 import {
-  createRandomECInstancesNode, createRandomLabelCompositeValue, createRandomLabelDefinition, createTestCategoryDescription,
-  createTestContentDescriptor, createTestContentItem, createTestECInstanceKey, createTestSimpleContentField,
+  createRandomECInstancesNode,
+  createRandomLabelCompositeValue,
+  createRandomLabelDefinition,
+  createTestCategoryDescription,
+  createTestContentDescriptor,
+  createTestContentItem,
+  createTestECInstanceKey,
+  createTestSimpleContentField,
 } from "./_helpers";
 
 function getTestLocalizedString(key: string) {
-  if (key.includes(":"))
+  if (key.includes(":")) {
     key = key.split(":", 2)[1];
+  }
   return key;
 }
 
@@ -28,7 +36,6 @@ describe("LocalizationHelper", () => {
   });
 
   describe("translate", () => {
-
     it("does not translate if key not found", () => {
       const key = "WrongKey";
       const translated = localizationHelper.getLocalizedString(key);
@@ -46,94 +53,173 @@ describe("LocalizationHelper", () => {
       const translated = localizationHelper.getLocalizedString(text);
       expect(translated).to.be.eq("Front firstKey and secondKey End");
     });
-
   });
 
   describe("getLocalizedNodes", () => {
-
     it("translates labelDefinition", () => {
       const node = createRandomECInstancesNode();
       node.label.rawValue = "@namespace:LocalizedRawValue@";
       node.label.displayValue = "@namespace:LocalizedDisplayValue@";
       node.description = "@namespace:LocalizedDescription@";
-      localizationHelper.getLocalizedNodes([node]);
-      expect(node.label.rawValue).to.be.eq("LocalizedRawValue");
-      expect(node.label.displayValue).to.be.eq("LocalizedDisplayValue");
-      expect(node.description).to.be.eq("LocalizedDescription");
+      const result = localizationHelper.getLocalizedNodes([node]);
+      expect(result[0].label.rawValue).to.be.eq("LocalizedRawValue");
+      expect(result[0].label.displayValue).to.be.eq("LocalizedDisplayValue");
+      expect(result[0].description).to.be.eq("LocalizedDescription");
+    });
+  });
+
+  describe("getLocalizedNodePathElement", () => {
+    it("translates the node", () => {
+      const node1 = createRandomECInstancesNode();
+      node1.label.displayValue = "@namespace:LocalizedDisplayValue1@";
+
+      const node2 = createRandomECInstancesNode();
+      node2.label.displayValue = "@namespace:LocalizedDisplayValue2@";
+
+      const npe: NodePathElement = {
+        index: 0,
+        node: node1,
+        children: [
+          {
+            index: 0,
+            node: node2,
+            children: [],
+          },
+        ],
+      };
+
+      const result = localizationHelper.getLocalizedNodePathElement(npe);
+      expect(result).to.containSubset({
+        node: {
+          label: { displayValue: "LocalizedDisplayValue1" },
+        },
+        children: [
+          {
+            node: {
+              label: { displayValue: "LocalizedDisplayValue2" },
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe("getLocalizedDisplayValueGroup", () => {
+    it("leaves undefined display value as-is", () => {
+      const group: DisplayValueGroup = {
+        displayValue: undefined,
+        groupedRawValues: [],
+      };
+      const result = localizationHelper.getLocalizedDisplayValueGroup(group);
+      expect(result.displayValue).to.be.undefined;
     });
 
+    it("translates string display value", () => {
+      const group: DisplayValueGroup = {
+        displayValue: "@namespace:LocalizedDisplayValue@",
+        groupedRawValues: [],
+      };
+      const result = localizationHelper.getLocalizedDisplayValueGroup(group);
+      expect(result.displayValue).to.eq("LocalizedDisplayValue");
+    });
+
+    it("translates array display value", () => {
+      const group: DisplayValueGroup = {
+        displayValue: ["@namespace:LocalizedDisplayValue1@", "@namespace:LocalizedDisplayValue2@"],
+        groupedRawValues: [],
+      };
+      const result = localizationHelper.getLocalizedDisplayValueGroup(group);
+      expect(result.displayValue).to.deep.eq(["LocalizedDisplayValue1", "LocalizedDisplayValue2"]);
+    });
+
+    it("translates object display value", () => {
+      const group: DisplayValueGroup = {
+        displayValue: {
+          x: "@namespace:LocalizedDisplayValue1@",
+          y: "@namespace:LocalizedDisplayValue2@",
+        },
+        groupedRawValues: [],
+      };
+      const result = localizationHelper.getLocalizedDisplayValueGroup(group);
+      expect(result.displayValue).to.deep.eq({ x: "LocalizedDisplayValue1", y: "LocalizedDisplayValue2" });
+    });
   });
 
   describe("getLocalizedContent", () => {
-
     it("translates contentItem labelDefinitions", () => {
       const contentItem = new Item([], createRandomLabelDefinition(), "", undefined, {}, {}, []);
       contentItem.label.rawValue = "@namespace:LocalizedValue@";
       const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.contentSet[0]!.label.rawValue).to.be.eq("LocalizedValue");
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.contentSet[0]!.label.rawValue).to.be.eq("LocalizedValue");
     });
 
     it("translates contentItem value", () => {
       const contentItem = new Item([], createRandomLabelDefinition(), "", undefined, {}, {}, []);
       contentItem.values.property = "@namespace:LocalizedValue@";
       const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.contentSet[0]!.values.property).to.be.eq("LocalizedValue");
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.contentSet[0]!.values.property).to.be.eq("LocalizedValue");
     });
 
     it("translates contentItem nested value", () => {
       const contentItem = createTestContentItem({
         values: {
-          parent: [{
-            primaryKeys: [createTestECInstanceKey()],
-            values: {
-              child: "@namespace:LocalizedValue@",
+          parent: [
+            {
+              primaryKeys: [createTestECInstanceKey()],
+              values: {
+                child: "@namespace:LocalizedValue@",
+              },
+              displayValues: {
+                child: "@namespace:DisplayValue@",
+              },
+              mergedFieldNames: [],
             },
-            displayValues: {
-              child: "@namespace:DisplayValue@",
-            },
-            mergedFieldNames: [],
-          }],
+          ],
         },
         displayValues: {},
       });
       const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.contentSet[0]!.values.parent).to.have.lengthOf(1).and.to.containSubset([{
-        displayValues: {
-          child: "DisplayValue",
-        },
-        mergedFieldNames: [],
-        primaryKeys: [createTestECInstanceKey()],
-        values: {
-          child: "LocalizedValue",
-        },
-      }]);
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.contentSet[0]!.values.parent)
+        .to.have.lengthOf(1)
+        .and.to.containSubset([
+          {
+            displayValues: {
+              child: "DisplayValue",
+            },
+            mergedFieldNames: [],
+            primaryKeys: [createTestECInstanceKey()],
+            values: {
+              child: "LocalizedValue",
+            },
+          },
+        ]);
     });
 
     it("translates contentItem display value", () => {
       const contentItem = new Item([], createRandomLabelDefinition(), "", undefined, {}, {}, []);
       contentItem.displayValues.property = "@namespace:LocalizedValue@";
       const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.contentSet[0]!.displayValues.property).to.be.eq("LocalizedValue");
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.contentSet[0]!.displayValues.property).to.be.eq("LocalizedValue");
     });
 
     it("does not translate contentItem non-translatable value", () => {
       const contentItem = new Item([], createRandomLabelDefinition(), "", undefined, {}, {}, []);
       contentItem.values.property = 10;
       const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.contentSet[0]!.values.property).to.be.eq(10);
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.contentSet[0]!.values.property).to.be.eq(10);
     });
 
     it("translates content descriptor field label", () => {
       const contentItem = new Item([], createRandomLabelDefinition(), "", undefined, {}, {}, []);
       const field = createTestSimpleContentField({ label: "@namespace:LocalizedValue@" });
       const content = new Content(createTestContentDescriptor({ fields: [field] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.descriptor.fields[0].label).to.be.eq("LocalizedValue");
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.descriptor.fields[0].label).to.be.eq("LocalizedValue");
     });
 
     it("translates content descriptor category label", () => {
@@ -141,8 +227,8 @@ describe("LocalizationHelper", () => {
       const testCategory = createTestCategoryDescription({ label: "@namespace:LocalizedLabel@" });
       const field = createTestSimpleContentField({ category: testCategory });
       const content = new Content(createTestContentDescriptor({ fields: [field], categories: [testCategory] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.descriptor.categories[0].label).to.be.eq("LocalizedLabel");
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.descriptor.categories[0].label).to.be.eq("LocalizedLabel");
     });
 
     it("translates content descriptor category description", () => {
@@ -150,8 +236,8 @@ describe("LocalizationHelper", () => {
       const testCategory = createTestCategoryDescription({ description: "@namespace:LocalizedDescription@" });
       const field = createTestSimpleContentField({ category: testCategory });
       const content = new Content(createTestContentDescriptor({ fields: [field], categories: [testCategory] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      expect(content.descriptor.categories[0].description).to.be.eq("LocalizedDescription");
+      const result = localizationHelper.getLocalizedContent(content);
+      expect(result.descriptor.categories[0].description).to.be.eq("LocalizedDescription");
     });
 
     it("translates navigation property value label", () => {
@@ -168,8 +254,8 @@ describe("LocalizationHelper", () => {
         displayValues: {},
       });
       const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
-      localizationHelper.getLocalizedContent(content);
-      const localizedValue = content.contentSet[0]!.values.navigationProperty as NavigationPropertyValue;
+      const result = localizationHelper.getLocalizedContent(content);
+      const localizedValue = result.contentSet[0]!.values.navigationProperty as NavigationPropertyValue;
       expect(localizedValue.label.rawValue).to.be.eq("LocalizedValue");
     });
 
@@ -177,16 +263,14 @@ describe("LocalizationHelper", () => {
       const elementProperties = localizationHelper.getLocalizedElementProperties({ class: "class", label: "@namespace:LocalizedLabel@", id: "id", items: {} });
       expect(elementProperties.label).to.be.eq("LocalizedLabel");
     });
-
   });
 
   describe("getLocalizedLabelDefinition", () => {
-
     it("translates labelDefinition", () => {
       const labelDefinition = createRandomLabelDefinition();
       labelDefinition.rawValue = "@namespace:LocalizedValue@";
-      localizationHelper.getLocalizedLabelDefinition(labelDefinition);
-      expect(labelDefinition.rawValue).to.be.eq("LocalizedValue");
+      const result = localizationHelper.getLocalizedLabelDefinition(labelDefinition);
+      expect(result.rawValue).to.be.eq("LocalizedValue");
     });
 
     it("translates labelDefinition with composite value", () => {
@@ -199,11 +283,10 @@ describe("LocalizationHelper", () => {
         rawValue: compositeValue,
         typeName: LabelDefinition.COMPOSITE_DEFINITION_TYPENAME,
       };
-      localizationHelper.getLocalizedLabelDefinition(labelDefinition);
-      compositeValue.values.forEach((value) => {
+      const result = localizationHelper.getLocalizedLabelDefinition(labelDefinition);
+      (result.rawValue as LabelCompositeValue).values.forEach((value) => {
         expect(value.rawValue).to.be.eq("LocalizedValue");
       });
-
     });
 
     it("does not translate non string value", () => {
@@ -212,23 +295,19 @@ describe("LocalizationHelper", () => {
         rawValue: 10,
         typeName: "int",
       };
-      localizationHelper.getLocalizedLabelDefinition(labelDefinition);
-      expect(labelDefinition.rawValue).to.be.eq(10);
+      const result = localizationHelper.getLocalizedLabelDefinition(labelDefinition);
+      expect(result.rawValue).to.be.eq(10);
     });
-
   });
 
   describe("getLocalizedLabelDefinitions", () => {
-
     it("translates labelDefinitions", () => {
       const labelDefinitions = [createRandomLabelDefinition(), createRandomLabelDefinition()];
-      labelDefinitions.forEach((labelDefinition) => labelDefinition.rawValue = "@namespace:LocalizedValue@");
-      localizationHelper.getLocalizedLabelDefinitions(labelDefinitions);
-      labelDefinitions.forEach((labelDefinition) => {
+      labelDefinitions.forEach((labelDefinition) => (labelDefinition.rawValue = "@namespace:LocalizedValue@"));
+      const result = localizationHelper.getLocalizedLabelDefinitions(labelDefinitions);
+      result.forEach((labelDefinition) => {
         expect(labelDefinition.rawValue).to.be.eq("LocalizedValue");
       });
     });
-
   });
-
 });

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -350,7 +350,8 @@ export class PresentationManager implements IDisposable {
     const options = await this.addRulesetAndVariablesToOptions(requestOptions);
     const rpcOptions = this.toRpcTokenOptions({ ...options });
     const result = await this._requestsHandler.getNodesDescriptor(rpcOptions);
-    return Descriptor.fromJSON(result);
+    const descriptor = Descriptor.fromJSON(result);
+    return descriptor ? this._localizationHelper.getLocalizedContentDescriptor(descriptor) : undefined;
   }
 
   /** Retrieves paths from root nodes to children nodes according to specified keys. Intersecting paths will be merged. */
@@ -360,7 +361,7 @@ export class PresentationManager implements IDisposable {
     const rpcOptions = this.toRpcTokenOptions({ ...options });
     const result = await this._requestsHandler.getNodePaths(rpcOptions);
     // eslint-disable-next-line deprecation/deprecation
-    return result.map(NodePathElement.fromJSON);
+    return result.map(NodePathElement.fromJSON).map((npe) => this._localizationHelper.getLocalizedNodePathElement(npe));
   }
 
   /** Retrieves paths from root nodes to nodes containing filter text in their label. */
@@ -369,7 +370,7 @@ export class PresentationManager implements IDisposable {
     const options = await this.addRulesetAndVariablesToOptions(requestOptions);
     const result = await this._requestsHandler.getFilteredNodePaths(this.toRpcTokenOptions(options));
     // eslint-disable-next-line deprecation/deprecation
-    return result.map(NodePathElement.fromJSON);
+    return result.map(NodePathElement.fromJSON).map((npe) => this._localizationHelper.getLocalizedNodePathElement(npe));
   }
 
   /**
@@ -393,7 +394,8 @@ export class PresentationManager implements IDisposable {
       keys: stripTransientElementKeys(options.keys).toJSON(),
     });
     const result = await this._requestsHandler.getContentDescriptor(rpcOptions);
-    return Descriptor.fromJSON(result);
+    const descriptor = Descriptor.fromJSON(result);
+    return descriptor ? this._localizationHelper.getLocalizedContentDescriptor(descriptor) : undefined;
   }
 
   /** Retrieves overall content set size. */
@@ -468,7 +470,7 @@ export class PresentationManager implements IDisposable {
     return {
       ...result,
       // eslint-disable-next-line deprecation/deprecation
-      items: result.items.map(DisplayValueGroup.fromJSON),
+      items: result.items.map(DisplayValueGroup.fromJSON).map((g) => this._localizationHelper.getLocalizedDisplayValueGroup(g)),
     };
   }
 

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -589,6 +589,22 @@ describe("PresentationManager", () => {
       rpcRequestsHandlerMock.verifyAll();
     });
 
+    it("handles undefined descriptor", async () => {
+      const parentNodeKey = createRandomECInstancesNodeKey();
+      const options: HierarchyLevelDescriptorRequestOptions<IModelConnection, NodeKey> = {
+        imodel: testData.imodelMock.object,
+        rulesetOrId: testData.rulesetId,
+        parentKey: parentNodeKey,
+      };
+      rpcRequestsHandlerMock
+        .setup(async (x) => x.getNodesDescriptor(toRulesetRpcOptions({ ...options, parentKey: parentNodeKey })))
+        .returns(async () => undefined)
+        .verifiable();
+      const actualResult = await manager.getNodesDescriptor(options);
+      rpcRequestsHandlerMock.verifyAll();
+      expect(actualResult).to.be.undefined;
+    });
+
   });
 
   describe("getFilteredNodePaths", () => {
@@ -788,7 +804,7 @@ describe("PresentationManager", () => {
         .verifiable();
       const actualResult = await manager.getContent(options);
       expect(actualResult).to.be.instanceOf(Content);
-      expect(actualResult!.descriptor).to.eq(descriptor);
+      expect(actualResult!.descriptor).to.deep.eq(descriptor);
       expect(actualResult!.contentSet).to.deep.eq(result.items);
       rpcRequestsHandlerMock.verifyAll();
     });
@@ -870,7 +886,7 @@ describe("PresentationManager", () => {
         .verifiable();
       const actualResult = await manager.getContent(options);
       expect(actualResult).to.be.instanceOf(Content);
-      expect(actualResult!.descriptor).to.eq(descriptor);
+      expect(actualResult!.descriptor).to.deep.eq(descriptor);
       expect(actualResult!.contentSet).to.have.lengthOf(1);
       expect(actualResult!.contentSet[0].displayValues[fieldName]).to.be.undefined;
       expect(actualResult!.contentSet[0].values[fieldName]).to.be.eq(1.234);
@@ -911,7 +927,7 @@ describe("PresentationManager", () => {
         .verifiable();
       const actualResult = await manager.getContent(options);
       expect(actualResult).to.be.instanceOf(Content);
-      expect(actualResult!.descriptor).to.eq(descriptor);
+      expect(actualResult!.descriptor).to.deep.eq(descriptor);
       expect(actualResult!.contentSet).to.have.lengthOf(1);
       expect(actualResult!.contentSet[0].displayValues[fieldName]).to.be.eq("1.23");
       expect(actualResult!.contentSet[0].values[fieldName]).to.be.eq(1.234);


### PR DESCRIPTION
This is a proper fix for an issue that's worked around in https://github.com/iTwin/viewer-components-react/pull/745.

Add tests, missing calls to our localization handler, clarify docs.