### PR TITLE
Add GL headless support on linux chrome

### DIFF
--- a/test-apps/display-performance-test-app/src/backend/WebMain.ts
+++ b/test-apps/display-performance-test-app/src/backend/WebMain.ts
@@ -58,6 +58,10 @@ function startWebServer() {
       browser = arg;
     else if (arg === "headless")
       chromeFlags.push("--headless");
+    else if (arg === "egl"){
+      chromeFlags.push("--use-gl=angle");
+      chromeFlags.push("--use-angle=gl-egl");
+    }
   });
 
   if (serverConfig === undefined) {

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -44,9 +44,9 @@ export interface TestSetsProps extends TestConfigProps {
 
 /** Context for any number of TestCases to be run against an iModel. */
 interface TestContext {
-  readonly iModelName: string;
   readonly iModel: IModelConnection;
   readonly externalSavedViews: ViewStateSpec[];
+  readonly iModelKey: string;
 }
 
 /** The view against which a specific TestCase is to be run. */
@@ -290,10 +290,11 @@ export class TestRunner {
 
       for (const iModelName of iModelNames) {
         this.curConfig.iModelName = iModelName;
-        this.curConfig.viewName = originalViewName;
+        this.curConfig.viewName = originalViewName;        
+        const iModelKey = this.curConfig.iModelId ? this.curConfig.iModelId : `${this.curConfig.iModelLocation}${separator}${this.curConfig.iModelName}`;
 
         try {
-          const reuseContext = context && set.reuseContext && context.iModelName == iModelName;
+          const reuseContext = context && set.reuseContext && context.iModelKey == iModelKey;
           if(!reuseContext){
             if(context){
               context?.iModel.close();
@@ -702,7 +703,7 @@ export class TestRunner {
         throw new Error("Missing iTwinId for remote iModel");
       const iModel = await CheckpointConnection.openRemote(iTwinId, iModelId);
       const externalSavedViews = await this._savedViewsFetcher.getSavedViews(iTwinId, iModelId, await IModelApp.getAccessToken());
-      return { iModel, externalSavedViews, iModelName: this.curConfig.iModelName };
+      return { iModel, externalSavedViews, iModelKey: this.curConfig.iModelId };
     } else {
       // Load local iModel and its saved views
       const filepath = `${this.curConfig.iModelLocation}${separator}${this.curConfig.iModelName}`;
@@ -722,7 +723,7 @@ export class TestRunner {
           };
         });
       }
-      return { iModel, externalSavedViews, iModelName: this.curConfig.iModelName};
+      return { iModel, externalSavedViews, iModelKey: filepath };
     }
   }
 

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -315,11 +315,10 @@ export class TestRunner {
           await this.logError(`Failed to run tests on iModel ${iModelName}`);
         } 
       }
-      
-      await context?.iModel.close();
       this._config.pop();
     }
-
+      
+    await context?.iModel.close();
     this._config.pop();
   }
 

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -257,52 +257,57 @@ export class TestRunner {
     };
     // Perform all the tests for this iModel. If the iModel name contains an asterisk,
     // treat it as a wildcard and run tests for each iModel that matches the given wildcard.
