### PR TITLE
Fix Incorrect Commit Message when Manually run Finalize Release Workflow

### DIFF
--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -76,12 +76,16 @@ let currentBranch = await $`git branch --show-current`;
 
 let commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`;
 
+console.log(`commit msg before doing anything: ${commitMessage}`);
+
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');
 currentBranch = String(currentBranch).replace(/\n/g, '');
 // currentBranch = "origin/release/3.8.x"
 
 commitMessage = String(commitMessage).replace(/\n/g, '');
+console.log(`commit msg after rm nl: ${commitMessage}`);
+
 const substring = " Changelogs";
 if (commitMessage.includes(substring)) {
   commitMessage = commitMessage.replace(substring, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -66,8 +66,9 @@ await $`mkdir ${incomingPath}`
 
 // find the latest release branch, and make that the target for the changelogs
 let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x" | tail -n1 | sed 's/  remotes\\///'`;
-let currentBranch = await $`git branch --show-current`;
 await `git checkout release/3.8.x`;
+let currentBranch = await $`git branch --show-current`;
+
 // the version in the commit message can be extracted from the latest commit with commit message starting with "X.X.X" (except X.X.X-dev.X)
 let commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+[^-]*$" -n 1 --pretty=format:%s`;
 

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -78,6 +78,7 @@ let commitMessage = versionMatch ? versionMatch[1] : null;
 targetBranch = String(targetBranch).replace(/\n/g, '');
 currentBranch = String(currentBranch).replace(/\n/g, '');
 currentBranch = "origin/release/3.8.x"
+
 commitMessage = String(commitMessage).replace(/\n/g, '');
 const substring = " Changelogs";
 if (commitMessage.includes(substring)) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ const tag = latestTag.stdout.trim();
 const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+" -n 1 --pretty=format:%s`
+const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`
 console.log(result.stdout.trim())
 
 // remove extra null and new line characters from git cmds

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -77,6 +77,7 @@ let commitMessage = versionMatch ? versionMatch[1] : null;
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');
 currentBranch = String(currentBranch).replace(/\n/g, '');
+currentBranch = "origin/release/3.8.x"
 commitMessage = String(commitMessage).replace(/\n/g, '');
 const substring = " Changelogs";
 if (commitMessage.includes(substring)) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ const tag = latestTag.stdout.trim();
 const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const commitOutput = await $`git log --grep='^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' --format='%H %s' | head -n 1`
+const commitOutput = await $`git log --grep='^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' --format='%H %s' | awk 'NR==1{print; exit}'`
 const commitInfo = commitOutput.stdout.trim()
 console.log(commitInfo)
 

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -93,7 +93,6 @@ if (targetBranch === `origin/${currentBranch}`) {
 } else {
   console.log(`The current branch is ${currentBranch}, so the target will be ${targetBranch} branch`)
 }
-
 // copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -71,7 +71,7 @@ let currentBranch = await $`git branch --show-current`;
 const latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
 const tag = latestTag.stdout.trim();
 const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
-const commitMessage = versionMatch ? versionMatch[1] : null;
+let commitMessage = versionMatch ? versionMatch[1] : null;
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,6 +74,10 @@ const tag = latestTag.stdout.trim();
 const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 let commitMessage = versionMatch ? versionMatch[1] : null;
 
+const commitOutput = await $`git log --grep='^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' --format='%H %s' | head -n 1`
+const commitInfo = commitOutput.stdout.trim()
+console.log(commitInfo)
+
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');
 currentBranch = String(currentBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -67,14 +67,11 @@ await $`mkdir ${incomingPath}`
 // find the latest release branch, and make that the target for the changelogs
 let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x" | tail -n1 | sed 's/  remotes\\///'`;
 let currentBranch = await $`git branch --show-current`;
-let commitMessage = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
-let latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
-let tag = latestTag.stdout.trim();
 
-const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/)
-const version = versionMatch ? versionMatch[1] : null
-
-console.log(version)
+const latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
+const tag = latestTag.stdout.trim();
+const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
+const commitMessage = versionMatch ? versionMatch[1] : null;
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ let currentBranch = await $`git branch --show-current`;
 // const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 // let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`;
+const result = await $`git log --grep="^[0-9]+\\.[0-9]+\\.[0-9]+($|\\s.*$)" -n 1 --pretty=format:%s`;
 let commitMessage = result.stdout.trim();
 
 // remove extra null and new line characters from git cmds

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,8 +74,7 @@ let currentBranch = await $`git branch --show-current`;
 // const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 // let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const result = await $`git log --grep="^[0-9]+\\.[0-9]+\\.[0-9]+($|\\s.*$)" -n 1 --pretty=format:%s`;
-let commitMessage = result.stdout.trim();
+const commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`;
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -94,8 +94,6 @@ if (targetBranch === `origin/${currentBranch}`) {
   console.log(`The current branch is ${currentBranch}, so the target will be ${targetBranch} branch`)
 }
 
-// //---------------------------------------------------------------------------
-
 // // copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
 // await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -68,6 +68,7 @@ await $`mkdir ${incomingPath}`
 let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x" | tail -n1 | sed 's/  remotes\\///'`;
 let currentBranch = await $`git branch --show-current`;
 
+// the version in the commit message can be extracted from the latest tag
 const latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
 const tag = latestTag.stdout.trim();
 const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -67,24 +67,14 @@ await $`mkdir ${incomingPath}`
 // find the latest release branch, and make that the target for the changelogs
 let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x" | tail -n1 | sed 's/  remotes\\///'`;
 let currentBranch = await $`git branch --show-current`;
-
-// the version in the commit message can be extracted from the latest tag
-// const latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
-// const tag = latestTag.stdout.trim();
-// const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
-// let commitMessage = versionMatch ? versionMatch[1] : null;
-
+await `git checkout origin/release/3.8.x`
+// the version in the commit message can be extracted from the latest commit with commit message starting with "X.X.X" (except X.X.X-dev.X)
 let commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+[^-]*$" -n 1 --pretty=format:%s`;
-
-console.log(`commit msg before doing anything: ${commitMessage}`);
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');
 currentBranch = String(currentBranch).replace(/\n/g, '');
-// currentBranch = "origin/release/3.8.x"
-
 commitMessage = String(commitMessage).replace(/\n/g, '');
