### PR TITLE
`LineString3d.globalFractionToSegmentIndexAndLocalFraction` bug fix

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -251,6 +251,7 @@
     "nondimensional",
     "noninteractive",
     "nonnull",
+    "nonpositive",
     "nonsingular",
     "nullptr",
     "numeronyms",

--- a/common/changes/@itwin/core-geometry/da4-linestring-fraction-mapper-bug_2024-06-14-16-05.json
+++ b/common/changes/@itwin/core-geometry/da4-linestring-fraction-mapper-bug_2024-06-14-16-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "linestring global->local fraction map fix",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/curve/LineString3d.ts
+++ b/core/geometry/src/curve/LineString3d.ts
@@ -596,16 +596,18 @@ export class LineString3d extends CurvePrimitive implements BeJSONFunctions {
   /**
    * Convert a segment index and local fraction to a global linestring fraction.
    * @param index index of segment being evaluated
-   * @param localFraction local fraction in [0,1] within the segment
-   * @return global fraction f in [0,1] such that the segment is parameterized by index/N <= f <= (index+1)/N.
+   * @param localFraction local fraction relative to the segment, typically in [0,1]. Fraction may be negative (or greater than 1) to represent extension of the first (or last) segment.
+   * @return global fraction f such that the segment is parameterized by index/N <= f <= (index+1)/N.
    */
   public segmentIndexAndLocalFractionToGlobalFraction(index: number, localFraction: number): number {
     return LineString3d.mapLocalToGlobalFraction(index, localFraction, this._points.length - 1);
   }
   /**
-   * Convert a global fraction to a segment index and local fraction.
-   * @param globalFraction a fraction f in [0,1] in the linestring parameterization, where the i_th segment
-   * (0 <= i < N) is parameterized by i/N <= f <= (i+1)/N.
+   * Convert a global linestring fraction to a segment index and local fraction.
+   * @param globalFraction a fraction f in the linestring parameterization, where the i_th segment
+   * (0 <= i < N) is parameterized by i/N <= f <= (i+1)/N. If `globalFraction` is negative (or greater than 1),
+   * so is the returned local fraction, which corresponds to the first (last) segment.
+   * @param numSegment number N of segments in the linestring
    * @returns segment index and local fraction
    */
   public static mapGlobalToLocalFraction(globalFraction: number, numSegment: number): { index: number, fraction: number } {
@@ -613,9 +615,9 @@ export class LineString3d extends CurvePrimitive implements BeJSONFunctions {
       return { index: 0, fraction: 0.0 };
     const scaledGlobalFraction = globalFraction * numSegment;
     let segmentIndex: number;
-    if (globalFraction < 0)
+    if (globalFraction <= 0)
       segmentIndex = 0;
-    else if (globalFraction > 1)
+    else if (globalFraction >= 1)
       segmentIndex = numSegment - 1;
     else  // globalFraction in [0,1]
       segmentIndex = Math.floor(scaledGlobalFraction);
@@ -623,9 +625,9 @@ export class LineString3d extends CurvePrimitive implements BeJSONFunctions {
   }
   /**
    * Convert a global linestring fraction to a segment index and local fraction.
-   * @param globalFraction a fraction f in [0,1] in the linestring parameterization, where the i_th segment
-   * (0 <= i < N) is parameterized by i/N <= f <= (i+1)/N.
-   * @param numSegment number N of segments in the linestring
+   * @param globalFraction a fraction f in the linestring parameterization, where the i_th segment
+   * (0 <= i < N) is parameterized by i/N <= f <= (i+1)/N. If `globalFraction` is negative (or greater than 1),
+   * so is the returned local fraction, which corresponds to the first (last) segment.
    * @returns segment index and local fraction
    */
   public globalFractionToSegmentIndexAndLocalFraction(globalFraction: number): { index: number, fraction: number } {

--- a/core/geometry/src/test/curve/LineString3d.test.ts
+++ b/core/geometry/src/test/curve/LineString3d.test.ts
@@ -315,7 +315,6 @@ describe("LineString3d", () => {
   it("FrenetFrame", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
-    // data from iModel ("fdt inspect element" outputs world coords)
     const ls = LineString3d.createPoints([
       Point3d.create(0, 0, 1),
       Point3d.create(10, 0, 1),
@@ -337,6 +336,43 @@ describe("LineString3d", () => {
     ck.testPoint3d(frame.getOrigin(), ls.fractionToPoint(fraction), "frame origin matches point");
 
     GeometryCoreTestIO.saveGeometry(allGeometry, "LineString3d", "FrenetFrame");
+    expect(ck.getNumErrors()).equals(0);
+  });
+  it("FractionMap", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+    const ls = LineString3d.createPoints([
+      Point3d.create(0, 0, 0),
+      Point3d.create(10, 0, 1),
+      Point3d.create(0, -10, 0),
+      Point3d.create(10, -10, -1),
+    ]);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, ls);
+    const numSegments = ls.numEdges();
+    const eps = Geometry.smallFraction;
+    for (const globalFraction of [-1, -0.5, -eps, 0, eps, 0.25, 0.5, 2/3, 1 - eps, 1, 1 + eps, 4/3, 2]) {
+      const local = ls.globalFractionToSegmentIndexAndLocalFraction(globalFraction);
+      const globalFractionRoundTrip = ls.segmentIndexAndLocalFractionToGlobalFraction(local.index, local.fraction);
+      ck.testExactNumber(globalFraction, globalFractionRoundTrip, "global fraction roundtrips thru local");
+      const localPt = ls.getIndexedSegment(local.index)!.fractionToPoint(local.fraction);
+      const globalPt = ls.fractionToPoint(globalFraction);
+      ck.testPoint3d(localPt, globalPt, "same point resolved by local and global params");
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, globalPt, 0.05);
+      if (globalFraction <= 0) {
+        ck.testExactNumber(local.index, 0, "nonpositive global fraction maps to first segment");
+        ck.testLE(local.fraction, 0, "nonpositive global fraction maps to nonpositive local fraction");
+      } else if (globalFraction >= 1) {
+        ck.testExactNumber(local.index, numSegments - 1, "global fraction greater than 1 maps to last segment");
+        ck.testLE(1, local.fraction, "global fraction >= 1 maps to local fraction >= 1");
+      }
+      ck.testLE(0, local.index, "local index is nonnegative");
+      ck.testLE(local.index, numSegments - 1, "local index is not too large");
+      if (Geometry.isIn01(globalFraction)) {
+        ck.testLE(0, local.fraction, "global fraction in [0,1] results in nonnegative local fraction");
+        ck.testLE(local.fraction, 1, "global fraction in [0,1] results in local fraction that's not too large");
+      }
+    }
+    GeometryCoreTestIO.saveGeometry(allGeometry, "LineString3d", "FractionMap");
     expect(ck.getNumErrors()).equals(0);
   });
 });

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -300,6 +300,8 @@ export class TestRunner {
               await context?.iModel.close();
             }
             context = await this.openIModel();
+          } else {
+            context?.iModel.selectionSet.emptyAll();
           }
         } catch (e: any) {
           await this.logError(`Failed to open iModel ${iModelName}: ${(e as Error).message}`);


### PR DESCRIPTION
Global fraction 1.0 resulted in invalid segment index.

Addresses https://github.com/iTwin/itwinjs-backlog/issues/1143