-    for (const testProps of set.tests) {
-      this._config.push(testProps);
+    // for (const testProps of set.tests) {
+    //   this._config.push(set);
 
-      // Ensure IModelApp is initialized with options required by this test.
-      if (IModelApp.initialized && this.curConfig.requiresRestart(this.lastRestartConfig)) {
-        await IModelApp.shutdown();
-      }
-      if (!IModelApp.initialized) {
-        const renderOptions: RenderSystem.Options = this.curConfig.renderOptions ?? {};
-        if (!this.curConfig.useDisjointTimer) {
-          const ext = this.curConfig.renderOptions?.disabledExtensions;
-          renderOptions.disabledExtensions = Array.isArray(ext) ? ext.concat(["EXT_disjoint_timer_query", "EXT_disjoint_timer_query_webgl2"]) : ["EXT_disjoint_timer_query", "EXT_disjoint_timer_query_webgl2"];
-        }
-        await DisplayPerfTestApp.startup({
-          renderSys: renderOptions,
-          tileAdmin: this.curConfig.tileProps,
-          realityDataAccess: new RealityDataAccessClient(realityDataClientOptions),
-        });
-        this.lastRestartConfig = this.curConfig;
-      }
-
-      // Run test against all iModels matching the test config.
-      const iModelNames = await this.getIModelNames();
-      const originalViewName = this.curConfig.viewName;
-      for (const iModelName of iModelNames) {
-        this.curConfig.iModelName = iModelName;
-        this.curConfig.viewName = originalViewName;
-
-        let context: TestContext;
-        try {
-          context = await this.openIModel();
-        } catch (e: any) {
-          await this.logError(`Failed to open iModel ${iModelName}: ${(e as Error).message}`);
-          continue;
-        }
-
-        try {
-          await this.runTests(context);
-        } catch {
-          await this.logError(`Failed to run tests on iModel ${iModelName}`);
-        } finally {
-          await context.iModel.close();
-        }
-      }
-      this._config.pop();
+    // Ensure IModelApp is initialized with options required by this test.
+    if (IModelApp.initialized && this.curConfig.requiresRestart(this.lastRestartConfig)) {
+      await IModelApp.shutdown();
     }
+    if (!IModelApp.initialized) {
+      const renderOptions: RenderSystem.Options = this.curConfig.renderOptions ?? {};
+      if (!this.curConfig.useDisjointTimer) {
+        const ext = this.curConfig.renderOptions?.disabledExtensions;
+        renderOptions.disabledExtensions = Array.isArray(ext) ? ext.concat(["EXT_disjoint_timer_query", "EXT_disjoint_timer_query_webgl2"]) : ["EXT_disjoint_timer_query", "EXT_disjoint_timer_query_webgl2"];
+      }
+      await DisplayPerfTestApp.startup({
+        renderSys: renderOptions,
+        tileAdmin: this.curConfig.tileProps,
+        realityDataAccess: new RealityDataAccessClient(realityDataClientOptions),
+      });
+      this.lastRestartConfig = this.curConfig;
+    }
+
+    // Run test against all iModels matching the test config.
+    const iModelNames = await this.getIModelNames();
+    const originalViewName = this.curConfig.viewName;
+    for (const iModelName of iModelNames) {
+      this.curConfig.iModelName = iModelName;
+      this.curConfig.viewName = originalViewName;
+
+      let context: TestContext;
+      try {
+        context = await this.openIModel();
+      } catch (e: any) {
+        await this.logError(`Failed to open iModel ${iModelName}: ${(e as Error).message}`);
+        continue;
+      }
+
+      try {
+
+        for (const testProps of set.tests) {
+          this._config.push(testProps);
+          await this.runTests(context);
+          this._config.pop();
+        }
+      } catch {
+        await this.logError(`Failed to run tests on iModel ${iModelName}`);
+      } finally {
+        await context.iModel.close();
+      }
+    }
+    //   this._config.pop();
+    // }
 
     this._config.pop();
   }

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -44,6 +44,7 @@ export interface TestSetsProps extends TestConfigProps {
 
 /** Context for any number of TestCases to be run against an iModel. */
 interface TestContext {
+  readonly iModelName: string;
   readonly iModel: IModelConnection;
   readonly externalSavedViews: ViewStateSpec[];
 }
@@ -292,7 +293,7 @@ export class TestRunner {
         this.curConfig.viewName = originalViewName;
 
         try {
-          const reuseContext = context && set.reuseContext && context.iModel.name == iModelName;
+          const reuseContext = context && set.reuseContext && context.iModelName == iModelName;
           if(!reuseContext){
             if(context){
               context?.iModel.close();
@@ -309,7 +310,7 @@ export class TestRunner {
             await this.runTests(context);
           }
           else{
-            await this.logError(`Failed to run tests on iModel ${iModelName}`);
+            await this.logError(`Invalid test context on iModel ${iModelName}`);
           }
         } catch {
           await this.logError(`Failed to run tests on iModel ${iModelName}`);
@@ -701,7 +702,7 @@ export class TestRunner {
         throw new Error("Missing iTwinId for remote iModel");
       const iModel = await CheckpointConnection.openRemote(iTwinId, iModelId);
       const externalSavedViews = await this._savedViewsFetcher.getSavedViews(iTwinId, iModelId, await IModelApp.getAccessToken());
-      return { iModel, externalSavedViews };
+      return { iModel, externalSavedViews, iModelName: this.curConfig.iModelName };
     } else {
       // Load local iModel and its saved views
       const filepath = `${this.curConfig.iModelLocation}${separator}${this.curConfig.iModelName}`;
@@ -721,7 +722,7 @@ export class TestRunner {
           };
         });
       }
-      return { iModel, externalSavedViews };
+      return { iModel, externalSavedViews, iModelName: this.curConfig.iModelName};
     }
   }
 

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -31,7 +31,6 @@ import { Transform } from "@itwin/core-geometry";
 /** JSON representation of a set of tests. Each test in the set inherits the test set's configuration. */
 export interface TestSetProps extends TestConfigProps {
   tests: TestConfigProps[];
-  reuseContext: boolean;
 }
 
 /** JSON representation of TestRunner. The tests inherit the base configuration options. */
@@ -46,7 +45,6 @@ export interface TestSetsProps extends TestConfigProps {
 interface TestContext {
   readonly iModel: IModelConnection;
   readonly externalSavedViews: ViewStateSpec[];
-  readonly iModelKey: string;
 }
 
 /** The view against which a specific TestCase is to be run. */
@@ -257,9 +255,6 @@ export class TestRunner {
       /** API Url. Used to select environment. Defaults to "https://api.bentley.com/realitydata" */
       baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com`,
     };
-      
-    let context: TestContext | undefined = undefined;
-
     // Perform all the tests for this iModel. If the iModel name contains an asterisk,
     // treat it as a wildcard and run tests for each iModel that matches the given wildcard.
     for (const testProps of set.tests) {
@@ -267,7 +262,6 @@ export class TestRunner {
 
       // Ensure IModelApp is initialized with options required by this test.
       if (IModelApp.initialized && this.curConfig.requiresRestart(this.lastRestartConfig)) {
-        context = undefined;
         await IModelApp.shutdown();
       }
       if (!IModelApp.initialized) {
@@ -287,40 +281,29 @@ export class TestRunner {
       // Run test against all iModels matching the test config.
       const iModelNames = await this.getIModelNames();
       const originalViewName = this.curConfig.viewName;
-
       for (const iModelName of iModelNames) {
         this.curConfig.iModelName = iModelName;
-        this.curConfig.viewName = originalViewName;        
-        const iModelKey = this.curConfig.iModelId ? this.curConfig.iModelId : `${this.curConfig.iModelLocation}${separator}${this.curConfig.iModelName}`;
+        this.curConfig.viewName = originalViewName;
 
+        let context: TestContext;
         try {
-          const reuseContext = context && set.reuseContext && context.iModelKey == iModelKey;
-          if(!reuseContext){
-            if(context){
-              context?.iModel.close();
-            }
-            context = await this.openIModel();
-          }
+          context = await this.openIModel();
         } catch (e: any) {
           await this.logError(`Failed to open iModel ${iModelName}: ${(e as Error).message}`);
           continue;
         }
 
-        try {              
-          if(context){
-            await this.runTests(context);
-          }
-          else{
-            await this.logError(`Invalid test context on iModel ${iModelName}`);
-          }
+        try {
+          await this.runTests(context);
         } catch {
           await this.logError(`Failed to run tests on iModel ${iModelName}`);
-        } 
+        } finally {
+          await context.iModel.close();
+        }
       }
       this._config.pop();
     }
-      
-    await context?.iModel.close();
+
     this._config.pop();
   }
 
@@ -703,7 +686,7 @@ export class TestRunner {
         throw new Error("Missing iTwinId for remote iModel");
       const iModel = await CheckpointConnection.openRemote(iTwinId, iModelId);
       const externalSavedViews = await this._savedViewsFetcher.getSavedViews(iTwinId, iModelId, await IModelApp.getAccessToken());
-      return { iModel, externalSavedViews, iModelKey: this.curConfig.iModelId };
+      return { iModel, externalSavedViews };
     } else {
       // Load local iModel and its saved views
       const filepath = `${this.curConfig.iModelLocation}${separator}${this.curConfig.iModelName}`;
@@ -723,7 +706,7 @@ export class TestRunner {
           };
         });
       }
-      return { iModel, externalSavedViews, iModelKey: filepath };
+      return { iModel, externalSavedViews };
     }
   }
 

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -256,14 +256,17 @@ export class TestRunner {
       /** API Url. Used to select environment. Defaults to "https://api.bentley.com/realitydata" */
       baseUrl: `https://${process.env.IMJS_URL_PREFIX ?? ""}api.bentley.com`,
     };
+      
+    let context: TestContext | undefined = undefined;
 
     // Perform all the tests for this iModel. If the iModel name contains an asterisk,
     // treat it as a wildcard and run tests for each iModel that matches the given wildcard.
     for (const testProps of set.tests) {
-      this._config.push(set);
+      this._config.push(testProps);
 
       // Ensure IModelApp is initialized with options required by this test.
       if (IModelApp.initialized && this.curConfig.requiresRestart(this.lastRestartConfig)) {
+        context = undefined;
         await IModelApp.shutdown();
       }
       if (!IModelApp.initialized) {
@@ -283,8 +286,6 @@ export class TestRunner {
       // Run test against all iModels matching the test config.
       const iModelNames = await this.getIModelNames();
       const originalViewName = this.curConfig.viewName;
-      
-      let context: TestContext | undefined = undefined;
 
       for (const iModelName of iModelNames) {
         this.curConfig.iModelName = iModelName;
@@ -293,7 +294,6 @@ export class TestRunner {
         try {
           const reuseContext = context && set.reuseContext && context.iModel.name == iModelName;
           if(!reuseContext){
-
             if(context){
               context?.iModel.close();
             }


### PR DESCRIPTION
Also add a new flag to enable EGL for creating headless GL context on chrome / linux.

This is required to run image tests on headless linux virtual machines, e.g., that do not have a display.