### PR TITLE
Allow async methods on worker proxy

### DIFF
--- a/common/changes/@itwin/core-frontend/MathieuM-asyncWorker_2024-08-15-19-04.json
+++ b/common/changes/@itwin/core-frontend/MathieuM-asyncWorker_2024-08-15-19-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/worker/WorkerProxy.test.ts
+++ b/core/frontend/src/test/worker/WorkerProxy.test.ts
@@ -45,4 +45,13 @@ describe("WorkerProxy", () => {
 
     worker.terminate();
   });
+
+  it("awaits on worker proxy async operation", async () => {
+    const worker = createWorker();
+    const asyncOpTime = await worker.someLongRunningAsyncOperation();
+    const syncOpTime = await worker.someFastSynchronousOperation();
+
+    expect(asyncOpTime).to.be.lessThan(syncOpTime);
+    worker.terminate();
+  });
 });

--- a/core/frontend/src/test/worker/WorkerProxy.test.ts
+++ b/core/frontend/src/test/worker/WorkerProxy.test.ts
@@ -46,12 +46,15 @@ describe("WorkerProxy", () => {
     worker.terminate();
   });
 
-  it("awaits on worker proxy async operation", async () => {
+  it.only("awaits on worker proxy async operation", async () => {
     const worker = createWorker();
-    const asyncOpTime = await worker.someLongRunningAsyncOperation();
-    const syncOpTime = await worker.someFastSynchronousOperation();
+    const asyncVeryLongOpPromise = worker.someVeryLongRunningAsyncOperation();
+    const asyncLongOpPromise = worker.someLongRunningAsyncOperation();
+    const syncOpPromise = worker.someFastSynchronousOperation();
 
-    expect(asyncOpTime).to.be.lessThan(syncOpTime);
+    const tasksEndDate = await Promise.all([asyncVeryLongOpPromise, asyncLongOpPromise, syncOpPromise]);
+    expect(tasksEndDate[2]).to.be.lessThan(tasksEndDate[1]);
+    expect(tasksEndDate[1]).to.be.lessThan(tasksEndDate[0]);
     worker.terminate();
   });
 });

--- a/core/frontend/src/test/worker/WorkerProxy.test.ts
+++ b/core/frontend/src/test/worker/WorkerProxy.test.ts
@@ -66,7 +66,7 @@ describe("WorkerProxy", () => {
     const first = await worker.someVeryLongRunningAsyncOperation();
     const second = await worker.someLongRunningAsyncOperation();
     const third = await worker.someFastSynchronousOperation();
-    
+
     expect(first).to.be.lessThan(second);
     expect(second).to.be.lessThan(third);
   });

--- a/core/frontend/src/test/worker/WorkerProxy.test.ts
+++ b/core/frontend/src/test/worker/WorkerProxy.test.ts
@@ -46,7 +46,7 @@ describe("WorkerProxy", () => {
     worker.terminate();
   });
 
