### PR TITLE
Reinstate ecschema-metadata clean script

### DIFF
--- a/common/changes/@itwin/ecschema-metadata/pmc-ecschema-metadata-clean_2024-07-01-09-38.json
+++ b/common/changes/@itwin/ecschema-metadata/pmc-ecschema-metadata-clean_2024-07-01-09-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-metadata/package.json
+++ b/core/ecschema-metadata/package.json
@@ -15,6 +15,7 @@
     "build": "npm run -s build:cjs && npm run -s build:esm",
     "build:cjs": "tsc 1>&2 --outDir lib/cjs && npm run -s copy:test-assets",
     "build:esm": "tsc 1>&2 --module ES2020 --outDir lib/esm",
+    "clean": "rimraf lib .rush/temp/package-deps*.json",
     "copy:test-assets": "cpx \"./src/test/assets/**/*\" ./lib/cjs/test/assets",
     "extract-api": "betools extract-api --entry=ecschema-metadata",
     "lint": "eslint -f visualstudio \"./src/**/*.ts\" 1>&2",


### PR DESCRIPTION
Removed in #6900. @williamkbentley I presume this was unintentional.
Causes `rush clean` to fail.