### PR TITLE
build-tools: Extract API script improvements

### DIFF
--- a/common/api/summary/appui-abstract.exports.csv
+++ b/common/api/summary/appui-abstract.exports.csv
@@ -185,6 +185,8 @@ deprecated;UiEvent
 public;UiEventDispatcher
 deprecated;UiEventDispatcher
 public;UiFlags
+public;UiItemProviderOverrides = MarkRequired
+deprecated;UiItemProviderOverrides = MarkRequired
 public;UiItemProviderRegisteredEventArgs
 deprecated;UiItemProviderRegisteredEventArgs
 public;UiItemsApplicationAction

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -320,6 +320,7 @@ public;PullChangesArgs = ToChangesetArgs &
 public;PushChangesArgs 
 beta;QueryLocalChangesArgs
 beta;QueryWorkspaceResourcesArgs
+beta;QueryWorkspaceResourcesCallback = (resources: Iterable
 beta;class RecipeDefinitionElement 
 public;Relationship 
 public;Relationships

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -132,6 +132,7 @@ public;CommonMapLayerProps
 internal;compareIModelTileTreeIds(lhs: IModelTileTreeId, rhs: IModelTileTreeId): number
 internal;CompositeTileHeader 
 internal;computeChildTileProps(parent: TileMetadata, idProvider: ContentIdProvider, root: TileTreeMetadata):
+internal;computeChildTileRanges(tile: TileMetadata, root: TileTreeMetadata): Array
 alpha;ComputeNodeId = (feature: PackedFeatureWithIndex) => number
 internal;computeTileChordTolerance(tile: TileMetadata, is3d: boolean, tileScreenSize: number): number
 alpha;ConcreteEntityTypes

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -245,6 +245,7 @@ public;GeometryTileTreeReference
 public;GeoServices
 internal;GeoServicesOptions = Omit
 public;getCenteredViewRect(viewRect: ViewRect, aspectRatio?: number): ViewRect
+internal;getCesiumAccessTokenAndEndpointUrl(assetId: string, requestKey?: string): Promise
 public;getCesiumAssetUrl(osmAssetId: number, requestKey: string): string
 internal;getCesiumOSMBuildingsUrl(): string | undefined
 internal;getCesiumTerrainProvider(opts: TerrainMeshProviderOptions): Promise
@@ -559,6 +560,7 @@ public;ReadImageBufferArgs
 internal;readImdlContent(args: ImdlReaderCreateArgs &
 public;ReadMeshArgs
 internal;ReadonlyTileUserSet 
+internal;readPointCloudTileContent(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, _is3d: boolean, tile: RealityTile, system: RenderSystem): Promise
 alpha;RealityDataError 
 beta;RealityDataSource
 beta;RealityDataSource
@@ -736,6 +738,7 @@ public;TileRequest
 public;TileRequestChannel
 public;TileRequestChannels
 public;TileRequestChannelStatistics
+public;Tiles 
 beta;TileStorage
 public;class TileTree
 public;TileTreeDiscloser

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -29,6 +29,7 @@ public;IModelContentChangeEventArgs
 public;IModelHierarchyChangeEventArgs
 internal;IMODELJS_PRESENTATION_SETTING_NAMESPACE = "imodeljs.presentation"
 public;ISelectionProvider
+public;MultipleValuesRequestOptions = Paged
 internal;NoopFavoritePropertiesStorage 
 internal;OfflineCachingFavoritePropertiesStorage 
 internal;OfflineCachingFavoritePropertiesStorageProps

--- a/common/changes/@itwin/build-tools/extract-api-enhancement_2024-07-29-11-19.json
+++ b/common/changes/@itwin/build-tools/extract-api-enhancement_2024-07-29-11-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "extract-api: Add option to extract indirect (unexported) APIs. extract-api-summary: Fix API regex, add improved output option.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/bin/betools.js
+++ b/tools/build/bin/betools.js
@@ -88,6 +88,31 @@ yargs.strict(true)
         },
         "apiSummaryFolder": {
           describe: "Directory for the API summary. Defaults to `<Rush repository root>/common/api/summary`."
+        },
+        "includeUnexportedApis": {
+          boolean: true,
+          describe: "If this flag is set, then APIs that are unexported but are accessible via exported APIs will also be included to the API report. Defaults to `false`"
+        },
+        "summaryVersion": {
+          describe: `Version of the API summary style.
+
+            1 (default) - outputs release tag and name of API items with the function signature or union type definition.
+            2 - outputs release tag, type of the API (function, interface, type, etc.) and names of the API items.
+            
+            Given the following API:
+              export type Foo = string | number;
+              export namespace Foo { ... }
+            
+            1:
+              public;Foo = string | number
+              public;Foo
+            
+            2:
+              public;type;Foo
+              public;namespace;Foo
+          `,
+          choices: [1, 2],
+          default: 1,
         }
       })
     },
