### PR TITLE
Promote ScreenViewport and OnScreenViewport constructors

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -7600,6 +7600,8 @@ export namespace MockRender {
     export type SystemFactory = () => RenderSystem;
     // (undocumented)
     export abstract class Target extends RenderTarget {
+        // (undocumented)
+        protected readonly [_implementationProhibited]: undefined;
         protected constructor(_system: RenderSystem);
         // (undocumented)
         get analysisFraction(): number;
@@ -7887,6 +7889,8 @@ export class NullRenderSystem extends RenderSystem {
 // @internal
 export class NullTarget extends RenderTarget {
     // (undocumented)
+    protected readonly [_implementationProhibited]: undefined;
+    // (undocumented)
     get analysisFraction(): number;
     set analysisFraction(_fraction: number);
     // (undocumented)
@@ -7954,7 +7958,6 @@ export class OffScreenTarget extends Target {
 
 // @public
 export class OffScreenViewport extends Viewport {
-    // @internal
     protected constructor(target: RenderTarget);
     // (undocumented)
     static create(options: OffScreenViewportOptions): OffScreenViewport;
@@ -9915,82 +9918,91 @@ export interface RenderSystemDebugControl {
     resultsCallback?: GLTimerResultCallback;
 }
 
-// @internal
+// @public
 export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer {
+    // @internal (undocumented)
+    protected abstract readonly [_implementationProhibited]: unknown;
+    // @internal (undocumented)
     adjustPixelSizeForLOD(cssPixelSize: number): number;
-    // (undocumented)
+    // @internal (undocumented)
     abstract get analysisFraction(): number;
     abstract set analysisFraction(fraction: number);
-    // (undocumented)
+    // @internal (undocumented)
     get animationBranches(): AnimationBranchStates | undefined;
     set animationBranches(_transforms: AnimationBranchStates | undefined);
-    // (undocumented)
+    // @internal (undocumented)
     get antialiasSamples(): number;
     set antialiasSamples(_numSamples: number);
-    // (undocumented)
+    // @internal (undocumented)
     assignFrameStatsCollector(_collector: FrameStatsCollector): void;
-    // (undocumented)
+    // @internal (undocumented)
     abstract changeDecorations(decorations: Decorations): void;
-    // (undocumented)
+    // @internal (undocumented)
     abstract changeDynamics(dynamics?: GraphicList): void;
-    // (undocumented)
+    // @internal (undocumented)
     abstract changeRenderPlan(plan: RenderPlan): void;
-    // (undocumented)
+    // @internal (undocumented)
     abstract changeScene(scene: Scene): void;
-    // (undocumented)
+    // @internal (undocumented)
     collectStatistics(_stats: RenderMemory.Statistics): void;
-    // (undocumented)
+    // @internal (undocumented)
     createGraphicBuilder(options: CustomGraphicBuilderOptions | ViewportGraphicBuilderOptions): GraphicBuilder;
-    // (undocumented)
+    // @internal (undocumented)
     createPlanarClassifier(_properties?: ActiveSpatialClassifier): RenderPlanarClassifier | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     cssPixelsToDevicePixels(cssPixels: number, floor?: boolean): number;
-    // (undocumented)
+    // @internal (undocumented)
     get debugControl(): RenderTargetDebugControl | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     get devicePixelRatio(): number;
-    // (undocumented)
+    // @internal (undocumented)
     dispose(): void;
-    // (undocumented)
+    // @internal (undocumented)
     abstract drawFrame(sceneMilSecElapsed?: number): void;
-    // (undocumented)
+    // @internal (undocumented)
     getPlanarClassifier(_id: string): RenderPlanarClassifier | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     getTextureDrape(_id: Id64String): RenderTextureDrape | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     onBeforeRender(_viewport: Viewport, _setSceneNeedRedraw: (redraw: boolean) => void): void;
-    // (undocumented)
+    // @internal (undocumented)
     onResized(): void;
-    // (undocumented)
+    // @internal (undocumented)
     overrideFeatureSymbology(_ovr: FeatureSymbology.Overrides): void;
-    // (undocumented)
+    // @internal (undocumented)
     pickOverlayDecoration(_pt: XAndY): CanvasDecoration | undefined;
+    // @internal (undocumented)
     queryVisibleTileFeatures(_options: QueryTileFeaturesOptions, _iModel: IModelConnection, callback: QueryVisibleFeaturesCallback): void;
-    // @deprecated (undocumented)
+    // @internal (undocumented)
     readImage(_rect: ViewRect, _targetSize: Point2d, _flipVertically: boolean): ImageBuffer | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     readImageBuffer(_args?: ReadImageBufferArgs): ImageBuffer | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     readImageToCanvas(): HTMLCanvasElement;
+    // @internal (undocumented)
     abstract readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable: boolean): void;
-    // (undocumented)
+    // @internal (undocumented)
     abstract get renderSystem(): RenderSystem;
-    // (undocumented)
+    // @internal (undocumented)
     reset(): void;
+    // @internal (undocumented)
     abstract get screenSpaceEffects(): Iterable<string>;
     abstract set screenSpaceEffects(_effectNames: Iterable<string>);
-    // (undocumented)
+    // @internal (undocumented)
     setFlashed(_elementId: Id64String, _intensity: number): void;
-    // (undocumented)
+    // @internal (undocumented)
     setHiliteSet(_hilited: HiliteSet): void;
+    // @internal (undocumented)
     setRenderToScreen(_toScreen: boolean): HTMLCanvasElement | undefined;
-    // (undocumented)
+    // @internal (undocumented)
     abstract setViewRect(_rect: ViewRect, _temporary: boolean): void;
+    // @internal (undocumented)
     updateSolarShadows(_context: SceneContext | undefined): void;
-    // (undocumented)
+    // @internal (undocumented)
     abstract updateViewRect(): boolean;
+    // @internal (undocumented)
     abstract get viewRect(): ViewRect;
-    // (undocumented)
+    // @internal (undocumented)
     abstract get wantInvertBlackBackground(): boolean;
 }
 
@@ -10209,7 +10221,6 @@ export interface ScreenSpaceEffectSource {
 
 // @public
 export class ScreenViewport extends Viewport {
-    // @internal
     protected constructor(canvas: HTMLCanvasElement, parentDiv: HTMLDivElement, target: RenderTarget);
     protected addDecorations(decorations: Decorations): void;
     // @internal (undocumented)
@@ -11131,6 +11142,8 @@ export function synchronizeViewportViews(source: Viewport): SynchronizeViewports
 
 // @internal (undocumented)
 export abstract class Target extends RenderTarget implements RenderTargetDebugControl, WebGLDisposable {
+    // (undocumented)
+    protected readonly [_implementationProhibited]: undefined;
     protected constructor(rect?: ViewRect);
     // (undocumented)
     activeVolumeClassifierModelId?: Id64String;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -9973,7 +9973,7 @@ export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer
     pickOverlayDecoration(_pt: XAndY): CanvasDecoration | undefined;
     // @internal (undocumented)
     queryVisibleTileFeatures(_options: QueryTileFeaturesOptions, _iModel: IModelConnection, callback: QueryVisibleFeaturesCallback): void;
-    // @internal (undocumented)
+    // @internal @deprecated (undocumented)
     readImage(_rect: ViewRect, _targetSize: Point2d, _flipVertically: boolean): ImageBuffer | undefined;
     // @internal (undocumented)
     readImageBuffer(_args?: ReadImageBufferArgs): ImageBuffer | undefined;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -617,7 +617,7 @@ internal;RenderSkySphereParams
 public;class RenderSystem 
 public;RenderSystem
 beta;RenderSystemDebugControl
-internal;class RenderTarget 
+public;class RenderTarget 
 internal;RenderTargetDebugControl
 internal;class RenderTerrainGeometry 
 internal;class RenderTextureDrape 

--- a/common/changes/@itwin/core-frontend/pmc-public-viewport-constructor_2024-08-01-18-00.json
+++ b/common/changes/@itwin/core-frontend/pmc-public-viewport-constructor_2024-08-01-18-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Promote ScreenViewport and OffScreenViewport constructors.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/NoRenderApp.ts
+++ b/core/frontend/src/NoRenderApp.ts
@@ -12,6 +12,7 @@ import { AnimationBranchStates } from "./render/GraphicBranch";
 import { RenderSystem } from "./render/RenderSystem";
 import { RenderTarget } from "./render/RenderTarget";
 import { ViewRect } from "./common/ViewRect";
+import { _implementationProhibited } from "./common/internal/Symbols";
 
 /**
  * A RenderTarget for applications that must run in environments where WebGL is not present.
@@ -19,6 +20,7 @@ import { ViewRect } from "./common/ViewRect";
  * @internal
  */
 export class NullTarget extends RenderTarget {
+  protected override readonly [_implementationProhibited] = undefined;
   public get analysisFraction(): number { return 0; }
   public set analysisFraction(_fraction: number) { }
   public get renderSystem() { return undefined as any; }

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -1119,7 +1119,7 @@ export abstract class Viewport implements IDisposable, TileUser {
   protected initialize(): void {
   }
 
-  /** @internal */
+  /** @internal because subclasses must derive from ScreenViewport or OffScreenviewport. */
   protected constructor(target: RenderTarget) {
     this._target = target;
     target.assignFrameStatsCollector(this._frameStatsCollector);
@@ -3134,7 +3134,6 @@ export class ScreenViewport extends Viewport {
     logo.onmousemove = logo.onmousedown = logo.onmouseup = (ev) => ev.stopPropagation();
   }
 
-  /** @internal */
   protected constructor(canvas: HTMLCanvasElement, parentDiv: HTMLDivElement, target: RenderTarget) {
     super(target);
     this.canvas = canvas;
@@ -3724,7 +3723,6 @@ export class OffScreenViewport extends Viewport {
   protected _isAspectRatioLocked = false;
   private _drawingToSheetTransform?: Transform;
 
-  /** @internal */
   protected constructor(target: RenderTarget) {
     super(target);
   }

--- a/core/frontend/src/render/MockRender.ts
+++ b/core/frontend/src/render/MockRender.ts
@@ -28,6 +28,7 @@ import { RenderPlan } from "./RenderPlan";
 import { RenderAreaPattern, RenderGeometry, RenderSystem } from "./RenderSystem";
 import { RenderTarget } from "./RenderTarget";
 import { Scene } from "./Scene";
+import { _implementationProhibited } from "../common/internal/Symbols";
 
 /** Contains extensible mock implementations of the various components of a RenderSystem, intended for use in tests.
  * Use these for tests instead of the default RenderSystem wherever possible because:
@@ -44,6 +45,8 @@ import { Scene } from "./Scene";
 export namespace MockRender {
   /** @internal */
   export abstract class Target extends RenderTarget {
+    protected override readonly [_implementationProhibited] = undefined;
+
     protected constructor(private readonly _system: RenderSystem) { super(); }
 
     public get renderSystem(): RenderSystem { return this._system; }

--- a/core/frontend/src/render/RenderTarget.ts
+++ b/core/frontend/src/render/RenderTarget.ts
@@ -169,8 +169,9 @@ export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer
   /** `rect` is specified in *CSS* pixels. */
   /** @internal */
   public abstract readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable: boolean): void;
-  /** @deprecated in 3.x. use readImageBuffer */
-  /** @internal */
+  /** @deprecated in 3.x. use readImageBuffer
+   * @internal
+   */
   public readImage(_rect: ViewRect, _targetSize: Point2d, _flipVertically: boolean): ImageBuffer | undefined { return undefined; }
   /** @internal */
   public readImageBuffer(_args?: ReadImageBufferArgs): ImageBuffer | undefined { return undefined; }

--- a/core/frontend/src/render/RenderTarget.ts
+++ b/core/frontend/src/render/RenderTarget.ts
@@ -29,6 +29,7 @@ import { RenderSystem, RenderTextureDrape } from "./RenderSystem";
 import { Scene } from "./Scene";
 import { QueryTileFeaturesOptions, QueryVisibleFeaturesCallback } from "./VisibleFeature";
 import { ActiveSpatialClassifier } from "../SpatialClassifiersState";
+import { _implementationProhibited } from "../common/internal/Symbols";
 
 /** Used for debugging purposes, to toggle display of instanced or batched primitives.
  * @see [[RenderTargetDebugControl]].
@@ -69,20 +70,28 @@ export interface RenderTargetDebugControl {
   getRenderCommands(): Array<{ name: string, count: number }>;
 }
 
-/** A RenderTarget connects a [[Viewport]] to a WebGLRenderingContext to enable the viewport's contents to be displayed on the screen.
- * Application code rarely interacts directly with a RenderTarget - instead, it interacts with a Viewport which forwards requests to the implementation
- * of the RenderTarget.
- * @internal
+/** Connects a [[Viewport]] to a graphics renderer such as a [WebGLRenderingContext](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext)
+ * to enable the viewport's contents to be rendered to the screen or to an off-screen buffer.
+ * Application code never interacts directly with a `RenderTarget` - it interacts with the `Viewport`'s API which forwards requests to the `RenderTarget`.
+ * @public
  */
 export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer {
+  /** @internal */
+  protected abstract readonly [_implementationProhibited]: unknown;
+
+  /** @internal */
   public pickOverlayDecoration(_pt: XAndY): CanvasDecoration | undefined { return undefined; }
 
+  /** @internal */
   public abstract get renderSystem(): RenderSystem;
 
   /** NB: *Device pixels*, not CSS pixels! */
+  /** @internal */
   public abstract get viewRect(): ViewRect;
 
+  /** @internal */
   public get devicePixelRatio(): number { return 1; }
+  /** @internal */
   public cssPixelsToDevicePixels(cssPixels: number, floor = true): number {
     const pix = cssPixels * this.devicePixelRatio;
     return floor ? Math.floor(pix) : pix;
@@ -91,61 +100,93 @@ export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer
   /** Given the size of a logical pixel in meters, convert it to the size of a physical pixel in meters, if [[RenderSystem.dpiAwareLOD]] is `true`.
    * Used when computing LOD for graphics.
    */
+  /** @internal */
   public adjustPixelSizeForLOD(cssPixelSize: number): number {
     return this.renderSystem.dpiAwareLOD ? this.cssPixelsToDevicePixels(cssPixelSize, false) : cssPixelSize;
   }
 
+  /** @internal */
   public abstract get wantInvertBlackBackground(): boolean;
 
+  /** @internal */
   public abstract get analysisFraction(): number;
   public abstract set analysisFraction(fraction: number);
 
+  /** @internal */
   public get animationBranches(): AnimationBranchStates | undefined { return undefined; }
   public set animationBranches(_transforms: AnimationBranchStates | undefined) { }
 
+  /** @internal */
   public get antialiasSamples(): number { return 1; }
   public set antialiasSamples(_numSamples: number) { }
 
+  /** @internal */
   public assignFrameStatsCollector(_collector: FrameStatsCollector) { }
 
   /** Update the solar shadow map. If a SceneContext is supplied, shadows are enabled; otherwise, shadows are disabled. */
+  /** @internal */
   public updateSolarShadows(_context: SceneContext | undefined): void { }
+  /** @internal */
   public getPlanarClassifier(_id: string): RenderPlanarClassifier | undefined { return undefined; }
+  /** @internal */
   public createPlanarClassifier(_properties?: ActiveSpatialClassifier): RenderPlanarClassifier | undefined { return undefined; }
+  /** @internal */
   public getTextureDrape(_id: Id64String): RenderTextureDrape | undefined { return undefined; }
 
+  /** @internal */
   public createGraphicBuilder(options: CustomGraphicBuilderOptions | ViewportGraphicBuilderOptions) {
     return this.renderSystem.createGraphic(options);
   }
 
+  /** @internal */
   public dispose(): void { }
+  /** @internal */
   public reset(): void { }
+  /** @internal */
   public abstract changeScene(scene: Scene): void;
+  /** @internal */
   public abstract changeDynamics(dynamics?: GraphicList): void;
+  /** @internal */
   public abstract changeDecorations(decorations: Decorations): void;
+  /** @internal */
   public abstract changeRenderPlan(plan: RenderPlan): void;
+  /** @internal */
   public abstract drawFrame(sceneMilSecElapsed?: number): void;
+  /** @internal */
   public overrideFeatureSymbology(_ovr: FeatureSymbology.Overrides): void { }
+  /** @internal */
   public setHiliteSet(_hilited: HiliteSet): void { }
+  /** @internal */
   public setFlashed(_elementId: Id64String, _intensity: number): void { }
+  /** @internal */
   public onBeforeRender(_viewport: Viewport, _setSceneNeedRedraw: (redraw: boolean) => void): void { }
+  /** @internal */
   public abstract setViewRect(_rect: ViewRect, _temporary: boolean): void;
+  /** @internal */
   public onResized(): void { }
+  /** @internal */
   public abstract updateViewRect(): boolean; // force a RenderTarget viewRect to resize if necessary since last draw
   /** `rect` is specified in *CSS* pixels. */
+  /** @internal */
   public abstract readPixels(rect: ViewRect, selector: Pixel.Selector, receiver: Pixel.Receiver, excludeNonLocatable: boolean): void;
   /** @deprecated in 3.x. use readImageBuffer */
+  /** @internal */
   public readImage(_rect: ViewRect, _targetSize: Point2d, _flipVertically: boolean): ImageBuffer | undefined { return undefined; }
+  /** @internal */
   public readImageBuffer(_args?: ReadImageBufferArgs): ImageBuffer | undefined { return undefined; }
+  /** @internal */
   public readImageToCanvas(): HTMLCanvasElement { return document.createElement("canvas"); }
+  /** @internal */
   public collectStatistics(_stats: RenderMemory.Statistics): void { }
 
   /** Specify whether webgl content should be rendered directly to the screen.
    * If rendering to screen becomes enabled, returns the canvas to which to render the webgl content.
    * Returns undefined if rendering to screen becomes disabled, or is not supported by this RenderTarget.
    */
+  /** @internal */
   public setRenderToScreen(_toScreen: boolean): HTMLCanvasElement | undefined { return undefined; }
 
+  /** @internal */
   public get debugControl(): RenderTargetDebugControl | undefined { return undefined; }
 
   /** An ordered list of names of screen-space post-processing effects to be applied to the image produced by this target.
@@ -153,12 +194,14 @@ export abstract class RenderTarget implements IDisposable, RenderMemory.Consumer
    * This may have no effect if this target does not support screen-space effects.
    * @see [[RenderSystem.createScreenSpaceEffectBuilder]] to create and register new effects.
    */
+  /** @internal */
   public abstract get screenSpaceEffects(): Iterable<string>;
   public abstract set screenSpaceEffects(_effectNames: Iterable<string>);
 
   /** Implementation for [[Viewport.queryVisibleFeatures]]. Not intended for direct usage. The returned iterable remains valid only for the duration of the
    * Viewport.queryVisibleFeatures call.
    */
+  /** @internal */
   public queryVisibleTileFeatures(_options: QueryTileFeaturesOptions, _iModel: IModelConnection, callback: QueryVisibleFeaturesCallback): void {
     callback([]);
   }

--- a/core/frontend/src/render/webgl/Target.ts
+++ b/core/frontend/src/render/webgl/Target.ts
@@ -63,6 +63,7 @@ import { VisibleTileFeatures } from "./VisibleTileFeatures";
 import { FrameStatsCollector } from "../FrameStats";
 import { ActiveSpatialClassifier } from "../../SpatialClassifiersState";
 import { AnimationNodeId } from "../../common/internal/render/AnimationNodeId";
+import { _implementationProhibited } from "../../common/internal/Symbols";
 
 function swapImageByte(image: ImageBuffer, i0: number, i1: number) {
   const tmp = image.data[i0];
@@ -98,6 +99,7 @@ interface ReadPixelResources {
 
 /** @internal */
 export abstract class Target extends RenderTarget implements RenderTargetDebugControl, WebGLDisposable {
+  protected override readonly [_implementationProhibited] = undefined;
   public readonly graphics = new TargetGraphics();
   private _planarClassifiers?: PlanarClassifierMap;
   private _textureDrapes?: TextureDrapeMap;


### PR DESCRIPTION
Part of https://github.com/iTwin/itwinjs-backlog/issues/1103.

They both take a `RenderTarget`. Promote `RenderTarget` to public as an opaque type that `Viewport` subclasses can forward to `super`.