### PR TITLE
Remove optional ElementGeometryBuilderParams arg from…

### DIFF
--- a/common/api/editor-backend.api.md
+++ b/common/api/editor-backend.api.md
@@ -17,7 +17,6 @@ import { EcefLocationProps } from '@itwin/core-common';
 import { EdgeParameterRangeProps } from '@itwin/editor-common';
 import { EditCommandIpc } from '@itwin/editor-common';
 import { ElementGeometryBuilderParams } from '@itwin/core-common';
-import { ElementGeometryBuilderParamsForPart } from '@itwin/core-common';
 import { ElementGeometryCacheFilter } from '@itwin/editor-common';
 import { ElementGeometryInfo } from '@itwin/core-common';
 import { ElementGeometryResultOptions } from '@itwin/editor-common';
@@ -64,9 +63,9 @@ export class BasicManipulationCommand extends EditCommand implements BasicManipu
     // (undocumented)
     deleteElements(ids: CompressedId64Set): Promise<IModelStatus>;
     // (undocumented)
-    insertGeometricElement(props: GeometricElementProps, data?: ElementGeometryBuilderParams): Promise<Id64String>;
+    insertGeometricElement(props: GeometricElementProps): Promise<Id64String>;
     // (undocumented)
-    insertGeometryPart(props: GeometryPartProps, data?: ElementGeometryBuilderParamsForPart): Promise<Id64String>;
+    insertGeometryPart(props: GeometryPartProps): Promise<Id64String>;
     // (undocumented)
     onStart(): Promise<string>;
     // (undocumented)

--- a/common/api/editor-common.api.md
+++ b/common/api/editor-common.api.md
@@ -9,7 +9,6 @@ import { ColorDefProps } from '@itwin/core-common';
 import { CompressedId64Set } from '@itwin/core-bentley';
 import { EcefLocationProps } from '@itwin/core-common';
 import { ElementGeometryBuilderParams } from '@itwin/core-common';
-import { ElementGeometryBuilderParamsForPart } from '@itwin/core-common';
 import { ElementGeometryDataEntry } from '@itwin/core-common';
 import { ElementGeometryInfo } from '@itwin/core-common';
 import { ElementGeometryOpcode } from '@itwin/core-common';
