### PR TITLE
Improvement to SchemaSync for iModel Hub forking/init case

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4688,10 +4688,12 @@ export namespace SchemaSync {
         openMode?: OpenMode;
         user?: string;
     }, operation: (access: CloudAccess) => Promise<void>) => Promise<void>;
+    const pull: (iModel: TestCacheIModel) => Promise<void>;
     const // (undocumented)
     initializeForIModel: (arg: {
         iModel: IModelDb;
         containerProps: CloudSqlite.ContainerProps;
+        overrideContainer?: boolean;
     }) => Promise<void>;
     export class SchemaSyncDb extends VersionedSqliteDb {
         // (undocumented)

--- a/common/changes/@itwin/core-backend/affanK-fix-schema-sync-for-imodel-hub_2024-05-02-18-22.json
+++ b/common/changes/@itwin/core-backend/affanK-fix-schema-sync-for-imodel-hub_2024-05-02-18-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "schemaUpgrade() now push change to schema sync",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}


### PR DESCRIPTION
Changes
### IModel Hub initializing & forking usecase
1. `SyncId` now mean `ContainerId` which of type string (instead of BeGuid) and must be provided by caller when initializing schema sync container. Previously it was random Guid that was problem when forking iModel from specific changeset.
2. For a given iModel a schema sync container can be initialized again with new container. In this case SchemaSync will assign new `containerId` to `SyncId` and also copy `DataVer` from iModel to container.

### Profile upgrades
When iModel goes through profile upgrade its is also pushed to schema sync container. (previously it was not pushed)
1. Under new rule profile version of schema sync container and iModel must follow following rules
   * **On pull**: iModel ECDb profile version <= schema sync container ECDb profile version.
   * **On push**: iModel ECDb profile version >= schema sync container ECDb profile version. 
2. iTwin `IModelDb.upgradeSchemas()`  will ensure profile upgrade is pushed to user.

### Misc
Add ability to pull new schema changes from schema sync on iTwin.js side.

imodel-native: https://github.com/iTwin/imodel-native/pull/744