### PR TITLE
LockControl.releaseAllLocks

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3969,6 +3969,28 @@ export class LockConflict extends IModelError {
     readonly briefcaseId: BriefcaseId;
 }
 
+// @public
+export interface LockControl {
+    // @internal
+    [_close]: () => void;
+    // @internal
+    [_elementWasCreated]: (id: Id64String) => void;
+    // @internal (undocumented)
+    readonly [_implementationProhibited]: unknown;
+    // @internal
+    [_releaseAllLocks]: () => Promise<void>;
+    acquireLocks(arg: {
+        shared?: Id64Arg;
+        exclusive?: Id64Arg;
+    }): Promise<void>;
+    checkExclusiveLock(id: Id64String, type: string, operation: string): void;
+    checkSharedLock(id: Id64String, type: string, operation: string): void;
+    holdsExclusiveLock(id: Id64String): boolean;
+    holdsSharedLock(id: Id64String): boolean;
+    readonly isServerBased: boolean;
+    releaseAllLocks(): Promise<void>;
+}
+
 // @internal (undocumented)
 export type LockMap = Map<Id64String, LockState_2>;
 

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -261,6 +261,7 @@ internal;LocalhostIpcHost
 internal;LocalhostIpcHostOpts
 internal;LocalHub
 beta;LockConflict 
+public;LockControl
 internal;LockMap = Map
 beta;LockProps
 public;LockState

