### PR TITLE
Add extra cleanup functionality in PrimitiveTool

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -10780,6 +10780,8 @@ export abstract class PrimitiveTool extends InteractiveTool {
     get iModel(): IModelConnection;
     isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean;
     isValidLocation(ev: BeButtonEvent, isButtonEvent: boolean): boolean;
+    // @internal (undocumented)
+    onCleanup(): Promise<void>;
     onRedoPreviousStep(): Promise<boolean>;
     onReinitialize(): Promise<void>;
     abstract onRestartTool(): Promise<void>;
@@ -17482,6 +17484,8 @@ export abstract class ViewTool extends InteractiveTool {
     exitTool(): Promise<void>;
     // (undocumented)
     inDynamicUpdate: boolean;
+    // (undocumented)
+    onCleanup(): Promise<void>;
     // (undocumented)
     onResetButtonUp(_ev: BeButtonEvent): Promise<EventHandled>;
     // (undocumented)

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -10780,7 +10780,7 @@ export abstract class PrimitiveTool extends InteractiveTool {
     get iModel(): IModelConnection;
     isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean;
     isValidLocation(ev: BeButtonEvent, isButtonEvent: boolean): boolean;
-    // @internal (undocumented)
+    // (undocumented)
     onCleanup(): Promise<void>;
     onRedoPreviousStep(): Promise<boolean>;
     onReinitialize(): Promise<void>;

--- a/common/changes/@itwin/core-frontend/nam-tool-cleanup_2024-04-09-20-45.json
+++ b/common/changes/@itwin/core-frontend/nam-tool-cleanup_2024-04-09-20-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "clean up tools on shutdown",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-markup/nam-tool-cleanup_2024-04-09-20-45.json
+++ b/common/changes/@itwin/core-markup/nam-tool-cleanup_2024-04-09-20-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-markup",
+      "comment": "clean up tools on shutdown",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-markup"
+}

--- a/common/changes/@itwin/frontend-devtools/nam-tool-cleanup_2024-04-09-20-45.json
+++ b/common/changes/@itwin/frontend-devtools/nam-tool-cleanup_2024-04-09-20-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "clean up tools on shutdown",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/frontend-devtools/src/tools/PlanarMaskTools.ts
+++ b/core/frontend-devtools/src/tools/PlanarMaskTools.ts
@@ -121,6 +121,7 @@ export abstract class PlanarMaskBaseTool extends PrimitiveTool {
     if (0 !== this._acceptedElementIds.size)
       this.iModel.hilited.setHilite(this._acceptedElementIds, false);
     this.clearIds();
+    return super.onCleanup();
   }
 
   public override async filterHit(hit: HitDetail, _out?: LocateResponse): Promise<LocateFilterStatus> {

--- a/core/frontend/src/test/IModelApp.test.ts
+++ b/core/frontend/src/test/IModelApp.test.ts
@@ -171,3 +171,18 @@ describe("IModelApp", () => {
     expect(IModelApp.renderSystem).instanceof(MockRender.System);
   });
 });
+
+describe("IModelApp Shutdown", () => {
+  beforeEach(async () => {
+    await TestApp.startup();
+    await IModelApp.localization.registerNamespace("TestApp");  // we must wait for the localization read to finish.
+  });
+
+  it("on shutdown, should dispose of all tools", async () => {
+    await TestApp.shutdown();
+    expect(IModelApp.toolAdmin.activeTool).to.be.undefined;
+    expect(IModelApp.toolAdmin.primitiveTool).to.be.undefined;
+    expect(IModelApp.toolAdmin.viewTool).to.be.undefined;
+    expect(IModelApp.tools.tools.size).to.equal(0);
+  });
+});

--- a/core/frontend/src/tools/ElementSetTool.ts
+++ b/core/frontend/src/tools/ElementSetTool.ts
@@ -982,9 +982,9 @@ export abstract class ElementSetTool extends PrimitiveTool {
 
   /** Make sure elements from [[ElementSetTool.agenda]] that aren't also from [[SelectionSet]] aren't left hilited. */
   public override async onCleanup() {
-    await super.onCleanup();
     if (undefined !== this._agenda)
       this._agenda.clear();
+    return super.onCleanup();
   }
 
   /** Exit and start default tool when [[ElementSetTool.isSelectionSetModify]] is true to allow [[SelectionSet]] to be modified,

--- a/core/frontend/src/tools/MeasureTool.ts
+++ b/core/frontend/src/tools/MeasureTool.ts
@@ -1274,6 +1274,7 @@ export abstract class MeasureElementTool extends PrimitiveTool {
   public override async onCleanup() {
     if (0 !== this._acceptedIds.length)
       this.iModel.hilited.setHilite(this._acceptedIds, false);
+    return super.onCleanup();
   }
 
   /** @internal */

--- a/core/frontend/src/tools/PrimitiveTool.ts
+++ b/core/frontend/src/tools/PrimitiveTool.ts
@@ -44,6 +44,11 @@ export abstract class PrimitiveTool extends InteractiveTool {
     return iModel?.isBriefcaseConnection() ? iModel : undefined;
   }
 
+  public override async onCleanup(): Promise<void> {
+    this.targetView = undefined;
+    return super.onCleanup();
+  }
+
   /**
    * Establish this tool as the active PrimitiveTool.
    * @return true if this tool was installed (though it may have exited too)

--- a/core/frontend/src/tools/SelectTool.ts
+++ b/core/frontend/src/tools/SelectTool.ts
@@ -650,6 +650,7 @@ export class SelectionTool extends PrimitiveTool {
   public override async onCleanup() {
     if (this.wantEditManipulators())
       IModelApp.toolAdmin.manipulatorToolEvent.raiseEvent(this, ManipulatorToolEvent.Stop);
+    return super.onCleanup();
   }
 
   public override async onPostInstall() {

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -480,6 +480,7 @@ export class ToolAdmin {
   /** @internal */
   public onShutDown() {
     this.clearMotionPromises();
+    void this.callOnCleanup();
     this._idleTool = undefined;
     IconSprites.emptyAll(); // clear cache of icon sprites
     ToolAdmin._removals.forEach((remove) => remove());
@@ -1880,8 +1881,10 @@ export class ToolAdmin {
   public async callOnCleanup() {
     await this.exitViewTool();
     await this.exitInputCollector();
-    if (undefined !== this._primitiveTool)
+    if (undefined !== this._primitiveTool) {
       await this._primitiveTool.onCleanup();
+      this._primitiveTool = undefined;
+    }
   }
 }
 

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -502,6 +502,7 @@ export class ToolAdmin {
 
     // Remove any events associated with this viewport.
     ToolAdmin._toolEvents = ToolAdmin._toolEvents.filter((ev) => ev.vp !== vp);
+    void this.currentTool.onCleanup();
   }
 
   private getMousePosition(event: ToolEvent): XAndY {

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -113,6 +113,12 @@ export abstract class ViewTool extends InteractiveTool {
   public constructor(public viewport?: ScreenViewport) {
     super();
   }
+
+  public override async onCleanup(): Promise<void> {
+    this.viewport = undefined;
+    return super.onCleanup();
+  }
+
   public override async onResetButtonUp(_ev: BeButtonEvent) {
     await this.exitTool();
     return EventHandled.Yes;

--- a/core/markup/src/RedlineTool.ts
+++ b/core/markup/src/RedlineTool.ts
@@ -42,7 +42,10 @@ export abstract class RedlineTool extends MarkupTool {
   protected clearDynamicsMarkup(_isDynamics: boolean): void { this.markup.svgDynamics!.clear(); }
 
   public override async onRestartTool() { return this.exitTool(); } // Default to single shot and return control to select tool...
-  public override async onCleanup() { this.clearDynamicsMarkup(false); }
+  public override async onCleanup() {
+    this.clearDynamicsMarkup(false);
+    return super.onCleanup();
+  }
 
   public override async onReinitialize() {
     this.clearDynamicsMarkup(false);

--- a/core/markup/src/SelectTool.ts
+++ b/core/markup/src/SelectTool.ts
@@ -543,7 +543,10 @@ export class SelectTool extends MarkupTool {
     this.cancelDrag();
     this.markup.selected.emptyAll();
   }
-  public override async onCleanup() { this.clearSelect(); }
+  public override async onCleanup() {
+    this.clearSelect();
+    return super.onCleanup();
+  }
   public override async onPostInstall() {
     this.initSelect();
     return super.onPostInstall();

--- a/core/markup/src/TextEdit.ts
+++ b/core/markup/src/TextEdit.ts
@@ -193,6 +193,7 @@ export class EditTextTool extends MarkupTool {
     this.editDiv.remove();
     this.editDiv = undefined;
     this.editor = undefined;
+    return super.onCleanup();
   }
 
   public override async onInstall() {


### PR DESCRIPTION
A continuation of the memory leak we see on refreshes and navigation away from a viewer. 

In [ToolAdmin](https://github.com/iTwin/itwinjs-core/blob/be0a9dca5d53a34b10bc04a9253c7195049d7a8c/core/frontend/src/tools/ToolAdmin.ts#L339), we see PrimitiveTool objects still carrying references to [targetView](https://github.com/iTwin/itwinjs-core/blob/be0a9dca5d53a34b10bc04a9253c7195049d7a8c/core/frontend/src/tools/PrimitiveTool.ts#L27C10-L27C20), a Viewport object, preventing Viewport objects to be garbage collected, even after the ViewManager calls [onShutdown()](https://github.com/iTwin/itwinjs-core/blob/be0a9dca5d53a34b10bc04a9253c7195049d7a8c/core/frontend/src/ViewManager.ts#L139).

This PR removes that reference to the viewport object when the PrimitiveTool's cleanup function is called, and also adds this cleanup functionality to the ToolAdmin's onShutdown().

Also, refactored the onCleanup() of subclasses extending from PrimitiveTool, to call super.cleanup() after custom cleanup functionality - Some custom cleanup functionality might rely on the iModel the tool is associated with, which is accessed through the renderTarget's [reference](https://github.com/iTwin/itwinjs-core/blob/be0a9dca5d53a34b10bc04a9253c7195049d7a8c/core/frontend/src/tools/PrimitiveTool.ts#L38). We don't want to remove that reference until after custom cleanup functionality from the subclasses have ran.