### PR TITLE
Support EXT_meshopt_compression

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -659,6 +659,10 @@
       "allowedCategories": [ "tools" ]
     },
     {
+      "name": "meshoptimizer",
+      "allowedCategories": [ "frontend" ]
+    },
+    {
       "name": "mkdirp",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -591,6 +591,7 @@ importers:
       eslint: ^8.44.0
       fuse.js: ^3.3.0
       glob: ^7.1.2
+      meshoptimizer: ~0.20.0
       mocha: ^10.2.0
       nyc: ^15.1.0
       rimraf: ^3.0.2
@@ -609,6 +610,7 @@ importers:
       '@loaders.gl/core': 3.1.6
       '@loaders.gl/draco': 3.1.6
       fuse.js: 3.3.0
+      meshoptimizer: 0.20.0
       wms-capabilities: 0.4.0
     devDependencies:
       '@itwin/appui-abstract': link:../../ui/appui-abstract
@@ -4894,7 +4896,7 @@ packages:
   /@types/cpx/1.5.2:
     resolution: {integrity: sha512-CL9DbTAdf5NYcbYpBTli6JxVIpCAhJp1FeQiXd9SNjbC4o9k6McnHkU0FHgj9UYoN7TVX3poaaBrwFabTY7Skw==}
     dependencies:
-      '@types/node': 18.16.20
+      '@types/node': 18.16.1
     dev: false
 
   /@types/debug/4.1.12:
@@ -5078,6 +5080,10 @@ packages:
   /@types/node/16.18.87:
     resolution: {integrity: sha512-+IzfhNirR/MDbXz6Om5eHV54D9mQlEMGag6AgEzlju0xH3M8baCXYwqQ6RKgGMpn9wSTx6Ltya/0y4Z8eSfdLw==}
     dev: true
+
+  /@types/node/18.16.1:
+    resolution: {integrity: sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA==}
+    dev: false
 
   /@types/node/18.16.20:
     resolution: {integrity: sha512-nL54VfDjThdP2UXJXZao5wp76CDiDw4zSRO8d4Tk7UgDqNKGKVEQB0/t3ti63NS+YNNkIQDvwEAF04BO+WYu7Q==}
@@ -10004,6 +10010,10 @@ packages:
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  /meshoptimizer/0.20.0:
+    resolution: {integrity: sha512-olcJ1q+YVnjroRJpCL1Dj5aZxr2JMr2hRutMUwhuHZvpAL7SIZgOT6eMlFF4TbBGSR89tawE/gqB79J/LrW/Nw==}
+    dev: false
 
   /methods/1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -99,6 +99,7 @@
     "@loaders.gl/core": "^3.1.6",
     "@loaders.gl/draco": "^3.1.6",
     "fuse.js": "^3.3.0",
+    "meshoptimizer": "~0.20.0",
     "wms-capabilities": "0.4.0"
   },
   "nyc": {

--- a/core/frontend/src/common/gltf/GltfSchema.ts
+++ b/core/frontend/src/common/gltf/GltfSchema.ts
@@ -502,6 +502,12 @@ export function isGltf1Material(material: GltfMaterial): material is Gltf1Materi
 export interface GltfBuffer extends GltfChildOfRootProperty {
   uri?: string;
   byteLength?: number;
+  extensions?: GltfExtensions & {
+    // https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+    EXT_meshopt_compression?: {
+      fallback?: boolean;
+    };
+  };
 }
 
 /** @internal */
@@ -511,6 +517,18 @@ export interface GltfBufferViewProps extends GltfChildOfRootProperty {
   byteOffset?: number;
   byteStride?: number;
   target?: GltfBufferTarget;
+  extensions?: GltfExtensions & {
+    // https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+    EXT_meshopt_compression?: {
+      buffer: number;
+      byteOffset?: number;
+      byteLength: number;
+      byteStride: number;
+      count: number;
+      mode: "ATTRIBUTES" | "TRIANGLES" | "INDICES";
+      filter?: "NONE" | "OCTAHEDRAL" | "QUATERNION";
+    };
+  };
 }
 
 /** @internal */

--- a/core/frontend/src/common/gltf/GltfSchema.ts
+++ b/core/frontend/src/common/gltf/GltfSchema.ts
@@ -510,6 +510,19 @@ export interface GltfBuffer extends GltfChildOfRootProperty {
   };
 }
 
