### PR TITLE
Add `GenericInstanceFilter` definition

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -3428,6 +3428,97 @@ export interface FunctionalElementProps extends ElementProps {
     typeDefinition?: RelatedElementProps;
 }
 
+// @beta
+export interface GenericInstanceFilter {
+    filteredClassNames?: string[];
+    propertyClassNames: string[];
+    relatedInstances: GenericInstanceFilterRelatedInstanceDescription[];
+    rules: GenericInstanceFilterRule | GenericInstanceFilterRuleGroup;
+}
+
+// @beta (undocumented)
+export namespace GenericInstanceFilter {
+    export function isFilterRuleGroup(obj: GenericInstanceFilterRule | GenericInstanceFilterRuleGroup): obj is GenericInstanceFilterRuleGroup;
+}
+
+// @beta
+export interface GenericInstanceFilterRelatedInstanceDescription {
+    alias: string;
+    path: GenericInstanceFilterRelationshipStep[];
+}
+
+// @beta
+export interface GenericInstanceFilterRelationshipStep {
+    isForwardRelationship: boolean;
+    relationshipClassName: string;
+    sourceClassName: string;
+    targetClassName: string;
+}
+
+// @beta
+export interface GenericInstanceFilterRule {
+    operator: GenericInstanceFilterRuleOperator;
+    propertyName: string;
+    propertyTypeName: string;
+    sourceAlias: string;
+    value?: GenericInstanceFilterRuleValue;
+}
+
+// @beta
+export interface GenericInstanceFilterRuleGroup {
+    operator: GenericInstanceFilterRuleGroupOperator;
+    rules: Array<GenericInstanceFilterRule | GenericInstanceFilterRuleGroup>;
+}
+
+// @beta
+export type GenericInstanceFilterRuleGroupOperator = "and" | "or";
+
+// @beta
+export type GenericInstanceFilterRuleOperator = "is-equal" | "is-not-equal" | "is-null" | "is-not-null" | "is-true" | "is-false" | "less" | "less-or-equal" | "greater" | "greater-or-equal" | "like";
+
+// @beta
+export interface GenericInstanceFilterRuleValue {
+    // (undocumented)
+    displayValue: string;
+    // (undocumented)
+    rawValue: GenericInstanceFilterRuleValue.Values;
+}
+
+// @beta (undocumented)
+export namespace GenericInstanceFilterRuleValue {
+    // (undocumented)
+    export interface InstanceKey {
+        // (undocumented)
+        className: string;
+        // (undocumented)
+        id: string;
+    }
+    // (undocumented)
+    export function isInstanceKey(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.InstanceKey;
+    // (undocumented)
+    export function isPoint2d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point2d;
+    // (undocumented)
+    export function isPoint3d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point3d;
+    // (undocumented)
+    export interface Point2d {
+        // (undocumented)
+        x: number;
+        // (undocumented)
+        y: number;
+    }
+    // (undocumented)
+    export interface Point3d {
+        // (undocumented)
+        x: number;
+        // (undocumented)
+        y: number;
+        // (undocumented)
+        z: number;
+    }
+    // (undocumented)
+    export type Values = string | number | boolean | Date | GenericInstanceFilterRuleValue.Point2d | GenericInstanceFilterRuleValue.Point3d | GenericInstanceFilterRuleValue.InstanceKey;
+}
+
 // @public
 export class GeocentricTransform implements GeocentricTransformProps {
     constructor(data?: GeocentricTransformProps);

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -3493,11 +3493,8 @@ export namespace GenericInstanceFilterRuleValue {
         // (undocumented)
         id: string;
     }
-    // (undocumented)
     export function isInstanceKey(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.InstanceKey;
-    // (undocumented)
     export function isPoint2d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point2d;
-    // (undocumented)
     export function isPoint3d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point3d;
     // (undocumented)
     export interface Point2d {

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -279,6 +279,16 @@ public;Frustum
 public;FrustumPlanes
 public;FrustumPlanes
 public;FunctionalElementProps 
+beta;GenericInstanceFilter
+beta;GenericInstanceFilter
+beta;GenericInstanceFilterRelatedInstanceDescription
+beta;GenericInstanceFilterRelationshipStep
+beta;GenericInstanceFilterRule
+beta;GenericInstanceFilterRuleGroup
+beta;GenericInstanceFilterRuleGroupOperator = "and" | "or"
+beta;GenericInstanceFilterRuleOperator = "is-equal" | "is-not-equal" | "is-null" | "is-not-null" | "is-true" | "is-false" | "less" | "less-or-equal" | "greater" | "greater-or-equal" | "like"
+beta;GenericInstanceFilterRuleValue
+beta;GenericInstanceFilterRuleValue
 public;GeocentricTransform 
 public;GeocentricTransformProps
 beta;GeoCoordinatesRequestProps

--- a/common/changes/@itwin/core-common/add_generic_instance_filter_definition_2024-02-07-15-45.json
+++ b/common/changes/@itwin/core-common/add_generic_instance_filter_definition_2024-02-07-15-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Added `GenericInstanceFilter` definition for storing information necessary for building filtering queries.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -72,12 +72,15 @@ export namespace GenericInstanceFilterRuleValue {
     id: string;
     className: string;
   }
+  /** Checks if supplied value is `Point2d` like. Returns `true` for `Point2d` and `Point3d`. */
   export function isPoint2d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point2d {
     return (value as GenericInstanceFilterRuleValue.Point2d).x !== undefined && (value as GenericInstanceFilterRuleValue.Point2d).y !== undefined;
   }
+  /** Checks if supplied value is `Point3d` like. */
   export function isPoint3d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point3d {
     return isPoint2d(value) && (value as GenericInstanceFilterRuleValue.Point3d).z !== undefined;
   }
+  /** Checks if supplied value is `InstanceKey` like. */
   export function isInstanceKey(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.InstanceKey {
     return (value as GenericInstanceFilterRuleValue.InstanceKey) !== undefined && (value as GenericInstanceFilterRuleValue.InstanceKey).className !== undefined;
   }

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -110,7 +110,7 @@ export interface GenericInstanceFilterRule {
    */
   operator: GenericInstanceFilterRuleOperator;
   /**
-   * Value to which property values is compared to. For unary operators value is 'undefined'.
+   * Value to which property values is compared to. For unary operators value is `undefined`.
    */
   value?: GenericInstanceFilterRuleValue;
   /**
@@ -161,16 +161,16 @@ export interface GenericInstanceFilterRelatedInstanceDescription {
  * @beta
  */
 export interface GenericInstanceFilterRelationshipStep {
-  /** Class name of the source class. */
+  /** Full class name of the source class, e.g. `BisCore.Element`. */
   sourceClassName: string;
   /** Class name of the target class. */
   targetClassName: string;
   /** Class name of the relationship class that should be used to move from source to target. */
   relationshipClassName: string;
   /**
-   * Flag that describes if this step follows relationship class in `Forward` or `Backward` direction.
-   * If step follows relationship class in `Forward` direction than `sourceClassName` matches relationship source class and `targetClassName` matches relationship target class.
-   * Otherwise `sourceClassName` matches relationship target class and `targetClassName` matches relationship source class.
+   * A flag that describes if this step follows relationship class in forward or backward direction.
+   * If the step follows relationship in forward direction then `sourceClassName` matches relationship's source class and `targetClassName` matches relationship's target class.
+   * Otherwise, `sourceClassName` matches relationship's target class and `targetClassName` matches relationship's source class.
    */
   isForwardRelationship: boolean;
 }

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -166,9 +166,9 @@ export interface GenericInstanceFilterRelatedInstanceDescription {
 export interface GenericInstanceFilterRelationshipStep {
   /** Full class name of the source class, e.g. `BisCore.Element`. */
   sourceClassName: string;
-  /** Class name of the target class. */
+  /** Full class name of the target class, e.g. `BisCore.Element`. */
   targetClassName: string;
-  /** Class name of the relationship class that should be used to move from source to target. */
+  /** Full class name of the relationship class that should be used to move from source to target, e.g. `BisCore.ElementOwnsChildElements`. */
   relationshipClassName: string;
   /**
    * A flag that describes if this step follows relationship class in forward or backward direction.

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -16,7 +16,7 @@ export interface GenericInstanceFilter {
   /**
    * Information about related instances that has access to the properties used in filter.
    * These can be used to create `JOIN` clause when building `ECSQL` query. Each related property
-   * used in rule will have `sourceAlias` that matches `GenericInstanceFilterRelatedInstanceDescription.alias`.
+   * used in rule will have [[GenericInstanceFilterRule.sourceAlias]] that matches [[GenericInstanceFilterRelatedInstanceDescription.alias]].
    * If more than one property of the same related instance is used, they will share the same alias.
    */
   relatedInstances: GenericInstanceFilterRelatedInstanceDescription[];
@@ -32,7 +32,7 @@ export interface GenericInstanceFilter {
 }
 
 /**
- * Type definition that describes operators supported by `GenericInstanceFilterRule`.
+ * Type definition that describes operators supported by [[GenericInstanceFilterRule]].
  * @beta
  */
 export type GenericInstanceFilterRuleOperator =
@@ -49,7 +49,7 @@ export type GenericInstanceFilterRuleOperator =
   | "like";
 
 /**
- * Type definition that describes value of `GenericInstanceFilterRule`.
+ * Type definition that describes value of [[GenericInstanceFilterRule]].
  * @beta
  */
 export interface GenericInstanceFilterRuleValue {
@@ -72,15 +72,15 @@ export namespace GenericInstanceFilterRuleValue {
     id: string;
     className: string;
   }
-  /** Checks if supplied value is `Point2d` like. Returns `true` for `Point2d` and `Point3d`. */
+  /** Checks if supplied value is [[GenericInstanceFilterRuleValue.Point2d]] like. Returns `true` for `Point2d` and [[GenericInstanceFilterRuleValue.Point3d]]. */
   export function isPoint2d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point2d {
     return (value as GenericInstanceFilterRuleValue.Point2d).x !== undefined && (value as GenericInstanceFilterRuleValue.Point2d).y !== undefined;
   }
-  /** Checks if supplied value is `Point3d` like. */
+  /** Checks if supplied value is [[GenericInstanceFilterRuleValue.Point3d]] like. */
   export function isPoint3d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point3d {
     return isPoint2d(value) && (value as GenericInstanceFilterRuleValue.Point3d).z !== undefined;
   }
-  /** Checks if supplied value is `InstanceKey` like. */
+  /** Checks if supplied value is [[GenericInstanceFilterRuleValue.InstanceKey]] like. */
   export function isInstanceKey(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.InstanceKey {
     return (value as GenericInstanceFilterRuleValue.InstanceKey) !== undefined && (value as GenericInstanceFilterRuleValue.InstanceKey).className !== undefined;
   }
@@ -101,7 +101,7 @@ export namespace GenericInstanceFilterRuleValue {
 export interface GenericInstanceFilterRule {
   /**
    * Alias of the source to access this property. For related properties `sourceAlias` should match
-   * `GenericInstanceFilterRelatedInstanceDescription.alias` of one `GenericInstanceFilter.relatedInstances`.
+   * [[GenericInstanceFilterRelatedInstanceDescription.alias]] of one [[GenericInstanceFilter.relatedInstances]].
    */
   sourceAlias: string;
   /**
@@ -123,7 +123,7 @@ export interface GenericInstanceFilterRule {
 }
 
 /**
- * Type definition that describes operators supported by `GenericInstanceFilterRuleGroup`.
+ * Type definition that describes operators supported by [[GenericInstanceFilterRuleGroup]].
  * @beta
  */
 export type GenericInstanceFilterRuleGroupOperator = "and" | "or";
@@ -153,7 +153,7 @@ export interface GenericInstanceFilterRelatedInstanceDescription {
    */
   path: GenericInstanceFilterRelationshipStep[];
   /**
-   * Related instance alias. This alias match `sourceAlias` in all filter rules where
+   * Related instance alias. This alias match [[GenericInstanceFilterRule.sourceAlias]] in all filter rules where
    * properties of this related instance is used.
    */
   alias: string;

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utils
+ */
+
+/**
+ * Generic instance filter that has all the necessary information to build filtering query.
+ * @beta
+ */
+export interface GenericInstanceFilter {
+  /** Single filter rule or multiple rules joined by logical operator. */
+  rules: GenericInstanceFilterRule | GenericInstanceFilterRuleGroup;
+  /**
+   * Information about related instances that has access to the properties used in filter.
+   * These can be used to create `JOIN` clause when building `ECSQL` query. Each related property
+   * used in rule will have `sourceAlias` that matches `GenericInstanceFilterRelatedInstanceDescription.alias`.
+   * If more than one property of the same related instance is used, they will share the same alias.
+   */
+  relatedInstances: GenericInstanceFilterRelatedInstanceDescription[];
+  /**
+   * List of class names whose properties are used in rules. Might be used to find common base class when building
+   * filter for instances of different classes.
+   */
+  propertyClassNames: string[];
+  /**
+   * List of class names which will be used for additionally only querying instances of specific classes.
+   */
+  filteredClassNames?: string[];
+}
+
+/**
+ * Type definition that describes operators supported by `GenericInstanceFilterRule`.
+ * @beta
+ */
+export type GenericInstanceFilterRuleOperator =
+  | "is-equal"
+  | "is-not-equal"
+  | "is-null"
+  | "is-not-null"
+  | "is-true"
+  | "is-false"
+  | "less"
+  | "less-or-equal"
+  | "greater"
+  | "greater-or-equal"
+  | "like";
+
+/**
+ * Type definition that describes value of `GenericInstanceFilterRule`.
+ * @beta
+ */
+export interface GenericInstanceFilterRuleValue {
+  displayValue: string;
+  rawValue: GenericInstanceFilterRuleValue.Values;
+}
+
+/** @beta */
+export namespace GenericInstanceFilterRuleValue {
+  export interface Point2d {
+    x: number;
+    y: number;
+  }
+  export interface Point3d {
+    x: number;
+    y: number;
+    z: number;
+  }
+  export interface InstanceKey {
+    id: string;
+    className: string;
+  }
+  export function isPoint2d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point2d {
+    return (value as GenericInstanceFilterRuleValue.Point2d).x !== undefined && (value as GenericInstanceFilterRuleValue.Point2d).y !== undefined;
+  }
+  export function isPoint3d(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.Point3d {
+    return isPoint2d(value) && (value as GenericInstanceFilterRuleValue.Point3d).z !== undefined;
+  }
+  export function isInstanceKey(value: GenericInstanceFilterRuleValue.Values): value is GenericInstanceFilterRuleValue.InstanceKey {
+    return (value as GenericInstanceFilterRuleValue.InstanceKey) !== undefined && (value as GenericInstanceFilterRuleValue.InstanceKey).className !== undefined;
+  }
+  export type Values =
+    | string
+    | number
+    | boolean
+    | Date
+    | GenericInstanceFilterRuleValue.Point2d
+    | GenericInstanceFilterRuleValue.Point3d
+    | GenericInstanceFilterRuleValue.InstanceKey;
+}
+
+/**
+ * Defines single filter rule.
+ * @beta
+ */
+export interface GenericInstanceFilterRule {
+  /**
+   * Alias of the source to access this property. For related properties `sourceAlias` should match
+   * `GenericInstanceFilterRelatedInstanceDescription.alias` of one `GenericInstanceFilter.relatedInstances`.
+   */
+  sourceAlias: string;
+  /**
+   * Property name for accessing property value.
+   */
+  propertyName: string;
+  /**
+   * Comparison operator that should be used to compare property value.
+   */
+  operator: GenericInstanceFilterRuleOperator;
+  /**
+   * Value to which property values is compared to. For unary operators value is 'undefined'.
+   */
+  value?: GenericInstanceFilterRuleValue;
+  /**
+   * Type name of the property.
+   */
+  propertyTypeName: string;
+}
+
+/**
+ * Type definition that describes operators supported by `GenericInstanceFilterRuleGroup`.
+ * @beta
+ */
+export type GenericInstanceFilterRuleGroupOperator = "and" | "or";
+
+/**
+ * Group of filter rules joined by logical operator.
+ * @beta
+ */
+export interface GenericInstanceFilterRuleGroup {
+  /**
+   * Operator that should be used to join rules.
+   */
+  operator: GenericInstanceFilterRuleGroupOperator;
+  /**
+   * List of rules or rule groups that should be joined by `operator`.
+   */
+  rules: Array<GenericInstanceFilterRule | GenericInstanceFilterRuleGroup>;
+}
+
+/**
+ * Describes related instance whose property was used in the filter.
+ * @beta
+ */
+export interface GenericInstanceFilterRelatedInstanceDescription {
+  /**
+   * Describes path that should be used to reach related instance from the source.
+   */
+  path: GenericInstanceFilterRelationshipStep[];
+  /**
+   * Related instance alias. This alias match `sourceAlias` in all filter rules where
+   * properties of this related instance is used.
+   */
+  alias: string;
+}
+
+/**
+ * Describes single step between source class and target class.
+ * @beta
+ */
+export interface GenericInstanceFilterRelationshipStep {
+  /** Class name of the source class. */
+  sourceClassName: string;
+  /** Class name of the target class. */
+  targetClassName: string;
+  /** Class name of the relationship class that should be used to move from source to target. */
+  relationshipClassName: string;
+  /**
+   * Flag that describes if this step follows relationship class in `Forward` or `Backward` direction.
+   * If step follows relationship class in `Forward` direction than `sourceClassName` matches relationship source class and `targetClassName` matches relationship target class.
+   * Otherwise `sourceClassName` matches relationship target class and `targetClassName` matches relationship source class.
+   */
+  isForwardRelationship: boolean;
+}
+
+/** @beta */
+export namespace GenericInstanceFilter {
+  /**
+   * Function that checks if supplied object is [[GenericInstanceFilterRuleGroup]].
+   * @beta
+   */
+  export function isFilterRuleGroup(obj: GenericInstanceFilterRule | GenericInstanceFilterRuleGroup): obj is GenericInstanceFilterRuleGroup {
+    return (obj as GenericInstanceFilterRuleGroup).rules !== undefined;
+  }
+}

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -164,11 +164,11 @@ export interface GenericInstanceFilterRelatedInstanceDescription {
  * @beta
  */
 export interface GenericInstanceFilterRelationshipStep {
-  /** Full class name of the source class, e.g. `BisCore.Element`. */
+  /** Full class name of the source class, e.g. `BisCore:Element`. */
   sourceClassName: string;
-  /** Full class name of the target class, e.g. `BisCore.Element`. */
+  /** Full class name of the target class, e.g. `BisCore:Element`. */
   targetClassName: string;
-  /** Full class name of the relationship class that should be used to move from source to target, e.g. `BisCore.ElementOwnsChildElements`. */
+  /** Full class name of the relationship class that should be used to move from source to target, e.g. `BisCore:ElementOwnsChildElements`. */
   relationshipClassName: string;
   /**
    * A flag that describes if this step follows relationship class in forward or backward direction.

--- a/core/common/src/core-common.ts
+++ b/core/common/src/core-common.ts
@@ -36,6 +36,7 @@ export * from "./FeatureSymbology";
 export * from "./FeatureTable";
 export * from "./Fonts";
 export * from "./Frustum";
+export * from "./GenericInstanceFilter";
 export * from "./GeoCoordinateServices";
 export * from "./geometry/AdditionalTransform";
 export * from "./geometry/AreaPattern";

--- a/core/common/src/test/GenericInstanceFilter.test.ts
+++ b/core/common/src/test/GenericInstanceFilter.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { GenericInstanceFilter, GenericInstanceFilterRule, GenericInstanceFilterRuleValue } from "../GenericInstanceFilter";
+
+describe("GenericInstanceFilterRuleValue", () => {
+  it("'isPoint2d' returns correct result", () => {
+    expect(GenericInstanceFilterRuleValue.isPoint2d({ x: 1, y: 2})).to.be.true;
+    expect(GenericInstanceFilterRuleValue.isPoint2d(1)).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint2d(false)).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint2d("text")).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint2d(new Date())).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint2d({ id: "0x1", className: "TestClass"})).to.be.false;
+  });
+
+  it("'isPoint3d' returns correct result", () => {
+    expect(GenericInstanceFilterRuleValue.isPoint3d({ x: 1, y: 2, z: 3})).to.be.true;
+    expect(GenericInstanceFilterRuleValue.isPoint3d({ x: 1, y: 2})).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint3d(1)).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint3d(false)).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint3d("text")).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint3d(new Date())).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint3d({ id: "0x1", className: "TestClass"})).to.be.false;
+  });
+
+  it("'isInstanceKey' returns correct result", () => {
+    expect(GenericInstanceFilterRuleValue.isInstanceKey({ id: "0x1", className: "TestClass"})).to.be.true;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey({ x: 1, y: 2, z: 3})).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey({ x: 1, y: 2})).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey(1)).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey(false)).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey("text")).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey(new Date())).to.be.false;
+  });
+});
+
+describe("GenericInstanceFilter", () => {
+  it("'isFilterRuleGroup' returns correct result", () => {
+    const rule: GenericInstanceFilterRule = {
+      operator: "is-equal",
+      propertyName: "PropName",
+      propertyTypeName: "string",
+      sourceAlias: "alias",
+    };
+
+    expect(GenericInstanceFilter.isFilterRuleGroup(rule)).to.be.false;
+    expect(GenericInstanceFilter.isFilterRuleGroup({ operator: "and", rules: [rule]})).to.be.true;
+  });
+});

--- a/core/common/src/test/GenericInstanceFilter.test.ts
+++ b/core/common/src/test/GenericInstanceFilter.test.ts
@@ -8,7 +8,8 @@ import { GenericInstanceFilter, GenericInstanceFilterRule, GenericInstanceFilter
 
 describe("GenericInstanceFilterRuleValue", () => {
   it("'isPoint2d' returns correct result", () => {
-    expect(GenericInstanceFilterRuleValue.isPoint2d({ x: 1, y: 2})).to.be.true;
+    expect(GenericInstanceFilterRuleValue.isPoint2d({ x: 1, y: 2 })).to.be.true;
+    expect(GenericInstanceFilterRuleValue.isPoint2d({ x: 1, y: 2, z: 3 })).to.be.true;
     expect(GenericInstanceFilterRuleValue.isPoint2d(1)).to.be.false;
     expect(GenericInstanceFilterRuleValue.isPoint2d(false)).to.be.false;
     expect(GenericInstanceFilterRuleValue.isPoint2d("text")).to.be.false;
@@ -17,8 +18,8 @@ describe("GenericInstanceFilterRuleValue", () => {
   });
 
   it("'isPoint3d' returns correct result", () => {
-    expect(GenericInstanceFilterRuleValue.isPoint3d({ x: 1, y: 2, z: 3})).to.be.true;
-    expect(GenericInstanceFilterRuleValue.isPoint3d({ x: 1, y: 2})).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isPoint3d({ x: 1, y: 2, z: 3 })).to.be.true;
+    expect(GenericInstanceFilterRuleValue.isPoint3d({ x: 1, y: 2 })).to.be.false;
     expect(GenericInstanceFilterRuleValue.isPoint3d(1)).to.be.false;
     expect(GenericInstanceFilterRuleValue.isPoint3d(false)).to.be.false;
     expect(GenericInstanceFilterRuleValue.isPoint3d("text")).to.be.false;
@@ -28,8 +29,8 @@ describe("GenericInstanceFilterRuleValue", () => {
 
   it("'isInstanceKey' returns correct result", () => {
     expect(GenericInstanceFilterRuleValue.isInstanceKey({ id: "0x1", className: "TestClass"})).to.be.true;
-    expect(GenericInstanceFilterRuleValue.isInstanceKey({ x: 1, y: 2, z: 3})).to.be.false;
-    expect(GenericInstanceFilterRuleValue.isInstanceKey({ x: 1, y: 2})).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey({ x: 1, y: 2, z: 3 })).to.be.false;
+    expect(GenericInstanceFilterRuleValue.isInstanceKey({ x: 1, y: 2 })).to.be.false;
     expect(GenericInstanceFilterRuleValue.isInstanceKey(1)).to.be.false;
     expect(GenericInstanceFilterRuleValue.isInstanceKey(false)).to.be.false;
     expect(GenericInstanceFilterRuleValue.isInstanceKey("text")).to.be.false;
@@ -47,6 +48,6 @@ describe("GenericInstanceFilter", () => {
     };
 
     expect(GenericInstanceFilter.isFilterRuleGroup(rule)).to.be.false;
-    expect(GenericInstanceFilter.isFilterRuleGroup({ operator: "and", rules: [rule]})).to.be.true;
+    expect(GenericInstanceFilter.isFilterRuleGroup({ operator: "and", rules: [rule] })).to.be.true;
   });
 });


### PR DESCRIPTION
Moved `GenericInstanceFilter` definition from `presentation-components` to `core-common`. It was introduced as an intermediate format when converting `PresentationInstanceFilter` into other formats (e.g. ECSQL) and does not depend on `presentation`. Having it in `core-common` allows to use it without having dependency on `presentation-components` and on `AppUI` as a result.