### PR TITLE
Promote and/or clean up a bunch of APIs

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3084,7 +3084,6 @@ export abstract class IModelDb extends IModel {
     isStandaloneDb(): this is StandaloneDb;
     // @internal (undocumented)
     protected loadWorkspaceSettings(): Promise<void>;
-    // @beta
     get locks(): LockControl;
     // @internal (undocumented)
     protected _locks?: LockControl;
@@ -3134,7 +3133,7 @@ export abstract class IModelDb extends IModel {
     restartQuery(token: string, ecsql: string, params?: QueryBinder, options?: QueryOptions): AsyncIterableIterator<any>;
     // @internal (undocumented)
     restartTxnSession(): void;
-    // @internal (undocumented)
+    // @internal @deprecated (undocumented)
     reverseTxns(numOperations: number): IModelStatus;
     saveChanges(description?: string): void;
     saveFileProperty(prop: FilePropertyProps, strValue: string | undefined, blobVal?: Uint8Array): void;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2731,13 +2731,13 @@ export namespace ElementGeometry {
     export function updateGeometryParams(entry: ElementGeometryDataEntry, geomParams: GeometryParams, localToWorld?: Transform): boolean;
 }
 
-// @beta
+// @public
 export interface ElementGeometryBuilderParams {
     entryArray: ElementGeometryDataEntry[];
     viewIndependent?: boolean;
 }
 
-// @beta
+// @public
 export interface ElementGeometryBuilderParamsForPart {
     entryArray: ElementGeometryDataEntry[];
     is2dPart?: boolean;
@@ -3773,7 +3773,6 @@ export interface GeometricElement3dProps extends GeometricElementProps {
 // @public
 export interface GeometricElementProps extends ElementProps {
     category: Id64String;
-    // @beta
     elementGeometryBuilderParams?: ElementGeometryBuilderParams;
     geom?: GeometryStreamProps;
     placement?: PlacementProps;
@@ -3882,7 +3881,6 @@ export interface GeometryPartInstanceProps {
 export interface GeometryPartProps extends ElementProps {
     // (undocumented)
     bbox?: LowAndHighXYZProps;
-    // @beta
     elementGeometryBuilderParams?: ElementGeometryBuilderParamsForPart;
     // (undocumented)
     geom?: GeometryStreamProps;
@@ -6776,20 +6774,16 @@ export interface PolylineFlags {
     is2d?: boolean;
     isDisjoint?: boolean;
     isPlanar?: boolean;
-    // @alpha
     type?: PolylineTypeFlags;
 }
 
 // @public
 export type PolylineIndices = number[];
 
-// @alpha
+// @public
 export enum PolylineTypeFlags {
-    // (undocumented)
-    Edge = 1,// Just an ordinary polyline
-    // (undocumented)
-    Normal = 0,// A polyline used to define the edges of a planar region.
-    // (undocumented)
+    Edge = 1,
+    Normal = 0,
     Outline = 2
 }
 
@@ -8820,7 +8814,7 @@ export interface RunLayoutResult {
 // @beta
 export type RunProps = TextRunProps | FractionRunProps | LineBreakRunProps;
 
-// @beta
+// @public
 export enum SchemaState {
     TooNew = 4,
     TooOld = 3,

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2161,7 +2161,7 @@ export class Cluster<T extends Marker> {
     get position(): Point3d;
 }
 
-// @beta
+// @public
 export type CollectTileStatus = "accept" | "reject" | "continue";
 
 // @internal
@@ -4326,7 +4326,7 @@ export class GeometryOptions {
     get wantSurfacesOnly(): boolean;
 }
 
-// @beta
+// @public
 export interface GeometryTileTreeReference extends TileTreeReference {
     collectTileGeometry: (collector: TileGeometryCollector) => void;
 }
@@ -6904,7 +6904,6 @@ export class IModelApp {
     static get notifications(): NotificationManager;
     static readonly onAfterStartup: BeEvent<() => void>;
     static readonly onBeforeShutdown: BeEvent<() => void>;
-    // @beta
     static get publicPath(): string;
     static get quantityFormatter(): QuantityFormatter;
     static queryRenderCompatibility(): WebGLRenderCompatibilityInfo;
@@ -6936,7 +6935,6 @@ export class IModelApp {
     // @beta
     static translateStatus(status: number): string;
     static get uiAdmin(): UiAdmin;
-    // @beta
     static get userPreferences(): UserPreferencesAccess | undefined;
     static get viewManager(): ViewManager;
 }
@@ -6957,7 +6955,6 @@ export interface IModelAppOptions {
     // @internal
     noRender?: boolean;
     notifications?: NotificationManager;
-    // @beta
     publicPath?: string;
     // @internal (undocumented)
     quantityFormatter?: QuantityFormatter;
@@ -6973,13 +6970,14 @@ export interface IModelAppOptions {
     tileAdmin?: TileAdmin.Props;
     toolAdmin?: ToolAdmin;
     uiAdmin?: UiAdmin;
-    // @beta
     userPreferences?: UserPreferencesAccess;
     viewManager?: ViewManager;
 }
 
 // @public
 export abstract class IModelConnection extends IModel {
+    // @internal
+    [_requestSnap](props: SnapRequestProps): Promise<SnapResponseProps>;
     // @internal
     protected constructor(iModelProps: IModelConnectionProps);
     // @internal
@@ -7034,7 +7032,6 @@ export abstract class IModelConnection extends IModel {
     // @internal
     get noGcsDefined(): boolean;
     static readonly onClose: BeEvent<(_imodel: IModelConnection) => void>;
-    // @beta
     readonly onClose: BeEvent<(_imodel: IModelConnection) => void>;
     // @internal
     readonly onMapElevationLoaded: BeEvent<(_imodel: IModelConnection) => void>;
@@ -7049,7 +7046,7 @@ export abstract class IModelConnection extends IModel {
     // @internal
     querySubCategories(compressedCategoryIds: CompressedId64Set): Promise<SubCategoryResultRow[]>;
     queryTextureData(textureLoadProps: TextureLoadProps): Promise<TextureData | undefined>;
-    // @internal
+    // @internal @deprecated (undocumented)
     requestSnap(props: SnapRequestProps): Promise<SnapResponseProps>;
     // @deprecated
     restartQuery(token: string, ecsql: string, params?: QueryBinder, options?: QueryOptions): AsyncIterableIterator<any>;
@@ -7490,15 +7487,16 @@ export class IntersectDetail extends SnapDetail {
 
 // @public
 export class IpcApp {
+    // @internal
+    static [_callIpcChannel](channelName: string, methodName: string, ...args: any[]): Promise<any>;
     static addListener(channel: string, handler: IpcListener): RemoveFunction;
     static appFunctionIpc: PickAsyncMethods<IpcAppFunctions>;
-    // @internal
+    // @internal @deprecated (undocumented)
     static callIpcChannel(channelName: string, methodName: string, ...args: any[]): Promise<any>;
     // @deprecated (undocumented)
     static callIpcHost<T extends AsyncMethodsOf<IpcAppFunctions>>(methodName: T, ...args: Parameters<IpcAppFunctions[T]>): Promise<PromiseReturnType<IpcAppFunctions[T]>>;
     static invoke(channel: string, ...args: any[]): Promise<any>;
     static get isValid(): boolean;
-    // @internal
     static makeIpcFunctionProxy<K>(channelName: string, functionName: string): PickAsyncMethods<K>;
     static makeIpcProxy<K>(channelName: string): PickAsyncMethods<K>;
     static removeListener(channel: string, listener: IpcListener): void;
@@ -7539,14 +7537,6 @@ export enum ItemField {
     X_Item = 2,
     Y_Item = 3,
     Z_Item = 4
-}
-
-// @beta
-export interface ITwinIdArg {
-    // (undocumented)
-    readonly iModelId?: GuidString;
-    // (undocumented)
-    readonly iTwinId?: GuidString;
 }
 
 // @public (undocumented)
@@ -10711,20 +10701,6 @@ export interface PolylineParams {
     weight: number;
 }
 
-// @beta
-export interface PreferenceArg extends PreferenceKeyArg {
-    // (undocumented)
-    readonly content?: any;
-}
-
-// @beta
-export interface PreferenceKeyArg {
-    // (undocumented)
-    readonly key: string;
-    // (undocumented)
-    readonly namespace?: string;
-}
-
 // @internal (undocumented)
 export enum PreserveOrder {
     // (undocumented)
@@ -11344,7 +11320,6 @@ export class RealityTile extends Tile {
     protected forceSelectRealityTile(): boolean;
     // @internal (undocumented)
     freeMemory(): void;
-    // @beta
     get geometry(): RealityTileGeometry | undefined;
     // @internal (undocumented)
     protected _geometry?: RealityTileGeometry;
@@ -11441,7 +11416,7 @@ export class RealityTileDrawArgs extends TileDrawArgs {
     get worldToViewMap(): Map4d;
 }
 
-// @beta
+// @public
 export interface RealityTileGeometry {
     polyfaces?: IndexedPolyface[];
 }
@@ -12399,6 +12374,11 @@ export class SavedState {
     rotationMode: RotationMode;
     // (undocumented)
     state: CurrentState;
+}
+
+// @public
+export interface SaveUserPreferenceArgs extends UserPreferenceKeyArgs {
+    content?: any;
 }
 
 // @public
@@ -14527,7 +14507,7 @@ export class TileDrawArgs {
     get worldToViewMap(): Map4d;
 }
 
-// @beta
+// @public
 export class TileGeometryCollector {
     constructor(options: TileGeometryCollectorOptions);
     addMissingTile(tile: Tile): void;
@@ -14539,7 +14519,7 @@ export class TileGeometryCollector {
     requestMissingTiles(): void;
 }
 
-// @beta
+// @public
 export interface TileGeometryCollectorOptions {
     chordTolerance: number;
     range: Range3d;
@@ -14859,18 +14839,14 @@ export abstract class TileTreeReference {
     canSupplyToolTip(_hit: HitDetail): boolean;
     get castsShadows(): boolean;
     collectStatistics(stats: RenderMemory.Statistics): void;
-    // @beta
     collectTileGeometry?: (collector: TileGeometryCollector) => void;
-    // @beta
     protected _collectTileGeometry(collector: TileGeometryCollector): void;
     protected computeTransform(tree: TileTree): Transform;
     computeWorldContentRange(): ElementAlignedBox3d;
     createDrawArgs(context: SceneContext): TileDrawArgs | undefined;
     // @beta
     static createFromRenderGraphic(args: RenderGraphicTileTreeArgs): TileTreeReference;
-    // @beta
     createGeometryTreeReference(): GeometryTileTreeReference | undefined;
-    // @beta
     protected _createGeometryTreeReference(): GeometryTileTreeReference | undefined;
     decorate(_context: DecorateContext): void;
     discloseTileTrees(trees: DisclosedTileTreeSet): void;
@@ -14985,12 +14961,6 @@ export enum TileVisibility {
     OutsideFrustum = 0,
     TooCoarse = 1,
     Visible = 2
-}
-
-// @beta
-export interface TokenArg {
-    // (undocumented)
-    accessToken?: AccessToken;
 }
 
 // @internal (undocumented)
@@ -15657,11 +15627,21 @@ export class UpsampledMapTile extends MapTile {
     get renderGeometry(): RenderTerrainGeometry | undefined;
 }
 
-// @beta
+// @public
+export interface UserPreferenceKeyArgs {
+    // (undocumented)
+    accessToken?: AccessToken;
+    iModelId?: GuidString;
+    iTwinId?: GuidString;
+    key: string;
+    namespace?: string;
+}
+
+// @public
 export interface UserPreferencesAccess {
-    delete: (arg: PreferenceKeyArg & ITwinIdArg & TokenArg) => Promise<void>;
-    get: (arg: PreferenceKeyArg & ITwinIdArg & TokenArg) => Promise<any>;
-    save: (arg: PreferenceArg & ITwinIdArg & TokenArg) => Promise<void>;
+    delete: (args: UserPreferenceKeyArgs) => Promise<void>;
+    get: (args: UserPreferenceKeyArgs) => Promise<any>;
+    save: (args: SaveUserPreferenceArgs) => Promise<void>;
 }
 
 // @beta
@@ -16551,7 +16531,6 @@ export class ViewManager implements Iterable<ScreenViewport> {
     getDecorationGeometry(hit: HitDetail): GeometryStreamProps | undefined;
     // @internal
     getDecorationToolTip(hit: HitDetail): Promise<HTMLElement | string>;
-    // @beta
     getElementToolTip(hit: HitDetail): Promise<HTMLElement | string>;
     getFirstOpenView(): ScreenViewport | undefined;
     // (undocumented)
@@ -16561,7 +16540,6 @@ export class ViewManager implements Iterable<ScreenViewport> {
     hasViewport(viewport: ScreenViewport): boolean;
     // (undocumented)
     inDynamicsMode: boolean;
-    // @beta
     invalidateCachedDecorationsAllViews(decorator: ViewportDecorator): void;
     invalidateDecorationsAllViews(): void;
     invalidateScenes(): void;

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -220,8 +220,8 @@ public;ElementAlignedBox2d = Range2d
 public;ElementAlignedBox3d = Range3d
 public;ElementAspectProps 
 beta;ElementGeometry
-beta;ElementGeometryBuilderParams
-beta;ElementGeometryBuilderParamsForPart
+public;ElementGeometryBuilderParams
+public;ElementGeometryBuilderParamsForPart
 public;ElementGeometryChange = ExtantElementGeometryChange | DeletedElementGeometryChange
 public;ElementGeometryChange
 public;ElementGeometryDataEntry
@@ -586,7 +586,7 @@ internal;POLICY: unique symbol
 internal;PolylineEdgeArgs
 public;PolylineFlags
 public;PolylineIndices = number[]
-alpha;PolylineTypeFlags
+public;PolylineTypeFlags
 public;PositionalVectorTransform 
 public;PositionalVectorTransformProps
 internal;PrimaryTileTreeId
@@ -742,7 +742,7 @@ beta;Run = TextRun | FractionRun | LineBreakRun
 beta;Run
 beta;RunLayoutResult
 beta;RunProps = TextRunProps | FractionRunProps | LineBreakRunProps
-beta;SchemaState
+public;SchemaState
 public;SectionDrawingLocationProps 
 public;SectionDrawingProps 
 public;SectionDrawingViewProps

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -111,7 +111,7 @@ public;CheckboxFormatPropEditorSpec
 public;CheckpointConnection 
 public;ClipEventType
 public;Cluster
-beta;CollectTileStatus = "accept" | "reject" | "continue"
+public;CollectTileStatus = "accept" | "reject" | "continue"
 internal;collectTransferables(document: ImdlModel.Document): Transferable[]
 internal;ColorMap 
 public;CompassMode
@@ -271,7 +271,7 @@ internal;GeometryAccumulator
 internal;GeometryList
 internal;class GeometryListBuilder 
 internal;GeometryOptions
-beta;GeometryTileTreeReference 
+public;GeometryTileTreeReference 
 public;GeoServices
 internal;GeoServicesOptions = Omit
 public;getCenteredViewRect(viewRect: ViewRect, aspectRatio?: number): ViewRect
@@ -472,7 +472,6 @@ public;isTextInputFormatPropEditorSpec: (item: CustomFormatPropEditorSpec) => it
 public;isTextSelectFormatPropEditorSpec: (item: CustomFormatPropEditorSpec) => item is TextSelectFormatPropEditorSpec
 internal;isValidSurfaceType(value: number): boolean
 public;ItemField
-beta;ITwinIdArg
 public;ITWINJS_CORE_VERSION: string
 public;KeyinParseError
 internal;KeyinStatus
@@ -661,8 +660,6 @@ public;PolylineArgs
 public;PolylineArgs
 internal;fromMesh(mesh: Mesh): PolylineArgs | undefined
 internal;PolylineParams
-beta;PreferenceArg 
-beta;PreferenceKeyArg
 internal;PreserveOrder
 internal;PrimitiveBuilder 
 internal;PrimitiveGeometryType = Loop | Path | IndexedPolyface | SolidPrimitive
@@ -723,7 +720,7 @@ internal;RealityModelTileUtils
 public;RealityTile 
 internal;RealityTileContent 
 internal;RealityTileDrawArgs 
-beta;RealityTileGeometry
+public;RealityTileGeometry
 internal;class RealityTileLoader
 internal;RealityTileParams 
 internal;RealityTileRegion
@@ -770,6 +767,7 @@ public;RotateViewTool
 public;RotationMode
 internal;RoundOff
 internal;SavedState
+public;SaveUserPreferenceArgs 
 public;Scene
 public;SceneContext 
 internal;SceneVolumeClassifier
@@ -885,8 +883,8 @@ internal;addToScene(provider: TiledGraphicsProvider, context: SceneContext): voi
 internal;isLoadingComplete(provider: TiledGraphicsProvider, viewport: Viewport): boolean
 public;TileDrawArgParams
 public;TileDrawArgs
-beta;TileGeometryCollector
-beta;TileGeometryCollectorOptions
+public;TileGeometryCollector
+public;TileGeometryCollectorOptions
 public;TileGraphicType
 public;TileLoadPriority
 public;TileLoadStatus
@@ -913,7 +911,6 @@ public;TileUser
 internal;TileUserIdSet 
 internal;TileUserIdSets 
 public;TileVisibility
-beta;TokenArg
 internal;ToleranceRatio
 internal;toMaterialParams(mat: ImdlModel.SurfaceMaterialParams): MaterialParams
 public;Tool
@@ -964,7 +961,8 @@ internal;UniqueTileUserSets
 public;UnitFormattingSettingsProvider
 public;UnitNameKey = string
 internal;UpsampledMapTile 
-beta;UserPreferencesAccess
+public;UserPreferenceKeyArgs
+public;UserPreferencesAccess
 beta;ValidateSourceArgs
 public;VaryingType
 internal;VertexIndices 

--- a/common/changes/@itwin/core-backend/pmc-booster-internal_2024-07-02-20-17.json
+++ b/common/changes/@itwin/core-backend/pmc-booster-internal_2024-07-02-20-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/pmc-booster-internal_2024-07-02-20-17.json
+++ b/common/changes/@itwin/core-common/pmc-booster-internal_2024-07-02-20-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-electron/pmc-booster-internal_2024-07-02-20-17.json
+++ b/common/changes/@itwin/core-electron/pmc-booster-internal_2024-07-02-20-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/changes/@itwin/core-frontend/pmc-booster-internal_2024-07-02-20-17.json
+++ b/common/changes/@itwin/core-frontend/pmc-booster-internal_2024-07-02-20-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-mobile/pmc-booster-internal_2024-07-02-20-17.json
+++ b/common/changes/@itwin/core-mobile/pmc-booster-internal_2024-07-02-20-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -186,10 +186,7 @@ export abstract class IModelDb extends IModel {
   /** @alpha */
   public get codeService() { return this._codeService; }
 
-  /**
-   * Get the [[LockControl]] for this iModel.
-   * @beta
-   */
+  /** The [[LockControl]] that orchestrates [concurrent editing]($docs/learning/backend/ConcurrencyControl.md) of this iModel. */
   public get locks(): LockControl { return this._locks!; } // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
   /**
@@ -204,7 +201,7 @@ export abstract class IModelDb extends IModel {
   }
 
   /** Acquire the exclusive schema lock on this iModel.
-   * > Note: To acquire the schema lock, all other briefcases must first release *all* their locks. No other briefcases
+   * @note: To acquire the schema lock, all other briefcases must first release *all* their locks. No other briefcases
    * will be able to acquire *any* locks while the schema lock is held.
    */
   public async acquireSchemaLock(): Promise<void> {
@@ -3082,7 +3079,7 @@ export class SnapshotDb extends IModelDb {
 
   /** Create an *empty* local [Snapshot]($docs/learning/backend/AccessingIModels.md#snapshot-imodels) iModel file.
    * Snapshots are not synchronized with iModelHub, so do not have a change timeline.
-   * > Note: A *snapshot* cannot be modified after [[close]] is called.
+   * @note: A *snapshot* cannot be modified after [[close]] is called.
    * @param filePath The file that will contain the new iModel *snapshot*
    * @param options The parameters that define the new iModel *snapshot*
    * @returns A writeable SnapshotDb
@@ -3102,7 +3099,7 @@ export class SnapshotDb extends IModelDb {
 
   /** Create a local [Snapshot]($docs/learning/backend/AccessingIModels.md#snapshot-imodels) iModel file, using this iModel as a *seed* or starting point.
    * Snapshots are not synchronized with iModelHub, so do not have a change timeline.
-   * > Note: A *snapshot* cannot be modified after [[close]] is called.
+   * @note: A *snapshot* cannot be modified after [[close]] is called.
    * @param iModelDb The snapshot will be initialized from the current contents of this iModelDb
    * @param snapshotFile The file that will contain the new iModel *snapshot*
    * @param options Optional properties that determine how the snapshot iModel is created.

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -757,7 +757,9 @@ export abstract class IModelDb extends IModel {
     }
   }
 
-  /** @internal */
+  /** @internal
+   * @deprecated in 4.8. Use `txns.reverseTxns`.
+   */
   public reverseTxns(numOperations: number): IModelStatus {
     return this.nativeDb.reverseTxns(numOperations);
   }

--- a/core/backend/src/LockControl.ts
+++ b/core/backend/src/LockControl.ts
@@ -10,8 +10,9 @@ import { Id64Arg, Id64String } from "@itwin/core-bentley";
 import { _close, _elementWasCreated, _implementationProhibited, _releaseAllLocks } from "./internal/Symbols";
 
 /**
- * Interface for acquiring element locks to coordinate simultaneous edits from multiple briefcases.
- * @beta
+ * Interface for acquiring element locks to [coordinate simultaneous edits]($docs/learning/backend/ConcurrencyControl.md) from multiple briefcases.
+ * @see [[IModelDb.locks]] to access the locks for an iModel.
+ * @public
  */
 export interface LockControl {
   /** @internal*/
@@ -37,30 +38,30 @@ export interface LockControl {
   /**
    * Throw if locks are required and the exclusive lock is not held on the supplied element.
    * Note: there is no need to check the shared locks on parents/models since an element cannot hold the exclusive lock without first obtaining them.
-   * Called by [[Element.onUpdate]], [[Element.onDelete]], etc.
+   * Called by functions like [[Element.onUpdate]], [[Element.onDelete]], etc.
    */
   checkExclusiveLock(id: Id64String, type: string, operation: string): void;
 
   /**
    * Throw if locks are required and a shared lock is not held on the supplied element.
-   * Called by [[Element.onInsert]] to ensure shared lock is held on model and parent.
+   * Called by [[Element.onInsert]] to ensure shared lock is held on the new element's model and parent element.
    */
   checkSharedLock(id: Id64String, type: string, operation: string): void;
 
   /**
-   * Determine whether the supplied element currently holds the exclusive lock
+   * Determine whether the owning iModel currently holds the exclusive lock on the specified element.
    */
   holdsExclusiveLock(id: Id64String): boolean;
 
   /**
-   * Determine whether the supplied element currently holds a shared lock
+   * Determine whether the owning iModel currently holds a shared lock on the specified element.
    */
   holdsSharedLock(id: Id64String): boolean;
 
   /**
    * Acquire locks on one or more elements from the lock server, if required and not already held.
    * If any required lock is not available, this method throws an exception and *none* of the requested locks are acquired.
-   * > Note: acquiring the exclusive lock on an element requires also obtaining a shared lock on all its owner elements. This method will
+   * @note Acquiring the exclusive lock on an element requires also obtaining a shared lock on all its owner elements. This method will
    * attempt to acquire all necessary locks for both sets of input ids.
    */
   acquireLocks(arg: {

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -515,7 +515,7 @@ export class TxnManager {
    * @note If numOperations is too large only the operations are reversible are reversed.
    */
   public reverseTxns(numOperations: number): IModelStatus {
-    return this._iModel.reverseTxns(numOperations);
+    return this._nativeDb.reverseTxns(numOperations);
   }
 
   /** Reverse the most recent operation. */

--- a/core/common/src/BriefcaseTypes.ts
+++ b/core/common/src/BriefcaseTypes.ts
@@ -240,7 +240,7 @@ export interface UpgradeOptions {
 /**
  * The state of the schemas in the Db compared with what the current version of the software expects
  * Note: The state may vary depending on whether the Db is to be opened ReadOnly or ReadWrite.
- * @beta
+ * @public
  */
 export enum SchemaState {
   /** The schemas in the Db are up-to-date, and do not need to be upgraded before opening it with the current version of the software */

--- a/core/common/src/ElementProps.ts
+++ b/core/common/src/ElementProps.ts
@@ -107,8 +107,8 @@ export interface GeometricElementProps extends ElementProps {
   category: Id64String;
   /** The geometry stream properties */
   geom?: GeometryStreamProps;
-  /** How to build the element's GeometryStream. This is used for insert and update only. It is not a persistent property. It will be undefined in the properties returned by functions that read a persistent element. It may be specified as an alternative to `geom` when inserting or updating an element.
-   * @beta
+  /** Describes how to build the element's GeometryStream, as an alternative to [[geom]]. This is used for insert and update operations only.
+   * It is not a persistent property - it will always be undefined in the properties returned by functions that read a persistent element.
    */
   elementGeometryBuilderParams?: ElementGeometryBuilderParams;
   /** The placement properties */
@@ -255,8 +255,8 @@ export interface TextAnnotation2dProps extends GeometricElement2dProps {
  */
 export interface GeometryPartProps extends ElementProps {
   geom?: GeometryStreamProps;
-  /** How to build the part's GeometryStream. This is used for insert and update only. It is not a persistent property. It will be undefined in the properties returned by functions that read a persistent element. It may be specified as an alternative to `geom` when inserting or updating an element.
-   * @beta
+  /** Describes how to build the part's GeometryStream, as an alternative to [[geom]]. This is used for insert and update operations only.
+   * It is not a persistent property - it will always be undefined in the properties returned by functions that read a persistent part.
    */
   elementGeometryBuilderParams?: ElementGeometryBuilderParamsForPart;
   bbox?: LowAndHighXYZProps;

--- a/core/common/src/Render.ts
+++ b/core/common/src/Render.ts
@@ -11,12 +11,17 @@ import { OctEncodedNormalPair } from "./OctEncodedNormal";
 // cSpell:ignore vals
 
 /** Describes the semantics of a [PolylineArgs]($frontend).
- * @alpha
+ * @public
  */
 export enum PolylineTypeFlags {
-  Normal = 0,      // Just an ordinary polyline
-  Edge = 1 << 0, // A polyline used to define the edges of a planar region.
-  Outline = 1 << 1, // Like Edge, but the edges are only displayed in wireframe mode when surface fill is undisplayed.
+  /** Just an ordinary polyline with no special semantics. */
+  Normal = 0,
+  /** A polyline used to define the edges of a planar region. */
+  Edge = 1 << 0,
+  /** Like [[Edge]], but the edges are only displayed in [[RenderMode.Wireframe]] when the surface's fill is not displayed.
+   * [[FillFlags]] controls whether the fill is displayed.
+   */
+  Outline = 1 << 1,
 }
 
 /** Flags describing a [PolylineArgs]($frontend).
@@ -29,9 +34,7 @@ export interface PolylineFlags {
   isPlanar?: boolean;
   /** If `true`, the polylines' positions all have the same z coordinate. */
   is2d?: boolean;
-  /** Default: Normal.
-   * @alpha
-   */
+  /** Default: Normal. */
   type?: PolylineTypeFlags;
 }
 

--- a/core/common/src/core-common.ts
+++ b/core/common/src/core-common.ts
@@ -105,7 +105,6 @@ export * from "./RgbColor";
 export * from "./RpcManager";
 export * from "./SessionProps";
 export * from "./SkyBox";
-export * from "./Snapping";
 export * from "./SolarCalculate";
 export * from "./SolarShadows";
 export * from "./SpatialClassification";
@@ -161,6 +160,8 @@ export * from "./tile/TileIO";
 export * from "./tile/TileMetadata";
 export * from "./tile/Tileset3dSchema";
 export * from "./WhiteOnWhiteReversalSettings";
+
+export * from "./internal/cross-package";
 
 /** @docs-package-description
  * The core-common package contains classes for working with iModels that can be used in both [frontend]($docs/learning/frontend/index.md) and [backend]($docs/learning/backend/index.md).

--- a/core/common/src/geometry/ElementGeometry.ts
+++ b/core/common/src/geometry/ElementGeometry.ts
@@ -129,19 +129,21 @@ export interface ElementGeometryRequest {
   minBRepFeatureSize?: number;
 }
 
-/** Parameters for building the geometry stream of a [[GeometricElement]] using ElementGeometry.Builder
- * Note: The geometry stream is always in local coordinates, that is, relative to the element's [[Placement]].
- * @beta
+/** Parameters for building the geometry stream of a GeometricElement](@backend) using [[ElementGeometry.Builder]].
+ * You can assign an object of this type to [[GeometricElementProps.elementGeometryBuilderParams]] when inserting or updating a geometric element.
+ * @note The geometry stream is always in local coordinates - that is, relative to the element's [[Placement]].
+ * @public
  */
 export interface ElementGeometryBuilderParams {
   /** The geometry stream data. Calling update element with a zero length array will clear the geometry stream and invalidate the placement. */
   entryArray: ElementGeometryDataEntry[];
-  /** If true, create geometry that displays oriented to face the camera */
+  /** If true, create geometry that always displays oriented to face the camera */
   viewIndependent?: boolean;
 }
 
-/** Parameters for building the geometry stream of a [[GeometryPart]] using ElementGeometry.Builder.
- * @beta
+/** Parameters for building the geometry stream of a GeometryPart](@backend) using [[ElementGeometry.Builder]].
+ * You can assign an object of this type to [[GeometryPartProps.elementGeometryBuilderParams]] when inserting or updating a part.
+ * @public
  */
 export interface ElementGeometryBuilderParamsForPart {
   /** The geometry stream data */

--- a/core/common/src/internal/Snapping.ts
+++ b/core/common/src/internal/Snapping.ts
@@ -8,12 +8,12 @@
 
 import { Id64Array, Id64String } from "@itwin/core-bentley";
 import { Matrix4dProps, XYZProps } from "@itwin/core-geometry";
-import { GeometryStreamProps } from "./geometry/GeometryStream";
-import { GeometryClass } from "./GeometryParams";
-import { ViewFlagProps } from "./ViewFlags";
+import { GeometryStreamProps } from "../geometry/GeometryStream";
+import { GeometryClass } from "../GeometryParams";
+import { ViewFlagProps } from "../ViewFlags";
 
 /** Information required to request a *snap* to a pickable decoration from the front end to the back end.
- * @internal
+ * @internal RPC glue.
  */
 export interface DecorationGeometryProps {
   readonly id: Id64String;
@@ -22,7 +22,7 @@ export interface DecorationGeometryProps {
 
 /** Information required to request a *snap* to an element from the front end to the back end.
  * Includes the viewing parameters so that snap can be relative to the view direction, viewing mode, etc.
- * @internal
+ * @internal RPC glue.
  */
 export interface SnapRequestProps {
   id: Id64String;
@@ -40,7 +40,7 @@ export interface SnapRequestProps {
 }
 
 /** Information returned from the back end to the front end holding the result of a *snap* operation.
- * @internal
+ * @internal RPC glue.
  */
 export interface SnapResponseProps {
   status: number;

--- a/core/common/src/internal/cross-package.ts
+++ b/core/common/src/internal/cross-package.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+export { DecorationGeometryProps, SnapRequestProps, SnapResponseProps } from "./Snapping";
+

--- a/core/common/src/rpc/IModelReadRpcInterface.ts
+++ b/core/common/src/rpc/IModelReadRpcInterface.ts
@@ -26,7 +26,7 @@ import {
 import { ModelProps } from "../ModelProps";
 import { RpcInterface } from "../RpcInterface";
 import { RpcManager } from "../RpcManager";
-import { SnapRequestProps, SnapResponseProps } from "../Snapping";
+import { SnapRequestProps, SnapResponseProps } from "../internal/Snapping";
 import { TextureData, TextureLoadProps } from "../TextureProps";
 import {
   CustomViewState3dCreatorOptions, CustomViewState3dProps, HydrateViewStateRequestProps, HydrateViewStateResponseProps, SubCategoryResultRow,

--- a/core/electron/src/frontend/ElectronApp.ts
+++ b/core/electron/src/frontend/ElectronApp.ts
@@ -86,6 +86,7 @@ export class ElectronApp {
    * @deprecated in 3.x. use [[dialogIpc]]
    */
   public static async callDialog<T extends DialogModuleMethod>(methodName: T, ...args: Parameters<Electron.Dialog[T]>) {
+    // eslint-disable-next-line deprecation/deprecation
     return IpcApp.callIpcChannel(electronIpcStrings.dialogChannel, "callDialog", methodName, ...args) as PromiseReturnType<Electron.Dialog[T]>;
   }
 

--- a/core/frontend/src/AccuSnap.ts
+++ b/core/frontend/src/AccuSnap.ts
@@ -19,6 +19,7 @@ import { ToolSettings } from "./tools/ToolSettings";
 import { DecorateContext } from "./ViewContext";
 import { Decorator } from "./ViewManager";
 import { ScreenViewport, Viewport } from "./Viewport";
+import { _requestSnap } from "./internal/Symbols";
 
 // cspell:ignore dont primitivetools
 
@@ -751,7 +752,7 @@ export class AccuSnap implements Decorator {
     }
 
     try {
-      const result = await thisHit.iModel.requestSnap(requestProps);
+      const result = await thisHit.iModel[_requestSnap](requestProps);
 
       if (out)
         out.snapStatus = result.status;

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -136,7 +136,6 @@ export interface IModelAppOptions {
   realityDataAccess?: RealityDataAccess;
   /** If present, overrides where public assets are fetched. The default is to fetch assets relative to the current URL.
    * The path should always end with a trailing `/`.
-   * @beta
    */
   publicPath?: string;
 }
@@ -290,10 +289,12 @@ export class IModelApp {
   public static get uiAdmin() { return this._uiAdmin; }
   /** The requested security options for the frontend. */
   public static get securityOptions() { return this._securityOptions; }
-  /** The root URL for the assets 'public' folder.
-   * @beta
+
+  /** If present, overrides where public assets are fetched. The default is to fetch assets relative to the current URL.
+   * The path should always end with a trailing `/`.
    */
   public static get publicPath() { return this._publicPath; }
+
   /** The [[TelemetryManager]] for this session
    * @internal
    */

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -85,9 +85,7 @@ export interface IModelAppOptions {
   applicationId?: string;
   /** If present, supplies the version of this application. Must be set for usage logging. */
   applicationVersion?: string;
-  /** If present, supplies the [[UserPreferencesAccess]] for this session.
-   * @beta
-   */
+  /** If present, supplies the [[UserPreferencesAccess]] for this session. */
   userPreferences?: UserPreferencesAccess;
   /** If present, supplies the [[ViewManager]] for this session. */
   viewManager?: ViewManager;
@@ -257,7 +255,7 @@ export class IModelApp {
   /** The [[Localization]] for this session. */
   public static get localization(): Localization { return this._localization; }
   /** The [[UserPreferencesAccess]] for this session.
-   * @beta
+   * @see [[IModelAppOptions.userPreferences]] to configure this at [[startup]].
    */
   public static get userPreferences(): UserPreferencesAccess | undefined { return this._userPreferences; }
   /** The Id of this application. Applications must set this to the Global Product Registry ID (GPRID) for usage logging. */

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -34,6 +34,7 @@ import { SubCategoriesCache } from "./SubCategoriesCache";
 import { BingElevationProvider } from "./tile/internal";
 import { Tiles } from "./Tiles";
 import { ViewState } from "./ViewState";
+import { _requestSnap } from "./internal/Symbols";
 
 const loggerCategory: string = FrontendLoggerCategory.IModelConnection;
 
@@ -367,8 +368,15 @@ export abstract class IModelConnection extends IModel {
    * @note callers must gracefully handle Promise rejected with AbandonedError
    * @internal
    */
-  public async requestSnap(props: SnapRequestProps): Promise<SnapResponseProps> {
+  public async [_requestSnap](props: SnapRequestProps): Promise<SnapResponseProps> {
     return this.isOpen ? this._snapRpc.request(props) : { status: 2 };
+  }
+
+  /** @internal
+   * @deprecated in 4.8. Use AccuSnap.doSnapRequest.
+   */
+  public async requestSnap(props: SnapRequestProps): Promise<SnapResponseProps> {
+    return this[_requestSnap](props);
   }
 
   private _toolTipRpc = new OneAtATimeAction<string[]>(async (id: string) => IModelReadRpcInterface.getClientForRouting(this.routingContext.token).getToolTipMessage(this.getRpcProps(), id));

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -142,9 +142,9 @@ export abstract class IModelConnection extends IModel {
    */
   public abstract get isClosed(): boolean;
 
-  /** Event called immediately before *any* IModelConnection is closed.
-   * @note This static event is called when *any* IModelConnection is closed, and the specific IModelConnection is passed as its argument. To
-   * monitor closing a specific IModelConnection, use the `onClose` instance event.
+  /** Event raised immediately before *any* IModelConnection is [[close]]d.
+   * @note This static event is raised when *any* IModelConnection is closed, and the specific IModelConnection is passed as its argument. To
+   * monitor closing a specific IModelConnection, listen for the `onClose` instance event instead.
    * @note Be careful not to perform any asynchronous operations on the IModelConnection because it will close before they are processed.
    */
   public static readonly onClose = new BeEvent<(_imodel: IModelConnection) => void>();
@@ -152,10 +152,9 @@ export abstract class IModelConnection extends IModel {
   /** Event called immediately after *any* IModelConnection is opened. */
   public static readonly onOpen = new BeEvent<(_imodel: IModelConnection) => void>();
 
-  /** Event called immediately before *this* IModelConnection is closed.
-   * @note This event is called only for this IModelConnection. To monitor *all* IModelConnections,use the static event.
+  /** Event raised immediately before this IModelConnection is [[close]]d.
+   * @note This event is raised only for this specific IModelConnection. To monitor *all* IModelConnections, listen for the static `onClose` event instead.
    * @note Be careful not to perform any asynchronous operations on the IModelConnection because it will close before they are processed.
-   * @beta
    */
   public readonly onClose = new BeEvent<(_imodel: IModelConnection) => void>();
 

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -361,7 +361,7 @@ export abstract class IModelConnection extends IModel {
 
   private _snapRpc = new OneAtATimeAction<SnapResponseProps>(
     async (props: SnapRequestProps) =>
-      IModelReadRpcInterface.getClientForRouting(this.routingContext.token).requestSnap(this.getRpcProps(), IModelApp.sessionId, props)
+      IModelReadRpcInterface.getClientForRouting(this.routingContext.token).requestSnap(this.getRpcProps(), IModelApp.sessionId, props),
   );
 
   /** Request a snap from the backend.

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -358,7 +358,11 @@ export abstract class IModelConnection extends IModel {
     return new Set(this.isOpen ? await IModelReadRpcInterface.getClientForRouting(this.routingContext.token).queryEntityIds(this.getRpcProps(), params) : undefined);
   }
 
-  private _snapRpc = new OneAtATimeAction<SnapResponseProps>(async (props: SnapRequestProps) => IModelReadRpcInterface.getClientForRouting(this.routingContext.token).requestSnap(this.getRpcProps(), IModelApp.sessionId, props));
+  private _snapRpc = new OneAtATimeAction<SnapResponseProps>(
+    async (props: SnapRequestProps) =>
+      IModelReadRpcInterface.getClientForRouting(this.routingContext.token).requestSnap(this.getRpcProps(), IModelApp.sessionId, props)
+  );
+
   /** Request a snap from the backend.
    * @note callers must gracefully handle Promise rejected with AbandonedError
    * @internal

--- a/core/frontend/src/IpcApp.ts
+++ b/core/frontend/src/IpcApp.ts
@@ -12,7 +12,7 @@ import {
   iTwinChannel, RemoveFunction,
 } from "@itwin/core-common";
 import { IModelApp, IModelAppOptions } from "./IModelApp";
-import { _callIpcChannel } from "./internal/Symbols"; 
+import { _callIpcChannel } from "./internal/Symbols";
 
 /**
  * Options for [[IpcApp.startup]]
@@ -108,7 +108,7 @@ export class IpcApp {
   public static async callIpcChannel(channelName: string, methodName: string, ...args: any[]): Promise<any> {
     return this[_callIpcChannel](channelName, methodName, args);
   }
-  
+
   /** Create a type safe Proxy object to make IPC calls to a registered backend interface.
    * @param channelName the channel registered by the backend handler.
    */

--- a/core/frontend/src/IpcApp.ts
+++ b/core/frontend/src/IpcApp.ts
@@ -12,6 +12,7 @@ import {
   iTwinChannel, RemoveFunction,
 } from "@itwin/core-common";
 import { IModelApp, IModelAppOptions } from "./IModelApp";
+import { _callIpcChannel } from "./internal/Symbols"; 
 
 /**
  * Options for [[IpcApp.startup]]
@@ -91,7 +92,7 @@ export class IpcApp {
    * @note Ipc is only supported if [[isValid]] is true.
    * @internal Use [[makeIpcProxy]] for a type-safe interface.
    */
-  public static async callIpcChannel(channelName: string, methodName: string, ...args: any[]): Promise<any> {
+  public static async [_callIpcChannel](channelName: string, methodName: string, ...args: any[]): Promise<any> {
     const retVal = (await this.invoke(channelName, methodName, ...args)) as IpcInvokeReturn;
     if (undefined !== retVal.error) {
       const err = new BackendError(retVal.error.errorNumber, retVal.error.name, retVal.error.message);
@@ -101,6 +102,13 @@ export class IpcApp {
     return retVal.result;
   }
 
+  /** @internal
+   * @deprecated in 4.8. Use [[makeIpcProxy]] for a type-safe interface.
+   */
+  public static async callIpcChannel(channelName: string, methodName: string, ...args: any[]): Promise<any> {
+    return this[_callIpcChannel](channelName, methodName, args);
+  }
+  
   /** Create a type safe Proxy object to make IPC calls to a registered backend interface.
    * @param channelName the channel registered by the backend handler.
    */
@@ -108,7 +116,7 @@ export class IpcApp {
     return new Proxy({} as PickAsyncMethods<K>, {
       get(_target, methodName: string) {
         return async (...args: any[]) =>
-          IpcApp.callIpcChannel(channelName, methodName, ...args);
+          IpcApp[_callIpcChannel](channelName, methodName, ...args);
       },
     });
   }
@@ -121,14 +129,14 @@ export class IpcApp {
     return new Proxy({} as PickAsyncMethods<K>, {
       get(_target, methodName: string) {
         return async (...args: any[]) =>
-          IpcApp.callIpcChannel(channelName, functionName, methodName, ...args);
+          IpcApp[_callIpcChannel](channelName, functionName, methodName, ...args);
       },
     });
   }
 
   /** @deprecated in 3.x. use [[appFunctionIpc]] */
   public static async callIpcHost<T extends AsyncMethodsOf<IpcAppFunctions>>(methodName: T, ...args: Parameters<IpcAppFunctions[T]>) {
-    return this.callIpcChannel(ipcAppChannels.functions, methodName, ...args) as PromiseReturnType<IpcAppFunctions[T]>;
+    return this[_callIpcChannel](ipcAppChannels.functions, methodName, ...args) as PromiseReturnType<IpcAppFunctions[T]>;
   }
 
   /** A Proxy to call one of the [IpcAppFunctions]($common) functions via IPC. */

--- a/core/frontend/src/IpcApp.ts
+++ b/core/frontend/src/IpcApp.ts
@@ -116,7 +116,6 @@ export class IpcApp {
   /** Create a type safe Proxy object to call an IPC function on a of registered backend handler that accepts a "methodName" argument followed by optional arguments
    * @param channelName the channel registered by the backend handler.
    * @param functionName the function to call on the handler.
-   * @internal
    */
   public static makeIpcFunctionProxy<K>(channelName: string, functionName: string): PickAsyncMethods<K> {
     return new Proxy({} as PickAsyncMethods<K>, {

--- a/core/frontend/src/LocalhostIpcApp.ts
+++ b/core/frontend/src/LocalhostIpcApp.ts
@@ -9,6 +9,7 @@
 import { InterceptedRpcRequest, IpcSession, IpcWebSocket, IpcWebSocketFrontend, IpcWebSocketMessage, IpcWebSocketTransport, rpcOverIpcStrings } from "@itwin/core-common";
 import { IpcApp } from "./IpcApp";
 import { IModelApp, IModelAppOptions } from "./IModelApp";
+import { _callIpcChannel } from "./internal/Symbols";
 
 /** @internal */
 export interface LocalHostIpcAppOpts {
@@ -70,7 +71,7 @@ class LocalTransport extends IpcWebSocketTransport {
 
 class LocalSession extends IpcSession {
   public override async handleRpc(info: InterceptedRpcRequest) {
-    return IpcApp.callIpcChannel(rpcOverIpcStrings.channelName, "request", info);
+    return IpcApp[_callIpcChannel](rpcOverIpcStrings.channelName, "request", info);
   }
 }
 

--- a/core/frontend/src/NativeApp.ts
+++ b/core/frontend/src/NativeApp.ts
@@ -17,6 +17,7 @@ import { FrontendLoggerCategory } from "./common/FrontendLoggerCategory";
 import { IpcApp, IpcAppOptions, NotificationHandler } from "./IpcApp";
 import { NativeAppLogger } from "./NativeAppLogger";
 import { OnDownloadProgress } from "./BriefcaseConnection";
+import { _callIpcChannel } from "./internal/Symbols";
 
 /** Properties for specifying the BriefcaseId for downloading. May either specify a BriefcaseId directly (preferable) or, for
  * backwards compatibility, a [SyncMode]($common). If [SyncMode.PullAndPush]($common) is supplied, a new briefcaseId will be acquired.
@@ -66,7 +67,7 @@ export class NativeApp {
 
   /** @deprecated in 3.x. use nativeAppIpc */
   public static async callNativeHost<T extends AsyncMethodsOf<NativeAppFunctions>>(methodName: T, ...args: Parameters<NativeAppFunctions[T]>) {
-    return IpcApp.callIpcChannel(nativeAppIpcStrings.channelName, methodName, ...args) as PromiseReturnType<NativeAppFunctions[T]>;
+    return IpcApp[_callIpcChannel](nativeAppIpcStrings.channelName, methodName, ...args) as PromiseReturnType<NativeAppFunctions[T]>;
   }
   /** A Proxy to call one of the [NativeAppFunctions]($common) functions via IPC. */
   public static nativeAppIpc = IpcApp.makeIpcProxy<NativeAppFunctions>(nativeAppIpcStrings.channelName);

--- a/core/frontend/src/UserPreferences.ts
+++ b/core/frontend/src/UserPreferences.ts
@@ -16,7 +16,7 @@ export interface UserPreferenceKeyArgs {
   /** If supplied, indicates the user preference is defined at the level of this iTwin. */
   iTwinId?: GuidString;
   /** If supplied, indicates the user preference is defined at the level of this iModel. */
-  iModelId?: GuidString
+  iModelId?: GuidString;
   accessToken?: AccessToken;
   /** A unique namespace for [[key]]. */
   namespace?: string;

--- a/core/frontend/src/UserPreferences.ts
+++ b/core/frontend/src/UserPreferences.ts
@@ -9,76 +9,56 @@
 
 import { AccessToken, GuidString } from "@itwin/core-bentley";
 
-/** Argument for methods that can supply an iTwinId and iModelId.
- * @beta
+/** Arguments supplied to [[UserPreferencesAccess]] methods to specify a single user preference.
+ * @public
  */
-export interface ITwinIdArg {
-  readonly iTwinId?: GuidString;
-  readonly iModelId?: GuidString;
-}
-
-/** Argument for methods that can supply an access token.
- * @beta
- */
-export interface TokenArg {
+export interface UserPreferenceKeyArgs {
+  /** If supplied, indicates the user preference is defined at the level of this iTwin. */
+  iTwinId?: GuidString;
+  /** If supplied, indicates the user preference is defined at the level of this iModel. */
+  iModelId?: GuidString
   accessToken?: AccessToken;
+  /** A unique namespace for [[key]]. */
+  namespace?: string;
+  /** The key that identifies the user preference. */
+  key: string;
 }
 
-/** Argument for methods that can supply the user preference content.
- * @beta
+/** Arguments supplied to [[UserPreferencesAccess.save]].
+ * @public
  */
-export interface PreferenceArg extends PreferenceKeyArg {
-  readonly content?: any;
-}
-
-/** Argument for methods that must supply a key for the user preference.
- * @beta
- */
-export interface PreferenceKeyArg {
-  readonly namespace?: string;
-  readonly key: string;
+export interface SaveUserPreferenceArgs extends UserPreferenceKeyArgs {
+  /** The value to associate with the user preference. */
+  content?: any;
 }
 
 /** User preferences provide a way to get, store and delete preferences for an application at
- * two different levels, iTwin and iModel.
+ * the level of an iTwin and/or iModel. They apply to a **single user**, as opposed to
+ * [Workspace settings]($docs/learning/backend/Workspace.md) which are shared across multiple users.
  *
- * The user preferences are separate from any iTwin or iModel configuration intended to be shared
- * across multiple users. See [Workspace]($docs/learning/backend/Workspace.md) for more details on
- * shared configuration.
- *
- * Note: Both the key and return type are intended to be abstract and allow any preferences to be stored.
- *     Based on this simple interface, the implementation of this interface can interpret the key as needed
- *     to store and retrieve the preferences.
- * @beta
+ * An object satisfying this interface can be supplied via [[IModelAppOptions.userPreferences]] when invoking [[IModelApp.startup]],
+ * and accessed during the session via [[IModelApp.userPreferences]].
+ * @public
  */
 export interface UserPreferencesAccess {
-  /** Method to get a user preference based off of a key within a namespace.
-   *
-   * If both iTwinId and iModelId are provided, the iModel level will be check first. If
-   * it does not exist, the iTwin level will checked next.
-   *
-   * @returns undefined if a preference is not found.
-   * @throws if an error occurs when attempting to retrieve a preference.
+  /** Obtain the value associated with a preference key.
+   * If an iModelId is specified and a preference value is defined for that iModel, that value will be returned.
+   * Otherwise, the method will attempt to look up the preference value at the iTwin level.
+   * @returns the value corresponding to the preference key, or undefined if no such value was found.
+   * @throws if an error occurs during retrieval.
    */
-  get: (arg: PreferenceKeyArg & ITwinIdArg & TokenArg) => Promise<any>;
+  get: (args: UserPreferenceKeyArgs) => Promise<any>;
 
   /** Deletes the specified preference by key, if it exists, within the level provided.
-   *
    * If both iTwinId and iModelId are provided, the key will be deleted from both levels.
-   *
    * If the key does not exist in either level provided, then this function will do nothing.
-   *
    * @throws if any error occurs when deleting the preference.
    */
-  delete: (arg: PreferenceKeyArg & ITwinIdArg & TokenArg) => Promise<void>;
+  delete: (args: UserPreferenceKeyArgs) => Promise<void>;
 
-  /** Saves the provided preference by the key within the provided level.
-   *
+  /** Saves the value of a preference, overwriting any pre-existing value.
    * If both iTwinId and iModelId are provided, the key will be saved to both levels.
-   *
-   * If the key already exists, in either level, the preference will be updated.
-   *
    * @throws if any error occurs while saving.
    */
-  save: (arg: PreferenceArg & ITwinIdArg & TokenArg) => Promise<void>;
+  save: (args: SaveUserPreferenceArgs) => Promise<void>;
 }

--- a/core/frontend/src/ViewManager.ts
+++ b/core/frontend/src/ViewManager.ts
@@ -337,10 +337,8 @@ export class ViewManager implements Iterable<ScreenViewport> {
     return this._viewports[Symbol.iterator]();
   }
 
-  /** Force each registered [[Viewport]] to regenerate all of its cached [[Decorations]] on the next frame. If the decorator parameter is specified, only
-   * the specified decorator will have its cached decorations invalidated for all viewports.
-   * @see [[Viewport.invalidateCachedDecorations]] to manually remove a decorator's cached decorations from a viewport, forcing them to be regenerated.
-   * @beta
+  /** Instruct each registered [[Viewport]] that the cached [[Decorations]] for the specified `decorator` should be discarded and recreated on the next frame.
+   * @see [[Viewport.invalidateCachedDecorations]] to invalidate the cached decorations for a single viewport.
    */
   public invalidateCachedDecorationsAllViews(decorator: ViewportDecorator): void {
     if (decorator.useCachedDecorations)
@@ -446,9 +444,8 @@ export class ViewManager implements Iterable<ScreenViewport> {
     }
   }
 
-  /** Get the tooltip for a persistent element.
-   * Calls the backend method [Element.getToolTipMessage]($backend), and replaces all instances of `${localizeTag}` with localized string from IModelApp.i18n.
-   * @beta
+  /** Compute the tooltip for a persistent element.
+   * This method calls the backend method [Element.getToolTipMessage]($backend), and replaces all instances of `${localizeTag}` with localized string from IModelApp.i18n.
    */
   public async getElementToolTip(hit: HitDetail): Promise<HTMLElement | string> {
     const msg: string[] = await hit.iModel.getToolTipMessage(hit.sourceId); // wait for the locate message(s) from the backend

--- a/core/frontend/src/internal/Symbols.ts
+++ b/core/frontend/src/internal/Symbols.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utils
+ */
+
+function sym(name: string): string {
+  return `${name}_core-frontend_INTERNAL_ONLY_DO_NOT_USE`;
+}
+
+export const _callIpcChannel = Symbol.for(sym("callIpcChannel"));
+export const _requestSnap = Symbol.for(sym("requestSnap"));

--- a/core/frontend/src/test/AccuSnap.test.ts
+++ b/core/frontend/src/test/AccuSnap.test.ts
@@ -13,6 +13,7 @@ import { ScreenViewport } from "../Viewport";
 import { AccuSnap } from "../AccuSnap";
 import { IModelApp } from "../IModelApp";
 import { testBlankViewportAsync } from "./openBlankViewport";
+import { _requestSnap } from "../internal/Symbols";
 
 interface HitDetailProps {
   hitPoint?: XYZProps; // defaults to [0, 0, 0]
@@ -50,7 +51,7 @@ describe("AccuSnap", () => {
 
   describe("requestSnap", () => {
     function overrideRequestSnap(iModel: IModelConnection, impl?: (props: SnapRequestProps) => SnapResponseProps): void {
-      iModel.requestSnap = async (props) => Promise.resolve(impl ? impl(props) : {
+      iModel[_requestSnap] = async (props) => Promise.resolve(impl ? impl(props) : {
         status: SnapStatus.Success,
         hitPoint: props.testPoint,
         snapPoint: props.testPoint,

--- a/core/frontend/src/tile/RealityTile.ts
+++ b/core/frontend/src/tile/RealityTile.ts
@@ -31,9 +31,9 @@ export interface RealityTileParams extends TileParams {
   readonly geometricError?: number;
 }
 
-/** The geometry representing the contents of a reality tile. Currently only polyfaces are returned
- * @beta
+/** The geometry representing the contents of a reality tile. Currently only polyfaces are returned.
  * @see [[RealityTile.geometry]] to access a particular tile's geometry.
+ * @public
  */
 export interface RealityTileGeometry {
   /** Polyfaces representing the tile's geometry. */
@@ -128,7 +128,6 @@ export class RealityTile extends Tile {
   public get isLoaded() { return this.loadStatus === TileLoadStatus.Ready; }      // Reality tiles may depend on secondary tiles (maps) so can ge loaded but not ready.
   /** A representation of the tile's geometry.
    * This property is only available when using [[TileGeometryCollector]].
-   * @beta
    */
   public get geometry(): RealityTileGeometry | undefined { return this._geometry; }
 

--- a/core/frontend/src/tile/TileGeometryCollector.ts
+++ b/core/frontend/src/tile/TileGeometryCollector.ts
@@ -16,12 +16,12 @@ import {
  * - "accept": The tile's geometry should be collected.
  * - "reject": The tile's geometry (and that of all of its child tiles) should be omitted.
  * - "continue": The tile's geometry should be omitted, but that of its child tiles should be evaluated for collection.
- * @beta
+ * @public
  */
 export type CollectTileStatus = "accept" | "reject" | "continue";
 
 /** Options for creating a [[TileGeometryCollector]].
- * @beta
+ * @public
  */
 export interface TileGeometryCollectorOptions {
   /** The chord tolerance in meters describing the minimum level of detail desired of the tile geometry. */
@@ -38,7 +38,7 @@ export interface TileGeometryCollectorOptions {
  * Subclasses can refine the collection criterion.
  * The tile geometry is obtained asynchronously, so successive collections over multiple frames may be required before all of the geometry
  * is collected.
- * @beta
+ * @public
  */
 export class TileGeometryCollector {
   /** The list of accumulated polyfaces, populated during [[GeometryTileTreeReference.collectTileGeometry]].
@@ -106,7 +106,7 @@ export class TileGeometryCollector {
 /** A [[TileTreeReference]] that can supply geometry in the form of [Polyface]($core-geometry)s from [[Tile]]s belonging to its [[TileTree]] and satisfying the criteria defined
  * by a [[TileGeometryCollector]].
  * Use [[TileTreeReference.createGeometryTreeReference]] to obtain a GeometryTileTreeReference from an existing TileTreeReference.
- * @beta
+ * @public
  */
 export interface GeometryTileTreeReference extends TileTreeReference {
   /** Populate [[TileGeometryCollector.polyfaces]] with geometry satisfying `collector`'s criteria.

--- a/core/frontend/src/tile/TileTreeReference.ts
+++ b/core/frontend/src/tile/TileTreeReference.ts
@@ -263,19 +263,16 @@ export abstract class TileTreeReference /* implements RenderMemory.Consumer */ {
   /** Create a tile tree reference equivalent to this one that also supplies an implementation of [[GeometryTileTreeReference.collectTileGeometry]].
    * Return `undefined` if geometry collection is not supported.
    * @see [[createGeometryTreeReference]].
-   * @beta
    */
   protected _createGeometryTreeReference(): GeometryTileTreeReference | undefined {
     return undefined;
   }
 
   /** If defined, supplies the implementation of [[GeometryTileTreeReference.collectTileGeometry]].
-   * @beta
    */
   public collectTileGeometry?: (collector: TileGeometryCollector) => void;
 
   /** A function that can be assigned to [[collectTileGeometry]] to enable geometry collection for references to tile trees that support geometry collection.
-   * @beta
    */
   protected _collectTileGeometry(collector: TileGeometryCollector): void {
     const tree = this.treeOwner.load();
@@ -294,7 +291,6 @@ export abstract class TileTreeReference /* implements RenderMemory.Consumer */ {
    * undefined if geometry collection is not supported.
    * Currently, only terrain and reality model tiles support geometry collection.
    * @note Do not override this method - override [[_createGeometryTreeReference]] instead.
-   * @beta
    */
   public createGeometryTreeReference(): GeometryTileTreeReference | undefined {
     if (this.collectTileGeometry) {

--- a/core/mobile/src/frontend/MobileApp.ts
+++ b/core/mobile/src/frontend/MobileApp.ts
@@ -41,6 +41,7 @@ export class MobileApp {
   public static onWillTerminate = new BeEvent<() => void>();
   public static onAuthAccessTokenChanged = new BeEvent<(accessToken: string | undefined, expirationDate: string | undefined) => void>();
   public static async callBackend<T extends AsyncMethodsOf<MobileAppFunctions>>(methodName: T, ...args: Parameters<MobileAppFunctions[T]>) {
+    // eslint-disable-next-line deprecation/deprecation
     return IpcApp.callIpcChannel(mobileAppStrings.mobileAppChannel, methodName, ...args) as PromiseReturnType<MobileAppFunctions[T]>;
   }
 


### PR DESCRIPTION
Part of https://github.com/iTwin/itwinjs-backlog/issues/1103.
I could have made a few dozen individual PRs but that would be overkill.

`EntityMetaData` et al will be addressed in a separate PR as the API needs refactoring.
`IModelDb.nativeDb` will be addressed in a separate PR as it will impact many files.

vite is being a complaining about exports from core-common's cross-package.ts when building display-performance-test-app and display-test-app. It doesn't have any such problem with the exports from core-bentley's cross-package.ts. @aruniverse I may need your help figuring out what it wants.
```
"DecorationGeometryProps" is not exported by "../../core/common/src/internal/Snapping.ts", imported by "../../core/common/src/internal/cross-package.ts".
file: /home/paul/c/js/s/itwinjs/core/common/src/internal/cross-package.ts:6:9
4: *--------------------------------------------------------------------------------------------*/
5:
6: export { DecorationGeometryProps, SnapRequestProps, SnapResponseProps } from "./Snapping";
            ^
error during build:
RollupError: "DecorationGeometryProps" is not exported by "../../core/common/src/internal/Snapping.ts", imported by "../../core/common/src/internal/cross-package.ts".
    at error (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:2287:30)
    at Module.error (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:13745:16)
    at Module.getVariableForExportName (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:13909:29)
    at getVariableForExportNameRecursive (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:13571:19)
    at Module.getVariableFromNamespaceReexports (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:14362:50)
    at Module.getVariableForExportName (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:13940:22)
    at Module.includeAllExports (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:13982:37)
    at Object.includeAllExports (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:14103:43)
    at NamespaceVariable.include (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:13181:22)
    at Module.includeVariable (file:///home/paul/c/js/s/itwinjs/common/temp/node_modules/.pnpm/rollup@3.29.4/node_modules/rollup/dist/es/shared/node-entry.js:14443:22)
```