### PR TITLE
Add undefined Error to CloudSqlite.requestToken

### DIFF
--- a/common/changes/@itwin/core-backend/mike-add-error-to-request-token_2024-03-14-21-09.json
+++ b/common/changes/@itwin/core-backend/mike-add-error-to-request-token_2024-03-14-21-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Throws an error if BlobContainer.service is undefined in CloudSqlite.requestToken",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -39,7 +39,11 @@ export namespace CloudSqlite {
   export async function requestToken(args: RequestTokenArgs): Promise<AccessToken> {
     // allow the userToken to be supplied via Rpc. If not supplied, or blank, use the backend's accessToken.
     const userToken = args.userToken ? args.userToken : (await IModelHost.getAccessToken());
-    const response = await BlobContainer.service?.requestToken({ ...args, userToken });
+    if (BlobContainer.service === undefined) {
+      logError(`BlobContainer.service is not defined`);
+      throw new Error(`BlobContainer.service is not defined`);
+    }
+    const response = await BlobContainer.service.requestToken({ ...args, userToken });
     return response?.token ?? "";
   }
 

--- a/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
+++ b/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
@@ -477,5 +477,12 @@ describe("CloudSqlite", () => {
     clock.restore();
     sinon.restore();
   });
+
+  it("should throw error if BlobContainer.service is undefined", async () => {
+    const contain1 = testContainers[0];
+    const contProps = { baseUri: AzuriteTest.baseUri, containerId: contain1.containerId, storageType: AzuriteTest.storageType, writeable: true };
+    const accessToken = await CloudSqlite.requestToken(contProps);
+    expect(() => accessToken).throws("BlobContainer.service is not defined");
+  });
 });
 


### PR DESCRIPTION
CloudSqlite.requestToken now throws an error if BlobContainer.service is undefined.

This prevents confusion in cases where the BlobContainer.service might be defined but authentication is unsuccessful. 

#6518 