### PR TITLE
Improve ChangesetConflictArgs & SqliteChangeSetReader API

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -51,9 +51,11 @@ import { Constructor } from '@itwin/core-bentley';
 import { CreateEmptySnapshotIModelProps } from '@itwin/core-common';
 import { CreateEmptyStandaloneIModelProps } from '@itwin/core-common';
 import { CreateSnapshotIModelProps } from '@itwin/core-common';
+import { DbChangeStage } from '@itwin/core-bentley';
 import { DbConflictCause } from '@itwin/core-bentley';
 import { DbOpcode } from '@itwin/core-bentley';
 import { DbResult } from '@itwin/core-bentley';
+import { DbValueType } from '@itwin/core-bentley';
 import { DefinitionElementProps } from '@itwin/core-common';
 import { DisplayStyle3dProps } from '@itwin/core-common';
 import { DisplayStyle3dSettings } from '@itwin/core-common';
@@ -696,11 +698,29 @@ export interface ChangesetConflictArgs {
     // (undocumented)
     changesetFile?: string;
     // (undocumented)
+    columnCount: number;
+    // (undocumented)
     dump: () => void;
     // (undocumented)
     getForeignKeyConflicts: () => number;
     // (undocumented)
+    getPrimaryKeyColumns: () => number[];
+    // (undocumented)
+    getValueBinary: (columnIndex: number, stage: DbChangeStage) => Uint8Array | null | undefined;
+    // (undocumented)
+    getValueDouble: (columnIndex: number, stage: DbChangeStage) => number | null | undefined;
+    // (undocumented)
+    getValueId: (columnIndex: number, stage: DbChangeStage) => Id64String | null | undefined;
+    // (undocumented)
+    getValueInteger: (columnIndex: number, stage: DbChangeStage) => number | null | undefined;
+    // (undocumented)
+    getValueText: (columnIndex: number, stage: DbChangeStage) => string | null | undefined;
+    // (undocumented)
+    getValueType: (columnIndex: number, stage: DbChangeStage) => DbValueType | null | undefined;
+    // (undocumented)
     indirect: boolean;
+    // (undocumented)
+    isValueNull: (columnIndex: number, stage: DbChangeStage) => boolean | undefined;
     // (undocumented)
     opcode: DbOpcode;
     // (undocumented)
@@ -5013,11 +5033,19 @@ export class SqliteChangesetReader implements IDisposable {
     get disableSchemaCheck(): boolean;
     dispose(): void;
     getChangeValue(columnIndex: number, stage: SqliteValueStage): SqliteValue_2;
+    getChangeValueBinary(columnIndex: number, stage: SqliteValueStage): Uint8Array | null | undefined;
+    getChangeValueDouble(columnIndex: number, stage: SqliteValueStage): number | null | undefined;
+    getChangeValueId(columnIndex: number, stage: SqliteValueStage): Id64String | null | undefined;
+    getChangeValueInteger(columnIndex: number, stage: SqliteValueStage): number | null | undefined;
     getChangeValuesArray(stage: SqliteValueStage): SqliteValueArray | undefined;
     getChangeValuesObject(stage: SqliteValueStage, args?: ChangeFormatArgs): SqliteChange | undefined;
+    getChangeValueText(columnIndex: number, stage: SqliteValueStage): string | null | undefined;
+    getChangeValueType(columnIndex: number, stage: SqliteValueStage): DbValueType | undefined;
     getColumnNames(tableName: string): string[];
+    getColumnValueType(columnIndex: number, stage: SqliteValueStage): DbValueType | undefined;
     getPrimaryKeyColumnNames(): string[];
     get hasRow(): boolean;
+    isColumnValueNull(columnIndex: number, stage: SqliteValueStage): boolean | undefined;
     get isIndirect(): boolean;
     get op(): SqliteChangeOp;
     static openFile(args: {

--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -278,6 +278,14 @@ export type ComputePriorityFunction<T> = (value: T) => number;
 export type Constructor<T> = new (...args: any[]) => T;
 
 // @internal
+export enum DbChangeStage {
+    // (undocumented)
+    New = 1,
+    // (undocumented)
+    Old = 0
+}
+
+// @internal
 export enum DbConflictCause {
     // (undocumented)
     Conflict = 3,
@@ -443,6 +451,20 @@ export enum DbResult {
     BE_SQLITE_ROW = 100,
     BE_SQLITE_SCHEMA = 17,
     BE_SQLITE_TOOBIG = 18
+}
+
+// @internal
+export enum DbValueType {
+    // (undocumented)
+    BlobVal = 4,
+    // (undocumented)
+    FloatVal = 2,
+    // (undocumented)
+    IntegerVal = 1,
+    // (undocumented)
+    NullVal = 5,
+    // (undocumented)
+    TextVal = 3
 }
 
 // @public

--- a/common/api/summary/core-bentley.exports.csv
+++ b/common/api/summary/core-bentley.exports.csv
@@ -32,10 +32,12 @@ public;CompressedId64Set = string
 public;CompressedId64Set
 public;ComputePriorityFunction
 public;Constructor
+internal;DbChangeStage
 internal;DbConflictCause
 internal;DbConflictResolution
 public;DbOpcode
 public;DbResult
+internal;DbValueType
 public;Dictionary
 public;DictionaryEntry
 public;DisposableList 

--- a/common/changes/@itwin/core-backend/affanK-improve-ts-changeset-api_2024-04-01-13-35.json
+++ b/common/changes/@itwin/core-backend/affanK-improve-ts-changeset-api_2024-04-01-13-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Improve ChangesetConflictArgs & SqliteChangeSetReader API",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-bentley/affanK-improve-ts-changeset-api_2024-04-01-13-35.json
+++ b/common/changes/@itwin/core-bentley/affanK-improve-ts-changeset-api_2024-04-01-13-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Improve ChangesetConflictArgs & SqliteChangeSetReader API",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   ../../core/backend:
     specifiers:
-      '@bentley/imodeljs-native': 4.6.0
+      '@bentley/imodeljs-native': 4.6.1
       '@itwin/build-tools': workspace:*
       '@itwin/cloud-agnostic-core': ^2.1.0
       '@itwin/core-bentley': workspace:*
@@ -57,7 +57,7 @@ importers:
       webpack: ^5.76.0
       ws: ^7.5.3
     dependencies:
-      '@bentley/imodeljs-native': 4.6.0
+      '@bentley/imodeljs-native': 4.6.1
       '@itwin/cloud-agnostic-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/core-telemetry': link:../telemetry
       '@itwin/object-storage-azure': 2.2.2_scz6qrwecfbbxg4vskopkl3a7u
@@ -3775,8 +3775,8 @@ packages:
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
     dev: false
 
-  /@bentley/imodeljs-native/4.6.0:
-    resolution: {integrity: sha512-txFWFMgYQFKklO3KSkAQF8+t72iYA5Ij2f6V4/At76W+6+WNbdXmfu232DfFcPZQy7/e9EUwNOiV4pVioQ2zEQ==}
+  /@bentley/imodeljs-native/4.6.1:
+    resolution: {integrity: sha512-PAm+P64ThOu2zwYxm8K5NLRJQgX6/ufiFWHFr8yjF8t25xPhXWvDwuvS0MoP24oySQ5Ps4LQNwdrZw2a5lSNFA==}
     requiresBuild: true
     dev: false
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -98,7 +98,7 @@
     "webpack": "^5.76.0"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "4.6.0",
+    "@bentley/imodeljs-native": "4.6.1",
     "@itwin/cloud-agnostic-core": "^2.1.0",
     "@itwin/core-telemetry": "workspace:*",
     "@itwin/object-storage-azure": "^2.2.2",

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -71,12 +71,12 @@ export interface ChangesetConflictArgs {
   dump: () => void;
   setLastError: (message: string) => void;
   getPrimaryKeyColumns: () => number[];
-  getValueType: (columnIndex: number, stage: DbChangeStage) => DbValueType | undefined;
-  getValueBinary: (columnIndex: number, stage: DbChangeStage) => Uint8Array | undefined;
-  getValueId: (columnIndex: number, stage: DbChangeStage) => Id64String | undefined;
-  getValueText: (columnIndex: number, stage: DbChangeStage) => string | undefined;
-  getValueInteger: (columnIndex: number, stage: DbChangeStage) => number | undefined;
-  getValueDouble: (columnIndex: number, stage: DbChangeStage) => number | undefined;
+  getValueType: (columnIndex: number, stage: DbChangeStage) => DbValueType | null | undefined;
+  getValueBinary: (columnIndex: number, stage: DbChangeStage) => Uint8Array | null | undefined;
+  getValueId: (columnIndex: number, stage: DbChangeStage) => Id64String | null | undefined;
+  getValueText: (columnIndex: number, stage: DbChangeStage) => string | null | undefined;
+  getValueInteger: (columnIndex: number, stage: DbChangeStage) => number | null | undefined;
+  getValueDouble: (columnIndex: number, stage: DbChangeStage) => number | null | undefined;
   isValueNull: (columnIndex: number, stage: DbChangeStage) => boolean | undefined;
 }
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -11,7 +11,7 @@ import { join } from "path";
 import * as touch from "touch";
 import { IModelJsNative } from "@bentley/imodeljs-native";
 import {
-  AccessToken, assert, BeEvent, BentleyStatus, ChangeSetStatus, DbConflictCause, DbConflictResolution, DbOpcode, DbResult, Guid, GuidString, Id64, Id64Arg, Id64Array, Id64Set, Id64String,
+  AccessToken, assert, BeEvent, BentleyStatus, ChangeSetStatus, DbChangeStage, DbConflictCause, DbConflictResolution, DbOpcode, DbResult, DbValueType, Guid, GuidString, Id64, Id64Arg, Id64Array, Id64Set, Id64String,
   IModelStatus, JsonUtils, Logger, LogLevel, OpenMode, UnexpectedErrors,
 } from "@itwin/core-bentley";
 import {
@@ -66,9 +66,18 @@ export interface ChangesetConflictArgs {
   indirect: boolean;
   tableName: string;
   changesetFile?: string;
+  columnCount: number;
   getForeignKeyConflicts: () => number;
   dump: () => void;
   setLastError: (message: string) => void;
+  getPrimaryKeyColumns: () => number[];
+  getValueType: (columnIndex: number, stage: DbChangeStage) => DbValueType | undefined;
+  getValueBinary: (columnIndex: number, stage: DbChangeStage) => Uint8Array | undefined;
+  getValueId: (columnIndex: number, stage: DbChangeStage) => Id64String | undefined;
+  getValueText: (columnIndex: number, stage: DbChangeStage) => string | undefined;
+  getValueInteger: (columnIndex: number, stage: DbChangeStage) => number | undefined;
+  getValueDouble: (columnIndex: number, stage: DbChangeStage) => number | undefined;
+  isValueNull: (columnIndex: number, stage: DbChangeStage) => boolean | undefined;
 }
 
 // spell:ignore fontid fontmap

--- a/core/backend/src/SqliteChangesetReader.ts
+++ b/core/backend/src/SqliteChangesetReader.ts
@@ -6,7 +6,7 @@
  * @module SQLiteDb
  */
 import { IModelJsNative } from "@bentley/imodeljs-native";
-import { DbOpcode, DbResult, IDisposable } from "@itwin/core-bentley";
+import { DbOpcode, DbResult, DbValueType, Id64String, IDisposable } from "@itwin/core-bentley";
 import { ECDb } from "./ECDb";
 import { IModelDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
@@ -189,6 +189,84 @@ export class SqliteChangesetReader implements IDisposable {
   public get tableName(): string {
     return this._nativeReader.getTableName();
   }
+
+  /**
+   * Get changed binary value for a column
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns value for changed column
+   * @beta
+   */
+  public getChangeValueBinary(columnIndex: number, stage: SqliteValueStage): Uint8Array | null | undefined {
+    return this._nativeReader.getColumnValueBinary(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+  }
+
+  /**
+   * Get changed double value for a column
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns value for changed column
+   * @beta
+   */
+  public getChangeValueDouble(columnIndex: number, stage: SqliteValueStage): number | null | undefined {
+    return this._nativeReader.getColumnValueDouble(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+  }
+
+  /**
+   * Get changed Id value for a column
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns value for changed column
+   * @beta
+   */
+  public getChangeValueId(columnIndex: number, stage: SqliteValueStage): Id64String | null | undefined {
+    return this._nativeReader.getColumnValueId(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+  }
+
+  /**
+   * Get changed integer value for a column
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns value for changed column
+   * @beta
+   */
+  public getChangeValueInteger(columnIndex: number, stage: SqliteValueStage): number | null | undefined {
+    return this._nativeReader.getColumnValueInteger(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+  }
+
+  /**
+   * Get changed text value for a column
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns value for changed column
+   * @beta
+   */
+  public getChangeValueText(columnIndex: number, stage: SqliteValueStage): string | null | undefined {
+    return this._nativeReader.getColumnValueText(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+  }
+
+  /**
+   * Check if change value is null
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns true if value is null
+   * @beta
+   */
+  public isColumnValueNull(columnIndex: number, stage: SqliteValueStage): boolean | undefined {
+    return this._nativeReader.isColumnValueNull(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+  }
+
+  /**
+   * Get change value type
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns change value type
+   * @beta
+   */
+  public getColumnValueType(columnIndex: number, stage: SqliteValueStage): DbValueType | undefined {
+    return this._nativeReader.getColumnValueType(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old) as DbValueType | undefined;
+  }
+
   /**
    * Get changed value for a column
    * @param columnIndex index of column in current change

--- a/core/backend/src/SqliteChangesetReader.ts
+++ b/core/backend/src/SqliteChangesetReader.ts
@@ -6,7 +6,7 @@
  * @module SQLiteDb
  */
 import { IModelJsNative } from "@bentley/imodeljs-native";
-import { DbOpcode, DbResult, DbValueType, Id64String, IDisposable } from "@itwin/core-bentley";
+import { DbChangeStage, DbOpcode, DbResult, DbValueType, Id64String, IDisposable } from "@itwin/core-bentley";
 import { ECDb } from "./ECDb";
 import { IModelDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
@@ -172,22 +172,27 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getPrimaryKeyColumnNames(): string[] {
-    const pks = [];
     const cols = this.getColumnNames(this.tableName);
     if (!this._disableSchemaCheck && cols.length !== this.columnCount)
       throw new Error(`changeset table ${this.tableName} columns count does not match db declared table. ${this.columnCount} <> ${cols.length}`);
 
-    for (let i = 0; i < this.columnCount; ++i)
-      if (this._nativeReader.isPrimaryKeyColumn(i))
-        pks.push(cols[i]);
-
-    return pks;
+    return this._nativeReader.getPrimaryKeyColumnIndexes().map((i) => cols[i]);
   }
   /** Get current change table.
    * @beta
   */
   public get tableName(): string {
     return this._nativeReader.getTableName();
+  }
+  /**
+   * Get changed binary value for a column
+   * @param columnIndex index of column in current change
+   * @param stage old or new value for change.
+   * @returns value for changed column
+   * @beta
+   */
+  public getChangeValueType(columnIndex: number, stage: SqliteValueStage): DbValueType | undefined {
+    return this._nativeReader.getColumnValueType(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old) as DbValueType;
   }
 
   /**
@@ -198,7 +203,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getChangeValueBinary(columnIndex: number, stage: SqliteValueStage): Uint8Array | null | undefined {
-    return this._nativeReader.getColumnValueBinary(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.getColumnValueBinary(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
 
   /**
@@ -209,7 +214,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getChangeValueDouble(columnIndex: number, stage: SqliteValueStage): number | null | undefined {
-    return this._nativeReader.getColumnValueDouble(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.getColumnValueDouble(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
 
   /**
@@ -220,7 +225,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getChangeValueId(columnIndex: number, stage: SqliteValueStage): Id64String | null | undefined {
-    return this._nativeReader.getColumnValueId(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.getColumnValueId(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
 
   /**
@@ -231,7 +236,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getChangeValueInteger(columnIndex: number, stage: SqliteValueStage): number | null | undefined {
-    return this._nativeReader.getColumnValueInteger(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.getColumnValueInteger(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
 
   /**
@@ -242,7 +247,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getChangeValueText(columnIndex: number, stage: SqliteValueStage): string | null | undefined {
-    return this._nativeReader.getColumnValueText(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.getColumnValueText(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
 
   /**
@@ -253,7 +258,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public isColumnValueNull(columnIndex: number, stage: SqliteValueStage): boolean | undefined {
-    return this._nativeReader.isColumnValueNull(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.isColumnValueNull(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
 
   /**
@@ -264,7 +269,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getColumnValueType(columnIndex: number, stage: SqliteValueStage): DbValueType | undefined {
-    return this._nativeReader.getColumnValueType(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old) as DbValueType | undefined;
+    return this._nativeReader.getColumnValueType(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old) as DbValueType | undefined;
   }
 
   /**
@@ -275,7 +280,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getChangeValue(columnIndex: number, stage: SqliteValueStage): SqliteValue {
-    return this._nativeReader.getColumnValue(columnIndex, stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.getColumnValue(columnIndex, stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
   /**
    * Get all changed value in current change as array
@@ -284,7 +289,7 @@ export class SqliteChangesetReader implements IDisposable {
    * @beta
    */
   public getChangeValuesArray(stage: SqliteValueStage): SqliteValueArray | undefined {
-    return this._nativeReader.getRow(stage === "New" ? IModelJsNative.DbChangeStage.New : IModelJsNative.DbChangeStage.Old);
+    return this._nativeReader.getRow(stage === "New" ? DbChangeStage.New : DbChangeStage.Old);
   }
   /**
    * Get change as object and format its content.

--- a/core/backend/src/test/standalone/ChangeConflictHandler.test.ts
+++ b/core/backend/src/test/standalone/ChangeConflictHandler.test.ts
@@ -25,7 +25,6 @@ import {
 import { IModelTestUtils, TestUserType } from "../IModelTestUtils";
 chai.use(chaiAsPromised);
 import sinon = require("sinon");
-import { Range3d } from "@itwin/core-geometry";
 
 async function assertThrowsAsync<T>(test: () => Promise<T>, msg?: string) {
   try {

--- a/core/bentley/src/BeSQLite.ts
+++ b/core/bentley/src/BeSQLite.ts
@@ -26,6 +26,25 @@ export enum DbOpcode {
   Update = 23,
 }
 
+/** Change value stage.
+ * @internal
+ */
+export enum DbChangeStage {
+  Old = 0,
+  New = 1
+}
+
+/** Change value type.
+ * @internal
+ */
+export enum DbValueType {
+  IntegerVal = 1,
+  FloatVal = 2,
+  TextVal = 3,
+  BlobVal = 4,
+  NullVal = 5
+}
+
 /** Cause of conflict when applying a changeset
  * @internal
  */

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:4.6.0'
+    implementation 'com.github.itwin:mobile-native-android:4.6.1'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.6.0;
+				version = 4.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.6.0;
+				version = 4.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Added the following methods to `ChangesetConflictArgs` to allow it access changed column and its values. A similar improvement is done to `SqliteChangeSetReader`  to allow it to access strong-type individual column values.

```ts
  getPrimaryKeyColumns: () => number[];
  getValueType: (columnIndex: number, stage: DbChangeStage) => DbValueType | undefined;
  getValueBinary: (columnIndex: number, stage: DbChangeStage) => Uint8Array | undefined;
  getValueId: (columnIndex: number, stage: DbChangeStage) => Id64String | undefined;
  getValueText: (columnIndex: number, stage: DbChangeStage) => string | undefined;
  getValueInteger: (columnIndex: number, stage: DbChangeStage) => number | undefined;
  getValueDouble: (columnIndex: number, stage: DbChangeStage) => number | undefined;
  isValueNull: (columnIndex: number, stage: DbChangeStage) => boolean | undefined;
```

imodel-native: https://github.com/iTwin/imodel-native/pull/698