### PR TITLE
Add missing `@itwin/eslint-plugin` devDependency to `@itwin/ecsql-common`

### DIFF
--- a/common/changes/@itwin/ecsql-common/as-add-missing-dep_2024-02-17-20-37.json
+++ b/common/changes/@itwin/ecsql-common/as-add-missing-dep_2024-02-17-20-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecsql-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecsql-common"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -417,6 +417,7 @@ importers:
     specifiers:
       '@itwin/build-tools': workspace:*
       '@itwin/core-bentley': workspace:*
+      '@itwin/eslint-plugin': 4.0.0-dev.44
       '@types/chai': 4.3.1
       '@types/mocha': ^10.0.6
       chai: ^4.3.10
@@ -429,6 +430,7 @@ importers:
       '@itwin/core-bentley': link:../../bentley
     devDependencies:
       '@itwin/build-tools': link:../../../tools/build
+      '@itwin/eslint-plugin': 4.0.0-dev.44_6ndl6d37z3ezupnqjymvncqbpi
       '@types/chai': 4.3.1
       '@types/mocha': 10.0.6
       chai: 4.3.10

--- a/core/ecsql/common/package.json
+++ b/core/ecsql/common/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",
     "@itwin/core-bentley": "workspace:*",
+    "@itwin/eslint-plugin": "4.0.0-dev.44",
     "@types/chai": "4.3.1",
     "@types/mocha": "^10.0.6",
     "chai": "^4.3.10",


### PR DESCRIPTION
Dependency is not specified even though the https://github.com/iTwin/itwinjs-core/blob/master/core/ecsql/common/eslint.config.js file has a `require("@itwin/eslint-plugin")` statement

Intellisense does not work without this dependency specified