### PR TITLE
Align text annotation anchor point with origin

### DIFF
--- a/common/changes/@itwin/core-backend/pmc-anchor-pt-at-origin_2024-06-12-16-37.json
+++ b/common/changes/@itwin/core-backend/pmc-anchor-pt-at-origin_2024-06-12-16-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "produceTextAnnotationGeometry aligns the anchor point with the origin.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/pmc-anchor-pt-at-origin_2024-06-12-16-37.json
+++ b/common/changes/@itwin/core-common/pmc-anchor-pt-at-origin_2024-06-12-16-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "TextAnnotation.computeTransform aligns the anchor point with the origin.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/TextAnnotationGeometry.ts
+++ b/core/backend/src/TextAnnotationGeometry.ts
@@ -151,16 +151,21 @@ function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Tr
       color: ColorDef.red.toJSON(),
     });
 
+    const lx = layout.range.low.x - debugAnchorPt.x;
+    const ly = layout.range.low.y - debugAnchorPt.y;
+    const hx = layout.range.high.x - debugAnchorPt.x;
+    const hy = layout.range.high.y - debugAnchorPt.y;
+    
     context.entries.push({
       separator: {
-        startPoint: [layout.range.low.x, debugAnchorPt.y, 0],
-        endPoint: [layout.range.high.x, debugAnchorPt.y, 0],
+        startPoint: [lx, 0, 0],
+        endPoint: [hx, 0, 0],
       },
     });
     context.entries.push({
       separator: {
-        startPoint: [debugAnchorPt.x, layout.range.low.y, 0],
-        endPoint: [debugAnchorPt.x, layout.range.high.y, 0],
+        startPoint: [0, ly, 0],
+        endPoint: [0, hy, 0],
       },
     });
   }

