### PR TITLE
Fix missing login dialog for some ArcGIS services

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -1191,6 +1191,8 @@ export enum ArcGisErrorCode {
     // (undocumented)
     InvalidToken = 498,
     // (undocumented)
+    MissingPermissions = 403,
+    // (undocumented)
     NoTokenService = 1001,
     // (undocumented)
     TokenRequired = 499,

--- a/common/changes/@itwin/core-frontend/geo-fixArcGisError403_2024-07-11-16-32.json
+++ b/common/changes/@itwin/core-frontend/geo-fixArcGisError403_2024-07-11-16-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix missing login dialog for some ArcGIS services",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/map-layers-formats/geo-fixArcGisError403_2024-07-11-16-32.json
+++ b/common/changes/@itwin/map-layers-formats/geo-fixArcGisError403_2024-07-11-16-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-formats",
+      "comment": "Fix missing login dialog for some ArcGIS services",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-formats"
+}

--- a/core/frontend/src/tile/map/ArcGisUtilities.ts
+++ b/core/frontend/src/tile/map/ArcGisUtilities.ts
@@ -18,6 +18,7 @@ import { headersIncludeAuthMethod } from "../../request/utils";
  */
 export enum ArcGisErrorCode {
   InvalidCredentials = 401,
+  MissingPermissions = 403,
   InvalidToken = 498,
   TokenRequired = 499,
   UnknownError = 1000,
@@ -189,7 +190,9 @@ export class ArcGisUtilities {
       // If we got a 'Token Required' error, lets check what authentification methods this ESRI service offers
       // and return information needed to initiate the authentification process... the end-user
       // will have to provide his credentials before we can fully validate this source.
-      if (json.error.code === ArcGisErrorCode.TokenRequired) {
+      // Note: Some servers will throw a error 403 (You do not have permissions to access this resource or perform this operation),
+      //       instead of 499 (TokenRequired)
+      if (json.error.code === ArcGisErrorCode.TokenRequired || json.error.code === ArcGisErrorCode.MissingPermissions)  {
         return (source.userName || source.password) ? {status: MapLayerSourceStatus.InvalidCredentials} : {status: MapLayerSourceStatus.RequireAuth};
       } else if (json.error.code === ArcGisErrorCode.InvalidCredentials)
         return { status: MapLayerSourceStatus.InvalidCredentials};
@@ -296,8 +299,7 @@ export class ArcGisUtilities {
       // Append security token when corresponding error code is returned by ArcGIS service
       let errorCode = await ArcGisUtilities.checkForResponseErrorCode(response);
       if (!accessTokenRequired
-        && errorCode !== undefined
-        && errorCode === ArcGisErrorCode.TokenRequired ) {
+        && (errorCode === ArcGisErrorCode.TokenRequired || errorCode === ArcGisErrorCode.MissingPermissions) ) {
         accessTokenRequired = true;
         // If token required
         const accessClient = IModelApp.mapLayerFormatRegistry.getAccessClient(formatId);

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISImageryProvider.ts
@@ -139,7 +139,10 @@ export abstract class ArcGISImageryProvider extends MapLayerImageryProvider {
       errorCode = await ArcGisUtilities.checkForResponseErrorCode(response);
 
       if (errorCode !== undefined &&
-       (errorCode === ArcGisErrorCode.TokenRequired || errorCode === ArcGisErrorCode.InvalidToken) ) {
+       (   errorCode === ArcGisErrorCode.TokenRequired
+        || errorCode === ArcGisErrorCode.InvalidToken
+        || errorCode === ArcGisErrorCode.MissingPermissions
+       ) ) {
 
         if (this._settings.userName && this._settings.userName.length > 0 && this._lastAccessToken ) {
         // **** Legacy token ONLY ***
@@ -161,7 +164,11 @@ export abstract class ArcGISImageryProvider extends MapLayerImageryProvider {
           errorCode  = await ArcGisUtilities.checkForResponseErrorCode(response);
         }
 
-        if (errorCode === ArcGisErrorCode.TokenRequired || errorCode === ArcGisErrorCode.InvalidToken) {
+        if (errorCode !== undefined &&
+          (   errorCode === ArcGisErrorCode.TokenRequired
+           || errorCode === ArcGisErrorCode.InvalidToken
+           || errorCode === ArcGisErrorCode.MissingPermissions
+          ) ) {
           // Looks like the initially generated token has expired.
 
           if (this.status === MapLayerImageryProviderStatus.Valid ) {

--- a/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/ImageryProviders/ArcGISMapLayerImageryProvider.ts
@@ -226,7 +226,10 @@ export class ArcGISMapLayerImageryProvider extends ArcGISImageryProvider {
       throw new ServerError(IModelStatus.ValidationFailed, "");
 
     const json = metadata.content;
-    if (json?.error?.code === ArcGisErrorCode.TokenRequired || json?.error?.code === ArcGisErrorCode.InvalidToken) {
+    if (json?.error?.code === ArcGisErrorCode.TokenRequired
+      || json?.error?.code === ArcGisErrorCode.InvalidToken
+      || json?.error?.code === ArcGisErrorCode.MissingPermissions
+    ) {
       // Check again layer status, it might have change during await.
       if (this.status === MapLayerImageryProviderStatus.Valid) {
         this.setStatus(MapLayerImageryProviderStatus.RequireAuth);

--- a/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureProvider.ts
+++ b/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureProvider.ts
@@ -118,7 +118,10 @@ export class ArcGisFeatureProvider extends ArcGISImageryProvider {
       throw new ServerError(IModelStatus.ValidationFailed, "");
     }
 
-    if (json?.error?.code === ArcGisErrorCode.TokenRequired || json?.error?.code === ArcGisErrorCode.InvalidToken) {
+    if (json?.error?.code === ArcGisErrorCode.TokenRequired
+      || json?.error?.code === ArcGisErrorCode.InvalidToken
+      || json?.error?.code === ArcGisErrorCode.MissingPermissions
+    ) {
       // Check again layer status, it might have change during await.
       if (this.status === MapLayerImageryProviderStatus.Valid) {
         this.setStatus(MapLayerImageryProviderStatus.RequireAuth);


### PR DESCRIPTION
Some ArcGIS service will throw an error 403 (You do not have permissions to access this resource or perform this operation),
when an OAuth token is required ( instead of the typical 499 error - TokenRequired).

So we now check for error 403 before triggering the Oauth2 login process.