### PR TITLE
Address memory leak regarding markers and decorators

### DIFF
--- a/common/changes/@itwin/core-frontend/nam-mem-leak-resolution_2024-02-28-21-45.json
+++ b/common/changes/@itwin/core-frontend/nam-mem-leak-resolution_2024-02-28-21-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Dispose of all viewports when IModelApp.shutdown() is called to clear up WebGL resources, and avoid memory leak",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/ViewManager.ts
+++ b/core/frontend/src/ViewManager.ts
@@ -141,7 +141,10 @@ export class ViewManager implements Iterable<ScreenViewport> {
       clearTimeout(this._idleWorkTimer);
       this._idleWorkTimer = undefined;
     }
-    this._viewports.map((viewport) => this.dropViewport(viewport, true));
+    this._viewports.map((viewport) => {
+      if (!viewport.isDisposed)
+        this.dropViewport(viewport, true);
+    });
     this._viewports.length = 0;
     this.decorators.length = 0;
     this.toolTipProviders.length = 0;

--- a/core/frontend/src/ViewManager.ts
+++ b/core/frontend/src/ViewManager.ts
@@ -141,6 +141,7 @@ export class ViewManager implements Iterable<ScreenViewport> {
       clearTimeout(this._idleWorkTimer);
       this._idleWorkTimer = undefined;
     }
+    this._viewports.map((viewport) => viewport.dispose());
     this._viewports.length = 0;
     this.decorators.length = 0;
     this.toolTipProviders.length = 0;

--- a/core/frontend/src/ViewManager.ts
+++ b/core/frontend/src/ViewManager.ts
@@ -141,7 +141,7 @@ export class ViewManager implements Iterable<ScreenViewport> {
       clearTimeout(this._idleWorkTimer);
       this._idleWorkTimer = undefined;
     }
-    this._viewports.map((viewport) => viewport.dispose());
+    this._viewports.map((viewport) => this.dropViewport(viewport, true));
     this._viewports.length = 0;
     this.decorators.length = 0;
     this.toolTipProviders.length = 0;

--- a/core/frontend/src/test/ViewManager.test.ts
+++ b/core/frontend/src/test/ViewManager.test.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { OnScreenTarget } from "../core-frontend";
 import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";
@@ -14,12 +14,12 @@ import { ColorDef, EmptyLocalization } from "@itwin/core-common";
 describe("ViewManager", () => {
   let imodel: IModelConnection;
 
-  before(async () => {
+  beforeEach(async () => {
     await IModelApp.startup({ localization: new EmptyLocalization() });
     imodel = createBlankConnection("view-manager-test");
   });
 
-  after(async () => {
+  afterEach(async () => {
     await imodel.close();
     await IModelApp.shutdown();
   });
@@ -58,5 +58,13 @@ describe("ViewManager", () => {
     vp.renderFrame();
     expectColors(vp, [ColorDef.red]);
     vp.dispose();
+  });
+
+  it("should dispose of viewport when onShutdown is called", async () => {
+    const vp = openBlankViewport({ width: 30, height: 30 });
+    IModelApp.viewManager.addViewport(vp);
+    await IModelApp.shutdown();
+
+    assert.isTrue(vp.isDisposed);
   });
 });


### PR DESCRIPTION
When ImodelApp.shutdown() is called, ViewManager's onShutdown() is called. Problem is, the  viewports that are a part of IModelApp do not have their dispose() functions called, which holds up WebGL resources. This results in a memory leak even after shutdown() is called: thousands of featureAppearance overrides are being retained every refresh, which are coming from ScreenViewport's OnScreenTarget.

Solution is to drop all viewports in IModelApp's viewManager when shutdown is called.