### PR TITLE
Fix incorrect geometry for black text

### DIFF
--- a/common/changes/@itwin/core-common/pmc-fix-black-text-line_2024-08-08-12-48.json
+++ b/common/changes/@itwin/core-common/pmc-fix-black-text-line_2024-08-08-12-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix GeometryStreamBuilder.appendTextBlock producing incorrect geometry for black text.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/geometry/GeometryStream.ts
+++ b/core/common/src/geometry/GeometryStream.ts
@@ -340,9 +340,9 @@ export class GeometryStreamBuilder {
   public appendTextBlock(block: TextBlockGeometryProps): boolean {
     for (const entry of block.entries) {
       let result: boolean;
-      if (entry.text) {
+      if (undefined !== entry.text) {
         result = this.appendTextString(new TextString(entry.text));
-      } else if (entry.color) {
+      } else if (undefined !== entry.color) {
         if (entry.color === "subcategory") {
           result = this.appendSubCategoryChange(Id64.invalid);
         } else {


### PR DESCRIPTION
Black = 0 = falsy.
Fixes #7048.