### PR TITLE
Ignore 409 errors when initializing tile storage

### DIFF
--- a/common/changes/@itwin/core-backend/TileStorage-init-409_2024-02-21-16-02.json
+++ b/common/changes/@itwin/core-backend/TileStorage-init-409_2024-02-21-16-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/TileStorage.ts
+++ b/core/backend/src/TileStorage.ts
@@ -47,6 +47,8 @@ export class TileStorage {
       try {
         await this.storage.createBaseDirectory({ baseDirectory: iModelId });
       } catch (e: any) {
+        // Ignore 409 errors. This is what Azure blob storage returns when the container already exists.
+        // Usually this means multiple backends tried to initialize tile storage at the same time.
         if(e.statusCode !== 409)
           throw e;
       }

--- a/core/backend/src/TileStorage.ts
+++ b/core/backend/src/TileStorage.ts
@@ -44,7 +44,12 @@ export class TileStorage {
     if (this._initializedIModels.has(iModelId))
       return;
     if (!(await this.storage.baseDirectoryExists({ baseDirectory: iModelId }))) {
-      await this.storage.createBaseDirectory({ baseDirectory: iModelId });
+      try {
+        await this.storage.createBaseDirectory({ baseDirectory: iModelId });
+      } catch (e: any) {
+        if(e.statusCode !== 409)
+          throw e;
+      }
     }
     this._initializedIModels.add(iModelId);
   }


### PR DESCRIPTION
A race condition can occur when multiple people try to open the same iModel at the same time. Since `@itwin/object-storage` doesn't have good error handling, this PR simply ignores 409 errors that come from Azure blob storage.