### PR TITLE
Struct property null update handling test

### DIFF
--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -59,45 +59,64 @@ interface TestElementAspect extends IPrimitive, IPrimitiveArray, ElementAspectPr
 interface TestElementRefersToElements extends IPrimitive, IPrimitiveArray, ElementRefersToElements { }
 
 function verifyPrimitiveBase(actualValue: IPrimitiveBase, expectedValue: IPrimitiveBase) {
-  if (expectedValue.i)
+  if (expectedValue.i !== undefined)
     assert.equal(actualValue.i, expectedValue.i, "'integer' type property did not roundtrip as expected");
-  if (expectedValue.l)
+  if (expectedValue.l !== undefined)
     assert.equal(actualValue.l, expectedValue.l, "'long' type property did not roundtrip as expected");
-  if (expectedValue.d)
+  if (expectedValue.d !== undefined)
     assert.equal(actualValue.d, expectedValue.d, "'double' type property did not roundtrip as expected");
-  if (expectedValue.b)
+  if (expectedValue.b !== undefined)
     assert.equal(actualValue.b, expectedValue.b, "'boolean' type property did not roundtrip as expected");
-  if (expectedValue.dt)
+  if (expectedValue.dt !== undefined)
     assert.equal(actualValue.dt, expectedValue.dt, "'dateTime' type property did not roundtrip as expected");
-  if (expectedValue.s)
+  if (expectedValue.s !== undefined)
     assert.equal(actualValue.s, expectedValue.s, "'string' type property did not roundtrip as expected");
   if (expectedValue.p2d) {
-    assert.equal(actualValue.p2d?.x, expectedValue.p2d?.x, "'Point2d.x' type property did not roundtrip as expected");
-    assert.equal(actualValue.p2d?.y, expectedValue.p2d?.y, "'Point2d.y' type property did not roundtrip as expected");
+    assert.equal(actualValue.p2d?.x, expectedValue.p2d.x, "'Point2d.x' type property did not roundtrip as expected");
+    assert.equal(actualValue.p2d?.y, expectedValue.p2d.y, "'Point2d.y' type property did not roundtrip as expected");
+  } else if(expectedValue.p2d === null) {
+    assert.equal(actualValue.p2d, expectedValue.p2d, "'Point2d' type property did not roundtrip as expected.");
   }
   if (expectedValue.p3d) {
-    assert.equal(actualValue.p3d?.x, expectedValue.p3d?.x, "'Point3d.x' type property did not roundtrip as expected");
-    assert.equal(actualValue.p3d?.y, expectedValue.p3d?.y, "'Point3d.y' type property did not roundtrip as expected");
-    assert.equal(actualValue.p3d?.z, expectedValue.p3d?.z, "'Point3d.z' type property did not roundtrip as expected");
+    assert.equal(actualValue.p3d?.x, expectedValue.p3d.x, "'Point3d.x' type property did not roundtrip as expected");
+    assert.equal(actualValue.p3d?.y, expectedValue.p3d.y, "'Point3d.y' type property did not roundtrip as expected");
+    assert.equal(actualValue.p3d?.z, expectedValue.p3d.z, "'Point3d.z' type property did not roundtrip as expected");
+  } else if(expectedValue.p3d === null) {
+    assert.equal(actualValue.p3d, expectedValue.p3d, "'Point3d' type property did not roundtrip as expected.");
   }
-  if (expectedValue.bin)
+  if (expectedValue.bin) {
     assert.isTrue(blobEqual(actualValue.bin, expectedValue.bin), "'binary' type property did not roundtrip as expected");
-  if (expectedValue.g)
+  } else if(expectedValue.bin === null) {
+    assert.equal(actualValue.bin, expectedValue.bin, "'binary' type property did not roundtrip as expected.");
+  }
+  if (expectedValue.g) {
     expect(actualValue.g, "'geometry' type property did not roundtrip as expected.").to.deep.equal(expectedValue.g);
+  } else if(expectedValue.g === null) {
+    assert.equal(actualValue.g, expectedValue.g, "'geometry' type property did not roundtrip as expected.");
+  }
 }
 
 function verifyPrimitiveArrayBase(actualValue: IPrimitiveArrayBase, expectedValue: IPrimitiveArrayBase) {
   if (expectedValue.array_bin) {
     assert.equal(actualValue.array_bin!.length, expectedValue.array_bin.length, "'binary[].length' array length mismatch");
     expectedValue.array_bin.forEach((value, index) => {
-      assert.isTrue(blobEqual(actualValue.array_bin![index], value), "'binary[]' type property did not roundtrip as expected");
+      if(value) {
+        assert.isTrue(blobEqual(actualValue.array_bin![index], value), "'binary[]' type property did not roundtrip as expected");
+      } else if(value === null) {
+        assert.equal(actualValue.array_bin![index], value, "'binary[]' type property did not roundtrip as expected");
+      }
     });
+  } else if(expectedValue.array_bin === null) {
+    assert.equal(actualValue.array_bin, expectedValue.array_bin, "'binary[]' type property did not roundtrip as expected.");
   }
+
   if (expectedValue.array_i) {
     assert.equal(actualValue.array_i!.length, expectedValue.array_i.length, "'integer[].length' array length mismatch");
     expectedValue.array_i.forEach((value, index) => {
       assert.equal(actualValue.array_i![index], value, "'integer[]' type property did not roundtrip as expected");
     });
+  } else if(expectedValue.array_i === null) {
+    assert.equal(actualValue.array_i, expectedValue.array_i, "'integer[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_l) {
@@ -105,6 +124,8 @@ function verifyPrimitiveArrayBase(actualValue: IPrimitiveArrayBase, expectedValu
     expectedValue.array_l.forEach((value, index) => {
       assert.equal(actualValue.array_l![index], value, "'long[]' type property did not roundtrip as expected");
     });
+  } else if(expectedValue.array_l === null) {
+    assert.equal(actualValue.array_l, expectedValue.array_l, "'long[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_d) {
@@ -112,6 +133,8 @@ function verifyPrimitiveArrayBase(actualValue: IPrimitiveArrayBase, expectedValu
     expectedValue.array_d.forEach((value, index) => {
       assert.equal(actualValue.array_d![index], value, "'double[]' type property did not roundtrip as expected");
     });
+  } else if(expectedValue.array_d === null) {
+    assert.equal(actualValue.array_d, expectedValue.array_d, "'double[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_b) {
@@ -119,6 +142,8 @@ function verifyPrimitiveArrayBase(actualValue: IPrimitiveArrayBase, expectedValu
     expectedValue.array_b.forEach((value, index) => {
       assert.equal(actualValue.array_b![index], value, "'boolean[]' type property did not roundtrip as expected");
     });
+  } else if(expectedValue.array_b === null) {
+    assert.equal(actualValue.array_b, expectedValue.array_b, "'boolean[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_dt) {
@@ -126,13 +151,21 @@ function verifyPrimitiveArrayBase(actualValue: IPrimitiveArrayBase, expectedValu
     expectedValue.array_dt.forEach((value, index) => {
       assert.equal(actualValue.array_dt![index], value, "'dateTime[]' type property did not roundtrip as expected");
     });
+  } else if(expectedValue.array_dt === null) {
+    assert.equal(actualValue.array_dt, expectedValue.array_dt, "'dateTime[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_g) {
     assert.equal(actualValue.array_g!.length, expectedValue.array_g.length, "'geometry[].length' array length mismatch");
     expectedValue.array_g.forEach((value, index) => {
-      expect(actualValue.array_g![index], "'geometry[]' type property did not roundtrip as expected").to.deep.equal(value);
+      if(value) {
+        expect(actualValue.array_g![index], "'geometry[]' type property did not roundtrip as expected").to.deep.equal(value);
+      } else if(value === null) {
+        assert.equal(actualValue.array_g![index], value, "'geometry[]' type property did not roundtrip as expected");
+      }
     });
+  } else if(expectedValue.array_g === null) {
+    assert.equal(actualValue.array_g, expectedValue.array_g, "'geometry[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_s) {
@@ -140,23 +173,37 @@ function verifyPrimitiveArrayBase(actualValue: IPrimitiveArrayBase, expectedValu
     expectedValue.array_s.forEach((value, index) => {
       assert.equal(actualValue.array_s![index], value, "'string[]' type property did not roundtrip as expected");
     });
+  } else if(expectedValue.array_s === null) {
+    assert.equal(actualValue.array_s, expectedValue.array_s, "'string[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_p2d) {
     assert.equal(actualValue.array_p2d!.length, expectedValue.array_p2d.length, "'point2d[].length' array length mismatch");
     expectedValue.array_p2d.forEach((value, index) => {
-      assert.equal(actualValue.array_p2d![index].x, value.x, "'point2d[].x' type property did not roundtrip as expected");
-      assert.equal(actualValue.array_p2d![index].y, value.y, "'point2d[].y' type property did not roundtrip as expected");
+      if (value) {
+        assert.equal(actualValue.array_p2d![index].x, value.x, "'point2d[].x' type property did not roundtrip as expected");
+        assert.equal(actualValue.array_p2d![index].y, value.y, "'point2d[].y' type property did not roundtrip as expected");
+      } else if (value === null) {
+        assert.equal(actualValue.array_p2d![index], value, "'point2d[]' type property did not roundtrip as expected.");
+      }
     });
+  } else if(expectedValue.array_p2d === null) {
+    assert.equal(actualValue.array_p2d, expectedValue.array_p2d, "'point2d[]' type property did not roundtrip as expected.");
   }
 
   if (expectedValue.array_p3d) {
     assert.equal(actualValue.array_p3d!.length, expectedValue.array_p3d.length, "'point3d[].length' array length mismatch");
     expectedValue.array_p3d.forEach((value, index) => {
-      assert.equal(actualValue.array_p3d![index].x, value.x, "'point3d[].x' type property did not roundtrip as expected");
-      assert.equal(actualValue.array_p3d![index].y, value.y, "'point3d[].y' type property did not roundtrip as expected");
-      assert.equal(actualValue.array_p3d![index].z, value.z, "'point3d[].z' type property did not roundtrip as expected");
+      if(value) {
+        assert.equal(actualValue.array_p3d![index].x, value.x, "'point3d[].x' type property did not roundtrip as expected");
+        assert.equal(actualValue.array_p3d![index].y, value.y, "'point3d[].y' type property did not roundtrip as expected");
+        assert.equal(actualValue.array_p3d![index].z, value.z, "'point3d[].z' type property did not roundtrip as expected");
+      } else if(value === null) {
+        assert.equal(actualValue.array_p3d![index], value, "'point3d[]' type property did not roundtrip as expected.");
+      }
     });
+  } else if(expectedValue.array_p3d === null) {
+    assert.equal(actualValue.array_p3d, expectedValue.array_p3d, "'point3d[]' type property did not roundtrip as expected.");
   }
 }
 
@@ -165,6 +212,8 @@ function verifyPrimitive(actualValue: IPrimitive, expectedValue: IPrimitive) {
   if (expectedValue.st) {
     verifyPrimitive(actualValue.st!, expectedValue.st);
     verifyPrimitiveArray(actualValue.st!, expectedValue.st);
+  } else if(expectedValue.st === null) {
+    assert.equal(actualValue.st, expectedValue.st, "'ComplexStruct' type property did not roundtrip as expected.");
   }
 }
 
@@ -176,6 +225,8 @@ function verifyPrimitiveArray(actualValue: IPrimitiveArray, expectedValue: IPrim
       verifyPrimitiveBase(lhs, expectedValue.array_st![i]);
       verifyPrimitiveArrayBase(lhs, expectedValue.array_st![i]);
     });
+  } else if(expectedValue.array_st === null) {
+    assert.equal(actualValue.array_st, expectedValue.array_st, "'ComplexStruct[]' type property did not roundtrip as expected.");
   }
 }
 
@@ -554,19 +605,43 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     imodel.close();
   });
 
+  async function verifyElementAspect(elementAspect: ElementAspectProps, elementId: string, expectedAspectFullName: string, iModel: SnapshotDb): Promise<ElementAspectProps[]>{
+    // Verify updated values
+    const updatedAspectValue: ElementAspectProps[] = iModel.elements.getAspects(elementId, expectedAspectFullName).map((x) => x.toJSON());
+    assert.equal(updatedAspectValue.length, 1);
+    verifyTestElementAspect(updatedAspectValue[0], elementAspect);
+
+    // Verify via a concurrent query
+    let rowCount = 0;
+    for await (const row of iModel.createQueryReader("SELECT * FROM ts.TestElementAspect", undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames })) {
+      verifyTestElementAspect(row.toRow() as TestElementAspect, elementAspect);
+      rowCount++;
+    }
+    assert.equal(rowCount, 1);
+
+    // Verify via an ECSql statement
+    await iModel.withPreparedStatement("SELECT * FROM ts.TestElementAspect", async (stmt: ECSqlStatement) => {
+      assert.equal(stmt.step(), DbResult.BE_SQLITE_ROW);
+      const stmtRow = stmt.getRow() as TestElementAspect;
+      verifyTestElementAspect(stmtRow, elementAspect);
+    });
+
+    return updatedAspectValue;
+  }
+
   it("Roundtrip all type of properties via ElementAspectApi, ConcurrentQuery and ECSqlStatement via insert and update", async () => {
     const testFileName = IModelTestUtils.prepareOutputFile(subDirName, "roundtrip_apsect_correct_data.bim");
     const imodel = IModelTestUtils.createSnapshotFromSeed(testFileName, iModelPath);
     const spatialCategoryId = SpatialCategory.queryCategoryIdByName(imodel, IModel.dictionaryId, categoryName);
     const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(imodel, Code.createEmpty(), true);
 
-    // create element to use with the ElementAspects
+    // Create an element to use with the ElementAspects
     const expectedValue = initElemProps("TestElement", imodel, newModelId, spatialCategoryId!, {}) as TestElement;
 
-    // insert a element
+    // Insert an element
     const geomElement = imodel.elements.createElement(expectedValue);
     const elId = imodel.elements.insertElement(geomElement.toJSON());
-    assert.isTrue(Id64.isValidId64(elId), "insert worked");
+    assert.isTrue(Id64.isValidId64(elId), "Element insertion succeeded");
 
     const expectedAspectValue = initElementAspectProps("TestElementAspect", imodel, elId, {
       ...primInst1,
@@ -575,31 +650,14 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
       array_st: [{ ...primInst1, ...primArrInst2 }, { ...primInst2, ...primArrInst1 }],
     }) as TestElementAspect;
 
-    // insert a element aspect
+    // Insert an element aspect
     imodel.elements.insertAspect(expectedAspectValue);
     imodel.saveChanges();
 
-    // verify inserted element aspect properties
-    const actualAspectValue: ElementAspectProps[] = imodel.elements.getAspects(elId, expectedAspectValue.classFullName).map((x) => x.toJSON());
-    assert.equal(actualAspectValue.length, 1);
-    verifyTestElementAspect(actualAspectValue[0], expectedAspectValue);
+    // Verify inserted element aspect properties
+    const actualAspectValue = await verifyElementAspect(expectedAspectValue, elId, expectedAspectValue.classFullName, imodel);
 
-    // verify via concurrent query
-    let rowCount = 0;
-    for await (const row of imodel.createQueryReader("SELECT * FROM ts.TestElementAspect", undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames })) {
-      verifyTestElementAspect(row.toRow() as TestElementAspect, expectedAspectValue);
-      rowCount++;
-    }
-    assert.equal(rowCount, 1);
-
-    // verify via ecsql statement
-    await imodel.withPreparedStatement("SELECT * FROM ts.TestElementAspect", async (stmt: ECSqlStatement) => {
-      assert.equal(stmt.step(), DbResult.BE_SQLITE_ROW);
-      const stmtRow = stmt.getRow() as TestElementAspect;
-      verifyTestElementAspect(stmtRow, expectedAspectValue);
-    });
-
-    // update the element autohandled properties
+    // Update the element's autohandled properties
     Object.assign(actualAspectValue[0], {
       ...primInst2,
       ...primArrInst2,
@@ -607,29 +665,12 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
       array_st: [{ ...primInst2, ...primArrInst2 }, { ...primInst1, ...primArrInst1 }],
     });
 
-    // update element
+    // Update the element
     imodel.elements.updateAspect(actualAspectValue[0]);
     imodel.saveChanges();
 
-    // verify updated values
-    const updatedAspectValue: ElementAspectProps[] = imodel.elements.getAspects(elId, expectedAspectValue.classFullName).map((x) => x.toJSON());
-    assert.equal(updatedAspectValue.length, 1);
-    verifyTestElementAspect(updatedAspectValue[0], actualAspectValue[0]);
-
-    // verify via concurrent query
-    rowCount = 0;
-    for await (const row of imodel.createQueryReader("SELECT * FROM ts.TestElementAspect", undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames })) {
-      verifyTestElementAspect(row.toRow() as TestElementAspect, actualAspectValue[0]);
-      rowCount++;
-    }
-    assert.equal(rowCount, 1);
-
-    // verify via ecsql statement
-    await imodel.withPreparedStatement("SELECT * FROM ts.TestElementAspect", async (stmt: ECSqlStatement) => {
-      assert.equal(stmt.step(), DbResult.BE_SQLITE_ROW);
-      const stmtRow = stmt.getRow() as TestElementAspect;
-      verifyTestElementAspect(stmtRow, actualAspectValue[0]);
-    });
+    // Verify updated element aspect properties
+    await verifyElementAspect(actualAspectValue[0], elId, expectedAspectValue.classFullName, imodel);
 
     imodel.close();
   });
@@ -851,5 +892,51 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     testBox({ originX: 0 }, 0);
     testBox({ baseOriginX: 5 }, 5);
     testBox({ originX: 2, baseOriginX: 4 }, 2);
+  });
+
+  it("Roundtrip setting struct propertty to null", async () => {
+    const testFileName = IModelTestUtils.prepareOutputFile(subDirName, "roundtrip_struct_property_null_update.bim");
+    const imodel = IModelTestUtils.createSnapshotFromSeed(testFileName, iModelPath);
+    const spatialCategoryId = SpatialCategory.queryCategoryIdByName(imodel, IModel.dictionaryId, categoryName);
+    const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(imodel, Code.createEmpty(), true);
+
+    // Create an element to use with the ElementAspects
+    const expectedValue = initElemProps("TestElement", imodel, newModelId, spatialCategoryId!, {}) as TestElement;
+
+    // Insert an element
+    const geomElement = imodel.elements.createElement(expectedValue);
+    const elId = imodel.elements.insertElement(geomElement.toJSON());
+    assert.isTrue(Id64.isValidId64(elId), "Element insertion succeeded");
+
+    const expectedAspectValue = initElementAspectProps("TestElementAspect", imodel, elId, {
+      ...primInst1,
+      ...primArrInst1,
+      st: { ...primArrInst2, ...primInst1 },
+      array_st: [{ ...primInst1, ...primArrInst2 }, { ...primInst2, ...primArrInst1 }],
+    }) as TestElementAspect;
+
+    // Insert an element aspect
+    imodel.elements.insertAspect(expectedAspectValue);
+    imodel.saveChanges();
+
+    // Verify inserted element aspect properties
+    const actualAspectValue = await verifyElementAspect(expectedAspectValue, elId, expectedAspectValue.classFullName, imodel);
+
+    // Update struct property to null.
+    {
+      Object.assign(actualAspectValue[0], {
+        ...actualAspectValue[0],
+        st: null,
+      });
+
+      // Update the element
+      imodel.elements.updateAspect(actualAspectValue[0]);
+      imodel.saveChanges();
+
+      // Verify updated element aspect properties
+      await verifyElementAspect(actualAspectValue[0], elId, expectedAspectValue.classFullName, imodel);
+    }
+
+    imodel.close();
   });
 });


### PR DESCRIPTION
Related PR on iModel-native side iTwin/imodel-native#688 aiming to solve issue iTwin/itwinjs-backlog#1057

This changes how we check for expectedValues in the test fixture, where null equals to setting to null and undefined means no change.