-console.log(`commit msg after rm nl: ${commitMessage}`);
 
 const substring = " Changelogs";
 if (commitMessage.includes(substring)) {

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,9 +74,8 @@ const tag = latestTag.stdout.trim();
 const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const commitOutput = await $`git log --grep='^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' --format='%s'`
-const commitInfo = commitOutput.stdout.trim()
-console.log(commitInfo)
+const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+" -n 1 --pretty=format:%s`
+console.log(result.stdout.trim())
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ let currentBranch = await $`git branch --show-current`;
 // const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 // let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`;
+let commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`;
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ const tag = latestTag.stdout.trim();
 const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const commitOutput = await $`git log --grep='^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' --format='%H %s' | awk 'NR==1{print; exit}'`
+const commitOutput = await $`git log --grep='^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+' --format='%s'`
 const commitInfo = commitOutput.stdout.trim()
 console.log(commitInfo)
 

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ let currentBranch = await $`git branch --show-current`;
 // const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 // let commitMessage = versionMatch ? versionMatch[1] : null;
 
-let commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`;
+let commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+[^-]*$" -n 1 --pretty=format:%s`;
 
 console.log(`commit msg before doing anything: ${commitMessage}`);
 

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -93,64 +93,66 @@ if (targetBranch === `origin/${currentBranch}`) {
 } else {
   console.log(`The current branch is ${currentBranch}, so the target will be ${targetBranch} branch`)
 }
-// copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
-await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
-// before checking out to target branch
-// if it is a major or minor release, we need to update `gather-docs.yaml`'s branchName value to be the release branch
-if (commitMessage.endsWith(".0")) {
-  const docsYamlPath = "common/config/azure-pipelines/templates/gather-docs.yaml";
-  editFileInPlaceSynchronously(docsYamlPath, /release\/\d+\.\d+\.\w+/g, currentBranch);
-  // commit these changes to our release branch
-  await $`git add ${docsYamlPath}`;
-  await $`git commit -m "Update gather-docs.yaml's branch name to the release branch"`;
-  await $`git push origin HEAD:${currentBranch}`;
-}
 
-targetBranch = targetBranch.replace("origin/", "");
-await $`git checkout ${targetBranch}`;
-// copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
-await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
+// // copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
+// await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
-const allTargetFiles = fs.readdirSync(targetPath);
-const incomingFiles = fs.readdirSync(incomingPath);
-// Only include packages from Current branch if they DO exist in the Incoming branch, ie. new packages in later versions of itwinjs-core.
-const targetFiles = allTargetFiles.filter((file) => {
-  if (incomingFiles.includes(file)) {
-    return file;
-  }
-  else {
-    console.log(`${file} is not a package in ${currentBranch}. Skipping this package.`);
-  }
-})
+// // before checking out to target branch
+// // if it is a major or minor release, we need to update `gather-docs.yaml`'s branchName value to be the release branch
+// if (commitMessage.endsWith(".0")) {
+//   const docsYamlPath = "common/config/azure-pipelines/templates/gather-docs.yaml";
+//   editFileInPlaceSynchronously(docsYamlPath, /release\/\d+\.\d+\.\w+/g, currentBranch);
+//   // commit these changes to our release branch
+//   await $`git add ${docsYamlPath}`;
+//   await $`git commit -m "Update gather-docs.yaml's branch name to the release branch"`;
+//   await $`git push origin HEAD:${currentBranch}`;
+// }
 
-fixChangeLogs(targetFiles);
+// targetBranch = targetBranch.replace("origin/", "");
+// await $`git checkout ${targetBranch}`;
+// // copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
+// await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
-// copy changelogs back to proper file paths and convert names back to: CHANGELOG.json
-await $`find ./temp-target-changelogs/ -type f -name "*CHANGELOG.json" -exec sh -c 'cp "{}" "$(echo "{}" | sed "s|temp-target-changelogs/\\(.*\\)_|./\\1/|; s|_|/|g")"' \\;`;
-// delete temps
-await $`rm -r ${targetPath}`;
-await $`rm -r ${incomingPath}`;
-// after already checking out to target branch
-// copy {release-version}.md to target branch if the commit that triggered this script run is from a major or minor version bump
-if (commitMessage.endsWith(".0")) {
-  await $`git checkout ${currentBranch} docs/changehistory/${commitMessage}.md`
+// const allTargetFiles = fs.readdirSync(targetPath);
+// const incomingFiles = fs.readdirSync(incomingPath);
+// // Only include packages from Current branch if they DO exist in the Incoming branch, ie. new packages in later versions of itwinjs-core.
+// const targetFiles = allTargetFiles.filter((file) => {
+//   if (incomingFiles.includes(file)) {
+//     return file;
+//   }
+//   else {
+//     console.log(`${file} is not a package in ${currentBranch}. Skipping this package.`);
+//   }
+// })
 
-  // also need to add reference to this new md in leftNav.md
-  const leftNavMdPath = "docs/changehistory/leftNav.md";
-  editFileInPlaceSynchronously(leftNavMdPath, "### Versions\n", `### Versions\n\n- [${commitMessage}](./${commitMessage}.md)\n`);
-}
-// # regen CHANGELOG.md
-await $`rush publish --regenerate-changelogs`;
-/*********************************************************************
-* Uncomment For Manual runs and fix branch name to appropriate version
-* the version should match your incoming branch
-*********************************************************************/
-// await $`git checkout -b finalize-release-X.X.X`;
-// targetBranch = "finalize-release-X.X.X"
-await $`git add .`;
-await $`git commit -m "${commitMessage} Changelogs"`;
-await $`rush change --bulk --message "" --bump-type none`;
-await $`git add .`;
-await $`git commit --amend --no-edit`;
-await $`git push origin HEAD:${targetBranch}`;
+// fixChangeLogs(targetFiles);
+
+// // copy changelogs back to proper file paths and convert names back to: CHANGELOG.json
+// await $`find ./temp-target-changelogs/ -type f -name "*CHANGELOG.json" -exec sh -c 'cp "{}" "$(echo "{}" | sed "s|temp-target-changelogs/\\(.*\\)_|./\\1/|; s|_|/|g")"' \\;`;
+// // delete temps
+// await $`rm -r ${targetPath}`;
+// await $`rm -r ${incomingPath}`;
+// // after already checking out to target branch
+// // copy {release-version}.md to target branch if the commit that triggered this script run is from a major or minor version bump
+// if (commitMessage.endsWith(".0")) {
+//   await $`git checkout ${currentBranch} docs/changehistory/${commitMessage}.md`
+
+//   // also need to add reference to this new md in leftNav.md
+//   const leftNavMdPath = "docs/changehistory/leftNav.md";
+//   editFileInPlaceSynchronously(leftNavMdPath, "### Versions\n", `### Versions\n\n- [${commitMessage}](./${commitMessage}.md)\n`);
+// }
+// // # regen CHANGELOG.md
+// await $`rush publish --regenerate-changelogs`;
+// /*********************************************************************
+// * Uncomment For Manual runs and fix branch name to appropriate version
+// * the version should match your incoming branch
+// *********************************************************************/
+// // await $`git checkout -b finalize-release-X.X.X`;
+// // targetBranch = "finalize-release-X.X.X"
+// await $`git add .`;
+// await $`git commit -m "${commitMessage} Changelogs"`;
+// await $`rush change --bulk --message "" --bump-type none`;
+// await $`git add .`;
+// await $`git commit --amend --no-edit`;
+// await $`git push origin HEAD:${targetBranch}`;

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -74,7 +74,7 @@ let currentBranch = await $`git branch --show-current`;
 // const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
 // let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+" -n 1 --pretty=format:%s`;
+const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`;
 let commitMessage = result.stdout.trim();
 
 // remove extra null and new line characters from git cmds

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -67,7 +67,7 @@ await $`mkdir ${incomingPath}`
 // find the latest release branch, and make that the target for the changelogs
 let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x" | tail -n1 | sed 's/  remotes\\///'`;
 let currentBranch = await $`git branch --show-current`;
-let commitMessage = await $`git log --format=%B -n 1`;
+let commitMessage = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -69,18 +69,18 @@ let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x"
 let currentBranch = await $`git branch --show-current`;
 
 // the version in the commit message can be extracted from the latest tag
-const latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
-const tag = latestTag.stdout.trim();
-const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
-let commitMessage = versionMatch ? versionMatch[1] : null;
+// const latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
+// const tag = latestTag.stdout.trim();
+// const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/);
+// let commitMessage = versionMatch ? versionMatch[1] : null;
 
-const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\b[^-]*$" -n 1 --pretty=format:%s`
-console.log(result.stdout.trim())
+const result = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+" -n 1 --pretty=format:%s`;
+let commitMessage = result.stdout.trim();
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');
 currentBranch = String(currentBranch).replace(/\n/g, '');
-currentBranch = "origin/release/3.8.x"
+// currentBranch = "origin/release/3.8.x"
 
 commitMessage = String(commitMessage).replace(/\n/g, '');
 const substring = " Changelogs";

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -68,6 +68,13 @@ await $`mkdir ${incomingPath}`
 let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x" | tail -n1 | sed 's/  remotes\\///'`;
 let currentBranch = await $`git branch --show-current`;
 let commitMessage = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
+let latestTag = await $`git describe --tags $(git rev-list --tags --max-count=1)`;
+let tag = latestTag.stdout.trim();
+
+const versionMatch = tag.match(/release\/(\d+\.\d+\.\d+)/)
+const version = versionMatch ? versionMatch[1] : null
+
+console.log(version)
 
 // remove extra null and new line characters from git cmds
 targetBranch = String(targetBranch).replace(/\n/g, '');

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -88,64 +88,67 @@ if (targetBranch === `origin/${currentBranch}`) {
 } else {
   console.log(`The current branch is ${currentBranch}, so the target will be ${targetBranch} branch`)
 }
-// copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
-await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
-// before checking out to target branch
-// if it is a major or minor release, we need to update `gather-docs.yaml`'s branchName value to be the release branch
-if (commitMessage.endsWith(".0")) {
-  const docsYamlPath = "common/config/azure-pipelines/templates/gather-docs.yaml";
-  editFileInPlaceSynchronously(docsYamlPath, /release\/\d+\.\d+\.\w+/g, currentBranch);
-  // commit these changes to our release branch
-  await $`git add ${docsYamlPath}`;
-  await $`git commit -m "Update gather-docs.yaml's branch name to the release branch"`;
-  await $`git push origin HEAD:${currentBranch}`;
-}
+// //---------------------------------------------------------------------------
 
-targetBranch = targetBranch.replace("origin/", "");
-await $`git checkout ${targetBranch}`;
-// copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
-await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
+// // copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
+// await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
-const allTargetFiles = fs.readdirSync(targetPath);
-const incomingFiles = fs.readdirSync(incomingPath);
-// Only include packages from Current branch if they DO exist in the Incoming branch, ie. new packages in later versions of itwinjs-core.
-const targetFiles = allTargetFiles.filter((file) => {
-  if (incomingFiles.includes(file)) {
-    return file;
-  }
-  else {
-    console.log(`${file} is not a package in ${currentBranch}. Skipping this package.`);
-  }
-})
+// // before checking out to target branch
+// // if it is a major or minor release, we need to update `gather-docs.yaml`'s branchName value to be the release branch
+// if (commitMessage.endsWith(".0")) {
+//   const docsYamlPath = "common/config/azure-pipelines/templates/gather-docs.yaml";
+//   editFileInPlaceSynchronously(docsYamlPath, /release\/\d+\.\d+\.\w+/g, currentBranch);
+//   // commit these changes to our release branch
+//   await $`git add ${docsYamlPath}`;
+//   await $`git commit -m "Update gather-docs.yaml's branch name to the release branch"`;
+//   await $`git push origin HEAD:${currentBranch}`;
+// }
 
-fixChangeLogs(targetFiles);
+// targetBranch = targetBranch.replace("origin/", "");
+// await $`git checkout ${targetBranch}`;
+// // copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json
+// await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-target-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
-// copy changelogs back to proper file paths and convert names back to: CHANGELOG.json
-await $`find ./temp-target-changelogs/ -type f -name "*CHANGELOG.json" -exec sh -c 'cp "{}" "$(echo "{}" | sed "s|temp-target-changelogs/\\(.*\\)_|./\\1/|; s|_|/|g")"' \\;`;
-// delete temps
-await $`rm -r ${targetPath}`;
-await $`rm -r ${incomingPath}`;
-// after already checking out to target branch
-// copy {release-version}.md to target branch if the commit that triggered this script run is from a major or minor version bump
-if (commitMessage.endsWith(".0")) {
-  await $`git checkout ${currentBranch} docs/changehistory/${commitMessage}.md`
+// const allTargetFiles = fs.readdirSync(targetPath);
+// const incomingFiles = fs.readdirSync(incomingPath);
+// // Only include packages from Current branch if they DO exist in the Incoming branch, ie. new packages in later versions of itwinjs-core.
+// const targetFiles = allTargetFiles.filter((file) => {
+//   if (incomingFiles.includes(file)) {
+//     return file;
+//   }
+//   else {
+//     console.log(`${file} is not a package in ${currentBranch}. Skipping this package.`);
+//   }
+// })
 
-  // also need to add reference to this new md in leftNav.md
-  const leftNavMdPath = "docs/changehistory/leftNav.md";
-  editFileInPlaceSynchronously(leftNavMdPath, "### Versions\n", `### Versions\n\n- [${commitMessage}](./${commitMessage}.md)\n`);
-}
-// # regen CHANGELOG.md
-await $`rush publish --regenerate-changelogs`;
-/*********************************************************************
-* Uncomment For Manual runs and fix branch name to appropriate version
-* the version should match your incoming branch
-*********************************************************************/
-// await $`git checkout -b finalize-release-X.X.X`;
-// targetBranch = "finalize-release-X.X.X"
-await $`git add .`;
-await $`git commit -m "${commitMessage} Changelogs"`;
-await $`rush change --bulk --message "" --bump-type none`;
-await $`git add .`;
-await $`git commit --amend --no-edit`;
-await $`git push origin HEAD:${targetBranch}`;
+// fixChangeLogs(targetFiles);
+
+// // copy changelogs back to proper file paths and convert names back to: CHANGELOG.json
+// await $`find ./temp-target-changelogs/ -type f -name "*CHANGELOG.json" -exec sh -c 'cp "{}" "$(echo "{}" | sed "s|temp-target-changelogs/\\(.*\\)_|./\\1/|; s|_|/|g")"' \\;`;
+// // delete temps
+// await $`rm -r ${targetPath}`;
+// await $`rm -r ${incomingPath}`;
+// // after already checking out to target branch
+// // copy {release-version}.md to target branch if the commit that triggered this script run is from a major or minor version bump
+// if (commitMessage.endsWith(".0")) {
+//   await $`git checkout ${currentBranch} docs/changehistory/${commitMessage}.md`
+
+//   // also need to add reference to this new md in leftNav.md
+//   const leftNavMdPath = "docs/changehistory/leftNav.md";
+//   editFileInPlaceSynchronously(leftNavMdPath, "### Versions\n", `### Versions\n\n- [${commitMessage}](./${commitMessage}.md)\n`);
+// }
+// // # regen CHANGELOG.md
+// await $`rush publish --regenerate-changelogs`;
+// /*********************************************************************
+// * Uncomment For Manual runs and fix branch name to appropriate version
+// * the version should match your incoming branch
+// *********************************************************************/
+// // await $`git checkout -b finalize-release-X.X.X`;
+// // targetBranch = "finalize-release-X.X.X"
+// await $`git add .`;
+// await $`git commit -m "${commitMessage} Changelogs"`;
+// await $`rush change --bulk --message "" --bump-type none`;
+// await $`git add .`;
+// await $`git commit --amend --no-edit`;
+// await $`git push origin HEAD:${targetBranch}`;

--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -67,7 +67,7 @@ await $`mkdir ${incomingPath}`
 // find the latest release branch, and make that the target for the changelogs
 let targetBranch = await $`git branch -a --list "origin/release/[0-9]*.[0-9]*.x" | tail -n1 | sed 's/  remotes\\///'`;
 let currentBranch = await $`git branch --show-current`;
-await `git checkout origin/release/3.8.x`
+await `git checkout release/3.8.x`;
 // the version in the commit message can be extracted from the latest commit with commit message starting with "X.X.X" (except X.X.X-dev.X)
 let commitMessage = await $`git log --grep="^[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+[^-]*$" -n 1 --pretty=format:%s`;
 

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - 'release/*'
+    - 'mikeN/fin-release-commit'
     paths:
     - '**/CHANGELOG.md'
 

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
-          ref: ${{ github.ref }} # checkouts the branch that triggered the workflow
+          ref: release/3.8.x # checkouts the branch that triggered the workflow
           fetch-depth: 0
       - name: Set Git Config
         run: |

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - 'release/*'
-    paths:
-    - '**/CHANGELOG.md'
+    - 'mikeN/fin-release-commit'
+    # paths:
+    # - '**/CHANGELOG.md'
 
 jobs:
   finalize:

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - 'mikeN/fin-release-commit'
+    - 'release/*'
     paths:
     - '**/CHANGELOG.md'
 

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -10,8 +10,8 @@ on:
   push:
     branches:
     - 'mikeN/fin-release-commit'
-    paths:
-    - '**/CHANGELOG.md'
+    # paths:
+    # - '**/CHANGELOG.md'
 
 jobs:
   finalize:

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -10,8 +10,8 @@ on:
   push:
     branches:
     - 'mikeN/fin-release-commit'
-    # paths:
-    # - '**/CHANGELOG.md'
+    paths:
+    - '**/CHANGELOG.md'
 
 jobs:
   finalize:

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
 
-THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #6
+THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #8
 
 ## 4.7.2
 Sat, 22 Jun 2024 01:09:54 GMT

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
 
-THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #3
+THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #5
 
 ## 4.7.2
 Sat, 22 Jun 2024 01:09:54 GMT

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -233,7 +233,7 @@ Tue, 17 Oct 2023 15:14:32 GMT
 - Use instance query to get aspects for abstract classes
 - ViewStore.ViewDb.getViewGroups select statement was referring to ParentId when parent was meant
 - Remove `storageType` from `BlobContainer.RequestTokenProps`.
-- Add 'provider' to 'BlobContainer.CreatedContainerProps'
+- Add 'provider' to 'BlobContainer.CreatedContainerProps' 
 - add TileStorage.getCachedTilesGenerator
 
 ## 4.1.9
@@ -285,7 +285,7 @@ Fri, 18 Aug 2023 13:02:53 GMT
 
 ### Updates
 
-- add `internal` `codeValueBehavior` API
+- add `internal` `codeValueBehavior` API 
 
 ## 4.1.0
 Mon, 14 Aug 2023 14:36:34 GMT
@@ -1012,7 +1012,7 @@ Mon, 26 Jul 2021 12:21:25 GMT
 
 - Reactivated test that stopped working when a previous PR for ecef dependency to geographicCRS was reverted
 - store changesetIndex on IModelDb
-- Better error checks when creating SpatialViewDefinition-s.
+- Better error checks when creating SpatialViewDefinition-s. 
 - remove internal barrel-import usage
 - throw exception when attempting to download a briefcase on top of an existing file
 - Add case for InterpolationCurve3d
@@ -1047,11 +1047,11 @@ Fri, 09 Jul 2021 18:11:24 GMT
 ### Updates
 
 - TemplateModelCloner now assigns a new FederationGuid for cloned element instances.
-- Accomodated the inability to reverse Changesets when creating change summaries.
+- Accomodated the inability to reverse Changesets when creating change summaries. 
 - fix lint issue
 - begin api transition to changeset index rather than changeset Id
 - Use ecef location calculated for projected iModels
-- Push refreshes access token if necessary.
+- Push refreshes access token if necessary. 
 - Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)
 - Add missing SectionDrawing properties.
 
@@ -1072,7 +1072,7 @@ Fri, 02 Jul 2021 15:38:31 GMT
 
 ### Updates
 
-- Update to @bentley/imodeljs-native@2.17.10
+- Update to @bentley/imodeljs-native@2.17.10 
 
 ## 2.17.0
 Mon, 28 Jun 2021 16:20:11 GMT
@@ -1338,8 +1338,8 @@ Thu, 28 Jan 2021 13:39:27 GMT
 
 - Changed storageType from azure to azure?sas=1 for getCommandArgs function
 - Fix brep DataProps to/from flatbuffer to account for base64 string header.
-- Element geometry creation by brep operations.
-- Reinstated behavior when re-opening files read-write.
+- Element geometry creation by brep operations. 
+- Reinstated behavior when re-opening files read-write. 
 - enhance BriefcaseManager and BriefcaseDb for edit commands
 - Improve ElementGeometry documentation.
 - Add a check to verify, and fix, the DbGuid in the iModel if it is different than the Guid in iModelHub.
@@ -1529,8 +1529,8 @@ Fri, 02 Oct 2020 18:03:32 GMT
 ### Updates
 
 - Update to @bentley/imodeljs-native@2.7.4
-- Fixes to front end methods to pull, merge and push.
-- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications.
+- Fixes to front end methods to pull, merge and push. 
+- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications. 
 - On iOS download in background
 - Fix ios hang issue
 - Modify queryModelRanges to handle non geometric model errors
@@ -1621,7 +1621,7 @@ Thu, 20 Aug 2020 20:57:09 GMT
 ### Updates
 
 - Update to imodeljs-native 2.5.0
-- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases.
+- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases. 
 - Fix for a recursive exception while closing a briefcase
 - Added mobile oidc client
 - Remove special code handling for mobile.
@@ -1685,7 +1685,7 @@ Fri, 10 Jul 2020 17:23:14 GMT
 - Changes to support imodel-bridge
 - fix spelling mistakes in Device class
 - Fix typo in comments
-- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades.
+- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades. 
 - disallow protected operations for missing schemas marked with SchemaHasBehavior custom attribute
 
 ## 2.2.1
@@ -1726,25 +1726,25 @@ Thu, 28 May 2020 22:48:59 GMT
 - Update to imodeljs-native 2.1.0
 - Support for finding an ExternalSourceAspect given scope, id, and kind/hash.
 - ApplyChangeset perf tests updated
-- Fixed token expiry check for desktop authorization.
+- Fixed token expiry check for desktop authorization. 
 - Download ChangeSets in chunks
 - (1) In xy region booleans, support curved edges; (2) ExportGraphicsMeshVisitor class
 - Add ability to convert ExportGraphicsMesh to Polyface
 - Fixed validation of Guids (ContextId, IModelId) cached within a briefcase.
 - Moved iModelBridgeFwk to a separate package
-- Simplified logging for monitoring briefcase operations.
+- Simplified logging for monitoring briefcase operations. 
 - Fix transforms for creating and querying part instance geometry in world coordinate.
 - Fix and improvement to performance tests
 - Added support for schema XML import to iModelJs backend via the IModelDb.importSchemaStrings method.
 - channel rules
-- Fixed logging usage when opening connections.
+- Fixed logging usage when opening connections. 
 
 ## 2.0.0
 Wed, 06 May 2020 13:17:49 GMT
 
 ### Updates
 
-- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API.
+- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API. 
 - Added RivisionUtility class for debug/testing
 - node addon 2.0.18
 - addon 2.0.25
@@ -1757,23 +1757,23 @@ Wed, 06 May 2020 13:17:49 GMT
 - Performance tests for Applying Changesets
 - `IModelHost.startup` is now async.
 - `IModelHost.shutdown` is now async.
-- Refined checks for briefcase id, and fixed failing integration tests.
+- Refined checks for briefcase id, and fixed failing integration tests. 
 - Product Backlog Item 276268: Deleting the briefcase cache if the cache version is incorrect should not attempt to delete the root directory.
 - Setup initialization of briefcase cache for offline workflows. (VSTS#286489)
-- Monitor progress of downloading briefcases, ability to cancel download of briefcases.
+- Monitor progress of downloading briefcases, ability to cancel download of briefcases. 
 - Move briefcase-specific events into BriefcaseIModelDb subclass
 - Fixed param when calling logger so that it is a function as the logger expects
-- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder.
+- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder. 
 - Changed ChangeSets download API
 - Added unlink for file handler
 - Update UlasClient tests to send more detailed feature log data
 - react to renaming of imodeljs-clients-backend to backend-itwin-client
 - apply changeset performance tests with local datasets
-- BriefcaseManager.delete should work in offline scenarios.
+- BriefcaseManager.delete should work in offline scenarios. 
 - Remove deprecated members of SectionLocation and downgrade to alpha pending refactor.
 - Support for progress/cancel from ios
 - Remove deprecated ExportGraphics types etc for 2.0
-- Updated docs.
+- Updated docs. 
 - IModelDb.findByKey replaces IModelDb.find
 - Include model extents with ViewStateProps for drawing views.
 - Remove deprecated APIs; see NextVersion.md for details.
@@ -1794,29 +1794,29 @@ Wed, 06 May 2020 13:17:49 GMT
 - Introduce the BriefcaseIModelDb class, make IModelDb abstract.
 - Cleaned up unused async-s in BriefcaseManager
 - Avoided casting of BriefcaseProps to IModelRpcProps.
-- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline.
+- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline. 
 - Move briefcase property from IModelDb --> BriefcaseIModelDb
 - BriefcaseId is now an enum instead of a class
 - Rename BriefcaseId --> ReservedBriefcaseId, introduce BriefcaseId type
-- VSTS#297017: Update cached briefcase information if changes were applied.
-- Refactored NativeApp API and RPC interfaces. This continues to be WIP.
-- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb.
-- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase.
+- VSTS#297017: Update cached briefcase information if changes were applied. 
+- Refactored NativeApp API and RPC interfaces. This continues to be WIP. 
+- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb. 
+- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase. 
 - Removed BriefcaseDb.create
-- Setup ability to use NativeApp.openBriefcase() in offline scenarios.
+- Setup ability to use NativeApp.openBriefcase() in offline scenarios. 
 - fixed flaky test
-- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP).
+- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP). 
 - do not throw exception in NativeAppBackend.startup()
-- VSTS#296110: Setup a way to close briefcases when the native application is offline.
+- VSTS#296110: Setup a way to close briefcases when the native application is offline. 
 - Move concurrencyControl from IModelDb to BriefcaseIModelDb
 - Renamed OIDC constructs for consistency; Removed SAML support.
 - Add support for password-protecting snapshot iModels
 - Fixed typo for ElementAspect perf tests
-- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly.
+- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly. 
 - Add purge dir method to iModelJsFs
 - react to creation of new clients packages from imodeljs-clients
 - ; substitute current date for feature usage without any set start/end dates
-- Removed deprecated utilities.
+- Removed deprecated utilities. 
 - enforce opening Snapshots readonly through StandaloneDb
 - Remove the deprecated Entity.clone method
 - Adjusted calls to some node addon changes (ECUtils removed)
@@ -1828,13 +1828,13 @@ Wed, 06 May 2020 13:17:49 GMT
 - Add FileNameResolver class
 - Move snapshot methods out of IModelDb and into new SnapshotIModelDb class.
 - Add TemplateModelCloner to place instances of a template model
-- Renamed TestOidcClient and related constructs for consistency.
+- Renamed TestOidcClient and related constructs for consistency. 
 - Add IModelDb.tryPrepareStatement
-- Fixed usage logging.
+- Fixed usage logging. 
 - fix failing ulas tests due to invalid featureId
 - update ULAS test logging & feedback
 - Update UlasUtilities to support exception-throwing native functions
-- Use standalone briefcases for PullOnly cases.
+- Use standalone briefcases for PullOnly cases. 
 
 ## 1.14.1
 Wed, 22 Apr 2020 19:04:00 GMT
@@ -1849,7 +1849,7 @@ Tue, 31 Mar 2020 15:44:19 GMT
 ### Updates
 
 - Update to addon 1.14.1
-- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted.
+- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted. 
 - Add handling for invalid predecessor ids to IModelTransformer
 - Accomodate updated imodeljs-native ULAS functions
 
@@ -1864,7 +1864,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 ### Updates
 
 - Fix IGeometry roundtripping issue through ECSql.  Fix insert/update binary properties for Element Aspect.
-- Separated out routines to download and open briefcases.
+- Separated out routines to download and open briefcases. 
 - bulk mode
 - Consolidated sign-in for integration tests
 - bulkmode
@@ -1875,7 +1875,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 - Add ViewDefinition.getAuxiliaryCoordinateSystemId and ViewDefinition.setAuxiliaryCoordinateSystemId methods
 - Add SpatialLocationModel.insert
 - Add optional isPlantProjection parameter to PhysicalModel.insert
-- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests.
+- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests. 
 - Better documentation of OidcDesktopClient
 - Fixed changeset perf test by using another iModel on Hub
 - Add ViewDetails to ViewDefinition.
@@ -1908,7 +1908,7 @@ Tue, 07 Jan 2020 19:44:01 GMT
 - Allow events to be sent from backend to frontend
 - Add tryGetInstance / tryGetInstanceProps methods to the Relationship class which return undefined rather than throwing an exception when a relationship is not found.
 - Fix webpack for ios test that were failing due to new dependencies
-- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors.
+- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors. 
 - Add tryGetElement / tryGetElementProps which return undefined rather than throwing an exception when an element is not found.
 - Add tryGetModel, tryGetModelProps, tryGetSubModel which return undefined instead of throwing exceptions when the model is not found.
 
@@ -1920,7 +1920,7 @@ Tue, 10 Dec 2019 18:08:56 GMT
 - Updated to addon 9.1.3
 - Added AliCloud tile cache service
 - Added framework to run imodeljs-backend test on ios using appcenter
-- Setup OidcDesktopClient for Electron use cases.
+- Setup OidcDesktopClient for Electron use cases. 
 - fix warnings from static analysis
 - Enabling testing code for updating LR aspects after fix in native side.
 - Addressing typo in a couple of members, making them match the schema properly.
@@ -1976,9 +1976,9 @@ Mon, 30 Sep 2019 22:28:48 GMT
 ### Updates
 
 - added support for blank IModelConnections
-- Setup a way to supply authorization through the backend for frontend requests.
-- Error log when downloading change sets should include iModelId for context.
-- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub.
+- Setup a way to supply authorization through the backend for frontend requests. 
+- Error log when downloading change sets should include iModelId for context. 
+- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub. 
 - Add IModelDb.Elements.hasSubModel
 - Make ExternalSourceAspect.checksum optional
 - Clear statement cache after schema import
@@ -1993,14 +1993,14 @@ Tue, 10 Sep 2019 12:09:49 GMT
 
 ### Updates
 
-- Setup a way to supply authorization through the backend for frontend requests.
-- Allow attaching change cache file before change summary extraction.
-- Added change summary test, and improved doc a little.
+- Setup a way to supply authorization through the backend for frontend requests. 
+- Allow attaching change cache file before change summary extraction. 
+- Added change summary test, and improved doc a little. 
 - Add minimum brep size option to IModelDb.exportGraphics
 - FunctionalSchema.importSchema is now deprecated.
 - Add support for GeometricModel.geometryGuid for detecting whether tiles for a model can be reused across versions
 - Added performance logging for tile upload
-- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase.
+- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase. 
 - Add method to create view with camera
 - Fixed misleading logging output in tile upload
 
@@ -2010,14 +2010,14 @@ Tue, 13 Aug 2019 20:25:53 GMT
 ### Updates
 
 - Allow custom tile cache services.
-- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows.
-- Added Change Summary integration test, and fixed documentation.
+- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows. 
+- Added Change Summary integration test, and fixed documentation. 
 - Trial code for tile upload errors
 - Fixed changeset performance tests
 - Tile upload logging.
 - Mark ExportGraphics API as public
 - Support for gzip compression of tiles
-- Fixed issue with opening iModels with names that are invalid on Unix or Windows.
+- Fixed issue with opening iModels with names that are invalid on Unix or Windows. 
 - Add IModelDb.isSnapshot
 - Tile upload error catching.
 - Azure tile upload logging
@@ -2029,7 +2029,7 @@ Wed, 24 Jul 2019 11:47:26 GMT
 ### Updates
 
 - Added option to restrict tile cache URLs by client IP address.
-- Apply change sets at the backend in a non-blocking worker thread.
+- Apply change sets at the backend in a non-blocking worker thread. 
 - Add ElementAspect handler methods
 - When deleting a parent element, make sure there are onDelete/onDeleted callbacks for child elements
 - Add support for linework to IModelDb.exportGraphics
@@ -2047,19 +2047,19 @@ Mon, 01 Jul 2019 19:04:29 GMT
 
 ### Updates
 
-- Open fixes when briefcase requires merges.
+- Open fixes when briefcase requires merges. 
 - Catch tile upload errors.
-- Setting up briefcase is always from an older checkpoint.
+- Setting up briefcase is always from an older checkpoint. 
 - Add materialId, subCategory to ExportGraphicsInfo
-- Fix crash in getViewThumbnail for odd number of bytes
+- Fix crash in getViewThumbnail for odd number of bytes 
 - Adding relationship class for GraphicalElement3dRepresentsElement.
 - Initial implementation of the LinearReferencing typescript domain
 - Adding domain classes for all relatinships in the LinearReferencing schema.
 - Exporting relationships module.
-- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s.
-- Fixed issues with deleting briefcases if there were errors with preparing briefcases.
+- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s. 
+- Fixed issues with deleting briefcases if there were errors with preparing briefcases. 
 - Add a new method `forceLoadSchemas` to `IModelJsNative.ECPresentationManager`.
-- Introduced AsyncMutex - a utility to run async blocks of code in sequence.
+- Introduced AsyncMutex - a utility to run async blocks of code in sequence. 
 - Properly document ModelSelector.models and CategorySelector.categories as Id64String arrays
 - Made `insertElement` not return Id64.invalid, throws error instead
 - Update to TypeScript 3.5
@@ -2070,7 +2070,7 @@ Mon, 03 Jun 2019 18:09:39 GMT
 
 ### Updates
 
-- Migrated agent applications to the newer client
+- Migrated agent applications to the newer client 
 - RPC system now accepts only basic values (primitives, "interface" objects, and binary).
 - Switched from iModelHub Project API to Context API
 - Fix bug in IModelDb.createSnapshotFromSeed
@@ -2118,12 +2118,12 @@ Mon, 13 May 2019 15:52:05 GMT
 - Cleanup old imodelbank references
 - Add InformationRecordModel.insert, GroupModel.insert
 - Introduce LoggerCategory enum to advertise logger categories used by this package.
-- Limited maximum cache size of the backend PromiseMemoizer.
+- Limited maximum cache size of the backend PromiseMemoizer. 
 - Missing dependency on node-report
-- Fixed memoization problem that caused an endless stream of 404 NotFound errors.
+- Fixed memoization problem that caused an endless stream of 404 NotFound errors. 
 - Reinstated old version of OidcAgentClient
-- Unauthorized open requests should cause a more obvious error.
-- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop.
+- Unauthorized open requests should cause a more obvious error. 
+- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop. 
 - Memoization fix when opening iModels in shared, read-only mode .
 - Fixed setup of application version.
 - Updated Element CRUD perf tests
