### PR TITLE
SectionDrawing.insert should insert a SectionDrawingModel

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1689,6 +1689,8 @@ export class Drawing extends Document_2 {
     // @internal (undocumented)
     static get className(): string;
     static createCode(iModel: IModelDb, scopeModelId: CodeScopeProps, codeValue: string): Code;
+    // @internal
+    protected static get drawingModelFullClassName(): string;
     static insert(iModelDb: IModelDb, documentListModelId: Id64String, name: string): Id64String;
 }
 
@@ -4770,6 +4772,8 @@ export class SectionDrawing extends Drawing {
     static get className(): string;
     displaySpatialView: boolean;
     drawingBoundaryClip?: ClipVector;
+    // @internal (undocumented)
+    protected static get drawingModelFullClassName(): string;
     drawingToSpatialTransform?: Transform;
     sectionType: SectionType;
     sheetToSpatialTransform?: Transform;

--- a/common/changes/@itwin/core-backend/AlfonsoM-potentialSectionDrawingInsertBug_2024-03-13-15-56.json
+++ b/common/changes/@itwin/core-backend/AlfonsoM-potentialSectionDrawingInsertBug_2024-03-13-15-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Adding a unit test to showcase a potential bug when calling SectionDrawing.insert. Do NOT merge, the unit test will always fail.",
+      "comment": "Fix SectionDrawing.insert to insert a SectionDrawingModel, not a DrawingModel.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/AlfonsoM-potentialSectionDrawingInsertBug_2024-03-13-15-56.json
+++ b/common/changes/@itwin/core-backend/AlfonsoM-potentialSectionDrawingInsertBug_2024-03-13-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Adding a unit test to showcase a potential bug when calling SectionDrawing.insert. Do NOT merge, the unit test will always fail.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -19,7 +19,7 @@ import { ClipVector, Range3d, Transform } from "@itwin/core-geometry";
 import { Entity } from "./Entity";
 import { IModelDb } from "./IModelDb";
 import { IModelElementCloneContext } from "./IModelElementCloneContext";
-import { DefinitionModel, DrawingModel, PhysicalModel } from "./Model";
+import { DefinitionModel, DrawingModel, PhysicalModel, SectionDrawingModel } from "./Model";
 import { SubjectOwnsSubjects } from "./NavigationRelationship";
 
 /** Argument for the `Element.onXxx` static methods
@@ -800,6 +800,11 @@ export class Drawing extends Document {
   public static override get className(): string { return "Drawing"; }
   protected constructor(props: ElementProps, iModel: IModelDb) { super(props, iModel); }
 
+  /** The name of the DrawingModel class modeled by this element type.
+   * @internal
+   */
+  protected static get drawingModelFullClassName(): string { return DrawingModel.classFullName; }
+
   /** Create a Code for a Drawing given a name that is meant to be unique within the scope of the specified DocumentListModel.
    * @param iModel  The IModelDb
    * @param scopeModelId The Id of the DocumentListModel that contains the Drawing and provides the scope for its name.
@@ -825,7 +830,7 @@ export class Drawing extends Document {
     };
     const drawingId: Id64String = iModelDb.elements.insertElement(drawingProps);
     const model: DrawingModel = iModelDb.models.createModel({
-      classFullName: DrawingModel.classFullName,
+      classFullName: this.drawingModelFullClassName,
       modeledElement: { id: drawingId },
     });
     return iModelDb.models.insertModel(model.toJSON());
@@ -856,6 +861,9 @@ export class SectionDrawing extends Drawing {
 
   /** @internal */
   public static override get className(): string { return "SectionDrawing"; }
+
+  /** @internal */
+  protected static override get drawingModelFullClassName(): string { return SectionDrawingModel.classFullName; }
 
   protected constructor(props: SectionDrawingProps, iModel: IModelDb) {
     super(props, iModel);

--- a/core/backend/src/test/standalone/SectionDrawing.test.ts
+++ b/core/backend/src/test/standalone/SectionDrawing.test.ts
@@ -7,22 +7,29 @@ import { Id64 } from "@itwin/core-bentley";
 import { Transform } from "@itwin/core-geometry";
 import { RelatedElement, SectionDrawingProps, SectionType } from "@itwin/core-common";
 import { Drawing, SectionDrawing } from "../../Element";
-import { DocumentListModel, DrawingModel } from "../../Model";
+import { DocumentListModel, DrawingModel, SectionDrawingModel } from "../../Model";
 import { SnapshotDb } from "../../IModelDb";
 import { IModelTestUtils } from "../IModelTestUtils";
 
 describe("SectionDrawing", () => {
-  it("should round-trip through JSON", () => {
+  let imodel: SnapshotDb;
+  let documentListModelId: string;
+  before(() => {
     const iModelPath = IModelTestUtils.prepareOutputFile("SectionDrawing", "SectionDrawing.bim");
-    const imodel = SnapshotDb.createEmpty(iModelPath, { rootSubject: { name: "SectionDrawingTest" } });
+    imodel = SnapshotDb.createEmpty(iModelPath, { rootSubject: { name: "SectionDrawingTest" } });
+    documentListModelId = DocumentListModel.insert(imodel, SnapshotDb.rootSubjectId, "DocumentList");
+  });
 
+  after(() => {
+    imodel.close();
+  });
+
+  it("should round-trip through JSON", () => {
     // Insert a SectionDrawing
-    const documentListModelId = DocumentListModel.insert(imodel, SnapshotDb.rootSubjectId, "DocumentList");
-
     const drawingId = imodel.elements.insertElement({
       classFullName: SectionDrawing.classFullName,
       model: documentListModelId,
-      code: Drawing.createCode(imodel, documentListModelId, "SectionDrawing"),
+      code: Drawing.createCode(imodel, documentListModelId, "SectionDrawingRoundTrip"),
     });
     expect(Id64.isValidId64(drawingId)).to.be.true;
 
@@ -74,7 +81,20 @@ describe("SectionDrawing", () => {
     // Expect persistent values
     expectProps(drawing);
     expectProps(drawing.toJSON());
+  });
 
-    imodel.close();
+  it("should create a SectionDrawing and SectionDrawingModel on insert", () => {
+    const sectionDrawingId = SectionDrawing.insert(imodel, documentListModelId, "SectionDrawingInsert");
+
+    expect(Id64.isValidId64(sectionDrawingId)).to.be.true;
+
+    const insertedSectionDrawing = imodel.elements.getElement(sectionDrawingId);
+
+    expect(insertedSectionDrawing instanceof SectionDrawing).to.be.true;
+
+    const insertedSectionDrawingModel = imodel.models.getModel(sectionDrawingId);
+
+    // Would have assumed a SectionDrawing would be modeled by a SectionDrawingModel, but this fails
+    expect(insertedSectionDrawingModel instanceof SectionDrawingModel).to.be.true;
   });
 });

--- a/core/backend/src/test/standalone/SectionDrawing.test.ts
+++ b/core/backend/src/test/standalone/SectionDrawing.test.ts
@@ -94,7 +94,6 @@ describe("SectionDrawing", () => {
 
     const insertedSectionDrawingModel = imodel.models.getModel(sectionDrawingId);
 
-    // Would have assumed a SectionDrawing would be modeled by a SectionDrawingModel, but this fails
     expect(insertedSectionDrawingModel.className).to.equal("SectionDrawingModel");
     expect(insertedSectionDrawingModel instanceof SectionDrawingModel).to.be.true;
   });

--- a/core/backend/src/test/standalone/SectionDrawing.test.ts
+++ b/core/backend/src/test/standalone/SectionDrawing.test.ts
@@ -95,6 +95,7 @@ describe("SectionDrawing", () => {
     const insertedSectionDrawingModel = imodel.models.getModel(sectionDrawingId);
 
     // Would have assumed a SectionDrawing would be modeled by a SectionDrawingModel, but this fails
+    expect(insertedSectionDrawingModel.className).to.equal("SectionDrawingModel");
     expect(insertedSectionDrawingModel instanceof SectionDrawingModel).to.be.true;
   });
 });


### PR DESCRIPTION
It was creating the supertype `DrawingModel` instead.
Fixes #6511.