### PR TITLE
Remove docs reference to internal package

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -38,7 +38,6 @@ The iTwin.js library is organized into the following separately downloadable [np
 - ($core-react)
 - ($components-react)
 - ($imodel-components-react)
-- ($appui-layout-react)
 - ($appui-react)
 
 ## iTwin.js Presentation Packages

--- a/docs/reference/leftNav.md
+++ b/docs/reference/leftNav.md
@@ -39,7 +39,6 @@ packageClassification:
           "core-react",
           "components-react",
           "imodel-components-react",
-          "appui-layout-react",
           "appui-react",
         ],
     },


### PR DESCRIPTION
This PR removes documentation referencing the internal package `@itwin/appui-layout-react`.