### PR TITLE
Fix failed HTTP RPC requests not being rejected if `X-Protocol-Version` is not available

### DIFF
--- a/common/changes/@itwin/core-common/gytis-fix-rpc-request-not-being-resolved_2024-05-23-11-30.json
+++ b/common/changes/@itwin/core-common/gytis-fix-rpc-request-not-being-resolved_2024-05-23-11-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix failed HTTP RPC request not being rejected if `X-Protocol-Version` is not available.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-frontend/gytis-fix-rpc-request-not-being-resolved_2024-05-23-11-30.json
+++ b/common/changes/@itwin/core-frontend/gytis-fix-rpc-request-not-being-resolved_2024-05-23-11-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix failed HTTP RPC request not being rejected if `X-Protocol-Version` is not available.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/common/src/rpc/core/RpcRequest.ts
+++ b/core/common/src/rpc/core/RpcRequest.ts
@@ -86,7 +86,7 @@ export type RpcRequestEventHandler = (type: RpcRequestEvent, request: RpcRequest
 /** Resolves "not found" responses for RPC requests.
  * @internal
  */
-export type RpcRequestNotFoundHandler = (request: RpcRequest, response: RpcNotFoundResponse, resubmit: () => void, reject: (reason: any) => void) => void;
+export type RpcRequestNotFoundHandler = (request: RpcRequest, response: RpcNotFoundResponse, resubmit: () => void, reject: (reason?: any) => void) => void;
 
 class Cancellable<T> {
   public promise: Promise<T | undefined>;
@@ -480,8 +480,8 @@ export abstract class RpcRequest<TResponse = any> {
         throw new IModelError(BentleyStatus.ERROR, `Already resubmitted using this handler.`);
 
       resubmitted = true;
-      this.submit(); // eslint-disable-line @typescript-eslint/no-floating-promises
-    }, (reason: any) => this.reject(reason));
+      void this.submit();
+    }, (reason: any) => reason ? this.reject(reason) : this.handleRejected(value));
     return;
   }
 

--- a/core/frontend/src/CheckpointConnection.ts
+++ b/core/frontend/src/CheckpointConnection.ts
@@ -117,13 +117,13 @@ export class CheckpointConnection extends IModelConnection {
     return openResponse;
   }
 
-  private _reopenConnectionHandler = async (request: RpcRequest<RpcNotFoundResponse>, response: any, resubmit: () => void, reject: (reason: any) => void) => { // eslint-disable-line deprecation/deprecation
+  private _reopenConnectionHandler = async (request: RpcRequest<RpcNotFoundResponse>, response: any, resubmit: () => void, reject: (reason?: any) => void) => {
     if (!response.hasOwnProperty("isIModelNotFoundResponse"))
-      return;
+      reject();
 
     const iModelRpcProps = request.parameters[0];
     if (this._fileKey !== iModelRpcProps.key)
-      return; // The handler is called for a different connection than this
+      reject(); // The handler is called for a different connection than this
 
     Logger.logTrace(loggerCategory, "Attempting to reopen connection", () => iModelRpcProps);
 


### PR DESCRIPTION
Due to CORS, `X-Protocol-Version` might be missing when running backend locally. See https://github.com/iTwin/itwinjs-core/issues/6757