### PR TITLE
check if current user still holds the write lock when upload changes

### DIFF
--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -10,7 +10,7 @@ import { mkdirSync, unlinkSync } from "fs";
 import { dirname, join } from "path";
 import { NativeLibrary } from "@bentley/imodeljs-native";
 import {
-  AccessToken, BeDuration, BriefcaseStatus, Constructor, GuidString, Logger, OpenMode, Optional, PickAsyncMethods, PickMethods, StopWatch,
+  AccessToken, BeDuration, BriefcaseStatus, Constructor, GuidString, Logger, LogLevel, OpenMode, Optional, PickAsyncMethods, PickMethods, StopWatch,
 } from "@itwin/core-bentley";
 import { LocalDirName, LocalFileName } from "@itwin/core-common";
 import { BlobContainer } from "./BlobContainerService";
@@ -771,6 +771,9 @@ export namespace CloudSqlite {
       const rootDir = args.cacheDir ?? join(IModelHost.profileDir, "CloudCaches", cacheName);
       IModelJsFs.recursiveMkDirSync(rootDir);
       const cache = new NativeLibrary.nativeLib.CloudCache({ rootDir, name: cacheName, cacheSize: args.cacheSize ?? "10G" });
+      if (Logger.getLevel("CloudSqlite") === LogLevel.Trace) {
+        cache.setLogMask(CloudSqlite.LoggingMask.All);
+      }
       this.cloudCaches.set(cacheName, cache);
       return cache;
     }

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -10,7 +10,7 @@ import { mkdirSync, unlinkSync } from "fs";
 import { dirname, join } from "path";
 import { NativeLibrary } from "@bentley/imodeljs-native";
 import {
-  AccessToken, BeDuration, BriefcaseStatus, Constructor, GuidString, Logger, LogLevel, OpenMode, Optional, PickAsyncMethods, PickMethods, StopWatch,
+  AccessToken, BeDuration, BriefcaseStatus, Constructor, GuidString, Logger, OpenMode, Optional, PickAsyncMethods, PickMethods, StopWatch,
 } from "@itwin/core-bentley";
 import { LocalDirName, LocalFileName } from "@itwin/core-common";
 import { BlobContainer } from "./BlobContainerService";
@@ -771,9 +771,6 @@ export namespace CloudSqlite {
       const rootDir = args.cacheDir ?? join(IModelHost.profileDir, "CloudCaches", cacheName);
       IModelJsFs.recursiveMkDirSync(rootDir);
       const cache = new NativeLibrary.nativeLib.CloudCache({ rootDir, name: cacheName, cacheSize: args.cacheSize ?? "10G" });
-      if (Logger.getLevel("CloudSqlite") === LogLevel.Trace) {
-        cache.setLogMask(CloudSqlite.LoggingMask.All);
-      }
       this.cloudCaches.set(cacheName, cache);
       return cache;
     }

--- a/full-stack-tests/backend/package.json
+++ b/full-stack-tests/backend/package.json
@@ -57,6 +57,8 @@
     "azurite": "^3.29.0",
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
+    "sqlite": "^5.1.1",
+    "sqlite3": "^5.1.7",
     "cpx2": "^3.0.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",

--- a/full-stack-tests/backend/src/integration/AzuriteTest.ts
+++ b/full-stack-tests/backend/src/integration/AzuriteTest.ts
@@ -94,7 +94,7 @@ export namespace AzuriteTest {
       emptyDirSync(name);
     };
 
-    export interface TestContainerProps { containerId: string, logId?: string, isPublic?: boolean, writeable?: boolean }
+    export interface TestContainerProps { containerId: string, logId?: string, isPublic?: boolean, writeable?: boolean, lockExpireSeconds?: number}
 
     export const makeContainer = async (arg: TestContainerProps): Promise<TestContainer> => {
       const containerProps = { ...arg, writeable: true, baseUri, storageType };

--- a/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
+++ b/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
@@ -227,7 +227,7 @@ describe("CloudSqlite", () => {
     testContainer0.disconnect();
   });
 
-  it.only("Should user1 fail to upload changes if user2 holds write lock after user1's expiration time", async () => {
+  it("Should user1 fail to upload changes if user2 holds write lock after user1's expiration time", async () => {
     // simulate two users in two processes
     // test container 1 and test container 2 are actually the same cloud container
     const testContainer1 = testContainers[3];
@@ -249,16 +249,7 @@ describe("CloudSqlite", () => {
     testContainer2.connect(testCache2);
     testContainer2.acquireWriteLock(user2);
     // user1 tries to upload changes, it should fail because user1's write lock has expired and user2 is using it
-    // await expect(testContainer1.uploadChanges()).to.eventually.be.rejectedWith("container is currently locked by another user");
     expect( async () => testContainer1.uploadChanges()).to.throw(`Container [${testContainer1.containerId}] is currently locked by another user`);
-
-    // expect(testContainer1.uploadChanges()).throws("container is currently locked by another user");
-    // try {
-    //   await testContainer1.uploadChanges();
-    // } catch (error: any) {
-    //   console.log(error.message);
-    // }
-    // await BeDuration.wait(6000);
     testContainer1.disconnect();
     testContainer2.disconnect();
   });

--- a/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
+++ b/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 import * as sinon from "sinon";
 import { _nativeDb, BlobContainer, BriefcaseDb, CloudSqlite, IModelHost, IModelJsFs, KnownLocations, PropertyStore, SnapshotDb, SQLiteDb } from "@itwin/core-backend";
 import { KnownTestLocations } from "@itwin/core-backend/lib/cjs/test";
-import { assert, BeDuration, DbResult, Guid, GuidString, Logger, LogLevel, OpenMode } from "@itwin/core-bentley";
+import { assert, BeDuration, DbResult, Guid, GuidString, OpenMode } from "@itwin/core-bentley";
 import { AzuriteTest } from "./AzuriteTest";
 
 import "./StartupShutdown"; // calls startup/shutdown IModelHost before/after all tests
@@ -30,8 +30,6 @@ describe("CloudSqlite", () => {
   const user2 = "CloudSqlite test2";
 
   before(async () => {
-    Logger.initializeToConsole();
-    Logger.setLevel("CloudSqlite", LogLevel.Trace);
     IModelHost.authorizationClient = new AzuriteTest.AuthorizationClient();
     AzuriteTest.userToken = AzuriteTest.service.userToken.readWrite;
 


### PR DESCRIPTION
iTwin/itwinjs-backlog#1170
 
There is a possible scenario that two users try to upload local changes to the same cloud container:
 
1. User1 grabs the write lock and sit there for a very long time. User1 does not release the write lock even after it has expired
2. User2 grabs the write lock after User1's write lock expires, and upload something to the cloud container
3. User1 then tries to upload changes,  we should disable User1 from uploading his changes because the write lock has expired
 
However, if there are no other users grab the write lock after User1, we allow User1 to upload changes(and refresh the write lock) even if the write lock has expired. 

Native change:
