### PR TITLE
Mathieuf/add math operation parsing

### DIFF
--- a/common/api/core-quantity.api.md
+++ b/common/api/core-quantity.api.md
@@ -30,6 +30,11 @@ export class BadUnit implements UnitProps {
 export class BaseFormat {
     constructor(name: string);
     // (undocumented)
+    get allowMathematicEquations(): boolean;
+    set allowMathematicEquations(allowMathematicEquations: boolean);
+    // (undocumented)
+    protected _allowMathematicEquations: boolean;
+    // (undocumented)
     get decimalSeparator(): string;
     set decimalSeparator(decimalSeparator: string);
     // (undocumented)
@@ -199,6 +204,8 @@ export class Format extends BaseFormat {
 // @beta
 export interface FormatProps {
     // (undocumented)
+    readonly allowMathematicEquations?: boolean;
+    // (undocumented)
     readonly composite?: {
         readonly spacer?: string;
         readonly includeZero?: boolean;
@@ -338,6 +345,8 @@ export interface ParsedQuantity {
 export enum ParseError {
     // (undocumented)
     InvalidParserSpec = 6,
+    // (undocumented)
+    MathematicEquationFoundButIsNotAllowed = 7,
     // (undocumented)
     NoValueOrUnitFoundInString = 2,
     // (undocumented)

--- a/common/changes/@itwin/core-quantity/mathieuf-add-math-operation-parsing_2024-07-30-20-49.json
+++ b/common/changes/@itwin/core-quantity/mathieuf-add-math-operation-parsing_2024-07-30-20-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-quantity",
+      "comment": "Added parsing of addition and subtraction.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-quantity"
+}

--- a/core/quantity/src/Formatter/Format.ts
+++ b/core/quantity/src/Formatter/Format.ts
@@ -36,6 +36,7 @@ export class BaseFormat {
   protected _minWidth?: number; // optional; positive int
   protected _scientificType?: ScientificType; // required if type is scientific; options: normalized, zeroNormalized
   protected _stationOffsetSize?: number; // required when type is station; positive integer > 0
+  protected _allowMathematicEquations: boolean = false; // optional; enables calculating mathematic operations like addition and subtraction; default is false.
 
   constructor(name: string) {
     this._name = name;
@@ -75,6 +76,9 @@ export class BaseFormat {
 
   public get stationOffsetSize(): number | undefined { return this._stationOffsetSize; }
   public set stationOffsetSize(stationOffsetSize: number | undefined) {stationOffsetSize =  this._stationOffsetSize = stationOffsetSize; }
+
+  public get allowMathematicEquations(): boolean { return this._allowMathematicEquations; }
+  public set allowMathematicEquations(allowMathematicEquations: boolean) { this._allowMathematicEquations = allowMathematicEquations; }
 
   public get formatTraits(): FormatTraits { return this._formatTraits; }
   public set formatTraits(formatTraits: FormatTraits) { this._formatTraits = formatTraits; }
@@ -175,6 +179,12 @@ export class BaseFormat {
       if (formatProps.stationSeparator.length > 1)
         throw new QuantityError(QuantityStatus.InvalidJson, `The Format ${this.name} has an invalid 'stationSeparator' attribute. It should be an empty or one character string.`);
       this._stationSeparator = formatProps.stationSeparator;
+    }
+
+    if (undefined !== formatProps.allowMathematicEquations) { // optional; default is false
+      if (typeof (formatProps.allowMathematicEquations) !== "boolean")
+        throw new QuantityError(QuantityStatus.InvalidJson, `The Format ${this.name} has an invalid 'allowMathematicEquations' attribute. It should be of type 'boolean'.`);
+      this._allowMathematicEquations = formatProps.allowMathematicEquations;
     }
   }
 }

--- a/core/quantity/src/Formatter/Interfaces.ts
+++ b/core/quantity/src/Formatter/Interfaces.ts
@@ -25,6 +25,7 @@ export interface FormatProps {
   readonly scientificType?: string; // conditionally required
   readonly stationOffsetSize?: number; // conditionally required
   readonly stationSeparator?: string;
+  readonly allowMathematicEquations?: boolean;
   readonly composite?: {
     readonly spacer?: string;
     readonly includeZero?: boolean; // not currently used in Native formatter

--- a/core/quantity/src/Parser.ts
+++ b/core/quantity/src/Parser.ts
@@ -23,6 +23,7 @@ export enum ParseError {
   UnknownUnit,
   UnableToConvertParseTokensToQuantity,
   InvalidParserSpec,
+  MathematicEquationFoundButIsNotAllowed,
 }
 
 /** Parse error result from [[Parser.parseToQuantityValue]] or [[Parser.parseToQuantityValue]].
@@ -45,6 +46,19 @@ export interface ParsedQuantity {
   value: number;
 }
 
+enum Operator {
+  addition = "+",
+  subtraction = "-",
+}
+
+function isOperator(char: number | string): boolean {
+  if(typeof char === "number"){
+    // Convert the charcode to string.
+    char = String.fromCharCode(char);
+  }
+  return Object.values(Operator).includes(char as Operator);
+}
+
 /**
  * Defines Results of parsing a string input by a user into its desired value type
  * @beta
@@ -55,16 +69,19 @@ export type QuantityParseResult = ParsedQuantity | ParseQuantityError;
  * @beta
  */
 class ParseToken {
-  public value: number | string;
+  public value: number | string | Operator;
+  public isOperator: boolean = false;
 
-  constructor(value: string | number) {
-    if (typeof value === "string")
+  constructor(value: string | number | Operator) {
+    if (typeof value === "string"){
       this.value = value.trim();
-    else
+      this.isOperator = isOperator(this.value);
+    } else{
       this.value = value;
+    }
   }
 
-  public get isString(): boolean { return typeof this.value === "string"; }
+  public get isString(): boolean { return !this.isOperator && typeof this.value === "string"; }
   public get isNumber(): boolean { return typeof this.value === "number"; }
 }
 
@@ -189,6 +206,7 @@ export class Parser {
     let processingNumber = false;
     let wipToken = "";
     let signToken = "";
+    let isStationSeparatorAdded = false;
     let uomSeparatorToIgnore = 0;
     let fractionDashCode = 0;
 
@@ -283,9 +301,16 @@ export class Parser {
             }
           }
 
-          // ignore any codes in skipCodes
-          if (skipCodes.findIndex((ref) => ref === charCode) !== -1)
+          if (format.type === FormatType.Station && charCode === format.stationSeparator.charCodeAt(0)){
+            if(!isStationSeparatorAdded){
+              isStationSeparatorAdded = true;
+              continue;
+            }
+            isStationSeparatorAdded = false;
+          } else if (skipCodes.findIndex((ref) => ref === charCode) !== -1){
+            // ignore any codes in skipCodes
             continue;
+          }
 
           if (signToken.length > 0) {
             wipToken = signToken + wipToken;
@@ -296,11 +321,26 @@ export class Parser {
 
           wipToken = (i < str.length) ? str[i] : "";
           processingNumber = false;
+
+          if(wipToken.length === 1 && isOperator(wipToken)){
+            tokens.push(new ParseToken(wipToken)); // Push operator token.
+            wipToken = "";
+          }
         } else {
           // not processing a number
-          if ((charCode === QuantityConstants.CHAR_PLUS || charCode === QuantityConstants.CHAR_MINUS)) {
-            if (0 === tokens.length) // sign token only needed for left most value
-              signToken = str[i];
+          if (isOperator(charCode)) {
+            if(wipToken.length > 0){
+              // There is a token is progress, process it now, before adding the new operator token.
+              tokens.push(new ParseToken(wipToken));
+              wipToken = "";
+            }
+
+            tokens.push(new ParseToken(str[i])); // Push an Operator Token in the list.
+            continue;
+          }
+
+          if(wipToken.length === 0 && charCode === QuantityConstants.CHAR_SPACE){
+            // Dont add space when the wip token is empty.
             continue;
           }
 
@@ -322,6 +362,18 @@ export class Parser {
     }
 
     return tokens;
+  }
+
+  private static isMathematicEquation(tokens: ParseToken[]){
+    if(tokens.length > 1){
+      // The loop starts at one because the first token can be a operator without it being maths. Ex: "-5FT"
+      for(let i = 1; i < tokens.length; i++){
+        if(tokens[i].isOperator)
+          // Operator found, it's a math equation.
+          return true;
+      }
+    }
+    return false;
   }
 
   private static async lookupUnitByLabel(unitLabel: string, format: Format, unitsProvider: UnitsProvider, altUnitLabelsProvider?: AlternateUnitLabelsProvider) {
@@ -353,70 +405,59 @@ export class Parser {
     return foundUnit;
   }
 
-  private static async createQuantityFromParseTokens(tokens: ParseToken[], format: Format, unitsProvider: UnitsProvider, altUnitLabelsProvider?: AlternateUnitLabelsProvider): Promise<QuantityProps> {
-    let defaultUnit = format.units && format.units.length > 0 ? format.units[0][0] : undefined;
+  /**
+   * Get the output unit and all the conversion specs required to parse a given list of tokens.
+   */
+  private static async getRequiredUnitsConversionsToParseTokens(tokens: ParseToken[], format: Format, unitsProvider: UnitsProvider, altUnitLabelsProvider?: AlternateUnitLabelsProvider): Promise<{
+    outUnit?: UnitProps;
+    specs: UnitConversionSpec[];
+  }> {
+    let outUnit = (format.units && format.units.length > 0 ? format.units[0][0] : undefined);
+    const unitConversions: UnitConversionSpec[] = [];
+    const uniqueUnitLabels = [...new Set(tokens.filter((token) => token.isString).map((token) => token.value as string))];
+    for(const label of uniqueUnitLabels){
+      const unitProps = await this.lookupUnitByLabel(label, format, unitsProvider, altUnitLabelsProvider);
+      if(!outUnit){
+        // No default unit, assume that the first unit found is the desired output unit.
+        outUnit = unitProps;
+      }
 
-    // common case where single value is supplied
-    if (tokens.length === 1) {
-      if (tokens[0].isNumber) {
-        return new Quantity(defaultUnit, tokens[0].value as number);
+      let spec = unitConversions.find((specB) => specB.name === unitProps.name);
+      if(spec){
+        // Already in the list, just add the label.
+        spec.parseLabels?.push(label.toLocaleLowerCase());
       } else {
-        const unit = await this.lookupUnitByLabel(tokens[0].value as string, format, unitsProvider, altUnitLabelsProvider);
-        return new Quantity(unit);
-      }
-    }
-
-    // common case where single value and single label are supplied
-    if (tokens.length === 2) {
-      // unit specification comes before value (like currency)
-      if (tokens[1].isNumber && tokens[0].isString) {
-        tokens = [tokens[1], tokens[0]];
-      }
-      if (tokens[0].isNumber && tokens[1].isString) {
-        const unit = await this.lookupUnitByLabel(tokens[1].value as string, format, unitsProvider, altUnitLabelsProvider);
-        if (undefined === defaultUnit)
-          defaultUnit = unit;
-        if (defaultUnit && defaultUnit.name === unit.name) {
-          return new Quantity(defaultUnit, tokens[0].value as number);
-        } else if (defaultUnit) {
-          const conversion = await unitsProvider.getConversion(unit, defaultUnit);
-          const mag = ((tokens[0].value as number * conversion.factor)) + conversion.offset;
-          return new Quantity(defaultUnit, mag);
+        // Add new conversion to the list.
+        const conversion = await unitsProvider.getConversion(unitProps, outUnit);
+        if(conversion){
+          spec = {
+            conversion,
+            label: unitProps.label,
+            system: unitProps.system,
+            name: unitProps.name,
+            parseLabels: [label.toLocaleLowerCase()],
+          };
+          unitConversions.push(spec);
         }
       }
     }
 
-    // common case where there are multiple value/label pairs
-    if (tokens.length % 2 === 0) {
-      let mag = 0.0;
-      for (let i = 0; i < tokens.length; i = i + 2) {
-        if (tokens[i].isNumber && tokens[i + 1].isString) {
-          const value = tokens[i].value as number;
-          const unit = await this.lookupUnitByLabel(tokens[i + 1].value as string, format, unitsProvider, altUnitLabelsProvider);
-          if (undefined === defaultUnit)
-            defaultUnit = unit;
-          if (0 === i) {
-            if (defaultUnit.name === unit.name)
-              mag = value;
-            else {
-              const conversion = await unitsProvider.getConversion(unit, defaultUnit);
-              mag = ((value * conversion.factor)) + conversion.offset;
-            }
-          } else {
-            if (defaultUnit) {
-              const conversion = await unitsProvider.getConversion(unit, defaultUnit);
-              if (mag < 0.0)
-                mag = mag - ((value * conversion.factor)) + conversion.offset;
-              else
-                mag = mag + ((value * conversion.factor)) + conversion.offset;
-            }
-          }
-        }
+    return {outUnit, specs: unitConversions};
+  }
+
+  /**
+   * Get the units information asynchronously, then convert the tokens into quantity using the synchronous tokens -> value.
+   */
+  private static async createQuantityFromParseTokens(tokens: ParseToken[], format: Format, unitsProvider: UnitsProvider, altUnitLabelsProvider?: AlternateUnitLabelsProvider): Promise<QuantityProps> {
+    const unitConversionInfos = await this.getRequiredUnitsConversionsToParseTokens(tokens, format, unitsProvider, altUnitLabelsProvider);
+    if(unitConversionInfos.outUnit){
+      const value = Parser.getQuantityValueFromParseTokens(tokens, format, unitConversionInfos.specs, await unitsProvider.getConversion(unitConversionInfos.outUnit, unitConversionInfos.outUnit));
+      if(value.ok){
+        return new Quantity(unitConversionInfos.outUnit, value.value);
       }
-      return new Quantity(defaultUnit, mag);
     }
 
-    return new Quantity(defaultUnit);
+    return new Quantity();
   }
 
   /** Async method to generate a Quantity given a string that represents a quantity value and likely a unit label.
@@ -426,7 +467,7 @@ export class Parser {
    */
   public static async parseIntoQuantity(inString: string, format: Format, unitsProvider: UnitsProvider, altUnitLabelsProvider?: AlternateUnitLabelsProvider): Promise<QuantityProps> {
     const tokens: ParseToken[] = Parser.parseQuantitySpecification(inString, format);
-    if (tokens.length === 0)
+    if (tokens.length === 0 || (!format.allowMathematicEquations && Parser.isMathematicEquation(tokens)))
       return new Quantity();
 
     return Parser.createQuantityFromParseTokens(tokens, format, unitsProvider, altUnitLabelsProvider);
@@ -474,77 +515,116 @@ export class Parser {
     return undefined;
   }
 
-  private static getQuantityValueFromParseTokens(tokens: ParseToken[], format: Format, unitsConversions: UnitConversionSpec[]): QuantityParseResult {
+  /**
+   * Get what the unit conversion is for a unitless value.
+   */
+  private static getDefaultUnitConversion(tokens: ParseToken[], unitsConversions: UnitConversionSpec[], defaultUnit?: UnitProps){
+    let unitConversion = defaultUnit ? Parser.tryFindUnitConversion(defaultUnit.label, unitsConversions, defaultUnit) : undefined;
+    if(!unitConversion){
+      // No default unit conversion, take the first valid unit.
+      const uniqueUnitLabels = [...new Set(tokens.filter((token) => token.isString).map((token) => token.value as string))];
+      for(const label of uniqueUnitLabels){
+        unitConversion = Parser.tryFindUnitConversion(label, unitsConversions, defaultUnit);
+        if(unitConversion !== undefined)
+          return unitConversion;
+      }
+    }
+    return unitConversion;
+  }
+
+  // Get the next token pair to parse into a quantity.
+  private static getNextTokenPair(index: number, tokens: ParseToken[]): ParseToken[] | undefined {
+    if(index >= tokens.length)
+      return;
+
+    // 6 possible combination of token pair.
+    // Stringified to ease comparison later.
+    const validCombinations = [
+      JSON.stringify(["string"]), // ['FT']
+      JSON.stringify(["string", "number"]), // ['$', 5] unit specification comes before value (like currency)
+      JSON.stringify(["number"]), // [5]
+      JSON.stringify(["number", "string"]), // [5, 'FT']
+      JSON.stringify(["operator", "number"]), // ['-', 5]
+      JSON.stringify(["operator", "number", "string"]), // ['-', 5, 'FT']
+    ];
+
+    // Push up to 3 tokens in the list, if the length allows it.
+    const maxNbrTokensInThePair = Math.min(tokens.length - index, 3);
+    const tokenPair = tokens.slice(index, index + maxNbrTokensInThePair);
+    const currentCombination = tokenPair.map((token) => token.isOperator ? "operator" : (token.isNumber ? "number" : "string"));
+
+    // Check if the token pair is valid. If not, try again by removing the last token util empty.
+    // Ex: ['5', 'FT', '7'] invalid => ['5', 'FT'] valid returned
+    for(let i = currentCombination.length - 1; i >= 0; i--){
+      if(validCombinations.includes(JSON.stringify(currentCombination))){
+        break;
+      } else{
+        currentCombination.pop();
+        tokenPair.pop();
+      }
+    }
+
+    return tokenPair.length > 0 ? tokenPair : undefined;
+  }
+
+  /**
+   * Accumulate the given list of tokens into a single quantity value. Formatting the tokens along the way.
+   */
+  private static getQuantityValueFromParseTokens(tokens: ParseToken[], format: Format, unitsConversions: UnitConversionSpec[], defaultUnitConversion?: UnitConversionProps ): QuantityParseResult {
     const defaultUnit = format.units && format.units.length > 0 ? format.units[0][0] : undefined;
-    // common case where single value is supplied
-    if (tokens.length === 1) {
-      if (tokens[0].isNumber) {
-        if (defaultUnit) {
-          const conversion = Parser.tryFindUnitConversion(defaultUnit.label, unitsConversions, defaultUnit);
-          if (conversion) {
-            const value = (tokens[0].value as number) * conversion.factor + conversion.offset;
-            return { ok: true, value };
-          }
-        } else {
-          // if no conversion or no defaultUnit, just return parsed number
-          return { ok: true, value: tokens[0].value as number };
-        }
-      } else {
-        // only the unit label was specified so assume magnitude of 1
-        const conversion = Parser.tryFindUnitConversion(tokens[0].value as string, unitsConversions, defaultUnit);
-        if (undefined !== conversion)
-          return { ok: true, value: conversion.factor + conversion.offset };
-        else
-          return { ok: false, error: ParseError.NoValueOrUnitFoundInString };
-      }
-    }
+    defaultUnitConversion = defaultUnitConversion ? defaultUnitConversion : Parser.getDefaultUnitConversion(tokens, unitsConversions, defaultUnit);
 
-    // common case where single value and single label are supplied
-    if (tokens.length === 2) {
+    let tokenPair: ParseToken[] | undefined;
+    let increment: number = 1;
+    let mag = 0.0;
+    // The sign is saved outside from the loop for cases like this. '-1m 50cm 10mm + 2m 30cm 40mm' => -1.51m + 2.34m
+    let sign: 1 | -1 = 1;
+
+    for (let i = 0; i < tokens.length; i = i + increment) {
+      tokenPair = this.getNextTokenPair(i, tokens);
+      if(!tokenPair || tokenPair.length === 0){
+        return { ok: false, error: ParseError.UnableToConvertParseTokensToQuantity };
+      }
+      increment = tokenPair.length;
+
+      // Keep the sign so its applied to the next tokens.
+      if(tokenPair[0].isOperator){
+        sign = tokenPair[0].value === Operator.addition ? 1 : -1;
+        tokenPair.shift();
+      }
+
       // unit specification comes before value (like currency)
-      if (tokens[1].isNumber && tokens[0].isString) {
-        tokens = [tokens[1], tokens[0]];
+      if(tokenPair.length === 2 && tokenPair[0].isString){
+        // Invert it so the currency sign comes second.
+        tokenPair = [tokenPair[1], tokenPair[0]];
       }
-      if (tokens[0].isNumber && tokens[1].isString) {
-        let conversion = Parser.tryFindUnitConversion(tokens[1].value as string, unitsConversions, defaultUnit);
-        // if no conversion, ignore value in second token. If we have defaultUnit, use it.
-        if (!conversion && defaultUnit) {
-          conversion = Parser.tryFindUnitConversion(defaultUnit.label, unitsConversions, defaultUnit);
+
+      if(tokenPair[0].isNumber){
+        let value = sign * (tokenPair[0].value as number);
+        let conversion: UnitConversionProps | undefined;
+        if(tokenPair.length === 2 && tokenPair[1].isString){
+          conversion = Parser.tryFindUnitConversion(tokenPair[1].value as string, unitsConversions, defaultUnit);
         }
+        conversion = conversion ? conversion : defaultUnitConversion;
         if (conversion) {
-          const value = (tokens[0].value as number) * conversion.factor + conversion.offset;
-          return { ok: true, value };
+          value = (value * conversion.factor) + conversion.offset;
         }
-        // if no conversion, just return parsed number and ignore value in second token
-        return { ok: true, value: tokens[0].value as number };
-      }
-    }
-
-    // common case where there are multiple value/label pairs
-    if (tokens.length % 2 === 0) {
-      let mag = 0.0;
-      for (let i = 0; i < tokens.length; i = i + 2) {
-        if (tokens[i].isNumber && tokens[i + 1].isString) {
-          const value = tokens[i].value as number;
-          const conversion = Parser.tryFindUnitConversion(tokens[i + 1].value as string, unitsConversions, defaultUnit);
-          if (conversion) {
-            if (mag < 0.0)
-              mag = mag - ((value * conversion.factor)) + conversion.offset;
-            else
-              mag = mag + ((value * conversion.factor)) + conversion.offset;
-          }
+        mag = mag + value;
+      } else {
+        // only the unit label was specified so assume magnitude of 0
+        const conversion = Parser.tryFindUnitConversion(tokenPair[0].value as string, unitsConversions, defaultUnit);
+        if (conversion === undefined){
+          // Unknown unit label
+          return { ok: false, error: ParseError.NoValueOrUnitFoundInString };
         }
       }
-      return { ok: true, value: mag };
     }
-
-    return { ok: false, error: ParseError.UnableToConvertParseTokensToQuantity };
+    return { ok: true, value: mag };
   }
 
   /** Method to generate a Quantity given a string that represents a quantity value.
    *  @param inString A string that contains text represent a quantity.
    *  @param parserSpec unit label if not explicitly defined by user. Must have matching entry in supplied array of unitsConversions.
-   *  @param defaultValue default value to return if parsing is un successful
    */
   public static parseQuantityString(inString: string, parserSpec: ParserSpec): QuantityParseResult {
     return Parser.parseToQuantityValue(inString, parserSpec.format, parserSpec.unitConversions);
@@ -572,6 +652,10 @@ export class Parser {
     const tokens: ParseToken[] = Parser.parseQuantitySpecification(inString, format);
     if (tokens.length === 0)
       return { ok: false, error: ParseError.UnableToGenerateParseTokens };
+
+    if(!format.allowMathematicEquations && Parser.isMathematicEquation(tokens)){
+      return { ok: false, error: ParseError.MathematicEquationFoundButIsNotAllowed };
+    }
 
     if (Parser._log) {
       // eslint-disable-next-line no-console

--- a/core/quantity/src/test/Parsing.test.ts
+++ b/core/quantity/src/test/Parsing.test.ts
@@ -7,7 +7,7 @@ import { Format } from "../Formatter/Format";
 import { FormatterSpec } from "../Formatter/FormatterSpec";
 import { Formatter } from "../Formatter/Formatter";
 import { UnitProps } from "../Interfaces";
-import { Parser } from "../Parser";
+import { ParseError, Parser } from "../Parser";
 import { ParserSpec } from "../ParserSpec";
 import { Quantity } from "../Quantity";
 import { BadUnit } from "../Unit";
@@ -68,39 +68,36 @@ describe("Parsing tests:", () => {
   it("Generate Parse Tokens", async () => {
 
     const format = new Format("test");
-    const testStrings = ["", "0/1", "1/0", "1/2", "-1/2", "+1/2", "2 /", "1.616252eggs", "1.616252E-35eggs", "-1.616252E-35eggs", "756345.345", "12,345.345", "3.6252e3 Miles", "-1 1/2 FT", "+1 1/2 FT", "-135°11'30.5\"", "-2FT 6IN", "135°11'30.5\"", "2FT 6IN", "1 1/2 FT"];
-
-    const expectedTokens = [
-      [],
-      [{ value: 0 }],
-      [{ value: 1 }],
-      [{ value: 0.5 }],
-      [{ value: -0.5 }],
-      [{ value: 0.5 }],
-      [{ value: 2 }],
-      [{ value: 1.616252 }, { value: "eggs" }],
-      [{ value: 1.616252e-35 }, { value: "eggs" }],
-      [{ value: -1.616252e-35 }, { value: "eggs" }],
-      [{ value: 756345.345 }],
-      [{ value: 12345.345 }],
-      [{ value: 3625.2 }, { value: "Miles" }],
-      [{ value: -1.5 }, { value: "FT" }],
-      [{ value: 1.5 }, { value: "FT" }],
-      [{ value: -135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
-      [{ value: -2 }, { value: "FT" }, { value: 6 }, { value: "IN" }],
-      [{ value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
-      [{ value: 2 }, { value: "FT" }, { value: 6 }, { value: "IN" }],
-      [{ value: 1.5 }, { value: "FT" }],
+    const tests = [
+      {input: "", expectedTokens: []},
+      {input: "0/1", expectedTokens: [{ value: 0 }]},
+      {input: "1/0", expectedTokens: [{ value: 1 }]},
+      {input: "1/2", expectedTokens: [{ value: 0.5 }]},
+      {input: "-1/2", expectedTokens: [{value: "-", isOperand: true}, { value: 0.5 }]},
+      {input: "+1/2", expectedTokens: [{value: "+", isOperand: true}, { value: 0.5 }]},
+      {input: "2 /", expectedTokens: [{ value: 2 }]},
+      {input: "1.616252eggs", expectedTokens: [{ value: 1.616252 }, { value: "eggs" }]},
+      {input: "1.616252E-35eggs", expectedTokens: [{ value: 1.616252e-35 }, { value: "eggs" }]},
+      {input: "-1.616252E-35eggs", expectedTokens: [{value: "-", isOperand: true}, { value: 1.616252e-35 }, { value: "eggs" }]},
+      {input: "756345.345", expectedTokens: [{ value: 756345.345 }]},
+      {input: "12,345.345", expectedTokens: [{ value: 12345.345 }]},
+      {input: "3.6252e3 Miles", expectedTokens: [{ value: 3625.2 }, { value: "Miles" }]},
+      {input: "-1 1/2 FT", expectedTokens: [{value: "-", isOperand: true}, { value: 1.5 }, { value: "FT" }]},
+      {input: "+1 1/2 FT", expectedTokens: [{value: "+", isOperand: true}, { value: 1.5 }, { value: "FT" }]},
+      {input: "-135°11'30.5\"", expectedTokens: [{value: "-", isOperand: true}, { value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }]},
+      {input: "-2FT 6IN", expectedTokens: [{value: "-", isOperand: true}, { value: 2 }, { value: "FT" }, { value: 6 }, { value: "IN" }]},
+      {input: "135°11'30.5\"", expectedTokens: [{ value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }]},
+      {input: "2FT 6IN", expectedTokens: [{ value: 2 }, { value: "FT" }, { value: 6 }, { value: "IN" }]},
+      {input: "1 1/2 FT", expectedTokens: [{ value: 1.5 }, { value: "FT" }]},
     ];
 
     let i = 0;
-    for (const strVal of testStrings) {
-      const tokens = Parser.parseQuantitySpecification(strVal, format);
-      assert.isTrue(tokens.length === expectedTokens[i].length);
+    for (const test of tests) {
+      const tokens = Parser.parseQuantitySpecification(test.input, format);
+      assert.isTrue(tokens.length === test.expectedTokens.length);
 
-      // eslint-disable-next-line @typescript-eslint/prefer-for-of
       for (let j = 0; j < tokens.length; j++) {
-        assert.isTrue(tokens[j].value === expectedTokens[i][j].value);
+        assert.isTrue(tokens[j].value === test.expectedTokens[j].value);
       }
 
       i = i + 1;
@@ -108,17 +105,15 @@ describe("Parsing tests:", () => {
   });
 
   it("Generate Parse Tokens given different decimal and thousand separators", async () => {
-    const testStrings = ["1,616252eggs", "1,616252E-35eggs", "-1,616252E-35eggs", "756345,345", "12.345,345", "3,6252e3 Miles", "-135°11'30,5\"", "135°11'30,5\""];
-
-    const expectedTokens = [
-      [{ value: 1.616252 }, { value: "eggs" }],
-      [{ value: 1.616252e-35 }, { value: "eggs" }],
-      [{ value: -1.616252e-35 }, { value: "eggs" }],
-      [{ value: 756345.345 }],
-      [{ value: 12345.345 }],
-      [{ value: 3625.2 }, { value: "Miles" }],
-      [{ value: -135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
-      [{ value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }],
+    const tests = [
+      {input: "1,616252eggs", expectedTokens: [{ value: 1.616252 }, { value: "eggs" }]},
+      {input: "1,616252E-35eggs", expectedTokens: [{ value: 1.616252e-35 }, { value: "eggs" }]},
+      {input: "-1,616252E-35eggs", expectedTokens: [{value: "-", isOperand: true}, { value: 1.616252e-35 }, { value: "eggs" }]},
+      {input: "756345,345", expectedTokens: [{ value: 756345.345 }]},
+      {input: "12.345,345", expectedTokens: [{ value: 12345.345 }]},
+      {input: "3,6252e3 Miles", expectedTokens: [{ value: 3625.2 }, { value: "Miles" }]},
+      {input: "-135°11'30,5\"", expectedTokens: [{value: "-", isOperand: true}, { value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }]},
+      {input: "135°11'30,5\"", expectedTokens: [{ value: 135 }, { value: "°" }, { value: 11 }, { value: "'" }, { value: 30.5 }, { value: "\"" }]},
     ];
 
     const formatData = {
@@ -131,13 +126,13 @@ describe("Parsing tests:", () => {
     await format.fromJSON(unitsProvider, formatData).catch(() => { });
 
     let i = 0;
-    for (const strVal of testStrings) {
-      const tokens = Parser.parseQuantitySpecification(strVal, format);
-      assert.isTrue(tokens.length === expectedTokens[i].length);
+    for (const test of tests) {
+      const tokens = Parser.parseQuantitySpecification(test.input, format);
+      assert.isTrue(tokens.length === test.expectedTokens.length);
 
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
       for (let j = 0; j < tokens.length; j++) {
-        assert.isTrue(tokens[j].value === expectedTokens[i][j].value);
+        assert.isTrue(tokens[j].value === test.expectedTokens[j].value);
       }
 
       i = i + 1;
@@ -215,7 +210,7 @@ describe("Parsing tests:", () => {
       { value: "-2FT 6IN", quantity: { magnitude: -2.5, unitName: "Units.FT" } },
       { value: "1 1/2 FT", quantity: { magnitude: 1.5, unitName: "Units.FT" } },
       { value: "2FT 6IN", quantity: { magnitude: 2.5, unitName: "Units.FT" } },
-      { value: `2'-6"`, quantity: { magnitude: 2.5, unitName: "Units.FT" } },
+      { value: `2' 6"`, quantity: { magnitude: 2.5, unitName: "Units.FT" } },
       { value: "-3IN", quantity: { magnitude: -0.25, unitName: "Units.FT" } },
       // Test with invalid unit specifier -- should default to -3 ft
       { value: "-3 ABCDEF", quantity: { magnitude: -3, unitName: "Units.FT" } },
@@ -284,6 +279,7 @@ describe("Parsing tests:", () => {
       precision: 4,
       type: "Decimal",
       uomSeparator: "*",
+      allowMathematicEquations: true,
     };
 
     const testData = [
@@ -294,6 +290,7 @@ describe("Parsing tests:", () => {
       { value: "1 1/2*FT", quantity: { magnitude: 1.5, unitName: "Units.FT" } },
       { value: "2*FT 6*IN", quantity: { magnitude: 2.5, unitName: "Units.FT" } },
       { value: "-3*IN", quantity: { magnitude: -0.25, unitName: "Units.FT" } },
+      { value: "2*FT 6*IN - 3*IN", quantity: { magnitude: 2.25, unitName: "Units.FT" } },
     ];
 
     const unitsProvider = new TestUnitsProvider();
@@ -327,11 +324,15 @@ describe("Parsing tests:", () => {
       precision: 2,
       stationOffsetSize: 2,
       type: "Station",
+      allowMathematicEquations: true,
     };
 
     const testData = [
       { value: "7563+45.345", quantity: { magnitude: 756345.345, unitName: "Units.FT" } },
       { value: "-7563+45.345", quantity: { magnitude: -756345.345, unitName: "Units.FT" } },
+      { value: "-7563+45.345 - 5.5", quantity: { magnitude: -756350.845, unitName: "Units.FT" } },
+      { value: "-7563+45.345 + 5.5", quantity: { magnitude: -756339.845, unitName: "Units.FT" } },
+      { value: "10m + 7563+45.345 + 5.5", quantity: { magnitude: 32.8084 + 756350.845, unitName: "Units.FT" } },
     ];
 
     const format = new Format("test");
@@ -369,11 +370,14 @@ describe("Parsing tests:", () => {
       precision: 4,
       type: "Decimal",
       uomSeparator: "",
+      allowMathematicEquations: true,
     };
 
     const testData = [
       { value: "-135°11'30.5\"", defaultUnit: "Units.ARC_DEG", quantity: { magnitude: -135.19180555555556, unitName: "Units.ARC_DEG" } },
       { value: "135°11'30.5\"", defaultUnit: "Units.ARC_DEG", quantity: { magnitude: 135.19180555555556, unitName: "Units.ARC_DEG" } },
+      { value: "135°11'30.5\" + 5", defaultUnit: "Units.ARC_DEG", quantity: { magnitude: 140.19180555555556, unitName: "Units.ARC_DEG" } },
+      { value: "130°10'20.1\" + 5°01'10.4\"", defaultUnit: "Units.ARC_DEG", quantity: { magnitude: 135.19180555555556, unitName: "Units.ARC_DEG" } },
     ];
 
     const unitsProvider = new TestUnitsProvider();
@@ -394,11 +398,16 @@ describe("Parsing tests:", () => {
       precision: 8,
       type: "Fractional",
       uomSeparator: " ",
+      allowMathematicEquations: true,
     };
 
     const testData = [
       { value: "-1-1/2FT", quantity: { magnitude: -1.5, unitName: "Units.FT" } },
       { value: "1-1/2 FT", quantity: { magnitude: 1.5, unitName: "Units.FT" } },
+      { value: "1-1/2 FT + 1-1/2 FT", quantity: { magnitude: 3, unitName: "Units.FT" } },
+      { value: "1-1/2 FT - 1-1/2 FT", quantity: { magnitude: 0, unitName: "Units.FT" } },
+      { value: "-1-1/2 FT - 1-1/2 FT", quantity: { magnitude: -3, unitName: "Units.FT" } },
+      { value: "-1-1/2 FT + 1-1/2 FT", quantity: { magnitude: 0, unitName: "Units.FT" } },
       { value: "FT", quantity: { magnitude: 0.0, unitName: "Units.FT" } },
     ];
 
@@ -424,6 +433,7 @@ describe("Parsing tests:", () => {
       formatTraits: ["keepSingleZero", "showUnitLabel"],
       precision: 4,
       type: "Decimal",
+      allowMathematicEquations: true,
     };
 
     const testData = [
@@ -436,6 +446,7 @@ describe("Parsing tests:", () => {
       { value: "1000 ABCDEF", magnitude: 304.8006096012192 },  // invalid label, should default to SURVEY_FT from Format since the unit is provided
       { value: "1000 f", magnitude: 304.8 },  // "f" is only valid for Units.FT so convert based on feet
       { value: "1000'", magnitude: 304.8 },  // "'" is only valid for Units.FT so convert based on feet
+      { value: "1100 usft - 100", magnitude: 304.8006096012192 },  // label should match the label in the Format so it will use SURVEY_FT
     ];
 
     const unitsAndAltLabelsProvider = new TestUnitsProvider();
@@ -465,6 +476,7 @@ describe("Parsing tests:", () => {
       formatTraits: ["keepSingleZero", "showUnitLabel"],
       precision: 4,
       type: "Decimal",
+      allowMathematicEquations: true,
     };
 
     const testData = [
@@ -476,6 +488,7 @@ describe("Parsing tests:", () => {
       { value: "1000", quantity: { magnitude: 1000, unitName: "Units.US_SURVEY_FT" } },  // no label should default to SURVEY_FT from Format
       { value: "1000 f", quantity: { magnitude: 999.998, unitName: "Units.US_SURVEY_FT" } },  // "f" is only valid for Units.FT so convert based on feet
       { value: "1000'", quantity: { magnitude: 999.998, unitName: "Units.US_SURVEY_FT" } },  // "'" is only valid for Units.FT so convert based on feet
+      { value: "1100 usft - 100", quantity: { magnitude: 1000, unitName: "Units.US_SURVEY_FT" } },  // label should match the label in the Format so it will use SURVEY_FT
     ];
 
     const unitsProvider = new TestUnitsProvider();
@@ -490,6 +503,99 @@ describe("Parsing tests:", () => {
       expect(quantityProps.unit.name).to.be.eql(testEntry.quantity.unitName);
     }
   });
+
+  it("Parse mathematic equations into quantity async", async () => {
+    const formatData = {
+      formatTraits: ["keepSingleZero", "applyRounding", "showUnitLabel"],
+      precision: 4,
+      type: "Decimal",
+      uomSeparator: "",
+      composite: {
+        units: [
+          {
+            label: "m",
+            name: "Units.M",
+          },
+        ],
+      },
+      allowMathematicEquations: true,
+    };
+
+    const testData = [
+      // When unitless, the format unit is used to determine unit. (The unit the user is working on.)
+      { value: "12,345.345 - 1", quantity: { magnitude: 12344.345, unitName: "Units.M" }},
+      { value: "1yd + 2", quantity: { magnitude: 0.9144 + 2, unitName: "Units.M" }},
+      { value: "1yd + 1m + 2", quantity: { magnitude: 0.9144 + 3, unitName: "Units.M" }},
+      { value: "1 FT + 6IN", quantity: { magnitude: 0.45720000000000005, unitName: "Units.M" }},
+      { value: "-1-1", quantity: { magnitude: -2, unitName: "Units.M" }},
+      { value: "1 ' + 1 FT", quantity: { magnitude: 0.6096, unitName: "Units.M" }},
+      { value: "-1 FT + 1", quantity: { magnitude: -0.3048 + 1, unitName: "Units.M" }},
+      { value: "1 F + 1.5", quantity: { magnitude: 0.3048 + 1.5, unitName: "Units.M" }},
+      { value: "-2FT 6IN + 6IN", quantity: { magnitude: -0.6096, unitName: "Units.M" }},
+      { value: "1 1/2FT + 1/2IN", quantity: { magnitude: 0.45720000000000005 + 0.0127, unitName: "Units.M" }},
+      { value: "2' 6\"-0.5", quantity: { magnitude: 0.762 - 0.5, unitName: "Units.M" }},
+      { value: "1 yd + 1FT 6IN", quantity: { magnitude: 1.3716, unitName: "Units.M" }},
+      { value: "1 m -1FT +6IN", quantity: { magnitude: 1 - 0.1524, unitName: "Units.M" }},
+      { value: "-1m 1CM 1mm - 1 FT + 6IN + 1yd", quantity: { magnitude: -0.24899999999999978, unitName: "Units.M" }},
+    ];
+
+    const unitsProvider = new TestUnitsProvider();
+    const format = new Format("test");
+    await format.fromJSON(unitsProvider, formatData).catch(() => { });
+
+    for (const testEntry of testData) {
+      const quantityProps = await Parser.parseIntoQuantity(testEntry.value, format, unitsProvider);
+      // console.log (`quantityProps=${JSON.stringify(quantityProps)}`);
+      expect(Math.fround(quantityProps.magnitude)).to.eql(Math.fround(testEntry.quantity.magnitude));
+      expect(quantityProps.unit.name).to.eql(testEntry.quantity.unitName);
+    }
+  });
+
+  it("Parse mathematic equations into an invalid result when maths are not allowed async", async () => {
+    const formatData = {
+      formatTraits: ["keepSingleZero", "applyRounding", "showUnitLabel"],
+      precision: 4,
+      type: "Decimal",
+      uomSeparator: "",
+      composite: {
+        units: [
+          {
+            label: "m",
+            name: "Units.M",
+          },
+        ],
+      },
+      // allowMathematicEquations: false, <- Also test that, when not set, it default to false
+    };
+
+    const testData = [
+      "12,345.345 - 1",
+      "1yd + 2",
+      "1yd + 1m + 2",
+      "1 FT + 6IN",
+      "-1-1",
+      "1 ' + 1 FT",
+      "-1 FT + 1",
+      "1 F + 1.5",
+      "-2FT 6IN + 6IN",
+      "1 1/2FT + 1/2IN",
+      "2' 6\"-0.5",
+      "1 yd + 1FT 6IN",
+      "1 m -1FT +6IN",
+      "-1m 1CM 1mm - 1 FT + 6IN + 1yd",
+    ];
+
+    const unitsProvider = new TestUnitsProvider();
+    const format = new Format("test");
+    await format.fromJSON(unitsProvider, formatData).catch(() => { });
+
+    for (const testEntry of testData) {
+      const quantityProps = await Parser.parseIntoQuantity(testEntry, format, unitsProvider);
+      expect(quantityProps.isValid).to.eql(false);
+      expect(quantityProps.magnitude).to.eql(0);
+    }
+  });
+
 });
 
 describe("Synchronous Parsing tests:", async () => {
@@ -515,8 +621,8 @@ describe("Synchronous Parsing tests:", async () => {
     precision: 8,
     type: "Fractional",
     uomSeparator: "",
+    allowMathematicEquations: true,
   };
-
   const format = new Format("test");
   await format.fromJSON(unitsProvider, formatData).catch(() => { });
 
@@ -546,6 +652,7 @@ describe("Synchronous Parsing tests:", async () => {
     precision: 2,
     type: "Decimal",
     uomSeparator: "",
+    allowMathematicEquations: true,
   };
 
   const angleFormat = new Format("testAngle");
@@ -554,14 +661,146 @@ describe("Synchronous Parsing tests:", async () => {
   const angleParserSpec = await ParserSpec.create(angleFormat, unitsProvider, outAngleUnit, unitsProvider);
   const angleFormatSpec = await FormatterSpec.create("test", angleFormat, unitsProvider, outAngleUnit);
 
+  it("Parse mathematic equations into quantity synchronously", () => {
+    const testData = [
+      // When unitless, the format unit is used to determine unit.
+      { value: "12,345.345 - 1", magnitude: 3762.861156 - 0.3048},
+      { value: "1yd + 2", magnitude: 0.9144 + 0.6096},
+      { value: "1yd + 1m + 2", magnitude: 0.9144 + 1 + 0.6096},
+      { value: "1 FT + 6IN", magnitude: 0.45720000000000005 },
+      { value: "-1-1", magnitude: -0.6096 },
+      { value: "1 ' + 1 FT", magnitude: 0.6096 },
+      { value: "-1 FT + 1", magnitude: 0 },
+      { value: "1 F + 1.5", magnitude: 0.762 },
+      { value: "-2FT 6IN + 6IN", magnitude: -0.6096 },
+      { value: "1 1/2FT + 1/2IN", magnitude: 0.45720000000000005 + 0.0127 },
+      { value: "2' 6\"-0.5", magnitude: 0.6096 },
+      { value: "1 yd + 1FT 6IN", magnitude: 1.3716 },
+      { value: "1 m -1FT +6IN", magnitude: 1 - 0.1524 },
+      { value: "-1m 1CM 1mm - 1 FT + 6IN + 1yd", magnitude: -0.24899999999999978 },
+    ];
+
+    if (logTestOutput) {
+      for (const spec of meterConversionSpecs) {
+        // eslint-disable-next-line no-console
+        console.log(`unit ${spec.name} factor= ${spec.conversion.factor} labels=${spec.parseLabels}`);
+      }
+    }
+
+    for (const testEntry of testData) {
+      const parseResult = Parser.parseToQuantityValue(testEntry.value, format, meterConversionSpecs);
+      if (logTestOutput) {
+        if (Parser.isParsedQuantity(parseResult))
+          console.log(`input=${testEntry.value} output=${parseResult.value}`); // eslint-disable-line no-console
+        else if (Parser.isParseError(parseResult))
+          console.log(`input=${testEntry.value} error=${parseResult.error}`); // eslint-disable-line no-console
+      }
+      assert.isTrue(Parser.isParsedQuantity(parseResult));
+      if (Parser.isParsedQuantity(parseResult))
+        expect(parseResult.value).closeTo(testEntry.magnitude, 0.0001);
+    }
+  });
+
+  it("Parse mathematic equations into an ParserError when maths are not allowed synchronously", async () => {
+    const formatDataMathNotAllowed = {
+      formatTraits: ["keepSingleZero", "showUnitLabel"],
+      precision: 8,
+      type: "Fractional",
+      uomSeparator: "",
+      allowMathematicEquations: false,
+    };
+    const formatMathNotAllowed = new Format("test");
+    await formatMathNotAllowed.fromJSON(unitsProvider, formatDataMathNotAllowed).catch(() => { });
+
+    const testData = [
+      "12,345.345 - 1",
+      "1yd + 2",
+      "1yd + 1m + 2",
+      "1 FT + 6IN",
+      "-1-1",
+      "1 ' + 1 FT",
+      "-1 FT + 1",
+      "1 F + 1.5",
+      "-2FT 6IN + 6IN",
+      "1 1/2FT + 1/2IN",
+      "2' 6\"-0.5",
+      "1 yd + 1FT 6IN",
+      "1 m -1FT +6IN",
+      "-1m 1CM 1mm - 1 FT + 6IN + 1yd",
+    ];
+
+    if (logTestOutput) {
+      for (const spec of meterConversionSpecs) {
+        // eslint-disable-next-line no-console
+        console.log(`unit ${spec.name} factor= ${spec.conversion.factor} labels=${spec.parseLabels}`);
+      }
+    }
+
+    for (const testEntry of testData) {
+      const parseResult = Parser.parseToQuantityValue(testEntry, formatMathNotAllowed, meterConversionSpecs);
+      if (logTestOutput) {
+        if (Parser.isParsedQuantity(parseResult))
+          console.log(`input=${testEntry} output=${parseResult.value}`); // eslint-disable-line no-console
+        else if (Parser.isParseError(parseResult))
+          console.log(`input=${testEntry} error=${parseResult.error}`); // eslint-disable-line no-console
+      }
+      assert.isTrue(Parser.isParseError(parseResult));
+      if (Parser.isParseError(parseResult))
+        expect(parseResult.error).to.eql(ParseError.MathematicEquationFoundButIsNotAllowed);
+    }
+  });
+
+  it("Parse taking the first unit if no unit specified in the Format.", async () => {
+    const formatDataUnitless = {
+      formatTraits: ["keepSingleZero", "showUnitLabel"],
+      precision: 8,
+      type: "Fractional",
+      uomSeparator: "",
+      allowMathematicEquations: true,
+    };
+    const formatUnitless = new Format("test");
+    await formatUnitless.fromJSON(unitsProvider, formatDataUnitless).catch(() => { });
+
+    const testData = [
+      { value: "12,345.345 - 1", magnitude: 12345.345 - 1}, // unitless
+      { value: "1m + 1FT + 1", magnitude: 1 + 0.3048 + 1}, // default to meters
+      { value: "1FT + 1m + 1", magnitude: 0.3048 + 1 + 0.3048}, // default to feet
+      { value: "1 + 1 FT + 1m", magnitude: 0.3048 + 0.3048 + 1 }, // default to feet
+    ];
+
+    if (logTestOutput) {
+      for (const spec of meterConversionSpecs) {
+        // eslint-disable-next-line no-console
+        console.log(`unit ${spec.name} factor= ${spec.conversion.factor} labels=${spec.parseLabels}`);
+      }
+    }
+
+    for (const testEntry of testData) {
+      const parseResult = Parser.parseToQuantityValue(testEntry.value, formatUnitless, meterConversionSpecs);
+      if (logTestOutput) {
+        if (Parser.isParsedQuantity(parseResult))
+          console.log(`input=${testEntry.value} output=${parseResult.value}`); // eslint-disable-line no-console
+        else if (Parser.isParseError(parseResult))
+          console.log(`input=${testEntry.value} error=${parseResult.error}`); // eslint-disable-line no-console
+      }
+      assert.isTrue(Parser.isParsedQuantity(parseResult));
+      if (Parser.isParsedQuantity(parseResult))
+        expect(parseResult.value).closeTo(testEntry.magnitude, 0.0001);
+    }
+  });
+
   it("Parse into length values using custom parse labels", () => {
     const testData = [
       // if no quantity is provided then the format unit is used to determine unit
       { value: "12,345.345", magnitude: 3762.861156 },
       { value: "1", magnitude: 0.3048 },
       { value: "1 '", magnitude: 0.3048 },
+      { value: "-1", magnitude: -0.3048 },
       { value: "1 FT", magnitude: 0.3048 },
+      { value: "FT", magnitude: 0 },
+      { value: "-1 FT", magnitude: -0.3048 },
       { value: "1 F", magnitude: 0.3048 },
+      { value: "1/2 F", magnitude: 0.3048 / 2 },
       { value: "-2FT 6IN", magnitude: -0.762 },
       { value: "1 1/2FT", magnitude: 0.45720000000000005 },
       { value: "2' 6\"", magnitude: 0.762 },
@@ -658,6 +897,7 @@ describe("Synchronous Parsing tests:", async () => {
       // if no quantity is provided then the format unit is used to determine unit
       { value: "15^30'", magnitude: 15.5 },
       { value: "15.5", magnitude: 15.5 },
+      { value: "10.0 + 5.5", magnitude: 15.5 },
     ];
 
     if (logTestOutput) {

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -14,6 +14,7 @@ Table of contents:
 - [ListenerType helper](#listenertype-helper)
 - [CustomAttributeClass containerType renamed](#customattributeclass-containertype-renamed)
 - [Improve the performance of the ECSchemaRpcLocater](#improve-the-performance-of-the-ecschemarpclocater)
+- [Mathematical equations formatting](#Mathematical-equations-formatting)
 
 ## Workspaces
 
@@ -50,3 +51,29 @@ The Xml and JSON representations of a custom attribute (and related TypeScript i
 ## Improve the performance of the ECSchemaRpcLocater
 
 Improve the performance of the ECSchemaRpcLocater by making all of the underlying ECSchemaRpcInterface methods GET by default so responses are cached by default. Previously each client had to set the methods to be GET or they would default to POST and were not cached.
+
+## Mathematical operation parsing
+
+The quantity formatter now supports parsing mathematical operations. Ex :
+```Typescript
+"5 ft + 12 in + 1 yd -1 ft 6 in" => 7.5 (feet)
+(5 + 1 + 3 - 1.5) => 7.5
+```
+
+### Limitations
+Only plus(`+`) and minus(`-`) signs are supported for now.
+Other opertaors will end up returning a parsing error or an invalid input result.
+
+The parsing of mathematical equations is disabled by default.
+To enable it, you can override the default QuantityFormatter. Ex :
+```Typescript
+  // App specific
+  const quantityType = QuantityType.LengthEngineering;
+
+  // Default props for the desired quantityType
+  const props = IModelApp.quantityFormatter.getFormatPropsByQuantityType(quantityType);
+
+  // Override the formatter and enable mathematical operations.
+  await IModelApp.quantityFormatter.setOverrideFormat(quantityType, { ...props, allowMathematicEquations: true });
+```
+


### PR DESCRIPTION
Pull request for the issue feature #6935 

## Added initial support for parsing math equations. + and - 
Plus and minus signs are supported.
Ex: 
5 ft + 12 in + 1 yd -1 ft 6 in = 7.5 ft
(5 + 1 + 3 - 1.5)
Multiplication and division are not supported yet. 

## Special case + Refactoring
I noticed that the functions `createQuantityFromParseTokens` and `getQuantityValueFromParseTokens` where doing the same "tokens to value" logic. So I de-duplicated them.  
There was one inconsistent output between these methods. 
The case where only the unit label was specified. <- See line 601 in `Parser.ts`.
The output for the 2 methods where :   'FT' = 1   and    'FT' = 0
I opted to assume that the magnitude is 1. 

Another special case, which I assume was a bug, is the parsing of `2'-6"`. <- See line 218 in the file `Parsing.test.ts`. 
The minus sign was threated like a formatTraits `fractionDash`, but the format did not specified `fractionDash`, so it should've been 0 or error. 
Now it's treated like a minus sign when fractionDash is NOT specified, and a fractionDash when fractionDah is specified. 