### PR TITLE
Update gather-docs yaml to correct branch name

### DIFF
--- a/common/config/azure-pipelines/templates/gather-docs.yaml
+++ b/common/config/azure-pipelines/templates/gather-docs.yaml
@@ -118,6 +118,6 @@ steps:
       project: 2c48216e-e72f-48b4-a4eb-40ff1c04e8e4
       pipeline: 7436 # iTwin.js/Docs/iTwin.js Docs - YAML
       buildVersionToDownload: latestFromBranch
-      branchName: refs/heads/release/4.4.x
+      branchName: refs/heads/release/4.5.x
       artifactName: .updated.json
       targetPath: ${{ parameters.stagingDir }}/config/


### PR DESCRIPTION
This step has been automated here: https://github.com/iTwin/itwinjs-core/blob/17656436e63ba98e1d413acd251676f18caf4002/.github/workflows/automation-scripts/update-changelogs.mjs#L96C1-L96C36

However, this automation is done when the finalize release script runs after a minor release. The scripts checks for the most recent commit message to verify it is a minor release then does this change. During this minor release, this check failed because when the finalize release step ran, there was already a commit made after the minor release commit. Hence, the part of the script that does this edit also did not run and now needs to be done manually for this minor. 

Minors releases in the future shouldn't need this