### PR TITLE
Change RPC SpanKind to internal

### DIFF
--- a/common/changes/@itwin/core-backend/otel-internal-span_2024-04-15-10-20.json
+++ b/common/changes/@itwin/core-backend/otel-internal-span_2024-04-15-10-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Change SpanKind of RPC requests to Internal",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/rpc/tracing.ts
+++ b/core/backend/src/rpc/tracing.ts
@@ -50,7 +50,7 @@ export class RpcTrace {
   public static async runWithSpan<T>(activity: RpcActivity, fn: () => Promise<T>): Promise<T> {
     return Tracing.withSpan(activity.rpcMethod ?? "unknown RPC method", async () => RpcTrace.run(activity, fn), {
       attributes: { ...RpcInvocation.sanitizeForLog(activity) },
-      kind: SpanKind.SERVER,
+      kind: SpanKind.INTERNAL,
     });
   }
 }


### PR DESCRIPTION
There should be only one "server" span for each "client" span and it should be in a direct parent-child relationship. The way it was set up, you couldn't insert any spans before this one without breaking the rule. This was problematic especially with HTTP auto-instrumentation, which is otherwise very useful.

If this happens to be the root span (there's no client, proxy etc. with tracing enabled), "internal" is the most suitable option. If it's not the root span, users will probably want to use a transport layer instrumentation library to enable context propagation anyway, and that will add a "server" span above this RPC span.