### PR TITLE
Picking assembly parent wasn't selecting members.

### DIFF
--- a/common/changes/@itwin/core-frontend/elementsettool-select-assembly_2024-07-25-18-19.json
+++ b/common/changes/@itwin/core-frontend/elementsettool-select-assembly_2024-07-25-18-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}


### PR DESCRIPTION
As getGroupIds was originally written with assemblies created from dgn cells in mind, and since the geometric element created to represent the cell header doesn't have a geometry stream (not locatable), selecting the parent wasn't tested.