### PR TITLE
Reenable iOS backend unit tests

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -102,10 +102,10 @@ steps:
       IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
     condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
-  # - script: npm run ios:all
-  #   workingDirectory: core/backend
-  #   displayName: Build & run iOS backend unit tests in Simulator
-  #   condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
+  - script: npm run ios:all
+    workingDirectory: core/backend
+    displayName: Build & run iOS backend unit tests in Simulator
+    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: node common/scripts/install-run-rush.js lint
     displayName: rush lint

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "0ae447e8f7f1402540a78ecfef8233159b3822ce7f14cc0b6b98d9f5822b767e",
   "pins" : [
     {
       "identity" : "mobile-native-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/iTwin/mobile-native-ios",
       "state" : {
-        "revision" : "2f6675d9b997e3f8fdad1aec31c175e15a4f61b6",
-        "version" : "4.2.10"
+        "revision" : "b365b0ca9fe2b16cddaf26f59e8f38148027608c",
+        "version" : "4.8.11"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "0ae447e8f7f1402540a78ecfef8233159b3822ce7f14cc0b6b98d9f5822b767e",
   "pins" : [
     {
       "identity" : "mobile-native-ios",
@@ -11,5 +10,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/tools/internal/ios/core-test-runner/core-test-runner/ViewController.swift
+++ b/tools/internal/ios/core-test-runner/core-test-runner/ViewController.swift
@@ -95,6 +95,7 @@ class ViewController: ObservableObject {
         let main = URL(fileURLWithPath: mainPath)
         log("(ios): Running tests.")
         host.loadBackend(main, withAuthClient: nil, withInspect: true) { [self] (numFailed: UInt32) in
+            log("(ios): Starting Mocha Result XML dump...")
             do {
                 let text = try String(contentsOf: testResultsUrl, encoding: .utf8)
                 for line in text.components(separatedBy: .newlines) {
@@ -103,6 +104,7 @@ class ViewController: ObservableObject {
             } catch {
                 log("(ios): Failed to read mocha test results.")
             }
+            log("(ios): Mocha Result XML dump complete.")
 
             // Indicate via UI that the tests have finished.
             self.testStatus = "Tests finished."


### PR DESCRIPTION
These were failing during CI but not failing for me locally, so there is a decent chance they will still fail now that they are reenabled, so I added a small amount of extra output printing during the run.