### PR TITLE
Presentation: Use label definition instead of label for nested content values

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1821,7 +1821,7 @@ export interface NestedContentFieldJSON<TClassInfoJSON = ClassInfoJSON> extends 
 // @public
 export interface NestedContentValue {
     displayValues: ValuesDictionary<DisplayValue>;
-    label?: string;
+    labelDefinition?: LabelDefinition;
     mergedFieldNames: string[];
     primaryKeys: InstanceKey[];
     values: ValuesDictionary<Value>;
@@ -3070,9 +3070,9 @@ export interface StartItemProps {
 
 // @public
 export interface StartStructProps {
-    description?: string;
     displayValues: DisplayValuesMap;
     hierarchy: FieldHierarchy;
+    label?: LabelDefinition;
     parentFieldName?: string;
     rawValues: ValuesMap;
     valueType: TypeDescription;

--- a/common/changes/@itwin/presentation-common/nested-content-value-label_2024-07-08-08-17.json
+++ b/common/changes/@itwin/presentation-common/nested-content-value-label_2024-07-08-08-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/presentation-common",
-      "comment": "Add `NestedContentValue.label` property which is passed to `IContentVisitor.startStruct`.",
+      "comment": "Add `NestedContentValue.labelDefinition` property which is passed to `IContentVisitor.startStruct`.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/presentation-common/presentation-ncv-label-refactor_2024-07-15-12-58.json
+++ b/common/changes/@itwin/presentation-common/presentation-ncv-label-refactor_2024-07-15-12-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/common/src/presentation-common/content/ContentTraverser.ts
+++ b/presentation/common/src/presentation-common/content/ContentTraverser.ts
@@ -22,11 +22,12 @@ import {
   ValuesArray as PresentationValuesArray,
   ValuesMap as PresentationValuesMap,
 } from "./Value";
+import { LabelDefinition } from "../LabelDefinition";
 
-const NESTED_CONTENT_DESCRIPTION_SYMBOL = Symbol();
+const NESTED_CONTENT_LABEL_SYMBOL = Symbol();
 
 type ValuesMap = PresentationValuesMap & {
-  [NESTED_CONTENT_DESCRIPTION_SYMBOL]?: string;
+  [NESTED_CONTENT_LABEL_SYMBOL]?: LabelDefinition;
 };
 
 type Value = Exclude<PresentationValue, PresentationValuesMap> | ValuesMap;
@@ -107,8 +108,8 @@ export interface StartStructProps {
   rawValues: PresentationValuesMap;
   /** Member display values. */
   displayValues: DisplayValuesMap;
-  /** Struct description. */
-  description?: string;
+  /** Label definition of the ECInstance that the struct represents. */
+  label?: LabelDefinition;
 }
 
 /**
@@ -490,8 +491,8 @@ function traverseContentItemStructFieldValue(
   displayValues: DisplayValuesMap,
 ) {
   assert(valueType.valueFormat === PropertyValueFormat.Struct);
-  const description = rawValues[NESTED_CONTENT_DESCRIPTION_SYMBOL];
-  if (!visitor.startStruct({ hierarchy: fieldHierarchy, valueType, parentFieldName, rawValues, displayValues, description })) {
+  const label = rawValues[NESTED_CONTENT_LABEL_SYMBOL];
+  if (!visitor.startStruct({ hierarchy: fieldHierarchy, valueType, parentFieldName, rawValues, displayValues, label })) {
     return;
   }
 
@@ -783,7 +784,7 @@ function convertNestedContentValuesToStructArrayValuesRecursive(fieldHierarchy: 
     const values: ValuesMap = { ...ncv.values };
     const displayValues: DisplayValuesMap = { ...ncv.displayValues };
     const mergedFieldNames: string[] = [...ncv.mergedFieldNames];
-    values[NESTED_CONTENT_DESCRIPTION_SYMBOL] = ncv.label;
+    values[NESTED_CONTENT_LABEL_SYMBOL] = ncv.labelDefinition;
 
     fieldHierarchy.childFields.forEach((childFieldHierarchy) => {
       const childFieldName = childFieldHierarchy.field.name;

--- a/presentation/common/src/presentation-common/content/Value.ts
+++ b/presentation/common/src/presentation-common/content/Value.ts
@@ -193,7 +193,7 @@ export interface NestedContentValue {
   /** Names of fields whose values are merged */
   mergedFieldNames: string[];
   /** Label of the ECInstance that this `NestedContentValue` is based on. */
-  label?: string;
+  labelDefinition?: LabelDefinition;
 }
 
 /**

--- a/presentation/common/src/test/content/ContentTraverser.test.ts
+++ b/presentation/common/src/test/content/ContentTraverser.test.ts
@@ -35,6 +35,7 @@ import {
   createTestSimpleContentField,
 } from "../_helpers/Content";
 import { createTestECInstanceKey } from "../_helpers/EC";
+import { NestedContentValue } from "../../presentation-common";
 
 describe("ContentTraverser", () => {
   class TestContentVisitor implements IContentVisitor {
@@ -1326,14 +1327,14 @@ describe("ContentTraverser", () => {
     const primitiveField1 = createTestSimpleContentField({ name: "primitive1", category });
     const primitiveField2 = createTestSimpleContentField({ name: "primitive2", category });
     const parentField = createTestNestedContentField({ nestedFields: [primitiveField1, primitiveField2], category });
-    const nestedContentLabel1 = "Description 1";
-    const nestedContentLabel2 = "Description 2";
+    const nestedContentLabel1 = { displayValue: "Description 1", typeName: "string", rawValue: "" };
+    const nestedContentLabel2 = { displayValue: "Description 2", typeName: "string", rawValue: "" };
     const descriptor = createTestContentDescriptor({ fields: [parentField], categories: [category] });
     const item = createTestContentItem({
       values: {
         [parentField.name]: [
           {
-            displayLabel: nestedContentLabel1,
+            labelDefinition: nestedContentLabel1,
             primaryKeys: [createTestECInstanceKey()],
             values: {
               [primitiveField1.name]: "value11",
@@ -1344,9 +1345,9 @@ describe("ContentTraverser", () => {
               [primitiveField2.name]: "display value 12",
             },
             mergedFieldNames: [],
-          },
+          } satisfies NestedContentValue,
           {
-            displayLabel: nestedContentLabel2,
+            labelDefinition: nestedContentLabel2,
             primaryKeys: [createTestECInstanceKey()],
             values: {
               [primitiveField1.name]: "value21",
@@ -1357,7 +1358,7 @@ describe("ContentTraverser", () => {
               [primitiveField2.name]: "display value 22",
             },
             mergedFieldNames: [],
-          },
+          } satisfies NestedContentValue,
         ],
       },
       displayValues: {
@@ -1367,8 +1368,8 @@ describe("ContentTraverser", () => {
     traverseContentItem(visitor, descriptor, item);
 
     expect(startStructSpy).to.be.calledTwice;
-    expect(startStructSpy.firstCall.firstArg).to.containSubset({ description: nestedContentLabel1 });
-    expect(startStructSpy.secondCall.firstArg).to.containSubset({ description: nestedContentLabel2 });
+    expect(startStructSpy.firstCall.firstArg).to.containSubset({ label: nestedContentLabel1 });
+    expect(startStructSpy.secondCall.firstArg).to.containSubset({ label: nestedContentLabel2 });
   });
 
   it("passes deeply nested `NestedContentValue` labels to `startStruct`", () => {
@@ -1378,20 +1379,20 @@ describe("ContentTraverser", () => {
     const childPrimitiveField = createTestSimpleContentField({ name: "primitive2", category });
     const childNestedContentField = createTestNestedContentField({ nestedFields: [childPrimitiveField], category });
     const parentNestedContentField = createTestNestedContentField({ nestedFields: [parentPrimitiveField, childNestedContentField], category });
-    const parentNestedContentLabel = "Description 1";
-    const childNestedContentLabel = "Description 2";
+    const parentNestedContentLabel = { displayValue: "Description 1", typeName: "string", rawValue: "" };
+    const childNestedContentLabel = { displayValue: "Description 2", typeName: "string", rawValue: "" };
     const descriptor = createTestContentDescriptor({ fields: [parentNestedContentField], categories: [category] });
     const item = createTestContentItem({
       values: {
         [parentNestedContentField.name]: [
           {
-            displayLabel: parentNestedContentLabel,
+            labelDefinition: parentNestedContentLabel,
             primaryKeys: [createTestECInstanceKey()],
             values: {
               [parentPrimitiveField.name]: "parentPrimitiveValue",
               [childNestedContentField.name]: [
                 {
-                  displayLabel: childNestedContentLabel,
+                  labelDefinition: childNestedContentLabel,
                   primaryKeys: [createTestECInstanceKey()],
                   values: {
                     [childPrimitiveField.name]: "ChildPrimitiveValue",
@@ -1400,7 +1401,7 @@ describe("ContentTraverser", () => {
                     [childNestedContentField.name]: "ChildPrimitiveDisplayValue",
                   },
                   mergedFieldNames: [],
-                },
+                } satisfies NestedContentValue,
               ],
             },
             displayValues: {
@@ -1408,7 +1409,7 @@ describe("ContentTraverser", () => {
               [childNestedContentField.name]: "ChildNestedContentDisplayValue",
             },
             mergedFieldNames: [],
-          },
+          } satisfies NestedContentValue,
         ],
       },
       displayValues: {
@@ -1418,8 +1419,8 @@ describe("ContentTraverser", () => {
     traverseContentItem(visitor, descriptor, item);
 
     expect(startStructSpy).to.be.calledTwice;
-    expect(startStructSpy.firstCall.firstArg).to.containSubset({ description: parentNestedContentLabel });
-    expect(startStructSpy.secondCall.firstArg).to.containSubset({ description: childNestedContentLabel });
+    expect(startStructSpy.firstCall.firstArg).to.containSubset({ label: parentNestedContentLabel });
+    expect(startStructSpy.secondCall.firstArg).to.containSubset({ label: childNestedContentLabel });
   });
 });
 

--- a/presentation/common/src/test/content/ContentTraverser.test.ts
+++ b/presentation/common/src/test/content/ContentTraverser.test.ts
@@ -1333,7 +1333,7 @@ describe("ContentTraverser", () => {
       values: {
         [parentField.name]: [
           {
-            label: nestedContentLabel1,
+            displayLabel: nestedContentLabel1,
             primaryKeys: [createTestECInstanceKey()],
             values: {
               [primitiveField1.name]: "value11",
@@ -1346,7 +1346,7 @@ describe("ContentTraverser", () => {
             mergedFieldNames: [],
           },
           {
-            label: nestedContentLabel2,
+            displayLabel: nestedContentLabel2,
             primaryKeys: [createTestECInstanceKey()],
             values: {
               [primitiveField1.name]: "value21",
@@ -1385,13 +1385,13 @@ describe("ContentTraverser", () => {
       values: {
         [parentNestedContentField.name]: [
           {
-            label: parentNestedContentLabel,
+            displayLabel: parentNestedContentLabel,
             primaryKeys: [createTestECInstanceKey()],
             values: {
               [parentPrimitiveField.name]: "parentPrimitiveValue",
               [childNestedContentField.name]: [
                 {
-                  label: childNestedContentLabel,
+                  displayLabel: childNestedContentLabel,
                   primaryKeys: [createTestECInstanceKey()],
                   values: {
                     [childPrimitiveField.name]: "ChildPrimitiveValue",


### PR DESCRIPTION
This amends https://github.com/iTwin/itwinjs-core/pull/6941 and is needed to accommodate changes: https://github.com/iTwin/imodel-native/pull/811