### PR TITLE
Clamp batched tile fit volume to project extents.

### DIFF
--- a/common/changes/@itwin/frontend-tiles/pmc-clamp-batched-models-extents_2024-03-07-14-29.json
+++ b/common/changes/@itwin/frontend-tiles/pmc-clamp-batched-models-extents_2024-03-07-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "Clamp the fit volume of a batched tile tree to the project extents.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/src/BatchedModels.ts
+++ b/extensions/frontend-tiles/src/BatchedModels.ts
@@ -10,12 +10,14 @@ import { ModelMetadata } from "./BatchedTilesetReader";
 
 export class BatchedModels {
   private _viewedModels!: Set<Id64String>;
+  private readonly _projectExtents: Range3d;
   private readonly _viewedExtents = new Range3d();
   private readonly _viewedModelIdPairs = new Id64.Uint32Set();
   private readonly _metadata: Map<Id64String, ModelMetadata>;
 
   public constructor(view: SpatialViewState, metadata: Map<Id64String, ModelMetadata>) {
     this._metadata = metadata;
+    this._projectExtents = view.iModel.projectExtents;
     this.setViewedModels(view.modelSelector.models);
   }
 
@@ -30,6 +32,8 @@ export class BatchedModels {
       if (range)
         this._viewedExtents.extendRange(range);
     }
+
+    this._viewedExtents.intersect(this._projectExtents, this._viewedExtents);
   }
 
   public views(modelId: Id64String): boolean {


### PR DESCRIPTION
The iModel's project extents are supposed to clamp the range of viewable geometry. The tileset publisher enforces this. However, at display time we compute the volume of the displayed viewable models by taking the union of the bounding boxes of each model, which may extend (sometimes very far!) outside of the project extents. This can arbitrarily expand the viewed volume so that when you fit the view, it zooms way out; and can negatively affect depth buffer precision, producing visual artifacts.

Add project extents clamping when computing viewed extents in BatchedModels.

Needs to be backported to 4.4.x ASAP. Running ImageTests first.