### PR TITLE
Change gpuMemoryLimit setting used when undefined

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -14200,7 +14200,7 @@ export namespace TileAdmin {
         aggressive: number;
         relaxed: number;
     };
-    const // (undocumented)
+    const // @internal
     nonMobileUndefinedGpuMemoryLimit: number;
     const mobileGpuMemoryLimits: {
         default: number;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -14200,6 +14200,8 @@ export namespace TileAdmin {
         aggressive: number;
         relaxed: number;
     };
+    const // (undocumented)
+    nonMobileUndefinedGpuMemoryLimit: number;
     const mobileGpuMemoryLimits: {
         default: number;
         aggressive: number;

--- a/common/changes/@itwin/core-frontend/djs-chg-desktop-GPUMemLimit_2024-02-23-20-43.json
+++ b/common/changes/@itwin/core-frontend/djs-chg-desktop-GPUMemLimit_2024-02-23-20-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Change gpuMemoryLimit setting used when undefined",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/tile/TileAdmin.test.ts
+++ b/core/frontend/src/test/tile/TileAdmin.test.ts
@@ -32,14 +32,15 @@ describe("TileAdmin", () => {
 
     const mobileLimits = TileAdmin.mobileGpuMemoryLimits;
     const desktopLimits = TileAdmin.nonMobileGpuMemoryLimits;
+    const desktopUndefinedLimit = TileAdmin.nonMobileUndefinedGpuMemoryLimit;
     const keys: Array<"relaxed" | "default" | "aggressive"> = ["relaxed", "default", "aggressive"];
 
     it("defaults to 'default' on mobile", () => {
       expectAdmin(true, undefined, "default", mobileLimits.default);
     });
 
-    it("defaults to 'none' on desktop", () => {
-      expectAdmin(false, undefined, "none", undefined);
+    it("defaults to desktopUndefinedLimit on desktop", () => {
+      expectAdmin(false, undefined, desktopUndefinedLimit, desktopUndefinedLimit);
     });
 
     it("can be specified at initialization", () => {

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -249,11 +249,8 @@ export class TileAdmin {
     else
       gpuMemoryLimit = gpuMemoryLimits;
 
-    if (undefined === gpuMemoryLimit && isMobile)
-      gpuMemoryLimit = "default";
-
-    if (undefined === gpuMemoryLimit && !isMobile)
-      gpuMemoryLimit = TileAdmin.nonMobileUndefinedGpuMemoryLimit;
+    if (undefined === gpuMemoryLimit)
+      gpuMemoryLimit = isMobile ? "default" : TileAdmin.nonMobileUndefinedGpuMemoryLimit;
 
     if (undefined !== gpuMemoryLimit)
       this.gpuMemoryLimit = gpuMemoryLimit;

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -92,7 +92,7 @@ export type GpuMemoryLimit = "none" | "default" | "aggressive" | "relaxed" | num
 export interface GpuMemoryLimits {
   /** Limits applied to clients running on mobile devices. Defaults to "default" if undefined. */
   mobile?: GpuMemoryLimit;
-  /** Limits applied to clients running on non-mobile devices. Defaults to "none" if undefined. */
+  /** Limits applied to clients running on non-mobile devices. Defaults to 6,000 MB if undefined. */
   nonMobile?: GpuMemoryLimit;
 }
 
@@ -1259,6 +1259,7 @@ export namespace TileAdmin { // eslint-disable-line no-redeclare
     relaxed: 2.5 * 1024 * 1024 * 1024, // 2.5 GB
   };
 
+  // @internal
   export const nonMobileUndefinedGpuMemoryLimit = 6000 * 1024 * 1024; // 6,000 MB - used when nonMobile limit is undefined
 
   /** The number of bytes of GPU memory associated with the various [[GpuMemoryLimit]]s for mobile devices.

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -1259,7 +1259,7 @@ export namespace TileAdmin { // eslint-disable-line no-redeclare
     relaxed: 2.5 * 1024 * 1024 * 1024, // 2.5 GB
   };
 
-  // @internal
+  /** @internal exported for tests */
   export const nonMobileUndefinedGpuMemoryLimit = 6000 * 1024 * 1024; // 6,000 MB - used when nonMobile limit is undefined
 
   /** The number of bytes of GPU memory associated with the various [[GpuMemoryLimit]]s for mobile devices.

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -252,6 +252,9 @@ export class TileAdmin {
     if (undefined === gpuMemoryLimit && isMobile)
       gpuMemoryLimit = "default";
 
+    if (undefined === gpuMemoryLimit && !isMobile)
+      gpuMemoryLimit = TileAdmin.nonMobileUndefinedGpuMemoryLimit;
+
     if (undefined !== gpuMemoryLimit)
       this.gpuMemoryLimit = gpuMemoryLimit;
 
@@ -1255,6 +1258,8 @@ export namespace TileAdmin { // eslint-disable-line no-redeclare
     aggressive: 500 * 1024 * 1024, // 500 MB
     relaxed: 2.5 * 1024 * 1024 * 1024, // 2.5 GB
   };
+
+  export const nonMobileUndefinedGpuMemoryLimit = 6000 * 1024 * 1024; // 6,000 MB - used when nonMobile limit is undefined
 
   /** The number of bytes of GPU memory associated with the various [[GpuMemoryLimit]]s for mobile devices.
    * @see [[TileAdmin.Props.gpuMemoryLimits]] to specify the limit at startup.


### PR DESCRIPTION
For non-mobile devices, the gpuMemoryLimit used a setting of "none" (no limit) when it was not defined.  This changes that setting to TileAdmin.nonMobileUndefinedGpuMemoryLimit (6,000 MB) instead.

Some very large reality data sets and imodels could on occasion cause a WebGL context loss with no limit imposed, so this attempts to set a generous limit that should prevent most of these problems for the common case of the gpuMemoryLimit being undefined.  If desired, the limit can still be set to "none".

See https://github.com/iTwin/itwinjs-backlog/issues/1047