### PR TITLE
Folks keep trying to make the default tool a ViewTool...

### DIFF
--- a/common/changes/@itwin/core-frontend/any-default-tool_2024-06-04-16-47.json
+++ b/common/changes/@itwin/core-frontend/any-default-tool_2024-06-04-16-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -355,7 +355,7 @@ export class ToolAdmin {
   private _mouseMoveOverTimeout?: NodeJS.Timeout;
   private _editCommandHandler?: EditCommandHandler;
 
-  /** The name of the [[InteractiveTool]] to use as the default tool, normally a sub-class of [[PrimitiveTool]].
+  /** The name of the [[PrimitiveTool]] to use as the default tool.
    * Defaults to "Select", referring to [[SelectionTool]].
    * @note An empty string signifies no default tool allowing more events to be handled by [[idleTool]].
    * @see [[startDefaultTool]] to activate the default tool.
@@ -1714,9 +1714,11 @@ export class ToolAdmin {
   }
 
   /**
-   * Starts the default [[InteractiveTool]], if any. Generally invoked automatically when other tools exit, so shouldn't be called directly.
-   * @note The default tool is normally a subclass of [[PrimitiveTool]]. A call to startDefaultTool is required to terminate
-   * an active [[ViewTool]] or [[InputCollector]] and replace or clear the current [[PrimitiveTool]].
+   * Starts the default [[PrimitiveTool]], if any. Generally invoked automatically when other tools exit, so shouldn't be called directly.
+   * @note The default tool, when specified, must be a subclass of [[PrimitiveTool]]. A call to startDefaultTool is required to terminate
+   * an active [[ViewTool]] or [[InputCollector]] and replace or clear the current [[PrimitiveTool]]. The default tool can not be
+   * a subclass of [[ViewTool]] as view tools replace each other and aren't suspended. This means [[ViewTool.exitTool]] would
+   * result in the active tool being undefined instead of making the default tool active.
    * The tool's [[Tool.run]] method is invoked with arguments specified by [[defaultToolArgs]].
    * @see [[defaultToolId]] to configure the default tool.
    */
@@ -1727,9 +1729,9 @@ export class ToolAdmin {
       if (!await tool.run(this.defaultToolArgs))
         return this.startPrimitiveTool(undefined);
     } else {
-      await this.startPrimitiveTool(undefined); // Ensure active primitive tool is terminated instead of suspended...
+      await this.startPrimitiveTool(undefined); // Ensure active primitive tool is terminated...
       if (undefined !== tool)
-        await tool.run(this.defaultToolArgs);
+        throw new Error("Default tool must be a subclass of PrimitiveTool");
     }
   }
 


### PR DESCRIPTION
Couldn't support this after all, you end up with ViewTool.exitTool leaving the active tool undefined. (ex. after double click of middle button to fit view). The default tool can only be a PrimitiveTool or none for things to work properly.