### PR TITLE
Deprecate nativeDb

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1696,6 +1696,8 @@ export abstract class DriverBundleElement extends InformationContentElement {
 
 // @public
 export class ECDb implements IDisposable {
+    // @internal (undocumented)
+    get [_nativeDb](): IModelJsNative.ECDb;
     constructor();
     abandonChanges(): void;
     // @internal
@@ -1709,7 +1711,7 @@ export class ECDb implements IDisposable {
     getSchemaProps(name: string): ECSchemaProps;
     importSchema(pathName: string): void;
     get isOpen(): boolean;
-    // @internal (undocumented)
+    // @internal @deprecated (undocumented)
     get nativeDb(): IModelJsNative.ECDb;
     openDb(pathName: string, openMode?: ECDbOpenMode): void;
     // @internal
@@ -3000,6 +3002,8 @@ export type IModelCloneContext = IModelElementCloneContext;
 
 // @public
 export abstract class IModelDb extends IModel {
+    // @internal (undocumented)
+    readonly [_nativeDb]: IModelJsNative.DgnDb;
     // @internal
     protected constructor(args: {
         nativeDb: IModelJsNative.DgnDb;
@@ -3091,8 +3095,8 @@ export abstract class IModelDb extends IModel {
     static readonly maxLimit = 10000;
     // (undocumented)
     readonly models: IModelDb.Models;
-    // @internal (undocumented)
-    readonly nativeDb: IModelJsNative.DgnDb;
+    // @internal @deprecated (undocumented)
+    get nativeDb(): IModelJsNative.DgnDb;
     // @internal (undocumented)
     notifyChangesetApplied(): void;
     readonly onBeforeClose: BeEvent<() => void>;
@@ -4119,6 +4123,9 @@ export class NativeAppStorage {
 
 export { NativeCloudSqlite }
 
+// @internal (undocumented)
+export const _nativeDb: unique symbol;
+
 // @public
 export class NativeHost {
     // (undocumented)
@@ -5106,6 +5113,8 @@ export interface SqliteChangesetReaderArgs {
 
 // @public
 export class SQLiteDb {
+    // @internal (undocumented)
+    readonly [_nativeDb]: IModelJsNative.SQLiteDb;
     abandonChanges(): void;
     closeDb(saveChanges?: boolean): void;
     // @internal (undocumented)
@@ -5124,8 +5133,8 @@ export class SQLiteDb {
     executeSQL(sql: string): DbResult;
     get isOpen(): boolean;
     get isReadonly(): boolean;
-    // @internal (undocumented)
-    readonly nativeDb: IModelJsNative.SQLiteDb;
+    // @internal @deprecated (undocumented)
+    get nativeDb(): IModelJsNative.SQLiteDb;
     openDb(dbName: string, openMode: OpenMode | SQLiteDb.OpenParams): void;
     // @beta (undocumented)
     openDb(dbName: string, openMode: OpenMode | SQLiteDb.OpenParams, container?: CloudSqlite.CloudContainer): void;

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -272,6 +272,7 @@ public;Model
 public;ModelSelector 
 internal;ModelSelectorRefersToModels 
 public;NativeAppStorage
+internal;_nativeDb: unique symbol
 public;NativeHost
 public;NativeHostOpts 
 beta;OnAspectArg

--- a/common/changes/@itwin/analytical-backend/pmc-nativedb_2024-07-08-19-03.json
+++ b/common/changes/@itwin/analytical-backend/pmc-nativedb_2024-07-08-19-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/analytical-backend"
+}

--- a/common/changes/@itwin/core-backend/pmc-nativedb_2024-07-08-19-03.json
+++ b/common/changes/@itwin/core-backend/pmc-nativedb_2024-07-08-19-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Deprecate the internal `nativeDb` fields of IModelDb, ECDb, and SQLiteDb, to be removed in 5.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-impl/pmc-nativedb_2024-07-08-19-03.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-impl/pmc-nativedb_2024-07-08-19-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-impl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-impl"
+}

--- a/common/changes/@itwin/presentation-backend/pmc-nativedb_2024-07-08-19-03.json
+++ b/common/changes/@itwin/presentation-backend/pmc-nativedb_2024-07-08-19-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/workspace-editor/pmc-nativedb_2024-07-08-19-03.json
+++ b/common/changes/@itwin/workspace-editor/pmc-nativedb_2024-07-08-19-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/workspace-editor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/workspace-editor"
+}

--- a/core/backend/src/ChangedElementsDb.ts
+++ b/core/backend/src/ChangedElementsDb.ts
@@ -14,6 +14,7 @@ import { ECDbOpenMode } from "./ECDb";
 import { IModelDb } from "./IModelDb";
 import { IModelHost } from "./IModelHost";
 import { IModelNative } from "./internal/NativePlatform";
+import { _nativeDb } from "./internal/Symbols";
 
 /**
  * Options for processChangesets function
@@ -58,7 +59,7 @@ export class ChangedElementsDb implements IDisposable {
    * @throws [IModelError]($common) if the operation failed.
    */
   private _createDb(briefcase: IModelDb, pathName: string): void {
-    const status: DbResult = this.nativeDb.createDb(briefcase.nativeDb, pathName);
+    const status: DbResult = this.nativeDb.createDb(briefcase[_nativeDb], pathName);
     if (status !== DbResult.BE_SQLITE_OK)
       throw new IModelError(status, "Failed to created ECDb");
   }
@@ -111,7 +112,7 @@ export class ChangedElementsDb implements IDisposable {
     // ChangeSets need to be processed from newest to oldest
     changesets.reverse();
     const status = this.nativeDb.processChangesets(
-      briefcase.nativeDb,
+      briefcase[_nativeDb],
       changesets,
       options.rulesetId,
       options.filterSpatial,

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -22,6 +22,7 @@ import { IModelHost } from "./IModelHost";
 import { IModelJsFs } from "./IModelJsFs";
 import { SnapshotDb, TokenArg } from "./IModelDb";
 import { IModelNative } from "./internal/NativePlatform";
+import { _nativeDb } from "./internal/Symbols";
 
 const loggerCategory = BackendLoggerCategory.IModelDb;
 
@@ -334,7 +335,7 @@ export class CheckpointManager {
       const prevLogLevel = Logger.getLevel(NativeLoggerCategory.SQLite) ?? LogLevel.Error; // Get log level before we set it to None.
       Logger.setLevel(NativeLoggerCategory.SQLite, LogLevel.None); // Ignores noisy error messages when applying changesets.
       const db = SnapshotDb.openForApplyChangesets(targetFile);
-      const nativeDb = db.nativeDb;
+      const nativeDb = db[_nativeDb];
       try {
 
         if (nativeDb.hasPendingTxns()) {
@@ -398,7 +399,7 @@ export class CheckpointManager {
   public static validateCheckpointGuids(checkpoint: CheckpointProps, snapshotDb: SnapshotDb) {
     const traceInfo = { iTwinId: checkpoint.iTwinId, iModelId: checkpoint.iModelId };
 
-    const nativeDb = snapshotDb.nativeDb;
+    const nativeDb = snapshotDb[_nativeDb];
     const dbChangeset = nativeDb.getCurrentChangeset();
     const iModelId = Guid.normalize(nativeDb.getIModelId());
     if (iModelId !== Guid.normalize(checkpoint.iModelId)) {

--- a/core/backend/src/ClassRegistry.ts
+++ b/core/backend/src/ClassRegistry.ts
@@ -13,6 +13,7 @@ import { IModelDb } from "./IModelDb";
 import { Schema, Schemas } from "./Schema";
 import { EntityReferences } from "./EntityReferences";
 import * as assert from "assert";
+import { _nativeDb } from "./internal/Symbols";
 
 const isGeneratedClassTag = Symbol("isGeneratedClassTag");
 
@@ -74,7 +75,7 @@ export class ClassRegistry {
    */
   public static getRootEntity(iModel: IModelDb, ecTypeQualifier: string): string {
     const [classSchema, className] = ecTypeQualifier.split(".");
-    const schemaItemJson = iModel.nativeDb.getSchemaItem(classSchema, className);
+    const schemaItemJson = iModel[_nativeDb].getSchemaItem(classSchema, className);
     if (schemaItemJson.error)
       throw new IModelError(schemaItemJson.error.status, `failed to get schema item '${ecTypeQualifier}'`);
 
@@ -150,7 +151,7 @@ export class ClassRegistry {
         // eslint-disable-next-line @typescript-eslint/no-shadow
         .map(([name, prop]) => {
           assert(prop.relationshipClass);
-          const maybeMetaData = iModel.nativeDb.getSchemaItem(...prop.relationshipClass.split(":") as [string, string]);
+          const maybeMetaData = iModel[_nativeDb].getSchemaItem(...prop.relationshipClass.split(":") as [string, string]);
           assert(maybeMetaData.result !== undefined, "The nav props relationship metadata was not found");
           const relMetaData = JSON.parse(maybeMetaData.result);
           const rootClassMetaData = ClassRegistry.getRootEntity(iModel, relMetaData.target.constraintClasses[0]);

--- a/core/backend/src/ECDb.ts
+++ b/core/backend/src/ECDb.ts
@@ -284,6 +284,11 @@ export class ECDb implements IDisposable {
     return stmt;
   }
 
+  /** @internal
+   * @deprecated in 4.8. This internal API will be removed in 5.0. Use ECDb's public API instead.
+   */
+  public get nativeDb(): IModelJsNative.ECDb { return this[_nativeDb]; }
+
   /** @internal */
   public get [_nativeDb](): IModelJsNative.ECDb {
     assert(undefined !== this._nativeDb);

--- a/core/backend/src/ECDb.ts
+++ b/core/backend/src/ECDb.ts
@@ -13,6 +13,7 @@ import { ConcurrentQuery } from "./ConcurrentQuery";
 import { ECSqlStatement } from "./ECSqlStatement";
 import { IModelNative } from "./internal/NativePlatform";
 import { SqliteStatement, StatementCache } from "./SqliteStatement";
+import { _nativeDb } from "./internal/Symbols";
 
 const loggerCategory: string = BackendLoggerCategory.ECDb;
 
@@ -62,7 +63,7 @@ export class ECDb implements IDisposable {
    * @throws [IModelError]($common) if the operation failed.
    */
   public createDb(pathName: string): void {
-    const status: DbResult = this.nativeDb.createDb(pathName);
+    const status: DbResult = this[_nativeDb].createDb(pathName);
     if (status !== DbResult.BE_SQLITE_OK)
       throw new IModelError(status, "Failed to created ECDb");
   }
@@ -75,13 +76,13 @@ export class ECDb implements IDisposable {
   public openDb(pathName: string, openMode: ECDbOpenMode = ECDbOpenMode.Readonly): void {
     const nativeOpenMode: OpenMode = openMode === ECDbOpenMode.Readonly ? OpenMode.Readonly : OpenMode.ReadWrite;
     const tryUpgrade: boolean = openMode === ECDbOpenMode.FileUpgrade;
-    const status: DbResult = this.nativeDb.openDb(pathName, nativeOpenMode, tryUpgrade);
+    const status: DbResult = this[_nativeDb].openDb(pathName, nativeOpenMode, tryUpgrade);
     if (status !== DbResult.BE_SQLITE_OK)
       throw new IModelError(status, "Failed to open ECDb");
   }
 
   /** Returns true if the ECDb is open */
-  public get isOpen(): boolean { return this.nativeDb.isOpen(); }
+  public get isOpen(): boolean { return this[_nativeDb].isOpen(); }
 
   /** Close the Db after saving any uncommitted changes.
    * @throws [IModelError]($common) if the database is not open.
@@ -89,7 +90,7 @@ export class ECDb implements IDisposable {
   public closeDb(): void {
     this._statementCache.clear();
     this._sqliteStatementCache.clear();
-    this.nativeDb.closeDb();
+    this[_nativeDb].closeDb();
   }
 
   /** @internal use to test statement caching */
@@ -107,7 +108,7 @@ export class ECDb implements IDisposable {
    * @throws [IModelError]($common) if the database is not open or if the operation failed.
    */
   public saveChanges(changesetName?: string): void {
-    const status: DbResult = this.nativeDb.saveChanges(changesetName);
+    const status: DbResult = this[_nativeDb].saveChanges(changesetName);
     if (status !== DbResult.BE_SQLITE_OK)
       throw new IModelError(status, "Failed to save changes");
   }
@@ -116,7 +117,7 @@ export class ECDb implements IDisposable {
    * @throws [IModelError]($common) if the database is not open or if the operation failed.
    */
   public abandonChanges(): void {
-    const status: DbResult = this.nativeDb.abandonChanges();
+    const status: DbResult = this[_nativeDb].abandonChanges();
     if (status !== DbResult.BE_SQLITE_OK)
       throw new IModelError(status, "Failed to abandon changes");
   }
@@ -128,7 +129,7 @@ export class ECDb implements IDisposable {
    * @throws [IModelError]($common) if the database is not open or if the operation failed.
    */
   public importSchema(pathName: string): void {
-    const status: DbResult = this.nativeDb.importSchema(pathName);
+    const status: DbResult = this[_nativeDb].importSchema(pathName);
     if (status !== DbResult.BE_SQLITE_OK) {
       Logger.logError(loggerCategory, `Failed to import schema from '${pathName}'.`);
       throw new IModelError(status, `Failed to import schema from '${pathName}'.`);
@@ -142,7 +143,7 @@ export class ECDb implements IDisposable {
    * @throws if the schema can not be found or loaded.
    */
   public getSchemaProps(name: string): ECSchemaProps {
-    return this.nativeDb.getSchemaProps(name);
+    return this[_nativeDb].getSchemaProps(name);
   }
 
   /**
@@ -210,7 +211,7 @@ export class ECDb implements IDisposable {
    */
   public prepareStatement(ecsql: string, logErrors = true): ECSqlStatement {
     const stmt = new ECSqlStatement();
-    stmt.prepare(this.nativeDb, ecsql, logErrors);
+    stmt.prepare(this[_nativeDb], ecsql, logErrors);
     return stmt;
   }
 
@@ -279,12 +280,12 @@ export class ECDb implements IDisposable {
    */
   public prepareSqliteStatement(sql: string, logErrors = true): SqliteStatement {
     const stmt = new SqliteStatement(sql);
-    stmt.prepare(this.nativeDb, logErrors);
+    stmt.prepare(this[_nativeDb], logErrors);
     return stmt;
   }
 
   /** @internal */
-  public get nativeDb(): IModelJsNative.ECDb {
+  public get [_nativeDb](): IModelJsNative.ECDb {
     assert(undefined !== this._nativeDb);
     return this._nativeDb;
   }
@@ -307,7 +308,7 @@ export class ECDb implements IDisposable {
     }
     const executor = {
       execute: async (request: DbQueryRequest) => {
-        return ConcurrentQuery.executeQueryRequest(this.nativeDb, request);
+        return ConcurrentQuery.executeQueryRequest(this[_nativeDb], request);
       },
     };
     return new ECSqlReader(executor, ecsql, params, config);

--- a/core/backend/src/ElementGraphics.ts
+++ b/core/backend/src/ElementGraphics.ts
@@ -6,12 +6,13 @@ import { assert, IModelStatus } from "@itwin/core-bentley";
 import { ElementGraphicsRequestProps, IModelError } from "@itwin/core-common";
 import { ElementGraphicsStatus } from "@bentley/imodeljs-native";
 import { IModelDb } from "./IModelDb";
+import { _nativeDb } from "./internal/Symbols";
 
 /** See [[IModelDb.generateElementGraphics]] and IModelTileRpcImpl.requestElementGraphics.
  * @internal
  */
 export async function generateElementGraphics(request: ElementGraphicsRequestProps, iModel: IModelDb): Promise<Uint8Array | undefined> {
-  const result = await iModel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+  const result = await iModel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
 
   let error: string | undefined;
   switch (result.status) {

--- a/core/backend/src/GeometrySummary.ts
+++ b/core/backend/src/GeometrySummary.ts
@@ -16,6 +16,7 @@ import {
 } from "@itwin/core-common";
 import { Element, GeometricElement, GeometryPart } from "./Element";
 import { IModelDb } from "./IModelDb";
+import { _nativeDb } from "./internal/Symbols";
 
 interface ElementGeom {
   iterator: GeometryStreamIterator;
@@ -118,7 +119,7 @@ class ResponseGenerator {
   }
 
   public summarizePartReferences(id: Id64String, is2d: boolean): string {
-    const refIds = this.iModel.nativeDb.findGeometryPartReferences([id], is2d);
+    const refIds = this.iModel[_nativeDb].findGeometryPartReferences([id], is2d);
     return `Part references (${refIds.length}): ${refIds.join()}`;
   }
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -67,7 +67,7 @@ import { LockControl } from "./LockControl";
 import { IModelNative } from "./internal/NativePlatform";
 import type { BlobContainer } from "./BlobContainerService";
 import { createNoOpLockControl } from "./internal/NoLocks";
-import { _close, _releaseAllLocks } from "./internal/Symbols";
+import { _close, _nativeDb, _releaseAllLocks } from "./internal/Symbols";
 
 // spell:ignore fontid fontmap
 
@@ -216,17 +216,17 @@ export abstract class IModelDb extends IModel {
   public readonly onChangesetApplied = new BeEvent<() => void>();
   /** @internal */
   public notifyChangesetApplied() {
-    this.changeset = this.nativeDb.getCurrentChangeset();
+    this.changeset = this[_nativeDb].getCurrentChangeset();
     this.onChangesetApplied.raiseEvent();
   }
 
   /** @internal */
   public restartDefaultTxn() {
-    this.nativeDb.restartDefaultTxn();
+    this[_nativeDb].restartDefaultTxn();
   }
 
   public get fontMap(): FontMap {
-    return this._fontMap ?? (this._fontMap = new FontMap(this.nativeDb.readFontMap()));
+    return this._fontMap ?? (this._fontMap = new FontMap(this[_nativeDb].readFontMap()));
   }
 
   /** @internal */
@@ -245,7 +245,7 @@ export abstract class IModelDb extends IModel {
   public addNewFont(name: string, type?: FontType): FontId {
     this.locks.checkExclusiveLock(IModel.repositoryModelId, "schema", "addNewFont");
     this.clearFontMap();
-    return this.nativeDb.addNewFont({ name, type: type ?? FontType.TrueType });
+    return this[_nativeDb].addNewFont({ name, type: type ?? FontType.TrueType });
   }
 
   /** Check if this iModel has been opened read-only or not. */
@@ -258,12 +258,12 @@ export abstract class IModelDb extends IModel {
   } // GuidString | undefined for the IModel superclass, but required for all IModelDb subclasses
 
   /** @internal*/
-  public readonly nativeDb: IModelJsNative.DgnDb;
+  public readonly [_nativeDb]: IModelJsNative.DgnDb;
 
   /** Get the full path fileName of this iModelDb
    * @note this member is only valid while the iModel is opened.
    */
-  public get pathName(): LocalFileName { return this.nativeDb.getFilePath(); }
+  public get pathName(): LocalFileName { return this[_nativeDb].getFilePath(); }
 
   /** Get the full path to this iModel's "watch file".
    * A read-only briefcase opened with `watchForChanges: true` creates this file next to the briefcase file on open, if it doesn't already exist.
@@ -277,7 +277,7 @@ export abstract class IModelDb extends IModel {
   /** @internal */
   protected constructor(args: { nativeDb: IModelJsNative.DgnDb, key: string, changeset?: ChangesetIdWithIndex }) {
     super({ ...args, iTwinId: args.nativeDb.getITwinId(), iModelId: args.nativeDb.getIModelId() });
-    this.nativeDb = args.nativeDb;
+    this[_nativeDb] = args.nativeDb;
 
     // it is illegal to create an IModelDb unless the nativeDb has been opened. Throw otherwise.
     if (!this.isOpen)
@@ -286,14 +286,14 @@ export abstract class IModelDb extends IModel {
     // PR https://github.com/iTwin/imodel-native/pull/558 renamed closeIModel to closeFile because it changed its behavior.
     // Ideally, nobody outside of core-backend would be calling it, but somebody important is.
     // Make closeIModel available so their code doesn't break.
-    (this.nativeDb as any).closeIModel = () => {
+    (this[_nativeDb] as any).closeIModel = () => {
       if (!this.isReadonly)
         this.saveChanges(); // preserve old behavior of closeIModel that was removed when renamed to closeFile
 
-      this.nativeDb.closeFile();
+      this[_nativeDb].closeFile();
     };
 
-    this.nativeDb.setIModelDb(this);
+    this[_nativeDb].setIModelDb(this);
 
     this.loadIModelSettings();
     GeoCoordConfig.loadForImodel(this.workspace.settings); // load gcs data specified by iModel's settings dictionaries, must be done before calling initializeIModelDb
@@ -327,7 +327,7 @@ export abstract class IModelDb extends IModel {
     this._codeService = undefined;
     if (!this.isReadonly)
       this.saveChanges();
-    this.nativeDb.closeFile();
+    this[_nativeDb].closeFile();
   }
 
   /** @internal */
@@ -347,7 +347,7 @@ export abstract class IModelDb extends IModel {
 
   /** @internal */
   protected initializeIModelDb() {
-    const props = this.nativeDb.getIModelProps();
+    const props = this[_nativeDb].getIModelProps();
     super.initialize(props.rootSubject.name, props);
     if (this._initialized)
       return;
@@ -391,10 +391,10 @@ export abstract class IModelDb extends IModel {
   /** Return `true` if the underlying nativeDb is open and valid.
    * @internal
    */
-  public get isOpen(): boolean { return this.nativeDb.isOpen(); }
+  public get isOpen(): boolean { return this[_nativeDb].isOpen(); }
 
   /** Get the briefcase Id of this iModel */
-  public getBriefcaseId(): BriefcaseId { return this.isOpen ? this.nativeDb.getBriefcaseId() : BriefcaseIdValue.Illegal; }
+  public getBriefcaseId(): BriefcaseId { return this.isOpen ? this[_nativeDb].getBriefcaseId() : BriefcaseIdValue.Illegal; }
 
   /**
    * Use a prepared ECSQL statement, potentially from the statement cache. If the requested statement doesn't exist
@@ -466,12 +466,12 @@ export abstract class IModelDb extends IModel {
    * @public
    * */
   public createQueryReader(ecsql: string, params?: QueryBinder, config?: QueryOptions): ECSqlReader {
-    if (!this.nativeDb.isOpen())
+    if (!this[_nativeDb].isOpen())
       throw new IModelError(DbResult.BE_SQLITE_ERROR, "db not open");
 
     const executor = {
       execute: async (request: DbQueryRequest) => {
-        return ConcurrentQuery.executeQueryRequest(this.nativeDb, request);
+        return ConcurrentQuery.executeQueryRequest(this[_nativeDb], request);
       },
     };
     return new ECSqlReader(executor, ecsql, params, config);
@@ -608,7 +608,7 @@ export abstract class IModelDb extends IModel {
    */
   public prepareSqliteStatement(sql: string, logErrors = true): SqliteStatement {
     const stmt = new SqliteStatement(sql);
-    stmt.prepare(this.nativeDb, logErrors);
+    stmt.prepare(this[_nativeDb], logErrors);
     return stmt;
   }
 
@@ -730,7 +730,7 @@ export abstract class IModelDb extends IModel {
   public computeProjectExtents(options?: ComputeProjectExtentsOptions): ComputedProjectExtents {
     const wantFullExtents = true === options?.reportExtentsWithOutliers;
     const wantOutliers = true === options?.reportOutliers;
-    const result = this.nativeDb.computeProjectExtents(wantFullExtents, wantOutliers);
+    const result = this[_nativeDb].computeProjectExtents(wantFullExtents, wantOutliers);
     return {
       extents: Range3d.fromJSON(result.extents),
       extentsWithOutliers: result.fullExtents ? Range3d.fromJSON(result.fullExtents) : undefined,
@@ -746,7 +746,7 @@ export abstract class IModelDb extends IModel {
 
   /** Update the IModelProps of this iModel in the database. */
   public updateIModelProps(): void {
-    this.nativeDb.updateIModelProps(this.toJSON());
+    this[_nativeDb].updateIModelProps(this.toJSON());
   }
 
   /** Commit pending changes to this iModel.
@@ -757,14 +757,14 @@ export abstract class IModelDb extends IModel {
     if (this.openMode === OpenMode.Readonly)
       throw new IModelError(IModelStatus.ReadOnly, "IModelDb was opened read-only");
 
-    const stat = this.nativeDb.saveChanges(description);
+    const stat = this[_nativeDb].saveChanges(description);
     if (DbResult.BE_SQLITE_OK !== stat)
       throw new IModelError(stat, `Could not save changes (${description})`);
   }
 
   /** Abandon pending changes in this iModel. */
   public abandonChanges(): void {
-    this.nativeDb.abandonChanges();
+    this[_nativeDb].abandonChanges();
   }
 
   /**
@@ -778,7 +778,7 @@ export abstract class IModelDb extends IModel {
   public performCheckpoint() {
     if (!this.isReadonly) {
       this.saveChanges();
-      this.nativeDb.performCheckpoint();
+      this[_nativeDb].performCheckpoint();
     }
   }
 
@@ -786,17 +786,17 @@ export abstract class IModelDb extends IModel {
    * @deprecated in 4.8. Use `txns.reverseTxns`.
    */
   public reverseTxns(numOperations: number): IModelStatus {
-    return this.nativeDb.reverseTxns(numOperations);
+    return this[_nativeDb].reverseTxns(numOperations);
   }
 
   /** @internal */
   public reinstateTxn(): IModelStatus {
-    return this.nativeDb.reinstateTxn();
+    return this[_nativeDb].reinstateTxn();
   }
 
   /** @internal */
   public restartTxnSession(): void {
-    return this.nativeDb.restartTxnSession();
+    return this[_nativeDb].restartTxnSession();
   }
 
   /** Import an ECSchema. On success, the schema definition is stored in the iModel.
@@ -814,21 +814,21 @@ export abstract class IModelDb extends IModel {
       return;
 
     const maybeCustomNativeContext = options?.ecSchemaXmlContext?.nativeContext;
-    if (this.nativeDb.schemaSyncEnabled()) {
+    if (this[_nativeDb].schemaSyncEnabled()) {
 
       await SchemaSync.withLockedAccess(this, { openMode: OpenMode.Readonly, operationName: "schema sync" }, async (syncAccess) => {
         const schemaSyncDbUri = syncAccess.getUri();
         this.saveChanges();
 
         try {
-          this.nativeDb.importSchemas(schemaFileNames, { schemaLockHeld: false, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
+          this[_nativeDb].importSchemas(schemaFileNames, { schemaLockHeld: false, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
         } catch (outerErr: any) {
           if (DbResult.BE_SQLITE_ERROR_DataTransformRequired === outerErr.errorNumber) {
             this.abandonChanges();
-            if (this.nativeDb.getITwinId() !== Guid.empty)
+            if (this[_nativeDb].getITwinId() !== Guid.empty)
               await this.acquireSchemaLock();
             try {
-              this.nativeDb.importSchemas(schemaFileNames, { schemaLockHeld: true, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
+              this[_nativeDb].importSchemas(schemaFileNames, { schemaLockHeld: true, ecSchemaXmlContext: maybeCustomNativeContext, schemaSyncDbUri });
             } catch (innerErr: any) {
               throw new IModelError(innerErr.errorNumber, innerErr.message);
             }
@@ -843,11 +843,11 @@ export abstract class IModelDb extends IModel {
         ecSchemaXmlContext: maybeCustomNativeContext,
       };
 
-      if (this.nativeDb.getITwinId() !== Guid.empty) // if this iModel is associated with an iTwin, importing schema requires the schema lock
+      if (this[_nativeDb].getITwinId() !== Guid.empty) // if this iModel is associated with an iTwin, importing schema requires the schema lock
         await this.acquireSchemaLock();
 
       try {
-        this.nativeDb.importSchemas(schemaFileNames, nativeImportOptions);
+        this[_nativeDb].importSchemas(schemaFileNames, nativeImportOptions);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, err.message);
       }
@@ -868,19 +868,19 @@ export abstract class IModelDb extends IModel {
     if (serializedXmlSchemas.length === 0)
       return;
 
-    if (this.nativeDb.schemaSyncEnabled()) {
+    if (this[_nativeDb].schemaSyncEnabled()) {
       await SchemaSync.withLockedAccess(this, { openMode: OpenMode.Readonly, operationName: "schemaSync" }, async (syncAccess) => {
         const schemaSyncDbUri = syncAccess.getUri();
         this.saveChanges();
         try {
-          this.nativeDb.importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: false, schemaSyncDbUri });
+          this[_nativeDb].importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: false, schemaSyncDbUri });
         } catch (outerErr: any) {
           if (DbResult.BE_SQLITE_ERROR_DataTransformRequired === outerErr.errorNumber) {
             this.abandonChanges();
-            if (this.nativeDb.getITwinId() !== Guid.empty)
+            if (this[_nativeDb].getITwinId() !== Guid.empty)
               await this.acquireSchemaLock();
             try {
-              this.nativeDb.importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true, schemaSyncDbUri });
+              this[_nativeDb].importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true, schemaSyncDbUri });
             } catch (innerErr: any) {
               throw new IModelError(innerErr.errorNumber, innerErr.message);
             }
@@ -894,7 +894,7 @@ export abstract class IModelDb extends IModel {
         await this.acquireSchemaLock();
 
       try {
-        this.nativeDb.importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true });
+        this[_nativeDb].importXmlSchemas(serializedXmlSchemas, { schemaLockHeld: true });
       } catch (err: any) {
         throw new IModelError(err.errorNumber, err.message);
       }
@@ -1039,7 +1039,7 @@ export abstract class IModelDb extends IModel {
    */
   public prepareStatement(sql: string, logErrors = true): ECSqlStatement {
     const stmt = new ECSqlStatement();
-    stmt.prepare(this.nativeDb, sql, logErrors);
+    stmt.prepare(this[_nativeDb], sql, logErrors);
     return stmt;
   }
 
@@ -1049,7 +1049,7 @@ export abstract class IModelDb extends IModel {
    */
   public tryPrepareStatement(sql: string): ECSqlStatement | undefined {
     const statement = new ECSqlStatement();
-    const result = statement.tryPrepare(this.nativeDb, sql);
+    const result = statement.tryPrepare(this[_nativeDb], sql);
     return DbResult.BE_SQLITE_OK === result.status ? statement : undefined;
   }
 
@@ -1138,7 +1138,7 @@ export abstract class IModelDb extends IModel {
     if (className.length !== 2)
       throw new IModelError(IModelStatus.BadArg, `Invalid classFullName: ${classFullName}`);
 
-    const val = this.nativeDb.getECClassMetaData(className[0], className[1]);
+    const val = this[_nativeDb].getECClassMetaData(className[0], className[1]);
     if (val.error)
       throw new IModelError(val.error.status, `Error getting class meta data for: ${classFullName}`);
 
@@ -1157,7 +1157,7 @@ export abstract class IModelDb extends IModel {
    * @throws if the schema can not be found or loaded.
    */
   public getSchemaProps(name: string): ECSchemaProps {
-    return this.nativeDb.getSchemaProps(name);
+    return this[_nativeDb].getSchemaProps(name);
   }
 
   /** Query if this iModel contains the definition of the specified class.
@@ -1168,7 +1168,7 @@ export abstract class IModelDb extends IModel {
    */
   public containsClass(classFullName: string): boolean {
     const classNameParts = classFullName.replace(".", ":").split(":");
-    return classNameParts.length === 2 && this.nativeDb.getECClassMetaData(classNameParts[0], classNameParts[1]).error === undefined;
+    return classNameParts.length === 2 && this[_nativeDb].getECClassMetaData(classNameParts[0], classNameParts[1]).error === undefined;
   }
 
   /** Query for a schema of the specified name in this iModel.
@@ -1194,21 +1194,21 @@ export abstract class IModelDb extends IModel {
    * @alpha
    */
   public async queryTextureData(props: TextureLoadProps): Promise<TextureData | undefined> {
-    return this.nativeDb.queryTextureData(props);
+    return this[_nativeDb].queryTextureData(props);
   }
 
   /** Query a "file property" from this iModel, as a string.
    * @returns the property string or undefined if the property is not present.
    */
   public queryFilePropertyString(prop: FilePropertyProps): string | undefined {
-    return this.nativeDb.queryFileProperty(prop, true) as string | undefined;
+    return this[_nativeDb].queryFileProperty(prop, true) as string | undefined;
   }
 
   /** Query a "file property" from this iModel, as a blob.
    * @returns the property blob or undefined if the property is not present.
    */
   public queryFilePropertyBlob(prop: FilePropertyProps): Uint8Array | undefined {
-    return this.nativeDb.queryFileProperty(prop, false) as Uint8Array | undefined;
+    return this[_nativeDb].queryFileProperty(prop, false) as Uint8Array | undefined;
   }
 
   /** Save a "file property" to this iModel
@@ -1216,21 +1216,21 @@ export abstract class IModelDb extends IModel {
    * @param value either a string or a blob to save as the file property
    */
   public saveFileProperty(prop: FilePropertyProps, strValue: string | undefined, blobVal?: Uint8Array): void {
-    this.nativeDb.saveFileProperty(prop, strValue, blobVal);
+    this[_nativeDb].saveFileProperty(prop, strValue, blobVal);
   }
 
   /** delete a "file property" from this iModel
    * @param prop the FilePropertyProps that describes the property
    */
   public deleteFileProperty(prop: FilePropertyProps): void {
-    this.nativeDb.saveFileProperty(prop, undefined, undefined);
+    this[_nativeDb].saveFileProperty(prop, undefined, undefined);
   }
 
   /** Query for the next available major id for a "file property" from this iModel.
    * @param prop the FilePropertyProps that describes the property
    * @returns the next available (that is, an unused) id for prop. If none are present, will return 0.
    */
-  public queryNextAvailableFileProperty(prop: FilePropertyProps) { return this.nativeDb.queryNextAvailableFileProperty(prop); }
+  public queryNextAvailableFileProperty(prop: FilePropertyProps) { return this[_nativeDb].queryNextAvailableFileProperty(prop); }
 
   /** @internal */
   public async requestSnap(sessionId: string, props: SnapRequestProps): Promise<SnapResponseProps> {
@@ -1242,7 +1242,7 @@ export abstract class IModelDb extends IModel {
       request.cancelSnap();
 
     try {
-      return await request.doSnap(this.nativeDb, JsonUtils.toObject(props));
+      return await request.doSnap(this[_nativeDb], JsonUtils.toObject(props));
     } finally {
       this._snaps.delete(sessionId);
     }
@@ -1261,22 +1261,22 @@ export abstract class IModelDb extends IModel {
 
   /** Get the clip containment status for the supplied elements. */
   public async getGeometryContainment(props: GeometryContainmentRequestProps): Promise<GeometryContainmentResponseProps> {
-    return this.nativeDb.getGeometryContainment(JsonUtils.toObject(props));
+    return this[_nativeDb].getGeometryContainment(JsonUtils.toObject(props));
   }
 
   /** Get the mass properties for the supplied elements. */
   public async getMassProperties(props: MassPropertiesRequestProps): Promise<MassPropertiesResponseProps> {
-    return this.nativeDb.getMassProperties(JsonUtils.toObject(props));
+    return this[_nativeDb].getMassProperties(JsonUtils.toObject(props));
   }
 
   /** Get the IModel coordinate corresponding to each GeoCoordinate point in the input */
   public async getIModelCoordinatesFromGeoCoordinates(props: IModelCoordinatesRequestProps): Promise<IModelCoordinatesResponseProps> {
-    return this.nativeDb.getIModelCoordinatesFromGeoCoordinates(props);
+    return this[_nativeDb].getIModelCoordinatesFromGeoCoordinates(props);
   }
 
   /** Get the GeoCoordinate (longitude, latitude, elevation) corresponding to each IModel Coordinate point in the input */
   public async getGeoCoordinatesFromIModelCoordinates(props: GeoCoordinatesRequestProps): Promise<GeoCoordinatesResponseProps> {
-    return this.nativeDb.getGeoCoordinatesFromIModelCoordinates(props);
+    return this[_nativeDb].getGeoCoordinatesFromIModelCoordinates(props);
   }
 
   /** Export meshes suitable for graphics APIs from arbitrary geometry in elements in this IModelDb.
@@ -1312,7 +1312,7 @@ export abstract class IModelDb extends IModel {
    * @public
    */
   public exportGraphics(exportProps: ExportGraphicsOptions): DbResult {
-    return this.nativeDb.exportGraphics(exportProps);
+    return this[_nativeDb].exportGraphics(exportProps);
   }
 
   /**
@@ -1328,7 +1328,7 @@ export abstract class IModelDb extends IModel {
    * @public
    */
   public exportPartGraphics(exportProps: ExportPartGraphicsOptions): DbResult {
-    return this.nativeDb.exportPartGraphics(exportProps);
+    return this[_nativeDb].exportPartGraphics(exportProps);
   }
 
   /** Request geometry stream information from an element in binary format instead of json.
@@ -1336,7 +1336,7 @@ export abstract class IModelDb extends IModel {
    * @beta
    */
   public elementGeometryRequest(requestProps: ElementGeometryRequest): IModelStatus {
-    return this.nativeDb.processGeometryStream(requestProps);
+    return this[_nativeDb].processGeometryStream(requestProps);
   }
 
   /** Create brep geometry for inclusion in an element's geometry stream.
@@ -1345,7 +1345,7 @@ export abstract class IModelDb extends IModel {
    * @alpha
    */
   public createBRepGeometry(createProps: BRepGeometryCreate): IModelStatus {
-    return this.nativeDb.createBRepGeometry(createProps);
+    return this[_nativeDb].createBRepGeometry(createProps);
   }
 
   /** Generate graphics for an element or geometry stream.
@@ -1388,7 +1388,7 @@ export abstract class IModelDb extends IModel {
 
   /** Load all setting dictionaries in this iModel into `this.workspace.settings` */
   private loadIModelSettings() {
-    if (!this.nativeDb.isOpen())
+    if (!this[_nativeDb].isOpen())
       return;
 
     this.withSqliteStatement("SELECT Name,StrData FROM be_Prop WHERE Namespace=?", (stmt) => {
@@ -1439,16 +1439,16 @@ export abstract class IModelDb extends IModel {
    * @public
    */
   public get codeValueBehavior(): "exact" | "trim-unicode-whitespace" {
-    return this.nativeDb.getCodeValueBehavior();
+    return this[_nativeDb].getCodeValueBehavior();
   }
 
   public set codeValueBehavior(newBehavior: "exact" | "trim-unicode-whitespace") {
-    this.nativeDb.setCodeValueBehavior(newBehavior);
+    this[_nativeDb].setCodeValueBehavior(newBehavior);
   }
 
   /** @internal */
   public computeRangesForText(args: ComputeRangesForTextLayoutArgs): TextLayoutRanges {
-    const props = this.nativeDb.computeRangesForText(args.chars, args.fontId, args.bold, args.italic, args.widthFactor, args.lineHeight);
+    const props = this[_nativeDb].computeRangesForText(args.chars, args.fontId, args.bold, args.italic, args.widthFactor, args.lineHeight);
     return {
       layout: Range2d.fromJSON(props.layout),
       justification: Range2d.fromJSON(props.justification),
@@ -1557,7 +1557,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     private tryGetModelJson<T extends ModelProps>(modelIdArg: ModelLoadProps): T | undefined {
       try {
-        return this._iModel.nativeDb.getModel(modelIdArg) as T;
+        return this._iModel[_nativeDb].getModel(modelIdArg) as T;
       } catch (err: any) {
         return undefined;
       }
@@ -1606,7 +1606,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertModel(props: ModelProps): Id64String {
       try {
-        return props.id = this._iModel.nativeDb.insertModel(props);
+        return props.id = this._iModel[_nativeDb].insertModel(props);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error inserting model [${err.message}], class=${props.classFullName}`);
       }
@@ -1618,7 +1618,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateModel(props: UpdateModelOptions): void {
       try {
-        this._iModel.nativeDb.updateModel(props);
+        this._iModel[_nativeDb].updateModel(props);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `error updating model [${err.message}] id=${props.id}`);
       }
@@ -1633,7 +1633,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @see [[TxnManager.onModelGeometryChanged]] for the event emitted in response to such a change.
      */
     public updateGeometryGuid(modelId: Id64String): void {
-      const error = this._iModel.nativeDb.updateModelGeometryGuid(modelId);
+      const error = this._iModel[_nativeDb].updateModelGeometryGuid(modelId);
       if (error !== IModelStatus.Success)
         throw new IModelError(error, `updating geometry guid for model ${modelId}`);
     }
@@ -1645,7 +1645,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     public deleteModel(ids: Id64Arg): void {
       Id64.toIdSet(ids).forEach((id) => {
         try {
-          this._iModel.nativeDb.deleteModel(id);
+          this._iModel[_nativeDb].deleteModel(id);
         } catch (err: any) {
           throw new IModelError(err.errorNumber, `error deleting model [${err.message}] id ${id}`);
         }
@@ -1664,7 +1664,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       if (ids.length === 0)
         return [];
 
-      return this._iModel.nativeDb.queryModelExtentsAsync(ids);
+      return this._iModel[_nativeDb].queryModelExtentsAsync(ids);
     }
 
     /** Computes the union of the volumes of all geometric elements within one or more [[GeometricModel]]s, specified by model Id.
@@ -1728,7 +1728,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     private tryGetElementJson<T extends ElementProps>(loadProps: ElementLoadProps): T | undefined {
       try {
-        return this._iModel.nativeDb.getElement(loadProps) as T;
+        return this._iModel[_nativeDb].getElement(loadProps) as T;
       } catch (err: any) {
         return undefined;
       }
@@ -1745,7 +1745,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
         props = { code: props };
       }
       try {
-        return this._iModel.nativeDb.getElement(props) as T;
+        return this._iModel[_nativeDb].getElement(props) as T;
       } catch (err: any) {
         throw new IModelError(err.errorNumber, err.message);
       }
@@ -1870,7 +1870,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertElement(elProps: ElementProps): Id64String {
       try {
-        return elProps.id = this._iModel.nativeDb.insertElement(elProps);
+        return elProps.id = this._iModel[_nativeDb].insertElement(elProps);
       } catch (err: any) {
         err.message = `Error inserting element [${err.message}]`;
         err.metadata = { elProps };
@@ -1891,7 +1891,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateElement<T extends ElementProps>(elProps: Partial<T>): void {
       try {
-        this._iModel.nativeDb.updateElement(elProps);
+        this._iModel[_nativeDb].updateElement(elProps);
       } catch (err: any) {
         err.message = `Error updating element [${err.message}], id: ${elProps.id}`;
         err.metadata = { elProps };
@@ -1908,7 +1908,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       const iModel = this._iModel;
       Id64.toIdSet(ids).forEach((id) => {
         try {
-          iModel.nativeDb.deleteElement(id);
+          iModel[_nativeDb].deleteElement(id);
         } catch (err: any) {
           err.message = `Error deleting element [${err.message}], id: ${id}`;
           err.metadata = { elementId: id };
@@ -1928,7 +1928,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      * @beta
      */
     public deleteDefinitionElements(definitionElementIds: Id64Array): Id64Set {
-      const usageInfo = this._iModel.nativeDb.queryDefinitionElementUsage(definitionElementIds);
+      const usageInfo = this._iModel[_nativeDb].queryDefinitionElementUsage(definitionElementIds);
       if (!usageInfo) {
         throw new IModelError(IModelStatus.BadRequest, "Error querying for DefinitionElement usage");
       }
@@ -1944,7 +1944,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       };
 
       try {
-        this._iModel.nativeDb.beginPurgeOperation();
+        this._iModel[_nativeDb].beginPurgeOperation();
         deleteIfUnused(usageInfo.spatialCategoryIds, usedIdSet);
         deleteIfUnused(usageInfo.drawingCategoryIds, usedIdSet);
         deleteIfUnused(usageInfo.viewDefinitionIds, usedIdSet);
@@ -1960,7 +1960,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
           this._iModel.elements.deleteElement(usageInfo.otherDefinitionElementIds);
         }
       } finally {
-        this._iModel.nativeDb.endPurgeOperation();
+        this._iModel[_nativeDb].endPurgeOperation();
       }
 
       if (usageInfo.viewDefinitionIds) {
@@ -1976,16 +1976,16 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
           viewRelatedIds = viewRelatedIds.concat(usageInfo.modelSelectorIds.filter((id) => usedIdSet.has(id)));
 
         if (viewRelatedIds.length > 0) {
-          const viewRelatedUsageInfo = this._iModel.nativeDb.queryDefinitionElementUsage(viewRelatedIds);
+          const viewRelatedUsageInfo = this._iModel[_nativeDb].queryDefinitionElementUsage(viewRelatedIds);
           if (viewRelatedUsageInfo) {
             const usedViewRelatedIdSet: Id64Set = viewRelatedUsageInfo.usedIds ? Id64.toIdSet(viewRelatedUsageInfo.usedIds) : new Set<Id64String>();
             try {
-              this._iModel.nativeDb.beginPurgeOperation();
+              this._iModel[_nativeDb].beginPurgeOperation();
               deleteIfUnused(viewRelatedUsageInfo.displayStyleIds, usedViewRelatedIdSet);
               deleteIfUnused(viewRelatedUsageInfo.categorySelectorIds, usedViewRelatedIdSet);
               deleteIfUnused(viewRelatedUsageInfo.modelSelectorIds, usedViewRelatedIdSet);
             } finally {
-              this._iModel.nativeDb.endPurgeOperation();
+              this._iModel[_nativeDb].endPurgeOperation();
             }
 
             viewRelatedIds.forEach((id) => {
@@ -2148,7 +2148,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
 
       // Check if class is abstract
       const fullClassName = aspectClassFullName.replace(".", ":").split(":");
-      const val = this._iModel.nativeDb.getECClassMetaData(fullClassName[0], fullClassName[1]);
+      const val = this._iModel[_nativeDb].getECClassMetaData(fullClassName[0], fullClassName[1]);
       if (val.result !== undefined) {
         const metaData = new EntityMetaData(JSON.parse(val.result));
         if (metaData.modifier !== "Abstract") // Class is not abstract, use normal query to retrieve aspects
@@ -2192,7 +2192,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public insertAspect(aspectProps: ElementAspectProps): Id64String {
       try {
-        return this._iModel.nativeDb.insertElementAspect(aspectProps);
+        return this._iModel[_nativeDb].insertElementAspect(aspectProps);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error inserting ElementAspect [${err.message}], class: ${aspectProps.classFullName}`);
       }
@@ -2204,7 +2204,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public updateAspect(aspectProps: ElementAspectProps): void {
       try {
-        this._iModel.nativeDb.updateElementAspect(aspectProps);
+        this._iModel[_nativeDb].updateElementAspect(aspectProps);
       } catch (err: any) {
         throw new IModelError(err.errorNumber, `Error updating ElementAspect [${err.message}], id: ${aspectProps.id}`);
       }
@@ -2218,7 +2218,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       const iModel = this._iModel;
       Id64.toIdSet(aspectInstanceIds).forEach((aspectInstanceId) => {
         try {
-          iModel.nativeDb.deleteElementAspect(aspectInstanceId);
+          iModel[_nativeDb].deleteElementAspect(aspectInstanceId);
         } catch (err: any) {
           throw new IModelError(err.errorNumber, `Error deleting ElementAspect [${err.message}], id: ${aspectInstanceId}`);
         }
@@ -2374,7 +2374,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
       const viewStateData = this.loadViewData(viewDefinitionId, options);
       const baseModelId = (viewStateData.viewDefinitionProps as ViewDefinition2dProps).baseModelId;
       if (baseModelId) {
-        const drawingExtents = Range3d.fromJSON(this._iModel.nativeDb.queryModelExtents({ id: baseModelId }).modelExtents);
+        const drawingExtents = Range3d.fromJSON(this._iModel[_nativeDb].queryModelExtents({ id: baseModelId }).modelExtents);
         if (!drawingExtents.isNull)
           viewStateData.modelExtents = drawingExtents.toJSON();
       }
@@ -2406,12 +2406,12 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
      */
     public getThumbnail(viewDefinitionId: Id64String): ThumbnailProps | undefined {
       const viewArg = this.getViewThumbnailArg(viewDefinitionId);
-      const sizeProps = this._iModel.nativeDb.queryFileProperty(viewArg, true) as string;
+      const sizeProps = this._iModel[_nativeDb].queryFileProperty(viewArg, true) as string;
       if (undefined === sizeProps)
         return undefined;
 
       const out = JSON.parse(sizeProps) as ThumbnailProps;
-      out.image = this._iModel.nativeDb.queryFileProperty(viewArg, false) as Uint8Array;
+      out.image = this._iModel[_nativeDb].queryFileProperty(viewArg, false) as Uint8Array;
       return out;
     }
 
@@ -2423,7 +2423,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     public saveThumbnail(viewDefinitionId: Id64String, thumbnail: ThumbnailProps): number {
       const viewArg = this.getViewThumbnailArg(viewDefinitionId);
       const props = { format: thumbnail.format, height: thumbnail.height, width: thumbnail.width };
-      this._iModel.nativeDb.saveFileProperty(viewArg, JSON.stringify(props), thumbnail.image);
+      this._iModel[_nativeDb].saveFileProperty(viewArg, JSON.stringify(props), thumbnail.image);
       return 0;
     }
 
@@ -2461,7 +2461,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     public async requestTileTreeProps(id: string): Promise<IModelTileTreeProps> {
 
       return new Promise<IModelTileTreeProps>((resolve, reject) => {
-        this._iModel.nativeDb.getTileTree(id, (ret: IModelJsNative.ErrorStatusOrResult<IModelStatus, any>) => {
+        this._iModel[_nativeDb].getTileTree(id, (ret: IModelJsNative.ErrorStatusOrResult<IModelStatus, any>) => {
           if (undefined !== ret.error)
             reject(new IModelError(ret.error.status, `TreeId=${id}`));
           else
@@ -2474,7 +2474,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
 
       let ret;
       try {
-        ret = this._iModel.nativeDb.pollTileContent(treeId, tileId);
+        ret = this._iModel[_nativeDb].pollTileContent(treeId, tileId);
       } catch (err) {
         // Typically "imodel not open".
         reject(err);
@@ -2516,7 +2516,7 @@ export namespace IModelDb { // eslint-disable-line no-redeclare
     /** @internal */
     public async getTileContent(treeId: string, tileId: string): Promise<Uint8Array> {
       const ret = await new Promise<IModelJsNative.ErrorStatusOrResult<any, Uint8Array>>((resolve) => {
-        this._iModel.nativeDb.getTileContent(treeId, tileId, resolve);
+        this._iModel[_nativeDb].getTileContent(treeId, tileId, resolve);
       });
 
       if (undefined !== ret.error) {
@@ -2623,7 +2623,7 @@ export class BriefcaseDb extends IModelDb {
    * - the "no locking" flag is not present. This is a property of an iModel, established when the iModel is created in IModelHub.
    */
   protected get useLockServer(): boolean {
-    return !this.nativeDb.isReadonly() && (this.briefcaseId !== BriefcaseIdValue.Unassigned) && (undefined === this.nativeDb.queryLocalValue(BriefcaseLocalValue.NoLocking));
+    return !this[_nativeDb].isReadonly() && (this.briefcaseId !== BriefcaseIdValue.Unassigned) && (undefined === this[_nativeDb].queryLocalValue(BriefcaseLocalValue.NoLocking));
   }
 
   // if the iModel uses a lock server, create a ServerBasedLocks LockControl for this BriefcaseDb.
@@ -2650,7 +2650,7 @@ export class BriefcaseDb extends IModelDb {
 
     const isSchemaSyncEnabled = await withBriefcaseDb(briefcase, async (db) => {
       await SchemaSync.pull(db);
-      return db.nativeDb.schemaSyncEnabled();
+      return db[_nativeDb].schemaSyncEnabled();
     }) as boolean;
 
     if (isSchemaSyncEnabled) {
@@ -2658,7 +2658,7 @@ export class BriefcaseDb extends IModelDb {
         const schemaSyncDbUri = syncAccess.getUri();
         executeUpgrade();
         await withBriefcaseDb(briefcase, async (db) => {
-          db.nativeDb.schemaSyncPush(schemaSyncDbUri);
+          db[_nativeDb].schemaSyncPush(schemaSyncDbUri);
           db.saveChanges();
         });
         syncAccess.synchronizeWithCloud();
@@ -2742,7 +2742,7 @@ export class BriefcaseDb extends IModelDb {
       // Restart default txn to trigger events when watch file is changed by some other process.
       const watcher = fs.watch(briefcaseDb.watchFilePathName, { persistent: false }, () => {
         nativeDb.restartDefaultTxn();
-        briefcaseDb.changeset = briefcaseDb.nativeDb.getCurrentChangeset();
+        briefcaseDb.changeset = briefcaseDb[_nativeDb].getCurrentChangeset();
       });
 
       // Stop the watcher when we close this connection.
@@ -2869,7 +2869,7 @@ export class BriefcaseDb extends IModelDb {
 
       // Note: There is no performance implication of follow code as it happen toward end of
       // apply_changeset only once so we be querying value for 'DebugAllowFkViolations' only once.
-      if (this.nativeDb.queryLocalValue("DebugAllowFkViolations")) {
+      if (this[_nativeDb].queryLocalValue("DebugAllowFkViolations")) {
         Logger.logError(category, `Detected ${nConflicts} foreign key conflicts in changeset. Continuing merge as 'DebugAllowFkViolations' flag is set. Run 'PRAGMA foreign_key_check' to get list of violations.`);
         return DbConflictResolution.Skip;
       } else {
@@ -2960,17 +2960,17 @@ export class BriefcaseDb extends IModelDb {
     this.clearCaches();
 
     // The following resets the native db's pointer to this JavaScript object.
-    this.nativeDb.closeFile();
-    this.nativeDb.openIModel(fileName, openMode);
+    this[_nativeDb].closeFile();
+    this[_nativeDb].openIModel(fileName, openMode);
 
     // Restore the native db's pointer to this JavaScript object.
-    this.nativeDb.setIModelDb(this);
+    this[_nativeDb].setIModelDb(this);
 
     // refresh cached properties that could have been changed by another process writing to the same briefcase
-    this.changeset = this.nativeDb.getCurrentChangeset();
+    this.changeset = this[_nativeDb].getCurrentChangeset();
 
     // assert what should never change
-    if (this.iModelId !== this.nativeDb.getIModelId() || this.iTwinId !== this.nativeDb.getITwinId())
+    if (this.iModelId !== this[_nativeDb].getIModelId() || this.iTwinId !== this[_nativeDb].getITwinId())
       throw new Error("closeAndReopen detected change in iModelId and/or iTwinId");
   }
 
@@ -2991,9 +2991,9 @@ export class BriefcaseDb extends IModelDb {
     if (this.briefcaseId === BriefcaseIdValue.Unassigned)
       return;
 
-    if (this.nativeDb.hasUnsavedChanges())
+    if (this[_nativeDb].hasUnsavedChanges())
       throw new IModelError(ChangeSetStatus.HasUncommittedChanges, "Cannot push with unsaved changes");
-    if (!this.nativeDb.hasPendingTxns())
+    if (!this[_nativeDb].hasPendingTxns())
       return; // nothing to push
 
     // pushing changes requires a writeable briefcase
@@ -3036,7 +3036,7 @@ class RefreshV2CheckpointSas {
     Logger.logInfo(BackendLoggerCategory.Authorization, "attempting to refresh sasToken for checkpoint");
     try {
       // this exchanges the supplied user accessToken for an expiring blob-store token to read the checkpoint.
-      const container = iModel.nativeDb.cloudContainer;
+      const container = iModel[_nativeDb].cloudContainer;
       if (!container)
         throw new Error("checkpoint is not from a cloud container");
 
@@ -3211,7 +3211,7 @@ export class SnapshotDb extends IModelDb {
       snapshot.restartDefaultTxn();
     }, (10 * 60) * 1000).unref(); // 10 minutes
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    snapshot._refreshSas = new RefreshV2CheckpointSas(snapshot.nativeDb.cloudContainer!.accessToken, checkpoint.reattachSafetySeconds);
+    snapshot._refreshSas = new RefreshV2CheckpointSas(snapshot[_nativeDb].cloudContainer!.accessToken, checkpoint.reattachSafetySeconds);
     return snapshot;
   }
 
@@ -3240,7 +3240,7 @@ export class SnapshotDb extends IModelDb {
       clearTimeout(this._restartDefaultTxnTimer);
 
     if (this._createClassViewsOnClose) { // check for flag set during create
-      if (BentleyStatus.SUCCESS !== this.nativeDb.createClassViewsInDb()) {
+      if (BentleyStatus.SUCCESS !== this[_nativeDb].createClassViewsInDb()) {
         throw new IModelError(IModelStatus.SQLiteError, "Error creating class views");
       } else {
         this.saveChanges();
@@ -3317,7 +3317,7 @@ export class StandaloneDb extends BriefcaseDb {
    * @beta
    */
   public createClassViews(): void {
-    const result = this.nativeDb.createClassViewsInDb();
+    const result = this[_nativeDb].createClassViewsInDb();
     if (BentleyStatus.SUCCESS !== result)
       throw new IModelError(result, "Error creating class views");
     else

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -257,6 +257,11 @@ export abstract class IModelDb extends IModel {
     return super.iModelId;
   } // GuidString | undefined for the IModel superclass, but required for all IModelDb subclasses
 
+  /** @internal
+   * @deprecated in 4.8. This internal API will be removed in 5.0. Use IModelDb's public API instead.
+   */
+  public get nativeDb(): IModelJsNative.DgnDb { return this[_nativeDb]; }
+
   /** @internal*/
   public readonly [_nativeDb]: IModelJsNative.DgnDb;
 

--- a/core/backend/src/IModelElementCloneContext.ts
+++ b/core/backend/src/IModelElementCloneContext.ts
@@ -13,6 +13,7 @@ import { Element } from "./Element";
 import { IModelDb } from "./IModelDb";
 import { IModelNative } from "./internal/NativePlatform";
 import { SQLiteDb } from "./SQLiteDb";
+import { _nativeDb } from "./internal/Symbols";
 
 /** The context for transforming a *source* Element to a *target* Element and remapping internal identifiers to the target iModel.
  * @beta
@@ -32,7 +33,7 @@ export class IModelElementCloneContext {
   public constructor(sourceDb: IModelDb, targetDb?: IModelDb) {
     this.sourceDb = sourceDb;
     this.targetDb = (undefined !== targetDb) ? targetDb : sourceDb;
-    this._nativeContext = new IModelNative.platform.ImportContext(this.sourceDb.nativeDb, this.targetDb.nativeDb);
+    this._nativeContext = new IModelNative.platform.ImportContext(this.sourceDb[_nativeDb], this.targetDb[_nativeDb]);
   }
 
   /** perform necessary initialization to use a clone context, namely caching the reference types in the source's schemas */
@@ -173,7 +174,7 @@ export class IModelElementCloneContext {
    * @internal
    */
   public saveStateToDb(db: SQLiteDb): void {
-    this._nativeContext.saveStateToDb(db.nativeDb);
+    this._nativeContext.saveStateToDb(db[_nativeDb]);
   }
 
   /**
@@ -181,6 +182,6 @@ export class IModelElementCloneContext {
    * @internal
    */
   public loadStateFromDb(db: SQLiteDb): void {
-    this._nativeContext.loadStateFromDb(db.nativeDb);
+    this._nativeContext.loadStateFromDb(db[_nativeDb]);
   }
 }

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -291,7 +291,7 @@ export class IModelHost {
 
   /** Provides access to the entirely internal, low-level, unstable APIs provided by @bentley/imodel-native.
    * Should not be used outside of @itwin/core-backend, and certainly not outside of the itwinjs-core repository
-   * @deprecated in 4.8. Use `IModelNative.platform` instead.
+   * @deprecated in 4.8. This internal API will be removed in 5.0. Use IModelHost's public API instead.
    * @internal
    */
   public static get platform(): typeof IModelJsNative { return IModelNative.platform; }

--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -18,6 +18,7 @@ import { BriefcaseDb, IModelDb, SnapshotDb, StandaloneDb } from "./IModelDb";
 import { IModelHost, IModelHostOptions } from "./IModelHost";
 import { cancelTileContentRequests } from "./rpc-impl/IModelTileRpcImpl";
 import { IModelNative } from "./internal/NativePlatform";
+import { _nativeDb } from "./internal/Symbols";
 
 /**
   * Options for [[IpcHost.startup]]
@@ -211,7 +212,7 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
     return cancelTileContentRequests(tokenProps, contentIds);
   }
   public async cancelElementGraphicsRequests(key: string, requestIds: string[]): Promise<void> {
-    return IModelDb.findByKey(key).nativeDb.cancelElementGraphicsRequests(requestIds);
+    return IModelDb.findByKey(key)[_nativeDb].cancelElementGraphicsRequests(requestIds);
   }
   public async openBriefcase(args: OpenBriefcaseProps): Promise<IModelConnectionProps> {
     const db = await BriefcaseDb.open(args);
@@ -230,20 +231,20 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
     IModelDb.findByKey(key).saveChanges(description);
   }
   public async hasPendingTxns(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.hasPendingTxns();
+    return IModelDb.findByKey(key)[_nativeDb].hasPendingTxns();
   }
 
   public async isUndoPossible(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.isUndoPossible();
+    return IModelDb.findByKey(key)[_nativeDb].isUndoPossible();
   }
   public async isRedoPossible(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.isRedoPossible();
+    return IModelDb.findByKey(key)[_nativeDb].isRedoPossible();
   }
   public async getUndoString(key: string): Promise<string> {
-    return IModelDb.findByKey(key).nativeDb.getUndoString();
+    return IModelDb.findByKey(key)[_nativeDb].getUndoString();
   }
   public async getRedoString(key: string): Promise<string> {
-    return IModelDb.findByKey(key).nativeDb.getUndoString();
+    return IModelDb.findByKey(key)[_nativeDb].getUndoString();
   }
 
   public async pullChanges(key: string, toIndex?: ChangesetIndex, options?: PullChangesOptions): Promise<ChangesetIndexAndId> {
@@ -282,27 +283,27 @@ class IpcAppHandler extends IpcHandler implements IpcAppFunctions {
   }
 
   public async toggleGraphicalEditingScope(key: string, startSession: boolean): Promise<boolean> {
-    const val: IModelJsNative.ErrorStatusOrResult<any, boolean> = IModelDb.findByKey(key).nativeDb.setGeometricModelTrackingEnabled(startSession);
+    const val: IModelJsNative.ErrorStatusOrResult<any, boolean> = IModelDb.findByKey(key)[_nativeDb].setGeometricModelTrackingEnabled(startSession);
     if (val.error)
       throw new IModelError(val.error.status, "Failed to toggle graphical editing scope");
     assert(undefined !== val.result);
     return val.result;
   }
   public async isGraphicalEditingSupported(key: string): Promise<boolean> {
-    return IModelDb.findByKey(key).nativeDb.isGeometricModelTrackingSupported();
+    return IModelDb.findByKey(key)[_nativeDb].isGeometricModelTrackingSupported();
   }
 
   public async reverseTxns(key: string, numOperations: number): Promise<IModelStatus> {
-    return IModelDb.findByKey(key).nativeDb.reverseTxns(numOperations);
+    return IModelDb.findByKey(key)[_nativeDb].reverseTxns(numOperations);
   }
   public async reverseAllTxn(key: string): Promise<IModelStatus> {
-    return IModelDb.findByKey(key).nativeDb.reverseAll();
+    return IModelDb.findByKey(key)[_nativeDb].reverseAll();
   }
   public async reinstateTxn(key: string): Promise<IModelStatus> {
-    return IModelDb.findByKey(key).nativeDb.reinstateTxn();
+    return IModelDb.findByKey(key)[_nativeDb].reinstateTxn();
   }
   public async restartTxnSession(key: string): Promise<void> {
-    return IModelDb.findByKey(key).nativeDb.restartTxnSession();
+    return IModelDb.findByKey(key)[_nativeDb].restartTxnSession();
   }
 
   public async queryConcurrency(pool: "io" | "cpu"): Promise<number> {

--- a/core/backend/src/Model.ts
+++ b/core/backend/src/Model.ts
@@ -18,7 +18,7 @@ import { DefinitionPartition, DocumentPartition, InformationRecordPartition, Phy
 import { Entity } from "./Entity";
 import { IModelDb } from "./IModelDb";
 import { SubjectOwnsPartitionElements } from "./NavigationRelationship";
-import { _verifyChannel } from "./internal/Symbols";
+import { _nativeDb, _verifyChannel } from "./internal/Symbols";
 
 /** Argument for the `Model.onXxx` static methods
  * @beta
@@ -243,7 +243,7 @@ export class GeometricModel extends Model {
    * @note This function blocks the JavaScript event loop. Consider using [[queryRange]] instead.
    */
   public queryExtents(): AxisAlignedBox3d {
-    const extents = this.iModel.nativeDb.queryModelExtents({ id: this.id }).modelExtents;
+    const extents = this.iModel[_nativeDb].queryModelExtents({ id: this.id }).modelExtents;
     return Range3d.fromJSON(extents);
   }
 

--- a/core/backend/src/Relationship.ts
+++ b/core/backend/src/Relationship.ts
@@ -11,6 +11,7 @@ import { EntityReferenceSet, IModelError, IModelStatus, RelationshipProps, Sourc
 import { ECSqlStatement } from "./ECSqlStatement";
 import { Entity } from "./Entity";
 import { IModelDb } from "./IModelDb";
+import { _nativeDb } from "./internal/Symbols";
 
 export type { SourceAndTarget, RelationshipProps } from "@itwin/core-common"; // for backwards compatibility
 
@@ -435,7 +436,7 @@ export class Relationships {
 
   /** Check classFullName to ensure it is a link table relationship class. */
   private checkRelationshipClass(classFullName: string) {
-    if (!this._iModel.nativeDb.isLinkTableRelationship(classFullName.replace(".", ":"))) {
+    if (!this._iModel[_nativeDb].isLinkTableRelationship(classFullName.replace(".", ":"))) {
       throw new IModelError(DbResult.BE_SQLITE_ERROR, `Class '${classFullName}' must be a relationship class and it should be subclass of BisCore:ElementRefersToElements or BisCore:ElementDrivesElement.`);
     }
   }
@@ -447,19 +448,19 @@ export class Relationships {
    */
   public insertInstance(props: RelationshipProps): Id64String {
     this.checkRelationshipClass(props.classFullName);
-    return props.id = this._iModel.nativeDb.insertLinkTableRelationship(props);
+    return props.id = this._iModel[_nativeDb].insertLinkTableRelationship(props);
   }
 
   /** Update the properties of an existing relationship instance in the iModel.
    * @param props the properties of the relationship instance to update. Any properties that are not present will be left unchanged.
    */
   public updateInstance(props: RelationshipProps): void {
-    this._iModel.nativeDb.updateLinkTableRelationship(props);
+    this._iModel[_nativeDb].updateLinkTableRelationship(props);
   }
 
   /** Delete an Relationship instance from this iModel. */
   public deleteInstance(props: RelationshipProps): void {
-    this._iModel.nativeDb.deleteLinkTableRelationship(props);
+    this._iModel[_nativeDb].deleteLinkTableRelationship(props);
   }
 
   /** Get the props of a Relationship instance

--- a/core/backend/src/SQLiteDb.ts
+++ b/core/backend/src/SQLiteDb.ts
@@ -27,6 +27,11 @@ import { _nativeDb } from "./internal/Symbols";
  * @public
  */
 export class SQLiteDb {
+  /** @internal
+   * @deprecated in 4.8. This internal API will be removed in 5.0. Use SQLiteDb's public API instead.
+   */
+  public get nativeDb(): IModelJsNative.SQLiteDb { return this[_nativeDb]; }
+
   /** @internal */
   public readonly [_nativeDb] = new IModelNative.platform.SQLiteDb();
   private _sqliteStatementCache = new StatementCache<SqliteStatement>();

--- a/core/backend/src/SchemaSync.ts
+++ b/core/backend/src/SchemaSync.ts
@@ -14,6 +14,7 @@ import { DbResult, OpenMode } from "@itwin/core-bentley";
 import { IModelError, LocalFileName } from "@itwin/core-common";
 import { IModelJsNative } from "@bentley/imodeljs-native";
 import { IModelNative } from "./internal/NativePlatform";
+import { _nativeDb } from "./internal/Symbols";
 
 /** @internal */
 export namespace SchemaSync {
@@ -30,16 +31,16 @@ export namespace SchemaSync {
   // for tests only
   export const setTestCache = (iModel: IModelDb, cacheName?: string) => {
     if (cacheName)
-      iModel.nativeDb.saveLocalValue(testSyncCachePropKey, cacheName);
+      iModel[_nativeDb].saveLocalValue(testSyncCachePropKey, cacheName);
     else
-      iModel.nativeDb.deleteLocalValue(testSyncCachePropKey);
+      iModel[_nativeDb].deleteLocalValue(testSyncCachePropKey);
   };
 
   const getCloudAccess = async (arg: IModelDb | { readonly fileName: LocalFileName }) => {
     let nativeDb: IModelJsNative.DgnDb | undefined;
     const argIsIModelDb = arg instanceof IModelDb;
     if (argIsIModelDb) {
-      nativeDb = arg.nativeDb;
+      nativeDb = arg[_nativeDb];
     } else {
       nativeDb = new IModelNative.platform.DgnDb();
       nativeDb.openIModel(arg.fileName, OpenMode.Readonly);
@@ -74,12 +75,12 @@ export namespace SchemaSync {
 
   /** Synchronize local briefcase schemas with cloud container */
   export const pull = async (iModel: IModelDb) => {
-    if (iModel.nativeDb.schemaSyncEnabled() && !iModel.isReadonly) {
+    if (iModel[_nativeDb].schemaSyncEnabled() && !iModel.isReadonly) {
       await SchemaSync.withLockedAccess(iModel, { openMode: OpenMode.Readonly, operationName: "schema sync" }, async (syncAccess) => {
         const schemaSyncDbUri = syncAccess.getUri();
         syncAccess.synchronizeWithCloud();
         iModel.clearCaches();
-        iModel.nativeDb.schemaSyncPull(schemaSyncDbUri);
+        iModel[_nativeDb].schemaSyncPull(schemaSyncDbUri);
         iModel.saveChanges("schema synchronized with cloud container");
       });
     }
@@ -99,7 +100,7 @@ export namespace SchemaSync {
     try {
       iModel.saveFileProperty(syncProperty, JSON.stringify(props));
       await withLockedAccess(arg.iModel, { operationName: "initialize schemaSync", openMode: OpenMode.Readonly }, async (syncAccess) => {
-        iModel.nativeDb.schemaSyncInit(syncAccess.getUri(), props.containerId, arg.overrideContainer ?? false);
+        iModel[_nativeDb].schemaSyncInit(syncAccess.getUri(), props.containerId, arg.overrideContainer ?? false);
         iModel.saveChanges(`Enable SchemaSync  (container id: ${props.containerId})`);
       });
     } catch (err) {
@@ -123,7 +124,7 @@ export namespace SchemaSync {
     }
 
     public getUri() {
-      return `${this.getCloudDb().nativeDb.getFilePath()}?vfs=${this.container.cache?.name}&writable=${this.container.isWriteable ? 1 : 0}`;
+      return `${this.getCloudDb()[_nativeDb].getFilePath()}?vfs=${this.container.cache?.name}&writable=${this.container.isWriteable ? 1 : 0}`;
     }
     /**
    * Initialize a cloud container for use as a SchemaSync. The container must first be created via its storage supplier api (e.g. Azure, or AWS).

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -16,6 +16,7 @@ import { BriefcaseDb, StandaloneDb } from "./IModelDb";
 import { IpcHost } from "./IpcHost";
 import { Relationship, RelationshipProps } from "./Relationship";
 import { SqliteStatement } from "./SqliteStatement";
+import { _nativeDb } from "./internal/Symbols";
 
 /** A string that identifies a Txn.
  * @public
@@ -303,7 +304,7 @@ export class TxnManager {
   /** Array of errors from dependency propagation */
   public readonly validationErrors: ValidationError[] = [];
 
-  private get _nativeDb() { return this._iModel.nativeDb; }
+  private get _nativeDb() { return this._iModel[_nativeDb]; }
   private _getElementClass(elClassName: string): typeof Element {
     return this._iModel.getJsClass(elClassName) as unknown as typeof Element;
   }

--- a/core/backend/src/ViewStore.ts
+++ b/core/backend/src/ViewStore.ts
@@ -20,6 +20,7 @@ import { Category } from "./Category";
 import { Model } from "./Model";
 import { Entity } from "./Entity";
 import { BlobContainer } from "./BlobContainerService";
+import { _nativeDb } from "./internal/Symbols";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
@@ -272,7 +273,7 @@ export namespace ViewStore {
       return existing !== 0 ? existing : this.withPreparedSqliteStatement(`INSERT INTO ${tableName.guids} (guid) VALUES(?)`, (stmt) => {
         stmt.bindGuid(1, guid);
         stmt.stepForWrite();
-        return this.nativeDb.getLastInsertRowId();
+        return this[_nativeDb].getLastInsertRowId();
       });
     }
 
@@ -290,7 +291,7 @@ export namespace ViewStore {
         stmt.bindInteger(8, args.categorySel);
         stmt.bindInteger(9, args.displayStyle);
         stmt.stepForWrite();
-        return this.nativeDb.getLastInsertRowId();
+        return this[_nativeDb].getLastInsertRowId();
       });
     }
 
@@ -303,7 +304,7 @@ export namespace ViewStore {
         stmt.bindInteger(3, args.parentId ?? 1);
         stmt.bindString(4, args.json);
         stmt.stepForWrite();
-        return this.nativeDb.getLastInsertRowId();
+        return this[_nativeDb].getLastInsertRowId();
       });
     }
 
@@ -313,7 +314,7 @@ export namespace ViewStore {
         stmt.bindString(2, args.json);
         stmt.maybeBindString(3, args.owner);
         stmt.stepForWrite();
-        return this.nativeDb.getLastInsertRowId();
+        return this[_nativeDb].getLastInsertRowId();
       });
     }
     /** add a row to the "modelSelectors" table, return the RowId
@@ -363,7 +364,7 @@ export namespace ViewStore {
         stmt.maybeBindString(3, args.owner);
         stmt.bindBlob(4, args.data);
         stmt.stepForWrite();
-        return this.nativeDb.getLastInsertRowId();
+        return this[_nativeDb].getLastInsertRowId();
       });
     }
 

--- a/core/backend/src/domains/FunctionalSchema.ts
+++ b/core/backend/src/domains/FunctionalSchema.ts
@@ -14,6 +14,7 @@ import { IModelDb } from "../IModelDb";
 import { KnownLocations } from "../IModelHost";
 import { Schema, Schemas } from "../Schema";
 import * as elementsModule from "./FunctionalElements";
+import { _nativeDb } from "../internal/Symbols";
 
 /** @public */
 export class FunctionalSchema extends Schema {
@@ -32,7 +33,7 @@ export class FunctionalSchema extends Schema {
     if (iModelDb.isBriefcaseDb())
       await iModelDb.acquireSchemaLock();
 
-    const stat = iModelDb.nativeDb.importFunctionalSchema();
+    const stat = iModelDb[_nativeDb].importFunctionalSchema();
     if (DbResult.BE_SQLITE_OK !== stat) {
       throw new IModelError(stat, "Error importing Functional schema");
     }

--- a/core/backend/src/internal/ChannelAdmin.ts
+++ b/core/backend/src/internal/ChannelAdmin.ts
@@ -12,7 +12,7 @@ import { Subject } from "../Element";
 import { IModelDb } from "../IModelDb";
 import { IModelHost } from "../IModelHost";
 import { ChannelControl, ChannelKey } from "../ChannelControl";
-import { _implementationProhibited, _verifyChannel } from "./Symbols";
+import { _implementationProhibited, _nativeDb, _verifyChannel } from "./Symbols";
 
 class ChannelAdmin implements ChannelControl {
   public static readonly channelClassName = "bis:ChannelRootAspect";
@@ -68,7 +68,7 @@ class ChannelAdmin implements ChannelControl {
 
   public [_verifyChannel](modelId: Id64String): void {
     // Note: indirect changes are permitted to change any channel
-    if (this._allowedModels.has(modelId) || this._iModel.nativeDb.isIndirectChanges())
+    if (this._allowedModels.has(modelId) || this._iModel[_nativeDb].isIndirectChanges())
       return;
 
     const deniedChannel = this._deniedModels.get(modelId);

--- a/core/backend/src/internal/ServerBasedLocks.ts
+++ b/core/backend/src/internal/ServerBasedLocks.ts
@@ -14,7 +14,7 @@ import { BriefcaseDb } from "../IModelDb";
 import { LockControl } from "../LockControl";
 import { IModelHost } from "../IModelHost";
 import { SQLiteDb } from "../SQLiteDb";
-import { _close, _elementWasCreated, _implementationProhibited, _releaseAllLocks } from "./Symbols";
+import { _close, _elementWasCreated, _implementationProhibited, _nativeDb, _releaseAllLocks } from "./Symbols";
 
 /**
  * Both the Model and Parent of an element are considered "owners" of their member elements. That means:
@@ -42,7 +42,7 @@ export class ServerBasedLocks implements LockControl {
 
   public constructor(iModel: BriefcaseDb) {
     this.briefcase = iModel;
-    const dbName = `${iModel.nativeDb.getTempFileBaseName()}-locks`;
+    const dbName = `${iModel[_nativeDb].getTempFileBaseName()}-locks`;
     try {
       this.lockDb.openDb(dbName, OpenMode.ReadWrite);
     } catch (_e) {

--- a/core/backend/src/internal/Symbols.ts
+++ b/core/backend/src/internal/Symbols.ts
@@ -14,5 +14,6 @@ function sym(name: string): string {
 
 export const _close = Symbol.for(sym("close"));
 export const _elementWasCreated = Symbol.for(sym("elementWasCreated"));
+export const _nativeDb = Symbol.for(sym("nativeDb"));
 export const _releaseAllLocks = Symbol.for(sym("releaseAllLocks"));
 export const _verifyChannel = Symbol.for(sym("verifyChannel"));

--- a/core/backend/src/internal/Symbols.ts
+++ b/core/backend/src/internal/Symbols.ts
@@ -14,6 +14,7 @@ function sym(name: string): string {
 
 export const _close = Symbol.for(sym("close"));
 export const _elementWasCreated = Symbol.for(sym("elementWasCreated"));
+/** @internal */
 export const _nativeDb = Symbol.for(sym("nativeDb"));
 export const _releaseAllLocks = Symbol.for(sym("releaseAllLocks"));
 export const _verifyChannel = Symbol.for(sym("verifyChannel"));

--- a/core/backend/src/internal/cross-package.ts
+++ b/core/backend/src/internal/cross-package.ts
@@ -5,3 +5,6 @@
 
 export { IModelJsNative, NativeCloudSqlite, NativeLoggerCategory } from "@bentley/imodeljs-native";
 export { IModelNative } from "./NativePlatform";
+export {
+  _nativeDb,
+} from "./Symbols";

--- a/core/backend/src/internal/workspace/WorkspaceImpl.ts
+++ b/core/backend/src/internal/workspace/WorkspaceImpl.ts
@@ -27,7 +27,7 @@ import {
 import { CreateNewWorkspaceContainerArgs, CreateNewWorkspaceDbVersionArgs, EditableWorkspaceContainer, EditableWorkspaceDb, WorkspaceEditor } from "../../workspace/WorkspaceEditor";
 import { WorkspaceSqliteDb } from "./WorkspaceSqliteDb";
 import { SettingsImpl } from "./SettingsImpl";
-import { _implementationProhibited } from "../Symbols";
+import { _implementationProhibited, _nativeDb } from "../Symbols";
 
 function workspaceDbNameWithDefault(dbName?: WorkspaceDbName): WorkspaceDbName {
   return dbName ?? "workspace-db";
@@ -196,7 +196,7 @@ class WorkspaceDbImpl implements WorkspaceDb {
   public get isOpen() { return this.sqliteDb.isOpen; }
   public get container(): WorkspaceContainer { return this._container; }
   public queryFileResource(rscName: WorkspaceResourceName): { localFileName: LocalFileName, info: IModelJsNative.EmbedFileQuery } | undefined {
-    const info = this.sqliteDb.nativeDb.queryEmbeddedFile(rscName);
+    const info = this.sqliteDb[_nativeDb].queryEmbeddedFile(rscName);
     if (undefined === info)
       return undefined;
 
@@ -234,7 +234,7 @@ class WorkspaceDbImpl implements WorkspaceDb {
 
   public get manifest(): WorkspaceDbManifest {
     return this._manifest ??= this.withOpenDb((db) => {
-      const manifestJson = db.nativeDb.queryFileProperty(workspaceManifestProperty, true) as string | undefined;
+      const manifestJson = db[_nativeDb].queryFileProperty(workspaceManifestProperty, true) as string | undefined;
       return manifestJson ? JSON.parse(manifestJson) : { workspaceName: this.dbName };
     });
   }
@@ -261,7 +261,7 @@ class WorkspaceDbImpl implements WorkspaceDb {
     return this.sqliteDb.withSqliteStatement("SELECT rowid from blobs WHERE id=?", (stmt) => {
       stmt.bindString(1, rscName);
       const blobReader = SQLiteDb.createBlobIO();
-      blobReader.open(this.sqliteDb.nativeDb, { tableName: "blobs", columnName: "value", row: stmt.getValueInteger(0) });
+      blobReader.open(this.sqliteDb[_nativeDb], { tableName: "blobs", columnName: "value", row: stmt.getValueInteger(0) });
       return blobReader;
     });
   }
@@ -295,7 +295,7 @@ class WorkspaceDbImpl implements WorkspaceDb {
       else
         IModelJsFs.recursiveMkDirSync(dirname(localFileName));
 
-      db.nativeDb.extractEmbeddedFile({ name: rscName, localFileName });
+      db[_nativeDb].extractEmbeddedFile({ name: rscName, localFileName });
       const date = new Date(info.date);
       fs.utimesSync(localFileName, date, date); // set the last-modified date of the file to match date in container
       fs.chmodSync(localFileName, "0444"); // set file readonly
@@ -667,7 +667,7 @@ class EditableDbImpl extends WorkspaceDbImpl implements EditableWorkspaceDb {
   }
 
   public updateManifest(manifest: WorkspaceDbManifest) {
-    this.sqliteDb.nativeDb.saveFileProperty(workspaceManifestProperty, JSON.stringify(manifest));
+    this.sqliteDb[_nativeDb].saveFileProperty(workspaceManifestProperty, JSON.stringify(manifest));
     this._manifest = undefined;
   }
   public updateSettingsResource(settings: SettingsContainer, rscName?: string) {
@@ -698,7 +698,7 @@ class EditableDbImpl extends WorkspaceDbImpl implements EditableWorkspaceDb {
     return this.sqliteDb.withSqliteStatement("SELECT rowid from blobs WHERE id=?", (stmt) => {
       stmt.bindString(1, rscName);
       const blobWriter = SQLiteDb.createBlobIO();
-      blobWriter.open(this.sqliteDb.nativeDb, { tableName: "blobs", columnName: "value", row: stmt.getValueInteger(0), writeable: true });
+      blobWriter.open(this.sqliteDb[_nativeDb], { tableName: "blobs", columnName: "value", row: stmt.getValueInteger(0), writeable: true });
       return blobWriter;
     });
   }
@@ -710,11 +710,11 @@ class EditableDbImpl extends WorkspaceDbImpl implements EditableWorkspaceDb {
     fileExt = fileExt ?? extname(localFileName);
     if (fileExt?.[0] === ".")
       fileExt = fileExt.slice(1);
-    this.sqliteDb.nativeDb.embedFile({ name: rscName, localFileName, date: this.getFileModifiedTime(localFileName), fileExt });
+    this.sqliteDb[_nativeDb].embedFile({ name: rscName, localFileName, date: this.getFileModifiedTime(localFileName), fileExt });
   }
   public updateFile(rscName: WorkspaceResourceName, localFileName: LocalFileName): void {
     this.queryFileResource(rscName); // throws if not present
-    this.sqliteDb.nativeDb.replaceEmbeddedFile({ name: rscName, localFileName, date: this.getFileModifiedTime(localFileName) });
+    this.sqliteDb[_nativeDb].replaceEmbeddedFile({ name: rscName, localFileName, date: this.getFileModifiedTime(localFileName) });
   }
   public removeFile(rscName: WorkspaceResourceName): void {
     const file = this.queryFileResource(rscName);
@@ -722,7 +722,7 @@ class EditableDbImpl extends WorkspaceDbImpl implements EditableWorkspaceDb {
       throw new Error(`file resource "${rscName}" does not exist`);
     if (file && fs.existsSync(file.localFileName))
       fs.unlinkSync(file.localFileName);
-    this.sqliteDb.nativeDb.removeEmbeddedFile(rscName);
+    this.sqliteDb[_nativeDb].removeEmbeddedFile(rscName);
   }
 }
 

--- a/core/backend/src/internal/workspace/WorkspaceSqliteDb.ts
+++ b/core/backend/src/internal/workspace/WorkspaceSqliteDb.ts
@@ -7,6 +7,7 @@
  */
 
 import { SQLiteDb, VersionedSqliteDb } from "../../SQLiteDb";
+import { _nativeDb } from "../Symbols";
 import { workspaceManifestProperty } from "./WorkspaceImpl";
 
 export class WorkspaceSqliteDb extends VersionedSqliteDb {
@@ -30,7 +31,7 @@ export class WorkspaceSqliteDb extends VersionedSqliteDb {
     createTrigger("strings");
     createTrigger("blobs");
     if (args?.manifest)
-      this.nativeDb.saveFileProperty(workspaceManifestProperty, JSON.stringify(args.manifest));
+      this[_nativeDb].saveFileProperty(workspaceManifestProperty, JSON.stringify(args.manifest));
   }
 }
 

--- a/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
@@ -32,6 +32,7 @@ import { PromiseMemoizer } from "../PromiseMemoizer";
 import { RpcTrace } from "../rpc/tracing";
 import { ViewStateHydrator } from "../ViewStateHydrator";
 import { RpcBriefcaseUtility } from "./RpcBriefcaseUtility";
+import { _nativeDb } from "../internal/Symbols";
 
 interface ViewStateRequestProps {
   accessToken: AccessToken;
@@ -135,7 +136,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
       Logger.logWarning(BackendLoggerCategory.IModelDb, "usePrimaryConn is only supported on imodel that is opened in read/write mode. The option will be ignored.", request);
       request.usePrimaryConn = false;
     }
-    return ConcurrentQuery.executeQueryRequest(iModelDb.nativeDb, request);
+    return ConcurrentQuery.executeQueryRequest(iModelDb[_nativeDb], request);
   }
 
   public async queryBlob(tokenProps: IModelRpcProps, request: DbBlobRequest): Promise<DbBlobResponse> {
@@ -144,7 +145,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
       Logger.logWarning(BackendLoggerCategory.IModelDb, "usePrimaryConn is only supported on imodel that is opened in read/write mode. The option will be ignored.", request);
       request.usePrimaryConn = false;
     }
-    return ConcurrentQuery.executeBlobRequest(iModelDb.nativeDb, request);
+    return ConcurrentQuery.executeBlobRequest(iModelDb[_nativeDb], request);
   }
 
   public async queryModelRanges(tokenProps: IModelRpcProps, modelIds: Id64String[]): Promise<Range3dProps[]> {
@@ -259,7 +260,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
 
   public async readFontJson(tokenProps: IModelRpcProps): Promise<FontMapProps> {
     const iModelDb = await getIModelForRpc(tokenProps);
-    return iModelDb.nativeDb.readFontMap();
+    return iModelDb[_nativeDb].readFontMap();
   }
 
   public async requestSnap(tokenProps: IModelRpcProps, sessionId: string, props: SnapRequestProps): Promise<SnapResponseProps> {
@@ -373,7 +374,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
 
   public async generateElementMeshes(tokenProps: IModelRpcProps, props: ElementMeshRequestProps): Promise<Uint8Array> {
     const db = await getIModelForRpc(tokenProps);
-    return db.nativeDb.generateElementMeshes(props);
+    return db[_nativeDb].generateElementMeshes(props);
   }
 
   /** @internal */

--- a/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelTileRpcImpl.ts
@@ -16,6 +16,7 @@ import { PromiseMemoizer, QueryablePromise } from "../PromiseMemoizer";
 import { RpcTrace } from "../rpc/tracing";
 import { RpcBriefcaseUtility } from "./RpcBriefcaseUtility";
 import { IModelNative } from "../internal/NativePlatform";
+import { _nativeDb } from "../internal/Symbols";
 
 interface TileRequestProps {
   accessToken?: AccessToken;
@@ -206,7 +207,7 @@ export class IModelTileRpcImpl extends RpcInterface implements IModelTileRpcInte
       return;
     }
 
-    return db.nativeDb.purgeTileTrees(modelIds);
+    return db[_nativeDb].purgeTileTrees(modelIds);
   }
 
   public async generateTileContent(tokenProps: IModelRpcProps, treeId: string, contentId: string, guid: string | undefined): Promise<TileContentSource> {
@@ -248,6 +249,6 @@ export async function cancelTileContentRequests(tokenProps: IModelRpcProps, cont
       RequestTileContentMemoizer.instance.deleteMemoized(props);
     }
 
-    iModel.nativeDb.cancelTileContentRequests(entry.treeId, entry.contentIds);
+    iModel[_nativeDb].cancelTileContentRequests(entry.treeId, entry.contentIds);
   }
 }

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -21,11 +21,11 @@ import { RequestNewBriefcaseArg } from "../BriefcaseManager";
 import { CheckpointProps, V1CheckpointManager } from "../CheckpointManager";
 import { ClassRegistry } from "../ClassRegistry";
 import {
-  AuxCoordSystem2d, BriefcaseDb, BriefcaseLocalValue, BriefcaseManager, CategorySelector, ChannelControl, DisplayStyle2d, DisplayStyle3d, DrawingCategory, DrawingViewDefinition,
-  ECSqlStatement, Element, ElementAspect, ElementOwnsChildElements, ElementOwnsMultiAspects, ElementOwnsUniqueAspect, ElementUniqueAspect,
-  ExternalSource, ExternalSourceIsInRepository, FunctionalModel, FunctionalSchema, GroupModel, IModelDb, IModelHost, IModelJsFs,
-  InformationPartitionElement, Model, ModelSelector, OrthographicViewDefinition, PhysicalModel, PhysicalObject, PhysicalPartition,
-  RenderMaterialElement, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements, Texture, ViewDefinition,
+  _nativeDb, AuxCoordSystem2d, BriefcaseDb, BriefcaseLocalValue, BriefcaseManager, CategorySelector, ChannelControl, DisplayStyle2d, DisplayStyle3d, DrawingCategory,
+  DrawingViewDefinition, ECSqlStatement, Element, ElementAspect, ElementOwnsChildElements, ElementOwnsMultiAspects, ElementOwnsUniqueAspect,
+  ElementUniqueAspect, ExternalSource, ExternalSourceIsInRepository, FunctionalModel, FunctionalSchema, GroupModel, IModelDb, IModelHost,
+  IModelJsFs, InformationPartitionElement, Model, ModelSelector, OrthographicViewDefinition, PhysicalModel, PhysicalObject,
+  PhysicalPartition, RenderMaterialElement, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements, Texture, ViewDefinition,
 } from "../core-backend";
 import { DefinitionPartition, Drawing, DrawingGraphic, GeometryPart, LinkElement, PhysicalElement, RepositoryLink, Subject } from "../Element";
 import { DefinitionModel, DocumentListModel, DrawingModel, InformationRecordModel, SpatialLocationModel } from "../Model";
@@ -148,7 +148,7 @@ export class HubWrappers {
     const props = await BriefcaseManager.downloadBriefcase(args);
     if (args.noLock) {
       const briefcase = await BriefcaseDb.open({ fileName: props.fileName });
-      briefcase.nativeDb.saveLocalValue(BriefcaseLocalValue.NoLocking, "true");
+      briefcase[_nativeDb].saveLocalValue(BriefcaseLocalValue.NoLocking, "true");
       briefcase.saveChanges();
       briefcase.close();
     }
@@ -492,7 +492,7 @@ export class IModelTestUtils {
 
   /** Flushes the Txns in the TxnTable - this allows importing of schemas */
   public static flushTxns(iModelDb: IModelDb): boolean {
-    iModelDb.nativeDb.deleteAllTxns();
+    iModelDb[_nativeDb].deleteAllTxns();
     return true;
   }
 

--- a/core/backend/src/test/ecdb/ECSqlQuery.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlQuery.test.ts
@@ -6,7 +6,7 @@ import { assert } from "chai";
 import { DbResult, Id64 } from "@itwin/core-bentley";
 import { DbQueryRequest, DbQueryResponse, DbRequestExecutor, DbRequestKind, ECSqlReader, QueryBinder, QueryOptionsBuilder, QueryPropertyMetaData, QueryRowFormat } from "@itwin/core-common";
 import { ConcurrentQuery } from "../../ConcurrentQuery";
-import { ECSqlStatement, IModelDb, SnapshotDb } from "../../core-backend";
+import { _nativeDb, ECSqlStatement, IModelDb, SnapshotDb } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { SequentialLogMatcher } from "../SequentialLogMatcher";
 
@@ -216,8 +216,8 @@ describe("ECSql Query", () => {
     let successful = 0;
     let rowCount = 0;
     try {
-      ConcurrentQuery.shutdown(imodel1.nativeDb);
-      ConcurrentQuery.resetConfig(imodel1.nativeDb, { globalQuota: { time: 1 }, ignoreDelay: false });
+      ConcurrentQuery.shutdown(imodel1[_nativeDb]);
+      ConcurrentQuery.resetConfig(imodel1[_nativeDb], { globalQuota: { time: 1 }, ignoreDelay: false });
 
       const scheduleQuery = async (delay: number) => {
         return new Promise<void>(async (resolve, reject) => {
@@ -253,8 +253,8 @@ describe("ECSql Query", () => {
       assert.isAtLeast(successful, 1, "successful should be at least 1");
       assert.isAtLeast(rowCount, 1, "rowCount should be at least 1");
     } finally {
-      ConcurrentQuery.shutdown(imodel1.nativeDb);
-      ConcurrentQuery.resetConfig(imodel1.nativeDb);
+      ConcurrentQuery.shutdown(imodel1[_nativeDb]);
+      ConcurrentQuery.resetConfig(imodel1[_nativeDb]);
     }
   });
   it("concurrent query should retry on timeout", async () => {
@@ -268,10 +268,10 @@ describe("ECSql Query", () => {
     }
 
     // Set time to 1 sec to simulate a timeout scenario
-    ConcurrentQuery.resetConfig(imodel1.nativeDb, { globalQuota: { time: 1 }, ignoreDelay: false });
+    ConcurrentQuery.resetConfig(imodel1[_nativeDb], { globalQuota: { time: 1 }, ignoreDelay: false });
     const executor = {
       execute: async (req: DbQueryRequest) => {
-        return ConcurrentQuery.executeQueryRequest(imodel1.nativeDb, req);
+        return ConcurrentQuery.executeQueryRequest(imodel1[_nativeDb], req);
       },
     };
     const request: DbQueryRequest = {

--- a/core/backend/src/test/ecdb/ECSqlStatement.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlStatement.test.ts
@@ -6,7 +6,7 @@ import { assert } from "chai";
 import { DbResult, Guid, GuidString, Id64, Id64String, using } from "@itwin/core-bentley";
 import { NavigationValue, QueryBinder, QueryOptions, QueryOptionsBuilder, QueryRowFormat } from "@itwin/core-common";
 import { Point2d, Point3d, Range3d, XAndY, XYAndZ } from "@itwin/core-geometry";
-import { ECDb, ECEnumValue, ECSqlColumnInfo, ECSqlInsertResult, ECSqlStatement, ECSqlValue, SnapshotDb } from "../../core-backend";
+import { _nativeDb, ECDb, ECEnumValue, ECSqlColumnInfo, ECSqlInsertResult, ECSqlStatement, ECSqlValue, SnapshotDb } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { SequentialLogMatcher } from "../SequentialLogMatcher";
@@ -206,7 +206,7 @@ describe("ECSqlStatement", () => {
         assert.equal(r.status, DbResult.BE_SQLITE_DONE);
       }
       ecdb.saveChanges();
-      ConcurrentQuery.resetConfig(ecdb.nativeDb, { globalQuota: { time: 1 }, ignoreDelay: false });
+      ConcurrentQuery.resetConfig(ecdb[_nativeDb], { globalQuota: { time: 1 }, ignoreDelay: false });
 
       let cancelled = 0;
       let successful = 0;

--- a/core/backend/src/test/element/ElementDependencyGraph.test.ts
+++ b/core/backend/src/test/element/ElementDependencyGraph.test.ts
@@ -13,7 +13,7 @@ import {
   UpgradeOptions,
 } from "@itwin/core-common";
 import { LineSegment3d, Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
-import { ChannelControl, ElementDrivesElementProps, IModelJsFs, PhysicalModel, SpatialCategory, StandaloneDb } from "../../core-backend";
+import { _nativeDb, ChannelControl, ElementDrivesElementProps, IModelJsFs, PhysicalModel, SpatialCategory, StandaloneDb } from "../../core-backend";
 import { IModelTestUtils, TestElementDrivesElement, TestPhysicalObject, TestPhysicalObjectProps } from "../IModelTestUtils";
 import { IModelNative } from "../../internal/NativePlatform";
 
@@ -66,8 +66,8 @@ class TestHelper {
     assert.isTrue(this.db !== undefined);
     this.db.channels.addAllowedChannel(ChannelControl.sharedChannelName);
 
-    this.db.nativeDb.enableTxnTesting();
-    assert.equal(this.db.nativeDb.addChildPropagatesChangesToParentRelationship("TestBim", "ChildPropagatesChangesToParent"), 0);
+    this.db[_nativeDb].enableTxnTesting();
+    assert.equal(this.db[_nativeDb].addChildPropagatesChangesToParentRelationship("TestBim", "ChildPropagatesChangesToParent"), 0);
     this.setElementDependencyGraphCallbacks();
   }
 
@@ -168,7 +168,7 @@ describe("ElementDependencyGraph", () => {
     const spatialCategoryId = SpatialCategory.insert(imodel, IModel.dictionaryId, "EDGTestSpatialCategory", new SubCategoryAppearance({ color: ColorByName.darkRed }));
     dbInfo = { physicalModelId, codeSpecId, spatialCategoryId, seedFileName: testFileName };
     imodel.saveChanges("");
-    imodel.nativeDb.deleteAllTxns();
+    imodel[_nativeDb].deleteAllTxns();
     imodel.close();
   });
 
@@ -267,7 +267,7 @@ describe("ElementDependencyGraph", () => {
       ede.insert();
     }
 
-    // db.nativeDb.writeFullElementDependencyGraphToFile(`${writeDbFileName}.dot`);
+    // db[_nativeDb].writeFullElementDependencyGraphToFile(`${writeDbFileName}.dot`);
 
     // The full graph:
     //     .-parent-> p2 -EDE-> p3

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -9,7 +9,7 @@ import {
   Placement3dProps, QueryRowFormat, SubCategoryAppearance,
 } from "@itwin/core-common";
 import { Angle, Arc3d, Cone, IModelJson as GeomJson, LineSegment3d, Point2d, Point3d } from "@itwin/core-geometry";
-import { ECSqlStatement, IModelDb, IModelJsFs, PhysicalModel, PhysicalObject, SnapshotDb, SpatialCategory } from "../../core-backend";
+import { _nativeDb, ECSqlStatement, IModelDb, IModelJsFs, PhysicalModel, PhysicalObject, SnapshotDb, SpatialCategory } from "../../core-backend";
 import { ElementRefersToElements } from "../../Relationship";
 import { IModelTestUtils } from "../IModelTestUtils";
 
@@ -521,7 +521,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
 
     const imodel = SnapshotDb.createEmpty(iModelPath, { rootSubject: { name: "RoundTripTest" } });
     await imodel.importSchemas([testSchemaPath]);
-    imodel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+    imodel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
     IModelTestUtils.createAndInsertPhysicalPartitionAndModel(imodel, Code.createEmpty(), true);
     let spatialCategoryId = SpatialCategory.queryCategoryIdByName(imodel, IModel.dictionaryId, categoryName);
     if (undefined === spatialCategoryId)

--- a/core/backend/src/test/element/NullStructArray.test.ts
+++ b/core/backend/src/test/element/NullStructArray.test.ts
@@ -8,7 +8,7 @@ import {
   BriefcaseIdValue, Code,  ColorDef,  GeometricElementProps, IModel,
   SubCategoryAppearance,
 } from "@itwin/core-common";
-import {   IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "../../core-backend";
+import {   _nativeDb, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
 interface TestElement extends GeometricElementProps {
@@ -57,7 +57,7 @@ describe("Insert Null elements in Struct Array, and ensure they are returned whi
 
     const imodel = SnapshotDb.createEmpty(iModelPath, { rootSubject: { name: "InsertNullStructArrayTest" } });
     await imodel.importSchemas([testSchemaPath]);
-    imodel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+    imodel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
     IModelTestUtils.createAndInsertPhysicalPartitionAndModel(imodel, Code.createEmpty(), true);
 
     let spatialCategoryId = SpatialCategory.queryCategoryIdByName(imodel, IModel.dictionaryId, categoryName);

--- a/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
+++ b/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
@@ -11,7 +11,7 @@ import { HubWrappers, IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { HubMock } from "../../HubMock";
 import { TestChangeSetUtility } from "../TestChangeSetUtility";
-import { ChannelControl } from "../../core-backend";
+import { _nativeDb, ChannelControl } from "../../core-backend";
 
 describe("BriefcaseManager", async () => {
   const testITwinId: string = Guid.createValue();
@@ -55,7 +55,7 @@ describe("BriefcaseManager", async () => {
     const iModelId = await HubWrappers.createIModel(accessToken, testITwinId, "imodel1");
     const args = { accessToken, iTwinId: testITwinId, iModelId, deleteFirst: true };
     const iModel1 = await HubWrappers.openCheckpointUsingRpc(args);
-    assert.equal(BriefcaseIdValue.Unassigned, iModel1.nativeDb.getBriefcaseId(), "checkpoint should be 0");
+    assert.equal(BriefcaseIdValue.Unassigned, iModel1[_nativeDb].getBriefcaseId(), "checkpoint should be 0");
 
     const iModel2 = await HubWrappers.openBriefcaseUsingRpc({ ...args, briefcaseId: 0 });
     assert.equal(BriefcaseIdValue.Unassigned, iModel2.briefcaseId, "pullOnly should be 0");
@@ -151,11 +151,11 @@ describe("BriefcaseManager", async () => {
     rootEl.userLabel = `${rootEl.userLabel}changed`;
     iModelPullAndPush.elements.updateElement(rootEl.toJSON());
 
-    assert.isTrue(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isFalse(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasPendingTxns());
     iModelPullAndPush.saveChanges();
-    assert.isFalse(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isTrue(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasPendingTxns());
 
     iModelPullAndPush.close();
 
@@ -165,8 +165,8 @@ describe("BriefcaseManager", async () => {
     const changesetPullAndPush = iModelPullAndPush.changeset;
     assert.strictEqual(iModelPullAndPush.briefcaseId, briefcaseId);
     assert.strictEqual(iModelPullAndPush.pathName, pathname);
-    assert.isFalse(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isTrue(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasPendingTxns());
 
     // User1 pushes a change set
     await testUtility.pushTestChangeSet();
@@ -183,8 +183,8 @@ describe("BriefcaseManager", async () => {
     assert.notStrictEqual(changesetPullAndPush3, changesetPullAndPush);
     assert.strictEqual(iModelPullAndPush.briefcaseId, briefcaseId);
     assert.strictEqual(iModelPullAndPush.pathName, pathname);
-    assert.isFalse(iModelPullAndPush.nativeDb.hasUnsavedChanges());
-    assert.isTrue(iModelPullAndPush.nativeDb.hasPendingTxns());
+    assert.isFalse(iModelPullAndPush[_nativeDb].hasUnsavedChanges());
+    assert.isTrue(iModelPullAndPush[_nativeDb].hasPendingTxns());
 
     // User2 should be able to push the changes now
     await iModelPullAndPush.pushChanges({ accessToken: userToken2, description: "test change" });

--- a/core/backend/src/test/hubaccess/CheckpointManager.test.ts
+++ b/core/backend/src/test/hubaccess/CheckpointManager.test.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 import * as sinon from "sinon";
 import { Guid } from "@itwin/core-bentley";
 import { CheckpointManager, V1CheckpointManager, V2CheckpointManager } from "../../CheckpointManager";
-import { IModelHost } from "../../core-backend";
+import { _nativeDb, IModelHost } from "../../core-backend";
 import { SnapshotDb } from "../../IModelDb";
 import { IModelJsFs } from "../../IModelJsFs";
 import { IModelTestUtils } from "../IModelTestUtils";
@@ -62,11 +62,11 @@ describe("V1 Checkpoint Manager", () => {
     const iModelId = Guid.createValue();  // This is wrong - it should be `snapshot.getGuid()`!
     const iTwinId = Guid.createValue();
     const changeset = IModelTestUtils.generateChangeSetId();
-    snapshot.nativeDb.setITwinId(iTwinId);
-    snapshot.nativeDb.saveLocalValue("ParentChangeSetId", changeset.id);
+    snapshot[_nativeDb].setITwinId(iTwinId);
+    snapshot[_nativeDb].saveLocalValue("ParentChangeSetId", changeset.id);
     snapshot.saveChanges();
 
-    assert.notEqual(iModelId, snapshot.nativeDb.getIModelId()); // Ensure the Snapshot dbGuid and iModelId are different
+    assert.notEqual(iModelId, snapshot[_nativeDb].getIModelId()); // Ensure the Snapshot dbGuid and iModelId are different
     snapshot.close();
 
     sinon.stub(V2CheckpointManager, "downloadCheckpoint").callsFake(async (arg) => {
@@ -79,7 +79,7 @@ describe("V1 Checkpoint Manager", () => {
     const request = { localFile, checkpoint: { iTwinId, iModelId, changeset } };
     await CheckpointManager.downloadCheckpoint(request);
     const db = V1CheckpointManager.openCheckpointV1(localFile, request.checkpoint);
-    assert.equal(iModelId, db.nativeDb.getIModelId(), "expected the V1 Checkpoint download to fix the improperly set dbGuid.");
+    assert.equal(iModelId, db[_nativeDb].getIModelId(), "expected the V1 Checkpoint download to fix the improperly set dbGuid.");
     db.close();
   });
 });
@@ -137,8 +137,8 @@ describe("Checkpoint Manager", () => {
     const iModelId = snapshot.iModelId;
     const iTwinId = Guid.createValue();
     const changeset = IModelTestUtils.generateChangeSetId();
-    snapshot.nativeDb.setITwinId(iTwinId);
-    snapshot.nativeDb.saveLocalValue("ParentChangeSetId", changeset.id);
+    snapshot[_nativeDb].setITwinId(iTwinId);
+    snapshot[_nativeDb].saveLocalValue("ParentChangeSetId", changeset.id);
     snapshot.saveChanges();
     snapshot.close();
 

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -21,12 +21,12 @@ import {
 import { V2CheckpointAccessProps } from "../../BackendHubAccess";
 import { V2CheckpointManager } from "../../CheckpointManager";
 import {
-  BisCoreSchema, Category, ClassRegistry, DefinitionContainer, DefinitionGroup, DefinitionGroupGroupsDefinitions, DefinitionModel,
-  DefinitionPartition, DictionaryModel, DisplayStyle3d, DisplayStyleCreationOptions, DocumentPartition, DrawingGraphic, ECSqlStatement, Element,
-  ElementDrivesElement, ElementGroupsMembers, ElementOwnsChildElements, Entity, GeometricElement2d, GeometricElement3d, GeometricModel,
-  GroupInformationPartition, IModelDb, IModelHost, IModelJsFs, InformationPartitionElement, InformationRecordElement, LightLocation, LinkPartition,
-  Model, PhysicalElement, PhysicalModel, PhysicalObject, PhysicalPartition, RenderMaterialElement, RenderMaterialElementParams, SnapshotDb, SpatialCategory, SqliteStatement,
-  SqliteValue, SqliteValueType, StandaloneDb, SubCategory, Subject, Texture, ViewDefinition,
+  _nativeDb, BisCoreSchema, Category, ClassRegistry, DefinitionContainer, DefinitionGroup, DefinitionGroupGroupsDefinitions,
+  DefinitionModel, DefinitionPartition, DictionaryModel, DisplayStyle3d, DisplayStyleCreationOptions, DocumentPartition, DrawingGraphic, ECSqlStatement,
+  Element, ElementDrivesElement, ElementGroupsMembers, ElementOwnsChildElements, Entity, GeometricElement2d, GeometricElement3d,
+  GeometricModel, GroupInformationPartition, IModelDb, IModelHost, IModelJsFs, InformationPartitionElement, InformationRecordElement, LightLocation,
+  LinkPartition, Model, PhysicalElement, PhysicalModel, PhysicalObject, PhysicalPartition, RenderMaterialElement, RenderMaterialElementParams, SnapshotDb, SpatialCategory,
+  SqliteStatement, SqliteValue, SqliteValueType, StandaloneDb, SubCategory, Subject, Texture, ViewDefinition,
 } from "../../core-backend";
 import { BriefcaseDb, SnapshotDbOpenArgs } from "../../IModelDb";
 import { HubMock } from "../../HubMock";
@@ -1052,7 +1052,7 @@ describe("iModel", () => {
     newExtents.high.z += .001;
     imodel1.updateProjectExtents(newExtents);
 
-    const updatedProps = imodel1.nativeDb.getIModelProps();
+    const updatedProps = imodel1[_nativeDb].getIModelProps();
     assert.isTrue(updatedProps.hasOwnProperty("projectExtents"), "Returned property JSON object has project extents");
     const updatedExtents = Range3d.fromJSON(updatedProps.projectExtents);
     assert.isTrue(newExtents.isAlmostEqual(updatedExtents), "Project extents successfully updated in database");
@@ -1627,7 +1627,7 @@ describe("iModel", () => {
 
     const testLocal = "TestLocal";
     const testValue = "this is a test";
-    const nativeDb = iModel.nativeDb;
+    const nativeDb = iModel[_nativeDb];
     assert.isUndefined(nativeDb.queryLocalValue(testLocal));
     nativeDb.saveLocalValue(testLocal, testValue);
     assert.equal(nativeDb.queryLocalValue(testLocal), testValue);

--- a/core/backend/src/test/native/DgnDbWorker.test.ts
+++ b/core/backend/src/test/native/DgnDbWorker.test.ts
@@ -10,6 +10,7 @@ import { IModelNative } from "../../internal/NativePlatform";
 import { StandaloneDb } from "../../IModelDb";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { IModelJsNative } from "@bentley/imodeljs-native";
+import { _nativeDb } from "../../internal/Symbols";
 
 describe("DgnDbWorker", () => {
   let imodel: StandaloneDb;
@@ -32,7 +33,7 @@ describe("DgnDbWorker", () => {
     private readonly _worker: IModelJsNative.TestWorker;
 
     public constructor() {
-      this._worker = new IModelNative.platform.TestWorker(imodel.nativeDb);
+      this._worker = new IModelNative.platform.TestWorker(imodel[_nativeDb]);
     }
 
     public queue() { this.promise = this._worker.queue(); }

--- a/core/backend/src/test/schema/FunctionalDomain.test.ts
+++ b/core/backend/src/test/schema/FunctionalDomain.test.ts
@@ -11,9 +11,9 @@ import { CodeScopeSpec, CodeSpec, ElementProps, IModel } from "@itwin/core-commo
 import { ClassRegistry } from "../../ClassRegistry";
 import { ElementUniqueAspect, OnAspectIdArg, OnAspectPropsArg } from "../../ElementAspect";
 import {
-  ChannelControl, ChannelKey, FunctionalBreakdownElement, FunctionalComponentElement, FunctionalModel, FunctionalPartition, FunctionalSchema,
-  InformationPartitionElement, OnChildElementIdArg, OnChildElementPropsArg, OnElementIdArg, OnElementInModelIdArg, OnElementInModelPropsArg,
-  OnElementPropsArg, OnModelIdArg, OnModelPropsArg, OnSubModelIdArg, OnSubModelPropsArg, Schemas, StandaloneDb,
+  _nativeDb, ChannelControl, ChannelKey, FunctionalBreakdownElement, FunctionalComponentElement, FunctionalModel, FunctionalPartition,
+  FunctionalSchema, InformationPartitionElement, OnChildElementIdArg, OnChildElementPropsArg, OnElementIdArg, OnElementInModelIdArg,
+  OnElementInModelPropsArg, OnElementPropsArg, OnModelIdArg, OnModelPropsArg, OnSubModelIdArg, OnSubModelPropsArg, Schemas, StandaloneDb,
 } from "../../core-backend";
 import { ElementOwnsChildElements, ElementOwnsUniqueAspect, SubjectOwnsPartitionElements } from "../../NavigationRelationship";
 import { IModelTestUtils } from "../IModelTestUtils";
@@ -243,7 +243,7 @@ describe("Functional Domain", () => {
       guid: Guid.createValue(),
     });
 
-    iModelDb.nativeDb.resetBriefcaseId(100);
+    iModelDb[_nativeDb].resetBriefcaseId(100);
 
     // Import the Functional schema
     FunctionalSchema.registerSchema();

--- a/core/backend/src/test/standalone/ChangesetReader.test.ts
+++ b/core/backend/src/test/standalone/ChangesetReader.test.ts
@@ -14,7 +14,7 @@ import { BriefcaseDb, SnapshotDb } from "../../IModelDb";
 import { SqliteChangesetReader } from "../../SqliteChangesetReader";
 import { HubWrappers, IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
-import { ChannelControl } from "../../core-backend";
+import { _nativeDb, ChannelControl } from "../../core-backend";
 
 describe("Changeset Reader API", async () => {
   let iTwinId: GuidString;
@@ -114,7 +114,7 @@ describe("Changeset Reader API", async () => {
     rwIModel.saveChanges("user 1: data");
 
     if ("test local changes") {
-      const reader = SqliteChangesetReader.openLocalChanges({ iModel: rwIModel.nativeDb, db: rwIModel, disableSchemaCheck: true });
+      const reader = SqliteChangesetReader.openLocalChanges({ iModel: rwIModel[_nativeDb], db: rwIModel, disableSchemaCheck: true });
       const adaptor = new ECChangesetAdaptor(reader);
       const cci = new PartialECChangeUnifier();
       while (adaptor.step()) {

--- a/core/backend/src/test/standalone/ElementGraphics.test.ts
+++ b/core/backend/src/test/standalone/ElementGraphics.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { assert } from "@itwin/core-bentley";
 import { CurrentImdlVersion, DynamicGraphicsRequest3dProps, ElementGeometry, ElementGeometryDataEntry, ElementGraphicsRequestProps, GeometryStreamIterator } from "@itwin/core-common";
 import { ElementGraphicsStatus } from "@bentley/imodeljs-native";
-import { GeometricElement3d, SnapshotDb } from "../../core-backend";
+import { _nativeDb, GeometricElement3d, SnapshotDb } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
 describe("ElementGraphics", () => {
@@ -35,7 +35,7 @@ describe("ElementGraphics", () => {
       formatVersion: CurrentImdlVersion.Major,
     };
 
-    const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+    const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
     expect(result.status).to.equal(ElementGraphicsStatus.Success);
     assert(result.status === ElementGraphicsStatus.Success);
 
@@ -64,7 +64,7 @@ describe("ElementGraphics", () => {
       geometry: { format: "json", data: element!.geom! },
     };
 
-    const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+    const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
     expect(result.status).to.equal(ElementGraphicsStatus.Success);
     assert(result.status === ElementGraphicsStatus.Success);
 
@@ -107,7 +107,7 @@ describe("ElementGraphics", () => {
       geometry: { format: "flatbuffer", data: entries },
     };
 
-    const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+    const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
     expect(result.status).to.equal(ElementGraphicsStatus.Success);
     assert(result.status === ElementGraphicsStatus.Success);
 
@@ -144,7 +144,7 @@ describe("ElementGraphics", () => {
         ...testCase[1],
       };
 
-      const result = await imodel.nativeDb.generateElementGraphics(request as any); // ###TODO update package versions in addon
+      const result = await imodel[_nativeDb].generateElementGraphics(request as any); // ###TODO update package versions in addon
       expect(result.status).to.equal(testCase[0]);
       if (result.status === ElementGraphicsStatus.Success)
         expect(result.content).not.to.be.undefined;

--- a/core/backend/src/test/standalone/ElementMesh.test.ts
+++ b/core/backend/src/test/standalone/ElementMesh.test.ts
@@ -11,7 +11,7 @@ import {
   Code, ColorDef, GeometricElement3dProps, GeometryParams, GeometryPartProps, GeometryStreamBuilder, GeometryStreamEntryProps, IModel, readElementMeshes,
 } from "@itwin/core-common";
 import {
-  GenericSchema, GeometryPart, PhysicalModel, PhysicalObject, PhysicalPartition, SnapshotDb, SpatialCategory, SubjectOwnsPartitionElements,
+  _nativeDb, GenericSchema, GeometryPart, PhysicalModel, PhysicalObject, PhysicalPartition, SnapshotDb, SpatialCategory, SubjectOwnsPartitionElements,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
@@ -47,7 +47,7 @@ describe("generateElementMeshes", () => {
   });
 
   it("throws if source is not a geometric element", async () => {
-    await expect(imodel.nativeDb.generateElementMeshes({source: "NotAnId"})).rejectedWith("Geometric element required");
+    await expect(imodel[_nativeDb].generateElementMeshes({source: "NotAnId"})).rejectedWith("Geometric element required");
   });
 
   function insertTriangleElement(origin = [0, 0, 0]): string {
@@ -77,7 +77,7 @@ describe("generateElementMeshes", () => {
 
   it("produces a polyface", async () => {
     const source = insertTriangleElement();
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(1);
     expect(meshes[0].range().isAlmostEqual(new Range3d(0, 0, 0, 1, 1, 0))).to.be.true;
@@ -85,7 +85,7 @@ describe("generateElementMeshes", () => {
 
   it("applies element placement transform", async () => {
     const source = insertTriangleElement([5, 0, -2]);
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(1);
     expect(meshes[0].range().isAlmostEqual(new Range3d(5, 0, -2, 6, 1, -2))).to.be.true;
@@ -110,7 +110,7 @@ describe("generateElementMeshes", () => {
     elBldr.appendGeometryPart3d(partId, new Point3d(0, 0, -1));
     const source = insertElement(elBldr.geometryStream, [2, -4, 0]);
 
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(2);
     expect(meshes[0].range().isAlmostEqual(new Range3d(2, -4, 1, 3, -3, 1))).to.be.true;
@@ -124,7 +124,7 @@ describe("generateElementMeshes", () => {
     bldr.appendGeometry(Loop.createPolygon([new Point3d(0, 0, 5), new Point3d(1, 0, 5), new Point3d(0, 1, 5), new Point3d(0, 0, 5)]));
     const source = insertElement(bldr.geometryStream);
 
-    const meshes = readElementMeshes(await imodel.nativeDb.generateElementMeshes({source}));
+    const meshes = readElementMeshes(await imodel[_nativeDb].generateElementMeshes({source}));
     expect(meshes.length).to.equal(2);
     expect(meshes[0].range().isAlmostEqual(new Range3d(0, 0, 0, 1, 1, 0))).to.be.true;
     expect(meshes[1].range().isAlmostEqual(new Range3d(0, 0, 5, 1, 1, 5))).to.be.true;
@@ -138,7 +138,7 @@ describe("generateElementMeshes", () => {
     bldr.appendGeometry(Loop.createPolygon([new Point3d(0, 0, 5), new Point3d(1, 0, 5), new Point3d(0, 1, 5), new Point3d(0, 0, 5)]));
     const source = insertElement(bldr.geometryStream);
 
-    const meshes = readElementMeshes(await imodel.nativeDb.generateElementMeshes({source}));
+    const meshes = readElementMeshes(await imodel[_nativeDb].generateElementMeshes({source}));
     expect(meshes.length).to.equal(2);
     expect(meshes[0].range().isAlmostEqual(new Range3d(0, 0, 0, 1, 1, 0))).to.be.true;
     expect(meshes[1].range().isAlmostEqual(new Range3d(0, 0, 5, 1, 1, 5))).to.be.true;
@@ -159,7 +159,7 @@ describe("generateElementMeshes", () => {
     bldr.appendGeometry(pf);
     const source = insertElement(bldr.geometryStream, [10, 0, 0]);
 
-    const bytes = await imodel.nativeDb.generateElementMeshes({source});
+    const bytes = await imodel[_nativeDb].generateElementMeshes({source});
     const meshes = readElementMeshes(bytes);
     expect(meshes.length).to.equal(1);
     expect(meshes[0].pointCount).to.equal(3);

--- a/core/backend/src/test/standalone/GeometryChangeEvents.test.ts
+++ b/core/backend/src/test/standalone/GeometryChangeEvents.test.ts
@@ -9,8 +9,8 @@ import {
   Code, ColorByName, GeometricElement3dProps, GeometryStreamBuilder, IModel, ModelGeometryChangesProps, SubCategoryAppearance,
 } from "@itwin/core-common";
 import {
-  ChannelControl,
-  IModelJsFs, PhysicalModel, SpatialCategory, StandaloneDb, VolumeElement,
+  _nativeDb,
+  ChannelControl, IModelJsFs, PhysicalModel, SpatialCategory, StandaloneDb, VolumeElement,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
@@ -32,12 +32,12 @@ describe("Model geometry changes", () => {
     modelId = PhysicalModel.insert(imodel, IModel.rootSubjectId, "TestModel");
     categoryId = SpatialCategory.insert(imodel, IModel.dictionaryId, "TestCategory", new SubCategoryAppearance({ color: ColorByName.darkRed }));
     imodel.saveChanges("set up");
-    imodel.nativeDb.deleteAllTxns();
+    imodel[_nativeDb].deleteAllTxns();
     imodel.txns.onGeometryChanged.addListener((props) => lastChanges = props);
   });
 
   after(async () => {
-    imodel.nativeDb.setGeometricModelTrackingEnabled(false);
+    imodel[_nativeDb].setGeometricModelTrackingEnabled(false);
     imodel.close();
   });
 
@@ -80,8 +80,8 @@ describe("Model geometry changes", () => {
   }
 
   it("emits events", async () => {
-    expect(imodel.nativeDb.isGeometricModelTrackingSupported()).to.be.true;
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(true).result).to.be.true;
+    expect(imodel[_nativeDb].isGeometricModelTrackingSupported()).to.be.true;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(true).result).to.be.true;
 
     const builder = new GeometryStreamBuilder();
     builder.appendGeometry(LineSegment3d.create(Point3d.createZero(), Point3d.create(5, 0, 0)));
@@ -128,8 +128,8 @@ describe("Model geometry changes", () => {
     expectChanges({ modelId, deleted: [elemId0] });
 
     // Stop tracking geometry changes
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(false).result).to.be.false;
-    expect(imodel.nativeDb.isGeometricModelTrackingSupported()).to.be.true;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(false).result).to.be.false;
+    expect(imodel[_nativeDb].isGeometricModelTrackingSupported()).to.be.true;
 
     // Modify element's geometry.
     props.id = elemId1;
@@ -139,7 +139,7 @@ describe("Model geometry changes", () => {
     expectNoChanges();
 
     // Restart tracking and undo everything.
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(true).result).to.be.true;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(true).result).to.be.true;
     expect(imodel.txns.reverseSingleTxn()).to.equal(IModelStatus.Success);
     expectChanges({ modelId, updated: [elemId1] });
 
@@ -177,6 +177,6 @@ describe("Model geometry changes", () => {
     expect(imodel.txns.reinstateTxn()).to.equal(IModelStatus.Success);
     expectChanges({ modelId, updated: [elemId1] });
 
-    expect(imodel.nativeDb.setGeometricModelTrackingEnabled(false).result).to.be.false;
+    expect(imodel[_nativeDb].setGeometricModelTrackingEnabled(false).result).to.be.false;
   });
 });

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -20,7 +20,7 @@ import {
   MassPropertiesRequestProps, PhysicalElementProps, Placement3d, Placement3dProps, TextString, TextStringGlyphData, TextStringProps, ThematicGradientMode,
   ThematicGradientSettings, ViewFlags,
 } from "@itwin/core-common";
-import { GeometricElement, GeometryPart, LineStyleDefinition, PhysicalObject, SnapshotDb } from "../../core-backend";
+import { _nativeDb, GeometricElement, GeometryPart, LineStyleDefinition, PhysicalObject, SnapshotDb } from "../../core-backend";
 import { createBRepDataProps } from "../GeometryTestUtil";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { Timer } from "../TestUtils";
@@ -511,7 +511,7 @@ describe("GeometryStream", () => {
     assert.isTrue(Id64.isValidId64(newId));
     imodel.saveChanges();
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId, styleId])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId, styleId])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isTrue(usageInfo.lineStyleIds!.includes(styleId));
     assert.isTrue(usageInfo.usedIds!.includes(partId));
@@ -574,7 +574,7 @@ describe("GeometryStream", () => {
     assert.isTrue(Id64.isValidId64(newId));
     imodel.saveChanges();
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId, styleId, seedElement.category])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId, styleId, seedElement.category])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isTrue(usageInfo.lineStyleIds!.includes(styleId));
     assert.isTrue(usageInfo.spatialCategoryIds!.includes(seedElement.category));
@@ -1082,7 +1082,7 @@ describe("GeometryStream", () => {
     }
     assert.isTrue(6 === iShape);
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isTrue(usageInfo.usedIds!.includes(partId));
   });
@@ -1195,7 +1195,7 @@ describe("GeometryStream", () => {
       assert.isTrue(geomArrayOut[i].isAlmostEqual(geomArray[i]));
     }
 
-    const usageInfo = imodel.nativeDb.queryDefinitionElementUsage([partId])!;
+    const usageInfo = imodel[_nativeDb].queryDefinitionElementUsage([partId])!;
     assert.isTrue(usageInfo.geometryPartIds!.includes(partId));
     assert.isUndefined(usageInfo.usedIds, "GeometryPart should not to be used by any GeometricElement");
   });

--- a/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
+++ b/core/backend/src/test/standalone/InlineGeometryPartReferences.test.ts
@@ -10,7 +10,7 @@ import {
   Code, ColorDef, GeometricElement3dProps, GeometryParams, GeometryPartProps, GeometryStreamBuilder, GeometryStreamIterator, IModel,
 } from "@itwin/core-common";
 import {
-  GenericSchema, GeometricElement3d, GeometryPart, PhysicalModel, PhysicalObject, PhysicalPartition, RenderMaterialElement, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements,
+  _nativeDb, GenericSchema, GeometricElement3d, GeometryPart, PhysicalModel, PhysicalObject, PhysicalPartition, RenderMaterialElement, SnapshotDb, SpatialCategory, SubCategory, SubjectOwnsPartitionElements,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
@@ -242,7 +242,7 @@ describe("DgnDb.inlineGeometryPartReferences", () => {
   }
 
   function inlinePartRefs(): number {
-    const result = imodel.nativeDb.inlineGeometryPartReferences();
+    const result = imodel[_nativeDb].inlineGeometryPartReferences();
     expect(result.numCandidateParts).to.equal(result.numPartsDeleted);
     expect(result.numRefsInlined).to.equal(result.numCandidateParts);
     return result.numRefsInlined;

--- a/core/backend/src/test/standalone/SnapshotDb.test.ts
+++ b/core/backend/src/test/standalone/SnapshotDb.test.ts
@@ -11,6 +11,7 @@ import { IModelDb, SnapshotDb } from "../../IModelDb";
 import { Logger } from "@itwin/core-bentley";
 import { IModelHost } from "../../IModelHost";
 import { HubMock } from "../../HubMock";
+import { _nativeDb } from "../../internal/Symbols";
 
 describe("SnapshotDb.refreshContainerForRpc", () => {
   afterEach(() => sinon.restore());
@@ -111,7 +112,7 @@ describe("SnapshotDb.refreshContainerForRpc", () => {
 
     const userAccessToken = "token";
     const checkpoint = await SnapshotDb.openCheckpointFromRpc({ accessToken: userAccessToken, iTwinId, iModelId, changeset, reattachSafetySeconds: 60 });
-    expect(checkpoint.nativeDb.cloudContainer?.accessToken).equal(mockCheckpointV2.sasToken);
+    expect(checkpoint[_nativeDb].cloudContainer?.accessToken).equal(mockCheckpointV2.sasToken);
     expect(openDgnDbStub.calledOnce).to.be.true;
     expect(openDgnDbStub.firstCall.firstArg.path).to.equal("fakeDb");
 

--- a/core/backend/src/test/standalone/TileCache.test.ts
+++ b/core/backend/src/test/standalone/TileCache.test.ts
@@ -16,6 +16,7 @@ import { GeometricModel3d } from "../../Model";
 import { RpcTrace } from "../../rpc/tracing";
 import { TestUtils } from "../TestUtils";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { _nativeDb } from "../../internal/Symbols";
 
 const fakeRpc: RpcActivity = { // eslint-disable-line deprecation/deprecation
   accessToken: "dummy",
@@ -122,8 +123,8 @@ describe("TileCache, open v2", async () => {
     const iModelId = snapshot.iModelId;
     const iTwinId = Guid.createValue();
     const changeset = IModelTestUtils.generateChangeSetId();
-    snapshot.nativeDb.setITwinId(iTwinId);
-    snapshot.nativeDb.saveLocalValue("ParentChangeSetId", changeset.id); // even fake checkpoints need a changesetId!
+    snapshot[_nativeDb].setITwinId(iTwinId);
+    snapshot[_nativeDb].saveLocalValue("ParentChangeSetId", changeset.id); // even fake checkpoints need a changesetId!
     snapshot.saveChanges();
     snapshot.close();
 
@@ -132,7 +133,7 @@ describe("TileCache, open v2", async () => {
     const tileRpcInterface = RpcRegistry.instance.getImplForInterface<IModelTileRpcInterface>(IModelTileRpcInterface);
     const tempFileBase = path.join(IModelHost.cacheDir, key);
     const checkpoint = SnapshotDb.openFile(dbPath, { key, tempFileBase });
-    expect(checkpoint.nativeDb.getTempFileBaseName()).equals(tempFileBase);
+    expect(checkpoint[_nativeDb].getTempFileBaseName()).equals(tempFileBase);
     // Generate tile
     const tileProps = await getTileProps(checkpoint);
     expect(tileProps).not.undefined;

--- a/core/backend/src/test/standalone/TileTree.test.ts
+++ b/core/backend/src/test/standalone/TileTree.test.ts
@@ -11,7 +11,8 @@ import {
   PrimaryTileTreeId, RenderSchedule,
 } from "@itwin/core-common";
 import {
-  GenericSchema, IModelDb, PhysicalModel, PhysicalObject, PhysicalPartition, RenderTimeline, SnapshotDb, SpatialCategory,
+  _nativeDb, GenericSchema, IModelDb, PhysicalModel, PhysicalObject, PhysicalPartition, RenderTimeline, SnapshotDb,
+  SpatialCategory,
   SubjectOwnsPartitionElements,
 } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
@@ -135,7 +136,7 @@ describe("tile tree", () => {
   });
 
   afterEach(() => {
-    db.nativeDb.purgeTileTrees(undefined);
+    db[_nativeDb].purgeTileTrees(undefined);
   });
 
   it("should update after changing project extents and purging", async () => {
@@ -179,7 +180,7 @@ describe("tile tree", () => {
     expect(tree.rootTile.isLeaf).to.be.false;
 
     // Purge tile trees for a specific (non-existent) model - still nothing should change for our model.
-    db.nativeDb.purgeTileTrees(["0x123abc"]);
+    db[_nativeDb].purgeTileTrees(["0x123abc"]);
 
     tree = await db.tiles.requestTileTreeProps(treeId);
     expect(tree).not.to.be.undefined;
@@ -195,7 +196,7 @@ describe("tile tree", () => {
     expect(tree.rootTile.isLeaf).to.be.false;
 
     // Purge tile trees for our model - now we should get updated tile tree props.
-    db.nativeDb.purgeTileTrees([modelId]);
+    db[_nativeDb].purgeTileTrees([modelId]);
 
     tree = await db.tiles.requestTileTreeProps(treeId);
     expect(tree).not.to.be.undefined;
@@ -215,7 +216,7 @@ describe("tile tree", () => {
 
     // Change extents again and purge tile trees for all loaded models (by passing `undefined` for model Ids).
     newExtents = scaleProjectExtents(db, 0.75);
-    db.nativeDb.purgeTileTrees(undefined);
+    db[_nativeDb].purgeTileTrees(undefined);
 
     tree = await db.tiles.requestTileTreeProps(treeId);
     expect(tree).not.to.be.undefined;
@@ -288,7 +289,7 @@ describe("tile tree", () => {
     expect(tree2).not.to.equal(tree1);
     expect(tree2).to.deep.equal(tree1);
 
-    db.nativeDb.purgeTileTrees(undefined);
+    db[_nativeDb].purgeTileTrees(undefined);
     const tree3 = await db.tiles.requestTileTreeProps(iModelTileTreeIdToString(modelId, treeId, options));
     expect(tree3).not.to.equal(tree2);
     expect(tree3).not.to.equal(tree1);

--- a/core/backend/src/test/standalone/TxnManager.test.ts
+++ b/core/backend/src/test/standalone/TxnManager.test.ts
@@ -10,6 +10,7 @@ import {
   Code, ColorByName, DomainOptions, EntityIdAndClassId, EntityIdAndClassIdIterable, GeometryStreamBuilder, IModel, IModelError, SubCategoryAppearance, TxnAction, UpgradeOptions,
 } from "@itwin/core-common";
 import {
+  _nativeDb,
   ChangeInstanceKey,
   ChannelControl,
   IModelJsFs, PhysicalModel, setMaxEntitiesPerEvent, SpatialCategory, StandaloneDb, TxnChangedEntities, TxnManager,
@@ -65,7 +66,7 @@ describe("TxnManager", () => {
     };
 
     imodel.saveChanges("schema change");
-    imodel.nativeDb.deleteAllTxns();
+    imodel[_nativeDb].deleteAllTxns();
     roImodel = StandaloneDb.openFile(testFileName, OpenMode.Readonly);
   });
 
@@ -76,7 +77,7 @@ describe("TxnManager", () => {
   });
 
   function makeEntity(id: string, classFullName: string): EntityIdAndClassId {
-    const classId = imodel.nativeDb.classNameToId(classFullName);
+    const classId = imodel[_nativeDb].classNameToId(classFullName);
     expect(Id64.isValid(classId)).to.be.true;
     return { id, classId };
   }
@@ -131,13 +132,13 @@ describe("TxnManager", () => {
     assert.isTrue(txns.hasPendingTxns);
     assert.isTrue(txns.hasLocalChanges);
 
-    expect(imodel.nativeDb.getCurrentTxnId()).not.equal(roImodel.nativeDb.getCurrentTxnId());
-    roImodel.nativeDb.restartDefaultTxn();
-    expect(imodel.nativeDb.getCurrentTxnId()).equal(roImodel.nativeDb.getCurrentTxnId());
+    expect(imodel[_nativeDb].getCurrentTxnId()).not.equal(roImodel[_nativeDb].getCurrentTxnId());
+    roImodel[_nativeDb].restartDefaultTxn();
+    expect(imodel[_nativeDb].getCurrentTxnId()).equal(roImodel[_nativeDb].getCurrentTxnId());
 
-    const classId = imodel.nativeDb.classNameToId(props.classFullName);
+    const classId = imodel[_nativeDb].classNameToId(props.classFullName);
     assert.isTrue(Id64.isValid(classId));
-    const class2 = imodel.nativeDb.classIdToName(classId);
+    const class2 = imodel[_nativeDb].classIdToName(classId);
     assert.equal(class2, props.classFullName);
     model = models.getModel(modelId);
     assert.isDefined(model.geometryGuid);
@@ -545,7 +546,7 @@ describe("TxnManager", () => {
     });
 
     EventAccumulator.testModels(roImodel, (accum) => {
-      roImodel.nativeDb.restartDefaultTxn();
+      roImodel[_nativeDb].restartDefaultTxn();
       accum.expectChanges({ inserted: [physicalModelEntity(newModelId)] });
     });
 
@@ -581,7 +582,7 @@ describe("TxnManager", () => {
     });
 
     EventAccumulator.testModels(roImodel, (accum) => {
-      roImodel.nativeDb.restartDefaultTxn();
+      roImodel[_nativeDb].restartDefaultTxn();
       accum.expectChanges({ deleted: [physicalModelEntity(newModelId)] });
     });
 
@@ -722,7 +723,7 @@ describe("TxnManager", () => {
       expect(changes[0].id).to.equal(modelId);
       expect(changes[0].guid).to.equal(guid1);
     });
-    roImodel.nativeDb.restartDefaultTxn();
+    roImodel[_nativeDb].restartDefaultTxn();
     expect(numRoEvents).equal(4);
     dropper();
   });
@@ -838,7 +839,7 @@ describe("TxnManager", () => {
 
   // This bug occurred in one of the authoring apps. This test reproduced the problem, and now serves as a regression test.
   it("doesn't crash when reversing a single txn that inserts a model and a contained element while geometric model tracking is enabled", () => {
-    imodel.nativeDb.setGeometricModelTrackingEnabled(true);
+    imodel[_nativeDb].setGeometricModelTrackingEnabled(true);
 
     const model = PhysicalModel.insert(imodel, IModel.rootSubjectId, Guid.createValue());
     expect(Id64.isValidId64(model)).to.be.true;
@@ -848,7 +849,7 @@ describe("TxnManager", () => {
     imodel.saveChanges("insert model and element");
     imodel.txns.reverseSingleTxn();
 
-    imodel.nativeDb.setGeometricModelTrackingEnabled(false);
+    imodel[_nativeDb].setGeometricModelTrackingEnabled(false);
   });
   it("get local changes", async () => {
     const elements = imodel.elements;

--- a/core/backend/src/test/standalone/Workspace.test.ts
+++ b/core/backend/src/test/standalone/Workspace.test.ts
@@ -14,6 +14,7 @@ import { Workspace, WorkspaceContainerProps, WorkspaceDbManifest, WorkspaceDbPro
 import { EditableWorkspaceDb, WorkspaceEditor } from "../../workspace/WorkspaceEditor";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { validateWorkspaceContainerId, validateWorkspaceDbName } from "../../internal/workspace/WorkspaceImpl";
+import { _nativeDb } from "../../internal/Symbols";
 
 describe("WorkspaceFile", () => {
 
@@ -145,7 +146,7 @@ describe("WorkspaceFile", () => {
     expect(wsFile.getBlob(blobRscName)).to.be.undefined;
 
     wsFile.addFile(fileRscName, inFile);
-    const writeFile = sinon.spy(wsFile.sqliteDb.nativeDb, "extractEmbeddedFile");
+    const writeFile = sinon.spy(wsFile.sqliteDb[_nativeDb], "extractEmbeddedFile");
     expect(writeFile.callCount).eq(0);
     const outFile = wsFile.getFile(fileRscName)!;
     expect(writeFile.callCount).eq(1);

--- a/core/ecschema-rpc/impl/src/ECSchemaRpcImpl.ts
+++ b/core/ecschema-rpc/impl/src/ECSchemaRpcImpl.ts
@@ -78,6 +78,6 @@ export class ECSchemaRpcImpl extends RpcInterface implements ECSchemaRpcInterfac
     }
 
     const iModelDb = await this.getIModelDatabase(tokenProps);
-    return iModelDb.nativeDb.getSchemaProps(schemaName);
+    return iModelDb[backend._nativeDb].getSchemaProps(schemaName);
   }
 }

--- a/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
+++ b/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 import * as semver from "semver";
 import { Guid, Id64, Id64String } from "@itwin/core-bentley";
 import {
-  BisCoreSchema, ClassRegistry, GenericSchema, GeometricElement3d, IModelDb, IModelHost, IModelJsFs, KnownLocations, PhysicalPartition, Schema,
+  _nativeDb, BisCoreSchema, ClassRegistry, GenericSchema, GeometricElement3d, IModelDb, IModelHost, IModelJsFs, KnownLocations, PhysicalPartition, Schema,
   Schemas, SnapshotDb, SpatialCategory, SubjectOwnsPartitionElements,
 } from "@itwin/core-backend";
 import {
@@ -70,8 +70,8 @@ describe("AnalyticalSchema", () => {
     assert.isTrue(IModelJsFs.existsSync(analyticalSchemaFileName));
     assert.isTrue(IModelJsFs.existsSync(testSchemaFileName));
     await iModelDb.importSchemas([analyticalSchemaFileName, testSchemaFileName]);
-    assert.isFalse(iModelDb.nativeDb.hasPendingTxns(), "Expect importSchemas to not have txns for snapshots");
-    assert.isFalse(iModelDb.nativeDb.hasUnsavedChanges(), "Expect no unsaved changes after importSchemas");
+    assert.isFalse(iModelDb[_nativeDb].hasPendingTxns(), "Expect importSchemas to not have txns for snapshots");
+    assert.isFalse(iModelDb[_nativeDb].hasUnsavedChanges(), "Expect no unsaved changes after importSchemas");
     iModelDb.saveChanges();
     // test querySchemaVersion
     const bisCoreSchemaVersion: string = iModelDb.querySchemaVersion(BisCoreSchema.schemaName)!;

--- a/full-stack-tests/backend/src/integration/Checkpoints.test.ts
+++ b/full-stack-tests/backend/src/integration/Checkpoints.test.ts
@@ -8,7 +8,7 @@ import { ChildProcess } from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as sinon from "sinon";
-import { CloudSqlite, IModelDb, IModelHost, IModelJsFs, NativeCloudSqlite, SettingsPriority, SnapshotDb, V2CheckpointAccessProps, V2CheckpointManager } from "@itwin/core-backend";
+import { _nativeDb, CloudSqlite, IModelDb, IModelHost, IModelJsFs, NativeCloudSqlite, SettingsPriority, SnapshotDb, V2CheckpointAccessProps, V2CheckpointManager } from "@itwin/core-backend";
 import { KnownTestLocations } from "@itwin/core-backend/lib/cjs/test/KnownTestLocations";
 import { AccessToken, GuidString } from "@itwin/core-bentley";
 import { ChangesetProps, IModelVersion } from "@itwin/core-common";
@@ -122,7 +122,7 @@ describe("Checkpoints", () => {
       iModelId: testIModelId,
       changeset: testChangeSet,
     });
-    expect(iModel.nativeDb.cloudContainer?.cache?.rootDir).contains("profile");
+    expect(iModel[_nativeDb].cloudContainer?.cache?.rootDir).contains("profile");
     iModel.close();
   });
 
@@ -182,7 +182,7 @@ describe("Checkpoints", () => {
 
     // make sure the sasToken for the checkpoint container is refreshed before it expires
     // (see explanation in CloudSqlite.test.ts "Auto refresh container tokens" for how this works)
-    const c1 = iModel.nativeDb.cloudContainer as CloudSqlite.CloudContainer & { refreshPromise?: Promise<void> };
+    const c1 = iModel[_nativeDb].cloudContainer as CloudSqlite.CloudContainer & { refreshPromise?: Promise<void> };
     const oldToken = c1.accessToken; // save current token
 
     expect(queryV2Checkpoint.callCount).equal(1);
@@ -353,7 +353,7 @@ describe("Checkpoints", () => {
       numModels = await queryBisModelCount(iModel);
       assert.equal(numModels, 32);
 
-      const checkpointContainer = iModel.nativeDb.cloudContainer;
+      const checkpointContainer = iModel[_nativeDb].cloudContainer;
       iModel.close();
 
       iModel = await SnapshotDb.openCheckpointFromRpc({
@@ -399,8 +399,8 @@ describe("Checkpoints", () => {
       assert.equal(numModels, 4);
 
       // all checkpoints for the same iModel should share a cloud container
-      expect(checkpointContainer).equal(iModel.nativeDb.cloudContainer);
-      expect(checkpointContainer).equal(iModel2.nativeDb.cloudContainer);
+      expect(checkpointContainer).equal(iModel[_nativeDb].cloudContainer);
+      expect(checkpointContainer).equal(iModel2[_nativeDb].cloudContainer);
 
       iModel.close();
       iModel2.close();

--- a/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
+++ b/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
@@ -8,7 +8,7 @@ import * as chaiAsPromised from "chai-as-promised";
 import { existsSync, removeSync } from "fs-extra";
 import { join } from "path";
 import * as sinon from "sinon";
-import { BlobContainer, BriefcaseDb, CloudSqlite, IModelHost, IModelJsFs, KnownLocations, PropertyStore, SnapshotDb, SQLiteDb } from "@itwin/core-backend";
+import { _nativeDb, BlobContainer, BriefcaseDb, CloudSqlite, IModelHost, IModelJsFs, KnownLocations, PropertyStore, SnapshotDb, SQLiteDb } from "@itwin/core-backend";
 import { KnownTestLocations } from "@itwin/core-backend/lib/cjs/test";
 import { assert, BeDuration, DbResult, Guid, GuidString, OpenMode } from "@itwin/core-bentley";
 import { AzuriteTest } from "./AzuriteTest";
@@ -264,9 +264,9 @@ describe("CloudSqlite", () => {
     const db = new SQLiteDb();
     db.openDb("c0-db1:0", OpenMode.Readonly, contain1);
     expect(db.isOpen);
-    expect(db.nativeDb.cloudContainer).equals(contain1);
+    expect(db[_nativeDb].cloudContainer).equals(contain1);
     db.closeDb();
-    expect(db.nativeDb.cloudContainer).undefined;
+    expect(db[_nativeDb].cloudContainer).undefined;
 
     dbProps = contain1.queryDatabase(dbs[0]);
     assert(dbProps !== undefined);
@@ -294,7 +294,7 @@ describe("CloudSqlite", () => {
       const briefcase = await BriefcaseDb.open({ fileName: "testBim2", container: contain1 });
       expect(briefcase.getBriefcaseId()).equals(0);
       expect(briefcase.iModelId).equals(testBimGuid);
-      expect(briefcase.nativeDb.cloudContainer).equals(contain1);
+      expect(briefcase[_nativeDb].cloudContainer).equals(contain1);
       briefcase.close();
     });
 

--- a/full-stack-tests/backend/src/integration/SchemaSync.test.ts
+++ b/full-stack-tests/backend/src/integration/SchemaSync.test.ts
@@ -5,7 +5,7 @@
 
 import { assert, expect } from "chai";
 import { Suite } from "mocha";
-import { BriefcaseDb, BriefcaseManager, CloudSqlite, HubMock, IModelDb, IModelHost, SchemaSync, SnapshotDb, SqliteStatement } from "@itwin/core-backend";
+import { _nativeDb, BriefcaseDb, BriefcaseManager, CloudSqlite, HubMock, IModelDb, IModelHost, SchemaSync, SnapshotDb, SqliteStatement } from "@itwin/core-backend";
 import { AzuriteTest } from "./AzuriteTest";
 import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test";
 import { AccessToken, DbResult, Guid, OpenMode } from "@itwin/core-bentley";
@@ -129,7 +129,7 @@ describe("Schema synchronization", function (this: Suite) {
   const synchronizeSchemas = async (iModel: IModelDb) => {
     await SchemaSync.withLockedAccess(iModel, { openMode: OpenMode.Readonly, operationName: "schemaSync" }, async (syncAccess) => {
       const uri = syncAccess.getUri();
-      iModel.nativeDb.schemaSyncPull(uri);
+      iModel[_nativeDb].schemaSyncPull(uri);
       iModel.clearCaches();
     });
   };
@@ -165,11 +165,11 @@ describe("Schema synchronization", function (this: Suite) {
 
     await SchemaSync.initializeForIModel({ iModel: b1, containerProps });
     await b1.pushChanges({ accessToken: user1AccessToken, description: "enable shared schema channel" });
-    assert.isTrue(b1.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b1[_nativeDb].schemaSyncEnabled());
 
     // b2 briefcase need to pull to enable shared schema channel.
     await b2.pullChanges({ accessToken: user2AccessToken });
-    assert.isTrue(b2.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b2[_nativeDb].schemaSyncEnabled());
 
     // Import schema into b1 but do not push it.
     const schema1 = `<?xml version="1.0" encoding="UTF-8"?>
@@ -263,11 +263,11 @@ describe("Schema synchronization", function (this: Suite) {
 
     await SchemaSync.initializeForIModel({ iModel: b1, containerProps });
     await b1.pushChanges({ accessToken: user1AccessToken, description: "enable shared schema channel" });
-    assert.isTrue(b1.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b1[_nativeDb].schemaSyncEnabled());
 
     // b2 briefcase need to pull to enable shared schema channel.
     await b2.pullChanges({ accessToken: user2AccessToken });
-    assert.isTrue(b2.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b2[_nativeDb].schemaSyncEnabled());
 
     // Import schema into b1 but do not push it.
     const schema1 = `<?xml version="1.0" encoding="UTF-8"?>
@@ -566,7 +566,7 @@ describe("Schema synchronization", function (this: Suite) {
     // initialize also save and push changeset.
     await SchemaSync.initializeForIModel({ iModel: b1, containerProps });
     assert.isFalse(b1.txns.hasLocalChanges);
-    assert.isTrue(b1.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b1[_nativeDb].schemaSyncEnabled());
     assert.equal(querySchemaSyncDataVer(b1), "0x1", "SchemaSync data version should be set");
     await assertChangesetTypeAndDescr(b1, ChangesetType.Regular, "Enable SchemaSync for iModel with container-id: imodel-sync-itwin-1");
 
@@ -603,7 +603,7 @@ describe("Schema synchronization", function (this: Suite) {
     await assertChangesetTypeAndDescr(b1, ChangesetType.SchemaSync, "Upgraded domain schemas");
     // upgradeSchema() also push changes.
     assert.isFalse(b1.txns.hasLocalChanges);
-    assert.isTrue(b1.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b1[_nativeDb].schemaSyncEnabled());
     await importSchema(b1, {
       name: "Test1",
       alias: "ts1",
@@ -644,7 +644,7 @@ describe("Schema synchronization", function (this: Suite) {
     //    * SchemaSync pull will also be executed to bring local briefcase schema in line with schema sync container.
     await b2.pullChanges();
     assert.equal(querySchemaSyncDataVer(b1), "0x4", "Last push from B1 should 0x3 though after pullChanges() we do SchemaSync.Pull()");
-    assert.isTrue(b2.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b2[_nativeDb].schemaSyncEnabled());
     assert.deepEqual(queryPropNames(b2, "Test1:Pipe1"), ["p0", "p1"]);
     await importSchema(b2, {
       name: "Test2",
@@ -878,7 +878,7 @@ describe("Schema synchronization", function (this: Suite) {
 
     await SchemaSync.initializeForIModel({ iModel: b1, containerProps });
     await b1.pushChanges({ accessToken: user1AccessToken, description: "enable shared schema channel" });
-    assert.isTrue(b1.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b1[_nativeDb].schemaSyncEnabled());
     const sequence = (start: number, stop: number, step: number = 1) => Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + (i * step));
 
     await importSchema(b1, {
@@ -904,7 +904,7 @@ describe("Schema synchronization", function (this: Suite) {
     await b1.pushChanges({ description: "schema with 5 props" });
 
     await b2.pullChanges();
-    assert.isTrue(b2.nativeDb.schemaSyncEnabled());
+    assert.isTrue(b2[_nativeDb].schemaSyncEnabled());
 
     await importSchema(b1, {
       name: "Test1",

--- a/full-stack-tests/backend/src/perftest/CloseIModalPerformance.test.ts
+++ b/full-stack-tests/backend/src/perftest/CloseIModalPerformance.test.ts
@@ -13,6 +13,7 @@ import {
   SubCategoryAppearance,
 } from "@itwin/core-common";
 import {
+  _nativeDb,
   IModelDb,
   IModelHost,
   IModelHostOptions,
@@ -95,7 +96,7 @@ describe("CloseIModalTest", () => {
       rootSubject: { name: "InsertNullStructArrayTest" },
     });
     await rootImodel.importSchemas([testSchemaPath]);
-    rootImodel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+    rootImodel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
     IModelTestUtils.createAndInsertPhysicalPartitionAndModel(
       rootImodel,
       Code.createEmpty(),

--- a/full-stack-tests/backend/src/perftest/ElementCRUD.test.ts
+++ b/full-stack-tests/backend/src/perftest/ElementCRUD.test.ts
@@ -10,7 +10,7 @@ import {
   BriefcaseIdValue, Code, ColorDef, GeometricElementProps, GeometryStreamProps, IModel, SubCategoryAppearance,
 } from "@itwin/core-common";
 import { Reporter } from "@itwin/perf-tools";
-import { DrawingCategory, ECSqlStatement, Element, IModelDb, IModelHost, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
+import { _nativeDb, DrawingCategory, ECSqlStatement, Element, IModelDb, IModelHost, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
 import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test/index";
 import { PerfTestUtility } from "./PerfTestUtils";
 
@@ -143,7 +143,7 @@ describe("PerformanceElementsTests", () => {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("ElementCRUDPerformance", fileName), { rootSubject: { name: "PerfTest" } });
         const testSchemaName = path.join(KnownTestLocations.assetsDir, "PerfTestDomain.ecschema.xml");
         await seedIModel.importSchemas([testSchemaName]);
-        seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
         assert.isDefined(seedIModel.getMetaData(`PerfTestDomain:${name}`), `${name}is present in iModel.`);
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");
@@ -353,7 +353,7 @@ describe("PerformanceElementsTests2d", () => {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("ElementCRUDPerformance2d", fileName), { rootSubject: { name: "PerfTest" } });
         const testSchemaName = path.join(KnownTestLocations.assetsDir, "PerfTestDomain.ecschema.xml");
         await seedIModel.importSchemas([testSchemaName]);
-        seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
         assert.isDefined(seedIModel.getMetaData(`PerfTestDomain:${name}`), `${name}is present in iModel.`);
 
         const codeProps = Code.createEmpty();

--- a/full-stack-tests/backend/src/perftest/MixinImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/MixinImpact.test.ts
@@ -10,7 +10,7 @@ import {
   BriefcaseIdValue, Code, ColorDef, GeometricElementProps, GeometryStreamProps, IModel, SubCategoryAppearance,
 } from "@itwin/core-common";
 import { Reporter } from "@itwin/perf-tools";
-import { ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
+import { _nativeDb, ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
 import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test/index";
 
 describe("SchemaDesignPerf Impact of Mixins", () => {
@@ -128,7 +128,7 @@ describe("SchemaDesignPerf Impact of Mixins", () => {
       if (!IModelJsFs.existsSync(seedName)) {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("MixinPerformance", `mixin_${hCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
-        seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
         assert.isDefined(seedIModel.getMetaData("TestMixinSchema:MixinElement"), "Mixin Class is not present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");

--- a/full-stack-tests/backend/src/perftest/PerfTestUtils.ts
+++ b/full-stack-tests/backend/src/perftest/PerfTestUtils.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { assert } from "chai";
 import * as path from "path";
-import { ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
+import { _nativeDb, ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
 import { IModelTestUtils } from "@itwin/core-backend/lib/cjs/test/index";
 import { Id64String } from "@itwin/core-bentley";
 import {
@@ -42,7 +42,7 @@ export class PerfTestDataMgr {
       if (undefined === this.catId) {
         this.catId = SpatialCategory.insert(this.db, IModel.dictionaryId, "MySpatialCategory", new SubCategoryAppearance({ color: ColorDef.fromString("rgb(255,0,0)").toJSON() }));
       }
-      this.db.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+      this.db[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
       this.db.saveChanges();
     }
   }

--- a/full-stack-tests/backend/src/perftest/PolymorphicQuery.test.ts
+++ b/full-stack-tests/backend/src/perftest/PolymorphicQuery.test.ts
@@ -10,7 +10,7 @@ import {
   BriefcaseIdValue, Code, ColorDef, GeometricElementProps, GeometryStreamProps, IModel, SubCategoryAppearance,
 } from "@itwin/core-common";
 import { Reporter } from "@itwin/perf-tools";
-import { ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
+import { _nativeDb, ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
 import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test/index";
 
 describe("SchemaDesignPerf Polymorphic query", () => {
@@ -136,7 +136,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");
         if (undefined === spatialCategoryId)
           spatialCategoryId = SpatialCategory.insert(seedIModel, IModel.dictionaryId, "MySpatialCategory", new SubCategoryAppearance({ color: ColorDef.fromString("rgb(255,0,0)").toJSON() }));
-        seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
         assert.isDefined(seedIModel.getMetaData("TestPolySchema:TestElement"), "Base Class is not present in iModel.");
         // create base class elements
         for (let i = 0; i < flatSeedCount; ++i) {
@@ -173,7 +173,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
       let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel2, IModel.dictionaryId, "MySpatialCategory");
       if (undefined === spatialCategoryId)
         spatialCategoryId = SpatialCategory.insert(seedIModel2, IModel.dictionaryId, "MySpatialCategory", new SubCategoryAppearance({ color: ColorDef.fromString("rgb(255,0,0)").toJSON() }));
-      seedIModel2.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+      seedIModel2[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
       assert.isDefined(seedIModel2.getMetaData("TestPolySchema:TestElement"), "Base Class is not present in iModel.");
       // create base class elements
       for (let i = 0; i < multiSeedCount; ++i) {

--- a/full-stack-tests/backend/src/perftest/PropertiesImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/PropertiesImpact.test.ts
@@ -10,7 +10,7 @@ import {
   BriefcaseIdValue, Code, ColorDef, GeometricElementProps, GeometryStreamProps, IModel, SubCategoryAppearance,
 } from "@itwin/core-common";
 import { Reporter } from "@itwin/perf-tools";
-import { ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
+import { _nativeDb, ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
 import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test/index";
 import { PerfTestUtility } from "./PerfTestUtils";
 
@@ -96,7 +96,7 @@ describe("SchemaDesignPerf Impact of Properties", () => {
       if (!IModelJsFs.existsSync(seedName)) {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("PropPerformance", `props_${pCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
-        seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
         assert.isDefined(seedIModel.getMetaData("TestPropsSchema:PropElement"), "PropsClass is present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");
@@ -347,7 +347,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
       if (!IModelJsFs.existsSync(seedName)) {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("IndexPerformance", `index_${iCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
-        seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
         assert.isDefined(seedIModel.getMetaData("TestIndexSchema:PropElement"), "PropsClass is present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");
@@ -374,7 +374,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
       if (!IModelJsFs.existsSync(seedName)) {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("IndexPerformance", `index_perclass_${iCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
-        seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
         assert.isDefined(seedIModel.getMetaData("TestIndexSchema:PropElement0"), "PropsClass is present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");

--- a/full-stack-tests/backend/src/perftest/RelationshipImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/RelationshipImpact.test.ts
@@ -10,7 +10,7 @@ import {
   BriefcaseIdValue, Code, ColorDef, GeometricElementProps, GeometryStreamProps, IModel, RelatedElement, RelationshipProps, SubCategoryAppearance,
 } from "@itwin/core-common";
 import { Reporter } from "@itwin/perf-tools";
-import { ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
+import { _nativeDb, ECSqlStatement, IModelDb, IModelJsFs, SnapshotDb, SpatialCategory } from "@itwin/core-backend";
 import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test/index";
 import { PerfTestUtility } from "./PerfTestUtils";
 
@@ -150,7 +150,7 @@ describe("SchemaDesignPerf Relationship Comparison", () => {
     if (!IModelJsFs.existsSync(seedName)) {
       const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("RelationshipPerformance", "relationship.bim"), { rootSubject: { name: "PerfTest" } });
       await seedIModel.importSchemas([st]);
-      seedIModel.nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
+      seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
       // first create Elements and then Relationship
       const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
       let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");

--- a/full-stack-tests/backend/src/perftest/SchemaLoader.test.ts
+++ b/full-stack-tests/backend/src/perftest/SchemaLoader.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import * as path from "path";
 import { Reporter } from "@itwin/perf-tools";
-import { IModelHost, IModelJsFs, KnownLocations, StandaloneDb } from "@itwin/core-backend";
+import { _nativeDb, IModelHost, IModelJsFs, KnownLocations, StandaloneDb } from "@itwin/core-backend";
 import { IModelTestUtils, KnownTestLocations } from "@itwin/core-backend/lib/cjs/test";
 import * as fs from "fs";
 import { OpenMode } from "@itwin/core-bentley";
@@ -119,7 +119,7 @@ describe("SchemaLoaderPerformance", () => {
     const imodel: StandaloneDb = StandaloneDb.openFile(iModelFilepath, OpenMode.Readonly);
 
     const startTime: number = new Date().getTime();
-    imodel.nativeDb.getSchemaProps(schemaName);
+    imodel[_nativeDb].getSchemaProps(schemaName);
     const endTime: number = new Date().getTime();
 
     const elapsedTime = endTime - startTime;
@@ -131,7 +131,7 @@ describe("SchemaLoaderPerformance", () => {
     const imodel: StandaloneDb = StandaloneDb.openFile(iModelFilepath, OpenMode.Readonly);
 
     const startTime: number = new Date().getTime();
-    const schemaResult =  await imodel.nativeDb.getSchemaPropsAsync(schemaName);
+    const schemaResult =  await imodel[_nativeDb].getSchemaPropsAsync(schemaName);
     const endTime: number = new Date().getTime();
 
     if (schemaResult === undefined) {

--- a/full-stack-tests/core/src/backend/RpcImpl.ts
+++ b/full-stack-tests/core/src/backend/RpcImpl.ts
@@ -5,7 +5,7 @@
 
 import * as nock from "nock";
 import * as path from "path";
-import { CloudSqlite, IModelDb, IModelHost, IModelJsFs, NativeHost, SnapshotDb, StandaloneDb, ViewStore } from "@itwin/core-backend";
+import { _nativeDb, CloudSqlite, IModelDb, IModelHost, IModelJsFs, NativeHost, SnapshotDb, StandaloneDb, ViewStore } from "@itwin/core-backend";
 import { V1CheckpointManager } from "@itwin/core-backend/lib/cjs/CheckpointManager";
 import { IModelRpcProps, RpcInterface, RpcManager } from "@itwin/core-common";
 import { AzuriteUsers, TestRpcInterface } from "../common/RpcInterfaces";
@@ -34,7 +34,7 @@ export class TestRpcImpl extends RpcInterface implements TestRpcInterface { // e
   }
 
   public async executeTest(tokenProps: IModelRpcProps, testName: string, params: any): Promise<any> {
-    return JSON.parse(IModelDb.findByKey(tokenProps.key).nativeDb.executeTest(testName, JSON.stringify(params)));
+    return JSON.parse(IModelDb.findByKey(tokenProps.key)[_nativeDb].executeTest(testName, JSON.stringify(params)));
   }
 
   public async purgeCheckpoints(iModelId: string): Promise<void> {

--- a/presentation/backend/src/presentation-backend/NativePlatform.ts
+++ b/presentation/backend/src/presentation-backend/NativePlatform.ts
@@ -6,7 +6,7 @@
  * @module Core
  */
 
-import { IModelDb, IModelJsNative, IModelNative } from "@itwin/core-backend";
+import { _nativeDb, IModelDb, IModelJsNative, IModelNative } from "@itwin/core-backend";
 import { assert, BeEvent, IDisposable } from "@itwin/core-bentley";
 import { FormatProps } from "@itwin/core-quantity";
 import {
@@ -197,7 +197,7 @@ export const createDefaultNativePlatform = (props: DefaultNativePlatformProps): 
       if (!imodel.isOpen) {
         throw new PresentationError(PresentationStatus.InvalidArgument, "imodel");
       }
-      return imodel.nativeDb;
+      return imodel[_nativeDb];
     }
     public registerSupplementalRuleset(serializedRulesetJson: string) {
       return this.handleResult<string>(this._nativeAddon.registerSupplementalRuleset(serializedRulesetJson));

--- a/presentation/backend/src/test/NativePlatform.test.ts
+++ b/presentation/backend/src/test/NativePlatform.test.ts
@@ -7,7 +7,7 @@ import * as faker from "faker";
 import { join } from "path";
 import sinon from "sinon";
 import * as moq from "typemoq";
-import { IModelDb, IModelHost, IModelJsNative, IModelNative } from "@itwin/core-backend";
+import { _nativeDb, IModelDb, IModelHost, IModelJsNative, IModelNative } from "@itwin/core-backend";
 import { BeEvent } from "@itwin/core-bentley";
 import { DiagnosticsScopeLogs, PresentationError, PresentationStatus, VariableValueTypes } from "@itwin/presentation-common";
 import { createDefaultNativePlatform, NativePlatformDefinition, PresentationNativePlatformResponseError } from "../presentation-backend/NativePlatform";
@@ -256,7 +256,7 @@ describe("default NativePlatform", () => {
   it("returns imodel addon from IModelDb", () => {
     const mock = moq.Mock.ofType<IModelDb>();
     mock
-      .setup((x) => x.nativeDb)
+      .setup((x) => x[_nativeDb])
       .returns(() => ({}) as any)
       .verifiable(moq.Times.atLeastOnce());
     expect(nativePlatform.getImodelAddon(mock.object)).be.instanceOf(Object);

--- a/utils/workspace-editor/src/WorkspaceEditor.ts
+++ b/utils/workspace-editor/src/WorkspaceEditor.ts
@@ -11,7 +11,7 @@ import { extname, join } from "path";
 import * as readline from "readline";
 import * as Yargs from "yargs";
 import {
-  CloudSqlite, EditableWorkspaceDb, IModelHost, IModelJsFs, SQLiteDb, SqliteStatement, WorkspaceContainerProps, WorkspaceDb, WorkspaceDbFullName, WorkspaceDbVersionIncrement, WorkspaceEditor, WorkspaceResourceName,
+  _nativeDb, CloudSqlite, EditableWorkspaceDb, IModelHost, IModelJsFs, SQLiteDb, SqliteStatement, WorkspaceContainerProps, WorkspaceDb, WorkspaceDbFullName, WorkspaceDbVersionIncrement, WorkspaceEditor, WorkspaceResourceName,
 } from "@itwin/core-backend";
 import {
   constructWorkspaceDb,
@@ -164,7 +164,7 @@ function friendlyFileSize(size: number) {
 /** open, call a function to process, then close a WorkspaceDb */
 async function processWorkspace<W extends EditableWorkspaceDb | WorkspaceDb, T extends WorkspaceDbOpt>(args: T, ws: W, fn: (ws: W, args: T) => Promise<void>) {
   ws.open();
-  showMessage(`WorkspaceDb [${ws.sqliteDb.nativeDb.getFilePath()}]`);
+  showMessage(`WorkspaceDb [${ws.sqliteDb[_nativeDb].getFilePath()}]`);
   try {
     await fn(ws, args);
   } finally {


### PR DESCRIPTION
for IModelDb, ECDb, and SQLiteDb. These were never intended for use outside of itwinjs-core. To be removed in iTwin.js 5.0.

Add `[_nativeDb]` property, which uses a `Symbol` that will become inaccessible outside of itwinjs-core in iTwin.js 5.0.
Deprecate the `nativeDb` property to give early warning to people using it outside of itwinjs-core.
All the rest of the changes are just `/s/\.nativeDb/[_nativeDb]`.