### PR TITLE
Allow pushing changes from a BriefcaseDb opened readonly

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -514,6 +514,8 @@ export class BriefcaseDb extends IModelDb {
     static findByKey(key: string): BriefcaseDb;
     get isBriefcase(): boolean;
     get iTwinId(): GuidString;
+    // (undocumented)
+    protected makeLockControl(): void;
     readonly onClosed: BeEvent<() => void>;
     // @alpha (undocumented)
     static readonly onCodeServiceCreated: BeEvent<(briefcase: BriefcaseDb) => void>;

--- a/common/changes/@itwin/core-backend/push-changes-writeable_2024-04-22-12-28.json
+++ b/common/changes/@itwin/core-backend/push-changes-writeable_2024-04-22-12-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "allow pushing changes from a briefcase opened readonly",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/standalone/IModelWrite.test.ts
+++ b/core/backend/src/test/standalone/IModelWrite.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../../core-backend";
 import { IModelTestUtils, TestUserType } from "../IModelTestUtils";
 import { ServerBasedLocks } from "../../ServerBasedLocks";
-import exp = require("constants");
+
 chai.use(chaiAsPromised);
 
 export async function createNewModelAndCategory(rwIModel: BriefcaseDb, parent?: Id64String) {


### PR DESCRIPTION
Use `BriefcaseDb.executeWriteable` and make that function open the `ServerBasedLocks` lock control.