### PR TITLE
Finalize TS5.3 and TypeDoc 0.25.x support. 

### DIFF
--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -86,7 +86,7 @@ jobs:
         workingDirectory: ${{ parameters.workingDir }}
         env:
           RUSH_BUILD_CACHE_CREDENTIAL: $(RushBuildCacheSAS)
-          RUSH_BUILD_CACHE_ENABLED: 1
+          # RUSH_BUILD_CACHE_ENABLED: 1
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
 
       - script: node common/scripts/install-run-rush.js docs

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -116,7 +116,7 @@ jobs:
           useCurrentConnectorFrameworkDocsArtifact: ${{ parameters.useCurrentConnectorFrameworkDocsArtifact }}
 
       # Currently BeMetalsmith is an internal only tool
-      - script: npm install @bentley/bemetalsmith@5.3.0-beta.0
+      - script: npm install @bentley/bemetalsmith@5.3.x
         displayName: Install BeMetalsmith
         workingDirectory: ${{ parameters.workingDir }}
 

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -46,13 +46,57 @@ parameters:
     default: false
 
 
+
 jobs:
+  - job: extract core docs
+    workspace:
+      clean: all
+    pool:
+      name: iModelTechCI
+      demands: Agent.OS -equals MacOS
+    steps:
+      - checkout: ${{ parameters.checkout }}
+        path: itwinjs-core
+        clean: true
+      - task: UseNode@1
+        displayName: Use Node 20
+        inputs:
+          version: 20.x
+          checkLatest: false
+      - script: |
+          git config --local user.email imodeljs-admin@users.noreply.github.com
+          git config --local user.name imodeljs-admin
+        displayName: Setup git config
+      # Only install, audit, and build the docs if not using the core artifact
+      - script: node common/scripts/install-run-rush.js install
+        displayName: rush install
+        workingDirectory: ${{ parameters.workingDir }}
+        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
+      - script: node common/scripts/install-run-rush.js audit
+        displayName: rush audit
+        workingDirectory: ${{ parameters.workingDir }}
+        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false), eq('${{ parameters.ignoreAudit }}', false))
+      - script: node common/scripts/install-run-rush.js build --to-version-policy prerelease-monorepo-lockStep
+        displayName: rush build
+        workingDirectory: ${{ parameters.workingDir }}
+        env:
+          RUSH_BUILD_CACHE_CREDENTIAL: $(RushBuildCacheSAS)
+          RUSH_BUILD_CACHE_ENABLED: 1
+        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
+      - script: node common/scripts/install-run-rush.js docs
+        displayName: rush docs
+        workingDirectory: ${{ parameters.workingDir }}
+        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
+      - publish: ${{ parameters.workingDir }}/generated-docs
+        artifact: Core Generated Docs
+        displayName: TEMP Publish Core Generated Docs Artifact
+
   - job: docsBuild
     workspace:
       clean: all
     pool:
       name: iModelTechCI
-      demands: Agent.OS -equals Linux
+      demands: Agent.OS -equals Windows_NT
 
     steps:
       - checkout: ${{ parameters.checkout }}
@@ -70,39 +114,18 @@ jobs:
           git config --local user.name imodeljs-admin
         displayName: Setup git config
 
-      # Only install, audit, and build the docs if not using the core artifact
-      - script: node common/scripts/install-run-rush.js install
-        displayName: rush install
-        workingDirectory: ${{ parameters.workingDir }}
-        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
-
-      - script: node common/scripts/install-run-rush.js audit
-        displayName: rush audit
-        workingDirectory: ${{ parameters.workingDir }}
-        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false), eq('${{ parameters.ignoreAudit }}', false))
-
-      - script: node common/scripts/install-run-rush.js build --to-version-policy prerelease-monorepo-lockStep
-        displayName: rush build
-        workingDirectory: ${{ parameters.workingDir }}
-        env:
-          RUSH_BUILD_CACHE_CREDENTIAL: $(RushBuildCacheSAS)
-          RUSH_BUILD_CACHE_ENABLED: 1
-        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
-
-      - script: node common/scripts/install-run-rush.js docs
-        displayName: rush docs
-        workingDirectory: ${{ parameters.workingDir }}
-        condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
-
-      - publish: ${{ parameters.workingDir }}/generated-docs
-        artifact: Core Generated Docs
-        displayName: TEMP Publish Core Generated Docs Artifact
       # - script: ls ${{parameters.workingDir}}/generated-docs
       #   displayName: List generated docs
 
       # - script: ls ${{parameters.stagingDir}}
       #   displayName: List staging files before docs
 
