### PR TITLE
Re-enabled RealityDataSource test

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/RealityDataAccess.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/RealityDataAccess.test.ts
@@ -243,7 +243,7 @@ describe("RealityDataAccess (#integration)", () => {
     }
   });
 
-  it.skip("should get RealityDataSource for reality data attachment in iModel", async () => {
+  it("should get RealityDataSource for reality data attachment in iModel", async () => {
     assert.isTrue(imodel !== undefined);
     const modelRealityDataInfos = await getAttachedRealityDataModelInfoSet(imodel);
     expect(modelRealityDataInfos.size).to.equal(3);


### PR DESCRIPTION
Re enabled "should get RealityDataSource for reality data attachment in iModel" test.

More test user rights had to be fixed.