### PR TITLE
Fix text rotation around anchor point 

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -9458,13 +9458,14 @@ export class TestRpcManager {
 // @beta
 export class TextAnnotation {
     anchor: TextAnnotationAnchor;
+    // @internal (undocumented)
+    computeAnchorPoint(layoutRange: Range2d): Point3d;
     // @internal
     computeDocumentTransform(layoutRange: Range2d): Transform;
     static create(args?: TextAnnotationCreateArgs): TextAnnotation;
     equals(other: TextAnnotation): boolean;
     static fromJSON(props: TextAnnotationProps | undefined): TextAnnotation;
     orientation: YawPitchRollAngles;
-    origin: Point3d;
     textBlock: TextBlock;
     toJSON(): TextAnnotationProps;
 }
@@ -9497,7 +9498,6 @@ export interface TextAnnotationAnchor {
 export interface TextAnnotationCreateArgs {
     anchor?: TextAnnotationAnchor;
     orientation?: YawPitchRollAngles;
-    origin?: Point3d;
     textBlock?: TextBlock;
 }
 
@@ -9505,7 +9505,6 @@ export interface TextAnnotationCreateArgs {
 export interface TextAnnotationProps {
     anchor?: TextAnnotationAnchor;
     orientation?: YawPitchRollProps;
-    origin?: XYZProps;
     textBlock?: TextBlockProps;
 }
 

--- a/common/changes/@itwin/core-backend/pmc-fix-text-anchor_2024-05-03-11-44.json
+++ b/common/changes/@itwin/core-backend/pmc-fix-text-anchor_2024-05-03-11-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fix text annotation rotation around anchor point.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/pmc-fix-text-anchor_2024-05-03-11-44.json
+++ b/common/changes/@itwin/core-common/pmc-fix-text-anchor_2024-05-03-11-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Remove unused TextAnnotation.origin.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/TextAnnotationGeometry.ts
+++ b/core/backend/src/TextAnnotationGeometry.ts
@@ -6,7 +6,7 @@
  * @module ElementGeometry
  */
 
-import { TextAnnotation, TextBlockGeometryProps, TextBlockGeometryPropsEntry, TextString, TextStyleColor } from "@itwin/core-common";
+import { ColorDef, TextAnnotation, TextBlockGeometryProps, TextBlockGeometryPropsEntry, TextString, TextStyleColor } from "@itwin/core-common";
 import { ComputeRangesForTextLayout, FindFontId, FindTextStyle, layoutTextBlock, RunLayout, TextBlockLayout } from "./TextAnnotationLayout";
 import { LineSegment3d, Point3d, Range2d, Transform, Vector2d } from "@itwin/core-geometry";
 import { assert } from "@itwin/core-bentley";
@@ -125,7 +125,7 @@ function processFractionRun(run: RunLayout, transform: Transform, context: Geome
   }
 }
 
-function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Transform): TextBlockGeometryProps {
+function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Transform, debugAnchorPt?: Point3d): TextBlockGeometryProps {
   const context: GeometryContext = { entries: [] };
   for (const line of layout.lines) {
     const lineTrans = Transform.createTranslationXYZ(line.offsetFromDocument.x, line.offsetFromDocument.y, 0);
@@ -145,6 +145,25 @@ function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Tr
     }
   }
 
+  if (debugAnchorPt) {
+    context.entries.push({
+      color: ColorDef.red.toJSON(),
+    });
+
+    context.entries.push({
+      separator: {
+        startPoint: [layout.range.low.x, debugAnchorPt.y, 0],
+        endPoint: [layout.range.high.x, debugAnchorPt.y, 0],
+      },
+    });
+    context.entries.push({
+      separator: {
+        startPoint: [debugAnchorPt.x, layout.range.low.y, 0],
+        endPoint: [debugAnchorPt.x, layout.range.high.y, 0],
+      },
+    });
+  }
+  
   return { entries: context.entries };
 }
 
