### PR TITLE
Handle restart of the active tool in onAfterUndoRedo txn event.

### DIFF
--- a/common/changes/@itwin/core-frontend/undo-redo-restart-active-tool_2024-06-06-18-23.json
+++ b/common/changes/@itwin/core-frontend/undo-redo-restart-active-tool_2024-06-06-18-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/editor-frontend/undo-redo-restart-active-tool_2024-06-06-18-23.json
+++ b/common/changes/@itwin/editor-frontend/undo-redo-restart-active-tool_2024-06-06-18-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -277,6 +277,8 @@ export class BriefcaseConnection extends IModelConnection {
     this._openMode = openMode;
     this.txns = new BriefcaseTxns(this);
     this._modelsMonitor = new ModelChangeMonitor(this);
+    if (OpenMode.ReadWrite === this._openMode)
+      this.txns.onAfterUndoRedo.addListener(async () => { await IModelApp.toolAdmin.restartPrimitiveTool(); });
   }
 
   /** Open a BriefcaseConnection to a [BriefcaseDb]($backend). */

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -1451,14 +1451,7 @@ export class ToolAdmin {
     if (undefined === imodel || imodel.isReadonly || !imodel.isBriefcaseConnection())
       return false;
 
-    if (IModelStatus.Success !== await imodel.txns.reverseSingleTxn())
-      return false;
-
-    // ### TODO Restart of primitive tool should be handled by Txn event listener...needs to happen even if not the active tool...
-    if (undefined !== this._primitiveTool)
-      await this._primitiveTool.onRestartTool();
-
-    return true;
+    return (IModelStatus.Success === await imodel.txns.reverseSingleTxn() ? true : false);
   }
 
   /** Called to redo previous data button for primitive tools or undo last write operation. */
@@ -1474,14 +1467,7 @@ export class ToolAdmin {
     if (undefined === imodel || imodel.isReadonly || !imodel.isBriefcaseConnection())
       return false;
 
-    if (IModelStatus.Success !== await imodel.txns.reinstateTxn())
-      return false;
-
-    // ### TODO Restart of primitive tool should be handled by Txn event listener...needs to happen even if not the active tool...
-    if (undefined !== this._primitiveTool)
-      await this._primitiveTool.onRestartTool();
-
-    return true;
+    return (IModelStatus.Success === await imodel.txns.reinstateTxn() ? true : false);
   }
 
   private onActiveToolChanged(tool: Tool, start: StartOrResume): void {

--- a/editor/frontend/src/UndoRedoTool.ts
+++ b/editor/frontend/src/UndoRedoTool.ts
@@ -20,10 +20,6 @@ export class UndoAllTool extends Tool {
       return true;
 
     await IpcApp.appFunctionIpc.reverseAllTxn(imodel.key);
-
-    // ### TODO Restart of primitive tool should be handled by Txn event listener...needs to happen even if not the active tool...
-    if (undefined !== IModelApp.toolAdmin.primitiveTool)
-      await IModelApp.toolAdmin.primitiveTool.onRestartTool();
     return true;
   }
 }


### PR DESCRIPTION
Required to avoid a potentially stale tool state.

Hopefully it's fine adding this directly to BriefcaseConnection...seemed like the most sensible place to me.