@@ -2133,7 +2133,7 @@ Mon, 13 May 2019 15:52:05 GMT
 - Remove ElementPropertyFormatter, IModelDb.getElementPropertiesForDisplay (use presentation rules instead)
 - Remove StandaloneIModelRpcImpl
 - Fix for Render Gradient.Symb test
-- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization.
+- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization. 
 - Add IModelDb.createSnapshot/openSnapshot/closeSnapshot, deprecate IModelDb.createStandalone/openStandalone/closeStandalone
 - Moved IModelJsExpressServer class into a new package (@itwin/express-server).
 - Simplified tile caching IModelHost config and removed dev flags. Allow
@@ -2160,7 +2160,7 @@ Wed, 06 Mar 2019 15:41:22 GMT
 - Changes package.json to include api-extractor and adds api-extractor.json
 - Use new buildIModelJsBuild script
 - AxisAlignedBox and ElementAlignedBox are now typed to Range3d rather than classes
-- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package.
+- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package. 
 - Clone methods are no longer generic
 - Remove unneeded typedoc plugin dependency
 - Added spatial <-> cartographic methods that check/use the geographic coordinate system before using ecef location.
@@ -2205,8 +2205,8 @@ Mon, 14 Jan 2019 23:09:10 GMT
 
 ### Updates
 
-- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics.
-- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current.
+- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics. 
+- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current. 
 - Renamed RequestProxy->RequestHost. Allowed applications to configure proxy server with HTTPS_PROXY env.
 - Add backend TextureAPI and accompanying test
 
@@ -2311,7 +2311,7 @@ Mon, 03 Dec 2018 18:52:58 GMT
 
 ### Updates
 
-- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application.
+- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application. 
 - Add ElementRefersToElements.insert
 - Fixed front end integration tests.
 - Document the intended purpose of IModelJsExpressServer within a deployment environment.
@@ -2380,11 +2380,11 @@ Thu, 08 Nov 2018 17:59:20 GMT
 
 - Fix JSON representation of DisplayStyle.
 - Add IModelImporter as a base class for utility methods needed by all importers
-- Removed assertion when deleting a memoized open call.
+- Removed assertion when deleting a memoized open call. 
 - Add more methods to IModelImporter
 - Fix snapping test
 - OIDC related enhancments (WIP).
-- Re-enabled several backend integration tests.
+- Re-enabled several backend integration tests. 
 - Refactor analysis-importer to use IModelImporter
 - Updated to TypeScript 3.1
 

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
 
-THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #5
+THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #6
 
 ## 4.7.2
 Sat, 22 Jun 2024 01:09:54 GMT

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -233,7 +233,7 @@ Tue, 17 Oct 2023 15:14:32 GMT
 - Use instance query to get aspects for abstract classes
 - ViewStore.ViewDb.getViewGroups select statement was referring to ParentId when parent was meant
 - Remove `storageType` from `BlobContainer.RequestTokenProps`.
-- Add 'provider' to 'BlobContainer.CreatedContainerProps' 
+- Add 'provider' to 'BlobContainer.CreatedContainerProps'
 - add TileStorage.getCachedTilesGenerator
 
 ## 4.1.9
@@ -1012,7 +1012,7 @@ Mon, 26 Jul 2021 12:21:25 GMT
 
 - Reactivated test that stopped working when a previous PR for ecef dependency to geographicCRS was reverted
 - store changesetIndex on IModelDb
-- Better error checks when creating SpatialViewDefinition-s.
+- Better error checks when creating SpatialViewDefinition-s. 
 - remove internal barrel-import usage
 - throw exception when attempting to download a briefcase on top of an existing file
 - Add case for InterpolationCurve3d

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Change Log - @itwin/core-backend
 
-This log was last generated on Sat, 08 Jun 2024 00:53:21 GMT and should not be manually modified.
+This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
+
+## 4.7.2
+Sat, 22 Jun 2024 01:09:54 GMT
+
+### Updates
+
+- Update changed elements process options for bounding box calculations
+- BriefcaseDb.closeAndReopen now refreshes the changeset property in case another process pulled changes
+
+## 4.7.1
+Thu, 13 Jun 2024 22:47:31 GMT
+
+_Version update only_
+
+## 4.7.0
+Wed, 12 Jun 2024 18:02:16 GMT
+
+### Updates
+
+- schemaUpgrade() now push change to schema sync
+- Remove @alpha BackendLoggerCategory.Editing
+- Added getAvailableCoordinateReferenceSystems.
+- Brotli compression enabled for RPC requests.
+- Increase restrictions on native app storage name.
+- Added computeTextBlockExtents
 
 ## 4.6.2
 Sat, 08 Jun 2024 00:50:25 GMT
@@ -208,7 +233,7 @@ Tue, 17 Oct 2023 15:14:32 GMT
 - Use instance query to get aspects for abstract classes
 - ViewStore.ViewDb.getViewGroups select statement was referring to ParentId when parent was meant
 - Remove `storageType` from `BlobContainer.RequestTokenProps`.
-- Add 'provider' to 'BlobContainer.CreatedContainerProps' 
+- Add 'provider' to 'BlobContainer.CreatedContainerProps'
 - add TileStorage.getCachedTilesGenerator
 
 ## 4.1.9
@@ -260,7 +285,7 @@ Fri, 18 Aug 2023 13:02:53 GMT
 
 ### Updates
 
-- add `internal` `codeValueBehavior` API 
+- add `internal` `codeValueBehavior` API
 
 ## 4.1.0
 Mon, 14 Aug 2023 14:36:34 GMT
@@ -987,7 +1012,7 @@ Mon, 26 Jul 2021 12:21:25 GMT
 
 - Reactivated test that stopped working when a previous PR for ecef dependency to geographicCRS was reverted
 - store changesetIndex on IModelDb
-- Better error checks when creating SpatialViewDefinition-s. 
+- Better error checks when creating SpatialViewDefinition-s.
 - remove internal barrel-import usage
 - throw exception when attempting to download a briefcase on top of an existing file
 - Add case for InterpolationCurve3d
@@ -1022,11 +1047,11 @@ Fri, 09 Jul 2021 18:11:24 GMT
 ### Updates
 
 - TemplateModelCloner now assigns a new FederationGuid for cloned element instances.
-- Accomodated the inability to reverse Changesets when creating change summaries. 
+- Accomodated the inability to reverse Changesets when creating change summaries.
 - fix lint issue
 - begin api transition to changeset index rather than changeset Id
 - Use ecef location calculated for projected iModels
-- Push refreshes access token if necessary. 
+- Push refreshes access token if necessary.
 - Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)
 - Add missing SectionDrawing properties.
 
@@ -1047,7 +1072,7 @@ Fri, 02 Jul 2021 15:38:31 GMT
 
 ### Updates
 
-- Update to @bentley/imodeljs-native@2.17.10 
+- Update to @bentley/imodeljs-native@2.17.10
 
 ## 2.17.0
 Mon, 28 Jun 2021 16:20:11 GMT
@@ -1313,8 +1338,8 @@ Thu, 28 Jan 2021 13:39:27 GMT
 
 - Changed storageType from azure to azure?sas=1 for getCommandArgs function
 - Fix brep DataProps to/from flatbuffer to account for base64 string header.
-- Element geometry creation by brep operations. 
-- Reinstated behavior when re-opening files read-write. 
+- Element geometry creation by brep operations.
+- Reinstated behavior when re-opening files read-write.
 - enhance BriefcaseManager and BriefcaseDb for edit commands
 - Improve ElementGeometry documentation.
 - Add a check to verify, and fix, the DbGuid in the iModel if it is different than the Guid in iModelHub.
@@ -1504,8 +1529,8 @@ Fri, 02 Oct 2020 18:03:32 GMT
 ### Updates
 
 - Update to @bentley/imodeljs-native@2.7.4
-- Fixes to front end methods to pull, merge and push. 
-- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications. 
+- Fixes to front end methods to pull, merge and push.
+- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications.
 - On iOS download in background
 - Fix ios hang issue
 - Modify queryModelRanges to handle non geometric model errors
@@ -1596,7 +1621,7 @@ Thu, 20 Aug 2020 20:57:09 GMT
 ### Updates
 
 - Update to imodeljs-native 2.5.0
-- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases. 
+- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases.
 - Fix for a recursive exception while closing a briefcase
 - Added mobile oidc client
 - Remove special code handling for mobile.
@@ -1660,7 +1685,7 @@ Fri, 10 Jul 2020 17:23:14 GMT
 - Changes to support imodel-bridge
 - fix spelling mistakes in Device class
 - Fix typo in comments
-- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades. 
+- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades.
 - disallow protected operations for missing schemas marked with SchemaHasBehavior custom attribute
 
 ## 2.2.1
@@ -1701,25 +1726,25 @@ Thu, 28 May 2020 22:48:59 GMT
 - Update to imodeljs-native 2.1.0
 - Support for finding an ExternalSourceAspect given scope, id, and kind/hash.
 - ApplyChangeset perf tests updated
-- Fixed token expiry check for desktop authorization. 
+- Fixed token expiry check for desktop authorization.
 - Download ChangeSets in chunks
 - (1) In xy region booleans, support curved edges; (2) ExportGraphicsMeshVisitor class
 - Add ability to convert ExportGraphicsMesh to Polyface
 - Fixed validation of Guids (ContextId, IModelId) cached within a briefcase.
 - Moved iModelBridgeFwk to a separate package
-- Simplified logging for monitoring briefcase operations. 
+- Simplified logging for monitoring briefcase operations.
 - Fix transforms for creating and querying part instance geometry in world coordinate.
 - Fix and improvement to performance tests
 - Added support for schema XML import to iModelJs backend via the IModelDb.importSchemaStrings method.
 - channel rules
-- Fixed logging usage when opening connections. 
+- Fixed logging usage when opening connections.
 
 ## 2.0.0
 Wed, 06 May 2020 13:17:49 GMT
 
 ### Updates
 
-- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API. 
+- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API.
 - Added RivisionUtility class for debug/testing
 - node addon 2.0.18
 - addon 2.0.25
@@ -1732,23 +1757,23 @@ Wed, 06 May 2020 13:17:49 GMT
 - Performance tests for Applying Changesets
 - `IModelHost.startup` is now async.
 - `IModelHost.shutdown` is now async.
-- Refined checks for briefcase id, and fixed failing integration tests. 
+- Refined checks for briefcase id, and fixed failing integration tests.
 - Product Backlog Item 276268: Deleting the briefcase cache if the cache version is incorrect should not attempt to delete the root directory.
 - Setup initialization of briefcase cache for offline workflows. (VSTS#286489)
-- Monitor progress of downloading briefcases, ability to cancel download of briefcases. 
+- Monitor progress of downloading briefcases, ability to cancel download of briefcases.
 - Move briefcase-specific events into BriefcaseIModelDb subclass
 - Fixed param when calling logger so that it is a function as the logger expects
-- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder. 
+- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder.
 - Changed ChangeSets download API
 - Added unlink for file handler
 - Update UlasClient tests to send more detailed feature log data
 - react to renaming of imodeljs-clients-backend to backend-itwin-client
 - apply changeset performance tests with local datasets
-- BriefcaseManager.delete should work in offline scenarios. 
+- BriefcaseManager.delete should work in offline scenarios.
 - Remove deprecated members of SectionLocation and downgrade to alpha pending refactor.
 - Support for progress/cancel from ios
 - Remove deprecated ExportGraphics types etc for 2.0
-- Updated docs. 
+- Updated docs.
 - IModelDb.findByKey replaces IModelDb.find
 - Include model extents with ViewStateProps for drawing views.
 - Remove deprecated APIs; see NextVersion.md for details.
@@ -1769,29 +1794,29 @@ Wed, 06 May 2020 13:17:49 GMT
 - Introduce the BriefcaseIModelDb class, make IModelDb abstract.
 - Cleaned up unused async-s in BriefcaseManager
 - Avoided casting of BriefcaseProps to IModelRpcProps.
-- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline. 
+- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline.
 - Move briefcase property from IModelDb --> BriefcaseIModelDb
 - BriefcaseId is now an enum instead of a class
 - Rename BriefcaseId --> ReservedBriefcaseId, introduce BriefcaseId type
-- VSTS#297017: Update cached briefcase information if changes were applied. 
-- Refactored NativeApp API and RPC interfaces. This continues to be WIP. 
-- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb. 
-- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase. 
+- VSTS#297017: Update cached briefcase information if changes were applied.
+- Refactored NativeApp API and RPC interfaces. This continues to be WIP.
+- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb.
+- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase.
 - Removed BriefcaseDb.create
-- Setup ability to use NativeApp.openBriefcase() in offline scenarios. 
+- Setup ability to use NativeApp.openBriefcase() in offline scenarios.
 - fixed flaky test
-- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP). 
+- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP).
 - do not throw exception in NativeAppBackend.startup()
-- VSTS#296110: Setup a way to close briefcases when the native application is offline. 
+- VSTS#296110: Setup a way to close briefcases when the native application is offline.
 - Move concurrencyControl from IModelDb to BriefcaseIModelDb
 - Renamed OIDC constructs for consistency; Removed SAML support.
 - Add support for password-protecting snapshot iModels
 - Fixed typo for ElementAspect perf tests
-- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly. 
+- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly.
 - Add purge dir method to iModelJsFs
 - react to creation of new clients packages from imodeljs-clients
 - ; substitute current date for feature usage without any set start/end dates
-- Removed deprecated utilities. 
+- Removed deprecated utilities.
 - enforce opening Snapshots readonly through StandaloneDb
 - Remove the deprecated Entity.clone method
 - Adjusted calls to some node addon changes (ECUtils removed)
@@ -1803,13 +1828,13 @@ Wed, 06 May 2020 13:17:49 GMT
 - Add FileNameResolver class
 - Move snapshot methods out of IModelDb and into new SnapshotIModelDb class.
 - Add TemplateModelCloner to place instances of a template model