--- a/common/changes/@itwin/core-backend/pmc-release-all-locks_2024-07-17-18-42.json
+++ b/common/changes/@itwin/core-backend/pmc-release-all-locks_2024-07-17-18-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add LockControl.releaseAllLocks, which throws if the briefcase contains local changes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2998,8 +2998,14 @@ export class BriefcaseDb extends IModelDb {
 
     if (this[_nativeDb].hasUnsavedChanges())
       throw new IModelError(ChangeSetStatus.HasUncommittedChanges, "Cannot push with unsaved changes");
-    if (!this[_nativeDb].hasPendingTxns())
-      return; // nothing to push
+    if (!this[_nativeDb].hasPendingTxns()) {
+      // Nothing to push.
+      // if (!arg.retainLocks) {
+      //   await this.locks[_releaseAllLocks]();
+      // }
+
+      return;
+    }
 
     // pushing changes requires a writeable briefcase
     await this.executeWritable(async () => {

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2996,13 +2996,13 @@ export class BriefcaseDb extends IModelDb {
     if (this.briefcaseId === BriefcaseIdValue.Unassigned)
       return;
 
-    if (this[_nativeDb].hasUnsavedChanges())
+    if (this[_nativeDb].hasUnsavedChanges()) {
       throw new IModelError(ChangeSetStatus.HasUncommittedChanges, "Cannot push with unsaved changes");
-    if (!this[_nativeDb].hasPendingTxns()) {
+    } else if (!this[_nativeDb].hasPendingTxns()) {
       // Nothing to push.
-      // if (!arg.retainLocks) {
-      //   await this.locks[_releaseAllLocks]();
-      // }
+      if (!arg.retainLocks) {
+        await this.locks.releaseAllLocks();
+      }
 
       return;
     }

--- a/core/backend/src/LockControl.ts
+++ b/core/backend/src/LockControl.ts
@@ -77,4 +77,12 @@ export interface LockControl {
    * @internal
    */
   [_releaseAllLocks]: () => Promise<void>;
+
+  /** Release all locks currently held by this briefcase from the locker server.
+   * This is typically done on your behalf by [[BriefcaseDb.pushChanges]].
+   * You may want to do it manually when abandoning all of your briefcase's local changes.
+   * You cannot release your locks if your briefcase contains local changes.
+   * @throws Error if the briefcase has local changes, or if any other error occurs while releasing the locks.
+   */
+  releaseAllLocks(): Promise<void>;
 }

--- a/core/backend/src/LockControl.ts
+++ b/core/backend/src/LockControl.ts
@@ -71,13 +71,6 @@ export interface LockControl {
     exclusive?: Id64Arg;
   }): Promise<void>;
 
-  /**
-   * Release all locks currently held by this Briefcase from the lock server.
-   * Not possible to release locks unless push or abandon all changes. Should only be called internally.
-   * @internal
-   */
-  [_releaseAllLocks]: () => Promise<void>;
-
   /** Release all locks currently held by this briefcase from the locker server.
    * This is typically done on your behalf by [[BriefcaseDb.pushChanges]].
    * You may want to do it manually when abandoning all of your briefcase's local changes.
@@ -85,4 +78,11 @@ export interface LockControl {
    * @throws Error if the briefcase has local changes, or if any other error occurs while releasing the locks.
    */
   releaseAllLocks(): Promise<void>;
+
+  /**
+   * Release all locks currently held by this Briefcase from the lock server.
+   * Not possible to release locks unless push or abandon all changes. Should only be called internally.
+   * @internal
+   */
+  [_releaseAllLocks]: () => Promise<void>;
 }

--- a/core/backend/src/core-backend.ts
+++ b/core/backend/src/core-backend.ts
@@ -47,6 +47,7 @@ export * from "./IpcHost";
 export * from "./LineStyle";
 export * from "./LocalhostIpcHost";
 export * from "./LocalHub";
+export * from "./LockControl";
 export * from "./Material";
 export * from "./Model";
 export * from "./NativeAppStorage";

--- a/core/backend/src/internal/NoLocks.ts
+++ b/core/backend/src/internal/NoLocks.ts
@@ -23,6 +23,7 @@ class NoLocks implements LockControl {
   public [_elementWasCreated](): void { }
   public async acquireLocks() { }
   public async [_releaseAllLocks](): Promise<void> { }
+  public async releaseAllLocks(): Promise<void> { }
 }
 
 export function createNoOpLockControl(): LockControl {

--- a/core/backend/src/internal/ServerBasedLocks.ts
+++ b/core/backend/src/internal/ServerBasedLocks.ts
@@ -97,6 +97,14 @@ export class ServerBasedLocks implements LockControl {
     this.clearAllLocks();
   }
 
+  public async releaseAllLocks(): Promise<void> {
+    if (this.briefcase.txns.hasLocalChanges) {
+      throw new Error("Locks cannot be released while the briefcase contains local changes");
+    }
+
+    return this[_releaseAllLocks]();
+  }
+
   private insertLock(id: Id64String, state: LockState, origin: LockOrigin): true {
     this.lockDb.withPreparedSqliteStatement("INSERT INTO locks(id,state,origin) VALUES (?,?,?) ON CONFLICT(id) DO UPDATE SET state=excluded.state,origin=excluded.origin", (stmt) => {
       stmt.bindId(1, id);

--- a/core/backend/src/test/standalone/ServerBasedLocks.test.ts
+++ b/core/backend/src/test/standalone/ServerBasedLocks.test.ts
@@ -258,6 +258,10 @@ describe.only("Server-based locks", () => {
       elem.update();
     }
 
+    async function push(retainLocks?: true): Promise<void> {
+      return bc.pushChanges({ retainLocks, accessToken: "token", description: "changes" });
+    }
+
     it("releases all locks", async () => {
       expectUnlocked();
       await bc.acquireSchemaLock();
@@ -282,19 +286,39 @@ describe.only("Server-based locks", () => {
     });
 
     it("is called when pushChanges is called with no local changes", async () => {
-      
+      await bc.acquireSchemaLock();
+      expectLocked();
+      await push();
+      expectUnlocked();
     });
 
     it("is called when pushing changes", async () => {
-      
+      await bc.acquireSchemaLock();
+      expectLocked();
+      write();
+      bc.saveChanges();
+      await push();
+      expectUnlocked();
     });
 
     it("is not called when pushChanges is called with no local changes if retainLocks is specified", async () => {
-      
+      await bc.acquireSchemaLock();
+      expectLocked();
+      await push(true);
+      expectLocked();
+      await locks.releaseAllLocks();
+      expectUnlocked();
     });
 
     it("is not called when pushing changes if retainLocks is specified", async () => {
-      
+      await bc.acquireSchemaLock();
+      expectLocked();
+      write();
+      bc.saveChanges();
+      await push(true);
+      expectLocked();
+      await locks.releaseAllLocks();
+      expectUnlocked();
     });
   });
 });

--- a/core/backend/src/test/standalone/ServerBasedLocks.test.ts
+++ b/core/backend/src/test/standalone/ServerBasedLocks.test.ts
@@ -270,21 +270,6 @@ describe.only("Server-based locks", () => {
       expectUnlocked();
     });
 
-    it("throws if briefcase has unpushed changes", async () => {
-      
-    });
-
-    it("throws if briefcase has unsaved changes", async () => {
-      expectUnlocked();
-      await bc.acquireSchemaLock();
-      write();
-      await expect(locks.releaseAllLocks()).to.eventually.be.rejectedWith("local changes");
-      expectLocked();
-      bc.abandonChanges();
-      await locks.releaseAllLocks();
-      expectUnlocked();
-    });
-
     it("is called when pushChanges is called with no local changes", async () => {
       await bc.acquireSchemaLock();
       expectLocked();
@@ -317,6 +302,28 @@ describe.only("Server-based locks", () => {
       bc.saveChanges();
       await push(true);
       expectLocked();
+      await locks.releaseAllLocks();
+      expectUnlocked();
+    });
+
+    it("throws if briefcase has unpushed changes", async () => {
+      expectUnlocked();
+      await bc.acquireSchemaLock();
+      expectLocked();
+      write();
+      bc.saveChanges();
+      await expect(locks.releaseAllLocks()).to.eventually.be.rejectedWith("local changes");
+      await push();
+      expectUnlocked();
+    });
+
+    it("throws if briefcase has unsaved changes", async () => {
+      expectUnlocked();
+      await bc.acquireSchemaLock();
+      write();
+      await expect(locks.releaseAllLocks()).to.eventually.be.rejectedWith("local changes");
+      expectLocked();
+      bc.abandonChanges();
       await locks.releaseAllLocks();
       expectUnlocked();
     });

--- a/core/backend/src/test/standalone/ServerBasedLocks.test.ts
+++ b/core/backend/src/test/standalone/ServerBasedLocks.test.ts
@@ -25,7 +25,7 @@ const expect = chai.expect;
 const assert = chai.assert;
 chai.use(chaiAsPromised);
 
-describe.only("Server-based locks", () => {
+describe("Server-based locks", () => {
   const createVersion0 = async () => {
     const dbName = IModelTestUtils.prepareOutputFile("ServerBasedLocks", "ServerBasedLocks.bim");
     const sourceDb = SnapshotDb.createEmpty(dbName, { rootSubject: { name: "server lock test" } });
@@ -239,7 +239,7 @@ describe.only("Server-based locks", () => {
       elemId = IModelTestUtils.queryByUserLabel(bc, "ChildObject1B");
       expect(elemId).not.to.equal("0");
     });
-    
+
     afterEach(() => bc.close());
 
     function expectLocked(): void {


### PR DESCRIPTION
This was removed from public API because documentation asserted it should never be used outside of core-backend. Connector framework was using it in [two cases](https://github.com/iTwin/connector-framework/blob/f1bdc691eda469e725d1123ffd18af3ad30dbbb3/src/ConnectorRunner.ts#L279):
1. They want to abandon their entire briefcase's local changes in response to an error, and relinquish all of their locks.
2. They sometimes call `pushChanges` when the briefcase does not actually contain any local changes, in which case `pushChanges` silently retains all locks.

Add `LockControl.releaseAllLocks`. It throws if the briefcase contains local changes. Also make `pushChanges` always release all locks unless `retainLocks` is specified.

Also, export LockControl from the core-backend barrel. It's pretty gross that extract-api can overlook things that are exposed through a package's public API.