### PR TITLE
Allow connector-framework to consume own docs during doc validation

### DIFF
--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -32,6 +32,9 @@ parameters:
   - name: useCurrentAuthClientsDocsArtifact
     type: boolean
     default: false
+  - name: useCurrentConnectorFrameworkDocsArtifact
+    type: boolean
+    default: false
   - name: shouldPublish
     type: boolean
     default: false
@@ -113,6 +116,7 @@ jobs:
           useCurrentPresentationDocsArtifact: ${{ parameters.useCurrentPresentationDocsArtifact }}
           useCurrentTransformerDocsArtifact: ${{ parameters.useCurrentTransformerDocsArtifact }}
           useCurrentAuthClientsDocsArtifact: ${{ parameters.useCurrentAuthClientsDocsArtifact }}
+          useCurrentConnectorFrameworkDocsArtifact: ${{ parameters.useCurrentConnectorFrameworkDocsArtifact }}
 
       # Currently BeMetalsmith is an internal only tool
       - script: npm install @bentley/bemetalsmith@5.2.x --legacy-peer-deps

--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -23,6 +23,9 @@ parameters:
   - name: useCurrentAuthClientsDocsArtifact
     type: boolean
     default: false
+  - name: useCurrentConnectorFrameworkDocsArtifact
+    type: boolean
+    default: false
 
 steps:
   # Call the copying script
@@ -99,7 +102,7 @@ steps:
       pipelineId: 5669 # iTwin.js/iTwin Connector Frameworks/iTwin.connector-framework
       artifactName: Connector-Framework Docs
       buildTag: hasDocs
-      useCurrentDocsArtifact: ${{ parameters.useCurrentAuthClientsDocsArtifact }}
+      useCurrentDocsArtifact: ${{ parameters.useCurrentConnectorFrameworkDocsArtifact }}
       stagingSteps:
         - task: CopyFiles@2
           displayName: Copy Connector Framework Docs to staging


### PR DESCRIPTION
When adding connector-framework docs (#6429), I neglected to add the ability for its docs validation build to use the published artifact from the current run. This PR remedies that error.