-  it.only("returns results out of sequence if caller does not await each operation", async () => {
+  it("returns results out of sequence if caller does not await each operation", async () => {
     const worker = createWorker();
 
     const [slowest, slow, fast] = await Promise.all([
@@ -60,7 +60,7 @@ describe("WorkerProxy", () => {
     worker.terminate();
   });
 
-  it.only("returns results in sequence if caller awaits each operation", async () => {
+  it("returns results in sequence if caller awaits each operation", async () => {
     const worker = createWorker();
 
     const first = await worker.someVeryLongRunningAsyncOperation();

--- a/core/frontend/src/test/worker/test-worker.ts
+++ b/core/frontend/src/test/worker/test-worker.ts
@@ -24,6 +24,7 @@ export interface TestWorker {
   throwString(): never;
   setTransfer(wantTransfer: boolean): undefined;
   createGraphic(context: WorkerGraphicDescriptionContextProps): WorkerGraphic;
+  someVeryLongRunningAsyncOperation(): Promise<number>;
   someLongRunningAsyncOperation(): Promise<number>;
   someFastSynchronousOperation(): number;
 }
@@ -88,6 +89,10 @@ registerWorker<TestWorker>({
     };
   },
 
+  someVeryLongRunningAsyncOperation: async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    return new Date().getTime();
+  },
   someLongRunningAsyncOperation: async () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 5));
     return new Date().getTime();

--- a/core/frontend/src/test/worker/test-worker.ts
+++ b/core/frontend/src/test/worker/test-worker.ts
@@ -24,6 +24,8 @@ export interface TestWorker {
   throwString(): never;
   setTransfer(wantTransfer: boolean): undefined;
   createGraphic(context: WorkerGraphicDescriptionContextProps): WorkerGraphic;
+  someLongRunningAsyncOperation(): Promise<number>;
+  someFastSynchronousOperation(): number;
 }
 
 let doTransfer = false;
@@ -84,5 +86,13 @@ registerWorker<TestWorker>({
       },
       transfer: Array.from(transferables),
     };
+  },
+
+  someLongRunningAsyncOperation: async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+    return new Date().getTime();
+  },
+  someFastSynchronousOperation: () => {
+    return new Date().getTime();
   },
 });

--- a/core/frontend/src/test/worker/test-worker.ts
+++ b/core/frontend/src/test/worker/test-worker.ts
@@ -38,6 +38,15 @@ function maybeTransfer<T>(result: T): T | { result: T, transfer: Transferable[] 
   return { result, transfer: [] };
 }
 
+let globalTickCounter = 0;
+
+async function waitNTicks(nTicks: number): Promise<void> {
+  let counter = 0;
+  while (++counter < nTicks) {
+    await new Promise<void>((resolve: any) => setTimeout(resolve, 1));
+  }
+}
+
 registerWorker<TestWorker>({
   zero: () => maybeTransfer("zero"),
   one: (arg: string) => maybeTransfer(arg),
@@ -90,14 +99,14 @@ registerWorker<TestWorker>({
   },
 
   someVeryLongRunningAsyncOperation: async () => {
-    await new Promise<void>((resolve) => setTimeout(resolve, 10));
-    return new Date().getTime();
+    await waitNTicks(10);
+    return ++globalTickCounter;
   },
   someLongRunningAsyncOperation: async () => {
-    await new Promise<void>((resolve) => setTimeout(resolve, 5));
-    return new Date().getTime();
+    await waitNTicks(5);
+    return ++globalTickCounter;
   },
   someFastSynchronousOperation: () => {
-    return new Date().getTime();
+    return ++globalTickCounter;
   },
 });

--- a/core/frontend/src/workers/RegisterWorker.ts
+++ b/core/frontend/src/workers/RegisterWorker.ts
@@ -30,7 +30,10 @@ export function registerWorker<T>(impl: WorkerImplementation<T>): void {
       assert(typeof req === "object" && "operation" in req && "payload" in req && "msgId" in req);
       const func = (impl as any)[req.operation];
       assert(typeof func === "function");
-      const ret = func.constructor.name === "AsyncFunction" ? await func(req.payload) : func(req.payload);
+      let ret = func(req.payload);
+      if (ret instanceof Promise) {
+        ret = await ret;
+      }
       if (typeof ret === "object" && "transfer" in ret)
         postMessage({ result: ret.result, msgId }, { transfer: ret.transfer });
       else

--- a/core/frontend/src/workers/RegisterWorker.ts
+++ b/core/frontend/src/workers/RegisterWorker.ts
@@ -23,14 +23,14 @@ interface WorkerRequest {
  * @beta
  */
 export function registerWorker<T>(impl: WorkerImplementation<T>): void {
-  onmessage = (e: MessageEvent) => {
+  onmessage = async (e: MessageEvent) => {
     const req = e.data as WorkerRequest;
     const msgId = req.msgId;
     try {
       assert(typeof req === "object" && "operation" in req && "payload" in req && "msgId" in req);
       const func = (impl as any)[req.operation];
       assert(typeof func === "function");
-      const ret = func(req.payload);
+      const ret = func.constructor.name === "AsyncFunction" ? await func(req.payload) : func(req.payload);
       if (typeof ret === "object" && "transfer" in ret)
         postMessage({ result: ret.result, msgId }, { transfer: ret.transfer });
       else


### PR DESCRIPTION
Adding async support to enable worker proxy so we can run async operation like fetch().  In my case, it is a large geojson stream that would like to avoid moving from the the main thread to the worker thread.