### PR TITLE
Don't clip 2d dynamic element graphics to project extents.

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-2d-dynamic-graphics-clip_2024-05-01-11-11.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-2d-dynamic-graphics-clip_2024-05-01-11-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix dynamic element graphics being clipped to the project extents in 2d models.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/DynamicIModelTile.ts
+++ b/core/frontend/src/tile/DynamicIModelTile.ts
@@ -362,7 +362,7 @@ class GraphicsTile extends Tile {
       omitEdges: !this.tree.edgeOptions,
       edgeType: this.tree.edgeOptions && "non-indexed" !== this.tree.edgeOptions.type ? 2 : 1,
       smoothPolyfaceEdges: this.tree.edgeOptions && this.tree.edgeOptions.smooth,
-      clipToProjectExtents: true,
+      clipToProjectExtents: this.tree.is3d,
       sectionCut: this.tree.stringifiedSectionClip,
     };
 


### PR DESCRIPTION
Duh.

Fixes #6672.