### PR TITLE
Presentation: Add `NestedContentValue.label` property which is passed to `IContentVisitor.startStruct`

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1821,6 +1821,7 @@ export interface NestedContentFieldJSON<TClassInfoJSON = ClassInfoJSON> extends 
 // @public
 export interface NestedContentValue {
     displayValues: ValuesDictionary<DisplayValue>;
+    label?: string;
     mergedFieldNames: string[];
     primaryKeys: InstanceKey[];
     values: ValuesDictionary<Value>;
@@ -3069,6 +3070,7 @@ export interface StartItemProps {
 
 // @public
 export interface StartStructProps {
+    description?: string;
     displayValues: DisplayValuesMap;
     hierarchy: FieldHierarchy;
     parentFieldName?: string;

--- a/common/changes/@itwin/presentation-common/nested-content-value-label_2024-07-08-08-17.json
+++ b/common/changes/@itwin/presentation-common/nested-content-value-label_2024-07-08-08-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/presentation-common",
-      "comment": "Add `label` property to `NestedContentValue` which is passed to `StartStructProps.description`. This value can be displayed next to the array index when rendering arrays of structs.",
+      "comment": "Add `NestedContentValue.label` property which is passed to `IContentVisitor.startStruct`.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/presentation-common/nested-content-value-label_2024-07-08-08-17.json
+++ b/common/changes/@itwin/presentation-common/nested-content-value-label_2024-07-08-08-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Add `label` property to `NestedContentValue` which is passed to `StartStructProps.description`. This value can be displayed next to the array index when rendering arrays of structs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/common/src/presentation-common/content/Value.ts
+++ b/presentation/common/src/presentation-common/content/Value.ts
@@ -192,7 +192,7 @@ export interface NestedContentValue {
   displayValues: ValuesDictionary<DisplayValue>;
   /** Names of fields whose values are merged */
   mergedFieldNames: string[];
-  /** Text label that should be displayed next to the index. */
+  /** Label of the ECInstance that this `NestedContentValue` is based on. */
   label?: string;
 }
 

--- a/presentation/common/src/presentation-common/content/Value.ts
+++ b/presentation/common/src/presentation-common/content/Value.ts
@@ -192,6 +192,8 @@ export interface NestedContentValue {
   displayValues: ValuesDictionary<DisplayValue>;
   /** Names of fields whose values are merged */
   mergedFieldNames: string[];
+  /** Text label that should be displayed next to the index. */
+  label?: string;
 }
 
 /**


### PR DESCRIPTION
Part of https://github.com/iTwin/presentation/issues/654
Will be consumed in `presentation-components` in https://github.com/iTwin/presentation/pull/664