### PR TITLE
Add CDN and version parameters to mesh-export/get-exports query

### DIFF
--- a/common/api/frontend-tiles.api.md
+++ b/common/api/frontend-tiles.api.md
@@ -6,22 +6,24 @@
 
 import { AccessToken } from '@itwin/core-bentley';
 import { IModelConnection } from '@itwin/core-frontend';
-import { SpatialTileTreeReferences } from '@itwin/core-frontend';
 
 // @beta
 export type ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise<URL | undefined>;
 
-// @internal (undocumented)
-export const createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeReferences.create;
-
 // @beta
 export interface FrontendTilesOptions {
     computeSpatialTilesetBaseUrl?: ComputeSpatialTilesetBaseUrl;
+    enableCDN?: boolean;
+    // @internal
+    enableEdges?: boolean;
     maxLevelsToSkip?: number;
 }
 
-// @internal (undocumented)
-export function getMaxLevelsToSkip(): number;
+// @internal
+export const frontendTilesOptions: {
+    maxLevelsToSkip: number;
+    enableEdges: boolean;
+};
 
 // @beta
 export function initializeFrontendTiles(options: FrontendTilesOptions): void;
@@ -68,6 +70,7 @@ export function obtainMeshExportTilesetUrl(args: ObtainMeshExportTilesetUrlArgs)
 // @beta
 export interface ObtainMeshExportTilesetUrlArgs {
     accessToken: AccessToken;
+    enableCDN?: boolean;
     iModel: IModelConnection;
     requireExactChangeset?: boolean;
     urlPrefix?: string;
@@ -80,6 +83,7 @@ export function queryMeshExports(args: QueryMeshExportsArgs): AsyncIterableItera
 export interface QueryMeshExportsArgs {
     accessToken: AccessToken;
     changesetId?: string;
+    enableCDN?: boolean;
     iModelId: string;
     includeIncomplete?: boolean;
     urlPrefix?: string;

--- a/common/api/frontend-tiles.api.md
+++ b/common/api/frontend-tiles.api.md
@@ -6,23 +6,22 @@
 
 import { AccessToken } from '@itwin/core-bentley';
 import { IModelConnection } from '@itwin/core-frontend';
+import { SpatialTileTreeReferences } from '@itwin/core-frontend';
 
 // @beta
 export type ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise<URL | undefined>;
 
+// @internal (undocumented)
+export const createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeReferences.create;
+
 // @beta
 export interface FrontendTilesOptions {
     computeSpatialTilesetBaseUrl?: ComputeSpatialTilesetBaseUrl;
-    // @internal
-    enableEdges?: boolean;
     maxLevelsToSkip?: number;
 }
 
-// @internal
-export const frontendTilesOptions: {
-    maxLevelsToSkip: number;
-    enableEdges: boolean;
-};
+// @internal (undocumented)
+export function getMaxLevelsToSkip(): number;
 
 // @beta
 export function initializeFrontendTiles(options: FrontendTilesOptions): void;

--- a/common/api/summary/frontend-tiles.exports.csv
+++ b/common/api/summary/frontend-tiles.exports.csv
@@ -1,9 +1,8 @@
 sep=;
 Release Tag;API Item
 beta;ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise
-internal;createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeReferences.create
 beta;FrontendTilesOptions
-internal;getMaxLevelsToSkip(): number
+internal;frontendTilesOptions:
 beta;initializeFrontendTiles(options: FrontendTilesOptions): void
 beta;MeshExport
 internal;MeshExports

--- a/common/api/summary/frontend-tiles.exports.csv
+++ b/common/api/summary/frontend-tiles.exports.csv
@@ -1,8 +1,9 @@
 sep=;
 Release Tag;API Item
 beta;ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise
+internal;createFallbackSpatialTileTreeReferences: typeof SpatialTileTreeReferences.create
 beta;FrontendTilesOptions
-internal;frontendTilesOptions:
+internal;getMaxLevelsToSkip(): number
 beta;initializeFrontendTiles(options: FrontendTilesOptions): void
 beta;MeshExport
 internal;MeshExports

--- a/common/changes/@itwin/frontend-tiles/diborra-new-options-for-mesh-export-service_2024-02-22-15-26.json
+++ b/common/changes/@itwin/frontend-tiles/diborra-new-options-for-mesh-export-service_2024-02-22-15-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/frontend-tiles",
-      "comment": "Add 'cdn' and 'version' parameters to mesh-export/get-exports query in Front",
+      "comment": "Add support for enabling CDN and filtering exports by version",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/frontend-tiles/diborra-new-options-for-mesh-export-service_2024-02-22-15-26.json
+++ b/common/changes/@itwin/frontend-tiles/diborra-new-options-for-mesh-export-service_2024-02-22-15-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "Add 'cdn' and 'version' parameters to mesh-export/get-exports query in Front",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/src/FrontendTiles.ts
+++ b/extensions/frontend-tiles/src/FrontendTiles.ts
@@ -16,11 +16,16 @@ import { createBatchedSpatialTileTreeReferences } from "./BatchedSpatialTileTree
  */
 export type ComputeSpatialTilesetBaseUrl = (iModel: IModelConnection) => Promise<URL | undefined>;
 
-function createMeshExportServiceQueryUrl(args: { iModelId: string, urlPrefix?: string, changesetId?: string }): string {
+function createMeshExportServiceQueryUrl(args: { iModelId: string, urlPrefix?: string, changesetId?: string, enableCDN?: boolean }): string {
   const prefix = args.urlPrefix ?? "";
   let url = `https://${prefix}api.bentley.com/mesh-export/?iModelId=${args.iModelId}&$orderBy=date:desc`;
   if (args.changesetId)
     url = `${url}&changesetId=${args.changesetId}`;
+
+  if (args.enableCDN)
+    url = `${url}&cdn=1`;
+
+  url = `${url}&version=1`;
 
   return url;
 }
@@ -77,6 +82,8 @@ export interface QueryMeshExportsArgs {
   urlPrefix?: string;
   /** If true, exports whose status is not "Complete" (indicating the export successfully finished) will be included in the results. */
   includeIncomplete?: boolean;
+  /** If true, enables a CDN (content delivery network) to access tiles faster. */
+  enableCDN?: boolean;
 }
 
 /** Query the [mesh export service](https://developer.bentley.com/apis/mesh-export/operations/get-exports/) for exports of type "IMODEL" matching
@@ -84,7 +91,7 @@ export interface QueryMeshExportsArgs {
  * The exports are sorted from most-recently- to least-recently-produced.
  * @beta
  */
-export async function * queryMeshExports(args: QueryMeshExportsArgs): AsyncIterableIterator<MeshExport> {
+export async function* queryMeshExports(args: QueryMeshExportsArgs): AsyncIterableIterator<MeshExport> {
   const headers = {
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     Authorization: args.accessToken ?? await IModelApp.getAccessToken(),
@@ -128,6 +135,8 @@ export interface ObtainMeshExportTilesetUrlArgs {
    * the most recent export for any changeset will be used.
    */
   requireExactChangeset?: boolean;
+  /** If true, enables a CDN (content delivery network) to access tiles faster. */
+  enableCDN?: boolean;
 }
 
 /** Obtains a URL pointing to a tileset appropriate for visualizing a specific iModel.
@@ -147,6 +156,7 @@ export async function obtainMeshExportTilesetUrl(args: ObtainMeshExportTilesetUr
     iModelId: args.iModel.iModelId,
     changesetId: args.iModel.changeset.id,
     urlPrefix: args.urlPrefix,
+    enableCDN: args.enableCDN,
   };
 
   let selectedExport;
@@ -198,6 +208,11 @@ export interface FrontendTilesOptions {
    * @internal
    */
   enableEdges?: boolean;
+  /** Specifies whether to enable a CDN (content delivery network) to access tiles faster.
+   * This option is only used if computeSpatialTilesetBaseUrl is not defined.
+   * @beta
+   */
+  enableCDN?: boolean;
 }
 
 /** Global configuration initialized by [[initializeFrontendTiles]].
@@ -219,7 +234,7 @@ export function initializeFrontendTiles(options: FrontendTilesOptions): void {
     frontendTilesOptions.enableEdges = true;
 
   const computeUrl = options.computeSpatialTilesetBaseUrl ?? (
-    async (iModel: IModelConnection) => obtainMeshExportTilesetUrl({ iModel, accessToken: await IModelApp.getAccessToken() })
+    async (iModel: IModelConnection) => obtainMeshExportTilesetUrl({ iModel, accessToken: await IModelApp.getAccessToken(), enableCDN: options.enableCDN })
   );
 
   SpatialTileTreeReferences.create = (view: SpatialViewState) => createBatchedSpatialTileTreeReferences(view, computeUrl);

--- a/extensions/frontend-tiles/src/FrontendTiles.ts
+++ b/extensions/frontend-tiles/src/FrontendTiles.ts
@@ -25,7 +25,7 @@ function createMeshExportServiceQueryUrl(args: { iModelId: string, urlPrefix?: s
   if (args.enableCDN)
     url = `${url}&cdn=1`;
 
-  url = `${url}&version=1`;
+  url = `${url}&tileVersion=1&exportType=IMODEL`;
 
   return url;
 }

--- a/extensions/frontend-tiles/src/test/FrontendTiles.test.ts
+++ b/extensions/frontend-tiles/src/test/FrontendTiles.test.ts
@@ -170,10 +170,9 @@ describe("obtainMeshExportTilesetUrl", () => {
       { id: "c", href: "http://tiles.com/c", changesetId: "ccc" },
     ];
 
-    const changesetPrefix = "changesetId=";
-    const changesetPrefixIndex = url.indexOf(changesetPrefix);
-    if (-1 !== changesetPrefixIndex) {
-      const changesetId = url.substring(changesetPrefixIndex + changesetPrefix.length);
+    const result = url.match(/changesetId=([^\&]+)/);
+    if (result) {
+      const changesetId = result[1];
       exports = exports.filter((x) => x.changesetId === changesetId);
     }
 


### PR DESCRIPTION
- Add the following parameters to the mesh-export/get-exports query:
  - version: filters the exports by version, to support multiple versions
  - cdn: activates the CDN (context delivery network) to make tile downloads faster
