### PR TITLE
Increase restrictions on native app storage name

### DIFF
--- a/common/changes/@itwin/core-backend/master_2024-05-27-13-55.json
+++ b/common/changes/@itwin/core-backend/master_2024-05-27-13-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Increase restrictions on native app storage name.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/standalone/NativeAppStorage.test.ts
+++ b/core/backend/src/test/standalone/NativeAppStorage.test.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import { IModelJsFs } from "../../IModelJsFs";
 import { NativeHost } from "../../NativeHost";
 import { NativeAppStorage } from "../../NativeAppStorage";
@@ -124,4 +124,11 @@ describe("NativeApp storage backend", () => {
     });
   });
 
+  it("should not allow null in the name", async () => {
+    expect(() => NativeAppStorage.open("my-storage\x00-name")).to.throw();
+  });
+
+  it("should not allow names which points to the parent directory", async () => {
+    expect(() => NativeAppStorage.open("dir/../../storage")).to.throw();
+  });
 });


### PR DESCRIPTION
This should prevent storage files from being created outside storage cache directory.

Alternative solution would be to not allow any sort of path elements in the storage name. However, this would break apps which use storage names likes `my-app/common-settings` (if such apps exist).