### PR TITLE
Within changeSummaryManager, try to rely on having an authClient defined where possible.

### DIFF
--- a/common/changes/@itwin/core-backend/nick-changesummariestoken_2024-06-26-15-42.json
+++ b/common/changes/@itwin/core-backend/nick-changesummariestoken_2024-06-26-15-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}


### PR DESCRIPTION
This is so potentially long running operations like pullChanges will refresh their token when downloadingChangesets because hubAccess methods call IModelHost.authorizationClient.getAccessToken if we don't pass a token.