### PR TITLE
`@itwin/express-server` missing peer dep on `@itwin/core-common`

### DIFF
--- a/common/changes/@itwin/express-server/express_server_missing_peer_2024-04-12-07-57.json
+++ b/common/changes/@itwin/express-server/express_server_missing_peer_2024-04-12-07-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/express-server",
+      "comment": "Added missing peer dependency on `@itwin/core-common`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/express-server"
+}

--- a/core/express-server/package.json
+++ b/core/express-server/package.json
@@ -57,7 +57,8 @@
     "typescript": "~5.0.2"
   },
   "peerDependencies": {
-    "@itwin/core-backend": "workspace:*"
+    "@itwin/core-backend": "workspace:*",
+    "@itwin/core-common": "workspace:*"
   },
   "dependencies": {
     "express": "^4.18.2",


### PR DESCRIPTION
`@itwin/express-server` uses `WebAppRpcProtocol` from `@itwin/core-common` in public API but does not have `@itwin/core-common` listed as peer dependency. 

https://github.com/iTwin/itwinjs-core/blob/fb405140fcff8bfb09a67b04d29491d48f0437cc/common/api/express-server.api.md?plain=1#L16