### PR TITLE
attempt to improve ao's default value

### DIFF
--- a/core/common/src/AmbientOcclusion.ts
+++ b/core/common/src/AmbientOcclusion.ts
@@ -34,8 +34,8 @@ export namespace AmbientOcclusion {
 
   /** Describes the properties with which ambient occlusion should be drawn. These properties correspond to a horizon-based ambient occlusion approach. */
   export class Settings implements Props {
-    private static _defaultBias: number = 0.25;
-    private static _defaultZLengthCap: number = 0.0025;
+    private static _defaultBias: number = 0.5;
+    private static _defaultZLengthCap: number = 0.00001385;
     private static _defaultMaxDistance: number = 10000.0;
     private static _defaultIntensity: number = 1.0;
     private static _defaultTexelStepSize: number = 1;

--- a/core/common/src/AmbientOcclusion.ts
+++ b/core/common/src/AmbientOcclusion.ts
@@ -35,7 +35,7 @@ export namespace AmbientOcclusion {
   /** Describes the properties with which ambient occlusion should be drawn. These properties correspond to a horizon-based ambient occlusion approach. */
   export class Settings implements Props {
     private static _defaultBias: number = 0.5;
-    private static _defaultZLengthCap: number = 0.00001385;
+    private static _defaultZLengthCap: number = 0.00002;
     private static _defaultMaxDistance: number = 10000.0;
     private static _defaultIntensity: number = 1.0;
     private static _defaultTexelStepSize: number = 1;

--- a/test-apps/display-test-app/src/frontend/AmbientOcclusion.ts
+++ b/test-apps/display-test-app/src/frontend/AmbientOcclusion.ts
@@ -69,8 +69,8 @@ export class AmbientOcclusionEditor {
       name: "Length Cap: ",
       id: "viewAttr_AOZLengthCap",
       min: "0.0",
-      step: "0.000025",
-      max: "0.25",
+      step: "0.00000005",
+      max: "0.003",
       value: "0.0",
       readout: "right",
       handler: (slider) => this.updateAmbientOcclusion((aoProps) => {


### PR DESCRIPTION
This pull request addresses the issue where the current Ambient Occlusion (AO) implementation has a noticeable "glow" effect. To resolve this, the following changes have been made:

1. **Changed Default Value of Z Length Cap**: Lowered the default value to reduce the "glow" effect.
https://github.com/iTwin/itwinjs-core/blob/e49833447653a3e98c332120d7070bfb823d0726/core/common/src/AmbientOcclusion.ts#L38

2. **Updated Slider Range and Step Value**: Adjusted the slider to accommodate the new Z length cap value more effectively.
https://github.com/iTwin/itwinjs-core/blob/e49833447653a3e98c332120d7070bfb823d0726/test-apps/display-test-app/src/frontend/AmbientOcclusion.ts#L72

3. **Modified Default Bias Value**: Tweaked the default bias value to enhance the AO effect without introducing artifacts.
https://github.com/iTwin/itwinjs-core/blob/e49833447653a3e98c332120d7070bfb823d0726/core/common/src/AmbientOcclusion.ts#L37

#### Before:
![image](https://github.com/user-attachments/assets/270f585a-e2f6-4a94-b695-17b248f866b4)

#### After:
![Snipaste_2024-08-08_14-29-18](https://github.com/user-attachments/assets/1f31e795-c072-4900-8b06-d72467e7a0a7)

