### PR TITLE
Double tap fix

### DIFF
--- a/common/changes/@itwin/core-frontend/travis-double-tap-fix_2024-07-16-22-12.json
+++ b/common/changes/@itwin/core-frontend/travis-double-tap-fix_2024-07-16-22-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -687,8 +687,10 @@ export class ToolAdmin {
         if (undefined === current.touchTapTimer) {
           current.touchTapTimer = Date.now();
           current.touchTapCount = 1;
+          // NOTE: We cannot await the executeAfter call below, because that prevents any other
+          // taps from being processed, which makes it impossible for double tap to happen.
           // eslint-disable-next-line @typescript-eslint/unbound-method
-          await ToolSettings.doubleTapTimeout.executeAfter(this.doubleTapTimeout, this);
+          void ToolSettings.doubleTapTimeout.executeAfter(this.doubleTapTimeout, this);
         } else if (undefined !== current.touchTapCount) {
           current.touchTapCount++;
         }


### PR DESCRIPTION
Fix for: https://github.com/iTwin/itwinjs-core/issues/6976
The double tap code had an `await` call when waiting for the double tap timeout. Unfortunately, that meant that it was impossible for the second tap to be registered until the first tap's timeout had already expired, thus preventing double taps from ever being registered. Changing `await` to `void` fixed the problem.