### PR TITLE
Cut Plane Graphics for Batched Tiles

### DIFF
--- a/common/changes/@itwin/core-frontend/man-cut-plane-graphics-for-batched-tiles_2024-03-14-14-07.json
+++ b/common/changes/@itwin/core-frontend/man-cut-plane-graphics-for-batched-tiles_2024-03-14-14-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "added ability of batched tiles to generate cut plane graphics",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/frontend-devtools/man-cut-plane-graphics-for-batched-tiles_2024-03-15-14-44.json
+++ b/common/changes/@itwin/frontend-devtools/man-cut-plane-graphics-for-batched-tiles_2024-03-15-14-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "enhanced fdt test clip style command",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -287,7 +287,10 @@ These keysins control the planar masking of reality models.
 * `fdt clear emphasized` - Undo the effects of `fdt emphasize selection` or `fdt emphasize visible`.
 * `fdt isolate selection` - Causes all elements except those currently in the selection set to stop drawing.
 * `fdt clear isolate` - Reverse the effects of `fdt isolate selection`.
-* `fdt test clip style ON|OFF` - Toggles a ClipStyle for the active viewport with hard-coded symbology overrides.
+* `fdt test clip style ON|OFF` - Toggles a ClipStyle for the active viewport with hard-coded symbology overrides
+  * if using ON, can also optionally specify a CutStyleProps to use instead of the hard-coded default
+  * for example, to produce cut plane geometry which is unlit solid orange you can specify the following command:
+    * `fdt test clip style ON {"viewflags":{"renderMode":6,"lighting":false},"appearance":{"rgb":{"r":255,"g":128,"b":0}}}`
 * `fdt tile bounds` - Sets the type of bounding volume decorations that will be displayed for each tile displayed in the view. Accepts at most one argument; if none is specified, it defaults to "volume", unless tile bounds are already displayed, in which it toggles them back off.
   * "none": Don't display bounding volumes.
   * "volume": Bounding box representing the full range of each tile.

--- a/core/frontend-devtools/src/tools/ClipTools.ts
+++ b/core/frontend-devtools/src/tools/ClipTools.ts
@@ -8,7 +8,7 @@
  */
 
 import {
-  ClipIntersectionStyle, ClipStyle, ClipStyleProps, ColorByName, ColorDef, LinePixels, RenderMode, RgbColor,
+  ClipIntersectionStyle, ClipStyle, ClipStyleProps, ColorByName, ColorDef, CutStyleProps, LinePixels, RenderMode, RgbColor,
 } from "@itwin/core-common";
 import { IModelApp, Tool, Viewport } from "@itwin/core-frontend";
 import { parseToggle } from "./parseToggle";
@@ -225,41 +225,47 @@ export class ToggleSectionCutTool extends Tool {
  */
 export class TestClipStyleTool extends DisplayStyleTool {
   public static override toolId = "TestClipStyle";
-  public static override get maxArgs() { return 1; }
+  public static override get maxArgs() { return 2; }
   public static override get minArgs() { return 1; }
 
   private _useStyle = false;
+  private _style?: CutStyleProps;
 
   protected override get require3d() { return true; }
 
   protected async parse(args: string[]): Promise<boolean> {
     this._useStyle = parseBoolean(args[0]) ?? false;
+    if (this._useStyle && args.length > 1)
+      this._style = JSON.parse(args[1]);
     return true;
   }
 
   protected async execute(vp: Viewport) {
     const props: ClipStyleProps = { produceCutGeometry: true };
     if (this._useStyle) {
-      props.cutStyle = {
-        viewflags: {
-          renderMode: RenderMode.SmoothShade,
-          visibleEdges: true,
-          hiddenEdges: false,
-        },
-        appearance: {
-          rgb: { r: 0xff, g: 0x7f, b: 0 },
-          transparency: 0.5,
-          nonLocatable: true,
-        },
-        hiddenLine: {
-          visible: {
-            ovrColor: true,
-            color: ColorByName.blue,
-            pattern: LinePixels.Solid,
-            width: 3,
+      if (this._style)
+        props.cutStyle = this._style;
+      else
+        props.cutStyle = {
+          viewflags: {
+            renderMode: RenderMode.SmoothShade,
+            visibleEdges: true,
+            hiddenEdges: false,
           },
-        },
-      };
+          appearance: {
+            rgb: { r: 0xff, g: 0x7f, b: 0 },
+            transparency: 0.5,
+            nonLocatable: true,
+          },
+          hiddenLine: {
+            visible: {
+              ovrColor: true,
+              color: ColorByName.blue,
+              pattern: LinePixels.Solid,
+              width: 3,
+            },
+          },
+        };
     }
 
     vp.displayStyle.settings.clipStyle = ClipStyle.fromJSON(props);


### PR DESCRIPTION
This modification allows cut plane graphics to be generated for batched tiles.

It also enhances the fdt test clip style key-in command so that you can optionally specify a CutStyleProps to use for the cut plane geometry instead of the hard-coded one.