### PR TITLE
resolve CVE-2022-25883

### DIFF
--- a/common/changes/@itwin/analytical-backend/nam-fix-cve_2024-08-08-17-48.json
+++ b/common/changes/@itwin/analytical-backend/nam-fix-cve_2024-08-08-17-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/analytical-backend"
+}

--- a/common/changes/@itwin/core-backend/nam-fix-cve_2024-08-08-17-48.json
+++ b/common/changes/@itwin/core-backend/nam-fix-cve_2024-08-08-17-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/presentation-backend/nam-fix-cve_2024-08-08-17-48.json
+++ b/common/changes/@itwin/presentation-backend/nam-fix-cve_2024-08-08-17-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
       nyc: ^15.1.0
       reflect-metadata: ^0.1.13
       rimraf: ^3.0.2
-      semver: ^7.3.5
+      semver: ^7.5.2
       sinon: ^17.0.1
       source-map-loader: ^4.0.0
       touch: ^3.1.0
@@ -73,7 +73,7 @@ importers:
       linebreak: 1.1.0
       multiparty: 4.2.1
       reflect-metadata: 0.1.13
-      semver: 7.3.5
+      semver: 7.5.4
       touch: 3.1.0
       ws: 7.5.10
     devDependencies:
@@ -1067,7 +1067,7 @@ importers:
       mocha: ^10.2.0
       nyc: ^15.1.0
       rimraf: ^3.0.2
-      semver: ^7.3.5
+      semver: ^7.5.2
       typescript: ~5.3.3
     devDependencies:
       '@itwin/build-tools': link:../../../tools/build
@@ -1086,7 +1086,7 @@ importers:
       mocha: 10.2.0
       nyc: 15.1.0
       rimraf: 3.0.2
-      semver: 7.3.5
+      semver: 7.5.4
       typescript: 5.3.3
 
   ../../domains/linear-referencing/backend:
@@ -2069,7 +2069,7 @@ importers:
       glob: ^10.3.12
       null-loader: ^4.0.1
       rimraf: ^3.0.2
-      semver: ^7.3.5
+      semver: ^7.5.2
       source-map-loader: ^4.0.0
       spdy: ^4.0.1
       stream-browserify: ^3.0.0
@@ -2086,7 +2086,7 @@ importers:
       '@itwin/express-server': link:../../core/express-server
       electron: 31.0.0
       express: 4.18.2
-      semver: 7.3.5
+      semver: 7.5.4
       spdy: 4.0.1
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
@@ -2251,7 +2251,7 @@ importers:
       rimraf: ^3.0.2
       rxjs: ^7.8.1
       rxjs-for-await: ^1.0.0
-      semver: ^7.3.5
+      semver: ^7.5.2
       sinon: ^17.0.1
       sinon-chai: ^3.7.0
       source-map-support: ^0.5.6
@@ -2261,7 +2261,7 @@ importers:
       object-hash: 1.3.1
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
-      semver: 7.3.5
+      semver: 7.5.4
     devDependencies:
       '@itwin/build-tools': link:../../tools/build
       '@itwin/core-backend': link:../../core/backend
@@ -10528,7 +10528,7 @@ packages:
       lodash: 4.17.21
       npmlog: 7.0.1
       rimraf: 5.0.5
-      semver: 7.3.5
+      semver: 7.6.0
       source-map-support: 0.5.6
       teen_process: 2.1.1
       uuid: 9.0.1
@@ -11819,20 +11819,12 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  /semver/7.3.5:
-    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-
   /semver/7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: false
 
   /semver/7.6.0:
     resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -110,7 +110,7 @@
     "linebreak": "^1.1.0",
     "multiparty": "^4.2.1",
     "reflect-metadata": "^0.1.13",
-    "semver": "^7.3.5",
+    "semver": "^7.5.2",
     "touch": "^3.1.0",
     "ws": "^7.5.10"
   },

--- a/domains/analytical/backend/package.json
+++ b/domains/analytical/backend/package.json
@@ -57,7 +57,7 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
-    "semver": "^7.3.5",
+    "semver": "^7.5.2",
     "typescript": "~5.3.3"
   },
   "TODO-dependencies": {

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -28,7 +28,7 @@
     "@itwin/express-server": "workspace:*",
     "electron": "^31.0.0",
     "express": "^4.18.2",
-    "semver": "^7.3.5",
+    "semver": "^7.5.2",
     "spdy": "^4.0.1"
   },
   "devDependencies": {

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -94,7 +94,7 @@
     "object-hash": "^1.3.1",
     "rxjs": "^7.8.1",
     "rxjs-for-await": "^1.0.0",
-    "semver": "^7.3.5"
+    "semver": "^7.5.2"
   },
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc"


### PR DESCRIPTION
Bump `semver` to `4.5.2` to address new high [CVE](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)