@@ -161,7 +186,9 @@ function extractApiCommand(options) {
   const apiReportFolderOpt = options.apiReportFolder ? ["--apiReportFolder", options.apiReportFolder] : [];
   const apiReportTempFolderOpt = options.apiReportTempFolder ? ["--apiReportTempFolder", options.apiReportTempFolder] : [];
   const apiSummaryFolderOpt = options.apiSummaryFolder ? ["--apiSummaryFolder", options.apiSummaryFolder] : [];
-  exec("node", [getScriptPath("extract-api.js"), ...entryOpt, ...ignoreTagsOpt, ...apiReportFolderOpt, ...apiReportTempFolderOpt, ...apiSummaryFolderOpt]);
+  const includeUnexportedApisOpt = options.includeUnexportedApis ? ["--includeUnexportedApis"] : [];
+  const summaryVersionOpt = options.summaryVersion ? ["--summaryVersion", options.summaryVersion] : [];
+  exec("node", [getScriptPath("extract-api.js"), ...entryOpt, ...ignoreTagsOpt, ...apiReportFolderOpt, ...apiReportTempFolderOpt, ...apiSummaryFolderOpt, ...includeUnexportedApisOpt, ...summaryVersionOpt]);
 }
 
 function pseudolocalizeCommand(options) {

--- a/tools/build/scripts/extract-api.js
+++ b/tools/build/scripts/extract-api.js
@@ -18,6 +18,7 @@ if (argv.entry === undefined) {
 const isCI = (process.env.TF_BUILD);
 const entryPointFileName = argv.entry;
 const ignoreMissingTags = argv.ignoreMissingTags;
+const includeUnexportedApis = argv.includeUnexportedApis;
 
 // Resolves the root of the Rush repo
 const resolveRoot = relativePath => {
@@ -53,6 +54,7 @@ const config = {
     enabled: true,
     reportFolder: path.resolve(apiReportFolder),
     reportTempFolder: path.resolve(apiReportTempFolder),
+    includeForgottenExports: !!includeUnexportedApis,
   },
   docModel: {
     enabled: false
@@ -129,6 +131,7 @@ spawn(require.resolve(".bin/api-extractor"), args).then((code) => {
     path.resolve(__dirname, "extract-api-summary.js"),
     "--apiSignature", path.resolve(path.join(apiReportFolder, `${entryPointFileName}.api.md`)),
     "--outDir", path.resolve(apiSummaryFolder),
+    ...(argv.summaryVersion === undefined ? [] : ["--summaryVersion", argv.summaryVersion]),
   ];
 
   spawn("node", extractSummaryArgs).then((code) => {


### PR DESCRIPTION
Closes #6980.

extract-api.js:
Added an option to extract unexported APIs.

This can be helpful to detect breaking changes in types that are not exposed by the authors directly but still can be indirectly 
 accessible by the consumers. For example, exporting interface of a React component properties can be undesirable because even adding an additional optional property can be considered a breaking change by the consumers that extend from this interface. 

This workflow is already utilized in Presentation libraries and a custom scripts had to be written to enforce this: https://github.com/iTwin/presentation/tree/master/apps/build-tools/bin

extract-api-summary.js
Fixed API regex, which was ignoring types with multi-line types such as
```ts
type X = Iterable<{
  a: number;
  b: number;
};
```
Added an option for improved output which will now contain type of the API (function, type, interface), and discard extra text right of the name of the APIs. This will help to distinguish duplicate lines when one of them signifies a type and another -- a namespace for that type. See changes to `betools.js` where an example is provided in the help text.