### PR TITLE
SchemaSync.pull() should not obtain write-lock on container

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4697,6 +4697,10 @@ export namespace SchemaSync {
         openMode?: OpenMode;
         user?: string;
     }, operation: (access: CloudAccess) => Promise<void>) => Promise<void>;
+    const // (undocumented)
+    withReadonlyAccess: (iModel: IModelDb | {
+        readonly fileName: LocalFileName;
+    }, operation: (access: CloudAccess) => Promise<void>) => Promise<void>;
     const pull: (iModel: IModelDb) => Promise<void>;
     const // (undocumented)
     initializeForIModel: (arg: {

--- a/common/changes/@itwin/core-backend/affanK-schema-sync-fix_2024-07-10-17-30.json
+++ b/common/changes/@itwin/core-backend/affanK-schema-sync-fix_2024-07-10-17-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "SchemaSync.pull() should not obtain write-lock on container",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/SchemaSync.ts
+++ b/core/backend/src/SchemaSync.ts
@@ -18,7 +18,7 @@ import { _nativeDb } from "./internal/Symbols";
 
 /** @internal */
 export namespace SchemaSync {
-  const lockParams: CloudSqlite.ObtainLockParams = { retryDelayMs: 1000, nRetries: 20 };
+  const lockParams: CloudSqlite.ObtainLockParams = { retryDelayMs: 1000, nRetries: 30 };
 
   /** A CloudSqlite database for synchronizing schema changes across briefcases.  */
   export class SchemaSyncDb extends VersionedSqliteDb {

--- a/core/backend/src/SchemaSync.ts
+++ b/core/backend/src/SchemaSync.ts
@@ -18,6 +18,7 @@ import { _nativeDb } from "./internal/Symbols";
 
 /** @internal */
 export namespace SchemaSync {
+  const lockParams: CloudSqlite.ObtainLockParams = { retryDelayMs: 1000, nRetries: 20 };
 
   /** A CloudSqlite database for synchronizing schema changes across briefcases.  */
   export class SchemaSyncDb extends VersionedSqliteDb {
@@ -53,6 +54,7 @@ export namespace SchemaSync {
       const props = JSON.parse(propsString) as CloudSqlite.ContainerProps;
       const accessToken = await CloudSqlite.requestToken(props);
       const access = new CloudAccess({ ...props, accessToken });
+      Object.assign(access.lockParams, lockParams);
       const testSyncCache = nativeDb.queryLocalValue(testSyncCachePropKey);
       if (testSyncCache)
         access.setCache(CloudSqlite.CloudCaches.getCache({ cacheName: testSyncCache }));
@@ -73,12 +75,22 @@ export namespace SchemaSync {
     }
   };
 
+  export const withReadonlyAccess = async (iModel: IModelDb | { readonly fileName: LocalFileName }, operation: (access: CloudAccess) => Promise<void>): Promise<void> => {
+    const access = await getCloudAccess(iModel);
+    access.synchronizeWithCloud();
+    access.openForRead();
+    try {
+      await operation(access);
+    } finally {
+      access.close();
+    }
+  };
+
   /** Synchronize local briefcase schemas with cloud container */
   export const pull = async (iModel: IModelDb) => {
     if (iModel[_nativeDb].schemaSyncEnabled() && !iModel.isReadonly) {
-      await SchemaSync.withLockedAccess(iModel, { openMode: OpenMode.Readonly, operationName: "schema sync" }, async (syncAccess) => {
+      await SchemaSync.withReadonlyAccess(iModel, async (syncAccess) => {
         const schemaSyncDbUri = syncAccess.getUri();
-        syncAccess.synchronizeWithCloud();
         iModel.clearCaches();
         iModel[_nativeDb].schemaSyncPull(schemaSyncDbUri);
         iModel.saveChanges("schema synchronized with cloud container");


### PR DESCRIPTION
Fixes
* `SchemaSync.pull()` should not obtain write-lock on container. Its a read-only container operation.
*  Set timeout to `1 sec` & `30 retries`. The default was `100 ms` & `20 retries` which is too small for `SchemaSync` operation that may take at least 1 sec or more.

The overall algorithm for retry need to be improved. This issue was reported on internal backlog by local sync.