### PR TITLE
Update leftNav.md after minor release

### DIFF
--- a/docs/changehistory/4.5.0.md
+++ b/docs/changehistory/4.5.0.md
@@ -1,0 +1,226 @@
+---
+deltaDoc: true
+version: '4.5.0'
+---
+# 4.5.0 Change Notes
+
+Table of contents:
+
+- [4.5.0 Change Notes](#4.5.0 Change Notes)
+  - [Display](#display)
+    - [Seafloor terrain](#seafloor-terrain)
+    - [Simplified TileTreeReference](#simplified-tiletreereference)
+    - [Dynamic classifiers](#dynamic-classifiers)
+  - [Electron 29 support](#electron-29-support)
+  - [Editor](#editor)
+  - [Lock Control](#lock-control)
+  - [Presentation](#presentation)
+    - [RPC interface version bump](#rpc-interface-version-bump)
+    - [Custom renderer and editor support for array items](#custom-renderer-and-editor-support-for-array-items)
+    - [Support for property overrides on ECStruct member properties](#support-for-property-overrides-on-ecstruct-member-properties)
+    - [Deprecation of async array results in favor of async iterators](#deprecation-of-async-array-results-in-favor-of-async-iterators)
+    - [Unified selection decoupling from `@itwin/presentation-frontend`](#unified-selection-decoupling-from-`@itwin/presentation-frontend`)
+  - [Fixed bounding box types](#fixed-bounding-box-types)
+
+## Display
+
+### Seafloor terrain
+
+The iTwin viewer supports visualizing the Earth's landmasses in 3d using [Cesium World Terrain](https://cesium.com/platform/cesium-ion/content/cesium-world-terrain), providing real-world context for infrastructure built on land. For undersea infrastructure, the context of the seafloor terrain can be just as important. Now, you can make use of [Cesium World Bathymetry](https://cesium.com/platform/cesium-ion/content/cesium-world-bathymetry/) to get a glimpse of the world under the waves.
+
+To enable seafloor terrain, create a [TerrainSettings]($common) specifying [CesiumTerrainAssetId.Bathymetry]($common) as the `dataSource`. For example:
+
+```ts
+  function enableBathymetry(viewport: Viewport): void {
+    viewport.changeBackgroundMapProps({
+      terrainSettings: {
+        dataSource: CesiumTerrainAssetId.Bathymetry,
+      }
+    });
+  }
+```
+
+You can alternatively specify the Id of any global Cesium ION asset to which you have access. Either way, make sure you add the asset to your ION account first.
+
+The new [TerrainSettings.dataSource]($common) property can be used by custom [TerrainProvider]($frontend)s as well, to select from different sources of terrain supplied by the same provider.
+
+Below, the islands of Cape Verde are visualized with bathymetric terrain, slightly exaggerated in height for emphasis:
+
+![Cape Verde terrain](./assets/bathymetric_terrain.jpg)
+
+### Simplified TileTreeReference
+
+iTwin.js provides two ways to add graphical content to a [Viewport]($frontend)'s scene:
+- [Decorator]($frontend)s provide temporary, "decoration" graphics. Their graphics are simple to create using the [GraphicBuilder]($frontend) API, but must be recreated frequently as the user navigates the view. A given Decorator is applied to all viewports registered with the [ViewManager]($frontend).
+- [TiledGraphicsProvider]($frontend)s inject more permanent graphics of arbitrary complexity that do not change frequently. Their graphics are supplied by a [TileTreeReference]($frontend), which requires implementing a lot of boilerplate code like [TileTreeSupplier]($frontend) and [TileTree]($frontend). A given TiledGraphicsProvider is registered only with specific viewport(s) using [Viewport.addTiledGraphicsProvider]($frontend).
+
+In some cases, you'd just like to add some relatively simple graphics to the viewport's scene using a TiledGraphicsProvider. To simplify that process, [TileTreeReference.createFromRenderGraphic]($frontend) accepts a graphic created using a GraphicBuilder and produces a tile tree from it, which you can then associate with a TiledGraphicsProvider. Here's an example:
+```ts
+[[include:TileTreeReference_createFromRenderGraphic]]
+```
+
+You can use this new API to easily create a tile tree for [dynamically classifying](#dynamic-classifiers) a reality model.
+
+### Dynamic classifiers
+
+Classification involves using geometry from a design model to "classify" the geometry of a reality model. Wherever a region of the reality model intersects with geometry belonging to an element in the design model, that region is treated as if it belongs to the element. For example, mousing over a classified region displays a tooltip describing the classifying element, and selecting the region selects the element. The color of the classified region can also be altered to match the classifying element's color. A classic use case is a photogrammetry model of a city, classified using polygons representing the footprints of buildings within the city, such that the user can interact with individual buildings within the reality model.
+
+The usefulness of this technique is limited by the constraint that the classifier geometry must originate from a persistent [GeometricModel]($backend) stored in an iModel. Imagine a scenario in which you have a reality model representing a building, and access to live data streamed from heat sensors placed in rooms within the building. You might wish to classify the rooms based on their current temperatures - but because the data is constantly changing, it wouldn't make sense to store it in a persistent model.
+
+Now, that constraint has been lifted. You can define your geometry at run-time and apply it to a reality model as a [DynamicSpatialClassifier]($frontend) by setting the `activeClassifier` property of [ContextRealityModelState.classifiers]($frontend). The geometry is supplied by a [TileTreeReference]($frontend), which can easily be created using the new [TileTreeReference.createFromRenderGraphic](#simplified-tiletreereference) API.
+
+Here's a simple example that classifies spherical regions of a reality model:
+```ts
+[[include:TileTreeReference_DynamicClassifier]]
+```
+
+## Electron 29 support
+
+In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 29](https://www.electronjs.org/blog/electron-29-0).
+
+## Editor
+
+Changes to @beta [BasicManipulationCommandIpc]($editor-common) class:
+
+- [BasicManipulationCommandIpc.insertGeometricElement]($editor-common) no longer takes an optional ElementGeometryBuilderParams as this can be specified in [GeometricElementProps]($common).
+- [BasicManipulationCommandIpc.insertGeometryPart]($editor-common) no longer takes an optional ElementGeometryBuilderParamsForPart as this can be specified in [GeometryPartProps]($common).
+
+Changes to @beta [CreateElementWithDynamicsTool]($editor-frontend) class:
+
+- [CreateElementWithDynamicsTool.doCreateElement]($editor-frontend) no longer takes an optional [ElementGeometryBuilderParams]($common) as it will be set on the supplied [GeometricElementProps]($common).
+
+Added [EditTools.registerProjectLocationTools]($editor-frontend) method. These tools are no longer automatically registered by [EditTools.initialize]($editor-frontend). Applications that wish to include these tools and also register the required [BasicManipulationCommand]($editor-backend) with [EditCommandAdmin]($editor-backend) should call this new method.
+
+Removal of several @alpha test tools for creating Generic:PhysicalObject class elements that didn't belong in the core package.
+
+## Lock Control
+
+Changes to @beta [LockControl]($backend) class to make releaseAllLocks @internal. Should only be called internally after pushing or abandoning all changes.
+
+## Presentation
+
+### RPC interface version bump
+
+The presentation backend now sends more properties-related information to the frontend than it did in previous version, and the frontend relies on that information for formatting and rendering the properties. As a result, the version of [PresentationRpcInterface]($presentation-common) has been bumped from `4.0.0` to `4.1.0`.
+
+### Custom renderer and editor support for array items
+
+Support for custom renderers and editors has been added for array items.
+
+A renderer / editor may be assigned to items of specific array by creating a [ContentModifier]($presentation-common) for
+a class that has the property and adding a property override for the array property with `[*]` suffix. Example:
+
+```json
+{
+  "ruleType": "ContentModifier",
+  "class": { "schemaName": "MySchemaName", "className": "MyClassName" },
+  "propertyOverrides": [
+    {
+      "name": "MyArrayProperty[*]",
+      "renderer": {
+        "rendererName": "test-renderer"
+      },
+      "editor": {
+        "editorName": "test-editor"
+      }
+    }
+  ]
+}
+```
+
+### Support for property overrides on ECStruct member properties
+
+Support for property overrides has been added for struct member properties.
+
+The overrides may be assigned to members of specific ECStruct class by creating a [ContentModifier]($presentation-common) for
+the struct class and adding property overrides for the members. Example:
+
+```json
+{
+  "ruleType": "ContentModifier",
+  "class": { "schemaName": "MySchemaName", "className": "MyStructClassName" },
+  "propertyOverrides": [
+    {
+      "name": "StructMemberProperty",
+      "renderer": {
+        "rendererName": "test-renderer"
+      }
+    }
+  ]
+}
+```
+
+### Deprecation of async array results in favor of async iterators
+
+`PresentationManager` contains a number of methods to retrieve sets of results like nodes, content, etc. All of these methods have been deprecated in favor of new ones that return an async iterator instead of an array:
+
+- Use `getContentIterator` instead of `getContent` and `getContentAndSize`.
+- Use `getDisplayLabelDefinitionsIterator` instead of `getDisplayLabelDefinitions`.
+- Use `getDistinctValuesIterator` instead of `getPagedDistinctValues`.
+- Use `getNodesIterator` instead of `getNodes` and `getNodesAndCount`.
+
+All of the above methods, including the deprecated ones, received ability to load large sets of results concurrently. Previously, when requesting a large set (page size > 1000), the result was created by sending a number of requests sequentially by requesting the first page, then the second, and so on, until the whole requested set was retrieved. Now, we send a request for the first page to determine total number of items and backend's page size limit, together with the first page of results, and then other requests are made all at once. At attribute `maxParallelRequests` was added to these methods to control how many parallel requests should be sent at a time.
+
+While performance-wise deprecated methods should be in line with the newly added async iterator ones, the latter have two advantages:
+
+1. Caller can start iterating over results as soon as we receive the first page, instead of having to wait for the whole set.
+2. The iterator version stops sending requests as soon as the caller stops iterating over the async iterator.
+
+> Example: Showing display labels for a large set of elements in a React component.
+>
+> The deprecated approach would be to use `PresentationManager.getDisplayLabelDefinitions` to retrieve labels of all elements. Because the API has to load all the data before returning it to the widget, user has to wait a long time to start seeing the results. Moreover, if he decides to close the widget (the component is unmounted), the `getDisplayLabelDefinitions` keeps building the array by sending requests to the backend - there's no way to cancel that.
+>
+> The new approach is to use `PresentationManager.getDisplayLabelDefinitionsIterator` to get the labels. The labels get streamed to the called as soon as the first results' page is retrieved, so user gets to see initial results quickly, while additional pages keep loading in the background. In addition, if the component is unmounted, iteration can be stopped, thus cancelling all further requests to the backend:
+>
+> ```ts
+> const { items } = await manager.getDisplayLabelDefinitionsIterator(requestProps);
+> for await (const label of items) {
+>  if (isComponentUnmounted) {
+>    break;
+>  }
+>  // update component's model to render the loaded label
+> }
+> ```
+
+### Unified selection decoupling from `@itwin/presentation-frontend`
+
+Ability to provide custom selection storage was added to `@itwin/presentation-frontend`. Prior to this change unified selection was tightly coupled with `@itwin/presentation-frontend` and tree component. Only instance keys and tree node keys could be added to unified selection.
+
+With a new version `@itwin/presentation-frontend` can be initialize with custom selection storage from `@itwin/unified-selection` package. This provides an API for storing different custom selectable object that later can be used in other components or contribute to hilited items in viewport.
+
+One side effect of these changes is that calling `Presentation.selection.getSelection` immediately after `Presentation.selection.(add*|replace*|remove*|clear*)` will not return the latest selection. This was never guaranteed and to get latest selection after any change `Presentation.selection.selectionChange` event should be used.
+
+```ts
+import { createStorage } from "@itwin/unified-selection";
+import { Presentation } from "@itwin/presentation-frontend";
+
+const unifiedSelectionStorage = createStorage();
+
+await Presentation.initialize({
+  selection: {
+    storage: unifiedSelectionStorage,
+  },
+});
+
+// existing unified selection API can be used to add keys
+Presentation.selection.addToSelection("SelectionSource", imodel, [{ id: "0x1", className: "Schema:Class" }]);
+
+// unified selection storage can be used directly to add custom selectable objects
+unifiedSelectionStorage.addToSelection({
+  iModelKey: imodel.key,
+  source: "SelectionSource",
+  selectables: [{
+    identifier: "customSelectable",
+    loadInstanceKeys: () => loadKeysFromCustomSource(),
+    // additional data can be stored to share between components using unified selection
+    data: additionalData
+  }],
+});
+```
+
+## Fixed bounding box types
+
+The `bbox` properties of [Placement2dProps]($common) and [Placement3dProps]($common) were incorrectly typed as [LowAndHighXY]($geometry) and [LowAndHighXYZ]($geometry), respectively. In actuality, they may also be of the type `{ low: number[]; high: number[]; }`, and will always be in this form when returned from the backend by functions like `getElementProps`. The types have been adjusted to [LowAndHighXYProps]($geometry) and [LowAndHighXYZProps]($geometry) to reflect this.
+
+An analogous adjustment was made to the `bbox` property of [GeometryPartProps]($common).
+

--- a/docs/changehistory/leftNav.md
+++ b/docs/changehistory/leftNav.md
@@ -10,6 +10,7 @@ closedPanels: ["Previous Versions", "Changelogs"]
 
 ### Versions
 
+- [4.5.0](./4.5.0.md)
 - [4.4.0](./4.4.0.md)
 - [4.3.0](./4.3.0.md)
 - [4.2.0](./4.2.0.md)


### PR DESCRIPTION
This step has been automated here: https://github.com/iTwin/itwinjs-core/blob/17656436e63ba98e1d413acd251676f18caf4002/.github/workflows/automation-scripts/update-changelogs.mjs#L131

However, this automation is done when the finalize release script runs after a minor release. The scripts checks for the most recent commit message to verify it is a minor release then does this change. During this minor release, this check failed because when the finalize release step ran, there was already a commit made after the minor release commit. Hence, the part of the script that does this edit also did not run and now needs to be done manually for this minor.

Minors releases in the future shouldn't need this