### PR TITLE
skip build number on native PR val

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -47,7 +47,7 @@ steps:
       Write-Host "##vso[build.updatebuildnumber]$newBuildNumber"
     displayName: Set build number
     workingDirectory: ${{ parameters.workingDir }}
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['System.JobAttempt'], '1'))
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['System.JobAttempt'], '1'), not(${{ parameters.nativePrVal }}))
 
   - script: node common/scripts/set-rush-write-cache-variables.js
     displayName: "Set Rush Write Cache Variables"


### PR DESCRIPTION
Skip this step when running native PR validation. This will ensure the pipeline run numbers stay consistent throughout the entire build, so when we use the run number to download and publish artifacts later we have a consistent run number to search for.