### PR TITLE
Terminate active markup tool before stopping session.

### DIFF
--- a/common/changes/@itwin/core-markup/markup-tool-cleanup_2024-07-15-18-12.json
+++ b/common/changes/@itwin/core-markup/markup-tool-cleanup_2024-07-15-18-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-markup",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-markup"
+}

--- a/core/markup/src/Markup.ts
+++ b/core/markup/src/Markup.ts
@@ -238,6 +238,7 @@ export class MarkupApp {
    * @note see [MarkupApp.props.result] for options.
    */
   public static async stop(): Promise<MarkupData> {
+    await IModelApp.toolAdmin.startDefaultTool(); // Make sure current markup tool exits first...
     const data = await this.readMarkup();
     if (!this.markup)
       return data;


### PR DESCRIPTION
The markup text tool will accept the current editor contents when it exits.
[Issue](https://github.com/iTwin/itwinjs-backlog/issues/1110)