-- Renamed TestOidcClient and related constructs for consistency. 
+- Renamed TestOidcClient and related constructs for consistency.
 - Add IModelDb.tryPrepareStatement
-- Fixed usage logging. 
+- Fixed usage logging.
 - fix failing ulas tests due to invalid featureId
 - update ULAS test logging & feedback
 - Update UlasUtilities to support exception-throwing native functions
-- Use standalone briefcases for PullOnly cases. 
+- Use standalone briefcases for PullOnly cases.
 
 ## 1.14.1
 Wed, 22 Apr 2020 19:04:00 GMT
@@ -1824,7 +1849,7 @@ Tue, 31 Mar 2020 15:44:19 GMT
 ### Updates
 
 - Update to addon 1.14.1
-- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted. 
+- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted.
 - Add handling for invalid predecessor ids to IModelTransformer
 - Accomodate updated imodeljs-native ULAS functions
 
@@ -1839,7 +1864,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 ### Updates
 
 - Fix IGeometry roundtripping issue through ECSql.  Fix insert/update binary properties for Element Aspect.
-- Separated out routines to download and open briefcases. 
+- Separated out routines to download and open briefcases.
 - bulk mode
 - Consolidated sign-in for integration tests
 - bulkmode
@@ -1850,7 +1875,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 - Add ViewDefinition.getAuxiliaryCoordinateSystemId and ViewDefinition.setAuxiliaryCoordinateSystemId methods
 - Add SpatialLocationModel.insert
 - Add optional isPlantProjection parameter to PhysicalModel.insert
-- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests. 
+- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests.
 - Better documentation of OidcDesktopClient
 - Fixed changeset perf test by using another iModel on Hub
 - Add ViewDetails to ViewDefinition.
@@ -1883,7 +1908,7 @@ Tue, 07 Jan 2020 19:44:01 GMT
 - Allow events to be sent from backend to frontend
 - Add tryGetInstance / tryGetInstanceProps methods to the Relationship class which return undefined rather than throwing an exception when a relationship is not found.
 - Fix webpack for ios test that were failing due to new dependencies
-- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors. 
+- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors.
 - Add tryGetElement / tryGetElementProps which return undefined rather than throwing an exception when an element is not found.
 - Add tryGetModel, tryGetModelProps, tryGetSubModel which return undefined instead of throwing exceptions when the model is not found.
 
@@ -1895,7 +1920,7 @@ Tue, 10 Dec 2019 18:08:56 GMT
 - Updated to addon 9.1.3
 - Added AliCloud tile cache service
 - Added framework to run imodeljs-backend test on ios using appcenter
-- Setup OidcDesktopClient for Electron use cases. 
+- Setup OidcDesktopClient for Electron use cases.
 - fix warnings from static analysis
 - Enabling testing code for updating LR aspects after fix in native side.
 - Addressing typo in a couple of members, making them match the schema properly.
@@ -1951,9 +1976,9 @@ Mon, 30 Sep 2019 22:28:48 GMT
 ### Updates
 
 - added support for blank IModelConnections
-- Setup a way to supply authorization through the backend for frontend requests. 
-- Error log when downloading change sets should include iModelId for context. 
-- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub. 
+- Setup a way to supply authorization through the backend for frontend requests.
+- Error log when downloading change sets should include iModelId for context.
+- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub.
 - Add IModelDb.Elements.hasSubModel
 - Make ExternalSourceAspect.checksum optional
 - Clear statement cache after schema import
@@ -1968,14 +1993,14 @@ Tue, 10 Sep 2019 12:09:49 GMT
 
 ### Updates
 
-- Setup a way to supply authorization through the backend for frontend requests. 
-- Allow attaching change cache file before change summary extraction. 
-- Added change summary test, and improved doc a little. 
+- Setup a way to supply authorization through the backend for frontend requests.
+- Allow attaching change cache file before change summary extraction.
+- Added change summary test, and improved doc a little.
 - Add minimum brep size option to IModelDb.exportGraphics
 - FunctionalSchema.importSchema is now deprecated.
 - Add support for GeometricModel.geometryGuid for detecting whether tiles for a model can be reused across versions
 - Added performance logging for tile upload
-- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase. 
+- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase.
 - Add method to create view with camera
 - Fixed misleading logging output in tile upload
 
@@ -1985,14 +2010,14 @@ Tue, 13 Aug 2019 20:25:53 GMT
 ### Updates
 
 - Allow custom tile cache services.
-- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows. 
-- Added Change Summary integration test, and fixed documentation. 
+- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows.
+- Added Change Summary integration test, and fixed documentation.
 - Trial code for tile upload errors
 - Fixed changeset performance tests
 - Tile upload logging.
 - Mark ExportGraphics API as public
 - Support for gzip compression of tiles
-- Fixed issue with opening iModels with names that are invalid on Unix or Windows. 
+- Fixed issue with opening iModels with names that are invalid on Unix or Windows.
 - Add IModelDb.isSnapshot
 - Tile upload error catching.
 - Azure tile upload logging
@@ -2004,7 +2029,7 @@ Wed, 24 Jul 2019 11:47:26 GMT
 ### Updates
 
 - Added option to restrict tile cache URLs by client IP address.
-- Apply change sets at the backend in a non-blocking worker thread. 
+- Apply change sets at the backend in a non-blocking worker thread.
 - Add ElementAspect handler methods
 - When deleting a parent element, make sure there are onDelete/onDeleted callbacks for child elements
 - Add support for linework to IModelDb.exportGraphics
@@ -2022,19 +2047,19 @@ Mon, 01 Jul 2019 19:04:29 GMT
 
 ### Updates
 
-- Open fixes when briefcase requires merges. 
+- Open fixes when briefcase requires merges.
 - Catch tile upload errors.
-- Setting up briefcase is always from an older checkpoint. 
+- Setting up briefcase is always from an older checkpoint.
 - Add materialId, subCategory to ExportGraphicsInfo
-- Fix crash in getViewThumbnail for odd number of bytes 
+- Fix crash in getViewThumbnail for odd number of bytes
 - Adding relationship class for GraphicalElement3dRepresentsElement.
 - Initial implementation of the LinearReferencing typescript domain
 - Adding domain classes for all relatinships in the LinearReferencing schema.
 - Exporting relationships module.
-- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s. 
-- Fixed issues with deleting briefcases if there were errors with preparing briefcases. 
+- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s.
+- Fixed issues with deleting briefcases if there were errors with preparing briefcases.
 - Add a new method `forceLoadSchemas` to `IModelJsNative.ECPresentationManager`.
-- Introduced AsyncMutex - a utility to run async blocks of code in sequence. 
+- Introduced AsyncMutex - a utility to run async blocks of code in sequence.
 - Properly document ModelSelector.models and CategorySelector.categories as Id64String arrays
 - Made `insertElement` not return Id64.invalid, throws error instead
 - Update to TypeScript 3.5
@@ -2045,7 +2070,7 @@ Mon, 03 Jun 2019 18:09:39 GMT
 
 ### Updates
 
-- Migrated agent applications to the newer client 
+- Migrated agent applications to the newer client
 - RPC system now accepts only basic values (primitives, "interface" objects, and binary).
 - Switched from iModelHub Project API to Context API
 - Fix bug in IModelDb.createSnapshotFromSeed
@@ -2093,12 +2118,12 @@ Mon, 13 May 2019 15:52:05 GMT
 - Cleanup old imodelbank references
 - Add InformationRecordModel.insert, GroupModel.insert
 - Introduce LoggerCategory enum to advertise logger categories used by this package.
-- Limited maximum cache size of the backend PromiseMemoizer. 
+- Limited maximum cache size of the backend PromiseMemoizer.
 - Missing dependency on node-report
-- Fixed memoization problem that caused an endless stream of 404 NotFound errors. 
+- Fixed memoization problem that caused an endless stream of 404 NotFound errors.
 - Reinstated old version of OidcAgentClient
-- Unauthorized open requests should cause a more obvious error. 
-- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop. 
+- Unauthorized open requests should cause a more obvious error.
+- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop.
 - Memoization fix when opening iModels in shared, read-only mode .
 - Fixed setup of application version.
 - Updated Element CRUD perf tests
@@ -2108,7 +2133,7 @@ Mon, 13 May 2019 15:52:05 GMT
 - Remove ElementPropertyFormatter, IModelDb.getElementPropertiesForDisplay (use presentation rules instead)
 - Remove StandaloneIModelRpcImpl
 - Fix for Render Gradient.Symb test
-- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization. 
+- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization.
 - Add IModelDb.createSnapshot/openSnapshot/closeSnapshot, deprecate IModelDb.createStandalone/openStandalone/closeStandalone
 - Moved IModelJsExpressServer class into a new package (@itwin/express-server).
 - Simplified tile caching IModelHost config and removed dev flags. Allow
@@ -2135,7 +2160,7 @@ Wed, 06 Mar 2019 15:41:22 GMT
 - Changes package.json to include api-extractor and adds api-extractor.json
 - Use new buildIModelJsBuild script
 - AxisAlignedBox and ElementAlignedBox are now typed to Range3d rather than classes
-- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package. 
+- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package.
 - Clone methods are no longer generic
 - Remove unneeded typedoc plugin dependency
 - Added spatial <-> cartographic methods that check/use the geographic coordinate system before using ecef location.
@@ -2180,8 +2205,8 @@ Mon, 14 Jan 2019 23:09:10 GMT
 
 ### Updates
 
-- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics. 
-- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current. 
+- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics.
+- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current.
 - Renamed RequestProxy->RequestHost. Allowed applications to configure proxy server with HTTPS_PROXY env.
 - Add backend TextureAPI and accompanying test
 
@@ -2286,7 +2311,7 @@ Mon, 03 Dec 2018 18:52:58 GMT
 
 ### Updates
 
-- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application. 
+- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application.
 - Add ElementRefersToElements.insert
 - Fixed front end integration tests.
 - Document the intended purpose of IModelJsExpressServer within a deployment environment.
@@ -2355,11 +2380,11 @@ Thu, 08 Nov 2018 17:59:20 GMT
 
 - Fix JSON representation of DisplayStyle.
 - Add IModelImporter as a base class for utility methods needed by all importers
-- Removed assertion when deleting a memoized open call. 
+- Removed assertion when deleting a memoized open call.
 - Add more methods to IModelImporter
 - Fix snapping test
 - OIDC related enhancments (WIP).
-- Re-enabled several backend integration tests. 
+- Re-enabled several backend integration tests.
 - Refactor analysis-importer to use IModelImporter
 - Updated to TypeScript 3.1
 

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2449,4 +2449,3 @@ Fri, 12 Oct 2018 23:00:10 GMT
 ### Updates
 
 - Initial release
-

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -1,31 +1,6 @@
 # Change Log - @itwin/core-backend
 
-This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
-
-## 4.7.2
-Sat, 22 Jun 2024 01:09:54 GMT
-
-### Updates
-
-- Update changed elements process options for bounding box calculations
-- BriefcaseDb.closeAndReopen now refreshes the changeset property in case another process pulled changes
-
-## 4.7.1
-Thu, 13 Jun 2024 22:47:31 GMT
-
-_Version update only_
-
-## 4.7.0
-Wed, 12 Jun 2024 18:02:16 GMT
-
-### Updates
-
-- schemaUpgrade() now push change to schema sync
-- Remove @alpha BackendLoggerCategory.Editing
-- Added getAvailableCoordinateReferenceSystems.
-- Brotli compression enabled for RPC requests.
-- Increase restrictions on native app storage name.
-- Added computeTextBlockExtents
+This log was last generated on Sat, 08 Jun 2024 00:53:21 GMT and should not be manually modified.
 
 ## 4.6.2
 Sat, 08 Jun 2024 00:50:25 GMT
@@ -233,7 +208,7 @@ Tue, 17 Oct 2023 15:14:32 GMT
 - Use instance query to get aspects for abstract classes
 - ViewStore.ViewDb.getViewGroups select statement was referring to ParentId when parent was meant
 - Remove `storageType` from `BlobContainer.RequestTokenProps`.
-- Add 'provider' to 'BlobContainer.CreatedContainerProps'
+- Add 'provider' to 'BlobContainer.CreatedContainerProps' 
 - add TileStorage.getCachedTilesGenerator
 
 ## 4.1.9
@@ -285,7 +260,7 @@ Fri, 18 Aug 2023 13:02:53 GMT
 
 ### Updates
 
-- add `internal` `codeValueBehavior` API
+- add `internal` `codeValueBehavior` API 
 
 ## 4.1.0
 Mon, 14 Aug 2023 14:36:34 GMT
@@ -1047,11 +1022,11 @@ Fri, 09 Jul 2021 18:11:24 GMT
 ### Updates
 
 - TemplateModelCloner now assigns a new FederationGuid for cloned element instances.
-- Accomodated the inability to reverse Changesets when creating change summaries.
+- Accomodated the inability to reverse Changesets when creating change summaries. 
 - fix lint issue
 - begin api transition to changeset index rather than changeset Id
 - Use ecef location calculated for projected iModels
-- Push refreshes access token if necessary.
+- Push refreshes access token if necessary. 
 - Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)
 - Add missing SectionDrawing properties.
 
@@ -1072,7 +1047,7 @@ Fri, 02 Jul 2021 15:38:31 GMT
 
 ### Updates
 
-- Update to @bentley/imodeljs-native@2.17.10
+- Update to @bentley/imodeljs-native@2.17.10 
 
 ## 2.17.0
 Mon, 28 Jun 2021 16:20:11 GMT
@@ -1338,8 +1313,8 @@ Thu, 28 Jan 2021 13:39:27 GMT
 
 - Changed storageType from azure to azure?sas=1 for getCommandArgs function
 - Fix brep DataProps to/from flatbuffer to account for base64 string header.
