### PR TITLE
Don't save to lock-database when inserting elements if their Model is locked

### DIFF
--- a/common/changes/@itwin/core-backend/lock-perf_2024-04-18-17-47.json
+++ b/common/changes/@itwin/core-backend/lock-perf_2024-04-18-17-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Don't lock child if parent is already locked",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/lock-perf_2024-04-18-17-47.json
+++ b/common/changes/@itwin/core-backend/lock-perf_2024-04-18-17-47.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Don't lock child if parent is already locked",
+      "comment": "Don't save to lock-database when inserting elements if their Model is locked",
       "type": "none"
     }
   ],

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -166,7 +166,9 @@ export class Element extends Entity {
    * @beta
    */
   protected static onInserted(arg: OnElementIdArg): void {
-    arg.iModel.locks.elementWasCreated(arg.id);
+    const locks = arg.iModel.locks;
+    if (locks && !locks.holdsExclusiveLock(arg.model))
+      locks.elementWasCreated(arg.id);
   }
 
   /** Called before an Element is updated.

--- a/core/backend/src/ServerBasedLocks.ts
+++ b/core/backend/src/ServerBasedLocks.ts
@@ -192,8 +192,6 @@ export class ServerBasedLocks implements LockControl {
 
   /** When an element is newly created in a session, we hold the lock on it implicitly. Save that fact. */
   public elementWasCreated(id: Id64String) {
-    if (this.ownerHoldsExclusiveLock(id))
-      return;
     this.insertLock(id, LockState.Exclusive, LockOrigin.NewElement);
     this.lockDb.saveChanges();
   }

--- a/core/backend/src/ServerBasedLocks.ts
+++ b/core/backend/src/ServerBasedLocks.ts
@@ -192,6 +192,8 @@ export class ServerBasedLocks implements LockControl {
 
   /** When an element is newly created in a session, we hold the lock on it implicitly. Save that fact. */
   public elementWasCreated(id: Id64String) {
+    if (this.ownerHoldsExclusiveLock(id))
+      return;
     this.insertLock(id, LockState.Exclusive, LockOrigin.NewElement);
     this.lockDb.saveChanges();
   }


### PR DESCRIPTION
Changes as requested by @abeesh after seeing a 20x slow down with local synchronizations compared to batch connectors. 