+/** https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
+ * @internal
+*/
+export interface GltfBufferViewMeshoptCompressionExtension {
+  buffer: number;
+  byteOffset?: number;
+  byteLength: number;
+  byteStride: number;
+  count: number;
+  mode: "ATTRIBUTES" | "TRIANGLES" | "INDICES";
+  filter?: "NONE" | "OCTAHEDRAL" | "QUATERNION";
+}
+
 /** @internal */
 export interface GltfBufferViewProps extends GltfChildOfRootProperty {
   buffer: GltfId;
@@ -518,16 +531,7 @@ export interface GltfBufferViewProps extends GltfChildOfRootProperty {
   byteStride?: number;
   target?: GltfBufferTarget;
   extensions?: GltfExtensions & {
-    // https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
-    EXT_meshopt_compression?: {
-      buffer: number;
-      byteOffset?: number;
-      byteLength: number;
-      byteStride: number;
-      count: number;
-      mode: "ATTRIBUTES" | "TRIANGLES" | "INDICES";
-      filter?: "NONE" | "OCTAHEDRAL" | "QUATERNION";
-    };
+    EXT_meshopt_compression?: GltfBufferViewMeshoptCompressionExtension;
   };
 }
 

--- a/core/frontend/src/common/gltf/GltfSchema.ts
+++ b/core/frontend/src/common/gltf/GltfSchema.ts
@@ -510,6 +510,12 @@ export interface GltfBuffer extends GltfChildOfRootProperty {
   };
 }
 
+/** @internal */
+export type ExtMeshoptCompressionMode = "ATTRIBUTES" | "TRIANGLES" | "INDICES";
+
+/** @internal */
+export type ExtMeshoptCompressionFilter = "NONE" | "OCTAHEDRAL" | "QUATERNION";
+
 /** https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/README.md
  * @internal
 */