@@ -176,5 +195,5 @@ export function produceTextAnnotationGeometry(args: ProduceTextAnnotationGeometr
   });
 
   const transform = args.annotation.computeDocumentTransform(layout.range);
-  return produceTextBlockGeometry(layout, transform);
+  return produceTextBlockGeometry(layout, transform /*, args.annotation.computeAnchorPoint(layout.range) */);
 }

--- a/core/backend/src/TextAnnotationGeometry.ts
+++ b/core/backend/src/TextAnnotationGeometry.ts
@@ -146,6 +146,7 @@ function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Tr
   }
 
   if (debugAnchorPt) {
+    // Draw lines representing the horizontal and vertical ranges, intersecting at the anchor point.
     context.entries.push({
       color: ColorDef.red.toJSON(),
     });
@@ -163,7 +164,7 @@ function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Tr
       },
     });
   }
-  
+
   return { entries: context.entries };
 }
 
@@ -197,6 +198,6 @@ export function produceTextAnnotationGeometry(args: ProduceTextAnnotationGeometr
   const transform = args.annotation.computeDocumentTransform(layout.range);
 
   const debugAnchorPointAndRange = false;
-  let anchorPoint = debugAnchorPointAndRange ? args.annotation.computeAnchorPoint(layout.range) : undefined;
+  const anchorPoint = debugAnchorPointAndRange ? args.annotation.computeAnchorPoint(layout.range) : undefined;
   return produceTextBlockGeometry(layout, transform, anchorPoint);
 }

--- a/core/backend/src/TextAnnotationGeometry.ts
+++ b/core/backend/src/TextAnnotationGeometry.ts
@@ -135,8 +135,8 @@ function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Tr
       }
 
       const runTrans = Transform.createTranslationXYZ(run.offsetFromLine.x, run.offsetFromLine.y, 0);
-      documentTransform.multiplyTransformTransform(runTrans, runTrans);
       lineTrans.multiplyTransformTransform(runTrans, runTrans);
+      documentTransform.multiplyTransformTransform(runTrans, runTrans);
       if ("text" === run.source.type) {
         processTextRun(run, runTrans, context);
       } else {
@@ -195,5 +195,8 @@ export function produceTextAnnotationGeometry(args: ProduceTextAnnotationGeometr
   });
 
   const transform = args.annotation.computeDocumentTransform(layout.range);
-  return produceTextBlockGeometry(layout, transform /*, args.annotation.computeAnchorPoint(layout.range) */);
+
+  const debugAnchorPointAndRange = false;
+  let anchorPoint = debugAnchorPointAndRange ? args.annotation.computeAnchorPoint(layout.range) : undefined;
+  return produceTextBlockGeometry(layout, transform, anchorPoint);
 }

--- a/core/backend/src/test/annotations/TextAnnotation.test.ts
+++ b/core/backend/src/test/annotations/TextAnnotation.test.ts
@@ -679,7 +679,6 @@ describe("TextAnnotation element", () => {
           vertical: "middle",
           horizontal: "right",
         },
-        origin: [0, -5, 100],
         orientation: { yaw: 1, pitch: 0, roll: -1 },
       });
     }

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -6,7 +6,7 @@
  * @module Annotation
  */
 
