### PR TITLE
Add `IndexedPolyfaceSubsetVisitor` constructor to iterate "top" facets of a mesh

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -2858,6 +2858,7 @@ export class IndexedPolyface extends Polyface {
 
 // @public
 export class IndexedPolyfaceSubsetVisitor extends IndexedPolyfaceVisitor {
+    createNormalComparison(mesh: IndexedPolyface | IndexedPolyfaceVisitor, compareVector: Vector3d, sideAngle?: Angle, numWrap?: number): IndexedPolyfaceSubsetVisitor;
     static createSubsetVisitor(polyface: IndexedPolyface, activeFacetIndices: number[], numWrap: number): IndexedPolyfaceSubsetVisitor;
     moveToNextFacet(): boolean;
     moveToReadIndex(activeIndex: number): boolean;
@@ -2874,7 +2875,7 @@ export class IndexedPolyfaceVisitor extends PolyfaceData implements PolyfaceVisi
     clientNormalIndex(i: number): number;
     clientParamIndex(i: number): number;
     clientPointIndex(i: number): number;
-    clientPolyface(): Polyface;
+    clientPolyface(): IndexedPolyface;
     static create(polyface: IndexedPolyface, numWrap: number): IndexedPolyfaceVisitor;
     currentReadIndex(): number;
     moveToNextFacet(): boolean;

--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -2858,11 +2858,12 @@ export class IndexedPolyface extends Polyface {
 
 // @public
 export class IndexedPolyfaceSubsetVisitor extends IndexedPolyfaceVisitor {
-    createNormalComparison(mesh: IndexedPolyface | IndexedPolyfaceVisitor, compareVector: Vector3d, sideAngle?: Angle, numWrap?: number): IndexedPolyfaceSubsetVisitor;
-    static createSubsetVisitor(polyface: IndexedPolyface, activeFacetIndices: number[], numWrap: number): IndexedPolyfaceSubsetVisitor;
+    static createNormalComparison(mesh: IndexedPolyface | IndexedPolyfaceVisitor, compareVector?: Vector3d, sideAngle?: Angle, numWrap?: number): IndexedPolyfaceSubsetVisitor;
+    static createSubsetVisitor(polyface: IndexedPolyface, activeFacetIndices: number[], numWrap?: number): IndexedPolyfaceSubsetVisitor;
+    getVisitableFacetCount(): number;
     moveToNextFacet(): boolean;
     moveToReadIndex(activeIndex: number): boolean;
-    parentFacetIndex(activeIndex: number): number | undefined;
+    parentFacetIndex(activeIndex?: number): number | undefined;
     reset(): void;
 }
 
@@ -2878,6 +2879,7 @@ export class IndexedPolyfaceVisitor extends PolyfaceData implements PolyfaceVisi
     clientPolyface(): IndexedPolyface;
     static create(polyface: IndexedPolyface, numWrap: number): IndexedPolyfaceVisitor;
     currentReadIndex(): number;
+    getVisitableFacetCount(): number;
     moveToNextFacet(): boolean;
     moveToReadIndex(facetIndex: number): boolean;
     get numEdgesThisFacet(): number;
@@ -4738,6 +4740,7 @@ export interface PolyfaceVisitor extends PolyfaceData {
     clientPointIndex(i: number): number;
     clientPolyface(): Polyface | undefined;
     currentReadIndex(): number;
+    getVisitableFacetCount?(): number;
     moveToNextFacet(): boolean;
     moveToReadIndex(index: number): boolean;
     pushDataFrom(other: PolyfaceVisitor, index: number): void;

--- a/common/changes/@itwin/core-geometry/da4-top-facet-subset-visitor_2024-05-29-22-20.json
+++ b/common/changes/@itwin/core-geometry/da4-top-facet-subset-visitor_2024-05-29-22-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "IndexedPolyfaceSubsetVisitor.createNormalComparison",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/polyface/IndexedPolyfaceVisitor.ts
+++ b/core/geometry/src/polyface/IndexedPolyfaceVisitor.ts
@@ -47,7 +47,7 @@ export class IndexedPolyfaceVisitor extends PolyfaceData implements PolyfaceVisi
   }
   /** Return the number of facets this visitor is able to visit. */
   public getVisitableFacetCount(): number {
-    return this._polyface.faceCount;
+    return this._polyface.facetCount;
   }
   /**
    * Set the number of vertices replicated in visitor arrays (both data and index arrays).

--- a/core/geometry/src/polyface/Polyface.ts
+++ b/core/geometry/src/polyface/Polyface.ts
@@ -687,4 +687,9 @@ export interface PolyfaceVisitor extends PolyfaceData {
    * * All data values are interpolated at `fraction` between `other` values at `index0` and `index1`.
    */
   pushInterpolatedDataFrom(other: PolyfaceVisitor, index0: number, fraction: number, index1: number): void;
+  /**
+   * Return the number of facets this visitor is able to visit.
+   * * Allows implementers to improve the efficiency of e.g., [[PolyfaceQuery.visitorClientFacetCount]].
+   */
+  getVisitableFacetCount?(): number;
 }


### PR DESCRIPTION
New method `IndexedPolyfaceSubsetVisitor.createNormalComparison` makes it easy to iterate facets of a mesh that satisfy a normal condition, e.g., the "top" facets of a DTM while avoiding "side" or "skirt" facets. In particular, many `Polyface` API methods take a mesh or a visitor, so passing in this visitor allows for operations on filtered facets.

Motivated by conversations with Map and Booster teams.

Also:
* Refactored and tested this visitor, which was not tested previously.
* Preserve readIndex in `PolyfaceQuery.visitorClientPointCount` and `PolyfaceQuery.visitorClientFacetCount`
* New optional `PolyfaceVisitor.getVisitableFacetCount` interface method allowing visitors to return facet count more efficiently.