### PR TITLE
Recompute the agenda appearance overrides when Reset...

### DIFF
--- a/common/api/editor-frontend.api.md
+++ b/common/api/editor-frontend.api.md
@@ -235,6 +235,8 @@ export abstract class ModifyElementWithDynamicsTool extends ModifyElementTool im
     // (undocumented)
     protected _graphicsProvider?: DynamicGraphicsProvider;
     // (undocumented)
+    protected onAgendaModified(): Promise<void>;
+    // (undocumented)
     onCleanup(): Promise<void>;
     // (undocumented)
     onDynamicFrame(_ev: BeButtonEvent, context: DynamicsContext): void;

--- a/common/changes/@itwin/editor-frontend/modify-agenda-appearance_2024-08-06-12-26.json
+++ b/common/changes/@itwin/editor-frontend/modify-agenda-appearance_2024-08-06-12-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/editor/frontend/src/ModifyElementTool.ts
+++ b/editor/frontend/src/ModifyElementTool.ts
@@ -197,6 +197,12 @@ export abstract class ModifyElementWithDynamicsTool extends ModifyElementTool im
     await this._graphicsProvider.createGraphic(elemProps.category, elemProps.placement, geometry);
   }
 
+  protected override async onAgendaModified(): Promise<void> {
+    if (!this._firstResult)
+      this.updateAgendaAppearanceProvider(); // When Reset cycles between elements, recompute feature overrides...
+    return super.onAgendaModified();
+  }
+
   public override onDynamicFrame(_ev: BeButtonEvent, context: DynamicsContext): void {
     if (undefined !== this._graphicsProvider)
       this._graphicsProvider.addGraphic(context);


### PR DESCRIPTION
...advances through the HitList, changing the element being modified after dynamics is started.

Found using the extend element tool which makes the accepted element very transparent in order to clearly show when making the element shorter and still allow it to be located for snapping.

Dynamics starts as soon as an element is picked, if there are other extendable elements identified in that HitList, Reset allows you to cycle through those elements. When this happens the feature overrides to make the previous element transparent need to be cleared and applied to the newly accepted element.