### PR TITLE
Enable Brotli compression for RPC requests by default

### DIFF
--- a/common/changes/@itwin/core-backend/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
+++ b/common/changes/@itwin/core-backend/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Brotli compression enabled for RPC requests.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
+++ b/common/changes/@itwin/core-common/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-common/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-common/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-common"
+}

--- a/common/changes/@itwin/presentation-common/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
+++ b/common/changes/@itwin/presentation-common/gytis-brotli-compression-for-rpc_2024-05-13-14-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/core/backend/src/rpc/web/response.ts
+++ b/core/backend/src/rpc/web/response.ts
@@ -102,17 +102,14 @@ async function configureEncoding(req: HttpServerRequest, res: HttpServerResponse
     params: {
       // Experimentation revealed that the default compression quality significantly increases the compression time for larger texts.
       // Reducing the quality improves speed substantially without a significant loss in the compression ratio.
-      [zlibConstants.BROTLI_PARAM_QUALITY]: zlibConstants.BROTLI_DEFAULT_QUALITY,
+      [zlibConstants.BROTLI_PARAM_QUALITY]: 3,
     },
   };
 
   if (responseBody instanceof Stream) {
-    const encodedStream = encoding === "br" ? createBrotliCompress(brotliOptions) : createGzip();
-    return responseBody.pipe(encodedStream);
+    const compressStream = encoding === "br" ? createBrotliCompress(brotliOptions) : createGzip();
+    return responseBody.pipe(compressStream);
   }
-
-  if (typeof responseBody === "string")
-    responseBody = Buffer.from(responseBody);
 
   return encoding === "br" ? promisify(brotliCompress)(responseBody, brotliOptions) : promisify(gzip)(responseBody);
 }

--- a/core/backend/src/rpc/web/response.ts
+++ b/core/backend/src/rpc/web/response.ts
@@ -24,9 +24,9 @@ import {
   WebAppRpcRequest,
 } from "@itwin/core-common";
 
-import { Readable, Stream } from "stream";
-import { promisify } from "util";
-import { brotliCompress, BrotliOptions, createBrotliCompress, createGzip, gzip, constants as zlibConstants } from "zlib";
+import { Readable, Stream } from "node:stream";
+import { promisify } from "node:util";
+import { brotliCompress, BrotliOptions, createBrotliCompress, createGzip, gzip, constants as zlibConstants } from "node:zlib";
 
 /* eslint-disable deprecation/deprecation */
 