+
+      # Download the artifact published in the previous job
+      - download: current
+        artifact: Core Generated Docs
+        displayName: Download Core Generated Docs Artifact
+        path: ${{ parameters.workingDir }}/generated-docs
 
       # if using the core artifact, download the Core Generated Docs artifact it to the workingDir using downloadPipelineArtifact task
       - task: DownloadPipelineArtifact@2

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -94,6 +94,12 @@ jobs:
         workingDirectory: ${{ parameters.workingDir }}
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
 
+      - script: ls ${{parameters.workingDir}}/generated-docs
+        displayName: List generated docs
+
+      - script: ls ${{parameters.stagingDir}}
+        displayName: List staging files before docs
+
 
       # if using the core artifact, download the Core Generated Docs artifact it to the workingDir using downloadPipelineArtifact task
       - task: DownloadPipelineArtifact@2

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -53,7 +53,7 @@ jobs:
       clean: all
     pool:
       name: iModelTechCI
-      demands: Agent.OS -equals MacOS
+      demands: Agent.OS -equals Darwin
     steps:
       - checkout: ${{ parameters.checkout }}
         path: itwinjs-core
@@ -92,6 +92,7 @@ jobs:
         displayName: TEMP Publish Core Generated Docs Artifact
 
   - job: docsBuild
+    dependsOn: TypeDocJsonOutput
     workspace:
       clean: all
     pool:

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -122,10 +122,12 @@ jobs:
 
 
       # Download the artifact published in the previous job
-      - download: current
-        artifact: Core Generated Docs
-        displayName: Download Core Generated Docs Artifact
-        path: ${{ parameters.workingDir }}/generated-docs
+      - task: DownloadPipelineArtifact@2
+        displayName: get json artifacts from above
+        inputs:
+          artifact: Core Generated Docs
+          source: current
+          path: ${{ parameters.workingDir }}/generated-docs
 
       # if using the core artifact, download the Core Generated Docs artifact it to the workingDir using downloadPipelineArtifact task
       - task: DownloadPipelineArtifact@2

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -48,7 +48,7 @@ parameters:
 
 
 jobs:
-  - job: extract core docs
+  - job: TypeDocJsonOutput
     workspace:
       clean: all
     pool:

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -86,7 +86,7 @@ jobs:
         workingDirectory: ${{ parameters.workingDir }}
         env:
           RUSH_BUILD_CACHE_CREDENTIAL: $(RushBuildCacheSAS)
-          # RUSH_BUILD_CACHE_ENABLED: 1
+          RUSH_BUILD_CACHE_ENABLED: 1
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
 
       - script: node common/scripts/install-run-rush.js docs
@@ -94,6 +94,9 @@ jobs:
         workingDirectory: ${{ parameters.workingDir }}
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
 
+      - publish: ${{ parameters.workingDir }}/generated-docs
+        artifact: Core Generated Docs
+        displayName: TEMP Publish Core Generated Docs Artifact
       # - script: ls ${{parameters.workingDir}}/generated-docs
       #   displayName: List generated docs
 

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -52,7 +52,7 @@ jobs:
       clean: all
     pool:
       name: iModelTechCI
-      demands: Agent.OS -equals Windows_NT
+      demands: Agent.OS -equals Linux
 
     steps:
       - checkout: ${{ parameters.checkout }}
@@ -153,14 +153,14 @@ jobs:
         condition: and(succeeded(), eq('${{ parameters.shouldPublish }}', true))
 
         # tag the build to trigger the release pipeline
