### PR TITLE
Increase maximum number of categories passed into querySubCategories.

### DIFF
--- a/common/changes/@itwin/core-frontend/nam-subcategories-increase_2024-05-28-20-57.json
+++ b/common/changes/@itwin/core-frontend/nam-subcategories-increase_2024-05-28-20-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Increase maximum number of categories passed into querySubCategories",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/SubCategoriesCache.ts
+++ b/core/frontend/src/SubCategoriesCache.ts
@@ -177,7 +177,7 @@ export namespace SubCategoriesCache { // eslint-disable-line no-redeclare
 
     public get wasCanceled() { return this._canceled || this._imodel.isClosed; }
 
-    public constructor(categoryIds: Set<string>, imodel: IModelConnection, maxCategoriesPerQuery = 200) {
+    public constructor(categoryIds: Set<string>, imodel: IModelConnection, maxCategoriesPerQuery = 2500) {
       this._imodel = imodel;
 
       const catIds = [...categoryIds];


### PR DESCRIPTION
The maximum number of categories passed into the function is changed to 2500, to address performance issues with the querySubCategories workflow for large iModels.