-- Element geometry creation by brep operations.
-- Reinstated behavior when re-opening files read-write.
+- Element geometry creation by brep operations. 
+- Reinstated behavior when re-opening files read-write. 
 - enhance BriefcaseManager and BriefcaseDb for edit commands
 - Improve ElementGeometry documentation.
 - Add a check to verify, and fix, the DbGuid in the iModel if it is different than the Guid in iModelHub.
@@ -1529,8 +1504,8 @@ Fri, 02 Oct 2020 18:03:32 GMT
 ### Updates
 
 - Update to @bentley/imodeljs-native@2.7.4
-- Fixes to front end methods to pull, merge and push.
-- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications.
+- Fixes to front end methods to pull, merge and push. 
+- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications. 
 - On iOS download in background
 - Fix ios hang issue
 - Modify queryModelRanges to handle non geometric model errors
@@ -1621,7 +1596,7 @@ Thu, 20 Aug 2020 20:57:09 GMT
 ### Updates
 
 - Update to imodeljs-native 2.5.0
-- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases.
+- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases. 
 - Fix for a recursive exception while closing a briefcase
 - Added mobile oidc client
 - Remove special code handling for mobile.
@@ -1685,7 +1660,7 @@ Fri, 10 Jul 2020 17:23:14 GMT
 - Changes to support imodel-bridge
 - fix spelling mistakes in Device class
 - Fix typo in comments
-- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades.
+- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades. 
 - disallow protected operations for missing schemas marked with SchemaHasBehavior custom attribute
 
 ## 2.2.1
@@ -1726,25 +1701,25 @@ Thu, 28 May 2020 22:48:59 GMT
 - Update to imodeljs-native 2.1.0
 - Support for finding an ExternalSourceAspect given scope, id, and kind/hash.
 - ApplyChangeset perf tests updated
-- Fixed token expiry check for desktop authorization.
+- Fixed token expiry check for desktop authorization. 
 - Download ChangeSets in chunks
 - (1) In xy region booleans, support curved edges; (2) ExportGraphicsMeshVisitor class
 - Add ability to convert ExportGraphicsMesh to Polyface
 - Fixed validation of Guids (ContextId, IModelId) cached within a briefcase.
 - Moved iModelBridgeFwk to a separate package
-- Simplified logging for monitoring briefcase operations.
+- Simplified logging for monitoring briefcase operations. 
 - Fix transforms for creating and querying part instance geometry in world coordinate.
 - Fix and improvement to performance tests
 - Added support for schema XML import to iModelJs backend via the IModelDb.importSchemaStrings method.
 - channel rules
-- Fixed logging usage when opening connections.
+- Fixed logging usage when opening connections. 
 
 ## 2.0.0
 Wed, 06 May 2020 13:17:49 GMT
 
 ### Updates
 
-- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API.
+- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API. 
 - Added RivisionUtility class for debug/testing
 - node addon 2.0.18
 - addon 2.0.25
@@ -1757,23 +1732,23 @@ Wed, 06 May 2020 13:17:49 GMT
 - Performance tests for Applying Changesets
 - `IModelHost.startup` is now async.
 - `IModelHost.shutdown` is now async.
-- Refined checks for briefcase id, and fixed failing integration tests.
+- Refined checks for briefcase id, and fixed failing integration tests. 
 - Product Backlog Item 276268: Deleting the briefcase cache if the cache version is incorrect should not attempt to delete the root directory.
 - Setup initialization of briefcase cache for offline workflows. (VSTS#286489)
-- Monitor progress of downloading briefcases, ability to cancel download of briefcases.
+- Monitor progress of downloading briefcases, ability to cancel download of briefcases. 
 - Move briefcase-specific events into BriefcaseIModelDb subclass
 - Fixed param when calling logger so that it is a function as the logger expects
-- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder.
+- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder. 
 - Changed ChangeSets download API
 - Added unlink for file handler
 - Update UlasClient tests to send more detailed feature log data
 - react to renaming of imodeljs-clients-backend to backend-itwin-client
 - apply changeset performance tests with local datasets
-- BriefcaseManager.delete should work in offline scenarios.
+- BriefcaseManager.delete should work in offline scenarios. 
 - Remove deprecated members of SectionLocation and downgrade to alpha pending refactor.
 - Support for progress/cancel from ios
 - Remove deprecated ExportGraphics types etc for 2.0
-- Updated docs.
+- Updated docs. 
 - IModelDb.findByKey replaces IModelDb.find
 - Include model extents with ViewStateProps for drawing views.
 - Remove deprecated APIs; see NextVersion.md for details.
@@ -1794,29 +1769,29 @@ Wed, 06 May 2020 13:17:49 GMT
 - Introduce the BriefcaseIModelDb class, make IModelDb abstract.
 - Cleaned up unused async-s in BriefcaseManager
 - Avoided casting of BriefcaseProps to IModelRpcProps.
-- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline.
+- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline. 
 - Move briefcase property from IModelDb --> BriefcaseIModelDb
 - BriefcaseId is now an enum instead of a class
 - Rename BriefcaseId --> ReservedBriefcaseId, introduce BriefcaseId type
-- VSTS#297017: Update cached briefcase information if changes were applied.
-- Refactored NativeApp API and RPC interfaces. This continues to be WIP.
-- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb.
-- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase.
+- VSTS#297017: Update cached briefcase information if changes were applied. 
+- Refactored NativeApp API and RPC interfaces. This continues to be WIP. 
+- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb. 
+- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase. 
 - Removed BriefcaseDb.create
-- Setup ability to use NativeApp.openBriefcase() in offline scenarios.
+- Setup ability to use NativeApp.openBriefcase() in offline scenarios. 
 - fixed flaky test
-- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP).
+- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP). 
 - do not throw exception in NativeAppBackend.startup()
-- VSTS#296110: Setup a way to close briefcases when the native application is offline.
+- VSTS#296110: Setup a way to close briefcases when the native application is offline. 
 - Move concurrencyControl from IModelDb to BriefcaseIModelDb
 - Renamed OIDC constructs for consistency; Removed SAML support.
 - Add support for password-protecting snapshot iModels
 - Fixed typo for ElementAspect perf tests
-- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly.
+- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly. 
 - Add purge dir method to iModelJsFs
 - react to creation of new clients packages from imodeljs-clients
 - ; substitute current date for feature usage without any set start/end dates
-- Removed deprecated utilities.
+- Removed deprecated utilities. 
 - enforce opening Snapshots readonly through StandaloneDb
 - Remove the deprecated Entity.clone method
 - Adjusted calls to some node addon changes (ECUtils removed)
@@ -1828,13 +1803,13 @@ Wed, 06 May 2020 13:17:49 GMT
 - Add FileNameResolver class
 - Move snapshot methods out of IModelDb and into new SnapshotIModelDb class.
 - Add TemplateModelCloner to place instances of a template model
-- Renamed TestOidcClient and related constructs for consistency.
+- Renamed TestOidcClient and related constructs for consistency. 
 - Add IModelDb.tryPrepareStatement
-- Fixed usage logging.
+- Fixed usage logging. 
 - fix failing ulas tests due to invalid featureId
 - update ULAS test logging & feedback
 - Update UlasUtilities to support exception-throwing native functions
-- Use standalone briefcases for PullOnly cases.
+- Use standalone briefcases for PullOnly cases. 
 
 ## 1.14.1
 Wed, 22 Apr 2020 19:04:00 GMT
@@ -1849,7 +1824,7 @@ Tue, 31 Mar 2020 15:44:19 GMT
 ### Updates
 
 - Update to addon 1.14.1
-- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted.
+- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted. 
 - Add handling for invalid predecessor ids to IModelTransformer
 - Accomodate updated imodeljs-native ULAS functions
 
@@ -1864,7 +1839,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 ### Updates
 
 - Fix IGeometry roundtripping issue through ECSql.  Fix insert/update binary properties for Element Aspect.
-- Separated out routines to download and open briefcases.
+- Separated out routines to download and open briefcases. 
 - bulk mode
 - Consolidated sign-in for integration tests
 - bulkmode
@@ -1875,7 +1850,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 - Add ViewDefinition.getAuxiliaryCoordinateSystemId and ViewDefinition.setAuxiliaryCoordinateSystemId methods
 - Add SpatialLocationModel.insert
 - Add optional isPlantProjection parameter to PhysicalModel.insert
-- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests.
+- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests. 
 - Better documentation of OidcDesktopClient
 - Fixed changeset perf test by using another iModel on Hub
 - Add ViewDetails to ViewDefinition.
@@ -1908,7 +1883,7 @@ Tue, 07 Jan 2020 19:44:01 GMT
 - Allow events to be sent from backend to frontend
 - Add tryGetInstance / tryGetInstanceProps methods to the Relationship class which return undefined rather than throwing an exception when a relationship is not found.
 - Fix webpack for ios test that were failing due to new dependencies
-- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors.
+- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors. 
 - Add tryGetElement / tryGetElementProps which return undefined rather than throwing an exception when an element is not found.
 - Add tryGetModel, tryGetModelProps, tryGetSubModel which return undefined instead of throwing exceptions when the model is not found.
 
@@ -1920,7 +1895,7 @@ Tue, 10 Dec 2019 18:08:56 GMT
 - Updated to addon 9.1.3
 - Added AliCloud tile cache service
 - Added framework to run imodeljs-backend test on ios using appcenter
-- Setup OidcDesktopClient for Electron use cases.
+- Setup OidcDesktopClient for Electron use cases. 
 - fix warnings from static analysis
 - Enabling testing code for updating LR aspects after fix in native side.
 - Addressing typo in a couple of members, making them match the schema properly.
@@ -1976,9 +1951,9 @@ Mon, 30 Sep 2019 22:28:48 GMT
 ### Updates
 
 - added support for blank IModelConnections
-- Setup a way to supply authorization through the backend for frontend requests.
-- Error log when downloading change sets should include iModelId for context.
-- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub.
+- Setup a way to supply authorization through the backend for frontend requests. 
+- Error log when downloading change sets should include iModelId for context. 
+- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub. 
 - Add IModelDb.Elements.hasSubModel
 - Make ExternalSourceAspect.checksum optional
 - Clear statement cache after schema import
@@ -1993,14 +1968,14 @@ Tue, 10 Sep 2019 12:09:49 GMT
 
 ### Updates
 
-- Setup a way to supply authorization through the backend for frontend requests.
-- Allow attaching change cache file before change summary extraction.
-- Added change summary test, and improved doc a little.
+- Setup a way to supply authorization through the backend for frontend requests. 
+- Allow attaching change cache file before change summary extraction. 
+- Added change summary test, and improved doc a little. 
 - Add minimum brep size option to IModelDb.exportGraphics
 - FunctionalSchema.importSchema is now deprecated.
 - Add support for GeometricModel.geometryGuid for detecting whether tiles for a model can be reused across versions
 - Added performance logging for tile upload
-- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase.
+- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase. 
 - Add method to create view with camera
 - Fixed misleading logging output in tile upload
 
@@ -2010,14 +1985,14 @@ Tue, 13 Aug 2019 20:25:53 GMT
 ### Updates
 
 - Allow custom tile cache services.
-- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows.
-- Added Change Summary integration test, and fixed documentation.
+- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows. 
+- Added Change Summary integration test, and fixed documentation. 
 - Trial code for tile upload errors
 - Fixed changeset performance tests
 - Tile upload logging.
 - Mark ExportGraphics API as public
 - Support for gzip compression of tiles
-- Fixed issue with opening iModels with names that are invalid on Unix or Windows.
+- Fixed issue with opening iModels with names that are invalid on Unix or Windows. 
 - Add IModelDb.isSnapshot
 - Tile upload error catching.
 - Azure tile upload logging
@@ -2029,7 +2004,7 @@ Wed, 24 Jul 2019 11:47:26 GMT
 ### Updates
 
 - Added option to restrict tile cache URLs by client IP address.
-- Apply change sets at the backend in a non-blocking worker thread.
+- Apply change sets at the backend in a non-blocking worker thread. 
 - Add ElementAspect handler methods
 - When deleting a parent element, make sure there are onDelete/onDeleted callbacks for child elements
 - Add support for linework to IModelDb.exportGraphics
@@ -2047,19 +2022,19 @@ Mon, 01 Jul 2019 19:04:29 GMT
 
 ### Updates
 
-- Open fixes when briefcase requires merges.
+- Open fixes when briefcase requires merges. 
 - Catch tile upload errors.
-- Setting up briefcase is always from an older checkpoint.
+- Setting up briefcase is always from an older checkpoint. 
 - Add materialId, subCategory to ExportGraphicsInfo
-- Fix crash in getViewThumbnail for odd number of bytes
+- Fix crash in getViewThumbnail for odd number of bytes 
 - Adding relationship class for GraphicalElement3dRepresentsElement.
 - Initial implementation of the LinearReferencing typescript domain
 - Adding domain classes for all relatinships in the LinearReferencing schema.
 - Exporting relationships module.
-- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s.
-- Fixed issues with deleting briefcases if there were errors with preparing briefcases.
+- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s. 
+- Fixed issues with deleting briefcases if there were errors with preparing briefcases. 
 - Add a new method `forceLoadSchemas` to `IModelJsNative.ECPresentationManager`.
-- Introduced AsyncMutex - a utility to run async blocks of code in sequence.
+- Introduced AsyncMutex - a utility to run async blocks of code in sequence. 
 - Properly document ModelSelector.models and CategorySelector.categories as Id64String arrays
 - Made `insertElement` not return Id64.invalid, throws error instead
 - Update to TypeScript 3.5
@@ -2070,7 +2045,7 @@ Mon, 03 Jun 2019 18:09:39 GMT
 
 ### Updates
 
-- Migrated agent applications to the newer client
+- Migrated agent applications to the newer client 
 - RPC system now accepts only basic values (primitives, "interface" objects, and binary).
 - Switched from iModelHub Project API to Context API
 - Fix bug in IModelDb.createSnapshotFromSeed
