### PR TITLE
Change SchemaDifference.changes to be not undefined

### DIFF
--- a/common/changes/@itwin/ecschema-editing/schema-editing-default-changes-array_2024-04-25-08-44.json
+++ b/common/changes/@itwin/ecschema-editing/schema-editing-default-changes-array_2024-04-25-08-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/core/ecschema-editing/src/Differencing/SchemaDifference.ts
+++ b/core/ecschema-editing/src/Differencing/SchemaDifference.ts
@@ -100,8 +100,8 @@ export namespace SchemaDifference {
     return {
       sourceSchemaName: schemaChanges.schema.schemaKey.toString(),
       targetSchemaName: targetSchema.schemaKey.toString(),
-      changes: changes.length > 0 ? changes : undefined,
       conflicts: visitor.conflicts.length > 0 ? visitor.conflicts : undefined,
+      changes,
     };
   }
 
@@ -256,7 +256,6 @@ export namespace SchemaDifference {
   export function isRelationshipConstraintClassDifference(difference: AnySchemaDifference): difference is RelationshipConstraintClassDifference {
     return difference.schemaType === SchemaOtherTypes.RelationshipConstraintClass;
   }
-
 }
 
 /**
@@ -270,7 +269,8 @@ export interface SchemaDifferences {
   readonly targetSchemaName: string;
 
   /** List of differences between the compared schemas. */
-  readonly changes?: AnySchemaDifference[];
+  readonly changes: AnySchemaDifference[];
+
   /** List of conflicts found while comparing the schemas. */
   readonly conflicts?: SchemaDifferenceConflict[];
 }

--- a/core/ecschema-editing/src/test/Differencing/Difference.test.ts
+++ b/core/ecschema-editing/src/test/Differencing/Difference.test.ts
@@ -129,8 +129,8 @@ describe("Schema Difference Reporting", () => {
     }, new SchemaContext());
 
     const differences = await SchemaDifference.fromSchemas(targetSchema, sourceSchema);
-    expect(differences.conflicts).equals(undefined, `This test should not have conflicts.`);
-    expect(differences.changes).equals(undefined, `This test should not have changes.`);
+    expect(differences.changes).has.lengthOf(0, "This test should not have changes.");
+    expect(differences.conflicts).equals(undefined, "This test should not have conflicts.");
   });
 
   it("should not return items that exists in both or in target schema", () => {

--- a/core/ecschema-editing/src/test/Merging/SchemaMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/SchemaMerger.test.ts
@@ -27,7 +27,8 @@ describe("Schema merge tests", () => {
     const merge = merger.merge({
       sourceSchemaName: "SourceSchema.01.02.03",
       targetSchemaName: "TargetSchema.01.00.00",
-      conflicts: [ conflict ],
+      conflicts: [conflict],
+      changes: [],
     });
 
     await expect(merge).to.be.rejectedWith(SchemaConflictsError, "Schema's can't be merged if there are unresolved conflicts.")


### PR DESCRIPTION
SchemaDifferences has a readonly array-property _changes_ that contain all differences between two compared schemas. At the moment, the changes array kept undefined if no changes were found, this however limits the ability for a consumer to add manually or apply pre-saved changes.