--- a/core/backend/src/TextAnnotationGeometry.ts
+++ b/core/backend/src/TextAnnotationGeometry.ts
@@ -155,7 +155,7 @@ function produceTextBlockGeometry(layout: TextBlockLayout, documentTransform: Tr
     const ly = layout.range.low.y - debugAnchorPt.y;
     const hx = layout.range.high.x - debugAnchorPt.x;
     const hy = layout.range.high.y - debugAnchorPt.y;
-    
+
     context.entries.push({
       separator: {
         startPoint: [lx, 0, 0],

--- a/core/backend/src/TextAnnotationGeometry.ts
+++ b/core/backend/src/TextAnnotationGeometry.ts
@@ -193,7 +193,7 @@ export interface ProduceTextAnnotationGeometryArgs {
   findFontId?: FindFontId;
 }
 
-/** Produce a geometric representation of a text annotation.
+/** Produce a geometric representation of a text annotation, with the annotation's anchor point at the origin.
  * The result can be supplied to [GeometryStreamBuilder.appendTextBlock]($common).
  * @see [[TextAnnotation2d.setAnnotation]] and [[TextAnnotation3d.setAnnotation]] to update the annotation, geometry, and placement of an annotation element.
  * @beta

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -13,7 +13,7 @@ import { TextBlock, TextBlockProps } from "./TextBlock";
  * The anchor point is a point on or inside of the 2d bounding box enclosing the contents of the annotation's [[TextBlock]].
  * The annotation can be rotated and translated relative to the anchor point. The anchor point also serves as the snap point
  * when [AccuSnap]($frontend) is set to [SnapMode.Origin]($frontend).
- * [produceTextAnnotationGeometry]($backend) will align the anchor point with (0, 0).
+ * [[TextAnnotation.computeTransform]] will align the anchor point with (0, 0).
  * @see [[TextAnnotation]] for a description of how the anchor point is computed.
  * @beta
  */

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -13,6 +13,7 @@ import { TextBlock, TextBlockProps } from "./TextBlock";
  * The anchor point is a point on or inside of the 2d bounding box enclosing the contents of the annotation's [[TextBlock]].
  * The annotation can be rotated and translated relative to the anchor point. The anchor point also serves as the snap point
  * when [AccuSnap]($frontend) is set to [SnapMode.Origin]($frontend).
+ * [produceTextAnnotationGeometry]($backend) will align the anchor point with (0, 0).
  * @see [[TextAnnotation]] for a description of how the anchor point is computed.
  * @beta
  */

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -154,7 +154,7 @@ export class TextAnnotation {
     const matrix = this.orientation.toMatrix3d();
 
     const rotation = Transform.createFixedPointAndMatrix(anchorPt, matrix);
-    const translation = Transform.createTranslation(this.offset);
+    const translation = Transform.createTranslation(this.offset.minus(anchorPt));
     return translation.multiplyTransformTransform(rotation, rotation);
   }
 

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -146,7 +146,7 @@ export class TextAnnotation {
   /** Compute the transform that positions and orients this annotation relative to its anchor point, based on the [[textBlock]]'s computed bounding box.
    * The anchor point is computed as specified by this annotation's [[anchor]] setting. For example, if the text block is anchored
    * at the bottom left, then the transform will be relative to the bottom-left corner of `textBlockExtents`.
-   * The text block will be rotated around the fixed anchor point according to [[orientation]], then the anchor point will be translated by [[offset]].
+   * The text block will be rotated around the fixed anchor point according to [[orientation]], then translated by [[offset]].
    * The anchor point will coincide with (0, 0, 0).
    * @param boundingBox A box fully containing the [[textBlock]].
    * @see [[computeAnchorPoint]] to compute the transform's anchor point.

--- a/core/common/src/annotation/TextAnnotation.ts
+++ b/core/common/src/annotation/TextAnnotation.ts
@@ -147,6 +147,7 @@ export class TextAnnotation {
    * The anchor point is computed as specified by this annotation's [[anchor]] setting. For example, if the text block is anchored
    * at the bottom left, then the transform will be relative to the bottom-left corner of `textBlockExtents`.
    * The text block will be rotated around the fixed anchor point according to [[orientation]], then the anchor point will be translated by [[offset]].
+   * The anchor point will coincide with (0, 0, 0).
    * @param boundingBox A box fully containing the [[textBlock]].
    * @see [[computeAnchorPoint]] to compute the transform's anchor point.
    */

--- a/core/common/src/test/annotations/TextAnnotation.test.ts
+++ b/core/common/src/test/annotations/TextAnnotation.test.ts
@@ -28,7 +28,24 @@ describe("TextAnnotation", () => {
     });
   });
 
-  describe("computeTransform", () => {
+  describe.only("computeTransform", () => {
+    const verticals = ["top", "middle", "bottom"] as const;
+    const horizontals = ["left", "center", "right"] as const;
+
+    it("puts anchor point at origin", () => {
+      const extents = new Range2d(0, 0, 20, 10);
+
+      for (const horizontal of horizontals) {
+        for (const vertical of verticals) {
+          const annotation = TextAnnotation.fromJSON({ anchor: { horizontal, vertical } });
+          const transform = annotation.computeTransform(extents);
+          const anchor = annotation.computeAnchorPoint(extents);
+          const transformed = transform.multiplyPoint3d(anchor);
+          expect(transformed.isAlmostZero).to.equal(true, `${transformed.toJSON()}`);
+        }
+      }
+    });
+
     function expectTransformedRange(expectedRange: [number, number, number, number], options?: {
       anchor?: TextAnnotationAnchor;
       origin?: number[];
@@ -69,9 +86,6 @@ describe("TextAnnotation", () => {
 
       expect(actual.isAlmostEqual(expected)).to.equal(true, `expected ${JSON.stringify(expected)} actual ${JSON.stringify(actual)}`);
     }
-
-    const verticals = ["top", "middle", "bottom"] as const;
-    const horizontals = ["left", "center", "right"] as const;
 
     it("should produce identity transform for identity orientation and zero origin", () => {
       for (const vertical of verticals) {

--- a/core/common/src/test/annotations/TextAnnotation.test.ts
+++ b/core/common/src/test/annotations/TextAnnotation.test.ts
@@ -44,7 +44,7 @@ describe("TextAnnotation", () => {
             const anchor = annotation.computeAnchorPoint(extents);
             const transformed = transform.multiplyPoint3d(anchor);
             const expected = annotation.offset;
-            expect(transformed.isAlmostEqual(expected)).to.equal(true, `expected ${transformed.toJSON()} to equal ${expected.toJSON()}`);
+            expect(transformed.isAlmostEqual(expected)).to.equal(true, `expected ${JSON.stringify(transformed.toJSON())} to equal ${JSON.stringify(expected.toJSON())}`);
           };
 
           // No offset nor rotation
@@ -81,9 +81,18 @@ describe("TextAnnotation", () => {
       const dimensions = { x: 20, y: 10 };
       const extents = new Range3d(0, -dimensions.y, 0, dimensions.x, 0, 0);
       const transform = annotation.computeTransform(new Range2d(0, -dimensions.y, dimensions.x, 0));
-      const expected = Range3d.createRange2d(new Range2d(expectedRange[0], expectedRange[1], expectedRange[2], expectedRange[3]));
-      const actual = transform.multiplyRange(extents);
 
+      // The anchor point is aligned with the origin (prior to translating by offset).
+      // Our tests were written before that was implemented.
+      // Keep the tests simple by subtracting the anchor from our expected range.
+      const anchor = annotation.computeAnchorPoint(new Range2d(0, -dimensions.y, dimensions.x, 0));
+      const expected = Range3d.createRange2d(new Range2d(expectedRange[0], expectedRange[1], expectedRange[2], expectedRange[3]));
+      expected.low.x -= anchor.x;
+      expected.high.x -= anchor.x;
+      expected.low.y -= anchor.y;
+      expected.high.y -= anchor.y;
+
+      const actual = transform.multiplyRange(extents);
       expect(actual.isAlmostEqual(expected)).to.equal(true, `expected ${JSON.stringify(expected)} actual ${JSON.stringify(actual)}`);
     }
 


### PR DESCRIPTION
This way the anchor point always coincides with the element's placement origin.