### PR TITLE
only run post success on PRs

### DIFF
--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -120,7 +120,7 @@ jobs:
     dependsOn:
     - CheckLinkedPR
     - Build
-    condition: and(succeeded(), eq(dependencies.CheckLinkedPR.outputs['checkForPr.RUN_BUILD'], 'true'))
+    condition: and(succeeded(), eq(dependencies.CheckLinkedPR.outputs['checkForPr.RUN_BUILD'], 'true'), eq(variables['Build.Reason'], 'PullRequest'))
     displayName: Post Success
     pool:
       vmImage: ubuntu-latest


### PR DESCRIPTION
Post success was running on all runs of iTwin.js pipeline. Its only needed for PRs. Will give errors otherwise.