### PR TITLE
Add note to GenericInstanceFilterRuleOperator

### DIFF
--- a/common/changes/@itwin/core-common/like-operator-note_2024-03-29-07-55.json
+++ b/common/changes/@itwin/core-common/like-operator-note_2024-03-29-07-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Added note to `GenericInstanceFilterRuleOperator` that `like` operator should be handled as a contains operator.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -33,6 +33,7 @@ export interface GenericInstanceFilter {
 
 /**
  * Type definition that describes operators supported by [[GenericInstanceFilterRule]].
+ * @note `like` operator should be handled as a contains operator - it matches all strings that contain a given string.
  * @beta
  */
 export type GenericInstanceFilterRuleOperator =


### PR DESCRIPTION
Added note to `GenericInstanceFilterRuleOperator` that `like` operator should be handled as a `contains` operator as discussed in [496](https://github.com/iTwin/presentation/pull/496).