### PR TITLE
Fix glTF instance transform

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-gltf-instance-transform_2024-03-18-16-47.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-gltf-instance-transform_2024-03-18-16-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix incorrect transforms computed for instanced glTF meshes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -303,7 +303,7 @@ function trsMatrix(translation: [number, number, number] | undefined, rotation: 
   const rotTf = Transform.createRefs(undefined, rotation ? Matrix3d.createFromQuaternion(Point4d.create(rotation[0], rotation[1], rotation[2], rotation[3])) : Matrix3d.identity);
   rotTf.matrix.transposeInPlace(); // See comment on Matrix3d.createFromQuaternion
   const transTf = Transform.createTranslation(translation ? new Point3d(translation[0], translation[1], translation[2]) : Point3d.createZero());
-  const tf = scaleTf.multiplyTransformTransform(rotTf, result);
+  const tf = rotTf.multiplyTransformTransform(scaleTf, result);
   transTf.multiplyTransformTransform(tf, tf);
   return tf;
 }


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwin-graphics-backlog/issues/124.
Rotation and scale were being multiplied in the opposite of the order mandated by the [specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md#transformation-order).