### PR TITLE
Fix issue where ECChangesetAdaptor fails when ExclusiveRootClassId is NULL for overflow table

### DIFF
--- a/common/changes/@itwin/core-backend/affanK-changeset-reader-fix_2024-07-11-13-09.json
+++ b/common/changes/@itwin/core-backend/affanK-changeset-reader-fix_2024-07-11-13-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Able to recover from when ExclusiveRootClassId is NULL for overflow table",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/standalone/ChangesetReader.test.ts
+++ b/core/backend/src/test/standalone/ChangesetReader.test.ts
@@ -15,7 +15,6 @@ import { SqliteChangesetReader } from "../../SqliteChangesetReader";
 import { HubWrappers, IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { _nativeDb, ChannelControl } from "../../core-backend";
-import exp = require("node:constants");
 
 describe("Changeset Reader API", async () => {
   let iTwinId: GuidString;
@@ -74,14 +73,19 @@ describe("Changeset Reader API", async () => {
       const arcData = IModelJson.Writer.toIModelJson(geom);
       geometryStream.push(arcData);
     }
-    const props = Array(nProps).fill(undefined).map((_, i) => { return { [`p${i}`]: `test_${i}` } }).reduce((acc, curr) => { return { ...acc, ...curr } }, {});
+    const props = Array(nProps).fill(undefined).map((_, i) => {
+      return { [`p${i}`]: `test_${i}` };
+    }).reduce((acc, curr) => {
+      return { ...acc, ...curr };
+    }, {});
+
     const geomElement = {
       classFullName: `TestDomain:Test2dElement`,
       model: drawingModelId,
       category: drawingCategoryId,
       code: Code.createEmpty(),
       geom: geometryStream,
-      ...props
+      ...props,
     };
 
     // 2. Insert a element for the class.
@@ -95,7 +99,11 @@ describe("Changeset Reader API", async () => {
     // 4. Update the element.
     const updatedElementProps = Object.assign(
       rwIModel.elements.getElementProps(id),
-      Array(nProps).fill(undefined).map((_, i) => { return { [`p${i}`]: `updated_${i}` } }).reduce((acc, curr) => { return { ...acc, ...curr } }, {}));
+      Array(nProps).fill(undefined).map((_, i) => {
+        return { [`p${i}`]: `updated_${i}` };
+      }).reduce((acc, curr) => {
+        return { ...acc, ...curr };
+      }, {}));
 
     await rwIModel.locks.acquireLocks({ exclusive: id });
     rwIModel.elements.updateElement(updatedElementProps);
@@ -120,30 +128,35 @@ describe("Changeset Reader API", async () => {
 
     const adaptor = new ECChangesetAdaptor(reader);
     let assertOnOverflowTable = false;
+
     const expectedInserted = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       ECClassId: undefined,
-      ECInstanceId: '',
-      '$meta': {
-        tables: ['bis_GeometricElement2d_Overflow'],
-        op: 'Updated',
-        classFullName: 'BisCore:GeometricElement2d',
-        fallbackClassId: '0x5e',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ECInstanceId: "",
+      $meta: {
+        tables: ["bis_GeometricElement2d_Overflow"],
+        op: "Updated",
+        classFullName: "BisCore:GeometricElement2d",
+        fallbackClassId: "0x5e",
         changeIndexes: [3],
-        stage: 'New'
-      }
+        stage: "New",
+      },
     };
     const expectedDeleted = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       ECClassId: undefined,
-      ECInstanceId: '',
-      '$meta': {
-        tables: ['bis_GeometricElement2d_Overflow'],
-        op: 'Updated',
-        classFullName: 'BisCore:GeometricElement2d',
-        fallbackClassId: '0x5e',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ECInstanceId: "",
+      $meta: {
+        tables: ["bis_GeometricElement2d_Overflow"],
+        op: "Updated",
+        classFullName: "BisCore:GeometricElement2d",
+        fallbackClassId: "0x5e",
         changeIndexes: [3],
-        stage: 'Old'
-      }
-    }
+        stage: "Old",
+      },
+    };
 
     while (adaptor.step()) {
       if (adaptor.op === "Updated" && adaptor.inserted?.$meta?.tables[0] === "bis_GeometricElement2d_Overflow") {

--- a/core/backend/src/test/standalone/ChangesetReader.test.ts
+++ b/core/backend/src/test/standalone/ChangesetReader.test.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { GuidString, Id64 } from "@itwin/core-bentley";
+import { DbResult, GuidString, Id64 } from "@itwin/core-bentley";
 import { Code, ColorDef, GeometryStreamProps, IModel, SubCategoryAppearance } from "@itwin/core-common";
 import { Arc3d, IModelJson, Point3d } from "@itwin/core-geometry";
 import { assert, expect } from "chai";
@@ -15,6 +15,7 @@ import { SqliteChangesetReader } from "../../SqliteChangesetReader";
 import { HubWrappers, IModelTestUtils } from "../IModelTestUtils";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { _nativeDb, ChannelControl } from "../../core-backend";
+import exp = require("node:constants");
 
 describe("Changeset Reader API", async () => {
   let iTwinId: GuidString;
@@ -24,7 +25,137 @@ describe("Changeset Reader API", async () => {
     iTwinId = HubMock.iTwinId;
   });
   after(() => HubMock.shutdown());
+  it.only("Able to recover from when ExclusiveRootClassId is NULL for overflow table", async () => {
+    /**
+     * 1. Import schema with class that span overflow table.
+     * 2. Insert a element for the class.
+     * 3. Push changes to hub.
+     * 4. Update the element.
+     * 5. Push changes to hub.
+     * 6. Delete the element.
+     * 7. Set ExclusiveRootClassId to NULL for overflow table. (Simulate the issue)
+     * 8. ECChangesetAdaptor should be able to read the changeset 2 in which element is updated against latest imodel where element is deleted.
+     */
+    const adminToken = "super manager token";
+    const iModelName = "test";
+    const nProps = 36;
+    const rwIModelId = await HubMock.createNewIModel({ iTwinId, iModelName, description: "TestSubject", accessToken: adminToken });
+    assert.isNotEmpty(rwIModelId);
+    const rwIModel = await HubWrappers.downloadAndOpenBriefcase({ iTwinId, iModelId: rwIModelId, accessToken: adminToken });
+    // 1. Import schema with class that span overflow table.
+    const schema = `<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestDomain" alias="ts" version="01.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="BisCore" version="01.00" alias="bis"/>
+        <ECEntityClass typeName="Test2dElement">
+            <BaseClass>bis:GraphicalElement2d</BaseClass>
+            ${Array(nProps).fill(undefined).map((_, i) => `<ECProperty propertyName="p${i}" typeName="string"/>`).join("\n")}
+        </ECEntityClass>
+    </ECSchema>`;
+    await rwIModel.importSchemaStrings([schema]);
+    rwIModel.channels.addAllowedChannel(ChannelControl.sharedChannelName);
 
+    // Create drawing model and category
+    await rwIModel.locks.acquireLocks({ shared: IModel.dictionaryId });
+    const codeProps = Code.createEmpty();
+    codeProps.value = "DrawingModel";
+    const [, drawingModelId] = IModelTestUtils.createAndInsertDrawingPartitionAndModel(rwIModel, codeProps, true);
+    let drawingCategoryId = DrawingCategory.queryCategoryIdByName(rwIModel, IModel.dictionaryId, "MyDrawingCategory");
+    if (undefined === drawingCategoryId)
+      drawingCategoryId = DrawingCategory.insert(rwIModel, IModel.dictionaryId, "MyDrawingCategory", new SubCategoryAppearance({ color: ColorDef.fromString("rgb(255,0,0)").toJSON() }));
+
+    // Insert element with 100 properties
+    const geomArray: Arc3d[] = [
+      Arc3d.createXY(Point3d.create(0, 0), 5),
+      Arc3d.createXY(Point3d.create(5, 5), 2),
+      Arc3d.createXY(Point3d.create(-5, -5), 20),
+    ];
+    const geometryStream: GeometryStreamProps = [];
+    for (const geom of geomArray) {
+      const arcData = IModelJson.Writer.toIModelJson(geom);
+      geometryStream.push(arcData);
+    }
+    const props = Array(nProps).fill(undefined).map((_, i) => { return { [`p${i}`]: `test_${i}` } }).reduce((acc, curr) => { return { ...acc, ...curr } }, {});
+    const geomElement = {
+      classFullName: `TestDomain:Test2dElement`,
+      model: drawingModelId,
+      category: drawingCategoryId,
+      code: Code.createEmpty(),
+      geom: geometryStream,
+      ...props
+    };
+
+    // 2. Insert a element for the class.
+    const id = rwIModel.elements.insertElement(geomElement);
+    assert.isTrue(Id64.isValidId64(id), "insert worked");
+    rwIModel.saveChanges();
+
+    // 3. Push changes to hub.
+    await rwIModel.pushChanges({ description: "insert element", accessToken: adminToken });
+
+    // 4. Update the element.
+    const updatedElementProps = Object.assign(
+      rwIModel.elements.getElementProps(id),
+      Array(nProps).fill(undefined).map((_, i) => { return { [`p${i}`]: `updated_${i}` } }).reduce((acc, curr) => { return { ...acc, ...curr } }, {}));
+
+    await rwIModel.locks.acquireLocks({ exclusive: id });
+    rwIModel.elements.updateElement(updatedElementProps);
+    rwIModel.saveChanges();
+
+    // 5. Push changes to hub.
+    await rwIModel.pushChanges({ description: "update element", accessToken: adminToken });
+
+    await rwIModel.locks.acquireLocks({ exclusive: id });
+
+    // 6. Delete the element.
+    rwIModel.elements.deleteElement(id);
+    rwIModel.saveChanges();
+    await rwIModel.pushChanges({ description: "delete element", accessToken: adminToken });
+
+    const targetDir = path.join(KnownTestLocations.outputDir, rwIModelId, "changesets");
+    const changesets = await HubMock.downloadChangesets({ iModelId: rwIModelId, targetDir });
+    const reader = SqliteChangesetReader.openFile({ fileName: changesets[1].pathname, db: rwIModel, disableSchemaCheck: true });
+
+    // Set ExclusiveRootClassId to NULL for overflow table to simulate the issue
+    expect(rwIModel[_nativeDb].executeSql("UPDATE ec_Table SET ExclusiveRootClassId=NULL WHERE Name='bis_GeometricElement2d_Overflow'")).to.be.eq(DbResult.BE_SQLITE_OK);
+
+    const adaptor = new ECChangesetAdaptor(reader);
+    let assertOnOverflowTable = false;
+    const expectedInserted = {
+      ECClassId: undefined,
+      ECInstanceId: '',
+      '$meta': {
+        tables: ['bis_GeometricElement2d_Overflow'],
+        op: 'Updated',
+        classFullName: 'BisCore:GeometricElement2d',
+        fallbackClassId: '0x5e',
+        changeIndexes: [3],
+        stage: 'New'
+      }
+    };
+    const expectedDeleted = {
+      ECClassId: undefined,
+      ECInstanceId: '',
+      '$meta': {
+        tables: ['bis_GeometricElement2d_Overflow'],
+        op: 'Updated',
+        classFullName: 'BisCore:GeometricElement2d',
+        fallbackClassId: '0x5e',
+        changeIndexes: [3],
+        stage: 'Old'
+      }
+    }
+
+    while (adaptor.step()) {
+      if (adaptor.op === "Updated" && adaptor.inserted?.$meta?.tables[0] === "bis_GeometricElement2d_Overflow") {
+        assert.deepEqual(adaptor.inserted as any, expectedInserted);
+        assert.deepEqual(adaptor.deleted as any, expectedDeleted);
+        assertOnOverflowTable = true;
+      }
+    }
+
+    assert.isTrue(assertOnOverflowTable);
+    rwIModel.close();
+  });
   it("Changeset reader / EC adaptor", async () => {
     const adminToken = "super manager token";
     const iModelName = "test";

--- a/core/backend/src/test/standalone/ChangesetReader.test.ts
+++ b/core/backend/src/test/standalone/ChangesetReader.test.ts
@@ -24,7 +24,7 @@ describe("Changeset Reader API", async () => {
     iTwinId = HubMock.iTwinId;
   });
   after(() => HubMock.shutdown());
-  it.only("Able to recover from when ExclusiveRootClassId is NULL for overflow table", async () => {
+  it("Able to recover from when ExclusiveRootClassId is NULL for overflow table", async () => {
     /**
      * 1. Import schema with class that span overflow table.
      * 2. Insert a element for the class.


### PR DESCRIPTION
The issue can be reproduced as follows: It is unclear why the user dataset contains `NULL` for `ExclusiveRootClassId`.

1. Import a schema with a class that spans an overflow table.
2. Insert an element for the class.
3. Push the changes to the hub.
4. Update the element.
5. Push the changes to the hub again.
6. Delete the element.
7. Set ExclusiveRootClassId to NULL for the overflow table to simulate the issue.
8. The ECChangesetAdaptor should be able to read changeset 2, in which the element is updated, against the latest iModel where the element is deleted.

Fixes: https://github.com/iTwin/itwinjs-backlog/issues/1168