### PR TITLE
Presentation: Fix `Presentation.selection.selectionChange` event not being emitted for `BlankConnection`

### DIFF
--- a/common/changes/@itwin/presentation-frontend/presentation-selection-fix_2024-07-25-12-28.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-selection-fix_2024-07-25-12-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Fix `Presentation.selection.selectionChange` event not being emitted for `BlankConnection`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -374,6 +374,7 @@ export class SelectionManager implements ISelectionProvider {
           return this._currentSelection.computeSelection(args.iModelKey, args.level, currentSelectables, args.selectables).pipe(
             mergeMap(({ level, changedSelection }): Observable<SelectionChangeEventArgs> => {
               const imodel = this._knownIModels.get(args.iModelKey);
+              // istanbul ignore if
               if (!imodel) {
                 return EMPTY;
               }

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -160,6 +160,10 @@ export class SelectionManager implements ISelectionProvider {
   }
 
   private handleEvent(evt: SelectionChangeEventArgs): void {
+    if (!this._knownIModels.has(evt.imodel.key)) {
+      this._knownIModels.set(evt.imodel.key, evt.imodel);
+    }
+
     switch (evt.changeType) {
       case SelectionChangeType.Add:
         this._selectionStorage.addToSelection({


### PR DESCRIPTION
Fixed `selectionChange` event not being emitted for `BlankConnection`. This fixes element highlighting in unified selection viewport.