@@ -519,8 +525,8 @@ export interface GltfBufferViewMeshoptCompressionExtension {
   byteLength: number;
   byteStride: number;
   count: number;
-  mode: "ATTRIBUTES" | "TRIANGLES" | "INDICES";
-  filter?: "NONE" | "OCTAHEDRAL" | "QUATERNION";
+  mode: ExtMeshoptCompressionMode;
+  filter?: ExtMeshoptCompressionFilter;
 }
 
 /** @internal */

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1630,7 +1630,7 @@ export abstract class GltfReader {
     for (const bv of gltfDictionaryIterator(this._bufferViews)) {
       const ext = bv.extensions?.EXT_meshopt_compression;
       if (ext) {
-        const bufferData = this._buffers[bv.buffer]?.resolvedBuffer;
+        const bufferData = this._buffers[ext.buffer]?.resolvedBuffer;
         if (bufferData) {
           const source = new Uint8Array(bufferData.buffer, bufferData.byteOffset + (ext.byteOffset ?? 0), ext.byteLength ?? 0);
           const decode = async () => {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1388,9 +1388,17 @@ export abstract class GltfReader {
       if (GltfDataType.UnsignedShort !== view.type)
         return false;
 
+      let rangeMin, rangeMax;
       const quantized = view.accessor.extensions?.WEB3D_quantized_attributes;
-      const rangeMin = quantized?.decodedMin;
-      const rangeMax = quantized?.decodedMax;
+      if (quantized) {
+        rangeMin = quantized.decodedMin;
+        rangeMax = quantized.decodedMax;
+      } else {
+        // Assume KHR_mesh_quantization...
+        rangeMin = view.accessor.min;
+        rangeMax = view.accessor.max;
+      }
+      
       if (!rangeMin || !rangeMax) // required by spec...
         return false;
 

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -28,6 +28,7 @@ import { Triangle } from "../render/primitives/Primitives";
 import { RenderGraphic } from "../render/RenderGraphic";
 import { RenderSystem } from "../render/RenderSystem";
 import { RealityTileGeometry, TileContent } from "./internal";
+import { decodeMeshoptBuffer } from "./MeshoptCompression";
 import type { DracoLoader, DracoMesh } from "@loaders.gl/draco";
 import { CreateRenderMaterialArgs } from "../render/CreateRenderMaterialArgs";
 import { DisplayParams } from "../common/render/primitives/DisplayParams";

--- a/core/frontend/src/tile/MeshoptCompression.ts
+++ b/core/frontend/src/tile/MeshoptCompression.ts
@@ -71,6 +71,7 @@ class Loader {
     } catch (err) {
       Logger.logException(FrontendLoggerCategory.Render, err);
       this._status = "failed";
+    } finally {
       this._promise = undefined;
     }
   }

--- a/core/frontend/src/tile/MeshoptCompression.ts
+++ b/core/frontend/src/tile/MeshoptCompression.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Tiles
+ */
+
+import { assert, Logger } from "@itwin/core-bentley";
+import { FrontendLoggerCategory } from "../common/FrontendLoggerCategory";
+import type { MeshoptDecoder } from "meshoptimizer";
+import type { ExtMeshoptCompressionFilter, ExtMeshoptCompressionMode } from "../common/gltf/GltfSchema";
+
+export interface DecodeMeshoptBufferArgs {
+  byteStride: number;
+  count: number;
+  mode: ExtMeshoptCompressionMode;
+  filter?: ExtMeshoptCompressionFilter;
+}
+
+class Loader {
+  private _status: "uninitialized" | "loading" | "ready" | "failed";
+  private _promise?: Promise<void>;
+  private _decoder?: typeof MeshoptDecoder;
+
+  public constructor() {
+    this._status = "uninitialized";
+  }
+
+  public async getDecoder(): Promise<typeof MeshoptDecoder | undefined> {
+    const status = this._status;
+    switch (status) {
+      case "failed":
+        assert(undefined === this._decoder);
+        assert(undefined === this._promise);
+        return undefined;
+      case "ready":
+        assert(undefined !== this._decoder);
+        assert(undefined === this._promise);
+        return this._decoder;
+      case "loading":
+        assert(undefined !== this._promise);
+        await this._promise;
+        assert("failed" === this._status || "ready" === this._status);
+        assert(undefined === this._promise);
+        return this._decoder;
+    }
+
+    assert("uninitialized" === status);
+    this._status = "loading";
+    this._promise = this.load();
+
+    return this.getDecoder();
+  }
+
+  private async load(): Promise<void> {
+    try {
+      // Import the module on first use.
+      const decoder = (await import("meshoptimizer")).MeshoptDecoder;
+      await decoder.ready;
+
+      // Configure it to do the decoding outside of the main thread. No compelling reason to use more than one worker.
+      decoder.useWorkers(1);
+
+      this._status = "ready";
+      this._decoder = decoder;
+    } catch (err) {
+      Logger.logException(FrontendLoggerCategory.Render, err);
+      this._status = "failed";
+      this._promise = undefined;
+    }
+  }
+}
+
+const loader = new Loader();
+
+/** @internal */
+export async function decodeMeshoptBuffer(source: Uint8Array, args: DecodeMeshoptBufferArgs): Promise<Uint8Array | undefined> {
+  const decoder = await loader.getDecoder();
+  if (!decoder) {
+    return undefined;
+  }
+
+  return decoder.decodeGltfBufferAsync(args.count, args.byteStride, source, args.mode, args.filter);
+}

--- a/core/frontend/src/tile/MeshoptCompression.ts
+++ b/core/frontend/src/tile/MeshoptCompression.ts
@@ -11,6 +11,9 @@ import { FrontendLoggerCategory } from "../common/FrontendLoggerCategory";
 import type { MeshoptDecoder } from "meshoptimizer";
 import type { ExtMeshoptCompressionFilter, ExtMeshoptCompressionMode } from "../common/gltf/GltfSchema";
 
+/** Arguments supplied to decodeMeshoptBuffer.
+ * @internal
+ */
 export interface DecodeMeshoptBufferArgs {
   byteStride: number;
   count: number;
@@ -18,6 +21,7 @@ export interface DecodeMeshoptBufferArgs {
   filter?: ExtMeshoptCompressionFilter;
 }
 
+/** Loads and configures the MeshoptDecoder module on demand. */
 class Loader {
   private _status: "uninitialized" | "loading" | "ready" | "failed";
   private _promise?: Promise<void>;


### PR DESCRIPTION
This is the only type of compression supported by glTF for points. It significantly reduces the file size, so we want to use it in our point cloud exporters.

The [meshoptimizer decoder library](https://www.npmjs.com/package/meshoptimizer/v/0.20.0) is the de facto standard (provided by the same people who maintain the C++ encoder+decoder). I'm doing the decoding in a single web worker to avoid blocking the main event loop.

I'm testing against the [pirate sample](https://github.com/zeux/meshoptimizer/blob/master/demo/pirate.glb); awaiting a point cloud sample.
The pirate sample uses a couple of other glTF features that we lack, so I'm adding them too:
- [x] KHR_mesh_quantization
- [ ] signed, normalized, 8-bit normals