### PR TITLE
Enforce package-internal API visibility

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3059,6 +3059,8 @@ export type IModelCloneContext = IModelElementCloneContext;
 
 // @public
 export abstract class IModelDb extends IModel {
+    // @internal (undocumented)
+    readonly [_nativeDb]: IModelJsNative.DgnDb;
     // @internal
     protected constructor(args: {
         nativeDb: IModelJsNative.DgnDb;
@@ -3149,8 +3151,8 @@ export abstract class IModelDb extends IModel {
     static readonly maxLimit = 10000;
     // (undocumented)
     readonly models: IModelDb.Models;
-    // @internal (undocumented)
-    readonly nativeDb: IModelJsNative.DgnDb;
+    // @internal @deprecated (undocumented)
+    get nativeDb(): IModelJsNative.DgnDb;
     // @internal (undocumented)
     notifyChangesetApplied(): void;
     readonly onBeforeClose: BeEvent<() => void>;

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -23,6 +23,7 @@ import { BriefcaseDb, IModelDb, TokenArg } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
 import { IModelJsFs } from "./IModelJsFs";
 import { SchemaSync } from "./SchemaSync";
+import { _nativeDb } from "./internal/Internal";
 
 const loggerCategory = BackendLoggerCategory.IModelDb;
 
@@ -409,8 +410,8 @@ export class BriefcaseManager {
     if (changesetFile.changesType === ChangesetType.Schema || changesetFile.changesType === ChangesetType.SchemaSync)
       db.clearCaches(); // for schema changesets, statement caches may become invalid. Do this *before* applying, in case db needs to be closed (open statements hold db open.)
 
-    db.nativeDb.applyChangeset(changesetFile);
-    db.changeset = db.nativeDb.getCurrentChangeset();
+    db[_nativeDb].applyChangeset(changesetFile);
+    db.changeset = db[_nativeDb].getCurrentChangeset();
 
     // we're done with this changeset, delete it
     IModelJsFs.removeSync(changesetFile.pathname);
@@ -418,7 +419,7 @@ export class BriefcaseManager {
 
   /** @internal */
   public static async pullAndApplyChangesets(db: IModelDb, arg: PullChangesArgs): Promise<void> {
-    if (!db.isOpen || db.nativeDb.isReadonly()) // don't use db.isReadonly - we reopen the file writable just for this operation but db.isReadonly is still true
+    if (!db.isOpen || db[_nativeDb].isReadonly()) // don't use db.isReadonly - we reopen the file writable just for this operation but db.isReadonly is still true
       throw new IModelError(ChangeSetStatus.ApplyError, "Briefcase must be open ReadWrite to process change sets");
 
     let currentIndex = db.changeset.index;
@@ -454,7 +455,7 @@ export class BriefcaseManager {
 
   /** create a changeset from the current changes, and push it to iModelHub */
   private static async pushChanges(db: BriefcaseDb, arg: PushChangesArgs): Promise<void> {
-    const changesetProps = db.nativeDb.startCreateChangeset() as ChangesetFileProps;
+    const changesetProps = db[_nativeDb].startCreateChangeset() as ChangesetFileProps;
     changesetProps.briefcaseId = db.briefcaseId;
     changesetProps.description = arg.description;
     const fileSize = IModelJsFs.lstatSync(changesetProps.pathname)?.size;
@@ -468,8 +469,8 @@ export class BriefcaseManager {
       try {
         const accessToken = await IModelHost.getAccessToken();
         const index = await IModelHost.hubAccess.pushChangeset({ accessToken, iModelId: db.iModelId, changesetProps });
-        db.nativeDb.completeCreateChangeset({ index });
-        db.changeset = db.nativeDb.getCurrentChangeset();
+        db[_nativeDb].completeCreateChangeset({ index });
+        db.changeset = db[_nativeDb].getCurrentChangeset();
         if (!arg.retainLocks)
           await db.locks.releaseAllLocks();
 
@@ -488,7 +489,7 @@ export class BriefcaseManager {
         };
 
         if (!shouldRetry()) {
-          db.nativeDb.abandonCreateChangeset();
+          db[_nativeDb].abandonCreateChangeset();
           throw err;
         }
       } finally {

--- a/core/backend/src/ChangeSummaryManager.ts
+++ b/core/backend/src/ChangeSummaryManager.ts
@@ -16,6 +16,7 @@ import { ECSqlStatement } from "./ECSqlStatement";
 import { BriefcaseDb, IModelDb, TokenArg } from "./IModelDb";
 import { IModelHost, KnownLocations } from "./IModelHost";
 import { IModelJsFs } from "./IModelJsFs";
+import { _nativeDb } from "./internal/Internal";
 
 const loggerCategory: string = BackendLoggerCategory.ECDb;
 
@@ -83,7 +84,7 @@ export class ChangeSummaryManager {
     if (!iModel || !iModel.isOpen)
       throw new IModelError(IModelStatus.BadRequest, "Briefcase must be open");
 
-    return iModel.nativeDb.isChangeCacheAttached();
+    return iModel[_nativeDb].isChangeCacheAttached();
   }
 
   /** Attaches the *Change Cache file* to the specified iModel if it hasn't been attached yet.
@@ -106,7 +107,7 @@ export class ChangeSummaryManager {
     }
 
     assert(IModelJsFs.existsSync(changesCacheFilePath));
-    const res: DbResult = iModel.nativeDb.attachChangeCache(changesCacheFilePath);
+    const res: DbResult = iModel[_nativeDb].attachChangeCache(changesCacheFilePath);
     if (res !== DbResult.BE_SQLITE_OK)
       throw new IModelError(res, `Failed to attach Change Cache file to ${iModel.pathName}.`);
   }
@@ -121,7 +122,7 @@ export class ChangeSummaryManager {
       throw new IModelError(IModelStatus.BadRequest, "Briefcase must be open");
 
     iModel.clearCaches();
-    const res: DbResult = iModel.nativeDb.detachChangeCache();
+    const res: DbResult = iModel[_nativeDb].detachChangeCache();
     if (res !== DbResult.BE_SQLITE_OK)
       throw new IModelError(res, `Failed to detach Change Cache file from ${iModel.pathName}.`);
   }
@@ -153,7 +154,7 @@ export class ChangeSummaryManager {
     if (!iModel?.isOpen)
       throw new IModelError(IModelStatus.BadArg, "Invalid iModel object. iModel must be open.");
 
-    const stat: DbResult = iModel.nativeDb.createChangeCache(changesFile.nativeDb, changeCacheFilePath);
+    const stat: DbResult = iModel[_nativeDb].createChangeCache(changesFile.nativeDb, changeCacheFilePath);
     if (stat !== DbResult.BE_SQLITE_OK)
       throw new IModelError(stat, `Failed to create Change Cache file at "${changeCacheFilePath}".`);
 
@@ -390,7 +391,7 @@ export class ChangeSummaryManager {
         return changeSummaryId;
       }
 
-      const stat = iModel.nativeDb.extractChangeSummary(changesFile.nativeDb, changeset.pathname);
+      const stat = iModel[_nativeDb].extractChangeSummary(changesFile.nativeDb, changeset.pathname);
       if (stat.error && stat.error.status !== DbResult.BE_SQLITE_OK)
         throw new IModelError(stat.error.status, stat.error.message);
 

--- a/core/backend/src/ChangedElementsDb.ts
+++ b/core/backend/src/ChangedElementsDb.ts
@@ -13,6 +13,7 @@ import { BriefcaseManager } from "./BriefcaseManager";
 import { ECDbOpenMode } from "./ECDb";
 import { IModelDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
+import { _nativeDb } from "./internal/Internal";
 
 /**
  * Options for processChangesets function
@@ -56,7 +57,7 @@ export class ChangedElementsDb implements IDisposable {
    * @throws [IModelError]($common) if the operation failed.
    */
   private _createDb(briefcase: IModelDb, pathName: string): void {
-    const status: DbResult = this.nativeDb.createDb(briefcase.nativeDb, pathName);
+    const status: DbResult = this.nativeDb.createDb(briefcase[_nativeDb], pathName);
     if (status !== DbResult.BE_SQLITE_OK)
       throw new IModelError(status, "Failed to created ECDb");
   }
@@ -109,7 +110,7 @@ export class ChangedElementsDb implements IDisposable {
     // ChangeSets need to be processed from newest to oldest
     changesets.reverse();
     const status = this.nativeDb.processChangesets(
-      briefcase.nativeDb,
+      briefcase[_nativeDb],
       changesets,
       options.rulesetId,
       options.filterSpatial,

--- a/core/backend/src/ChannelControl.ts
+++ b/core/backend/src/ChannelControl.ts
@@ -11,6 +11,7 @@ import { ChannelRootAspectProps, IModel, IModelError } from "@itwin/core-common"
 import { Subject } from "./Element";
 import { IModelDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
+import { _nativeDb } from "./internal/Internal";
 
 /** The key for a channel. Used for "allowed channels" in [[ChannelControl]]
  * @beta
@@ -120,7 +121,7 @@ export class ChannelAdmin implements ChannelControl {
   }
   public verifyChannel(modelId: Id64String): void {
     // Note: indirect changes are permitted to change any channel
-    if (this._allowedModels.has(modelId) || this._iModel.nativeDb.isIndirectChanges())
+    if (this._allowedModels.has(modelId) || this._iModel[_nativeDb].isIndirectChanges())
       return;
 
     const deniedChannel = this._deniedModels.get(modelId);

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -21,6 +21,7 @@ import { CloudSqlite } from "./CloudSqlite";
 import { IModelHost } from "./IModelHost";
 import { IModelJsFs } from "./IModelJsFs";
 import { SnapshotDb, TokenArg } from "./IModelDb";
+import { _nativeDb } from "./internal/Internal";
 
 const loggerCategory = BackendLoggerCategory.IModelDb;
 
@@ -333,7 +334,7 @@ export class CheckpointManager {
       const prevLogLevel = Logger.getLevel(NativeLoggerCategory.SQLite) ?? LogLevel.Error; // Get log level before we set it to None.
       Logger.setLevel(NativeLoggerCategory.SQLite, LogLevel.None); // Ignores noisy error messages when applying changesets.
       const db = SnapshotDb.openForApplyChangesets(targetFile);
-      const nativeDb = db.nativeDb;
+      const nativeDb = db[_nativeDb];
       try {
 
         if (nativeDb.hasPendingTxns()) {
@@ -397,7 +398,7 @@ export class CheckpointManager {
   public static validateCheckpointGuids(checkpoint: CheckpointProps, snapshotDb: SnapshotDb) {
     const traceInfo = { iTwinId: checkpoint.iTwinId, iModelId: checkpoint.iModelId };
 
-    const nativeDb = snapshotDb.nativeDb;
+    const nativeDb = snapshotDb[_nativeDb];
     const dbChangeset = nativeDb.getCurrentChangeset();
     const iModelId = Guid.normalize(nativeDb.getIModelId());
     if (iModelId !== Guid.normalize(checkpoint.iModelId)) {

--- a/core/backend/src/ClassRegistry.ts
+++ b/core/backend/src/ClassRegistry.ts
@@ -13,6 +13,7 @@ import { IModelDb } from "./IModelDb";
 import { Schema, Schemas } from "./Schema";
 import { EntityReferences } from "./EntityReferences";
 import * as assert from "assert";
+import { _nativeDb } from "./internal/Internal"; 
 
 const isGeneratedClassTag = Symbol("isGeneratedClassTag");
 
@@ -74,7 +75,7 @@ export class ClassRegistry {
    */
   public static getRootEntity(iModel: IModelDb, ecTypeQualifier: string): string {
     const [classSchema, className] = ecTypeQualifier.split(".");
-    const schemaItemJson = iModel.nativeDb.getSchemaItem(classSchema, className);
+    const schemaItemJson = iModel[_nativeDb].getSchemaItem(classSchema, className);
     if (schemaItemJson.error)
       throw new IModelError(schemaItemJson.error.status, `failed to get schema item '${ecTypeQualifier}'`);
 
@@ -150,7 +151,7 @@ export class ClassRegistry {
         // eslint-disable-next-line @typescript-eslint/no-shadow
         .map(([name, prop]) => {
           assert(prop.relationshipClass);
-          const maybeMetaData = iModel.nativeDb.getSchemaItem(...prop.relationshipClass.split(":") as [string, string]);
+          const maybeMetaData = iModel[_nativeDb].getSchemaItem(...prop.relationshipClass.split(":") as [string, string]);
           assert(maybeMetaData.result !== undefined, "The nav props relationship metadata was not found");
           const relMetaData = JSON.parse(maybeMetaData.result);
           const rootClassMetaData = ClassRegistry.getRootEntity(iModel, relMetaData.target.constraintClasses[0]);

--- a/core/backend/src/ElementGraphics.ts
+++ b/core/backend/src/ElementGraphics.ts
@@ -6,12 +6,13 @@ import { assert, IModelStatus } from "@itwin/core-bentley";
 import { ElementGraphicsRequestProps, IModelError } from "@itwin/core-common";
 import { ElementGraphicsStatus } from "@bentley/imodeljs-native";
 import { IModelDb } from "./IModelDb";
+import { _nativeDb } from "./internal/Internal";
 
 /** See [[IModelDb.generateElementGraphics]] and IModelTileRpcImpl.requestElementGraphics.
  * @internal
  */
 export async function generateElementGraphics(request: ElementGraphicsRequestProps, iModel: IModelDb): Promise<Uint8Array | undefined> {
-  const result = await iModel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+  const result = await iModel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
 
   let error: string | undefined;
   switch (result.status) {

--- a/core/backend/src/GeometrySummary.ts
+++ b/core/backend/src/GeometrySummary.ts
@@ -16,6 +16,7 @@ import {
 } from "@itwin/core-common";
 import { Element, GeometricElement, GeometryPart } from "./Element";
 import { IModelDb } from "./IModelDb";
+import { _nativeDb } from "./internal/Internal";
 
 interface ElementGeom {
   iterator: GeometryStreamIterator;
@@ -118,7 +119,7 @@ class ResponseGenerator {
   }
 
   public summarizePartReferences(id: Id64String, is2d: boolean): string {
-    const refIds = this.iModel.nativeDb.findGeometryPartReferences([id], is2d);
+    const refIds = this.iModel[_nativeDb].findGeometryPartReferences([id], is2d);
     return `Part references (${refIds.length}): ${refIds.join()}`;
   }
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -58,6 +58,7 @@ import { ViewStore } from "./ViewStore";
 import { BaseSettings, SettingDictionary, SettingName, SettingResolver, SettingsPriority, SettingType } from "./workspace/Settings";
 import { Workspace } from "./workspace/Workspace";
 import { ComputeRangesForTextLayoutArgs, TextLayoutRanges } from "./TextAnnotationLayout";
+import { _nativeDb } from "./internal/Internal";
 
 import type { BlobContainer } from "./BlobContainerService";
 /** @internal */
@@ -305,17 +306,17 @@ export abstract class IModelDb extends IModel {
   public readonly onChangesetApplied = new BeEvent<() => void>();
   /** @internal */
   public notifyChangesetApplied() {
-    this.changeset = this.nativeDb.getCurrentChangeset();
+    this.changeset = this[_nativeDb].getCurrentChangeset();
     this.onChangesetApplied.raiseEvent();
   }
 
   /** @internal */
   public restartDefaultTxn() {
-    this.nativeDb.restartDefaultTxn();
+    this[_nativeDb].restartDefaultTxn();
   }
 
   public get fontMap(): FontMap {
-    return this._fontMap ?? (this._fontMap = new FontMap(this.nativeDb.readFontMap()));
+    return this._fontMap ?? (this._fontMap = new FontMap(this[_nativeDb].readFontMap()));
   }
 
   /** @internal */
@@ -334,7 +335,7 @@ export abstract class IModelDb extends IModel {
   public addNewFont(name: string, type?: FontType): FontId {
     this.locks.checkExclusiveLock(IModel.repositoryModelId, "schema", "addNewFont");
     this.clearFontMap();
-    return this.nativeDb.addNewFont({ name, type: type ?? FontType.TrueType });
+    return this[_nativeDb].addNewFont({ name, type: type ?? FontType.TrueType });
   }
 
   /** Check if this iModel has been opened read-only or not. */
@@ -347,12 +348,17 @@ export abstract class IModelDb extends IModel {
   } // GuidString | undefined for the IModel superclass, but required for all IModelDb subclasses
 
   /** @internal*/
-  public readonly nativeDb: IModelJsNative.DgnDb;
+  public readonly [_nativeDb]: IModelJsNative.DgnDb;
+
+  /** @internal
+   * @deprecated To be removed in iTwin.js 5.0.0. This property is internal and should not be used by any code outside of the iTwin.js core repository.
+   */
+  public get nativeDb(): IModelJsNative.DgnDb { return this[_nativeDb]; }
 
   /** Get the full path fileName of this iModelDb
    * @note this member is only valid while the iModel is opened.
    */
-  public get pathName(): LocalFileName { return this.nativeDb.getFilePath(); }
+  public get pathName(): LocalFileName { return this[_nativeDb].getFilePath(); }
 
   /** Get the full path to this iModel's "watch file".
    * A read-only briefcase opened with `watchForChanges: true` creates this file next to the briefcase file on open, if it doesn't already exist.
@@ -366,7 +372,7 @@ export abstract class IModelDb extends IModel {
   /** @internal */
   protected constructor(args: { nativeDb: IModelJsNative.DgnDb, key: string, changeset?: ChangesetIdWithIndex }) {
     super({ ...args, iTwinId: args.nativeDb.getITwinId(), iModelId: args.nativeDb.getIModelId() });
-    this.nativeDb = args.nativeDb;
+    this[_nativeDb] = args.nativeDb;
 
     // it is illegal to create an IModelDb unless the nativeDb has been opened. Throw otherwise.
     if (!this.isOpen)
@@ -375,14 +381,14 @@ export abstract class IModelDb extends IModel {
     // PR https://github.com/iTwin/imodel-native/pull/558 renamed closeIModel to closeFile because it changed its behavior.
     // Ideally, nobody outside of core-backend would be calling it, but somebody important is.
     // Make closeIModel available so their code doesn't break.
-    (this.nativeDb as any).closeIModel = () => {
+    (this[_nativeDb] as any).closeIModel = () => {
       if (!this.isReadonly)
         this.saveChanges(); // preserve old behavior of closeIModel that was removed when renamed to closeFile
 
-      this.nativeDb.closeFile();
+      this[_nativeDb].closeFile();
     };
 
-    this.nativeDb.setIModelDb(this);
+    this[_nativeDb].setIModelDb(this);
 
     this.loadSettingDictionaries();
     GeoCoordConfig.loadForImodel(this.workspace.settings); // load gcs data specified by iModel's settings dictionaries, must be done before calling initializeIModelDb
@@ -416,7 +422,7 @@ export abstract class IModelDb extends IModel {
     this._codeService = undefined;
     if (!this.isReadonly)
       this.saveChanges();
-    this.nativeDb.closeFile();
+    this[_nativeDb].closeFile();
   }
 
   /** @internal */
@@ -436,7 +442,7 @@ export abstract class IModelDb extends IModel {
 
   /** @internal */
   protected initializeIModelDb() {
-    const props = this.nativeDb.getIModelProps();
+    const props = this[_nativeDb].getIModelProps();
     super.initialize(props.rootSubject.name, props);
     if (this._initialized)
       return;
@@ -480,10 +486,10 @@ export abstract class IModelDb extends IModel {
   /** Return `true` if the underlying nativeDb is open and valid.
    * @internal
    */
-  public get isOpen(): boolean { return this.nativeDb.isOpen(); }
+  public get isOpen(): boolean { return this[_nativeDb].isOpen(); }
 
   /** Get the briefcase Id of this iModel */
-  public getBriefcaseId(): BriefcaseId { return this.isOpen ? this.nativeDb.getBriefcaseId() : BriefcaseIdValue.Illegal; }
+  public getBriefcaseId(): BriefcaseId { return this.isOpen ? this[_nativeDb].getBriefcaseId() : BriefcaseIdValue.Illegal; }
 
   /**
    * Use a prepared ECSQL statement, potentially from the statement cache. If the requested statement doesn't exist
@@ -555,12 +561,12 @@ export abstract class IModelDb extends IModel {
    * @public
    * */
   public createQueryReader(ecsql: string, params?: QueryBinder, config?: QueryOptions): ECSqlReader {
-    if (!this.nativeDb.isOpen())
+    if (!this[_nativeDb].isOpen())
       throw new IModelError(DbResult.BE_SQLITE_ERROR, "db not open");
 
     const executor = {
       execute: async (request: DbQueryRequest) => {
-        return ConcurrentQuery.executeQueryRequest(this.nativeDb, request);
+        return ConcurrentQuery.executeQueryRequest(this[_nativeDb], request);
       },
     };
     return new ECSqlReader(executor, ecsql, params, config);
@@ -697,7 +703,7 @@ export abstract class IModelDb extends IModel {
    */
   public prepareSqliteStatement(sql: string, logErrors = true): SqliteStatement {
     const stmt = new SqliteStatement(sql);
-    stmt.prepare(this.nativeDb, logErrors);
+    stmt.prepare(this[_nativeDb], logErrors);
     return stmt;
   }
 
@@ -794,7 +800,7 @@ export abstract class IModelDb extends IModel {
   public computeProjectExtents(options?: ComputeProjectExtentsOptions): ComputedProjectExtents {
     const wantFullExtents = true === options?.reportExtentsWithOutliers;
     const wantOutliers = true === options?.reportOutliers;
-    const result = this.nativeDb.computeProjectExtents(wantFullExtents, wantOutliers);
+    const result = this[_nativeDb].computeProjectExtents(wantFullExtents, wantOutliers);
     return {
       extents: Range3d.fromJSON(result.extents),
       extentsWithOutliers: result.fullExtents ? Range3d.fromJSON(result.fullExtents) : undefined,
@@ -810,7 +816,7 @@ export abstract class IModelDb extends IModel {
 
   /** Update the IModelProps of this iModel in the database. */
   public updateIModelProps(): void {
-    this.nativeDb.updateIModelProps(this.toJSON());
+    this[_nativeDb].updateIModelProps(this.toJSON());
   }
 
   /** Commit pending changes to this iModel.
@@ -821,14 +827,14 @@ export abstract class IModelDb extends IModel {
     if (this.openMode === OpenMode.Readonly)
       throw new IModelError(IModelStatus.ReadOnly, "IModelDb was opened read-only");
 
-    const stat = this.nativeDb.saveChanges(description);
+    const stat = this[_nativeDb].saveChanges(description);
     if (DbResult.BE_SQLITE_OK !== stat)
       throw new IModelError(stat, `Could not save changes (${description})`);
   }
 
   /** Abandon pending changes in this iModel. */
   public abandonChanges(): void {
-    this.nativeDb.abandonChanges();
+    this[_nativeDb].abandonChanges();
   }
 
   /**
@@ -842,23 +848,23 @@ export abstract class IModelDb extends IModel {
   public performCheckpoint() {
     if (!this.isReadonly) {
       this.saveChanges();
-      this.nativeDb.performCheckpoint();
+      this[_nativeDb].performCheckpoint();
     }
   }
 
   /** @internal */
   public reverseTxns(numOperations: number): IModelStatus {
-    return this.nativeDb.reverseTxns(numOperations);
+    return this[_nativeDb].reverseTxns(numOperations);
   }
 
   /** @internal */
   public reinstateTxn(): IModelStatus {
-    return this.nativeDb.reinstateTxn();
+    return this[_nativeDb].reinstateTxn();
   }
 
   /** @internal */
   public restartTxnSession(): void {
-    return this.nativeDb.restartTxnSession();
+    return this[_nativeDb].restartTxnSession();
   }
 
   /** Import an ECSchema. On success, the schema definition is stored in the iModel.
@@ -876,21 +882,21 @@ export abstract class IModelDb extends IModel {
       return;
 
     const maybeCustomNativeContext = options?.ecSchemaXmlContext?.nativeContext;
-    if (this.nativeDb.schemaSyncEnabled()) {
+    if (this[_nativeDb].schemaSyncEnabled()) {
 
       await SchemaSync.withLockedAccess(this, { openMode: OpenMode.Readonly, operationName: "schema sync" }, async (syncAccess) => {
         const schemaSyncDbUri = syncAccess.getUri();
         this.saveChanges();
 
         try {
-          this.nativeDb.importSchemas(schemaFileNames, { schemaLockHeld: false, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
+          this[_nativeDb].importSchemas(schemaFileNames, { schemaLockHeld: false, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
         } catch (outerErr: any) {
           if (DbResult.BE_SQLITE_ERROR_DataTransformRequired === outerErr.errorNumber) {
             this.abandonChanges();
-            if (this.nativeDb.getITwinId() !== Guid.empty)
+            if (this[_nativeDb].getITwinId() !== Guid.empty)
               await this.acquireSchemaLock();
             try {
-              this.nativeDb.importSchemas(schemaFileNames, { schemaLockHeld: true, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
+              this[_nativeDb].importSchemas(schemaFileNames, { schemaLockHeld: true, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
             } catch (innerErr: any) {
               throw new IModelError(innerErr.errorNumber, innerErr.message);
             }
@@ -905,11 +911,11 @@ export abstract class IModelDb extends IModel {
         ecSchemaXmlContext: maybeCustomNativeContext,
       };
 
-      if (this.nativeDb.getITwinId() !== Guid.empty) // if this iModel is associated with an iTwin, importing schema requires the schema lock
+      if (this[_nativeDb].getITwinId() !== Guid.empty) // if this iModel is associated with an iTwin, importing schema requires the schema lock
         await this.acquireSchemaLock();
 
       try {
-        this.nativeDb.importSchemas(schemaFileNames, nativeImportOptions);
+        this[_nativeDb].importSchemas(schemaFileNames, nativeImportOptions);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, err.message);
       }
@@ -930,19 +936,19 @@ export abstract class IModelDb extends IModel {
     if (serializedXmlSchemas.length === 0)
       return;
 
-    if (this.nativeDb.schemaSyncEnabled()) {
+    if (this[_nativeDb].schemaSyncEnabled()) {
       await SchemaSync.withLockedAccess(this, { openMode: OpenMode.Readonly, operationName: "schemaSync" }, async (syncAccess) => {
         const schemaSyncDbUri = syncAccess.getUri();
         this.saveChanges();
         try {
-          this.nativeDb.importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: false, schemaSyncDbUri });
+          this[_nativeDb].importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: false, schemaSyncDbUri });
         } catch (outerErr: any) {
           if (DbResult.BE_SQLITE_ERROR_DataTransformRequired === outerErr.errorNumber) {
             this.abandonChanges();
-            if (this.nativeDb.getITwinId() !== Guid.empty)
+            if (this[_nativeDb].getITwinId() !== Guid.empty)
               await this.acquireSchemaLock();
             try {
-              this.nativeDb.importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true, schemaSyncDbUri });
+              this[_nativeDb].importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true, schemaSyncDbUri });
             } catch (innerErr: any) {
               throw new IModelError(innerErr.errorNumber, innerErr.message);
             }
@@ -956,7 +962,7 @@ export abstract class IModelDb extends IModel {
         await this.acquireSchemaLock();
 
       try {
-        this.nativeDb.importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true });
+        this[_nativeDb].importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true });
       } catch (err: any) {
         throw new IModelError(err.errorNumber, err.message);
       }
@@ -1101,7 +1107,7 @@ export abstract class IModelDb extends IModel {
    */
   public prepareStatement(sql: string, logErrors = true): ECSqlStatement {
     const stmt = new ECSqlStatement();
-    stmt.prepare(this.nativeDb, sql, logErrors);
+    stmt.prepare(this[_nativeDb], sql, logErrors);
     return stmt;
   }
 
@@ -1111,7 +1117,7 @@ export abstract class IModelDb extends IModel {
    */
   public tryPrepareStatement(sql: string): ECSqlStatement | undefined {
     const statement = new ECSqlStatement();
-    const result = statement.tryPrepare(this.nativeDb, sql);
+    const result = statement.tryPrepare(this[_nativeDb], sql);
     return DbResult.BE_SQLITE_OK === result.status ? statement : undefined;
   }
 
@@ -1200,7 +1206,7 @@ export abstract class IModelDb extends IModel {
     if (className.length !== 2)
       throw new IModelError(IModelStatus.BadArg, `Invalid classFullName: ${classFullName}`);
 
-    const val = this.nativeDb.getECClassMetaData(className[0], className[1]);
+    const val = this[_nativeDb].getECClassMetaData(className[0], className[1]);
     if (val.error)
       throw new IModelError(val.error.status, `Error getting class meta data for: ${classFullName}`);
 
@@ -1219,7 +1225,7 @@ export abstract class IModelDb extends IModel {
    * @throws if the schema can not be found or loaded.
    */
   public getSchemaProps(name: string): ECSchemaProps {
-    return this.nativeDb.getSchemaProps(name);
+    return this[_nativeDb].getSchemaProps(name);
   }
 
   /** Query if this iModel contains the definition of the specified class.
@@ -1230,7 +1236,7 @@ export abstract class IModelDb extends IModel {
    */
   public containsClass(classFullName: string): boolean {
     const classNameParts = classFullName.replace(".", ":").split(":");
-    return classNameParts.length === 2 && this.nativeDb.getECClassMetaData(classNameParts[0], classNameParts[1]).error === undefined;
+    return classNameParts.length === 2 && this[_nativeDb].getECClassMetaData(classNameParts[0], classNameParts[1]).error === undefined;
   }
 
   /** Query for a schema of the specified name in this iModel.
@@ -1256,21 +1262,21 @@ export abstract class IModelDb extends IModel {
    * @alpha
    */
   public async queryTextureData(props: TextureLoadProps): Promise<TextureData | undefined> {
-    return this.nativeDb.queryTextureData(props);
+    return this[_nativeDb].queryTextureData(props);
   }
 
   /** Query a "file property" from this iModel, as a string.
    * @returns the property string or undefined if the property is not present.
    */
   public queryFilePropertyString(prop: FilePropertyProps): string | undefined {
-    return this.nativeDb.queryFileProperty(prop, true) as string | undefined;
+    return this[_nativeDb].queryFileProperty(prop, true) as string | undefined;
   }
 
   /** Query a "file property" from this iModel, as a blob.
    * @returns the property blob or undefined if the property is not present.
    */
   public queryFilePropertyBlob(prop: FilePropertyProps): Uint8Array | undefined {
-    return this.nativeDb.queryFileProperty(prop, false) as Uint8Array | undefined;
+    return this[_nativeDb].queryFileProperty(prop, false) as Uint8Array | undefined;
   }
 
   /** Save a "file property" to this iModel
@@ -1278,21 +1284,21 @@ export abstract class IModelDb extends IModel {
    * @param value either a string or a blob to save as the file property
    */
   public saveFileProperty(prop: FilePropertyProps, strValue: string | undefined, blobVal?: Uint8Array): void {
-    this.nativeDb.saveFileProperty(prop, strValue, blobVal);
+    this[_nativeDb].saveFileProperty(prop, strValue, blobVal);
   }
 
   /** delete a "file property" from this iModel
    * @param prop the FilePropertyProps that describes the property
    */
   public deleteFileProperty(prop: FilePropertyProps): void {
-    this.nativeDb.saveFileProperty(prop, undefined, undefined);
+    this[_nativeDb].saveFileProperty(prop, undefined, undefined);
   }
 
   /** Query for the next available major id for a "file property" from this iModel.
    * @param prop the FilePropertyProps that describes the property
    * @returns the next available (that is, an unused) id for prop. If none are present, will return 0.
    */
-  public queryNextAvailableFileProperty(prop: FilePropertyProps) { return this.nativeDb.queryNextAvailableFileProperty(prop); }
+  public queryNextAvailableFileProperty(prop: FilePropertyProps) { return this[_nativeDb].queryNextAvailableFileProperty(prop); }
 
   /** @internal */
   public async requestSnap(sessionId: string, props: SnapRequestProps): Promise<SnapResponseProps> {
@@ -1304,7 +1310,7 @@ export abstract class IModelDb extends IModel {
       request.cancelSnap();
 
     try {
-      return await request.doSnap(this.nativeDb, JsonUtils.toObject(props));
+      return await request.doSnap(this[_nativeDb], JsonUtils.toObject(props));
     } finally {
       this._snaps.delete(sessionId);
     }
@@ -1323,22 +1329,22 @@ export abstract class IModelDb extends IModel {
 
   /** Get the clip containment status for the supplied elements. */
   public async getGeometryContainment(props: GeometryContainmentRequestProps): Promise<GeometryContainmentResponseProps> {
-    return this.nativeDb.getGeometryContainment(JsonUtils.toObject(props));
+    return this[_nativeDb].getGeometryContainment(JsonUtils.toObject(props));
   }
 
   /** Get the mass properties for the supplied elements. */
   public async getMassProperties(props: MassPropertiesRequestProps): Promise<MassPropertiesResponseProps> {
-    return this.nativeDb.getMassProperties(JsonUtils.toObject(props));
+    return this[_nativeDb].getMassProperties(JsonUtils.toObject(props));
   }
 
   /** Get the IModel coordinate corresponding to each GeoCoordinate point in the input */
   public async getIModelCoordinatesFromGeoCoordinates(props: IModelCoordinatesRequestProps): Promise<IModelCoordinatesResponseProps> {
-    return this.nativeDb.getIModelCoordinatesFromGeoCoordinates(props);
+    return this[_nativeDb].getIModelCoordinatesFromGeoCoordinates(props);
   }
 
   /** Get the GeoCoordinate (longitude, latitude, elevation) corresponding to each IModel Coordinate point in the input */
   public async getGeoCoordinatesFromIModelCoordinates(props: GeoCoordinatesRequestProps): Promise<GeoCoordinatesResponseProps> {
-    return this.nativeDb.getGeoCoordinatesFromIModelCoordinates(props);
+    return this[_nativeDb].getGeoCoordinatesFromIModelCoordinates(props);
   }
 
   /** Export meshes suitable for graphics APIs from arbitrary geometry in elements in this IModelDb.
@@ -1374,7 +1380,7 @@ export abstract class IModelDb extends IModel {
    * @public
    */
   public exportGraphics(exportProps: ExportGraphicsOptions): DbResult {
-    return this.nativeDb.exportGraphics(exportProps);
+    return this[_nativeDb].exportGraphics(exportProps);
   }
 
   /**
@@ -1390,7 +1396,7 @@ export abstract class IModelDb extends IModel {
    * @public
    */
   public exportPartGraphics(exportProps: ExportPartGraphicsOptions): DbResult {
-    return this.nativeDb.exportPartGraphics(exportProps);
+    return this[_nativeDb].exportPartGraphics(exportProps);
   }
 
   /** Request geometry stream information from an element in binary format instead of json.
@@ -1398,7 +1404,7 @@ export abstract class IModelDb extends IModel {
    * @beta
    */
   public elementGeometryRequest(requestProps: ElementGeometryRequest): IModelStatus {
-    return this.nativeDb.processGeometryStream(requestProps);
+    return this[_nativeDb].processGeometryStream(requestProps);
   }
 
   /** Create brep geometry for inclusion in an element's geometry stream.
@@ -1407,7 +1413,7 @@ export abstract class IModelDb extends IModel {
    * @alpha
    */
   public createBRepGeometry(createProps: BRepGeometryCreate): IModelStatus {
-    return this.nativeDb.createBRepGeometry(createProps);
+    return this[_nativeDb].createBRepGeometry(createProps);
   }
 
   /** Generate graphics for an element or geometry stream.
@@ -1450,7 +1456,7 @@ export abstract class IModelDb extends IModel {
 
   /** Load all setting dictionaries in this iModel into `this.workspace.settings` */
   private loadSettingDictionaries() {
-    if (!this.nativeDb.isOpen())
+    if (!this[_nativeDb].isOpen())
       return;
 
     this.withSqliteStatement("SELECT Name,StrData FROM be_Prop WHERE Namespace=?", (stmt) => {
@@ -1471,16 +1477,16 @@ export abstract class IModelDb extends IModel {
    * @public
    */
   public get codeValueBehavior(): "exact" | "trim-unicode-whitespace" {
-    return this.nativeDb.getCodeValueBehavior();
+    return this[_nativeDb].getCodeValueBehavior();
   }
 
   public set codeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace") {
-    this.nativeDb.setCodeValueBehavior(newBehavior);
+    this[_nativeDb].setCodeValueBehavior(newBehavior);
   }
 
   /** @internal */
   public computeRangesForText(args: ComputeRangesForTextLayoutArgs): TextLayoutRanges {
-    const props = this.nativeDb.computeRangesForText(args.chars, args.fontId, args.bold, args.italic, args.widthFactor, args.lineHeight);
+    const props = this[_nativeDb].computeRangesForText(args.chars, args.fontId, args.bold, args.italic, args.widthFactor, args.lineHeight);
     return {
       layout: Range2d.fromJSON(props.layout),
       justification: Range2d.fromJSON(props.justification),
@@ -1589,7 +1595,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     private tryGetModelJson<T extends ModelProps>(modelIdArg: ModelLoadProps): T | undefined {
       try {
-        return this._iModel.nativeDb.getModel(modelIdArg) as T;
+        return this._iModel[_nativeDb].getModel(modelIdArg) as T;
       } catch (err: any) {
         return undefined;
       }
@@ -1638,7 +1644,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertModel(props: ModelProps): Id64String {
       try {
-        return props.id = this._iModel.nativeDb.insertModel(props);
+        return props.id = this._iModel[_nativeDb].insertModel(props);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error inserting model [${err.message}], class=${props.classFullName}`);
       }
@@ -1650,7 +1656,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateModel(props: UpdateModelOptions): void {
       try {
-        this._iModel.nativeDb.updateModel(props);
+        this._iModel[_nativeDb].updateModel(props);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `error updating model [${err.message}] id=${props.id}`);
       }
@@ -1665,7 +1671,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @see [[TxnManager.onModelGeometryChanged]] for the event emitted in response to such a change.
      */
     public updateGeometryGuid(modelId: Id64String): void {
-      const error = this._iModel.nativeDb.updateModelGeometryGuid(modelId);
+      const error = this._iModel[_nativeDb].updateModelGeometryGuid(modelId);
       if (error !== IModelStatus.Success)
         throw new IModelError(error, `updating geometry guid for model ${modelId}`);
     }
@@ -1677,7 +1683,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     public deleteModel(ids: Id64Arg): void {
       Id64.toIdSet(ids).forEach((id) => {
         try {
-          this._iModel.nativeDb.deleteModel(id);
+          this._iModel[_nativeDb].deleteModel(id);
         } catch (err: any) {
           throw new IModelError(err.errorNumber, `error deleting model [${err.message}] id ${id}`);
         }
@@ -1696,7 +1702,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       if (ids.length === 0)
         return [];
 
-      return this._iModel.nativeDb.queryModelExtentsAsync(ids);
+      return this._iModel[_nativeDb].queryModelExtentsAsync(ids);
     }
 
     /** Computes the union of the volumes of all geometric elements within one or more [[GeometricModel]]s, specified by model Id.
@@ -1760,7 +1766,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     private tryGetElementJson<T extends ElementProps>(loadProps: ElementLoadProps): T | undefined {
       try {
-        return this._iModel.nativeDb.getElement(loadProps) as T;
+        return this._iModel[_nativeDb].getElement(loadProps) as T;
       } catch (err: any) {
         return undefined;
       }
@@ -1777,7 +1783,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
         props = { code: props };
       }
       try {
-        return this._iModel.nativeDb.getElement(props) as T;
+        return this._iModel[_nativeDb].getElement(props) as T;
       } catch (err: any) {
         throw new IModelError(err.errorNumber, err.message);
       }
@@ -1902,7 +1908,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertElement(elProps: ElementProps): Id64String {
       try {
-        return elProps.id = this._iModel.nativeDb.insertElement(elProps);
+        return elProps.id = this._iModel[_nativeDb].insertElement(elProps);
       } catch (err: any) {
         err.message = `Error inserting element [${err.message}]`;
         err.metadata = { elProps };
@@ -1923,7 +1929,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateElement<T extends ElementProps>(elProps: Partial<T>): void {
       try {
-        this._iModel.nativeDb.updateElement(elProps);
+        this._iModel[_nativeDb].updateElement(elProps);
       } catch (err: any) {
         err.message = `Error updating element [${err.message}], id: ${elProps.id}`;
         err.metadata = { elProps };
@@ -1940,7 +1946,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       const iModel = this._iModel;
       Id64.toIdSet(ids).forEach((id) => {
         try {
-          iModel.nativeDb.deleteElement(id);
+          iModel[_nativeDb].deleteElement(id);
         } catch (err: any) {
           err.message = `Error deleting element [${err.message}], id: ${id}`;
           err.metadata = { elementId: id };
@@ -1960,7 +1966,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @beta
      */
     public deleteDefinitionElements(definitionElementIds: Id64Array): Id64Set {
-      const usageInfo = this._iModel.nativeDb.queryDefinitionElementUsage(definitionElementIds);
+      const usageInfo = this._iModel[_nativeDb].queryDefinitionElementUsage(definitionElementIds);
       if (!usageInfo) {
         throw new IModelError(IModelStatus.BadRequest, "Error querying for DefinitionElement usage");
       }
@@ -1976,7 +1982,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       };
 
       try {
-        this._iModel.nativeDb.beginPurgeOperation();
+        this._iModel[_nativeDb].beginPurgeOperation();
         deleteIfUnused(usageInfo.spatialCategoryIds, usedIdSet);
         deleteIfUnused(usageInfo.drawingCategoryIds, usedIdSet);
         deleteIfUnused(usageInfo.viewDefinitionIds, usedIdSet);
@@ -1992,7 +1998,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
           this._iModel.elements.deleteElement(usageInfo.otherDefinitionElementIds);
         }
       } finally {
-        this._iModel.nativeDb.endPurgeOperation();
+        this._iModel[_nativeDb].endPurgeOperation();
       }
 
       if (usageInfo.viewDefinitionIds) {
@@ -2008,16 +2014,16 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
           viewRelatedIds = viewRelatedIds.concat(usageInfo.modelSelectorIds.filter((id) => usedIdSet.has(id)));
 
         if (viewRelatedIds.length > 0) {
-          const viewRelatedUsageInfo = this._iModel.nativeDb.queryDefinitionElementUsage(viewRelatedIds);
+          const viewRelatedUsageInfo = this._iModel[_nativeDb].queryDefinitionElementUsage(viewRelatedIds);
           if (viewRelatedUsageInfo) {
             const usedViewRelatedIdSet: Id64Set = viewRelatedUsageInfo.usedIds ? Id64.toIdSet(viewRelatedUsageInfo.usedIds) : new Set<Id64String>();
             try {
-              this._iModel.nativeDb.beginPurgeOperation();
+              this._iModel[_nativeDb].beginPurgeOperation();
               deleteIfUnused(viewRelatedUsageInfo.displayStyleIds, usedViewRelatedIdSet);
               deleteIfUnused(viewRelatedUsageInfo.categorySelectorIds, usedViewRelatedIdSet);
               deleteIfUnused(viewRelatedUsageInfo.modelSelectorIds, usedViewRelatedIdSet);
             } finally {
-              this._iModel.nativeDb.endPurgeOperation();
+              this._iModel[_nativeDb].endPurgeOperation();
             }
 
             viewRelatedIds.forEach((id) => {
@@ -2180,7 +2186,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
 
       // Check if class is abstract
       const fullClassName = aspectClassFullName.replace(".", ":").split(":");
-      const val = this._iModel.nativeDb.getECClassMetaData(fullClassName[0], fullClassName[1]);
+      const val = this._iModel[_nativeDb].getECClassMetaData(fullClassName[0], fullClassName[1]);
       if (val.result !== undefined) {
         const metaData = new EntityMetaData(JSON.parse(val.result));
         if (metaData.modifier !== "Abstract") // Class is not abstract, use normal query to retrieve aspects
@@ -2224,7 +2230,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertAspect(aspectProps: ElementAspectProps): Id64String {
       try {
-        return this._iModel.nativeDb.insertElementAspect(aspectProps);
+        return this._iModel[_nativeDb].insertElementAspect(aspectProps);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error inserting ElementAspect [${err.message}], class: ${aspectProps.classFullName}`);
       }
@@ -2236,7 +2242,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateAspect(aspectProps: ElementAspectProps): void {
       try {
-        this._iModel.nativeDb.updateElementAspect(aspectProps);
+        this._iModel[_nativeDb].updateElementAspect(aspectProps);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error updating ElementAspect [${err.message}], id: ${aspectProps.id}`);
       }
@@ -2250,7 +2256,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       const iModel = this._iModel;
       Id64.toIdSet(aspectInstanceIds).forEach((aspectInstanceId) => {
         try {
-          iModel.nativeDb.deleteElementAspect(aspectInstanceId);
+          iModel[_nativeDb].deleteElementAspect(aspectInstanceId);
         } catch (err: any) {
           throw new IModelError(err.errorNumber, `Error deleting ElementAspect [${err.message}], id: ${aspectInstanceId}`);
         }
@@ -2407,7 +2413,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       const viewStateData = this.loadViewData(viewDefinitionId, options);
       const baseModelId = (viewStateData.viewDefinitionProps as ViewDefinition2dProps).baseModelId;
       if (baseModelId) {
-        const drawingExtents = Range3d.fromJSON(this._iModel.nativeDb.queryModelExtents({ id: baseModelId }).modelExtents);
+        const drawingExtents = Range3d.fromJSON(this._iModel[_nativeDb].queryModelExtents({ id: baseModelId }).modelExtents);
         if (!drawingExtents.isNull)
           viewStateData.modelExtents = drawingExtents.toJSON();
       }
@@ -2439,12 +2445,12 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public getThumbnail(viewDefinitionId: Id64String): ThumbnailProps | undefined {
       const viewArg = this.getViewThumbnailArg(viewDefinitionId);
-      const sizeProps = this._iModel.nativeDb.queryFileProperty(viewArg, true) as string;
+      const sizeProps = this._iModel[_nativeDb].queryFileProperty(viewArg, true) as string;
       if (undefined === sizeProps)
         return undefined;
 
       const out = JSON.parse(sizeProps) as ThumbnailProps;
-      out.image = this._iModel.nativeDb.queryFileProperty(viewArg, false) as Uint8Array;
+      out.image = this._iModel[_nativeDb].queryFileProperty(viewArg, false) as Uint8Array;
       return out;
     }
 
@@ -2456,7 +2462,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     public saveThumbnail(viewDefinitionId: Id64String, thumbnail: ThumbnailProps): number {
       const viewArg = this.getViewThumbnailArg(viewDefinitionId);
       const props = { format: thumbnail.format, height: thumbnail.height, width: thumbnail.width };
-      this._iModel.nativeDb.saveFileProperty(viewArg, JSON.stringify(props), thumbnail.image);
+      this._iModel[_nativeDb].saveFileProperty(viewArg, JSON.stringify(props), thumbnail.image);
       return 0;
     }
 
@@ -2494,7 +2500,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     public async requestTileTreeProps(id: string): Promise<IModelTileTreeProps> {
 
       return new Promise<IModelTileTreeProps>((resolve, reject) => {
-        this._iModel.nativeDb.getTileTree(id, (ret: IModelJsNative.ErrorStatusOrResult<IModelStatus, any>) => {
+        this._iModel[_nativeDb].getTileTree(id, (ret: IModelJsNative.ErrorStatusOrResult<IModelStatus, any>) => {
           if (undefined !== ret.error)
             reject(new IModelError(ret.error.status, `TreeId=${id}`));
           else
@@ -2507,7 +2513,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
 
       let ret;
       try {
-        ret = this._iModel.nativeDb.pollTileContent(treeId, tileId);
+        ret = this._iModel[_nativeDb].pollTileContent(treeId, tileId);
       } catch (err) {
         // Typically "imodel not open".
         reject(err);
@@ -2549,7 +2555,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     /** @internal */
     public async getTileContent(treeId: string, tileId: string): Promise<Uint8Array> {
       const ret = await new Promise<IModelJsNative.ErrorStatusOrResult<any, Uint8Array>>((resolve) => {
-        this._iModel.nativeDb.getTileContent(treeId, tileId, resolve);
+        this._iModel[_nativeDb].getTileContent(treeId, tileId, resolve);
       });
 
       if (undefined !== ret.error) {
@@ -2656,7 +2662,7 @@ export class BriefcaseDb extends IModelDb {
    * - the "no locking" flag is not present. This is a property of an iModel, established when the iModel is created in IModelHub.
    */
   protected get useLockServer(): boolean {
-    return !this.nativeDb.isReadonly() && (this.briefcaseId !== BriefcaseIdValue.Unassigned) && (undefined === this.nativeDb.queryLocalValue(BriefcaseLocalValue.NoLocking));
+    return !this[_nativeDb].isReadonly() && (this.briefcaseId !== BriefcaseIdValue.Unassigned) && (undefined === this[_nativeDb].queryLocalValue(BriefcaseLocalValue.NoLocking));
   }
 
   // if the iModel uses a lock server, create a ServerBasedLocks LockControl for this BriefcaseDb.
@@ -2683,7 +2689,7 @@ export class BriefcaseDb extends IModelDb {
 
     const isSchemaSyncEnabled = await withBriefcaseDb(briefcase, async (db) => {
       await SchemaSync.pull(db);
-      return db.nativeDb.schemaSyncEnabled();
+      return db[_nativeDb].schemaSyncEnabled();
     }) as boolean;
 
     if (isSchemaSyncEnabled) {
@@ -2691,7 +2697,7 @@ export class BriefcaseDb extends IModelDb {
         const schemaSyncDbUri = syncAccess.getUri();
         executeUpgrade();
         await withBriefcaseDb(briefcase, async (db) => {
-          db.nativeDb.schemaSyncPush(schemaSyncDbUri);
+          db[_nativeDb].schemaSyncPush(schemaSyncDbUri);
           db.saveChanges();
         });
         syncAccess.synchronizeWithCloud();
@@ -2883,7 +2889,7 @@ export class BriefcaseDb extends IModelDb {
 
       // Note: There is no performance implication of follow code as it happen toward end of
       // apply_changeset only once so we be querying value for 'DebugAllowFkViolations' only once.
-      if (this.nativeDb.queryLocalValue("DebugAllowFkViolations")) {
+      if (this[_nativeDb].queryLocalValue("DebugAllowFkViolations")) {
         Logger.logError(category, `Detected ${nConflicts} foreign key conflicts in changeset. Continuing merge as 'DebugAllowFkViolations' flag is set. Run 'PRAGMA foreign_key_check' to get list of violations.`);
         return DbConflictResolution.Skip;
       } else {
@@ -2975,11 +2981,11 @@ export class BriefcaseDb extends IModelDb {
     this.clearCaches();
 
     // The following resets the native db's pointer to this JavaScript object.
-    this.nativeDb.closeFile();
-    this.nativeDb.openIModel(fileName, openMode);
+    this[_nativeDb].closeFile();
+    this[_nativeDb].openIModel(fileName, openMode);
 
     // Restore the native db's pointer to this JavaScript object.
-    this.nativeDb.setIModelDb(this);
+    this[_nativeDb].setIModelDb(this);
   }
 
   /** Pull and apply changesets from iModelHub */
@@ -2998,9 +3004,9 @@ export class BriefcaseDb extends IModelDb {
     if (this.briefcaseId === BriefcaseIdValue.Unassigned)
       return;
 
-    if (this.nativeDb.hasUnsavedChanges())
+    if (this[_nativeDb].hasUnsavedChanges())
       throw new IModelError(ChangeSetStatus.HasUncommittedChanges, "Cannot push with unsaved changes");
-    if (!this.nativeDb.hasPendingTxns())
+    if (!this[_nativeDb].hasPendingTxns())
       return; // nothing to push
 
     // pushing changes requires a writeable briefcase
@@ -3042,7 +3048,7 @@ class RefreshV2CheckpointSas {
     Logger.logInfo(BackendLoggerCategory.Authorization, "attempting to refresh sasToken for checkpoint");
     try {
       // this exchanges the supplied user accessToken for an expiring blob-store token to read the checkpoint.
-      const container = iModel.nativeDb.cloudContainer;
+      const container = iModel[_nativeDb].cloudContainer;
       if (!container)
         throw new Error("checkpoint is not from a cloud container");
 
@@ -3211,7 +3217,7 @@ export class SnapshotDb extends IModelDb {
       snapshot.restartDefaultTxn();
     }, (10 * 60) * 1000).unref(); // 10 minutes
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    snapshot._refreshSas = new RefreshV2CheckpointSas(snapshot.nativeDb.cloudContainer!.accessToken, checkpoint.reattachSafetySeconds);
+    snapshot._refreshSas = new RefreshV2CheckpointSas(snapshot[_nativeDb].cloudContainer!.accessToken, checkpoint.reattachSafetySeconds);
     return snapshot;
   }
 
@@ -3240,7 +3246,7 @@ export class SnapshotDb extends IModelDb {
       clearTimeout(this._restartDefaultTxnTimer);
 
     if (this._createClassViewsOnClose) { // check for flag set during create
-      if (BentleyStatus.SUCCESS !== this.nativeDb.createClassViewsInDb()) {
+      if (BentleyStatus.SUCCESS !== this[_nativeDb].createClassViewsInDb()) {
         throw new IModelError(IModelStatus.SQLiteError, "Error creating class views");
       } else {
         this.saveChanges();
@@ -3317,7 +3323,7 @@ export class StandaloneDb extends BriefcaseDb {
    * @beta
    */
   public createClassViews(): void {
-    const result = this.nativeDb.createClassViewsInDb();
+    const result = this[_nativeDb].createClassViewsInDb();
     if (BentleyStatus.SUCCESS !== result)
       throw new IModelError(result, "Error creating class views");
     else

--- a/core/backend/src/IModelElementCloneContext.ts
+++ b/core/backend/src/IModelElementCloneContext.ts
@@ -13,6 +13,7 @@ import { Element } from "./Element";
 import { IModelDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
 import { SQLiteDb } from "./SQLiteDb";
+import { _nativeDb } from "./internal/Internal";
 
 /** The context for transforming a *source* Element to a *target* Element and remapping internal identifiers to the target iModel.
  * @beta
@@ -32,7 +33,7 @@ export class IModelElementCloneContext {
   public constructor(sourceDb: IModelDb, targetDb?: IModelDb) {
     this.sourceDb = sourceDb;
     this.targetDb = (undefined !== targetDb) ? targetDb : sourceDb;
-    this._nativeContext = new IModelHost.platform.ImportContext(this.sourceDb.nativeDb, this.targetDb.nativeDb);
+    this._nativeContext = new IModelHost.platform.ImportContext(this.sourceDb[_nativeDb], this.targetDb[_nativeDb]);
   }
 
   /** perform necessary initialization to use a clone context, namely caching the reference types in the source's schemas */

--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -17,6 +17,7 @@ import { ProgressFunction, ProgressStatus } from "./CheckpointManager";
 import { BriefcaseDb, IModelDb, SnapshotDb, StandaloneDb } from "./IModelDb";
 import { IModelHost, IModelHostOptions } from "./IModelHost";
 import { cancelTileContentRequests } from "./rpc-impl/IModelTileRpcImpl";
+import { _nativeDb } from "./internal/Internal";
 
 /**
   * Options for [[IpcHost.startup]]
@@ -210,7 +211,7 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
     return cancelTileContentRequests(tokenProps, contentIds);
   }
   public async cancelElementGraphicsRequests(key: string, requestIds: string[]): Promise<void> {
-    return IModelDb.findByKey(key).nativeDb.cancelElementGraphicsRequests(requestIds);
+    return IModelDb.findByKey(key)[_nativeDb].cancelElementGraphicsRequests(requestIds);
   }
   public async openBriefcase(args: OpenBriefcaseProps): Promise<IModelConnectionProps> {
     const db = await BriefcaseDb.open(args);
@@ -229,20 +230,20 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
     IModelDb.findByKey(key).saveChanges(description);
   }
   public async hasPendingTxns(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.hasPendingTxns();
+    return IModelDb.findByKey(key)[_nativeDb].hasPendingTxns();
   }
 
   public async isUndoPossible(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.isUndoPossible();
+    return IModelDb.findByKey(key)[_nativeDb].isUndoPossible();
   }
   public async isRedoPossible(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.isRedoPossible();
+    return IModelDb.findByKey(key)[_nativeDb].isRedoPossible();
   }
   public async getUndoString(key: string): Promise<string> {
-    return IModelDb.findByKey(key).nativeDb.getUndoString();
+    return IModelDb.findByKey(key)[_nativeDb].getUndoString();
   }
   public async getRedoString(key: string): Promise<string> {
-    return IModelDb.findByKey(key).nativeDb.getUndoString();
+    return IModelDb.findByKey(key)[_nativeDb].getUndoString();
   }
 
   public async pullChanges(key: string, toIndex?: ChangesetIndex, options?: PullChangesOptions): Promise<ChangesetIndexAndId> {
@@ -281,27 +282,27 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
   }
 
   public async toggleGraphicalEditingScope(key: string, startSession: boolean): Promise<boolean> {
-    const val: IModelJsNative.ErrorStatusOrResult<any, boolean> = IModelDb.findByKey(key).nativeDb.setGeometricModelTrackingEnabled(startSession);
+    const val: IModelJsNative.ErrorStatusOrResult<any, boolean> = IModelDb.findByKey(key)[_nativeDb].setGeometricModelTrackingEnabled(startSession);
     if (val.error)
       throw new IModelError(val.error.status, "Failed to toggle graphical editing scope");
     assert(undefined !== val.result);
     return val.result;
   }
   public async isGraphicalEditingSupported(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.isGeometricModelTrackingSupported();
+    return IModelDb.findByKey(key)[_nativeDb].isGeometricModelTrackingSupported();
   }
 
   public async reverseTxns(key: string, numOperations: number): Promise<IModelStatus> {
-    return IModelDb.findByKey(key).nativeDb.reverseTxns(numOperations);
+    return IModelDb.findByKey(key)[_nativeDb].reverseTxns(numOperations);
   }
   public async reverseAllTxn(key: string): Promise<IModelStatus> {
-    return IModelDb.findByKey(key).nativeDb.reverseAll();
+    return IModelDb.findByKey(key)[_nativeDb].reverseAll();
   }
   public async reinstateTxn(key: string): Promise<IModelStatus> {
-    return IModelDb.findByKey(key).nativeDb.reinstateTxn();
+    return IModelDb.findByKey(key)[_nativeDb].reinstateTxn();
   }
   public async restartTxnSession(key: string): Promise<void> {
-    return IModelDb.findByKey(key).nativeDb.restartTxnSession();
+    return IModelDb.findByKey(key)[_nativeDb].restartTxnSession();
   }
 
   public async queryConcurrency(pool: "io" | "cpu"): Promise<number> {

--- a/core/backend/src/Model.ts
+++ b/core/backend/src/Model.ts
@@ -18,6 +18,7 @@ import { DefinitionPartition, DocumentPartition, InformationRecordPartition, Phy
 import { Entity } from "./Entity";
 import { IModelDb } from "./IModelDb";
 import { SubjectOwnsPartitionElements } from "./NavigationRelationship";
+import { _nativeDb } from "./internal/Internal";
 
 /** Argument for the `Model.onXxx` static methods
  * @beta
@@ -244,7 +245,7 @@ export class GeometricModel extends Model {
    * @note This function blocks the JavaScript event loop. Consider using [[queryRange]] instead.
    */
   public queryExtents(): AxisAlignedBox3d {
-    const extents = this.iModel.nativeDb.queryModelExtents({ id: this.id }).modelExtents;
+    const extents = this.iModel[_nativeDb].queryModelExtents({ id: this.id }).modelExtents;
     return Range3d.fromJSON(extents);
   }
 

--- a/core/backend/src/Relationship.ts
+++ b/core/backend/src/Relationship.ts
@@ -11,6 +11,7 @@ import { EntityReferenceSet, IModelError, IModelStatus, RelationshipProps, Sourc
 import { ECSqlStatement } from "./ECSqlStatement";
 import { Entity } from "./Entity";
 import { IModelDb } from "./IModelDb";
+import { _nativeDb } from "./internal/Internal";
 
 export type { SourceAndTarget, RelationshipProps } from "@itwin/core-common"; // for backwards compatibility
 
@@ -447,7 +448,7 @@ export class Relationships {
 
   /** Check classFullName to ensure it is a link table relationship class. */
   private checkRelationshipClass(classFullName: string) {
-    if (!this._iModel.nativeDb.isLinkTableRelationship(classFullName.replace(".", ":"))) {
+    if (!this._iModel[_nativeDb].isLinkTableRelationship(classFullName.replace(".", ":"))) {
       throw new IModelError(DbResult.BE_SQLITE_ERROR, `Class '${classFullName}' must be a relationship class and it should be subclass of BisCore:ElementRefersToElements or BisCore:ElementDrivesElement.`);
     }
   }
@@ -459,19 +460,19 @@ export class Relationships {
    */
   public insertInstance(props: RelationshipProps): Id64String {
     this.checkRelationshipClass(props.classFullName);
-    return props.id = this._iModel.nativeDb.insertLinkTableRelationship(props);
+    return props.id = this._iModel[_nativeDb].insertLinkTableRelationship(props);
   }
 
   /** Update the properties of an existing relationship instance in the iModel.
    * @param props the properties of the relationship instance to update. Any properties that are not present will be left unchanged.
    */
   public updateInstance(props: RelationshipProps): void {
-    this._iModel.nativeDb.updateLinkTableRelationship(props);
+    this._iModel[_nativeDb].updateLinkTableRelationship(props);
   }
 
   /** Delete an Relationship instance from this iModel. */
   public deleteInstance(props: RelationshipProps): void {
-    this._iModel.nativeDb.deleteLinkTableRelationship(props);
+    this._iModel[_nativeDb].deleteLinkTableRelationship(props);
   }
 
   /** Get the props of a Relationship instance

--- a/core/backend/src/ServerBasedLocks.ts
+++ b/core/backend/src/ServerBasedLocks.ts
@@ -13,6 +13,7 @@ import { LockMap, LockState } from "./BackendHubAccess";
 import { BriefcaseDb, LockControl } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
 import { SQLiteDb } from "./SQLiteDb";
+import { _nativeDb } from "./internal/Internal"; 
 
 /**
  * Both the Model and Parent of an element are considered "owners" of their member elements. That means:
@@ -40,7 +41,7 @@ export class ServerBasedLocks implements LockControl {
 
   public constructor(iModel: BriefcaseDb) {
     this.briefcase = iModel;
-    const dbName = `${iModel.nativeDb.getTempFileBaseName()}-locks`;
+    const dbName = `${iModel[_nativeDb].getTempFileBaseName()}-locks`;
     try {
       this.lockDb.openDb(dbName, OpenMode.ReadWrite);
     } catch (_e) {

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -16,6 +16,7 @@ import { BriefcaseDb, StandaloneDb } from "./IModelDb";
 import { IpcHost } from "./IpcHost";
 import { Relationship, RelationshipProps } from "./Relationship";
 import { SqliteStatement } from "./SqliteStatement";
+import { _nativeDb } from "./internal/Internal"; 
 
 /** A string that identifies a Txn.
  * @public
@@ -303,7 +304,7 @@ export class TxnManager {
   /** Array of errors from dependency propagation */
   public readonly validationErrors: ValidationError[] = [];
 
-  private get _nativeDb() { return this._iModel.nativeDb; }
+  private get _nativeDb() { return this._iModel[_nativeDb]; }
   private _getElementClass(elClassName: string): typeof Element {
     return this._iModel.getJsClass(elClassName) as unknown as typeof Element;
   }

--- a/core/backend/src/domains/FunctionalSchema.ts
+++ b/core/backend/src/domains/FunctionalSchema.ts
@@ -14,6 +14,7 @@ import { IModelDb } from "../IModelDb";
 import { KnownLocations } from "../IModelHost";
 import { Schema, Schemas } from "../Schema";
 import * as elementsModule from "./FunctionalElements";
+import { _nativeDb } from "../internal/Internal"; 
 
 /** @public */
 export class FunctionalSchema extends Schema {
@@ -32,7 +33,7 @@ export class FunctionalSchema extends Schema {
     if (iModelDb.isBriefcaseDb())
       await iModelDb.acquireSchemaLock();
 
-    const stat = iModelDb.nativeDb.importFunctionalSchema();
+    const stat = iModelDb[_nativeDb].importFunctionalSchema();
     if (DbResult.BE_SQLITE_OK !== stat) {
       throw new IModelError(stat, "Error importing Functional schema");
     }

--- a/core/backend/src/internal/Internal.ts
+++ b/core/backend/src/internal/Internal.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+/** This file defines `Symbol`s for "package-internal" APIs - that is, APIs that should never be used by any code outside of iTwin.js core.
+ * Top-level APIs like classes, interfaces, enums, and functions that are not intended for use outside
+ * of the monorepo should never be exported from the package's barrel file, thereby excluding them
+ * from the package's public API.
+ * But some top-level public APIs may contain interior APIs that should be used only within the monorepo.
+ * These should be minimized where possible, e.g., by moving a package-internal function out of a public namespace.
+ * In some cases, like class properties, extracting the package-internal API from the public top-level API is not feasible.
+ * Instead, you can define a `Symbol` in this file to serve as the name of the package-internal API.
+ * These symbols are not exported from the package's barrel file, which prevents any code outside of the package from
+ * accessing them without jumping through several hoops.
+ *
+ * The symbol names should begin with an underscore. It is fine to reuse the same symbol in different contexts - e.g.,
+ * two `close` methods on two unrelated classes can use the same `_close` symbol.
+ *
+ * Example: in IModelDb.ts:
+ * ```ts
+ *  import { _isOpen, _nativeDb } from "./internal/Internal";
+ *  class IModelDb {
+ *    // A package-internal property, initialized in the constructor, accessed as `this[_nativeDb]`.
+ *    public readonly [_nativeDb]: IModelJsNative.DgnDb;
+ *
+ *    // A package-internal method, accessed as `this[_isOpen]()`.
+ *    public [_isOpen]: () => boolean {
+ *      return this[_nativeDb].isOpen();
+ *    }
+ *  }
+ * ```
+ *
+ * The declarations of package-internal APIs should be annotated with the `@internal` release tag.
+ * Every API annotated as `@internal` must be accessed via a symbol.
+ */
+
+export const _isOpen = Symbol("isOpen");
+export const _nativeDb = Symbol("nativeDb");

--- a/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
@@ -32,6 +32,7 @@ import { PromiseMemoizer } from "../PromiseMemoizer";
 import { RpcTrace } from "../rpc/tracing";
 import { ViewStateHydrator } from "../ViewStateHydrator";
 import { RpcBriefcaseUtility } from "./RpcBriefcaseUtility";
+import { _nativeDb } from "../internal/Internal";
 
 interface ViewStateRequestProps {
   accessToken: AccessToken;
@@ -130,7 +131,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
       Logger.logWarning(BackendLoggerCategory.IModelDb, "usePrimaryConn is only supported on imodel that is opened in read/write mode. The option will be ignored.", request);
       request.usePrimaryConn = false;
     }
-    return ConcurrentQuery.executeQueryRequest(iModelDb.nativeDb, request);
+    return ConcurrentQuery.executeQueryRequest(iModelDb[_nativeDb], request);
   }
 
   public async queryBlob(tokenProps: IModelRpcProps, request: DbBlobRequest): Promise<DbBlobResponse> {
@@ -139,7 +140,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
       Logger.logWarning(BackendLoggerCategory.IModelDb, "usePrimaryConn is only supported on imodel that is opened in read/write mode. The option will be ignored.", request);
       request.usePrimaryConn = false;
     }
-    return ConcurrentQuery.executeBlobRequest(iModelDb.nativeDb, request);
+    return ConcurrentQuery.executeBlobRequest(iModelDb[_nativeDb], request);
   }
 
   public async queryModelRanges(tokenProps: IModelRpcProps, modelIds: Id64String[]): Promise<Range3dProps[]> {
@@ -254,7 +255,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
 
   public async readFontJson(tokenProps: IModelRpcProps): Promise<FontMapProps> {
     const iModelDb = await getIModelForRpc(tokenProps);
-    return iModelDb.nativeDb.readFontMap();
+    return iModelDb[_nativeDb].readFontMap();
   }
 
   public async requestSnap(tokenProps: IModelRpcProps, sessionId: string, props: SnapRequestProps): Promise<SnapResponseProps> {
@@ -368,7 +369,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
 
   public async generateElementMeshes(tokenProps: IModelRpcProps, props: ElementMeshRequestProps): Promise<Uint8Array> {
     const db = await getIModelForRpc(tokenProps);
-    return db.nativeDb.generateElementMeshes(props);
+    return db[_nativeDb].generateElementMeshes(props);
   }
 
   /** @internal */

--- a/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
@@ -15,6 +15,7 @@ import { IModelHost } from "../IModelHost";
 import { PromiseMemoizer, QueryablePromise } from "../PromiseMemoizer";
 import { RpcTrace } from "../rpc/tracing";
 import { RpcBriefcaseUtility } from "./RpcBriefcaseUtility";
+import { _nativeDb } from "../internal/Internal";
 
 interface TileRequestProps {
   accessToken?: AccessToken;
@@ -205,7 +206,7 @@ export class IModelTileRpcImpl extends RpcInterface implements IModelTileRpcInte
       return;
     }
 
-    return db.nativeDb.purgeTileTrees(modelIds);
+    return db[_nativeDb].purgeTileTrees(modelIds);
   }
 
   public async generateTileContent(tokenProps: IModelRpcProps, treeId: string, contentId: string, guid: string | undefined): Promise<TileContentSource> {
@@ -247,6 +248,6 @@ export async function cancelTileContentRequests(tokenProps: IModelRpcProps, cont
       RequestTileContentMemoizer.instance.deleteMemoized(props);
     }
 
-    iModel.nativeDb.cancelTileContentRequests(entry.treeId, entry.contentIds);
+    iModel[_nativeDb].cancelTileContentRequests(entry.treeId, entry.contentIds);
   }
 }

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -35,6 +35,7 @@ import { Schema, Schemas } from "../Schema";
 import { HubMock } from "../HubMock";
 import { KnownTestLocations } from "./KnownTestLocations";
 import { BackendHubAccess } from "../BackendHubAccess";
+import { _nativeDb } from "../internal/Internal";
 
 chai.use(chaiAsPromised);
 
@@ -148,7 +149,7 @@ export class HubWrappers {
     const props = await BriefcaseManager.downloadBriefcase(args);
     if (args.noLock) {
       const briefcase = await BriefcaseDb.open({ fileName: props.fileName });
-      briefcase.nativeDb.saveLocalValue(BriefcaseLocalValue.NoLocking, "true");
+      briefcase[_nativeDb].saveLocalValue(BriefcaseLocalValue.NoLocking, "true");
       briefcase.saveChanges();
       briefcase.close();
     }
@@ -492,7 +493,7 @@ export class IModelTestUtils {
 
   /** Flushes the Txns in the TxnTable - this allows importing of schemas */
   public static flushTxns(iModelDb: IModelDb): boolean {
-    iModelDb.nativeDb.deleteAllTxns();
+    iModelDb[_nativeDb].deleteAllTxns();
     return true;
   }
 

--- a/core/backend/src/test/ecdb/ECSqlQuery.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlQuery.test.ts
@@ -9,6 +9,7 @@ import { ConcurrentQuery } from "../../ConcurrentQuery";
 import { ECSqlStatement, IModelDb, SnapshotDb } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { SequentialLogMatcher } from "../SequentialLogMatcher";
+import { _nativeDb } from "../../internal/Internal";
 
 // cspell:ignore mirukuru ibim
 
@@ -216,8 +217,8 @@ describe("ECSql Query", () => {
     let successful = 0;
     let rowCount = 0;
     try {
-      ConcurrentQuery.shutdown(imodel1.nativeDb);
-      ConcurrentQuery.resetConfig(imodel1.nativeDb, { globalQuota: { time: 1 }, ignoreDelay: false });
+      ConcurrentQuery.shutdown(imodel1[_nativeDb]);
+      ConcurrentQuery.resetConfig(imodel1[_nativeDb], { globalQuota: { time: 1 }, ignoreDelay: false });
 
       const scheduleQuery = async (delay: number) => {
         return new Promise<void>(async (resolve, reject) => {
@@ -253,8 +254,8 @@ describe("ECSql Query", () => {
       assert.isAtLeast(successful, 1, "successful should be at least 1");
       assert.isAtLeast(rowCount, 1, "rowCount should be at least 1");
     } finally {
-      ConcurrentQuery.shutdown(imodel1.nativeDb);
-      ConcurrentQuery.resetConfig(imodel1.nativeDb);
+      ConcurrentQuery.shutdown(imodel1[_nativeDb]);
+      ConcurrentQuery.resetConfig(imodel1[_nativeDb]);
     }
   });
   it("concurrent query should retry on timeout", async () => {
@@ -268,10 +269,10 @@ describe("ECSql Query", () => {
     }
 
     // Set time to 1 sec to simulate a timeout scenario
-    ConcurrentQuery.resetConfig(imodel1.nativeDb, { globalQuota: { time: 1 }, ignoreDelay: false });
+    ConcurrentQuery.resetConfig(imodel1[_nativeDb], { globalQuota: { time: 1 }, ignoreDelay: false });
     const executor = {
       execute: async (req: DbQueryRequest) => {
-        return ConcurrentQuery.executeQueryRequest(imodel1.nativeDb, req);
+        return ConcurrentQuery.executeQueryRequest(imodel1[_nativeDb], req);
       },
     };
     const request: DbQueryRequest = {

--- a/core/backend/src/test/element/ElementDependencyGraph.test.ts
+++ b/core/backend/src/test/element/ElementDependencyGraph.test.ts
@@ -15,6 +15,7 @@ import {
 import { LineSegment3d, Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { ChannelControl, ElementDrivesElementProps, IModelHost, IModelJsFs, PhysicalModel, SpatialCategory, StandaloneDb } from "../../core-backend";
 import { IModelTestUtils, TestElementDrivesElement, TestPhysicalObject, TestPhysicalObjectProps } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 export function copyFile(newName: string, pathToCopy: string): string {
   const newPath = path.join(path.dirname(pathToCopy), newName);
@@ -65,8 +66,8 @@ class TestHelper {
     assert.isTrue(this.db !== undefined);
     this.db.channels.addAllowedChannel(ChannelControl.sharedChannelName);
 
-    this.db.nativeDb.enableTxnTesting();
-    assert.equal(this.db.nativeDb.addChildPropagatesChangesToParentRelationship("TestBim", "ChildPropagatesChangesToParent"), 0);
+    this.db[_nativeDb].enableTxnTesting();
+    assert.equal(this.db[_nativeDb].addChildPropagatesChangesToParentRelationship("TestBim", "ChildPropagatesChangesToParent"), 0);
     this.setElementDependencyGraphCallbacks();
   }
 
@@ -167,7 +168,7 @@ describe("ElementDependencyGraph", () => {
     const spatialCategoryId = SpatialCategory.insert(imodel, IModel.dictionaryId, "EDGTestSpatialCategory", new SubCategoryAppearance({ color: ColorByName.darkRed }));
     dbInfo = { physicalModelId, codeSpecId, spatialCategoryId, seedFileName: testFileName };
     imodel.saveChanges("");
-    imodel.nativeDb.deleteAllTxns();
+    imodel[_nativeDb].deleteAllTxns();
     imodel.close();
   });
 

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -12,6 +12,7 @@ import { Angle, Arc3d, Cone, IModelJson as GeomJson, LineSegment3d, Point2d, Poi
 import { ECSqlStatement, IModelDb, IModelJsFs, PhysicalModel, PhysicalObject, SnapshotDb, SpatialCategory } from "../../core-backend";
 import { ElementRefersToElements } from "../../Relationship";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -470,7 +471,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
 
     const imodel = SnapshotDb.createEmpty(iModelPath, { rootSubject: { name: "RoundTripTest" } });
     await imodel.importSchemas([testSchemaPath]);
-    imodel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+    imodel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
     IModelTestUtils.createAndInsertPhysicalPartitionAndModel(imodel, Code.createEmpty(), true);
     let spatialCategoryId = SpatialCategory.queryCategoryIdByName(imodel, IModel.dictionaryId, categoryName);
     if (undefined === spatialCategoryId)

--- a/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
+++ b/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
@@ -12,6 +12,7 @@ import { KnownTestLocations } from "../KnownTestLocations";
 import { HubMock } from "../../HubMock";
 import { TestChangeSetUtility } from "../TestChangeSetUtility";
 import { ChannelControl } from "../../core-backend";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("BriefcaseManager", async () => {
   const testITwinId: string = Guid.createValue();
@@ -55,7 +56,7 @@ describe("BriefcaseManager", async () => {
     const iModelId = await HubWrappers.createIModel(accessToken, testITwinId, "imodel1");
     const args = { accessToken, iTwinId: testITwinId, iModelId, deleteFirst: true };
     const iModel1 = await HubWrappers.openCheckpointUsingRpc(args);
-    assert.equal(BriefcaseIdValue.Unassigned, iModel1.nativeDb.getBriefcaseId(), "checkpoint should be 0");
+    assert.equal(BriefcaseIdValue.Unassigned, iModel1[_nativeDb].getBriefcaseId(), "checkpoint should be 0");
 
     const iModel2 = await HubWrappers.openBriefcaseUsingRpc({ ...args, briefcaseId: 0 });
     assert.equal(BriefcaseIdValue.Unassigned, iModel2.briefcaseId, "pullOnly should be 0");
@@ -151,11 +152,11 @@ describe("BriefcaseManager", async () => {
     rootEl.userLabel = `${rootEl.userLabel}changed`;
     iModelPullAndPush.elements.updateElement(rootEl.toJSON());
 
-    assert.isTrue(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isFalse(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasPendingTxns());
     iModelPullAndPush.saveChanges();
-    assert.isFalse(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isTrue(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasPendingTxns());
 
     iModelPullAndPush.close();
 
@@ -165,8 +166,8 @@ describe("BriefcaseManager", async () => {
     const changesetPullAndPush = iModelPullAndPush.changeset;
     assert.strictEqual(iModelPullAndPush.briefcaseId, briefcaseId);
     assert.strictEqual(iModelPullAndPush.pathName, pathname);
-    assert.isFalse(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isTrue(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasPendingTxns());
 
     // User1 pushes a change set
     await testUtility.pushTestChangeSet();
@@ -183,8 +184,8 @@ describe("BriefcaseManager", async () => {
     assert.notStrictEqual(changesetPullAndPush3, changesetPullAndPush);
     assert.strictEqual(iModelPullAndPush.briefcaseId, briefcaseId);
     assert.strictEqual(iModelPullAndPush.pathName, pathname);
-    assert.isFalse(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isTrue(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasPendingTxns());
 
     // User2 should be able to push the changes now
     await iModelPullAndPush.pushChanges({ accessToken: userToken2, description: "test change" });

--- a/core/backend/src/test/hubaccess/CheckpointManager.test.ts
+++ b/core/backend/src/test/hubaccess/CheckpointManager.test.ts
@@ -13,6 +13,7 @@ import { SnapshotDb } from "../../IModelDb";
 import { IModelJsFs } from "../../IModelJsFs";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { HubMock } from "../../HubMock";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("V1 Checkpoint Manager", () => {
   it("empty props", async () => {
@@ -62,11 +63,11 @@ describe("V1 Checkpoint Manager", () => {
     const iModelId = Guid.createValue();  // This is wrong - it should be `snapshot.getGuid()`!
     const iTwinId = Guid.createValue();
     const changeset = IModelTestUtils.generateChangeSetId();
-    snapshot.nativeDb.setITwinId(iTwinId);
-    snapshot.nativeDb.saveLocalValue("ParentChangeSetId", changeset.id);
+    snapshot[_nativeDb].setITwinId(iTwinId);
+    snapshot[_nativeDb].saveLocalValue("ParentChangeSetId", changeset.id);
     snapshot.saveChanges();
 
-    assert.notEqual(iModelId, snapshot.nativeDb.getIModelId()); // Ensure the Snapshot dbGuid and iModelId are different
+    assert.notEqual(iModelId, snapshot[_nativeDb].getIModelId()); // Ensure the Snapshot dbGuid and iModelId are different
     snapshot.close();
 
     sinon.stub(V2CheckpointManager, "downloadCheckpoint").callsFake(async (arg) => {
@@ -79,7 +80,7 @@ describe("V1 Checkpoint Manager", () => {
     const request = { localFile, checkpoint: { iTwinId, iModelId, changeset } };
     await CheckpointManager.downloadCheckpoint(request);
     const db = V1CheckpointManager.openCheckpointV1(localFile, request.checkpoint);
-    assert.equal(iModelId, db.nativeDb.getIModelId(), "expected the V1 Checkpoint download to fix the improperly set dbGuid.");
+    assert.equal(iModelId, db[_nativeDb].getIModelId(), "expected the V1 Checkpoint download to fix the improperly set dbGuid.");
     db.close();
   });
 });
@@ -137,8 +138,8 @@ describe("Checkpoint Manager", () => {
     const iModelId = snapshot.iModelId;
     const iTwinId = Guid.createValue();
     const changeset = IModelTestUtils.generateChangeSetId();
-    snapshot.nativeDb.setITwinId(iTwinId);
-    snapshot.nativeDb.saveLocalValue("ParentChangeSetId", changeset.id);
+    snapshot[_nativeDb].setITwinId(iTwinId);
+    snapshot[_nativeDb].saveLocalValue("ParentChangeSetId", changeset.id);
     snapshot.saveChanges();
     snapshot.close();
 

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -35,6 +35,7 @@ import { IModelTestUtils } from "../IModelTestUtils";
 import { DisableNativeAssertions } from "../TestUtils";
 import { samplePngTexture } from "../imageData";
 import { performance } from "perf_hooks";
+import { _nativeDb } from "../../internal/Internal";
 // spell-checker: disable
 
 async function getIModelError<T>(promise: Promise<T>): Promise<IModelError | undefined> {
@@ -1052,7 +1053,7 @@ describe("iModel", () => {
     newExtents.high.z += .001;
     imodel1.updateProjectExtents(newExtents);
 
-    const updatedProps = imodel1.nativeDb.getIModelProps();
+    const updatedProps = imodel1[_nativeDb].getIModelProps();
     assert.isTrue(updatedProps.hasOwnProperty("projectExtents"), "Returned property JSON object has project extents");
     const updatedExtents = Range3d.fromJSON(updatedProps.projectExtents);
     assert.isTrue(newExtents.isAlmostEqual(updatedExtents), "Project extents successfully updated in database");
@@ -1627,7 +1628,7 @@ describe("iModel", () => {
 
     const testLocal = "TestLocal";
     const testValue = "this is a test";
-    const nativeDb = iModel.nativeDb;
+    const nativeDb = iModel[_nativeDb];
     assert.isUndefined(nativeDb.queryLocalValue(testLocal));
     nativeDb.saveLocalValue(testLocal, testValue);
     assert.equal(nativeDb.queryLocalValue(testLocal), testValue);

--- a/core/backend/src/test/native/DgnDbWorker.test.ts
+++ b/core/backend/src/test/native/DgnDbWorker.test.ts
@@ -10,6 +10,7 @@ import { IModelHost } from "../../IModelHost";
 import { StandaloneDb } from "../../IModelDb";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { IModelJsNative } from "@bentley/imodeljs-native";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("DgnDbWorker", () => {
   let imodel: StandaloneDb;
@@ -32,7 +33,7 @@ describe("DgnDbWorker", () => {
     private readonly _worker: IModelJsNative.TestWorker;
 
     public constructor() {
-      this._worker = new IModelHost.platform.TestWorker(imodel.nativeDb);
+      this._worker = new IModelHost.platform.TestWorker(imodel[_nativeDb]);
     }
 
     public queue() { this.promise = this._worker.queue(); }

--- a/core/backend/src/test/schema/FunctionalDomain.test.ts
+++ b/core/backend/src/test/schema/FunctionalDomain.test.ts
@@ -19,6 +19,7 @@ import { ElementOwnsChildElements, ElementOwnsUniqueAspect, SubjectOwnsPartition
 import { IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
 import Sinon = require("sinon");
+import { _nativeDb } from "../../internal/Internal";
 
 let iModelDb: StandaloneDb;
 const insertedLabel = "inserted label";
@@ -243,7 +244,7 @@ describe("Functional Domain", () => {
       guid: Guid.createValue(),
     });
 
-    iModelDb.nativeDb.resetBriefcaseId(100);
+    iModelDb[_nativeDb].resetBriefcaseId(100);
 
     // Import the Functional schema
     FunctionalSchema.registerSchema();

--- a/core/backend/src/test/standalone/ChangesetReader.test.ts
+++ b/core/backend/src/test/standalone/ChangesetReader.test.ts
@@ -15,6 +15,7 @@ import { SqliteChangesetReader } from "../../SqliteChangesetReader";
 import { HubWrappers, IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { ChannelControl } from "../../core-backend";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("Changeset Reader API", async () => {
   let iTwinId: GuidString;
@@ -114,7 +115,7 @@ describe("Changeset Reader API", async () => {
     rwIModel.saveChanges("user 1: data");
 
     if ("test local changes") {
-      const reader = SqliteChangesetReader.openLocalChanges({ iModel: rwIModel.nativeDb, db: rwIModel, disableSchemaCheck: true });
+      const reader = SqliteChangesetReader.openLocalChanges({ iModel: rwIModel[_nativeDb], db: rwIModel, disableSchemaCheck: true });
       const adaptor = new ECChangesetAdaptor(reader);
       const cci = new PartialECChangeUnifier();
       while (adaptor.step()) {

--- a/core/backend/src/test/standalone/ElementGraphics.test.ts
+++ b/core/backend/src/test/standalone/ElementGraphics.test.ts
@@ -9,6 +9,7 @@ import { CurrentImdlVersion, DynamicGraphicsRequest3dProps, ElementGeometry, Ele
 import { ElementGraphicsStatus } from "@bentley/imodeljs-native";
 import { GeometricElement3d, SnapshotDb } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("ElementGraphics", () => {
   let imodel: SnapshotDb;
@@ -35,7 +36,7 @@ describe("ElementGraphics", () => {
       formatVersion: CurrentImdlVersion.Major,
     };
 
-    const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+    const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
     expect(result.status).to.equal(ElementGraphicsStatus.Success);
     assert(result.status === ElementGraphicsStatus.Success);
 
@@ -64,7 +65,7 @@ describe("ElementGraphics", () => {
       geometry: { format: "json", data: element!.geom! },
     };
 
-    const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+    const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
     expect(result.status).to.equal(ElementGraphicsStatus.Success);
     assert(result.status === ElementGraphicsStatus.Success);
 
@@ -107,7 +108,7 @@ describe("ElementGraphics", () => {
       geometry: { format: "flatbuffer", data: entries },
     };
 
-    const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+    const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
     expect(result.status).to.equal(ElementGraphicsStatus.Success);
     assert(result.status === ElementGraphicsStatus.Success);
 
@@ -144,7 +145,7 @@ describe("ElementGraphics", () => {
         ...testCase[1],
       };
 
-      const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+      const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
       expect(result.status).to.equal(testCase[0]);
       if (result.status === ElementGraphicsStatus.Success)
         expect(result.content).not.to.be.undefined;

--- a/core/backend/src/test/standalone/ElementMesh.test.ts
+++ b/core/backend/src/test/standalone/ElementMesh.test.ts
@@ -14,6 +14,7 @@ import {
   GenericSchema, GeometryPart, PhysicalModel, PhysicalObject, PhysicalPartition, SnapshotDb, SpatialCategory, SubjectOwnsPartitionElements,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("generateElementMeshes", () => {
   let imodel: SnapshotDb;
@@ -47,7 +48,7 @@ describe("generateElementMeshes", () => {
   });
 
   it("throws if source is not a geometric element", async () => {
-    await expect(imodel.nativeDb.generateElementMeshes({source: "NotAnId"})).rejectedWith("Geometric element required");
+    await expect(imodel[_nativeDb].generateElementMeshes({source: "NotAnId"})).rejectedWith("Geometric element required");
   });
 
   function insertTriangleElement(origin = [0, 0, 0]): string {
@@ -77,7 +78,7 @@ describe("generateElementMeshes", () => {
 
   it("produces a polyface", async () => {
     const source = insertTriangleElement();
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(1);
     expect(meshes[0].range().isAlmostEqual(new Range3d(0, 0, 0, 1, 1, 0))).to.be.true;
@@ -85,7 +86,7 @@ describe("generateElementMeshes", () => {
 
   it("applies element placement transform", async () => {
     const source = insertTriangleElement([5, 0, -2]);
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(1);
     expect(meshes[0].range().isAlmostEqual(new Range3d(5, 0, -2, 6, 1, -2))).to.be.true;
@@ -110,7 +111,7 @@ describe("generateElementMeshes", () => {
     elBldr.appendGeometryPart3d(partId, new Point3d(0, 0, -1));
     const source = insertElement(elBldr.geometryStream, [2, -4, 0]);
 
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(2);
     expect(meshes[0].range().isAlmostEqual(new Range3d(2, -4, 1, 3, -3, 1))).to.be.true;
@@ -124,7 +125,7 @@ describe("generateElementMeshes", () => {
     bldr.appendGeometry(Loop.createPolygon([new Point3d(0, 0, 5), new Point3d(1, 0, 5), new Point3d(0, 1, 5), new Point3d(0, 0, 5)]));
     const source = insertElement(bldr.geometryStream);
 
-    const meshes = readElementMeshes(await imodel.nativeDb.generateElementMeshes({source}));
+    const meshes = readElementMeshes(await imodel[_nativeDb].generateElementMeshes({source}));
     expect(meshes.length).to.equal(2);
     expect(meshes[0].range().isAlmostEqual(new Range3d(0, 0, 0, 1, 1, 0))).to.be.true;
     expect(meshes[1].range().isAlmostEqual(new Range3d(0, 0, 5, 1, 1, 5))).to.be.true;
@@ -138,7 +139,7 @@ describe("generateElementMeshes", () => {
     bldr.appendGeometry(Loop.createPolygon([new Point3d(0, 0, 5), new Point3d(1, 0, 5), new Point3d(0, 1, 5), new Point3d(0, 0, 5)]));
     const source = insertElement(bldr.geometryStream);
 
-    const meshes = readElementMeshes(await imodel.nativeDb.generateElementMeshes({source}));
+    const meshes = readElementMeshes(await imodel[_nativeDb].generateElementMeshes({source}));
     expect(meshes.length).to.equal(2);
     expect(meshes[0].range().isAlmostEqual(new Range3d(0, 0, 0, 1, 1, 0))).to.be.true;
     expect(meshes[1].range().isAlmostEqual(new Range3d(0, 0, 5, 1, 1, 5))).to.be.true;
@@ -159,7 +160,7 @@ describe("generateElementMeshes", () => {
     bldr.appendGeometry(pf);
     const source = insertElement(bldr.geometryStream, [10, 0, 0]);
 
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(1);
     expect(meshes[0].pointCount).to.equal(3);

--- a/core/backend/src/test/standalone/GeometryChangeEvents.test.ts
+++ b/core/backend/src/test/standalone/GeometryChangeEvents.test.ts
@@ -13,6 +13,7 @@ import {
   IModelJsFs, PhysicalModel, SpatialCategory, StandaloneDb, VolumeElement,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("Model geometry changes", () => {
   let imodel: StandaloneDb;
@@ -32,12 +33,12 @@ describe("Model geometry changes", () => {
     modelId = PhysicalModel.insert(imodel, IModel.rootSubjectId, "TestModel");
     categoryId = SpatialCategory.insert(imodel, IModel.dictionaryId, "TestCategory", new SubCategoryAppearance({ color: ColorByName.darkRed }));
     imodel.saveChanges("set up");
-    imodel.nativeDb.deleteAllTxns();
+    imodel[_nativeDb].deleteAllTxns();
     imodel.txns.onGeometryChanged.addListener((props) => lastChanges = props);
   });
 
   after(async () => {
-    imodel.nativeDb.setGeometricModelTrackingEnabled(false);
+    imodel[_nativeDb].setGeometricModelTrackingEnabled(false);
     imodel.close();
   });
 
@@ -80,8 +81,8 @@ describe("Model geometry changes", () => {
   }
 
   it("emits events", async () => {
-    expect(imodel.nativeDb.isGeometricModelTrackingSupported()).to.be.true;
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(true).result).to.be.true;
+    expect(imodel[_nativeDb].isGeometricModelTrackingSupported()).to.be.true;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(true).result).to.be.true;
 
     const builder = new GeometryStreamBuilder();
     builder.appendGeometry(LineSegment3d.create(Point3d.createZero(), Point3d.create(5, 0, 0)));
@@ -128,8 +129,8 @@ describe("Model geometry changes", () => {
     expectChanges({ modelId, deleted: [elemId0] });
 
     // Stop tracking geometry changes
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(false).result).to.be.false;
-    expect(imodel.nativeDb.isGeometricModelTrackingSupported()).to.be.true;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(false).result).to.be.false;
+    expect(imodel[_nativeDb].isGeometricModelTrackingSupported()).to.be.true;
 
     // Modify element's geometry.
     props.id = elemId1;
@@ -139,7 +140,7 @@ describe("Model geometry changes", () => {
     expectNoChanges();
 
     // Restart tracking and undo everything.
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(true).result).to.be.true;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(true).result).to.be.true;
     expect(imodel.txns.reverseSingleTxn()).to.equal(IModelStatus.Success);
     expectChanges({ modelId, updated: [elemId1] });
 
@@ -177,6 +178,6 @@ describe("Model geometry changes", () => {
     expect(imodel.txns.reinstateTxn()).to.equal(IModelStatus.Success);
     expectChanges({ modelId, updated: [elemId1] });
 
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(false).result).to.be.false;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(false).result).to.be.false;
   });
 });

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -24,6 +24,7 @@ import { GeometricElement, GeometryPart, LineStyleDefinition, PhysicalObject, Sn
 import { createBRepDataProps } from "../GeometryTestUtil";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { Timer } from "../TestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 function assertTrue(expr: boolean): asserts expr {
   assert.isTrue(expr);
@@ -511,7 +512,7 @@ describe("GeometryStream", () => {
     assert.isTrue(Id64.isValidId64(newId));
     imodel.saveChanges();
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId, styleId])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId, styleId])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isTrue(usageInfo.lineStyleIds!.includes(styleId));
     assert.isTrue(usageInfo.usedIds!.includes(partId));
@@ -574,7 +575,7 @@ describe("GeometryStream", () => {
     assert.isTrue(Id64.isValidId64(newId));
     imodel.saveChanges();
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId, styleId, seedElement.category])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId, styleId, seedElement.category])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isTrue(usageInfo.lineStyleIds!.includes(styleId));
     assert.isTrue(usageInfo.spatialCategoryIds!.includes(seedElement.category));
@@ -1082,7 +1083,7 @@ describe("GeometryStream", () => {
     }
     assert.isTrue(6 === iShape);
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isTrue(usageInfo.usedIds!.includes(partId));
   });
@@ -1195,7 +1196,7 @@ describe("GeometryStream", () => {
       assert.isTrue(geomArrayOut[i].isAlmostEqual(geomArray[i]));
     }
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isUndefined(usageInfo.usedIds, "GeometryPart should not to be used by any GeometricElement");
   });

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -13,6 +13,7 @@ import {
   GenericSchema, GeometricElement3d, GeometryPart, PhysicalModel, PhysicalObject, PhysicalPartition, RenderMaterialElement, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 // The only geometry in our geometry streams will be squares of 1 meter in x and y, with origin at (pos, 0, 0).
 interface Primitive { pos: number }
@@ -242,7 +243,7 @@ describe("DgnDb.inlineGeometryPartReferences", () => {
   }
 
   function inlinePartRefs(): number {
-    const result = imodel.nativeDb.inlineGeometryPartReferences();
+    const result = imodel[_nativeDb].inlineGeometryPartReferences();
     expect(result.numCandidateParts).to.equal(result.numPartsDeleted);
     expect(result.numRefsInlined).to.equal(result.numCandidateParts);
     return result.numRefsInlined;

--- a/core/backend/src/test/standalone/SnapshotDb.test.ts
+++ b/core/backend/src/test/standalone/SnapshotDb.test.ts
@@ -11,6 +11,7 @@ import { IModelDb, SnapshotDb } from "../../IModelDb";
 import { Logger } from "@itwin/core-bentley";
 import { IModelHost } from "../../IModelHost";
 import { HubMock } from "../../HubMock";
+import { _nativeDb } from "../../internal/Internal";
 
 describe("SnapshotDb.refreshContainerForRpc", () => {
   afterEach(() => sinon.restore());
@@ -111,7 +112,7 @@ describe("SnapshotDb.refreshContainerForRpc", () => {
 
     const userAccessToken = "token";
     const checkpoint = await SnapshotDb.openCheckpointFromRpc({ accessToken: userAccessToken, iTwinId, iModelId, changeset, reattachSafetySeconds: 60 });
-    expect(checkpoint.nativeDb.cloudContainer?.accessToken).equal(mockCheckpointV2.sasToken);
+    expect(checkpoint[_nativeDb].cloudContainer?.accessToken).equal(mockCheckpointV2.sasToken);
     expect(openDgnDbStub.calledOnce).to.be.true;
     expect(openDgnDbStub.firstCall.firstArg.path).to.equal("fakeDb");
 

--- a/core/backend/src/test/standalone/TileCache.test.ts
+++ b/core/backend/src/test/standalone/TileCache.test.ts
@@ -16,6 +16,7 @@ import { GeometricModel3d } from "../../Model";
 import { RpcTrace } from "../../rpc/tracing";
 import { TestUtils } from "../TestUtils";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 const fakeRpc: RpcActivity = { // eslint-disable-line deprecation/deprecation
   accessToken: "dummy",
@@ -122,8 +123,8 @@ describe("TileCache, open v2", async () => {
     const iModelId = snapshot.iModelId;
     const iTwinId = Guid.createValue();
     const changeset = IModelTestUtils.generateChangeSetId();
-    snapshot.nativeDb.setITwinId(iTwinId);
-    snapshot.nativeDb.saveLocalValue("ParentChangeSetId", changeset.id); // even fake checkpoints need a changesetId!
+    snapshot[_nativeDb].setITwinId(iTwinId);
+    snapshot[_nativeDb].saveLocalValue("ParentChangeSetId", changeset.id); // even fake checkpoints need a changesetId!
     snapshot.saveChanges();
     snapshot.close();
 
@@ -132,7 +133,7 @@ describe("TileCache, open v2", async () => {
     const tileRpcInterface = RpcRegistry.instance.getImplForInterface<IModelTileRpcInterface>(IModelTileRpcInterface);
     const tempFileBase = path.join(IModelHost.cacheDir, key);
     const checkpoint = SnapshotDb.openFile(dbPath, { key, tempFileBase });
-    expect(checkpoint.nativeDb.getTempFileBaseName()).equals(tempFileBase);
+    expect(checkpoint[_nativeDb].getTempFileBaseName()).equals(tempFileBase);
     // Generate tile
     const tileProps = await getTileProps(checkpoint);
     expect(tileProps).not.undefined;

--- a/core/backend/src/test/standalone/TileTree.test.ts
+++ b/core/backend/src/test/standalone/TileTree.test.ts
@@ -15,6 +15,7 @@ import {
   SubjectOwnsPartitionElements,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Internal";
 
 let uniqueId = 0;
 
@@ -135,7 +136,7 @@ describe("tile tree", () => {
   });
 
   afterEach(() => {
-    db.nativeDb.purgeTileTrees(undefined);
+    db[_nativeDb].purgeTileTrees(undefined);
   });
 
   it("should update after changing project extents and purging", async () => {
@@ -179,7 +180,7 @@ describe("tile tree", () => {
     expect(tree.rootTile.isLeaf).to.be.false;
 
     // Purge tile trees for a specific (non-existent) model - still nothing should change for our model.
-    db.nativeDb.purgeTileTrees(["0x123abc"]);
+    db[_nativeDb].purgeTileTrees(["0x123abc"]);
 
     tree = await db.tiles.requestTileTreeProps(treeId);
     expect(tree).not.to.be.undefined;
@@ -195,7 +196,7 @@ describe("tile tree", () => {
     expect(tree.rootTile.isLeaf).to.be.false;
 
     // Purge tile trees for our model - now we should get updated tile tree props.
-    db.nativeDb.purgeTileTrees([modelId]);
+    db[_nativeDb].purgeTileTrees([modelId]);
 
     tree = await db.tiles.requestTileTreeProps(treeId);
     expect(tree).not.to.be.undefined;
@@ -215,7 +216,7 @@ describe("tile tree", () => {
 
     // Change extents again and purge tile trees for all loaded models (by passing `undefined` for model Ids).
     newExtents = scaleProjectExtents(db, 0.75);
-    db.nativeDb.purgeTileTrees(undefined);
+    db[_nativeDb].purgeTileTrees(undefined);
 
     tree = await db.tiles.requestTileTreeProps(treeId);
     expect(tree).not.to.be.undefined;
@@ -288,7 +289,7 @@ describe("tile tree", () => {
     expect(tree2).not.to.equal(tree1);
     expect(tree2).to.deep.equal(tree1);
 
-    db.nativeDb.purgeTileTrees(undefined);
+    db[_nativeDb].purgeTileTrees(undefined);
     const tree3 = await db.tiles.requestTileTreeProps(iModelTileTreeIdToString(modelId, treeId, options));
     expect(tree3).not.to.equal(tree2);
     expect(tree3).not.to.equal(tree1);


### PR DESCRIPTION
See internal/Internal.ts for the proposed policy. The policy is applied to `IModelDb._nativeDb` as an example.

Part of #6742