### PR TITLE
Add iTwinJS and Tile Version Tracking to Graphics Service Requests

### DIFF
--- a/common/changes/@itwin/frontend-tiles/andremig-version-tracking_2024-06-26-17-48.json
+++ b/common/changes/@itwin/frontend-tiles/andremig-version-tracking_2024-06-26-17-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "Add iTwinjs version and Tile version tracking to query params",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/extensions/frontend-tiles/src/GraphicsProvider/GraphicRepresentationProvider.ts
+++ b/extensions/frontend-tiles/src/GraphicsProvider/GraphicRepresentationProvider.ts
@@ -80,7 +80,7 @@ export type GraphicRepresentation = {
 });
 
 /** Creates a URL used to query for Graphic Representations */
-async function createGraphicRepresentationsQueryUrl(args: { sourceId: string, sourceType: string, urlPrefix?: string, changeId?: string, enableCDN?: boolean }): Promise<string> {
+function createGraphicRepresentationsQueryUrl(args: { sourceId: string, sourceType: string, urlPrefix?: string, changeId?: string, enableCDN?: boolean }): string {
   const prefix = args.urlPrefix ?? "";
   let url = `https://${prefix}api.bentley.com/mesh-export/?iModelId=${args.sourceId}&$orderBy=date:desc`;
   if (args.changeId)
@@ -170,7 +170,7 @@ export async function* queryGraphicRepresentations(args: QueryGraphicRepresentat
     TileVersion: tileVersion,
   };
 
-  let url: string | undefined = await createGraphicRepresentationsQueryUrl({ sourceId: args.dataSource.id, sourceType: args.dataSource.type, urlPrefix: args.urlPrefix, changeId: args.dataSource.changeId, enableCDN: args.enableCDN });
+  let url: string | undefined = createGraphicRepresentationsQueryUrl({ sourceId: args.dataSource.id, sourceType: args.dataSource.type, urlPrefix: args.urlPrefix, changeId: args.dataSource.changeId, enableCDN: args.enableCDN });
   while (url) {
     let result;
     try {

--- a/extensions/frontend-tiles/src/GraphicsProvider/GraphicRepresentationProvider.ts
+++ b/extensions/frontend-tiles/src/GraphicsProvider/GraphicRepresentationProvider.ts
@@ -154,7 +154,6 @@ export async function* queryGraphicRepresentations(args: QueryGraphicRepresentat
     };
   }
 
-  const tileVersion = IModelApp.tileAdmin.maximumMajorTileFormatVersion.toString();
   const headers = {
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     Authorization: args.accessToken,

--- a/extensions/frontend-tiles/src/GraphicsProvider/GraphicRepresentationProvider.ts
+++ b/extensions/frontend-tiles/src/GraphicsProvider/GraphicRepresentationProvider.ts
@@ -164,10 +164,6 @@ export async function* queryGraphicRepresentations(args: QueryGraphicRepresentat
     Prefer: "return=representation",
     /* eslint-disable-next-line @typescript-eslint/naming-convention */
     SessionId: args.sessionId,
-    /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    ITwinjsVersion: ITWINJS_CORE_VERSION,
-    /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    TileVersion: tileVersion,
   };
 
   let url: string | undefined = createGraphicRepresentationsQueryUrl({ sourceId: args.dataSource.id, sourceType: args.dataSource.type, urlPrefix: args.urlPrefix, changeId: args.dataSource.changeId, enableCDN: args.enableCDN });


### PR DESCRIPTION
Add iTwinJS Version and Tile Version as query params in the Graphic Representation query url for tracking purposes.
Export Type was also updated in the query url to reflect the actual export type, and not be hardcoded to "IMODEL".