### PR TITLE
Do Not Skip PR builds when native change is linked

### DIFF
--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -68,9 +68,9 @@ jobs:
 
           # No native PRs are linked
           if [[ -z "$NativeUrl" ]]; then
-            echo '##vso[task.setvariable variable=RUN_BUILD;isoutput=true]true'
+            echo '##vso[task.setvariable variable=POST_STATUS;isoutput=true]true'
           else
-            echo '##vso[task.setvariable variable=RUN_BUILD;isoutput=true]false'
+            echo '##vso[task.setvariable variable=POST_STATUS;isoutput=true]false'
           fi
 
         env:
@@ -79,7 +79,7 @@ jobs:
 
   - job: Build
     dependsOn: CheckLinkedPR
-    condition: and(succeeded(), eq(dependencies.CheckLinkedPR.outputs['checkForPr.RUN_BUILD'], 'true'))
+    condition: succeeded()
     strategy:
       matrix:
         "Windows_Node_20":
@@ -120,7 +120,7 @@ jobs:
     dependsOn:
     - CheckLinkedPR
     - Build
-    condition: and(succeeded(), eq(dependencies.CheckLinkedPR.outputs['checkForPr.RUN_BUILD'], 'true'), eq(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), eq(dependencies.CheckLinkedPR.outputs['checkForPr.POST_STATUS'], 'true'), eq(variables['Build.Reason'], 'PullRequest'))
     displayName: Post Success
     pool:
       vmImage: ubuntu-latest
@@ -137,6 +137,6 @@ jobs:
           -f state='success' \
           -f target_url='$(BUILD_URL)' \
           -f context='itwinjs-core PR validation' \
-          -f description='The internal linked PR build succeeded'
+          -f description='No native PR was linked'
       env:
         GITHUB_TOKEN: $(GH_TOKEN)


### PR DESCRIPTION
always build even if a native PR is linked. Just to be safe probably best to require builds before merging an itwinjs-core PR. If we decide to skip this part in the future it can easily be added back. This will also mean we don't need to change the requirements on any of our status checks. Also by doing this I would like to not build itwinjs-core during a the release process. 

Pros:
This doesn't necessarily save us time since other builds take longer. However, this reduces the chance for flaky tests failing during itwinjs-core builds and cause releases to be delayed. I just have a feeling people are more likely to not notice if Release builds fail, and cause longer delays in the release. If their PR fails they will definitely notice.

Cons:
Doing this we only verify that master and the new addon are fine during imodel-native PR. We won't know if a change to itwinjs-core that breaks the addon slipped in until after we merge the new addon into itwinjs-core master

imodel-native-internal: https://github.com/iTwin/imodel-native-internal/pull/404