### PR TITLE
delete layered definitions

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1446,7 +1446,7 @@ export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, 
 // @beta
 export function deleteElementTree(iModel: IModelDb, topElement: Id64String): void;
 
-// @beta (undocumented)
+// @beta
 export function deleteElementTree(args: DeleteElementTreeArgs): void;
 
 // @beta

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1446,6 +1446,16 @@ export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, 
 // @beta
 export function deleteElementTree(iModel: IModelDb, topElement: Id64String): void;
 
+// @beta (undocumented)
+export function deleteElementTree(args: DeleteElementTreeArgs): void;
+
+// @beta
+export interface DeleteElementTreeArgs {
+    iModel: IModelDb;
+    maxPasses?: number;
+    topElement: Id64String;
+}
+
 // @public
 export class DetailCallout extends Callout {
     constructor(props: CalloutProps, iModel: IModelDb);

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -77,6 +77,8 @@ public;DefinitionPartition
 public;class DefinitionSet 
 beta;deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter): void
 beta;deleteElementTree(iModel: IModelDb, topElement: Id64String): void
+beta;deleteElementTree(args: DeleteElementTreeArgs): void
+beta;DeleteElementTreeArgs
 public;DetailCallout 
 public;class DetailingSymbol 
 internal;DevTools

--- a/common/changes/@itwin/core-backend/samw-delete-layered-definitions_2024-07-23-12-43.json
+++ b/common/changes/@itwin/core-backend/samw-delete-layered-definitions_2024-07-23-12-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "deleteElementTree handles case where GeometryStream refers to LineStyle",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -450,12 +450,16 @@ export class ElementSubTreeDeleter extends ElementTreeTopDown {
 /** Deletes an element tree starting with the specified top element. The top element is also deleted. Uses ElementTreeDeleter.
  * @param iModel The iModel
  * @param topElement The parent of the sub-tree
+ * @param maxPasses Maximum number of passes to make when deleting definitions
  * @beta
  */
-export function deleteElementTree(iModel: IModelDb, topElement: Id64String): void {
-  const del = new ElementTreeDeleter(iModel);
-  del.deleteNormalElements(topElement);
-  del.deleteSpecialElements();
+export function deleteElementTree(iModel: IModelDb, topElement: Id64String, maxPasses: number = 5): void {
+  let pass = 0;
+  do {
+    const del = new ElementTreeDeleter(iModel);
+    del.deleteNormalElements(topElement);
+    del.deleteSpecialElements();
+  } while ((iModel.elements.tryGetElement(topElement) !== undefined) && (++pass < maxPasses));
 }
 
 /** Deletes all element sub-trees that are selected by the supplied filter. Uses ElementSubTreeDeleter.
@@ -464,10 +468,14 @@ export function deleteElementTree(iModel: IModelDb, topElement: Id64String): voi
  * @param iModel The iModel
  * @param topElement Where to start the search.
  * @param filter Callback that selects sub-trees that should be deleted.
+ * @param maxPasses Maximum number of passes to make when deleting definitions
  * @beta
  */
-export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter): void {
-  const del = new ElementSubTreeDeleter(iModel, filter);
-  del.deleteNormalElementSubTrees(topElement);
-  del.deleteSpecialElementSubTrees();
+export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter, maxPasses: number = 5): void {
+  let pass = 0;
+  do {
+    const del = new ElementSubTreeDeleter(iModel, filter);
+    del.deleteNormalElementSubTrees(topElement);
+    del.deleteSpecialElementSubTrees();
+  } while ((iModel.elements.tryGetElement(topElement) !== undefined) && (++pass < maxPasses));
 }

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -465,13 +465,14 @@ export function deleteElementTree(iModel: IModelDb, topElement: Id64String, maxP
 /** Deletes all element sub-trees that are selected by the supplied filter. Uses ElementSubTreeDeleter.
  * If the filter selects the top element itself, then the entire tree (including the top element) is deleted.
  * That has the same effect as calling [[deleteElementTree]] on the top element.
+ * @note The caller may have to call this function multiple times if there are multiple layers of dependencies among definition elements.
  * @param iModel The iModel
  * @param topElement Where to start the search.
  * @param filter Callback that selects sub-trees that should be deleted.
  * @param maxPasses Maximum number of passes to make when deleting definitions
  * @beta
  */
-export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter, maxPasses: number = 5): void {
+export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter): void {
   const del = new ElementSubTreeDeleter(iModel, filter);
   del.deleteNormalElementSubTrees(topElement);
   del.deleteSpecialElementSubTrees();

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -472,10 +472,7 @@ export function deleteElementTree(iModel: IModelDb, topElement: Id64String, maxP
  * @beta
  */
 export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter, maxPasses: number = 5): void {
-  let pass = 0;
-  do {
-    const del = new ElementSubTreeDeleter(iModel, filter);
-    del.deleteNormalElementSubTrees(topElement);
-    del.deleteSpecialElementSubTrees();
-  } while ((iModel.elements.tryGetElement(topElement) !== undefined) && (++pass < maxPasses));
+  const del = new ElementSubTreeDeleter(iModel, filter);
+  del.deleteNormalElementSubTrees(topElement);
+  del.deleteSpecialElementSubTrees();
 }

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -469,7 +469,6 @@ export function deleteElementTree(iModel: IModelDb, topElement: Id64String, maxP
  * @param iModel The iModel
  * @param topElement Where to start the search.
  * @param filter Callback that selects sub-trees that should be deleted.
- * @param maxPasses Maximum number of passes to make when deleting definitions
  * @beta
  */
 export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter): void {

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -469,7 +469,6 @@ export interface DeleteElementTreeArgs {
  */
 export function deleteElementTree(iModel: IModelDb, topElement: Id64String): void;
 /** Deletes an element tree starting with the specified top element. The top element is also deleted. Uses ElementTreeDeleter.
- * @param iModel The iModel
  * @param args Specifies the iModel and top element.
  * @beta
  */

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -464,7 +464,6 @@ export interface DeleteElementTreeArgs {
 /** Deletes an element tree starting with the specified top element. The top element is also deleted. Uses ElementTreeDeleter.
  * @param iModel The iModel
  * @param topElement The parent of the sub-tree
- * @param maxPasses Maximum number of passes to make when deleting definitions
  * @beta
  */
 export function deleteElementTree(iModel: IModelDb, topElement: Id64String): void;

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -447,13 +447,49 @@ export class ElementSubTreeDeleter extends ElementTreeTopDown {
   }
 }
 
+/** Arguments supplied to [[deleteElementTree]].
+ * @beta
+ */
+export interface DeleteElementTreeArgs {
+  /** The iModel containing the elements to delete. */
+  iModel: IModelDb;
+  /** The Id of the root element of the tree to delete. */
+  topElement: Id64String;
+  /** The maximum number of passes to make when deleting definition elements.
+   * Default: 5
+   */
+  maxPasses?: number;
+}
+
 /** Deletes an element tree starting with the specified top element. The top element is also deleted. Uses ElementTreeDeleter.
  * @param iModel The iModel
  * @param topElement The parent of the sub-tree
  * @param maxPasses Maximum number of passes to make when deleting definitions
  * @beta
  */
-export function deleteElementTree(iModel: IModelDb, topElement: Id64String, maxPasses: number = 5): void {
+export function deleteElementTree(iModel: IModelDb, topElement: Id64String): void;
+/** Deletes an element tree starting with the specified top element. The top element is also deleted. Uses ElementTreeDeleter.
+ * @param iModel The iModel
+ * @param args Specifies the iModel and top element.
+ * @beta
+ */
+export function deleteElementTree(args: DeleteElementTreeArgs): void;
+/** @internal */
+export function deleteElementTree(arg0: DeleteElementTreeArgs | IModelDb, arg1?: Id64String): void {
+  let maxPasses;
+  let iModel: IModelDb;
+  let topElement: Id64String;
+  if (arg0 instanceof IModelDb) {
+    assert(typeof arg1 === "string");
+    iModel = arg0;
+    topElement = arg1;
+  } else {
+    iModel = arg0.iModel;
+    topElement = arg0.topElement;
+    maxPasses = arg0.maxPasses;
+  }
+
+  maxPasses = maxPasses ?? 5;
   let pass = 0;
   do {
     const del = new ElementTreeDeleter(iModel);

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -535,7 +535,7 @@ describe("GeometryStream", () => {
 
     createGeometricElem3dUsingArrowHeadNoStrokePattern(myDefModel, myPhysicalModel);
 
-    deleteElementTree(imodel, mySubject, 1);
+    deleteElementTree({ iModel: imodel, topElement: mySubject, maxPasses: 1 });
     expect(imodel.elements.tryGetElement(mySubject)).not.undefined;
   });
 
@@ -546,7 +546,7 @@ describe("GeometryStream", () => {
 
     createGeometricElem3dUsingArrowHeadNoStrokePattern(myDefModel, myPhysicalModel);
 
-    deleteElementTree(imodel, mySubject, 2);
+    deleteElementTree({ iModel: imodel, topElement: mySubject, maxPasses: 2 });
     expect(imodel.elements.tryGetElement(mySubject)).undefined;
   });
 

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { assert, expect } from "chai";
-import { BentleyStatus, Id64, Id64String, IModelStatus, Logger, LogLevel } from "@itwin/core-bentley";
+import { BentleyStatus, Id64, Id64String, IModelStatus } from "@itwin/core-bentley";
 import {
   Angle, AngleSweep, Arc3d, Box, ClipMaskXYZRangePlanes, ClipPlane, ClipPlaneContainment, ClipPrimitive, ClipShape, ClipVector, ConvexClipPlaneSet,
   CurveCollection, CurvePrimitive, Geometry, GeometryQueryCategory, IndexedPolyface, InterpolationCurve3d, InterpolationCurve3dOptions, InterpolationCurve3dProps,
@@ -535,10 +535,6 @@ describe("GeometryStream", () => {
 
     createGeometricElem3dUsingArrowHeadNoStrokePattern(myDefModel, myPhysicalModel);
 
-    Logger.initializeToConsole();
-    Logger.setLevel("core-backend", LogLevel.Trace);
-    Logger.setLevel("core-backend.IModelDb", LogLevel.Trace);
-    Logger.setLevel("core-backend.IModelDb.ElementTreeWalker", LogLevel.Trace);
     deleteElementTree(imodel, mySubject, 1);
     expect(imodel.elements.tryGetElement(mySubject)).not.undefined;
   });
@@ -550,10 +546,6 @@ describe("GeometryStream", () => {
 
     createGeometricElem3dUsingArrowHeadNoStrokePattern(myDefModel, myPhysicalModel);
 
-    Logger.initializeToConsole();
-    Logger.setLevel("core-backend", LogLevel.Trace);
-    Logger.setLevel("core-backend.IModelDb", LogLevel.Trace);
-    Logger.setLevel("core-backend.IModelDb.ElementTreeWalker", LogLevel.Trace);
     deleteElementTree(imodel, mySubject, 2);
     expect(imodel.elements.tryGetElement(mySubject)).undefined;
   });

--- a/core/backend/src/test/standalone/GeometryStream.test.ts
+++ b/core/backend/src/test/standalone/GeometryStream.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { assert, expect } from "chai";
-import { BentleyStatus, Id64, Id64String, IModelStatus } from "@itwin/core-bentley";
+import { BentleyStatus, Id64, Id64String, IModelStatus, Logger, LogLevel } from "@itwin/core-bentley";
 import {
   Angle, AngleSweep, Arc3d, Box, ClipMaskXYZRangePlanes, ClipPlane, ClipPlaneContainment, ClipPrimitive, ClipShape, ClipVector, ConvexClipPlaneSet,
   CurveCollection, CurvePrimitive, Geometry, GeometryQueryCategory, IndexedPolyface, InterpolationCurve3d, InterpolationCurve3dOptions, InterpolationCurve3dProps,
@@ -20,7 +20,7 @@ import {
   MassPropertiesRequestProps, PhysicalElementProps, Placement3d, Placement3dProps, TextString, TextStringGlyphData, TextStringProps, ThematicGradientMode,
   ThematicGradientSettings, ViewFlags,
 } from "@itwin/core-common";
-import { _nativeDb, GeometricElement, GeometryPart, LineStyleDefinition, PhysicalObject, SnapshotDb } from "../../core-backend";
+import { _nativeDb, DefinitionModel, deleteElementTree, GeometricElement, GeometryPart, LineStyleDefinition, PhysicalObject, SnapshotDb, Subject } from "../../core-backend";
 import { createBRepDataProps } from "../GeometryTestUtil";
 import { IModelTestUtils } from "../IModelTestUtils";
 import { Timer } from "../TestUtils";
@@ -29,20 +29,20 @@ function assertTrue(expr: boolean): asserts expr {
   assert.isTrue(expr);
 }
 
-function createGeometryPartProps(geom?: GeometryStreamProps): GeometryPartProps {
+function createGeometryPartProps(geom?: GeometryStreamProps, modelId?: Id64String): GeometryPartProps {
   const partProps: GeometryPartProps = {
     classFullName: GeometryPart.classFullName,
-    model: IModel.dictionaryId,
+    model: modelId ?? IModel.dictionaryId,
     code: Code.createEmpty(),
     geom,
   };
   return partProps;
 }
 
-function createPhysicalElementProps(seedElement: GeometricElement, placement?: Placement3dProps, geom?: GeometryStreamProps): PhysicalElementProps {
+function createPhysicalElementProps(seedElement: GeometricElement, placement?: Placement3dProps, geom?: GeometryStreamProps, modelId?: Id64String): PhysicalElementProps {
   const elementProps: PhysicalElementProps = {
     classFullName: PhysicalObject.classFullName,
-    model: seedElement.model,
+    model: modelId ?? seedElement.model,
     category: seedElement.category,
     code: Code.createEmpty(),
     geom,
@@ -469,11 +469,17 @@ describe("GeometryStream", () => {
     }
   });
 
-  it("create GeometricElement3d using arrow head style w/o using stroke pattern", async () => {
+  function createGeometricElem3dUsingArrowHeadNoStrokePattern(definitionModelId?: Id64String, physicalModelId?: Id64String) {
     // Set up element to be placed in iModel
     const seedElement = imodel.elements.getElement<GeometricElement>("0x1d");
     assert.exists(seedElement);
     assert.isTrue(seedElement.federationGuid! === "18eb4650-b074-414f-b961-d9cfaa6c8746");
+
+    if (definitionModelId === undefined)
+      definitionModelId = IModel.dictionaryId;
+
+    if (physicalModelId === undefined)
+      physicalModelId = seedElement.model;
 
     const partBuilder = new GeometryStreamBuilder();
     const partParams = new GeometryParams(Id64.invalid); // category won't be used
@@ -482,7 +488,7 @@ describe("GeometryStream", () => {
     partBuilder.appendGeometryParamsChange(partParams);
     partBuilder.appendGeometry(Loop.create(LineString3d.create(Point3d.create(0.1, 0, 0), Point3d.create(0, -0.05, 0), Point3d.create(0, 0.05, 0), Point3d.create(0.1, 0, 0))));
 
-    const partProps = createGeometryPartProps(partBuilder.geometryStream);
+    const partProps = createGeometryPartProps(partBuilder.geometryStream, definitionModelId);
     const partId = imodel.elements.insertElement(partProps);
     assert.isTrue(Id64.isValidId64(partId));
 
@@ -496,7 +502,7 @@ describe("GeometryStream", () => {
     const compoundData = LineStyleDefinition.Utils.createCompoundComponent(imodel, { comps: [{ id: strokePointData.compId, type: strokePointData.compType }, { id: 0, type: LineStyleDefinition.ComponentType.Internal }] });
     assert.isTrue(undefined !== compoundData);
 
-    const styleId = LineStyleDefinition.Utils.createStyle(imodel, IModel.dictionaryId, "TestArrowStyle", compoundData);
+    const styleId = LineStyleDefinition.Utils.createStyle(imodel, definitionModelId, "TestArrowStyle", compoundData);
     assert.isTrue(Id64.isValidId64(styleId));
 
     const builder = new GeometryStreamBuilder();
@@ -506,7 +512,7 @@ describe("GeometryStream", () => {
     builder.appendGeometryParamsChange(params);
     builder.appendGeometry(LineSegment3d.create(Point3d.createZero(), Point3d.create(-1, -1, 0)));
 
-    const elementProps = createPhysicalElementProps(seedElement, undefined, builder.geometryStream);
+    const elementProps = createPhysicalElementProps(seedElement, undefined, builder.geometryStream, physicalModelId);
     const newId = imodel.elements.insertElement(elementProps);
     assert.isTrue(Id64.isValidId64(newId));
     imodel.saveChanges();
@@ -516,6 +522,40 @@ describe("GeometryStream", () => {
     assert.isTrue(usageInfo.lineStyleIds!.includes(styleId));
     assert.isTrue(usageInfo.usedIds!.includes(partId));
     assert.isTrue(usageInfo.usedIds!.includes(styleId));
+  }
+
+  it("create GeometricElement3d using arrow head style w/o using stroke pattern", async () => {
+    createGeometricElem3dUsingArrowHeadNoStrokePattern();
+  });
+
+  it("create GeometricElement3d using arrow head style w/o using stroke pattern - deleteElementTree fails", async () => {
+    const mySubject = Subject.insert(imodel, IModel.rootSubjectId, "My Subject - fails");
+    const myDefModel = DefinitionModel.insert(imodel, mySubject, "My Definitions - fails");
+    const myPhysicalModel = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(imodel, Code.createEmpty(), false, mySubject)[0];
+
+    createGeometricElem3dUsingArrowHeadNoStrokePattern(myDefModel, myPhysicalModel);
+
+    Logger.initializeToConsole();
+    Logger.setLevel("core-backend", LogLevel.Trace);
+    Logger.setLevel("core-backend.IModelDb", LogLevel.Trace);
+    Logger.setLevel("core-backend.IModelDb.ElementTreeWalker", LogLevel.Trace);
+    deleteElementTree(imodel, mySubject, 1);
+    expect(imodel.elements.tryGetElement(mySubject)).not.undefined;
+  });
+
+  it("create GeometricElement3d using arrow head style w/o using stroke pattern - deleteElementTree succeeds with 2 passes", async () => {
+    const mySubject = Subject.insert(imodel, IModel.rootSubjectId, "My Subject - success");
+    const myDefModel = DefinitionModel.insert(imodel, mySubject, "My Definitions - success");
+    const myPhysicalModel = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(imodel, Code.createEmpty(), false, mySubject)[0];
+
+    createGeometricElem3dUsingArrowHeadNoStrokePattern(myDefModel, myPhysicalModel);
+
+    Logger.initializeToConsole();
+    Logger.setLevel("core-backend", LogLevel.Trace);
+    Logger.setLevel("core-backend.IModelDb", LogLevel.Trace);
+    Logger.setLevel("core-backend.IModelDb.ElementTreeWalker", LogLevel.Trace);
+    deleteElementTree(imodel, mySubject, 2);
+    expect(imodel.elements.tryGetElement(mySubject)).undefined;
   });
 
   it("create GeometricElement3d using compound style with dash widths and symbol", async () => {


### PR DESCRIPTION
To handle layered dependencies, deleteElementTree must make multiple passes. In each pass, it creates and uses a new ElementTreeDeleter, which detects and classifies the remaining elements and calls IModelDb.deleteDefinitionElements on the remaining definition elements that it finds. 

Note that deleteDefinitionElements will delete only definition elements that are not "used" (as defined by NativeDb usage calculator).

Scenario: A LineStyle refers to a GeometryPart (which captures a LS symbol). The GeometryStreams and SubCategories that refer to the LineStyle must be deleted first. Then the LS symbol GeometryPart can be deleted. 

That's just one example. There can be further layers of dependencies. 