### PR TITLE
Upgrade core-backend to ES2022

### DIFF
--- a/common/changes/@itwin/core-backend/pmc-es2022_2024-04-12-13-47.json
+++ b/common/changes/@itwin/core-backend/pmc-es2022_2024-04-12-13-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/tsconfig.json
+++ b/core/backend/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "./node_modules/@itwin/build-tools/tsconfig-base.json",
+  "compilerOptions": {
+    "target": "ES2022"
+  },
   "include": [
     "./src/**/*.ts"
   ]


### PR DESCRIPTION
**Don't merge - for demonstration purposes only**.

This produces a slew of test failures, occurring when inserting a model, because `modeledElement` is undefined.

Model constructor calls Entity constructor. When Entity constructor exits, `this.modeledElement` is valid. When execution returns to Model constructor, `this.modeledElement` is undefined.

The property gets assigned via black magic in [Entity.forEachProperty](https://github.com/iTwin/itwinjs-core/blob/fb405140fcff8bfb09a67b04d29491d48f0437cc/core/backend/src/Entity.ts#L58). Something in ES2022 changes the behavior there.

I had upgraded core-backend to target ES2022 in #6572 because TypeScript doesn't provide type declarations for `Intl.Segmenter` for older targets.