-import { Point3d, Range2d, Transform, XYZProps, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
+import { Point3d, Range2d, Transform, YawPitchRollAngles, YawPitchRollProps } from "@itwin/core-geometry";
 import { TextBlock, TextBlockProps } from "./TextBlock";
 
 /**
@@ -149,7 +149,7 @@ export class TextAnnotation {
   public computeAnchorPoint(layoutRange: Range2d): Point3d {
     let x = 0;
     let y = 0;
-    
+
     switch (this.anchor.horizontal) {
       case "center":
         x += layoutRange.xLength() / 2;
@@ -167,7 +167,7 @@ export class TextAnnotation {
         y -= layoutRange.yLength();
         break;
     }
-    
+
     return new Point3d(x, y, 0);
   }
 

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -10,7 +10,11 @@ import { Point3d, Range2d, Transform, XYZProps, YawPitchRollAngles, YawPitchRoll
 import { TextBlock, TextBlockProps } from "./TextBlock";
 
 /**
- * Describes the horizontal and vertical alignment of a [[TextAnnotation]]'s text relative to [[TextAnnotation.origin]].
+ * Describes the horizontal and vertical alignment of a [[TextAnnotation]]'s text relative to the [Placement]($common) origin of
+ * the [TextAnnotation2d]($backend) or [TextAnnotation3d]($backend) host element, also referred to as the annotation's "anchor point".
+ * For example, if the anchor is specified as middle-center, the text will be centered on the element's origin.
+ * The anchor point also serves as the pivot point for [[TextAnnotation.rotation]], such that the text is rotated about the
+ * anchor point while the anchor point remains fixed.
  * @beta
  * @preview
  * @extensions
@@ -40,8 +44,6 @@ export interface TextAnnotationAnchor {
  * @extensions
  */
 export interface TextAnnotationProps {
-  /** See [[TextAnnotation.origin]]. Default: [0, 0, 0]*/
-  origin?: XYZProps;
   /** See [[TextAnnotation.orientation]]. Default: no rotation. */
   orientation?: YawPitchRollProps;
   /** See [[TextAnnotation.textBlock]]. Default: an empty text block. */
@@ -56,8 +58,6 @@ export interface TextAnnotationProps {
  * @extensions
  */
 export interface TextAnnotationCreateArgs {
-  /** See [[TextAnnotation.origin]]. Default: [0, 0, 0]*/
-  origin?: Point3d;
   /** See [[TextAnnotation.orientation]]. Default: no rotation. */
   orientation?: YawPitchRollAngles;
   /** See [[TextAnnotation.textBlock]]. Default: an empty text block. */
@@ -75,13 +75,6 @@ export interface TextAnnotationCreateArgs {
  */
 export class TextAnnotation {
   /**
-   * The point considered to be the origin of the annotation. The [[textBlock]]'s content is justified relative to this point as specified by [[anchor]].
-   * This point is also considered the origin by [AccuSnap]($frontend) when using [SnapMode.Origin]($frontend).
-   * Often, the origin is specified by a user clicking in a viewport when placing text annotations interactively.
-   * @note When defining an annotation for a [TextAnnotation2d]($backend), the `z` component should be zero.
-   */
-  public origin: Point3d;
-  /**
    * The rotation of the annotation.
    * @note When defining an annotation for a [TextAnnotation2d]($backend), only the `yaw` component (rotation around the Z axis) is used.
    */
@@ -91,12 +84,11 @@ export class TextAnnotation {
    */
   public textBlock: TextBlock;
   /**
-   * Describes how the [[textBlock]]'s content should be aligned relative to the [[origin]].
+   * Describes how the [[textBlock]]'s content should be aligned relative to the host element's origin.
    */
   public anchor: TextAnnotationAnchor;
 
-  private constructor(origin: Point3d, angles: YawPitchRollAngles, textBlock: TextBlock, anchor: TextAnnotationAnchor) {
-    this.origin = origin;
+  private constructor(angles: YawPitchRollAngles, textBlock: TextBlock, anchor: TextAnnotationAnchor) {
     this.orientation = angles;
     this.textBlock = textBlock;
     this.anchor = anchor;
@@ -104,12 +96,11 @@ export class TextAnnotation {
 
   /** Creates a new TextAnnotation. */
   public static create(args?: TextAnnotationCreateArgs): TextAnnotation {
-    const origin = args?.origin ?? new Point3d();
     const angles = args?.orientation ?? new YawPitchRollAngles();
     const textBlock = args?.textBlock ?? TextBlock.createEmpty();
     const anchor = args?.anchor ?? { vertical: "top", horizontal: "left" };
 
-    return new TextAnnotation(origin, angles, textBlock, anchor);
+    return new TextAnnotation(angles, textBlock, anchor);
   }
 
   /**
@@ -117,7 +108,6 @@ export class TextAnnotation {
    */
   public static fromJSON(props: TextAnnotationProps | undefined): TextAnnotation {
     return TextAnnotation.create({
-      origin: props?.origin ? Point3d.fromJSON(props.origin) : undefined,
       orientation: props?.orientation ? YawPitchRollAngles.fromJSON(props.orientation) : undefined,
       textBlock: props?.textBlock ? TextBlock.create(props.textBlock) : undefined,
       anchor: props?.anchor ? { ...props.anchor } : undefined,
@@ -134,10 +124,6 @@ export class TextAnnotation {
     // so the user can pick up where they left off editing it next time.
     props.textBlock = this.textBlock.toJSON();
 
-    if (!this.origin.isZero) {
-      props.origin = this.origin.toJSON();
-    }
-
     if (!this.orientation.isIdentity()) {
       props.orientation = this.orientation.toJSON();
     }
@@ -153,34 +139,41 @@ export class TextAnnotation {
    * @internal used by produceTextAnnotationGeometry; requires layoutRange computed by layoutTextBlock.
    */
   public computeDocumentTransform(layoutRange: Range2d): Transform {
-    const origin = this.origin.clone();
+    const origin = this.computeAnchorPoint(layoutRange);
     const matrix = this.orientation.toMatrix3d();
 
+    return Transform.createFixedPointAndMatrix(origin, matrix);
+  }
+
+  /** @internal */
+  public computeAnchorPoint(layoutRange: Range2d): Point3d {
+    let x = 0;
+    let y = 0;
+    
     switch (this.anchor.horizontal) {
       case "center":
-        origin.x -= layoutRange.xLength() / 2;
+        x += layoutRange.xLength() / 2;
         break;
       case "right":
-        origin.x -= layoutRange.xLength();
+        x += layoutRange.xLength();
         break;
     }
 
     switch (this.anchor.vertical) {
       case "middle":
-        origin.y += layoutRange.yLength() / 2;
+        y -= layoutRange.yLength() / 2;
         break;
       case "bottom":
-        origin.y += layoutRange.yLength();
+        y -= layoutRange.yLength();
         break;
     }
-
-    return Transform.createRefs(origin, matrix);
+    
+    return new Point3d(x, y, 0);
   }
 
   /** Returns true if this annotation is logically equivalent to `other`. */
   public equals(other: TextAnnotation): boolean {
     return this.anchor.horizontal === other.anchor.horizontal && this.anchor.vertical === other.anchor.vertical
-      && this.orientation.isAlmostEqual(other.orientation) && this.origin.isAlmostEqual(other.origin)
-      && this.textBlock.equals(other.textBlock);
+      && this.orientation.isAlmostEqual(other.orientation) && this.textBlock.equals(other.textBlock);
   }
 }

--- a/test-apps/display-test-app/src/frontend/TextDecoration.ts
+++ b/test-apps/display-test-app/src/frontend/TextDecoration.ts
@@ -158,7 +158,6 @@ export class TextDecorationTool extends Tool {
 
     const cmd = inArgs[0].toLowerCase();
     const arg = inArgs[1];
-    const arg2 = inArgs[2];
 
     switch (cmd) {
       case "clear":


### PR DESCRIPTION
Fixes #6688.

Added key-ins to display-test-app:
- `dta text rotation <degrees>`
- `dta text anchor <left|center|right|top|middle|bottom>`

Removed `TextAnnotation.origin`. It was not adding anything useful.
Clarified documentation of `TextAnnotationAnchor`.
Fixed inverted addition and subtraction in `TextAnnotation.computeDocumentTransform`, copied from rarely-if-ever-used C++ version.
Made `computeDocumentTransform` rotate about the fixed anchor point.

The results are *almost* correct.
- [x] The text doesn't rotate precisely about the anchor point. Matrix multiplication ordering mistake - fixed.
- [x]  The extremes of the rotated text get clipped out, seemingly by the element's bounding box. Likely a problem with how the bounding box is computed on the backend. This doesn't occur if the rotation is exactly +/-90 degrees. Fixed by https://github.com/iTwin/imodel-native/pull/746