### PR TITLE
Synch this code from @bentley/reality-data package.

### DIFF
--- a/common/changes/@itwin/core-frontend/marcB-CheckCRSValidityBeforeUsingForOCP_2024-08-01-17-58.json
+++ b/common/changes/@itwin/core-frontend/marcB-CheckCRSValidityBeforeUsingForOCP_2024-08-01-17-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Check validity of OCP CRS before using it.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/OPCFormatInterpreter.ts
+++ b/core/frontend/src/tile/OPCFormatInterpreter.ts
@@ -58,7 +58,6 @@ export class OPCFormatInterpreter  {
     // Check to isGeographicCRS and isProjectedCRS are both going to return false in that case and we will fallback to
     // use un-georeferenced code path.
     await CRSManager.ENGINE.prepareForArea(fileCrs, bounds);
-    // const _isGeoCentric = CRSManager.ENGINE.isGeocentricCRS(fileCrs);
     const isGeographicCRS = CRSManager.ENGINE.isGeographicCRS(fileCrs);
     const isProjectedCRS = CRSManager.ENGINE.isProjectedCRS(fileCrs);
     if (fileCrs && (isProjectedCRS || isGeographicCRS)) {

--- a/core/frontend/src/tile/OPCFormatInterpreter.ts
+++ b/core/frontend/src/tile/OPCFormatInterpreter.ts
@@ -54,7 +54,6 @@ export class OPCFormatInterpreter  {
     worldRange = Range3d.createXYZXYZ(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ(), bounds.getMaxX(), bounds.getMaxY(), bounds.getMaxZ());
     isGeolocated = false;
     const fileCrs = fileReader.getFileCRS();
-    // Fix https://dev.azure.com/bentleycs/SEG/_workitems/edit/1491612
     // the CRS 9300 is not defined in the CRS registry database, so we cannot use CRSManager
     // Check to isGeographicCRS and isProjectedCRS are both going to return false in that case and we will fallback to
     // use un-georeferenced code path.

--- a/test-apps/imodel-from-orbitgt/src/OrbitGtContextModelCreator.ts
+++ b/test-apps/imodel-from-orbitgt/src/OrbitGtContextModelCreator.ts
@@ -70,7 +70,6 @@ export class OrbitGtContextIModelCreator {
       // Check to isGeographicCRS and isProjectedCRS are both going to return false in that case and we will fallback to
       // use un-georeferenced code path.
       await CRSManager.ENGINE.prepareForArea(fileCrs, bounds);
-      // const _isGeoCentric = CRSManager.ENGINE.isGeocentricCRS(fileCrs);
       const isGeographicCRS = CRSManager.ENGINE.isGeographicCRS(fileCrs);
       const isProjectedCRS = CRSManager.ENGINE.isProjectedCRS(fileCrs);
       if (fileCrs && (isProjectedCRS || isGeographicCRS)) {

--- a/test-apps/imodel-from-orbitgt/src/OrbitGtContextModelCreator.ts
+++ b/test-apps/imodel-from-orbitgt/src/OrbitGtContextModelCreator.ts
@@ -66,8 +66,15 @@ export class OrbitGtContextIModelCreator {
       const bounds = fileReader.getFileBounds();
       let worldRange = Range3d.createXYZXYZ(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ(), bounds.getMaxX(), bounds.getMaxY(), bounds.getMaxZ());
       let geoLocated = false;
-      if (fileCrs.length > 0) {
-        await CRSManager.ENGINE.prepareForArea(fileCrs, bounds);
+      // Fix https://dev.azure.com/bentleycs/SEG/_workitems/edit/1491612
+      // the CRS 9300 is not defined in the CRS registry database, so we cannot use CRSManager
+      // Check to isGeographicCRS and isProjectedCRS are both going to return false in that case and we will fallback to
+      // use un-georeferenced code path.
+      await CRSManager.ENGINE.prepareForArea(fileCrs, bounds);
+      // const _isGeoCentric = CRSManager.ENGINE.isGeocentricCRS(fileCrs);
+      const isGeographicCRS = CRSManager.ENGINE.isGeographicCRS(fileCrs);
+      const isProjectedCRS = CRSManager.ENGINE.isProjectedCRS(fileCrs);
+      if (fileCrs && (isProjectedCRS || isGeographicCRS)) {
         const wgs84Crs = "4978";
         await CRSManager.ENGINE.prepareForArea(wgs84Crs, new OrbitGtBounds());
 

--- a/test-apps/imodel-from-orbitgt/src/OrbitGtContextModelCreator.ts
+++ b/test-apps/imodel-from-orbitgt/src/OrbitGtContextModelCreator.ts
@@ -66,7 +66,6 @@ export class OrbitGtContextIModelCreator {
       const bounds = fileReader.getFileBounds();
       let worldRange = Range3d.createXYZXYZ(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ(), bounds.getMaxX(), bounds.getMaxY(), bounds.getMaxZ());
       let geoLocated = false;
-      // Fix https://dev.azure.com/bentleycs/SEG/_workitems/edit/1491612
       // the CRS 9300 is not defined in the CRS registry database, so we cannot use CRSManager
       // Check to isGeographicCRS and isProjectedCRS are both going to return false in that case and we will fallback to
       // use un-georeferenced code path.


### PR DESCRIPTION
Found out that the CRS 9300 is not defined in the CRS registry database, so we cannot use CRSManager: https://ogtcrsregistry.blob.core.windows.net/registry/crs/9300.prj We will check for isGeographicCRS and isProjectedCRS and both are going to return false in that case and we will fallback to use un-georeferenced code path.