### PR TITLE
skip extract api on windows

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -138,4 +138,4 @@ steps:
   - script: node common/scripts/install-run-rush.js extract-api
     displayName: rush extract-api
     workingDirectory: ${{ parameters.workingDir }}
-    condition: ${{ parameters.nativePrVal }}
+    condition: and(${{ parameters.nativePrVal }}, ne(variables['Agent.OS'], 'Windows_NT'))


### PR DESCRIPTION
Running into issues caused by extract api behaving differently on windows vs linux. For PRs into itwinjs-core we only run extract api on linux, however in imodel-native we run it on all three platfroms. Right now only windows is causing a failure, so for now to unblock prs i guess its best to skip extract api on windows

Nick has a PR describing it fully here
https://github.com/iTwin/itwinjs-core/pull/6597