### PR TITLE
Make getSchemaKeys and getSchemaJSON schema rpc methods GETs by default

### DIFF
--- a/common/changes/@itwin/ecschema-rpcinterface-common/enable-response-caching-by-default-schema-rpc_2024-07-10-10-47.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-common/enable-response-caching-by-default-schema-rpc_2024-07-10-10-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-common",
+      "comment": "Make all RPC methods GET by default",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-common"
+}

--- a/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { IModelRpcProps, RpcInterface, RpcManager } from "@itwin/core-common";
+import { IModelRpcProps, RpcInterface, RpcManager, RpcOperation, RpcResponseCacheControl } from "@itwin/core-common";
 import { SchemaKeyProps, SchemaProps } from "@itwin/ecschema-metadata";
 
 /***
@@ -32,6 +32,7 @@ export abstract class ECSchemaRpcInterface extends RpcInterface { // eslint-disa
    * @param tokenProps        The iModelToken props that hold the information which iModel is used.
    * @returns                 An array of SchemaKeyProps.
    */
+  @RpcOperation.allowResponseCaching(RpcResponseCacheControl.Immutable) // eslint-disable-line deprecation/deprecation
   public async getSchemaKeys(_tokenProps: IModelRpcProps): Promise<SchemaKeyProps[]> {
     return this.forward.apply(this, [arguments]) as Promise<SchemaKeyProps[]>;
   }