--- a/core/backend/src/rpc/web/response.ts
+++ b/core/backend/src/rpc/web/response.ts
@@ -88,7 +88,7 @@ function configureStream(fulfillment: RpcRequestFulfillment) {
 }
 
 async function configureEncoding(req: HttpServerRequest, res: HttpServerResponse, responseBody: string | Buffer | Readable): Promise<string | Buffer | Readable> {
-  const acceptedEncodings = req.header("Accept-Encoding")?.split(" ");
+  const acceptedEncodings = req.header("Accept-Encoding")?.split(", ");
   if (!acceptedEncodings)
     return responseBody;
 

--- a/core/backend/src/rpc/web/response.ts
+++ b/core/backend/src/rpc/web/response.ts
@@ -24,6 +24,10 @@ import {
   WebAppRpcRequest,
 } from "@itwin/core-common";
 
+import { Readable, Stream } from "stream";
+import { promisify } from "util";
+import { brotliCompress, BrotliOptions, createBrotliCompress, createGzip, gzip, constants as zlibConstants } from "zlib";
+
 /* eslint-disable deprecation/deprecation */
 
 function configureResponse(protocol: WebAppRpcProtocol, request: SerializedRpcRequest, fulfillment: RpcRequestFulfillment, res: HttpServerResponse) {
@@ -83,6 +87,36 @@ function configureStream(fulfillment: RpcRequestFulfillment) {
   return fulfillment.result.stream!;
 }
 
+async function configureEncoding(req: HttpServerRequest, res: HttpServerResponse, responseBody: string | Buffer | Readable): Promise<string | Buffer | Readable> {
+  const acceptedEncodings = req.header("Accept-Encoding")?.split(" ");
+  if (!acceptedEncodings)
+    return responseBody;
+
+  const encoding = acceptedEncodings.includes("br") ? "br" : acceptedEncodings.includes("gzip") ? "gzip" : undefined;
+  if (!encoding)
+    return responseBody;
+
+  res.set("Content-Encoding", encoding);
+
+  const brotliOptions: BrotliOptions = {
+    params: {
+      // Experimentation revealed that the default compression quality significantly increases the compression time for larger texts.
+      // Reducing the quality improves speed substantially without a significant loss in the compression ratio.
+      [zlibConstants.BROTLI_PARAM_QUALITY]: zlibConstants.BROTLI_DEFAULT_QUALITY,
+    },
+  };
+
+  if (responseBody instanceof Stream) {
+    const encodedStream = encoding === "br" ? createBrotliCompress(brotliOptions) : createGzip();
+    return responseBody.pipe(encodedStream);
+  }
+
+  if (typeof responseBody === "string")
+    responseBody = Buffer.from(responseBody);
+
+  return encoding === "br" ? promisify(brotliCompress)(responseBody, brotliOptions) : promisify(gzip)(responseBody);
+}
+
 /** @internal */
 export async function sendResponse(protocol: WebAppRpcProtocol, request: SerializedRpcRequest, fulfillment: RpcRequestFulfillment, req: HttpServerRequest, res: HttpServerResponse) {
   logResponse(request, fulfillment.status, fulfillment.rawResult);
@@ -91,9 +125,6 @@ export async function sendResponse(protocol: WebAppRpcProtocol, request: Seriali
   if (versionHeader && RpcProtocol.protocolVersion) {
     res.set(versionHeader, RpcProtocol.protocolVersion.toString());
   }
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { Readable, Stream } = await import(/* webpackIgnore: true */ "stream");
-  const { createGzip } = await import(/* webpackIgnore: true */ "zlib");
 
   const transportType = WebAppRpcRequest.computeTransportType(fulfillment.result, fulfillment.rawResult);
   let responseBody;
@@ -110,11 +141,8 @@ export async function sendResponse(protocol: WebAppRpcProtocol, request: Seriali
   configureResponse(protocol, request, fulfillment, res);
   res.status(fulfillment.status);
 
-  if (fulfillment.allowCompression && req.header("Accept-Encoding")?.includes("gzip")) {
-    res.set("Content-Encoding", "gzip");
-    const readableResponseBody = (responseBody instanceof Stream) ? responseBody : Readable.from(responseBody);
-    responseBody = readableResponseBody.pipe(createGzip());
-  }
+  if (fulfillment.allowCompression)
+    responseBody = await configureEncoding(req, res, responseBody);
 
   // This check should in theory look for instances of Readable, but that would break backend implementation at
   // core/backend/src/RpcBackend.ts

--- a/core/backend/src/test/rpc/response.test.ts
+++ b/core/backend/src/test/rpc/response.test.ts
@@ -3,7 +3,7 @@ import { SinonStub, stub } from "sinon";
 import { Readable, Writable } from "stream";
 import { HttpServerRequest, HttpServerResponse, RpcRequestFulfillment, RpcRequestStatus, SerializedRpcRequest, WebAppRpcProtocol } from "@itwin/core-common";
 import { sendResponse } from "../../rpc/web/response";
-import { brotliDecompressSync, unzipSync } from "zlib";
+import { brotliDecompressSync, unzipSync } from "node:zlib";
 
 /* eslint-disable deprecation/deprecation */
 

--- a/core/backend/src/test/rpc/response.test.ts
+++ b/core/backend/src/test/rpc/response.test.ts
@@ -46,6 +46,7 @@ describe("sendResponse", () => {
   it("should compress response using Brotli", async () => {
     // Arrange
     const originalData = generateJson();
+    const originalDataSize = Buffer.byteLength(originalData);
     fulfillment.result.objects = originalData;
 
     // Act
@@ -56,13 +57,14 @@ describe("sendResponse", () => {
 
     const compressedData = res.send.getCall(0).args[0];
     expect(compressedData).to.not.be.undefined;
-    expect(compressedData.length).to.be.lessThan(originalData.length);
+    expect(compressedData.length).to.be.lessThan(originalDataSize);
     expect(brotliDecompressSync(compressedData).toString()).to.be.equal(originalData);
   });
 
   it("should compress response using Gzip if Brotli is not supported", async () => {
     // Arrange
     const originalData = generateJson();
+    const originalDataSize = Buffer.byteLength(originalData);
     fulfillment.result.objects = originalData;
     req.header = () => "gzip, deflate";
 
@@ -74,7 +76,7 @@ describe("sendResponse", () => {
 
     const compressedData = res.send.getCall(0).args[0];
     expect(compressedData).to.not.be.undefined;
-    expect(compressedData.length).to.be.lessThan(originalData.length);
+    expect(compressedData.length).to.be.lessThan(originalDataSize);
     expect(unzipSync(compressedData).toString()).to.be.equal(originalData);
   });
 
@@ -96,6 +98,7 @@ describe("sendResponse", () => {
   it("should compress stream", async () => {
     // Arrange
     const originalData = generateJson();
+    const originalDataSize = Buffer.byteLength(originalData);
     fulfillment.result.stream = Readable.from(originalData);
 
     // Act
@@ -105,7 +108,7 @@ describe("sendResponse", () => {
     // Assert
     const compressedData = res.buffer;
     expect(compressedData).to.not.be.undefined;
-    expect(compressedData.length).to.be.lessThan(originalData.length);
+    expect(compressedData.length).to.be.lessThan(originalDataSize);
     expect(brotliDecompressSync(compressedData).toString()).to.be.equal(originalData);
   });
 });

--- a/core/backend/src/test/rpc/response.test.ts
+++ b/core/backend/src/test/rpc/response.test.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+import { SinonStub, stub } from "sinon";
+import { Readable, Writable } from "stream";
+import { HttpServerRequest, HttpServerResponse, RpcRequestFulfillment, RpcRequestStatus, SerializedRpcRequest, WebAppRpcProtocol } from "@itwin/core-common";
+import { sendResponse } from "../../rpc/web/response";
+import { brotliDecompressSync, unzipSync } from "zlib";
+
+/* eslint-disable deprecation/deprecation */
+
+class StubResponse extends Writable implements HttpServerResponse {
+  public chunks: any[] = [];
+  public get buffer(): Buffer { return Buffer.concat(this.chunks); }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public override _write(chunk: any, _encoding: BufferEncoding, callback: VoidFunction): void {
+    this.chunks.push(chunk);
+    callback();
+  }
+
+  public send: SinonStub<any[], HttpServerResponse> = stub().returns(this);
+  public status: SinonStub<[number], HttpServerResponse> = stub();
+  public set: SinonStub<[string, string], void> = stub();
+}
+
+describe.only("sendResponse", () => {
+  let protocol: WebAppRpcProtocol;
+  let request: SerializedRpcRequest;
+  let fulfillment: RpcRequestFulfillment;
+  let req: HttpServerRequest;
+  let res: StubResponse;
+
+  beforeEach(() => {
+    protocol = { getStatus: () => RpcRequestStatus.Resolved } as any;
+    request = { operation: { operationName: "fake-RPC-operation" } } as any;
+    fulfillment = {
+      allowCompression: true,
+      status: 200,
+      result: {
+        data: [],
+      },
+    } as any;
+    req = { header: () => "gzip deflate br" } as any;
+    // res = new StubResponse();
+    res = new StubResponse();
+  });
+
+  it("should compress response using Brotli", async () => {
+    // Arrange
+    const originalData = generateJson();
+    fulfillment.result.objects = originalData;
+
+    // Act
+    await sendResponse(protocol, request, fulfillment, req, res);
+
+    // Assert
+    expect(res.set.calledWithExactly("Content-Encoding", "br")).to.be.true;
+
+    const compressedData = res.send.getCall(0).args[0];
+    expect(compressedData).to.not.be.undefined;
+    expect(compressedData.length).to.be.lessThan(originalData.length);
+    expect(brotliDecompressSync(compressedData).toString()).to.be.equal(originalData);
+  });
+
+  it("should compress response using Gzip if Brotli is not supported", async () => {
+    // Arrange
+    const originalData = generateJson();
+    fulfillment.result.objects = originalData;
+    req.header = () => "gzip deflate";
+
+    // Act
+    await sendResponse(protocol, request, fulfillment, req, res);
+
+    // Assert
+    expect(res.set.calledWithExactly("Content-Encoding", "gzip")).to.be.true;
+
+    const compressedData = res.send.getCall(0).args[0];
+    expect(compressedData).to.not.be.undefined;
+    expect(compressedData.length).to.be.lessThan(originalData.length);
+    expect(unzipSync(compressedData).toString()).to.be.equal(originalData);
+  });
+
+  it("should not compress if Brotli and Gzip is not supported", async () => {
+    // Arrange
+    const originalData = generateJson();
+    fulfillment.result.objects = originalData;
+    req.header = () => undefined;
+
+    // Act
+    await sendResponse(protocol, request, fulfillment, req, res);
+
+    // Assert
+    expect(res.set.calledWithMatch("Content-Encoding")).to.be.false;
+
+    expect(res.send.getCall(0).args[0]).to.be.equal(originalData);
+  });
+
+  it("should compress stream", async () => {
+    // Arrange
+    const originalData = generateJson();
+    fulfillment.result.stream = Readable.from(originalData);
+
+    // Act
+    await sendResponse(protocol, request, fulfillment, req, res);
+    await new Promise((resolve) => res.on("finish", resolve));
+
+    // Assert
+    const compressedData = res.buffer;
+    expect(compressedData).to.not.be.undefined;
+    expect(compressedData.length).to.be.lessThan(originalData.length);
+    expect(brotliDecompressSync(compressedData).toString()).to.be.equal(originalData);
+  });
+});
+
+function generateJson(minimumSize = 2000): string {
+  let propertyIdx = 0;
+  const obj = {} as any;
+
+  while (JSON.stringify(obj).length < minimumSize) {
+    obj[`property-${propertyIdx}`] = `value-${propertyIdx}`;
+    propertyIdx++;
+  }
+
+  return JSON.stringify(obj);
+}

--- a/core/backend/src/test/rpc/response.test.ts
+++ b/core/backend/src/test/rpc/response.test.ts
@@ -22,7 +22,7 @@ class StubResponse extends Writable implements HttpServerResponse {
   public set: SinonStub<[string, string], void> = stub();
 }
 
-describe.only("sendResponse", () => {
+describe("sendResponse", () => {
   let protocol: WebAppRpcProtocol;
   let request: SerializedRpcRequest;
   let fulfillment: RpcRequestFulfillment;

--- a/core/backend/src/test/rpc/response.test.ts
+++ b/core/backend/src/test/rpc/response.test.ts
@@ -39,8 +39,7 @@ describe.only("sendResponse", () => {
         data: [],
       },
     } as any;
-    req = { header: () => "gzip deflate br" } as any;
-    // res = new StubResponse();
+    req = { header: () => "gzip, deflate, br" } as any;
     res = new StubResponse();
   });
 
@@ -65,7 +64,7 @@ describe.only("sendResponse", () => {
     // Arrange
     const originalData = generateJson();
     fulfillment.result.objects = originalData;
-    req.header = () => "gzip deflate";
+    req.header = () => "gzip, deflate";
 
     // Act
     await sendResponse(protocol, request, fulfillment, req, res);

--- a/core/common/src/rpc/core/RpcInvocation.ts
+++ b/core/common/src/rpc/core/RpcInvocation.ts
@@ -279,7 +279,7 @@ export class RpcInvocation {
       status: this.protocol.getCode(this.status),
       id: this.request.id,
       interfaceName: (typeof (this.operation) === "undefined") ? "" : this.operation.interfaceDefinition.interfaceName,
-      allowCompression: this.operation?.policy.allowResponseCompression || false,
+      allowCompression: this.operation ? this.operation.policy.allowResponseCompression : true,
     };
 
     this.transformResponseStatus(fulfillment, rawResult);

--- a/core/common/src/rpc/core/RpcMarshaling.ts
+++ b/core/common/src/rpc/core/RpcMarshaling.ts
@@ -58,9 +58,8 @@ export class RpcMarshaling {
   public static serialize(protocol: RpcProtocol | undefined, value: any): RpcSerializedValue {
     const serialized = RpcSerializedValue.create();
 
-    if (typeof (value) === "undefined") {
+    if (value === undefined)
       return serialized;
-    }
 
     marshalingTarget = serialized;
     chunkThreshold = protocol ? protocol.transferChunkThreshold : 0;
@@ -119,7 +118,7 @@ class WireFormat {
     return value;
   }
 
-  private static marshalBinary(value: any): any {
+  private static marshalBinary(value: Uint8Array): MarshalingBinaryMarker | undefined {
     if (value instanceof Uint8Array || isBuffer(value)) {
       const marker: MarshalingBinaryMarker = { isBinary: true, index: -1, size: value.byteLength, chunks: 1 };
 
@@ -154,7 +153,7 @@ class WireFormat {
     }
   }
 
-  private static unmarshalBinary(value: MarshalingBinaryMarker): any {
+  private static unmarshalBinary(value: MarshalingBinaryMarker): Uint8Array {
     if (value.index >= marshalingTarget.data.length) {
       throw new IModelError(BentleyStatus.ERROR, `Cannot unmarshal missing binary value.`);
     }
@@ -178,7 +177,7 @@ class WireFormat {
     }
   }
 
-  private static marshalError(value: any) {
+  private static marshalError(value: unknown) {
     if (value instanceof Error) {
       const props = Object.getOwnPropertyDescriptors(value);
       props.isError = { configurable: true, enumerable: true, writable: true, value: true };

--- a/core/common/src/rpc/core/RpcOperation.ts
+++ b/core/common/src/rpc/core/RpcOperation.ts
@@ -47,7 +47,7 @@ export class RpcOperationPolicy {
   public allowTokenMismatch: boolean = false;
 
   /** Whether to compress the operation response with one of the client's supported encodings. */
-  public allowResponseCompression: boolean = false;
+  public allowResponseCompression: boolean = true;
 }
 
 /** An RPC operation descriptor.

--- a/core/common/src/rpc/core/RpcProtocol.ts
+++ b/core/common/src/rpc/core/RpcProtocol.ts
@@ -65,7 +65,7 @@ export interface RpcRequestFulfillment {
   /* A protocol-specific value for retrying this request. */
   retry?: string;
 
-  /** Whether to compress the result with one of the client's supported encodings. */
+  /** Whether to compress the result with one of the client's supported encodings. Defaults to true. */
   allowCompression?: boolean;
 }
 

--- a/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { IModelRpcProps, RpcInterface, RpcManager, RpcOperation } from "@itwin/core-common";
+import { IModelRpcProps, RpcInterface, RpcManager } from "@itwin/core-common";
 import { SchemaKeyProps, SchemaProps } from "@itwin/ecschema-metadata";
 
 /***
@@ -43,7 +43,6 @@ export abstract class ECSchemaRpcInterface extends RpcInterface { // eslint-disa
    * @param schemaName        The name of the schema that shall be returned.
    * @returns                 The SchemaProps.
    */
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getSchemaJSON(_tokenProps: IModelRpcProps, _schemaName: string): Promise<SchemaProps> {
     return this.forward.apply(this, [arguments]) as Promise<SchemaProps>;
   }

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -7,7 +7,7 @@
  */
 
 import { Id64String } from "@itwin/core-bentley";
-import { IModelRpcProps, RpcInterface, RpcOperation } from "@itwin/core-common";
+import { IModelRpcProps, RpcInterface } from "@itwin/core-common";
 import { DescriptorJSON, DescriptorOverrides, SelectClassInfoJSON } from "./content/Descriptor";
 import { ItemJSON } from "./content/Item";
 import { DisplayValueGroupJSON } from "./content/Value";
@@ -206,14 +206,12 @@ export class PresentationRpcInterface extends RpcInterface {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   // eslint-disable-next-line deprecation/deprecation
   public async getPagedNodes(_token: IModelRpcProps, _options: Paged<HierarchyRpcRequestOptions>): PresentationRpcResponse<PagedResponse<NodeJSON>> {
     return this.forward(arguments);
   }
 
   /** @beta */
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getNodesDescriptor(
     _token: IModelRpcProps,
     _options: HierarchyLevelDescriptorRpcRequestOptions,
@@ -222,25 +220,21 @@ export class PresentationRpcInterface extends RpcInterface {
   }
 
   // TODO: add paged version of this (#387280)
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   // eslint-disable-next-line deprecation/deprecation
   public async getNodePaths(_token: IModelRpcProps, _options: FilterByInstancePathsHierarchyRpcRequestOptions): PresentationRpcResponse<NodePathElementJSON[]> {
     return this.forward(arguments);
   }
 
   // TODO: add paged version of this (#387280)
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   // eslint-disable-next-line deprecation/deprecation
   public async getFilteredNodePaths(_token: IModelRpcProps, _options: FilterByTextHierarchyRpcRequestOptions): PresentationRpcResponse<NodePathElementJSON[]> {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getContentSources(_token: IModelRpcProps, _options: ContentSourcesRpcRequestOptions): PresentationRpcResponse<ContentSourcesRpcResult> {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getContentDescriptor(_token: IModelRpcProps, _options: ContentDescriptorRpcRequestOptions): PresentationRpcResponse<DescriptorJSON | undefined> {
     arguments[1] = { ...arguments[1], transport: "unparsed-json" };
     const response: PresentationRpcResponseData<DescriptorJSON | string | undefined> = await this.forward(arguments);
@@ -254,7 +248,6 @@ export class PresentationRpcInterface extends RpcInterface {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getPagedContent(
     _token: IModelRpcProps,
     _options: Paged<ContentRpcRequestOptions>,
@@ -262,12 +255,10 @@ export class PresentationRpcInterface extends RpcInterface {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getPagedContentSet(_token: IModelRpcProps, _options: Paged<ContentRpcRequestOptions>): PresentationRpcResponse<PagedResponse<ItemJSON>> {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getElementProperties(
     _token: IModelRpcProps,
     _options: SingleElementPropertiesRpcRequestOptions,
@@ -275,7 +266,6 @@ export class PresentationRpcInterface extends RpcInterface {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getPagedDistinctValues(
     _token: IModelRpcProps,
     _options: DistinctValuesRpcRequestOptions,
@@ -295,7 +285,6 @@ export class PresentationRpcInterface extends RpcInterface {
     return this.forward(arguments);
   }
 
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async getPagedDisplayLabelDefinitions(
     _token: IModelRpcProps,
     _options: DisplayLabelsRpcRequestOptions,
@@ -315,7 +304,6 @@ export class PresentationRpcInterface extends RpcInterface {
     _scopeId: string,
   ): PresentationRpcResponse<KeySetJSON>;
   public async computeSelection(_token: IModelRpcProps, _options: ComputeSelectionRpcRequestOptions): PresentationRpcResponse<KeySetJSON>;
-  @RpcOperation.setPolicy({ allowResponseCompression: true })
   public async computeSelection(
     _token: IModelRpcProps,
     _options: ComputeSelectionRpcRequestOptions | SelectionScopeRpcRequestOptions,


### PR DESCRIPTION
### Motivation
Enabling compression for RPC response bodies have show to significantly drop size of data which needs to be downloaded by the frontend. Right now, only certain RPC requests have Gzip compression enabled.

Also, Brotli compression have shown to have better compression ratio for our RPC requests without additional compressing time.

### Changes
- Make Brotli main compression instead of Gzip (if Brotli not supported by the browser, will fallback to Gzip).
- Enable compression for all RPC responses by default (to disable compression for specific RPC request, add following line above definition: `@RpcOperation.setPolicy({ allowResponseCompression: false })`.