### PR TITLE
Schema editing/remove obsolete checks

### DIFF
--- a/core/ecschema-editing/src/Differencing/SchemaDiagnosticVisitor.ts
+++ b/core/ecschema-editing/src/Differencing/SchemaDiagnosticVisitor.ts
@@ -181,12 +181,6 @@ export class SchemaDiagnosticVisitor {
 
   private visitChangedSchemaItem(diagnostic: AnyDiagnostic) {
     const schemaItem = diagnostic.ecDefinition as AnySchemaItem;
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === schemaItem.name)) {
-      return;
-    }
-
     const [propertyName, sourceValue, targetValue] = diagnostic.messageArgs as [string, unknown, unknown];
     if (propertyName === "schemaItemType") {
       return this.addConflict({
@@ -246,12 +240,6 @@ export class SchemaDiagnosticVisitor {
 
   private visitMissingEnumerator(diagnostic: AnyDiagnostic) {
     const enumeration = diagnostic.ecDefinition as Enumeration;
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemPathChanges.find((entry) => entry.changeType === "add" && entry.itemName === enumeration.name)) {
-      return;
-    }
-
     const [enumerator] = diagnostic.messageArgs as [AnyEnumerator];
     this.schemaItemPathChanges.push({
       changeType: "add",
@@ -274,12 +262,6 @@ export class SchemaDiagnosticVisitor {
 
   private visitChangedEnumerator(diagnostic: AnyDiagnostic) {
     const enumeration = diagnostic.ecDefinition as Enumeration;
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemPathChanges.find((entry) => entry.changeType === "add" && entry.itemName === enumeration.name)) {
-      return;
-    }
-
     const [enumerator, propertyName, sourceValue, targetValue] = diagnostic.messageArgs as [AnyEnumerator, keyof AnyEnumerator, any, any];
     if (this.lookupEnumeratorEntry("add", enumeration.name, enumerator.name)) {
       return;
@@ -328,12 +310,6 @@ export class SchemaDiagnosticVisitor {
 
   private visitMissingProperty(diagnostic: AnyDiagnostic) {
     const property = diagnostic.ecDefinition as Property;
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.schemaType in SchemaItemType && entry.itemName === property.class.name)) {
-      return;
-    }
-
     this.schemaItemPathChanges.push({
       changeType: "add",
       schemaType: SchemaOtherTypes.Property,
@@ -345,16 +321,6 @@ export class SchemaDiagnosticVisitor {
 
   private visitChangedProperty(diagnostic: AnyDiagnostic) {
     const property = diagnostic.ecDefinition as Property;
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === property.class.name)) {
-      return;
-    }
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemPathChanges.find((entry) => entry.changeType === "add" && entry.itemName === property.class.name && entry.path === property.name)) {
-      return;
-    }
-
     const [propertyName, sourceValue, targetValue] = diagnostic.messageArgs as [keyof PropertyProps, any, any];
     if (!this.validatePropertyChange(property, propertyName, sourceValue, targetValue)) {
       return;
@@ -398,12 +364,6 @@ export class SchemaDiagnosticVisitor {
 
   private visitMissingBaseClass(diagnostic: AnyDiagnostic) {
     const ecClass = diagnostic.ecDefinition as ECClass;
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === ecClass.name)) {
-      return;
-    }
-
     const [sourceBaseClass, targetBaseClass] = diagnostic.messageArgs as [ECClass, ECClass];
     if (!this.validateBaseClassChange(ecClass, sourceBaseClass, targetBaseClass)) {
       return;
@@ -470,12 +430,6 @@ export class SchemaDiagnosticVisitor {
 
   private visitMissingMixinOnClass(diagnostic: AnyDiagnostic) {
     const ecClass = diagnostic.ecDefinition as ECClass;
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === ecClass.name)) {
-      return;
-    }
-
     const [mixin] = diagnostic.messageArgs as [Mixin];
     if (!this.validateMixin(ecClass, mixin)) {
       return;
@@ -518,11 +472,6 @@ export class SchemaDiagnosticVisitor {
     const constraint = diagnostic.ecDefinition as RelationshipConstraint;
     const className = constraint.relationshipClass.name;
     const constraintPath = constraint.isSource ? "$source" : "$target";
-
-    // TODO: Remove after fix #6560 has been merged into master.
-    if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === className)) {
-      return;
-    }
 
     let modifyEntry = this.schemaItemPathChanges.find((entry): entry is RelationshipConstraintClassDifference => {
       return entry.changeType === "add" && entry.schemaType === SchemaOtherTypes.RelationshipConstraintClass, entry.itemName === className && entry.path === constraintPath;
@@ -606,10 +555,6 @@ export class SchemaDiagnosticVisitor {
     }
 
     if (SchemaItem.isSchemaItem(ecType)) {
-      // TODO: Remove after fix #6560 has been merged into master.
-      if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === ecType.name)) {
-        return;
-      }
       return this.customAttributeChanges.push({
         changeType: "add",
         schemaType: SchemaOtherTypes.CustomAttributeInstance,
@@ -620,15 +565,6 @@ export class SchemaDiagnosticVisitor {
     }
 
     if (Property.isProperty(ecType)) {
-      // TODO: Remove after fix #6560 has been merged into master.
-      if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === ecType.name)) {
-        return;
-      }
-      // TODO: Remove after fix #6560 has been merged into master.
-      if (this.schemaItemPathChanges.find((entry) => entry.changeType === "add" && entry.itemName === ecType.name && entry.path === ecType.name)) {
-        return;
-      }
-
       return this.customAttributeChanges.push({
         changeType: "add",
         schemaType: SchemaOtherTypes.CustomAttributeInstance,
@@ -640,11 +576,6 @@ export class SchemaDiagnosticVisitor {
     }
 
     if (RelationshipConstraint.isRelationshipConstraint(ecType)) {
-      // TODO: Remove after fix #6560 has been merged into master.
-      if (this.schemaItemChanges.find((entry) => entry.changeType === "add" && entry.itemName === ecType.relationshipClass.name)) {
-        return;
-      }
-
       return this.customAttributeChanges.push({
         changeType: "add",
         schemaType: SchemaOtherTypes.CustomAttributeInstance,

--- a/core/ecschema-editing/src/Validation/SchemaCompareVisitor.ts
+++ b/core/ecschema-editing/src/Validation/SchemaCompareVisitor.ts
@@ -65,10 +65,10 @@ export class SchemaCompareVisitor implements ISchemaPartVisitor {
     let propertyB: AnyProperty | undefined;
 
     const classB = await this._schemaB.lookupItem<ECClass>(propertyA.class.name);
-    if (classB)
+    if (classB) {
       propertyB = await classB.getProperty(propertyA.name) as AnyProperty;
-
-    this._schemaComparer.compareProperties(propertyA, propertyB);
+      this._schemaComparer.compareProperties(propertyA, propertyB);
+    }
   }
 
   /**

--- a/core/ecschema-editing/src/test/Differencing/Difference.test.ts
+++ b/core/ecschema-editing/src/test/Differencing/Difference.test.ts
@@ -94,7 +94,8 @@ describe("Schema Difference Reporting", () => {
     const targetSchema = await Schema.fromJson(targetJson, targetContext);
 
     schemaDifferences = await SchemaDifference.fromSchemas(targetSchema, sourceSchema);
-    expect(schemaDifferences.conflicts).equals(undefined, `This test suite should not have conflicts.`);
+    expect(schemaDifferences.conflicts).equals(undefined, "This test suite should not have conflicts.");
+    expect(schemaDifferences.changes).has.a.lengthOf(27, "Unexpected count of changes.");
   });
 
   it("should have the expected source and target schema names in differences", () => {

--- a/core/ecschema-editing/src/test/Differencing/sourceSchema.json.ts
+++ b/core/ecschema-editing/src/test/Differencing/sourceSchema.json.ts
@@ -33,14 +33,12 @@ export default {
   items: {
     AreaPhenomenon: {
       schemaItemType: "Phenomenon",
-      name: "AREA",
       label: "Area",
       description: "Area description",
       definition: "Units.LENGTH(4)",
     },
     TestUnitSystem: {
       schemaItemType: "UnitSystem",
-      name: "IMPERIAL",
       label: "Imperial",
     },
     MissingEnumeration: {
@@ -141,7 +139,7 @@ export default {
     },
     RelationshipEntity: {
       schemaItemType: "RelationshipClass",
-      name: "TestRelationship",
+      description: "TestRelationship",
       strength: "Embedding",
       strengthDirection: "Forward",
       source: {

--- a/core/ecschema-editing/src/test/Differencing/targetSchema.json.ts
+++ b/core/ecschema-editing/src/test/Differencing/targetSchema.json.ts
@@ -26,7 +26,6 @@ export default {
   items: {
     AreaPhenomenon: {
       schemaItemType: "Phenomenon",
-      name: "AREA",
       label: "Area",
       description: "Area description",
       definition: "Units.LENGTH(4)",
@@ -66,7 +65,7 @@ export default {
     },
     RelationshipEntity: {
       schemaItemType: "RelationshipClass",
-      name: "TestRelationship",
+      description: "TestRelationship",
       strength: "Embedding",
       strengthDirection: "Forward",
       source: {

--- a/core/ecschema-editing/src/test/Validation/SchemaComparer.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaComparer.test.ts
@@ -5,7 +5,7 @@
 
 import { expect } from "chai";
 import { AnyECType, AnyProperty, Constant, CustomAttributeClass, ECClass, EntityClass, Enumeration, Format, InvertedUnit, KindOfQuantity, Mixin, Phenomenon, PropertyCategory,
-  RelationshipClass, Schema, SchemaContext, Unit,
+  RelationshipClass, Schema, SchemaContext, StructClass, Unit,
 } from "@itwin/ecschema-metadata";
 import { AnyDiagnostic, DiagnosticCategory, DiagnosticType } from "../../Validation/Diagnostic";
 import { ISchemaChanges, SchemaChanges } from "../../Validation/SchemaChanges";
@@ -277,20 +277,34 @@ describe("Schema comparison tests", () => {
     it("Different SchemaItems, diagnostic reported for each schema", async () => {
       const aItems = {
         TestClassA: {
-          schemaItemType: "EntityClass",
+          schemaItemType: "StructClass",
+          properties: [
+            {
+              name: "BooleanProperty",
+              type: "PrimitiveProperty",
+              typeName: "boolean",
+            },
+          ],
         },
       };
       const bItems = {
         TestClassB: {
-          schemaItemType: "EntityClass",
+          schemaItemType: "StructClass",
+          properties: [
+            {
+              name: "StringProperty",
+              type: "PrimitiveProperty",
+              typeName: "string",
+            },
+          ],
         },
       };
       const aJson = getSchemaJsonWithItems(schemaAJson, aItems);
       const bJson = getSchemaJsonWithItems(schemaAJson, bItems);
       const schemaA = await Schema.fromJson(aJson, contextA);
       const schemaB = await Schema.fromJson(bJson, contextB);
-      const itemA = await schemaA.getItem<EntityClass>("TestClassA");
-      const itemB = await schemaB.getItem<EntityClass>("TestClassB");
+      const itemA = await schemaA.getItem<StructClass>("TestClassA");
+      const itemB = await schemaB.getItem<StructClass>("TestClassB");
 
       const comparer = new SchemaComparer(reporter);
       await comparer.compareSchemas(schemaA, schemaB);
@@ -660,6 +674,13 @@ describe("Schema comparison tests", () => {
           schemaItemType: "EntityClass",
           baseClass: "SchemaA.BaseClassA",
           modifier: "Sealed",
+          properties: [
+            {
+              name: "StringProperty",
+              type: "PrimitiveArrayProperty",
+              typeName: "string",
+            },
+          ],
         },
       };
       const bItems = {
@@ -2633,10 +2654,24 @@ describe("Schema comparison tests", () => {
         TestClassA: {
           schemaItemType: "EntityClass",
           mixins: ["SchemaA.MixinA"],
+          properties: [
+            {
+              name: "StringProperty",
+              type: "PrimitiveProperty",
+              typeName: "string",
+            },
+          ],
         },
         MixinA: {
           schemaItemType: "Mixin",
           appliesTo: "SchemaA.TestClassA",
+          properties: [
+            {
+              name: "IntegerProperty",
+              type: "PrimitiveProperty",
+              typeName: "int",
+            },
+          ],
         },
       };
       const bItems = {};
@@ -2754,6 +2789,13 @@ describe("Schema comparison tests", () => {
         MixinB: {
           schemaItemType: "Mixin",
           appliesTo: "SchemaA.TestClassA",
+          properties: [
+            {
+              name: "BooleanProperty",
+              type: "PrimitiveProperty",
+              typeName: "boolean",
+            },
+          ],
         },
       };
       const bItems = {
@@ -2790,6 +2832,13 @@ describe("Schema comparison tests", () => {
           schemaItemType: "RelationshipClass",
           strength: "referencing",
           strengthDirection: "forward",
+          properties: [
+            {
+              name: "StringProperty",
+              type: "PrimitiveProperty",
+              typeName: "string",
+            },
+          ],
           source: {
             multiplicity: "(0..*)",
             roleLabel: "LabelA",
@@ -3551,6 +3600,13 @@ describe("Schema comparison tests", () => {
         TestCustomAttribute: {
           schemaItemType: "CustomAttributeClass",
           appliesTo: "Schema, AnyProperty",
+          properties: [
+            {
+              name: "DoubleArrayProperty",
+              type: "PrimitiveArrayProperty",
+              typeName: "double",
+            },
+          ],
         },
       };
       const aJson = getSchemaJsonWithItems(schemaAJson, aItems);


### PR DESCRIPTION
Schema merger had checks to skip processing certain diagnosis entries if the related schema item has been detected as missing which cause it to be added entirely and we don't need additional entries that refer to the same item. After some latest additions, the diagnosis reports more efficiently and the checks became obsolete in the merger.

This PR also contains a fix for a bug in the SchemaComparer where the properties were still reported as missing for missing ecclasses.