### PR TITLE
Tile Caching Using IndexedDB

### DIFF
--- a/core/frontend/src/tile/TileRequestChannel.ts
+++ b/core/frontend/src/tile/TileRequestChannel.ts
@@ -203,6 +203,7 @@ export class TileRequestChannel {
    * @internal
    */
   public recordCompletion(tile: Tile, content: TileContent, elapsedMilliseconds: number): void {
+    console.log("record completion", tile.channel.name);
     this._statistics.recordCompletion(tile, elapsedMilliseconds);
 
     if (this.contentCallback)

--- a/core/frontend/src/tile/TileRequestChannel.ts
+++ b/core/frontend/src/tile/TileRequestChannel.ts
@@ -203,7 +203,6 @@ export class TileRequestChannel {
    * @internal
    */
   public recordCompletion(tile: Tile, content: TileContent, elapsedMilliseconds: number): void {
-    console.log("record completion", tile.channel.name);
     this._statistics.recordCompletion(tile, elapsedMilliseconds);
 
     if (this.contentCallback)


### PR DESCRIPTION
WIP

Cache Tiles using IndexedDB. Create a new Tile Request Channel which connects to an IDBDatabase. Through the channel, search for tiles in the db. If a match is found, check if the tile has expired (based on time of storage). If expired, delete the tile from the db and move to the next request channel. If no match is found, move to the next request channel. Once a tile has been successfully requested, store it in the db. 