### PR TITLE
Add public to constant.ts

### DIFF
--- a/common/changes/@itwin/core-geometry/nick-add-public_2024-07-03-13-55.json
+++ b/common/changes/@itwin/core-geometry/nick-add-public_2024-07-03-13-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/Constant.ts
+++ b/core/geometry/src/Constant.ts
@@ -9,6 +9,7 @@
 
 /**
  * Commonly used constant values.
+ * @public
  */
 export class Constant {
   /** symbolic name for 1 millimeter:  0.001 meter */


### PR DESCRIPTION
Without this, I get 

Analysis will use the bundled TypeScript version 5.4.2
Error: src/Constant.ts:13:1 - (ae-missing-release-tag) "Constant" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

API Extractor completed with errors

locally. 

As well as in my pipeline https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=2997999&view=logs&jobId=98bcb9af-6780-51c4-01f3-7d41d7c82e74&j=98bcb9af-6780-51c4-01f3-7d41d7c82e74&t=93a643e6-ba20-5515-aad8-b904d25149fa