### PR TITLE
Fix 3d tiles bounding box regression

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-3d-tile-range-transform_2024-02-05-21-21.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-3d-tile-range-transform_2024-02-05-21-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -512,10 +512,15 @@ export abstract class GltfReader {
     else
       renderGraphic = this._system.createGraphicList(renderGraphicList);
 
-    if (featureTable)
-      renderGraphic = this._system.createBatch(renderGraphic, PackedFeatureTable.pack(featureTable), contentRange);
-
     const transform = this.getTileTransform(transformToRoot, pseudoRtcBias);
+    let range = contentRange;
+    const invTransform = transform?.inverse();
+    if (invTransform)
+      range = invTransform.multiplyRange(contentRange);
+
+    if (featureTable)
+      renderGraphic = this._system.createBatch(renderGraphic, PackedFeatureTable.pack(featureTable), range);
+
     const viewFlagOverrides = this.viewFlagOverrides;
     if (transform || viewFlagOverrides) {
       const branch = new GraphicBranch(true);
@@ -525,9 +530,6 @@ export abstract class GltfReader {
       branch.add(renderGraphic);
       renderGraphic = this._system.createBranch(branch, transform ?? Transform.createIdentity());
     }
-
-    const invTransform = transform?.inverse();
-    const range = invTransform ? invTransform.multiplyRange(contentRange) : contentRange;
 
     return {
       readStatus,

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -513,13 +513,18 @@ export abstract class GltfReader {
       renderGraphic = this._system.createGraphicList(renderGraphicList);
 
     const transform = this.getTileTransform(transformToRoot, pseudoRtcBias);
+
+    // Compute range in tileset/world space.
     let range = contentRange;
     const invTransform = transform?.inverse();
     if (invTransform)
       range = invTransform.multiplyRange(contentRange);
 
+    // The batch range needs to be in tile coordinate space.
+    // If we computed the content range ourselves, it's already in tile space.
+    // If the content range was supplied by the caller, it's in tileset space and needs to be transformed to tile space.
     if (featureTable)
-      renderGraphic = this._system.createBatch(renderGraphic, PackedFeatureTable.pack(featureTable), range);
+      renderGraphic = this._system.createBatch(renderGraphic, PackedFeatureTable.pack(featureTable), this._computedContentRange ? contentRange : range);
 
     const viewFlagOverrides = this.viewFlagOverrides;
     if (transform || viewFlagOverrides) {


### PR DESCRIPTION
Introduced in #6379.
A Batch's content range needs to be in the local coordinate system of the batch.
Most batches are tiles. In that case the caller supplies a content range in the coordinate space of the tile tree, and we must apply the inverse transform to put it into the tile's coordinate space.

On the other hand, when decoding glTF graphics outside of the context of a tile tree, no content range is supplied - we must compute it from the geometry as we decode it.
In that case, the computed content range is in tile space, so no transform is required.
By "fixing" this case by removing the transform unconditionally, #6379 broke tiles.

This PR fixes the tile regression while preserving the fix for glTF.