@@ -43,6 +44,7 @@ export abstract class ECSchemaRpcInterface extends RpcInterface { // eslint-disa
    * @param schemaName        The name of the schema that shall be returned.
    * @returns                 The SchemaProps.
    */
+  @RpcOperation.allowResponseCaching(RpcResponseCacheControl.Immutable) // eslint-disable-line deprecation/deprecation
   public async getSchemaJSON(_tokenProps: IModelRpcProps, _schemaName: string): Promise<SchemaProps> {
     return this.forward.apply(this, [arguments]) as Promise<SchemaProps>;
   }

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -27,6 +27,10 @@ Added a new helper type [ListenerType]($core-bentley) to retrieve the listener t
 
 The Xml, JSON and interfaces all have an `appliesTo` property of type `CustomAttributeContainerType`, only the implementation had a `containerType` property. The existing `containerType` getter was marked as deprecated and `appliesTo` getter was added with no behavioral changes. The protected `_containerType` variable was renamed to `_appliesTo` for consistency even though this is a breaking change for any class that extends `CustomAttributeClass`, no know derived classes exist outside of the core packages.
 
+## ecschema-rpcinterface-common methods GET by default
+
+Made all ECSchemaRpcInterface methods GET by default so responses can be cached w/o each app setting flags on their own
+
 # Internal APIs
 
 iTwin.js categorizes the stability of each API using [release tags](../learning/api-support-policies.md#api-categories) like `@public`, `@beta`, and `@internal`. `@internal` APIs are intended strictly for use inside of the itwinjs-core repository. They can be tricky to use correctly, and may be changed or removed at any time, so consumers of iTwin.js should not write code that depends on them. Unfortunately, up until now they have been exported from the iTwin.js core packages just like any other type of APIs, making it easy for anyone to accidentally or intentionally introduce a dependency on them. To ensure that we can adhere to our commitment to providing stable libraries, we have begun to transition to a new approach to handling these kinds of APIs.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -35,6 +35,6 @@ We added a new helper type [ListenerType]($core-bentley) to retrieve the type of
 
 The Xml and JSON representations of a custom attribute (and related TypeScript interfaces) all use a property named `appliesTo` of type [CustomAttributeContainerType]($ecschema-metadata) to indicate the kind(s) of schema entities to which the attribute can be applied. Confusingly, the `@beta` [CustomAttributeClass]($ecschema-metadata) class exposes this same information via a property named `containerType`. To address this discrepancy, `containerType` has been deprecated in favor of the new `appliesTo` property. The protected `_containerType` property was renamed to `_appliesTo`.
 
-## ECSchemaRpcInterface caching
+## Improve the performance of the ECSchemaRpcLocater
 
-All methods of `ECSchemaRpcInterface` now use `GET` and automatically support response caching to speed up repeated queries.
+Improve the performance of the ECSchemaRpcLocater by making all of the underlying ECSchemaRpcInterface methods GET by default so responses are cached by default. Previously each client had to set the methods to be GET or they would default to POST and were not cached.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -8,8 +8,10 @@ Table of contents:
 
 - [Workspaces](#workspaces)
 - [Electron 31 support](#electron-31-support)
-- [`ListenerType` helper](#listenertype-helper)
 - [Internal APIs](#internal-apis)
+- [ListenerType helper](#listenertype-helper)
+- [CustomAttributeClass containerType renamed](#customattributeclass-containertype-renamed
+- [ECSchemaRpcInterface caching](#ecschemarpcinterface-caching)
 
 ## Workspaces
 
@@ -19,20 +21,20 @@ The `beta` [Workspace]($backend) and [Settings]($backend) APIs have been updated
 
 In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 31](https://www.electronjs.org/blog/electron-31-0).
 
-## `ListenerType` helper
-
-Added a new helper type [ListenerType]($core-bentley) to retrieve the listener type of a [BeEvent]($core-bentley). This type is useful when implicit types can not be used i.e. you need to define a listener outside of [BeEvent.addListener]($core-bentley).
-
-## ecschema-metadata CustomAttributeClass.containerType deprecated and replaced with appliesTo
-
-The Xml, JSON and interfaces all have an `appliesTo` property of type `CustomAttributeContainerType`, only the implementation had a `containerType` property. The existing `containerType` getter was marked as deprecated and `appliesTo` getter was added with no behavioral changes. The protected `_containerType` variable was renamed to `_appliesTo` for consistency even though this is a breaking change for any class that extends `CustomAttributeClass`, no know derived classes exist outside of the core packages.
-
-## ecschema-rpcinterface-common methods GET by default
-
-Made all ECSchemaRpcInterface methods GET by default so responses can be cached w/o each app setting flags on their own
-
-# Internal APIs
+## Internal APIs
 
 iTwin.js categorizes the stability of each API using [release tags](../learning/api-support-policies.md#api-categories) like `@public`, `@beta`, and `@internal`. `@internal` APIs are intended strictly for use inside of the itwinjs-core repository. They can be tricky to use correctly, and may be changed or removed at any time, so consumers of iTwin.js should not write code that depends on them. Unfortunately, up until now they have been exported from the iTwin.js core packages just like any other type of APIs, making it easy for anyone to accidentally or intentionally introduce a dependency on them. To ensure that we can adhere to our commitment to providing stable libraries, we have begun to transition to a new approach to handling these kinds of APIs.
 
 The [details](../learning/guidelines/release-tags-guidelines.md) are relevant primarily to contributors, but consumers should expect to find that `@internal` APIs they currently depend upon have been marked as deprecated. The deprecation messages include information about alternative public APIs to use instead, where appropriate. If you encounter a dependency on an `@internal` API which you struggle to remove, please [let us know](https://github.com/orgs/iTwin/discussions). Beginning in iTwin.js 5.0, you will no longer be able to access any `@internal` APIs.
+
+## ListenerType helper
+
+We added a new helper type [ListenerType]($core-bentley) to retrieve the type of the callback function for a given [BeEvent]($core-bentley). This is useful when implicit types cannot be used - for example, when you need to define a listener outside of a call to [BeEvent.addListener]($core-bentley).
+
+## ecschema-metadata CustomAttributeClass.containerType deprecated and replaced with appliesTo
+
+The Xml and JSON representations of a custom attribute (and related TypeScript interfaces) all use a property named `appliesTo` of type [CustomAttributeContainerType]($ecschema-metadata) to indicate the kind(s) of schema entities to which the attribute can be applied. Confusingly, the `@beta` [CustomAttributeClass]($ecschema-metadata) class exposes this same information via a property named `containerType`. To address this discrepancy, `containerType` has been deprecated in favor of the new `appliesTo` property. The protected `_containerType` property was renamed to `_appliesTo`.
+
+## ECSchemaRpcInterface caching
+
+All methods of `ECSchemaRpcInterface` now use `GET` and automatically support response caching to speed up repeated queries.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -10,8 +10,8 @@ Table of contents:
 - [Electron 31 support](#electron-31-support)
 - [Internal APIs](#internal-apis)
 - [ListenerType helper](#listenertype-helper)
-- [CustomAttributeClass containerType renamed](#customattributeclass-containertype-renamed
-- [ECSchemaRpcInterface caching](#ecschemarpcinterface-caching)
+- [CustomAttributeClass containerType renamed](#customattributeclass-containertype-renamed)
+- [Improve the performance of the ECSchemaRpcLocater](#improve-the-performance-of-the-ecschemarpclocater)
 
 ## Workspaces
 


### PR DESCRIPTION
This enables RPC caching as well