@@ -27,8 +26,8 @@ import { XYZProps } from '@itwin/core-geometry';
 export interface BasicManipulationCommandIpc extends EditCommandIpc {
     // (undocumented)
     deleteElements(ids: CompressedId64Set): Promise<IModelStatus>;
-    insertGeometricElement(props: GeometricElementProps, data?: ElementGeometryBuilderParams): Promise<Id64String>;
-    insertGeometryPart(props: GeometryPartProps, data?: ElementGeometryBuilderParamsForPart): Promise<Id64String>;
+    insertGeometricElement(props: GeometricElementProps): Promise<Id64String>;
+    insertGeometryPart(props: GeometryPartProps): Promise<Id64String>;
     requestElementGeometry(id: Id64String, filter?: FlatBufferGeometryFilter): Promise<ElementGeometryInfo | undefined>;
     // (undocumented)
     rotatePlacement(ids: CompressedId64Set, matrix: Matrix3dProps, aboutCenter: boolean): Promise<IModelStatus>;

--- a/common/api/editor-frontend.api.md
+++ b/common/api/editor-frontend.api.md
@@ -30,7 +30,6 @@ import { EcefLocation } from '@itwin/core-common';
 import { EcefLocationProps } from '@itwin/core-common';
 import { EditCommandIpc } from '@itwin/editor-common';
 import { EditManipulator } from '@itwin/core-frontend';
-import { ElementGeometryBuilderParams } from '@itwin/core-common';
 import { ElementGeometryCacheFilter } from '@itwin/editor-common';
 import { ElementGeometryInfo } from '@itwin/core-common';
 import { ElementGeometryResultProps } from '@itwin/editor-common';
@@ -709,7 +708,7 @@ export abstract class CreateElementWithDynamicsTool extends CreateElementTool {
     // (undocumented)
     protected createGraphics(ev: BeButtonEvent): Promise<void>;
     // (undocumented)
-    protected doCreateElement(_props: GeometricElementProps, _data?: ElementGeometryBuilderParams): Promise<void>;
+    protected doCreateElement(_props: GeometricElementProps): Promise<void>;
     // (undocumented)
     protected abstract getElementProps(placement: PlacementProps): GeometricElementProps | undefined;
     // (undocumented)
@@ -819,7 +818,7 @@ export abstract class CreateOrContinuePathTool extends CreateElementWithDynamics
     // (undocumented)
     decorate(context: DecorateContext): void;
     // (undocumented)
-    protected doCreateElement(props: GeometricElementProps, data?: ElementGeometryBuilderParams): Promise<void>;
+    protected doCreateElement(props: GeometricElementProps): Promise<void>;
     // (undocumented)
     protected getCurrentRotation(ev: BeButtonEvent): Matrix3d;
     // (undocumented)
@@ -2526,7 +2525,7 @@ export abstract class SolidPrimitiveTool extends CreateElementWithDynamicsTool {
     // (undocumented)
     protected current?: GeometryQuery;
     // (undocumented)
-    protected doCreateElement(props: GeometricElementProps, data?: ElementGeometryBuilderParams): Promise<void>;
+    protected doCreateElement(props: GeometricElementProps): Promise<void>;
     // (undocumented)
     protected getElementProps(placement: PlacementProps): GeometricElementProps | undefined;
     // (undocumented)

--- a/common/changes/@itwin/editor-backend/basic-manipulation-ipc_2024-02-29-20-32.json
+++ b/common/changes/@itwin/editor-backend/basic-manipulation-ipc_2024-02-29-20-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-backend"
+}

--- a/common/changes/@itwin/editor-common/basic-manipulation-ipc_2024-02-29-20-32.json
+++ b/common/changes/@itwin/editor-common/basic-manipulation-ipc_2024-02-29-20-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-common"
+}

--- a/common/changes/@itwin/editor-frontend/basic-manipulation-ipc_2024-02-29-20-32.json
+++ b/common/changes/@itwin/editor-frontend/basic-manipulation-ipc_2024-02-29-20-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -8,6 +8,7 @@ Table of contents:
 - [Display](#display)
   - [Seafloor terrain](#seafloor-terrain)
 - [Electron 29 support](#electron-29-support)
+- [Editor](#editor)
 
 ## Display
 
@@ -34,3 +35,14 @@ The new [TerrainSettings.dataSource]($common) property can be used by custom [Te
 ## Electron 29 support
 
 In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 29](https://www.electronjs.org/blog/electron-29-0).
+
+## Editor
+
+Changes to @beta BasicManipulationCommandIpc class:
+
+- BasicManipulationCommandIpc.insertGeometricElement no longer takes an optional ElementGeometryBuilderParams as this can be specified in GeometricElementProps.
+- BasicManipulationCommandIpc.insertGeometryPart no longer takes an optional ElementGeometryBuilderParamsForPart as this can be specified in GeometryPartProps.
+
+Changes to @beta CreateElementWithDynamicsTool class:
+
+- CreateElementWithDynamicsTool.doCreateElement no longer takes an optional ElementGeometryBuilderParams as it will be set on the supplied GeometricElementProps.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -38,11 +38,12 @@ In addition to [already supported Electron versions](../learning/SupportedPlatfo
 
 ## Editor
 
-Changes to @beta BasicManipulationCommandIpc class:
+Changes to @beta [BasicManipulationCommandIpc]($editor-common) class:
 
-- BasicManipulationCommandIpc.insertGeometricElement no longer takes an optional ElementGeometryBuilderParams as this can be specified in GeometricElementProps.
-- BasicManipulationCommandIpc.insertGeometryPart no longer takes an optional ElementGeometryBuilderParamsForPart as this can be specified in GeometryPartProps.
+- [BasicManipulationCommandIpc.insertGeometricElement]($editor-common) no longer takes an optional ElementGeometryBuilderParams as this can be specified in [GeometricElementProps]($common).
+- [BasicManipulationCommandIpc.insertGeometryPart]($editor-common) no longer takes an optional ElementGeometryBuilderParamsForPart as this can be specified in [GeometryPartProps]($common).
 
-Changes to @beta CreateElementWithDynamicsTool class:
+Changes to @beta [CreateElementWithDynamicsTool]($editor-frontend) class:
 
-- CreateElementWithDynamicsTool.doCreateElement no longer takes an optional ElementGeometryBuilderParams as it will be set on the supplied GeometricElementProps.
+- [CreateElementWithDynamicsTool.doCreateElement]($editor-frontend) no longer takes an optional [ElementGeometryBuilderParams]($common) as it will be set on the supplied [GeometricElementProps]($common).
+

--- a/editor/common/src/EditorBuiltInIpc.ts
+++ b/editor/common/src/EditorBuiltInIpc.ts
@@ -8,7 +8,7 @@
 
 import { CompressedId64Set, Id64String, IModelStatus } from "@itwin/core-bentley";
 import { AngleProps, Matrix3dProps, Range1dProps, Range3dProps, TransformProps, XYZProps } from "@itwin/core-geometry";
-import { ColorDefProps, EcefLocationProps, ElementGeometryBuilderParams, ElementGeometryBuilderParamsForPart, ElementGeometryDataEntry, ElementGeometryInfo, ElementGeometryOpcode, GeometricElementProps, GeometryPartProps } from "@itwin/core-common";
+import { ColorDefProps, EcefLocationProps, ElementGeometryBuilderParams, ElementGeometryDataEntry, ElementGeometryInfo, ElementGeometryOpcode, GeometricElementProps, GeometryPartProps } from "@itwin/core-common";
 import { EditCommandIpc } from "./EditorIpc";
 
 /** Command ids for built in EditCommandIpc classes.
@@ -48,19 +48,17 @@ export interface BasicManipulationCommandIpc extends EditCommandIpc {
 
   /** Create and insert a new geometric element.
    * @param props Properties for the new [GeometricElement]($backend)
-   * @param data Optional binary format GeometryStream representation used in lieu of [[GeometricElementProps.geom]] or [[GeometricElementProps.elementGeometryBuilderParams]].
    * @see [GeometryStream]($docs/learning/common/geometrystream.md), [ElementGeometry]($common)
    * @throws [[IModelError]] if unable to insert the element
    */
-  insertGeometricElement(props: GeometricElementProps, data?: ElementGeometryBuilderParams): Promise<Id64String>;
+  insertGeometricElement(props: GeometricElementProps): Promise<Id64String>;
 
   /** Create and insert a new geometry part element.
    * @param props Properties for the new [GeometryPart]($backend)
-   * @param data Optional binary format GeometryStream representation used in lieu of [[GeometryPartProps.geom]] or [[GeometryPartProps.elementGeometryBuilderParams]].
    * @see [GeometryStream]($docs/learning/common/geometrystream.md), [ElementGeometry]($common)
    * @throws [[IModelError]] if unable to insert the element
    */
-  insertGeometryPart(props: GeometryPartProps, data?: ElementGeometryBuilderParamsForPart): Promise<Id64String>;
+  insertGeometryPart(props: GeometryPartProps): Promise<Id64String>;
 
   /** Update an existing geometric element.
    * @param propsOrId Properties or element id to update for an existing [GeometricElement]($backend)

--- a/editor/frontend/src/CreateElementTool.ts
+++ b/editor/frontend/src/CreateElementTool.ts
@@ -9,7 +9,7 @@
 
 import { Id64, Id64String, IModelStatus } from "@itwin/core-bentley";
 import { Constant, Point3d, Range3d, Transform, Vector3d } from "@itwin/core-geometry";
-import { DynamicGraphicsRequest2dProps, DynamicGraphicsRequest3dProps, ElementGeometryBuilderParams, FlatBufferGeometryStream, GeometricElementProps, IModelError, isPlacement3dProps, JsonGeometryStream, PlacementProps } from "@itwin/core-common";
+import { DynamicGraphicsRequest2dProps, DynamicGraphicsRequest3dProps, FlatBufferGeometryStream, GeometricElementProps, IModelError, isPlacement3dProps, JsonGeometryStream, PlacementProps } from "@itwin/core-common";
 import { BeButtonEvent, CoordSystem, CoreTools, DynamicsContext, EventHandled, GraphicBranch, IModelApp, IModelConnection, PrimitiveTool, readElementGraphics, RenderGraphicOwner, ToolAssistance, ToolAssistanceImage, ToolAssistanceInputMethod, ToolAssistanceInstruction, ToolAssistanceSection, Viewport } from "@itwin/core-frontend";
 
 function computeChordToleranceFromPointAndRadius(vp: Viewport, center: Point3d, radius: number): number {
@@ -353,7 +353,7 @@ export abstract class CreateElementWithDynamicsTool extends CreateElementTool {
   protected abstract getGeometryProps(placement: PlacementProps): JsonGeometryStream | FlatBufferGeometryStream | undefined;
   protected abstract getElementProps(placement: PlacementProps): GeometricElementProps | undefined;
 
-  protected async doCreateElement(_props: GeometricElementProps, _data?: ElementGeometryBuilderParams): Promise<void> {}
+  protected async doCreateElement(_props: GeometricElementProps): Promise<void> {}
   protected async updateElementData(_ev: BeButtonEvent, _isDynamics: boolean): Promise<void> {}
 
   protected async updateDynamicData(ev: BeButtonEvent): Promise<boolean> {
@@ -377,15 +377,14 @@ export abstract class CreateElementWithDynamicsTool extends CreateElementTool {
     if (undefined === elemProps)
       return;
 
-    let data;
     if ("flatbuffer" === geometry.format) {
-      data = { entryArray: geometry.data };
       delete elemProps.geom; // Leave unchanged until replaced by flatbuffer geometry...
+      elemProps.elementGeometryBuilderParams = { entryArray: geometry.data };
     } else {
       elemProps.geom = geometry.data;
     }
 
-    return this.doCreateElement(elemProps, data);
+    return this.doCreateElement(elemProps);
   }
 
   protected setupAccuDraw(): void { }

--- a/editor/frontend/src/SketchTools.ts
+++ b/editor/frontend/src/SketchTools.ts
@@ -12,7 +12,7 @@ import {
 } from "@itwin/appui-abstract";
 import { BentleyError, Id64String } from "@itwin/core-bentley";
 import {
-  Code, ColorDef, ElementGeometry, ElementGeometryBuilderParams, ElementGeometryInfo, FlatBufferGeometryStream, GeometricElementProps, GeometryParams,
+  Code, ColorDef, ElementGeometry, ElementGeometryInfo, FlatBufferGeometryStream, GeometricElementProps, GeometryParams,
   GeometryStreamProps, isPlacement3dProps, JsonGeometryStream, LinePixels, PlacementProps,
 } from "@itwin/core-common";
 import {
@@ -651,13 +651,13 @@ export abstract class CreateOrContinuePathTool extends CreateElementWithDynamics
     return { classFullName: "BisCore:DrawingGraphic", model, category, code: Code.createEmpty(), placement };
   }
 
-  protected override async doCreateElement(props: GeometricElementProps, data?: ElementGeometryBuilderParams): Promise<void> {
+  protected override async doCreateElement(props: GeometricElementProps): Promise<void> {
     try {
       this._startedCmd = await this.startCommand();
       if (undefined === props.id)
-        await basicManipulationIpc.insertGeometricElement(props, data);
+        await basicManipulationIpc.insertGeometricElement(props);
       else
-        await basicManipulationIpc.updateGeometricElement(props, data);
+        await basicManipulationIpc.updateGeometricElement(props);
       await this.saveChanges();
     } catch (err) {
       IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, BentleyError.getErrorMessage(err) || "An unknown error occurred."));

--- a/editor/frontend/src/SolidPrimitiveTools.ts
+++ b/editor/frontend/src/SolidPrimitiveTools.ts
@@ -10,7 +10,7 @@
 import { DialogItem, DialogProperty, DialogPropertySyncItem, PropertyDescriptionHelper } from "@itwin/appui-abstract";
 import { BentleyError } from "@itwin/core-bentley";
 import {
-  Code, ColorDef, ElementGeometry, ElementGeometryBuilderParams, FlatBufferGeometryStream, GeometricElementProps, JsonGeometryStream, PlacementProps,
+  Code, ColorDef, ElementGeometry, FlatBufferGeometryStream, GeometricElementProps, JsonGeometryStream, PlacementProps,
 } from "@itwin/core-common";
 import {
   AccuDrawHintBuilder, AngleDescription, BeButtonEvent, DynamicsContext, EventHandled, GraphicType, IModelApp, LengthDescription, NotifyMessageDetails, OutputMessagePriority,
@@ -78,10 +78,10 @@ export abstract class SolidPrimitiveTool extends CreateElementWithDynamicsTool {
     return { classFullName: "Generic:PhysicalObject", model, category, code: Code.createEmpty(), placement };
   }
 
-  protected override async doCreateElement(props: GeometricElementProps, data?: ElementGeometryBuilderParams): Promise<void> {
+  protected override async doCreateElement(props: GeometricElementProps): Promise<void> {
     try {
       this._startedCmd = await this.startCommand();
-      await basicManipulationIpc.insertGeometricElement(props, data);
+      await basicManipulationIpc.insertGeometricElement(props);
       await this.saveChanges();
     } catch (err) {
       IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, BentleyError.getErrorMessage(err) || "An unknown error occurred."));


### PR DESCRIPTION
 BasicManipulationCommandIpc.insertGeometricElement now that it's included in GeometricElementProps.

note: The abstract tool base class CreateElementWithDynamicsTool and BasicManipulationCommandIpc are staying in the editor package after the tools are moved out to their own package.