-      - powershell: |
-          $commitMsg = "$(Build.SourceVersionMessage)"
-          if ($commitMsg -match '^(\d+.\d+.\d+)(-dev.\d+)?$') {
-            Write-Host `'$commitMsg`'` is a version bump
-            Write-Host '##vso[build.addbuildtag]iTwinJsDocsRelease'
-          } else {
-            Write-Host `'$commitMsg`'` is not a version bump
-          }
+      - bash: |
+          commitMsg=$(Build.SourceVersionMessage)
+          if [[ $commitMsg =~ ^(\d+.\d+.\d+)(-dev.\d+)?$ ]]; then
+          echo "$commitMsg is a version bump"
+          echo "##vso[build.addbuildtag]iTwinJsDocsRelease"
+            else
+          echo "$commitMsg is not a version bump"
+            fi
         displayName: Tag release if version bump
         condition: and(succeeded(), eq('${{ parameters.shouldPublish }}', true), eq('${{ parameters.isExternalBuild }}', false))
 

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -94,11 +94,11 @@ jobs:
         workingDirectory: ${{ parameters.workingDir }}
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
 
-      - script: ls ${{parameters.workingDir}}/generated-docs
-        displayName: List generated docs
+      # - script: ls ${{parameters.workingDir}}/generated-docs
+      #   displayName: List generated docs
 
-      - script: ls ${{parameters.stagingDir}}
-        displayName: List staging files before docs
+      # - script: ls ${{parameters.stagingDir}}
+      #   displayName: List staging files before docs
 
 
       # if using the core artifact, download the Core Generated Docs artifact it to the workingDir using downloadPipelineArtifact task

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -68,18 +68,17 @@ jobs:
           git config --local user.name imodeljs-admin
         displayName: Setup git config
 
-      - script: npm install @bentley/bemetalsmith@5.3.0-beta.0
-        displayName: Install BeMetalsmith
-        workingDirectory: ${{ parameters.workingDir }}
       # Only install, audit, and build the docs if not using the core artifact
       - script: node common/scripts/install-run-rush.js install
         displayName: rush install
         workingDirectory: ${{ parameters.workingDir }}
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
+
       - script: node common/scripts/install-run-rush.js audit
         displayName: rush audit
         workingDirectory: ${{ parameters.workingDir }}
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false), eq('${{ parameters.ignoreAudit }}', false))
+
       - script: node common/scripts/install-run-rush.js build --to-version-policy prerelease-monorepo-lockStep
         displayName: rush build
         workingDirectory: ${{ parameters.workingDir }}
@@ -87,52 +86,11 @@ jobs:
           RUSH_BUILD_CACHE_CREDENTIAL: $(RushBuildCacheSAS)
           RUSH_BUILD_CACHE_ENABLED: 1
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
+
       - script: node common/scripts/install-run-rush.js docs
         displayName: rush docs
         workingDirectory: ${{ parameters.workingDir }}
         condition: and(succeeded(), eq('${{ parameters.useCoreDocsArtifact }}', false))
-      - publish: ${{ parameters.workingDir }}/generated-docs
-        artifact: Core Generated Docs
-        displayName: TEMP Publish Core Generated Docs Artifact
-
-  - job: docsBuild
-    dependsOn: TypeDocJsonOutput
-    workspace:
-      clean: all
-    pool:
-      name: iModelTechCI
-      demands: Agent.OS -equals Windows_NT
-
-    steps:
-      - checkout: ${{ parameters.checkout }}
-        path: itwinjs-core
-        clean: true
-
-      - task: UseNode@1
-        displayName: Use Node 20
-        inputs:
-          version: 20.x
-          checkLatest: false
-
-      - script: |
-          git config --local user.email imodeljs-admin@users.noreply.github.com
-          git config --local user.name imodeljs-admin
-        displayName: Setup git config
-
-      # - script: ls ${{parameters.workingDir}}/generated-docs
-      #   displayName: List generated docs
-
-      # - script: ls ${{parameters.stagingDir}}
-      #   displayName: List staging files before docs
-
-
-      # Download the artifact published in the previous job
-      - task: DownloadPipelineArtifact@2
-        displayName: get json artifacts from above
-        inputs:
-          artifact: Core Generated Docs
-          source: current
-          path: ${{ parameters.workingDir }}/generated-docs
 
       # if using the core artifact, download the Core Generated Docs artifact it to the workingDir using downloadPipelineArtifact task
       - task: DownloadPipelineArtifact@2

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -67,6 +67,10 @@ jobs:
           git config --local user.email imodeljs-admin@users.noreply.github.com
           git config --local user.name imodeljs-admin
         displayName: Setup git config