@@ -2118,12 +2093,12 @@ Mon, 13 May 2019 15:52:05 GMT
 - Cleanup old imodelbank references
 - Add InformationRecordModel.insert, GroupModel.insert
 - Introduce LoggerCategory enum to advertise logger categories used by this package.
-- Limited maximum cache size of the backend PromiseMemoizer.
+- Limited maximum cache size of the backend PromiseMemoizer. 
 - Missing dependency on node-report
-- Fixed memoization problem that caused an endless stream of 404 NotFound errors.
+- Fixed memoization problem that caused an endless stream of 404 NotFound errors. 
 - Reinstated old version of OidcAgentClient
-- Unauthorized open requests should cause a more obvious error.
-- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop.
+- Unauthorized open requests should cause a more obvious error. 
+- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop. 
 - Memoization fix when opening iModels in shared, read-only mode .
 - Fixed setup of application version.
 - Updated Element CRUD perf tests
@@ -2133,7 +2108,7 @@ Mon, 13 May 2019 15:52:05 GMT
 - Remove ElementPropertyFormatter, IModelDb.getElementPropertiesForDisplay (use presentation rules instead)
 - Remove StandaloneIModelRpcImpl
 - Fix for Render Gradient.Symb test
-- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization.
+- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization. 
 - Add IModelDb.createSnapshot/openSnapshot/closeSnapshot, deprecate IModelDb.createStandalone/openStandalone/closeStandalone
 - Moved IModelJsExpressServer class into a new package (@itwin/express-server).
 - Simplified tile caching IModelHost config and removed dev flags. Allow
@@ -2160,7 +2135,7 @@ Wed, 06 Mar 2019 15:41:22 GMT
 - Changes package.json to include api-extractor and adds api-extractor.json
 - Use new buildIModelJsBuild script
 - AxisAlignedBox and ElementAlignedBox are now typed to Range3d rather than classes
-- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package.
+- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package. 
 - Clone methods are no longer generic
 - Remove unneeded typedoc plugin dependency
 - Added spatial <-> cartographic methods that check/use the geographic coordinate system before using ecef location.
@@ -2205,8 +2180,8 @@ Mon, 14 Jan 2019 23:09:10 GMT
 
 ### Updates
 
-- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics.
-- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current.
+- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics. 
+- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current. 
 - Renamed RequestProxy->RequestHost. Allowed applications to configure proxy server with HTTPS_PROXY env.
 - Add backend TextureAPI and accompanying test
 
@@ -2311,7 +2286,7 @@ Mon, 03 Dec 2018 18:52:58 GMT
 
 ### Updates
 
-- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application.
+- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application. 
 - Add ElementRefersToElements.insert
 - Fixed front end integration tests.
 - Document the intended purpose of IModelJsExpressServer within a deployment environment.
@@ -2380,11 +2355,11 @@ Thu, 08 Nov 2018 17:59:20 GMT
 
 - Fix JSON representation of DisplayStyle.
 - Add IModelImporter as a base class for utility methods needed by all importers
-- Removed assertion when deleting a memoized open call.
+- Removed assertion when deleting a memoized open call. 
 - Add more methods to IModelImporter
 - Fix snapping test
 - OIDC related enhancments (WIP).
-- Re-enabled several backend integration tests.
+- Re-enabled several backend integration tests. 
 - Refactor analysis-importer to use IModelImporter
 - Updated to TypeScript 3.1
 
@@ -2449,3 +2424,4 @@ Fri, 12 Oct 2018 23:00:10 GMT
 ### Updates
 
 - Initial release
+

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -233,7 +233,7 @@ Tue, 17 Oct 2023 15:14:32 GMT
 - Use instance query to get aspects for abstract classes
 - ViewStore.ViewDb.getViewGroups select statement was referring to ParentId when parent was meant
 - Remove `storageType` from `BlobContainer.RequestTokenProps`.
-- Add 'provider' to 'BlobContainer.CreatedContainerProps'
+- Add 'provider' to 'BlobContainer.CreatedContainerProps' 
 - add TileStorage.getCachedTilesGenerator
 
 ## 4.1.9

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
 
-THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #1
+THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #2
 
 ## 4.7.2
 Sat, 22 Jun 2024 01:09:54 GMT

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
 
+THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #1
+
 ## 4.7.2
 Sat, 22 Jun 2024 01:09:54 GMT
 
@@ -233,7 +235,7 @@ Tue, 17 Oct 2023 15:14:32 GMT
 - Use instance query to get aspects for abstract classes
 - ViewStore.ViewDb.getViewGroups select statement was referring to ParentId when parent was meant
 - Remove `storageType` from `BlobContainer.RequestTokenProps`.
-- Add 'provider' to 'BlobContainer.CreatedContainerProps' 
+- Add 'provider' to 'BlobContainer.CreatedContainerProps'
 - add TileStorage.getCachedTilesGenerator
 
 ## 4.1.9
@@ -285,7 +287,7 @@ Fri, 18 Aug 2023 13:02:53 GMT
 
 ### Updates
 
-- add `internal` `codeValueBehavior` API 
+- add `internal` `codeValueBehavior` API
 
 ## 4.1.0
 Mon, 14 Aug 2023 14:36:34 GMT
@@ -1012,7 +1014,7 @@ Mon, 26 Jul 2021 12:21:25 GMT
 
 - Reactivated test that stopped working when a previous PR for ecef dependency to geographicCRS was reverted
 - store changesetIndex on IModelDb
-- Better error checks when creating SpatialViewDefinition-s. 
+- Better error checks when creating SpatialViewDefinition-s.
 - remove internal barrel-import usage
 - throw exception when attempting to download a briefcase on top of an existing file
 - Add case for InterpolationCurve3d
@@ -1047,11 +1049,11 @@ Fri, 09 Jul 2021 18:11:24 GMT
 ### Updates
 
 - TemplateModelCloner now assigns a new FederationGuid for cloned element instances.
-- Accomodated the inability to reverse Changesets when creating change summaries. 
+- Accomodated the inability to reverse Changesets when creating change summaries.
 - fix lint issue
 - begin api transition to changeset index rather than changeset Id
 - Use ecef location calculated for projected iModels
-- Push refreshes access token if necessary. 
+- Push refreshes access token if necessary.
 - Do not reuse briefcase ids in ReadWrite workflows when using the RPC interfaces (if the briefcase was not found in the local file system)
 - Add missing SectionDrawing properties.
 
@@ -1072,7 +1074,7 @@ Fri, 02 Jul 2021 15:38:31 GMT
 
 ### Updates
 
-- Update to @bentley/imodeljs-native@2.17.10 
+- Update to @bentley/imodeljs-native@2.17.10
 
 ## 2.17.0
 Mon, 28 Jun 2021 16:20:11 GMT
@@ -1338,8 +1340,8 @@ Thu, 28 Jan 2021 13:39:27 GMT
 
 - Changed storageType from azure to azure?sas=1 for getCommandArgs function
 - Fix brep DataProps to/from flatbuffer to account for base64 string header.
-- Element geometry creation by brep operations. 
-- Reinstated behavior when re-opening files read-write. 
+- Element geometry creation by brep operations.
+- Reinstated behavior when re-opening files read-write.
 - enhance BriefcaseManager and BriefcaseDb for edit commands
 - Improve ElementGeometry documentation.
 - Add a check to verify, and fix, the DbGuid in the iModel if it is different than the Guid in iModelHub.
@@ -1529,8 +1531,8 @@ Fri, 02 Oct 2020 18:03:32 GMT
 ### Updates
 
 - Update to @bentley/imodeljs-native@2.7.4
-- Fixes to front end methods to pull, merge and push. 
-- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications. 
+- Fixes to front end methods to pull, merge and push.
+- Setup IModelHost.startup() to use proxy servers if configured/available - this is valuable for debugging agents, backends and electron applications.
 - On iOS download in background
 - Fix ios hang issue
 - Modify queryModelRanges to handle non geometric model errors
@@ -1621,7 +1623,7 @@ Thu, 20 Aug 2020 20:57:09 GMT
 ### Updates
 
 - Update to imodeljs-native 2.5.0
-- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases. 
+- VSTS#419723: Accomodated "bad" checkpoints that may have serialized transactions preventing their use in ReadWrite cases.
 - Fix for a recursive exception while closing a briefcase
 - Added mobile oidc client
 - Remove special code handling for mobile.
@@ -1685,7 +1687,7 @@ Fri, 10 Jul 2020 17:23:14 GMT
 - Changes to support imodel-bridge
 - fix spelling mistakes in Device class
 - Fix typo in comments
-- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades. 
+- Setup BriefcaseDb.open() to allow profile and domain schema validation and upgrades.
 - disallow protected operations for missing schemas marked with SchemaHasBehavior custom attribute
 
 ## 2.2.1
@@ -1726,25 +1728,25 @@ Thu, 28 May 2020 22:48:59 GMT
 - Update to imodeljs-native 2.1.0
 - Support for finding an ExternalSourceAspect given scope, id, and kind/hash.
 - ApplyChangeset perf tests updated
-- Fixed token expiry check for desktop authorization. 
+- Fixed token expiry check for desktop authorization.
 - Download ChangeSets in chunks
 - (1) In xy region booleans, support curved edges; (2) ExportGraphicsMeshVisitor class
 - Add ability to convert ExportGraphicsMesh to Polyface
 - Fixed validation of Guids (ContextId, IModelId) cached within a briefcase.
 - Moved iModelBridgeFwk to a separate package
-- Simplified logging for monitoring briefcase operations. 
+- Simplified logging for monitoring briefcase operations.
 - Fix transforms for creating and querying part instance geometry in world coordinate.
 - Fix and improvement to performance tests
 - Added support for schema XML import to iModelJs backend via the IModelDb.importSchemaStrings method.
 - channel rules
-- Fixed logging usage when opening connections. 
+- Fixed logging usage when opening connections.
 
 ## 2.0.0
 Wed, 06 May 2020 13:17:49 GMT
 
 ### Updates
 
-- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API. 
+- Fixed setup of UserInfo from browser clients, and more cleanups to AccessToken API.
 - Added RivisionUtility class for debug/testing
 - node addon 2.0.18
 - addon 2.0.25
@@ -1757,23 +1759,23 @@ Wed, 06 May 2020 13:17:49 GMT
 - Performance tests for Applying Changesets
 - `IModelHost.startup` is now async.
 - `IModelHost.shutdown` is now async.
-- Refined checks for briefcase id, and fixed failing integration tests. 
+- Refined checks for briefcase id, and fixed failing integration tests.
 - Product Backlog Item 276268: Deleting the briefcase cache if the cache version is incorrect should not attempt to delete the root directory.
 - Setup initialization of briefcase cache for offline workflows. (VSTS#286489)
-- Monitor progress of downloading briefcases, ability to cancel download of briefcases. 
+- Monitor progress of downloading briefcases, ability to cancel download of briefcases.
 - Move briefcase-specific events into BriefcaseIModelDb subclass
 - Fixed param when calling logger so that it is a function as the logger expects
-- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder. 
+- Setup a common cache locaton for iModel.js, with briefcases taking up a sub-folder.
 - Changed ChangeSets download API
 - Added unlink for file handler
 - Update UlasClient tests to send more detailed feature log data
 - react to renaming of imodeljs-clients-backend to backend-itwin-client
 - apply changeset performance tests with local datasets
-- BriefcaseManager.delete should work in offline scenarios. 
+- BriefcaseManager.delete should work in offline scenarios.
 - Remove deprecated members of SectionLocation and downgrade to alpha pending refactor.
 - Support for progress/cancel from ios
 - Remove deprecated ExportGraphics types etc for 2.0
-- Updated docs. 
+- Updated docs.
 - IModelDb.findByKey replaces IModelDb.find
 - Include model extents with ViewStateProps for drawing views.
 - Remove deprecated APIs; see NextVersion.md for details.
@@ -1794,29 +1796,29 @@ Wed, 06 May 2020 13:17:49 GMT
 - Introduce the BriefcaseIModelDb class, make IModelDb abstract.
 - Cleaned up unused async-s in BriefcaseManager
 - Avoided casting of BriefcaseProps to IModelRpcProps.
-- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline. 
+- Added NativeApp.deleteBriefcase, avoided authorization exceptions when offline.
 - Move briefcase property from IModelDb --> BriefcaseIModelDb
 - BriefcaseId is now an enum instead of a class
 - Rename BriefcaseId --> ReservedBriefcaseId, introduce BriefcaseId type
-- VSTS#297017: Update cached briefcase information if changes were applied. 
-- Refactored NativeApp API and RPC interfaces. This continues to be WIP. 
-- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb. 
-- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase. 
+- VSTS#297017: Update cached briefcase information if changes were applied.
+- Refactored NativeApp API and RPC interfaces. This continues to be WIP.
+- Removed the call to simultaneously download and open the briefcase at the backend. This should be done in two separate steps henceforth. The download must be done with BriefcaseManager, and the open is now a synchronous call in BriefcaseDb.
+- Added DownloadBriefcaseOptions and OpenBriefcaseOptions as parameters to the download/open calls for a briefcase.
 - Removed BriefcaseDb.create
-- Setup ability to use NativeApp.openBriefcase() in offline scenarios. 
+- Setup ability to use NativeApp.openBriefcase() in offline scenarios.
 - fixed flaky test
-- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP). 
+- VSTS#217447, 162382: Cleanups to implementation of downloading/opening/discovering briefcases in native applications (WIP).
 - do not throw exception in NativeAppBackend.startup()
-- VSTS#296110: Setup a way to close briefcases when the native application is offline. 
+- VSTS#296110: Setup a way to close briefcases when the native application is offline.
 - Move concurrencyControl from IModelDb to BriefcaseIModelDb
 - Renamed OIDC constructs for consistency; Removed SAML support.
 - Add support for password-protecting snapshot iModels
 - Fixed typo for ElementAspect perf tests
-- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly. 
+- VSTS#217447, VSTS#162382: Reinstated option to open briefcases with SyncMode = PullOnly.
 - Add purge dir method to iModelJsFs
 - react to creation of new clients packages from imodeljs-clients
 - ; substitute current date for feature usage without any set start/end dates
-- Removed deprecated utilities. 
+- Removed deprecated utilities.
 - enforce opening Snapshots readonly through StandaloneDb
 - Remove the deprecated Entity.clone method
 - Adjusted calls to some node addon changes (ECUtils removed)
@@ -1828,13 +1830,13 @@ Wed, 06 May 2020 13:17:49 GMT
 - Add FileNameResolver class
 - Move snapshot methods out of IModelDb and into new SnapshotIModelDb class.
 - Add TemplateModelCloner to place instances of a template model
-- Renamed TestOidcClient and related constructs for consistency. 
+- Renamed TestOidcClient and related constructs for consistency.
 - Add IModelDb.tryPrepareStatement
-- Fixed usage logging. 
+- Fixed usage logging.
 - fix failing ulas tests due to invalid featureId
 - update ULAS test logging & feedback
 - Update UlasUtilities to support exception-throwing native functions
-- Use standalone briefcases for PullOnly cases. 
+- Use standalone briefcases for PullOnly cases.
 
 ## 1.14.1
 Wed, 22 Apr 2020 19:04:00 GMT
@@ -1849,7 +1851,7 @@ Tue, 31 Mar 2020 15:44:19 GMT
 ### Updates
 
 - Update to addon 1.14.1
-- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted. 
+- Fixed downloading of files using https/streaming to resolve when the filestream is closed instead of when the input stream is exhausted.
 - Add handling for invalid predecessor ids to IModelTransformer
 - Accomodate updated imodeljs-native ULAS functions
 
@@ -1864,7 +1866,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 ### Updates
 
 - Fix IGeometry roundtripping issue through ECSql.  Fix insert/update binary properties for Element Aspect.
-- Separated out routines to download and open briefcases. 
+- Separated out routines to download and open briefcases.
 - bulk mode
 - Consolidated sign-in for integration tests
 - bulkmode
@@ -1875,7 +1877,7 @@ Wed, 12 Feb 2020 17:45:50 GMT
 - Add ViewDefinition.getAuxiliaryCoordinateSystemId and ViewDefinition.setAuxiliaryCoordinateSystemId methods
 - Add SpatialLocationModel.insert
 - Add optional isPlantProjection parameter to PhysicalModel.insert
-- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests. 
+- VSTS#256133: Fixed issue with reopening connections if the backend crashes. Fixes to integration tests.
 - Better documentation of OidcDesktopClient
 - Fixed changeset perf test by using another iModel on Hub
 - Add ViewDetails to ViewDefinition.
@@ -1908,7 +1910,7 @@ Tue, 07 Jan 2020 19:44:01 GMT
 - Allow events to be sent from backend to frontend
 - Add tryGetInstance / tryGetInstanceProps methods to the Relationship class which return undefined rather than throwing an exception when a relationship is not found.
 - Fix webpack for ios test that were failing due to new dependencies
-- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors. 
+- VSTS#225894 - Allowed agents to bypass usage logging calls. These cause usage logging errors.
 - Add tryGetElement / tryGetElementProps which return undefined rather than throwing an exception when an element is not found.
 - Add tryGetModel, tryGetModelProps, tryGetSubModel which return undefined instead of throwing exceptions when the model is not found.
 
@@ -1920,7 +1922,7 @@ Tue, 10 Dec 2019 18:08:56 GMT
 - Updated to addon 9.1.3
 - Added AliCloud tile cache service
 - Added framework to run imodeljs-backend test on ios using appcenter
-- Setup OidcDesktopClient for Electron use cases. 
+- Setup OidcDesktopClient for Electron use cases.
 - fix warnings from static analysis
 - Enabling testing code for updating LR aspects after fix in native side.
 - Addressing typo in a couple of members, making them match the schema properly.
@@ -1976,9 +1978,9 @@ Mon, 30 Sep 2019 22:28:48 GMT
 ### Updates
 
 - added support for blank IModelConnections
-- Setup a way to supply authorization through the backend for frontend requests. 
-- Error log when downloading change sets should include iModelId for context. 
-- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub. 
+- Setup a way to supply authorization through the backend for frontend requests.
+- Error log when downloading change sets should include iModelId for context.
+- Fixed the iModelHub client to properly dispose a file handle after upload to the iModelHub.
 - Add IModelDb.Elements.hasSubModel
 - Make ExternalSourceAspect.checksum optional
 - Clear statement cache after schema import
@@ -1993,14 +1995,14 @@ Tue, 10 Sep 2019 12:09:49 GMT
 
 ### Updates
 
-- Setup a way to supply authorization through the backend for frontend requests. 
-- Allow attaching change cache file before change summary extraction. 
-- Added change summary test, and improved doc a little. 
+- Setup a way to supply authorization through the backend for frontend requests.
+- Allow attaching change cache file before change summary extraction.
+- Added change summary test, and improved doc a little.
 - Add minimum brep size option to IModelDb.exportGraphics
 - FunctionalSchema.importSchema is now deprecated.
 - Add support for GeometricModel.geometryGuid for detecting whether tiles for a model can be reused across versions
 - Added performance logging for tile upload
-- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase. 
+- IModelConnection.close() for read-only connections should not close the Db at the backend; Opening an iModel with SyncModel.PullAndPush() multiple times (without disposing it) must reuse the briefcase.
 - Add method to create view with camera
 - Fixed misleading logging output in tile upload
 
@@ -2010,14 +2012,14 @@ Tue, 13 Aug 2019 20:25:53 GMT
 ### Updates
 
 - Allow custom tile cache services.
-- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows. 
-- Added Change Summary integration test, and fixed documentation. 
+- Always acquire a briefcase when creating a new backend instance for PullAndPush workflows.
+- Added Change Summary integration test, and fixed documentation.
 - Trial code for tile upload errors
 - Fixed changeset performance tests
 - Tile upload logging.
 - Mark ExportGraphics API as public
 - Support for gzip compression of tiles
-- Fixed issue with opening iModels with names that are invalid on Unix or Windows. 
+- Fixed issue with opening iModels with names that are invalid on Unix or Windows.
 - Add IModelDb.isSnapshot
 - Tile upload error catching.
 - Azure tile upload logging
@@ -2029,7 +2031,7 @@ Wed, 24 Jul 2019 11:47:26 GMT
 ### Updates
 
 - Added option to restrict tile cache URLs by client IP address.
-- Apply change sets at the backend in a non-blocking worker thread. 
+- Apply change sets at the backend in a non-blocking worker thread.
 - Add ElementAspect handler methods
 - When deleting a parent element, make sure there are onDelete/onDeleted callbacks for child elements
 - Add support for linework to IModelDb.exportGraphics
@@ -2047,19 +2049,19 @@ Mon, 01 Jul 2019 19:04:29 GMT
 
 ### Updates
 
-- Open fixes when briefcase requires merges. 
+- Open fixes when briefcase requires merges.
 - Catch tile upload errors.
-- Setting up briefcase is always from an older checkpoint. 
+- Setting up briefcase is always from an older checkpoint.
 - Add materialId, subCategory to ExportGraphicsInfo
-- Fix crash in getViewThumbnail for odd number of bytes 
+- Fix crash in getViewThumbnail for odd number of bytes
 - Adding relationship class for GraphicalElement3dRepresentsElement.
 - Initial implementation of the LinearReferencing typescript domain
 - Adding domain classes for all relatinships in the LinearReferencing schema.
 - Exporting relationships module.
-- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s. 
-- Fixed issues with deleting briefcases if there were errors with preparing briefcases. 
+- Fixes to opening iModel-s ReadWrite from mutiple IModelConnection-s.
+- Fixed issues with deleting briefcases if there were errors with preparing briefcases.
 - Add a new method `forceLoadSchemas` to `IModelJsNative.ECPresentationManager`.
-- Introduced AsyncMutex - a utility to run async blocks of code in sequence. 
+- Introduced AsyncMutex - a utility to run async blocks of code in sequence.
 - Properly document ModelSelector.models and CategorySelector.categories as Id64String arrays
 - Made `insertElement` not return Id64.invalid, throws error instead
 - Update to TypeScript 3.5
@@ -2070,7 +2072,7 @@ Mon, 03 Jun 2019 18:09:39 GMT
 
 ### Updates
 
-- Migrated agent applications to the newer client 
+- Migrated agent applications to the newer client
 - RPC system now accepts only basic values (primitives, "interface" objects, and binary).
 - Switched from iModelHub Project API to Context API
 - Fix bug in IModelDb.createSnapshotFromSeed
@@ -2118,12 +2120,12 @@ Mon, 13 May 2019 15:52:05 GMT
 - Cleanup old imodelbank references
 - Add InformationRecordModel.insert, GroupModel.insert
 - Introduce LoggerCategory enum to advertise logger categories used by this package.
-- Limited maximum cache size of the backend PromiseMemoizer. 
+- Limited maximum cache size of the backend PromiseMemoizer.
 - Missing dependency on node-report
-- Fixed memoization problem that caused an endless stream of 404 NotFound errors. 
+- Fixed memoization problem that caused an endless stream of 404 NotFound errors.
 - Reinstated old version of OidcAgentClient
-- Unauthorized open requests should cause a more obvious error. 
-- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop. 
+- Unauthorized open requests should cause a more obvious error.
+- Improved performance logging, especially of IModelDb open operations; ChangeSets are merged one-by-one to prevent hogging the event loop.
 - Memoization fix when opening iModels in shared, read-only mode .
 - Fixed setup of application version.
 - Updated Element CRUD perf tests
@@ -2133,7 +2135,7 @@ Mon, 13 May 2019 15:52:05 GMT
 - Remove ElementPropertyFormatter, IModelDb.getElementPropertiesForDisplay (use presentation rules instead)
 - Remove StandaloneIModelRpcImpl
 - Fix for Render Gradient.Symb test
-- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization. 
+- Setup a generic context for tracking client requests, and made various related enhancements to logging, usage tracking and authorization.
 - Add IModelDb.createSnapshot/openSnapshot/closeSnapshot, deprecate IModelDb.createStandalone/openStandalone/closeStandalone
 - Moved IModelJsExpressServer class into a new package (@itwin/express-server).
 - Simplified tile caching IModelHost config and removed dev flags. Allow
@@ -2160,7 +2162,7 @@ Wed, 06 Mar 2019 15:41:22 GMT
 - Changes package.json to include api-extractor and adds api-extractor.json
 - Use new buildIModelJsBuild script
 - AxisAlignedBox and ElementAlignedBox are now typed to Range3d rather than classes
-- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package. 
+- Moved AzureFileHandler, IOSAzureFileHandler, UrlFileHandler and the iModelHub tests to the imodeljs-clients-backend package. This removes the dependency of imodeljs-clients on the "fs" module, and turns it into a browser only package.
 - Clone methods are no longer generic
 - Remove unneeded typedoc plugin dependency
 - Added spatial <-> cartographic methods that check/use the geographic coordinate system before using ecef location.
@@ -2205,8 +2207,8 @@ Mon, 14 Jan 2019 23:09:10 GMT
 
 ### Updates
 
-- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics. 
-- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current. 
+- More logging of HTTP requests, and enabled use of fiddler for backend diagnostics.
+- Removed IModelDb's cache of accessToken. For long running operations like AutoPush, the user must explicitly supply an IAccessTokenManager to keep the token current.
 - Renamed RequestProxy->RequestHost. Allowed applications to configure proxy server with HTTPS_PROXY env.
 - Add backend TextureAPI and accompanying test
 
@@ -2311,7 +2313,7 @@ Mon, 03 Dec 2018 18:52:58 GMT
 
 ### Updates
 
-- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application. 
+- More information logged from BriefcaseManager.\nFixed deletion/cleanup of invalid briefcases.\nAdded OIDC support for simpleviewtest application.
 - Add ElementRefersToElements.insert
 - Fixed front end integration tests.
 - Document the intended purpose of IModelJsExpressServer within a deployment environment.
@@ -2380,11 +2382,11 @@ Thu, 08 Nov 2018 17:59:20 GMT
 
 - Fix JSON representation of DisplayStyle.
 - Add IModelImporter as a base class for utility methods needed by all importers
-- Removed assertion when deleting a memoized open call. 
+- Removed assertion when deleting a memoized open call.
 - Add more methods to IModelImporter
 - Fix snapping test
 - OIDC related enhancments (WIP).
-- Re-enabled several backend integration tests. 
+- Re-enabled several backend integration tests.
 - Refactor analysis-importer to use IModelImporter
 - Updated to TypeScript 3.1
 

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
 
-THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #2
+THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #3
 
 ## 4.7.2
 Sat, 22 Jun 2024 01:09:54 GMT

--- a/core/backend/CHANGELOG.md
+++ b/core/backend/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 This log was last generated on Sat, 22 Jun 2024 01:11:18 GMT and should not be manually modified.
 
-THIS LINE IS JUST FOR TEST AND SERVED NO PURPOSE #8
-
 ## 4.7.2
 Sat, 22 Jun 2024 01:09:54 GMT
 


### PR DESCRIPTION
This involves [Issue #1124](https://github.com/iTwin/itwinjs-backlog/issues/1124)

- Problem: Currently, when Finalize Release Workflow is triggered manually, we get incorrect commit message as seen [here](https://github.com/iTwin/itwinjs-core/commit/dd1cbc1ea98f34df1be0788ca4452d1cfab0090a)

- Approach: Instead of getting version from latest commit, extract version from latest git tag is more consistent

- Affected File(s): .github/workflows/automation-scripts/update-changelogs.mjs