### PR TITLE
`LineString3d.fractionToFrenetFrame` incorrect output

### DIFF
--- a/common/changes/@itwin/core-geometry/da4-linestring-frenet-bug_2024-06-12-13-28.json
+++ b/common/changes/@itwin/core-geometry/da4-linestring-frenet-bug_2024-06-12-13-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "fix linestring Frenet frame bug",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/curve/LineString3d.ts
+++ b/core/geometry/src/curve/LineString3d.ts
@@ -33,10 +33,10 @@ import { StrokeCountMap } from "./Query/StrokeCountMap";
 import { StrokeOptions } from "./StrokeOptions";
 
 /**
- * Starting with baseIndex and moving index by stepDirection:
- * If the vector from baseIndex to baseIndex +1 crossed with vectorA can be normalized, accumulate it (scaled) to normal.
- * Return when successful.
- * (Do nothing if everything is parallel through limits of the array)
+ * Starting with the segment at (baseIndex, baseIndex + 1):
+ * * If the segment vector and vectorA determine a normal, accumulate it (scaled) to normal, and return.
+ * * Otherwise move to next/previous segment if stepDirection is positive/negative and repeat.
+ * * Do nothing if everything is parallel through the end of the array.
  */
 function accumulateGoodUnitPerpendicular(
   points: GrowableXYZArray,
@@ -54,6 +54,8 @@ function accumulateGoodUnitPerpendicular(
       vectorA.crossProduct(workVector, workVector);
       if (workVector.normalizeInPlace()) {
         normal.addScaledInPlace(workVector, weight);
+        if (normal.isAlmostEqualXYZ(0, 0, 0, Geometry.smallFraction))
+          workVector.scale(-weight, normal); // Concavity changed! Revert to previous
         return true;
       }
     }
@@ -65,6 +67,8 @@ function accumulateGoodUnitPerpendicular(
       workVector.crossProduct(vectorA, workVector);
       if (workVector.normalizeInPlace()) {
         normal.addScaledInPlace(workVector, weight);
+        if (normal.isAlmostEqualXYZ(0, 0, 0, Geometry.smallFraction))
+          workVector.scale(-weight, normal); // Concavity changed! Revert to previous
         return true;
       }
     }

--- a/core/geometry/src/test/GeometryCoreTestIO.ts
+++ b/core/geometry/src/test/GeometryCoreTestIO.ts
@@ -7,6 +7,7 @@ import { Arc3d } from "../curve/Arc3d";
 import { CurveLocationDetail, CurveLocationDetailPair } from "../curve/CurveLocationDetail";
 import { GeometryQuery } from "../curve/GeometryQuery";
 import { CurveChainWireOffsetContext } from "../curve/internalContexts/PolygonOffsetContext";
+import { LineSegment3d } from "../curve/LineSegment3d";
 import { LineString3d } from "../curve/LineString3d";
 import { Loop } from "../curve/Loop";
 import { Geometry } from "../Geometry";
@@ -496,6 +497,14 @@ export class GeometryCoreTestIO {
       this.captureCurveLocationDetails(collection, data.detailA, markerSize, dx, dy, dz);
       this.captureCurveLocationDetails(collection, data.detailB, markerSize * 0.75, dx, dy, dz);
     }
+  }
+  /** Draw the scaled columns and origin to depict e.g., a Frenet frame. */
+  public static captureTransformAsFrame(collection: GeometryQuery[], frame: Transform, radius: number, axisLength: number = 1, x?: number, y?: number, z?: number): void {
+    const origin = Arc3d.createCenterNormalRadius(frame.getOrigin(), frame.matrix.columnZ(), radius);
+    const xAxis = LineSegment3d.create(frame.getOrigin(), frame.getOrigin().plusScaled(frame.matrix.columnX().normalizeWithDefault(0, 0, 0), axisLength));
+    const yAxis = LineSegment3d.create(frame.getOrigin(), frame.getOrigin().plusScaled(frame.matrix.columnY().normalizeWithDefault(0, 0, 0), axisLength));
+    const zAxis = LineSegment3d.create(frame.getOrigin(), frame.getOrigin().plusScaled(frame.matrix.columnZ().normalizeWithDefault(0, 0, 0), axisLength));
+    this.captureGeometry(collection, [origin, xAxis, yAxis, zAxis], x, y, z);
   }
 
   /** Read a flatbuffer file and interpret as GeometryQuery(s) */


### PR DESCRIPTION
When the input global fraction refers to the midpoint of an interior segment coplanar with its two neighbors, and they have opposite concavity with respect to the segment, the accumulated normal computed by `accumulateGoodUnitPerpendicular` vanished, resulting incorrectly in the default output (identity).

Applied fix: if the accumulated normal vanishes, we revert to its previous value.