### PR TITLE
suppress GHSA-8hc4-vh64-cxmj

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -5,9 +5,7 @@
   "globalPeerDependencyRules": {
     "ignoreMissing": ["@babel/core", "@types/node", "@typescript-eslint/parser"]
   },
-  "globalOverrides": {
-    "jsdom@19>ws": "^8.17.1" // https://github.com/advisories/GHSA-3h5v-q93c-6h6q > jsdom@19.0.0 > ws@8.16.0
-  },
+  "globalOverrides": {},
   // A list of temporary advisories excluded from the High and Critical list.
   // Warning this should only be used as a temporary measure to avoid build failures
   // for development dependencies only.
@@ -17,7 +15,9 @@
   "unsupportedPackageJsonSettings": {
     "pnpm": {
       "auditConfig": {
-        "ignoreCves": []
+        "ignoreCves": [
+          "CVE-2024-39338" // https://github.com/advisories/GHSA-8hc4-vh64-cxmj @itwin/object-storage-core@2.2.4 > axios@1.7.3
+        ]
       }
     }
   }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,8 +1,5 @@
 lockfileVersion: 5.4
 
-overrides:
-  jsdom@19>ws: ^8.17.1
-
 importers:
 
   .:
@@ -4039,7 +4036,7 @@ packages:
       debug: 4.3.6
       espree: 9.6.1
       globals: 13.24.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -4121,11 +4118,11 @@ packages:
       reflect-metadata: 0.1.13
     dev: false
 
-  /@itwin/core-common/4.8.0_67wltvhdskk2oee2c3z2o4tfly:
-    resolution: {integrity: sha512-C/gIZMtWt9GYRHZGgsVDOfRSg2UR0XA2o/EjR2ivCTFOzzD/YJ2yL26JB6g3k94ViRkOQhUc4wQPzjau7O30Yw==}
+  /@itwin/core-common/4.8.1_67wltvhdskk2oee2c3z2o4tfly:
+    resolution: {integrity: sha512-dIfw0ly+JFM83+mIQQ5xZ5WImazcjCBFuClTE8Fc5LMfFTe/Jtbj3nwA7aD7FcpuwtnV6kp4ykqrA5SoEz8Byg==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.8.0
-      '@itwin/core-geometry': ^4.8.0
+      '@itwin/core-bentley': ^4.8.1
+      '@itwin/core-geometry': ^4.8.1
     dependencies:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-geometry': link:../../core/geometry
@@ -4335,7 +4332,7 @@ packages:
     dependencies:
       '@itwin/certa': link:../../tools/certa
       '@itwin/core-bentley': link:../../core/bentley
-      '@itwin/core-common': 4.8.0_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/core-common': 4.8.1_67wltvhdskk2oee2c3z2o4tfly
       '@itwin/service-authorization': 1.2.2_67wltvhdskk2oee2c3z2o4tfly
       '@playwright/test': 1.41.2
       dotenv: 10.0.0
@@ -4364,7 +4361,7 @@ packages:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
     dependencies:
       '@itwin/core-bentley': link:../../core/bentley
-      '@itwin/core-common': 4.8.0_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/core-common': 4.8.1_67wltvhdskk2oee2c3z2o4tfly
       got: 11.8.6
       jsonwebtoken: 9.0.2
       jwks-rsa: 2.1.5
@@ -4379,7 +4376,7 @@ packages:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
     dependencies:
       '@itwin/core-bentley': link:../../core/bentley
-      '@itwin/core-common': 4.8.0_67wltvhdskk2oee2c3z2o4tfly
+      '@itwin/core-common': 4.8.1_67wltvhdskk2oee2c3z2o4tfly
       got: 12.6.1
       jsonwebtoken: 9.0.2
       jwks-rsa: 2.1.5
@@ -5294,7 +5291,7 @@ packages:
       debug: 4.3.6
       eslint: 8.56.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.6.3
       ts-api-utils: 1.3.0_typescript@5.3.3
@@ -6386,7 +6383,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001651
-      electron-to-chromium: 1.5.5
+      electron-to-chromium: 1.5.6
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0_browserslist@4.23.3
 
@@ -7423,8 +7420,8 @@ packages:
       type-fest: 2.19.0
     dev: false
 
-  /electron-to-chromium/1.5.5:
-    resolution: {integrity: sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA==}
+  /electron-to-chromium/1.5.6:
+    resolution: {integrity: sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==}
 
   /electron/31.0.0:
     resolution: {integrity: sha512-yJMhwu5NVqor7h5mt65uKtBsjSAD7NiRwNCigK8xAlJMaP0X2FKipEzQocOzusy7E0dny4gkTgOTATy+ucDtjw==}
@@ -8095,7 +8092,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.24.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -8794,7 +8791,7 @@ packages:
       dir-glob: 3.0.1
       fast-glob: 3.3.2
       glob: 7.2.3
-      ignore: 5.3.1
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -8806,7 +8803,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.1
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -8816,7 +8813,7 @@ packages:
     dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.1
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
     dev: false
@@ -9148,8 +9145,8 @@ packages:
     resolution: {integrity: sha512-gQQmIznCETPLEzfg1UH4Cs2oRq+HBPl8quroEUNXT8oybEG7/0lqI3dGgDSRry6B9HcCXw3PVkFFS0FF3CMddg==}
     dev: true
 
-  /ignore/5.3.1:
-    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
+  /ignore/5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
   /import-fresh/3.3.0:
@@ -10708,7 +10705,7 @@ packages:
       find-up: 4.1.0
       foreground-child: 2.0.0
       get-package-type: 0.1.0
-      glob: 7.2.0
+      glob: 7.2.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-hook: 3.0.0
       istanbul-lib-instrument: 4.0.3


### PR DESCRIPTION
temporarily suppress https://github.com/advisories/GHSA-8hc4-vh64-cxmj 
remove old global override for a cve that we resolved