+
+      - script: npm install @bentley/bemetalsmith@5.3.0-beta.0
+        displayName: Install BeMetalsmith
+        workingDirectory: ${{ parameters.workingDir }}
       # Only install, audit, and build the docs if not using the core artifact
       - script: node common/scripts/install-run-rush.js install
         displayName: rush install

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -138,7 +138,6 @@ jobs:
       - publish: ${{ parameters.outputDir }}
         artifact: DocsBuild
         displayName: Publish Pipeline Artifact - DocsBuild
-        condition: and(succeeded(), eq('${{ parameters.shouldPublish }}', true))
 
         # tag the build to trigger the release pipeline
       - bash: |

--- a/core/backend/src/BackendLoggerCategory.ts
+++ b/core/backend/src/BackendLoggerCategory.ts
@@ -92,8 +92,7 @@ export enum BackendLoggerCategory {
    */
   EventSink = "core-backend.EventSink",
 
-  /** The logger category used by the following classes:
-   * - [[iModels]]
+  /**
    * @alpha
    */
   Editing = "core-backend.Editing",

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -146,7 +146,7 @@ export class TextAnnotation {
    * The anchor point is computed as specified by this annotation's [[anchor]] setting. For example, if the text block is anchored
    * at the bottom left, then the transform will be relative to the bottom-left corner of `textBlockExtents`.
    * The text block will be rotated around the fixed anchor point according to [[orientation]], then the anchor point will be translated by [[offset]].
-   * @param textBlockDimensions The width and height of the bounding box containing the text block. You can compute this using [computeTextBlockExtents]($common).
+   * @param textBlockDimensions The width and height of the bounding box containing the text block. You can compute this using [computeTextBlockExtents]($backend).
    * @see [[computeAnchorPoint]] to compute the transform's anchor point.
    */
   public computeTransform(textBlockDimensions: XAndY): Transform {
@@ -159,7 +159,7 @@ export class TextAnnotation {
   }
 
   /** Compute the anchor point of this annotation as specified by [[anchor]].
-   * @param textBlockDimensions The width and height of the bounding box containing the [[textBlock]]. You can compute this using [computeTextBlockExtents]($common).
+   * @param textBlockDimensions The width and height of the bounding box containing the [[textBlock]]. You can compute this using [computeTextBlockExtents]($backend).
    * @see [[computeTransform]] to compute the transform relative to the anchor point.
    */
   public computeAnchorPoint(textBlockDimensions: XAndY): Point3d {

--- a/docs/learning/ECSQLTutorial/ChangeSummaryQueries.md
+++ b/docs/learning/ECSQLTutorial/ChangeSummaryQueries.md
@@ -2,7 +2,7 @@
 
 _Change Summaries_ are summaries of changes of ECInstances in an _iModel Changeset_. **Please read [Change Summaries](../ChangeSummaries.md) first, before doing this section of the tutorial.**
 
-[!alert text="The console does not support write operations, this functionality has been deprecated. This page is kept for historical and educational purposes" kind="danger"]
+[!alert text="The console does not support write operations, this functionality has been deprecated. This page is kept for historical and educational purposes" kind="negative"]
 
 ## Generate the Change Summaries
 

--- a/docs/learning/tutorials/index.md
+++ b/docs/learning/tutorials/index.md
@@ -6,31 +6,31 @@ Test iModels can be used for local development. There are a few different ways t
 
 &nbsp;
 &nbsp;
-[!bwc tile heading="Online iModel from sample" linkTo="create-test-imodel-sample" contents="Copy a provided sample iModel for online testing. Quickest." icon="imodel-hub.svg" step="13" width="28%"]
-[!bwc tile heading="Online iModel from local files" linkTo="create-test-imodel-itwin-sync" contents="Create a test iModel from local files for online testing" icon="imodel-hub-sync.svg" step="13" width="28%"]
-[!bwc tile heading="Offline snapshot from local files" linkTo="create-test-imodel-offline" contents="Create a local snapshot file from files on your local computer" icon="document.svg" step="13" width="28%"]
+[!iui tile heading="Online iModel from sample" linkTo="create-test-imodel-sample" contents="Copy a provided sample iModel for online testing. Quickest." icon="imodel-hub.svg"]
+[!iui tile heading="Online iModel from local files" linkTo="create-test-imodel-itwin-sync" contents="Create a test iModel from local files for online testing" icon="imodel-hub-sync.svg"]
+[!iui tile heading="Offline snapshot from local files" linkTo="create-test-imodel-offline" contents="Create a local snapshot file from files on your local computer" icon="document.svg"]
 
 ## Exploring iModels
 
-[!bwc tile heading="ECSQL tutorial" linkTo="index path=learning/ecsqltutorial/index subPath=/ecsqltutorial" contents="Familiarize yourself with the basics of ECSQL" icon="database.svg" step="13" width="28%"]
-[!bwc tile heading="View in iModelHub" linkTo="use-existing-imodel" contents="How to view your iModel in iModelHub" icon="visibility.svg" step="13" width="28%"]
-[!bwc tile heading="Explore iModel content" linkTo="explore-imodel-console" contents="How to query the data in your iModel" icon="developer.svg" step="13" width="28%"]
-[!bwc tile heading="Explore schemas in the iModel" linkTo="explore-schema-browser" contents="How to browse the schemas in your iModel" icon="ec-schema.svg" step="13" width="28%"]
+[!iui tile heading="ECSQL tutorial" linkTo="index path=learning/ecsqltutorial/index subPath=/ecsqltutorial" contents="Familiarize yourself with the basics of ECSQL" icon="database.svg"]
+[!iui tile heading="View in iModelHub" linkTo="use-existing-imodel" contents="How to view your iModel in iModelHub" icon="visibility.svg"]
+[!iui tile heading="Explore iModel content" linkTo="explore-imodel-console" contents="How to query the data in your iModel" icon="developer.svg"]
+[!iui tile heading="Explore schemas in the iModel" linkTo="explore-schema-browser" contents="How to browse the schemas in your iModel" icon="ec-schema.svg"]
 
 ## Starter Applications
 
-[!bwc tile heading="Web viewer" linkTo="develop-web-viewer" contents="Create a web based viewer" icon="network.svg" step="13" width="28%" ]
-[!bwc tile heading="Desktop viewer" linkTo="develop-desktop-viewer" contents="Create a desktop viewer" icon="computer.svg" step="13" width="28%"]
-[!bwc tile heading="Agent application" linkTo="develop-agent" contents="Create an agent application" icon="notification.svg" step="13" width="28%"]
+[!iui tile heading="Web viewer" linkTo="develop-web-viewer" contents="Create a web based viewer" icon="network.svg" ]
+[!iui tile heading="Desktop viewer" linkTo="develop-desktop-viewer" contents="Create a desktop viewer" icon="computer.svg"]
+[!iui tile heading="Agent application" linkTo="develop-agent" contents="Create an agent application" icon="notification.svg"]
 
 ## Building Applications
 
-[!bwc tile heading="iTwin Viewer - 'Hello World'" linkTo="hello-world-viewer" contents="Get a basic understanding of the iTwin Viewer" icon="network.svg" step="13" width="28%" ]
-[!bwc tile heading="Adding showcase widgets to the iTwin Viewer" linkTo="showcase-to-viewer" contents="Use widgets from the showcase in your own iTwin Viewer" icon="puzzle.svg" step="13" width="28%" ]
+[!iui tile heading="iTwin Viewer - 'Hello World'" linkTo="hello-world-viewer" contents="Get a basic understanding of the iTwin Viewer" icon="network.svg" ]
+[!iui tile heading="Adding showcase widgets to the iTwin Viewer" linkTo="showcase-to-viewer" contents="Use widgets from the showcase in your own iTwin Viewer" icon="puzzle.svg" ]
 
 ## Registering Applications
 
-[!bwc tile heading="Register application" linkTo="registering-applications" contents="Register an application for deployment" icon="applications.svg" step="13" width="28%"]
+[!iui tile heading="Register application" linkTo="registering-applications" contents="Register an application for deployment" icon="applications.svg"]
 
 ## Support
 

--- a/docs/learning/tutorials/itwin-snapshot-app.md
+++ b/docs/learning/tutorials/itwin-snapshot-app.md
@@ -10,6 +10,6 @@ Snapshot iModels should not be used in any production workflows as they do not p
 
 The iTwin Snapshot app was designed with developers in mind. The free tool allows developers to create snapshots and after the snapshot has been created, it guides you to a viewer to visualize the snapshot. It also contains links to iTwin.js documentation and blogs.
 
-[!bwc tile heading="Download iTwin Snapshot" link="https://autoupdatecdn.bentley.com/itsnp/client/iTwinSnapshot.exe" contents=" " icon="download.svg" step="13" width="20%"]
+[!iui tile heading="Download iTwin Snapshot" link="https://autoupdatecdn.bentley.com/itsnp/client/iTwinSnapshot.exe" contents=" " icon="download.svg"]
 
 Further information on how to use iTwin Snapshot can be found in the ["Create a snapshot iModel"](./create-test-imodel-offline.md) tutorial.

--- a/docs/presentation/index.md
+++ b/docs/presentation/index.md
@@ -2,11 +2,11 @@
 
 The Presentation library provides means to declaratively get data from iModels in a format that's ready to be displayed to end users. That includes creating hierarchical structures and content for components like list, table, property grid and others. See the [motivation page](./motivation/index.md) for more details.
 
-[!bwc tile heading="Motivation" linkTo="index path=presentation/motivation/index subPath=/motivation" contents="What is the purpose of the Presentation Library and why it should be used" icon="new.svg" step="13" width="28%"]
-[!bwc tile heading="Setting Up" linkTo="index path=presentation/setup/index subPath=/setup" contents="How to set up backend and frontend for using Presentation Library" icon="developer.svg" step="13" width="28%"]
+[!iui tile heading="Motivation" linkTo="index path=presentation/motivation/index subPath=/motivation" contents="What is the purpose of the Presentation Library and why it should be used" icon="new.svg"]
+[!iui tile heading="Setting Up" linkTo="index path=presentation/setup/index subPath=/setup" contents="How to set up backend and frontend for using Presentation Library" icon="developer.svg"]
 
-[!bwc tile heading="Content" linkTo="index path=presentation/content/index subPath=/content" contents="Learn presentation rules for producing content for tables, property grids, list views" icon="properties-list.svg" step="13" width="28%"]
-[!bwc tile heading="Hierarchies" linkTo="index path=presentation/hierarchies/index subPath=/hierarchies" contents="Learn presentation rules for producing hierarchies" icon="tree.svg" step="13" width="28%"]
-[!bwc tile heading="Customization" linkTo="index path=presentation/customization/index subPath=/customization" contents="Learn about customization of how instances are displayed" icon="palette.svg" step="13" width="28%"]
-[!bwc tile heading="Unified Selection" linkTo="index path=presentation/unified-selection/index subPath=/unified-selection" contents="Learn about sharing selection across UI components" icon="isolate.svg" step="13" width="28%"]
-[!bwc tile heading="Advanced" linkTo="index path=presentation/advanced/index subPath=/advanced" contents="Learn advanced topics about Presentation Library" icon="puzzle.svg" step="13" width="28%"]
+[!iui tile heading="Content" linkTo="index path=presentation/content/index subPath=/content" contents="Learn presentation rules for producing content for tables, property grids, list views" icon="properties-list.svg"]
+[!iui tile heading="Hierarchies" linkTo="index path=presentation/hierarchies/index subPath=/hierarchies" contents="Learn presentation rules for producing hierarchies" icon="tree.svg"]
+[!iui tile heading="Customization" linkTo="index path=presentation/customization/index subPath=/customization" contents="Learn about customization of how instances are displayed" icon="palette.svg"]
+[!iui tile heading="Unified Selection" linkTo="index path=presentation/unified-selection/index subPath=/unified-selection" contents="Learn about sharing selection across UI components" icon="isolate.svg"]
+[!iui tile heading="Advanced" linkTo="index path=presentation/advanced/index subPath=/advanced" contents="Learn advanced topics about Presentation Library" icon="puzzle.svg"]

--- a/docs/reference/leftNav.md
+++ b/docs/reference/leftNav.md
@@ -87,7 +87,3 @@ packageClassification:
     },
   ]
 ---
-
-<div>
-    {{{referenceLeftNav this}}}
-</div>


### PR DESCRIPTION
- Replace BWC with iTwinUI 
- Fix a couple of link errors. 
- Run docs json extraction on darwin/mac os boxes until TypeDoc discrepancy is resolved: TypeDoc produces different json output for at least core-common when built on different platforms. I have not yet come up with a minimal reproduction, but it surrounds the use of re-exporting types from another package: Is the re-exported type a reference or a declaration? On Windows, TypeDoc produces a reference, but on Mac it produces a declaration. 

 