### PR TITLE
Don't throw an error if sourceMap is null/undefined

### DIFF
--- a/common/changes/@itwin/core-backend/jiarui-doNotThrowErrorWhenSourcemapUndefined_2024-06-12-16-07.json
+++ b/common/changes/@itwin/core-backend/jiarui-doNotThrowErrorWhenSourcemapUndefined_2024-06-12-16-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Don't throw an error if sourceMap is null/undefined",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/jiarui-doNotThrowErrorWhenSourcemapUndefined_2024-06-12-19-22.json
+++ b/common/changes/@itwin/core-backend/jiarui-doNotThrowErrorWhenSourcemapUndefined_2024-06-12-19-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "keep sourceMap undefined/null in targetProps",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -196,7 +196,7 @@ export class RenderMaterialElement extends DefinitionElement {
       // sourceMap could be null/undefined, keep it the same in targetProps
       if (!sourceMap) {
         targetProps.jsonProperties.materialAssets.renderMaterial.Map[mapName] = sourceMap;
-        return;
+        continue;
       }
       if (!Id64.isValid(sourceMap.TextureId) || sourceMap.TextureId === undefined)
         continue;

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -193,7 +193,12 @@ export class RenderMaterialElement extends DefinitionElement {
       if (typeof mapName !== "string")
         continue;
       const sourceMap = sourceProps.jsonProperties.materialAssets.renderMaterial.Map[mapName];
-      if (!sourceMap || !Id64.isValid(sourceMap.TextureId) || sourceMap.TextureId === undefined)
+      // sourceMap could be null/undefined, keep it the same in targetProps
+      if (!sourceMap) {
+        targetProps.jsonProperties.materialAssets.renderMaterial.Map[mapName] = sourceMap;
+        return;
+      }
+      if (!Id64.isValid(sourceMap.TextureId) || sourceMap.TextureId === undefined)
         continue;
       targetProps.jsonProperties.materialAssets.renderMaterial.Map[mapName].TextureId = context.findTargetElementId(sourceMap.TextureId ?? Id64.invalid);
     }

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -193,7 +193,7 @@ export class RenderMaterialElement extends DefinitionElement {
       if (typeof mapName !== "string")
         continue;
       const sourceMap = sourceProps.jsonProperties.materialAssets.renderMaterial.Map[mapName];
-      if (!Id64.isValid(sourceMap.TextureId) || sourceMap.TextureId === undefined)
+      if (!sourceMap || !Id64.isValid(sourceMap.TextureId) || sourceMap.TextureId === undefined)
         continue;
       targetProps.jsonProperties.materialAssets.renderMaterial.Map[mapName].TextureId = context.findTargetElementId(sourceMap.TextureId ?? Id64.invalid);
     }

--- a/core/backend/src/test/standalone/RenderMaterialElement.test.ts
+++ b/core/backend/src/test/standalone/RenderMaterialElement.test.ts
@@ -358,6 +358,12 @@ describe("RenderMaterialElement", () => {
         UnknownTexture: { TextureId: "CLONED" },
         NoTextureId: { OtherProp: 1 },
       });
+
+      jsonProps.materialAssets.renderMaterial.Map = {"Pattern": undefined};
+      material.update();
+      RenderMaterialElement["onCloned"](context, sourceProps, targetProps);
+      // keep the sourceMap the same in targetProps
+      expect(targetProps.jsonProperties?.materialAssets?.renderMaterial?.Map?.Pattern).to.be.undefined;
     });
   });
 });

--- a/core/backend/src/test/standalone/RenderMaterialElement.test.ts
+++ b/core/backend/src/test/standalone/RenderMaterialElement.test.ts
@@ -359,8 +359,9 @@ describe("RenderMaterialElement", () => {
         NoTextureId: { OtherProp: 1 },
       });
 
-      jsonProps.materialAssets.renderMaterial.Map = {"Pattern": undefined};
+      jsonProps.materialAssets.renderMaterial.Map = {Pattern: undefined};
       material.update();
+      // eslint-disable-next-line @typescript-eslint/dot-notation
       RenderMaterialElement["onCloned"](context, sourceProps, targetProps);
       // keep the sourceMap the same in targetProps
       expect(targetProps.jsonProperties?.materialAssets?.renderMaterial?.Map?.Pattern).to.be.undefined;


### PR DESCRIPTION
fix iTwin/itwinjs-backlog#1123

sourceMap could be undefined/null in some cases. ignore it instead of throwing an error