### PR TITLE
Fix GPU timings

### DIFF
--- a/common/changes/@itwin/core-frontend/man-fix-gpu-timings_2024-03-11-19-45.json
+++ b/common/changes/@itwin/core-frontend/man-fix-gpu-timings_2024-03-11-19-45.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "fix gpu timings due behavior change of query for elapsed gpu time",
+      "comment": "Fix regression in GPU timings due a  change in chromium's behavior.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-frontend/man-fix-gpu-timings_2024-03-11-19-45.json
+++ b/common/changes/@itwin/core-frontend/man-fix-gpu-timings_2024-03-11-19-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "fix gpu timings due behavior change of query for elapsed gpu time",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}


### PR DESCRIPTION
This fixes a problem that started occurring with our GPU timing code which happened when a new chrome (and then later electron) were pushed.  We were depending on some un-documented behavior for querying the gpu timings and its behavior changed.  We implement a stack of timers so that we can time sub-processes of the render and were re-starting a timer query which used to add the results of both querries for you.  The behavior of this instead now resets the timer so we only get the time for the last time.  To fix this the code now starts a new timer instead and adds the results of all of the timers for the parent timing together when it is finished.