### PR TITLE
Bug Fix: Resolve `ECSqlReader.toRow()` crash while duplicate property names are selected

### DIFF
--- a/common/changes/@itwin/core-backend/aks-queryreader-crash-fix_2024-03-08-09-55.json
+++ b/common/changes/@itwin/core-backend/aks-queryreader-crash-fix_2024-03-08-09-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added new tests for selecting duplicate property names using UseECSqlPropertyNames QueryRowFormat.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/aks-queryreader-crash-fix_2024-03-08-09-55.json
+++ b/common/changes/@itwin/core-common/aks-queryreader-crash-fix_2024-03-08-09-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix the row formatting to avoid having same property name used multiple times.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/test/ecdb/ECSqlReader.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlReader.test.ts
@@ -289,6 +289,81 @@ describe("ECSqlReader", (() => {
       });
     });
 
+    describe("Get duplicate property names", () => {
+
+      it("Get duplicate property names using iterable iterator with unspecified rowFormat", async () => {
+        const expectedIds = ["0x1", "0xe", "0x10", "0x11", "0x12"];
+        let counter = 1;
+        for await (const row of iModel.createQueryReader("SELECT * FROM bis.Element c JOIN bis.Element p ON p.ECInstanceId = c.ECInstanceId", undefined, { limit: { count: 5 } })) {
+          const currentExpectedId = expectedIds[counter - 1];
+          assert.equal(row[0], currentExpectedId);
+          assert.equal(row.id, currentExpectedId);
+          assert.equal(row.ecinstanceid, currentExpectedId);
+          assert.equal(row.ECINSTANCEID, currentExpectedId);
+          assert.equal(row.ECInstanceId, currentExpectedId);
+          assert.equal(row.toArray()[0], currentExpectedId);
+          assert.equal(row.toRow().ECInstanceId, currentExpectedId);
+          counter++;
+          actualRowCount++;
+        }
+        assert.equal(actualRowCount, 5);
+      });
+
+      it("Get duplicate property names using iterable iterator with UseJsPropertyNames rowFormat", async () => {
+        const expectedIds = ["0x1", "0xe", "0x10", "0x11", "0x12"];
+        let counter = 1;
+        for await (const row of iModel.createQueryReader("SELECT * FROM bis.Element c JOIN bis.Element p ON p.ECInstanceId = c.ECInstanceId", undefined, { limit: { count: 5 }, rowFormat: QueryRowFormat.UseJsPropertyNames })) {
+          const currentExpectedId = expectedIds[counter - 1];
+          assert.equal(row[0], currentExpectedId);
+          assert.equal(row.id, currentExpectedId);
+          assert.equal(row.ecinstanceid, currentExpectedId);
+          assert.equal(row.ECINSTANCEID, currentExpectedId);
+          assert.equal(row.ECInstanceId, currentExpectedId);
+          assert.equal(row.toArray()[0], currentExpectedId);
+          assert.equal(row.toRow().id, currentExpectedId);
+          counter++;
+          actualRowCount++;
+        }
+        assert.equal(actualRowCount, 5);
+      });
+
+      it("Get duplicate property names using iterable iterator with UseECSqlPropertyNames rowFormat", async () => {
+        const expectedIds = ["0x1", "0xe", "0x10", "0x11", "0x12"];
+        let counter = 1;
+        for await (const row of iModel.createQueryReader("SELECT * FROM bis.Element c JOIN bis.Element p ON p.ECInstanceId = c.ECInstanceId", undefined, { limit: { count: 5 }, rowFormat: QueryRowFormat.UseECSqlPropertyNames })) {
+          const currentExpectedId = expectedIds[counter - 1];
+          assert.equal(row[0], currentExpectedId);
+          assert.equal(row.id, currentExpectedId);
+          assert.equal(row.ecinstanceid, currentExpectedId);
+          assert.equal(row.ECINSTANCEID, currentExpectedId);
+          assert.equal(row.ECInstanceId, currentExpectedId);
+          assert.equal(row.toArray()[0], currentExpectedId);
+          assert.equal(row.toRow().ECInstanceId, currentExpectedId);
+          counter++;
+          actualRowCount++;
+        }
+        assert.equal(actualRowCount, 5);
+      });
+
+      it("Get duplicate property names using iterable iterator with UseECSqlPropertyIndexes rowFormat", async () => {
+        const expectedIds = ["0x1", "0xe", "0x10", "0x11", "0x12"];
+        let counter = 1;
+        for await (const row of iModel.createQueryReader("SELECT * FROM bis.Element c JOIN bis.Element p ON p.ECInstanceId = c.ECInstanceId", undefined, { limit: { count: 5 }, rowFormat: QueryRowFormat.UseECSqlPropertyIndexes })) {
+          const currentExpectedId = expectedIds[counter - 1];
+          assert.equal(row[0], currentExpectedId);
+          assert.equal(row.id, currentExpectedId);
+          assert.equal(row.ecinstanceid, currentExpectedId);
+          assert.equal(row.ECINSTANCEID, currentExpectedId);
+          assert.equal(row.ECInstanceId, currentExpectedId);
+          assert.equal(row.toArray()[0], currentExpectedId);
+          assert.equal(row.toRow().ECInstanceId, currentExpectedId);
+          counter++;
+          actualRowCount++;
+        }
+        assert.equal(actualRowCount, 5);
+      });
+    });
+
     describe("Get specific values", () => {
 
       it("Get only ECInstanceId with unspecified rowFormat", async () => {

--- a/core/common/src/ECSqlReader.ts
+++ b/core/common/src/ECSqlReader.ts
@@ -404,11 +404,20 @@ export class ECSqlReader implements AsyncIterableIterator<QueryRowProxy> {
       return this.getRowInternal();
     }
     const formattedRow = {};
+    const uniqueNames = new Map<string, number>();
     for (const prop of this._props) {
       const propName = this._options.rowFormat === QueryRowFormat.UseJsPropertyNames ? prop.jsonName : prop.name;
       const val = this.getRowInternal()[prop.index];
       if (typeof val !== "undefined" && val !== null) {
-        Object.defineProperty(formattedRow, propName, {
+        let uniquePropName = propName;
+        if (uniqueNames.has(propName)) {
+          uniqueNames.set(propName, uniqueNames.get(propName)! + 1);
+          uniquePropName = `${propName}_${uniqueNames.get(propName)!}`;
+        } else {
+          uniqueNames.set(propName,0);
+        }
+
+        Object.defineProperty(formattedRow, uniquePropName, {
           value: val,
           enumerable: true,
         });


### PR DESCRIPTION
This Pull Request addresses a critical bug causing the `ECSqlReader.toRow()` method to crash when the `QueryRowFormat` is set to `UseECSqlPropertyNames` or `UseECSqlPropertyIndexes` and duplicate property names are selected.
Resolved the crash issue by updating the row formatting logic to prevent the use of the same property name multiple times.

Closes #6343