### PR TITLE
Added support for CTE in subquery for the command "PRAGMA parseTree"

### DIFF
--- a/common/api/ecsql-common.api.md
+++ b/common/api/ecsql-common.api.md
@@ -1085,13 +1085,13 @@ export abstract class StatementExpr extends Expr {
 
 // @alpha
 export class SubqueryExpr extends ValueExpr {
-    constructor(query: SelectStatementExpr);
+    constructor(query: SelectStatementExpr | CteExpr);
     // (undocumented)
     get children(): Expr[];
     // (undocumented)
     static deserialize(node: NativeECSqlParseNode): SubqueryExpr;
     // (undocumented)
-    readonly query: SelectStatementExpr;
+    readonly query: SelectStatementExpr | CteExpr;
     // (undocumented)
     static readonly type = ExprType.Subquery;
     // (undocumented)

--- a/common/changes/@itwin/core-backend/Soham-test_changes_2024-08-20-15-22.json
+++ b/common/changes/@itwin/core-backend/Soham-test_changes_2024-08-20-15-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added support for CTE in subquery for the command \"PRAGMA parseTree\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/ecsql-common/Soham-test_changes_2024-08-20-15-22.json
+++ b/common/changes/@itwin/ecsql-common/Soham-test_changes_2024-08-20-15-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecsql-common",
+      "comment": "Added support for CTE in subquery for the command \"PRAGMA parseTree\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecsql-common"
+}

--- a/core/backend/src/test/ecdb/ECSqlAst.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlAst.test.ts
@@ -290,8 +290,16 @@ describe("ECSql Abstract Syntax Tree", () => {
         expectedECSql: "SELECT IIF(EXISTS(SELECT 1), 'True', 'False')",
       },
       {
+        orignalECSql: "SELECT IIF(EXISTS(WITH temp(x) AS (SELECT 1) SELECT * FROM temp), 'True', 'False')",
+        expectedECSql: "SELECT IIF(EXISTS(WITH [temp]([x]) AS (SELECT 1) SELECT [temp].[x] FROM [temp]), 'True', 'False')",
+      },
+      {
         orignalECSql: "SELECT IIF(NOT EXISTS(SELECT 1), 'True', 'False')",
         expectedECSql: "SELECT IIF((NOT EXISTS(SELECT 1)), 'True', 'False')",
+      },
+      {
+        orignalECSql: "SELECT IIF(NOT EXISTS(WITH temp(x) AS (SELECT 1) SELECT * FROM temp), 'True', 'False')",
+        expectedECSql: "SELECT IIF((NOT EXISTS(WITH [temp]([x]) AS (SELECT 1) SELECT [temp].[x] FROM [temp])), 'True', 'False')",
       },
     ];
     for (const test of tests) {
@@ -607,6 +615,10 @@ describe("ECSql Abstract Syntax Tree", () => {
         expectedECSql: "SELECT (SELECT [b].[ECInstanceId] FROM [ECDbMeta].[ECPropertyDef] [b]) [S] FROM [ECDbMeta].[ECClassDef] [a]",
       },
       {
+        orignalECSql: "SELECT (WITH C(iD) AS (SELECT b.ECInstanceId FROM meta.ECPropertyDef b) SELECT * FROM C) AS S  FROM [ECDbMeta].[ECClassDef] a",
+        expectedECSql: "SELECT (WITH [C]([iD]) AS (SELECT [b].[ECInstanceId] FROM [ECDbMeta].[ECPropertyDef] [b]) SELECT [C].[iD] FROM [C]) [S] FROM [ECDbMeta].[ECClassDef] [a]",
+      },
+      {
         orignalECSql: "SELECT (SELECT 1 UNION SELECT 2) FROM meta.ECClassDef a",
         expectedECSql: "SELECT (SELECT 1 UNION SELECT 2) FROM [ECDbMeta].[ECClassDef] [a]",
       },
@@ -614,7 +626,10 @@ describe("ECSql Abstract Syntax Tree", () => {
         orignalECSql: "SELECT  1 FROM [ECDbMeta].[ECClassDef] [a] WHERE (SELECT [b].[ECInstanceId] FROM meta.ECPropertyDef b) = 1",
         expectedECSql: "SELECT 1 FROM [ECDbMeta].[ECClassDef] [a] WHERE ((SELECT [b].[ECInstanceId] FROM [ECDbMeta].[ECPropertyDef] [b]) = 1)",
       },
-
+      {
+        orignalECSql: "SELECT  1 FROM [ECDbMeta].[ECClassDef] [a] WHERE (WITH temp(Id) AS (SELECT [b].[ECInstanceId] FROM meta.ECPropertyDef b) SELECT * FROM temp) = 1",
+        expectedECSql: "SELECT 1 FROM [ECDbMeta].[ECClassDef] [a] WHERE ((WITH [temp]([Id]) AS (SELECT [b].[ECInstanceId] FROM [ECDbMeta].[ECPropertyDef] [b]) SELECT [temp].[Id] FROM [temp]) = 1)",
+      },
     ];
     for (const test of tests) {
       assert.equal(test.expectedECSql, await toNormalizeECSql(test.orignalECSql));

--- a/core/ecsql/common/src/ECSqlAst.ts
+++ b/core/ecsql/common/src/ECSqlAst.ts
@@ -1349,7 +1349,7 @@ export class SelectExpr extends Expr {
  */
 export class SubqueryExpr extends ValueExpr {
   public static readonly type = ExprType.Subquery;
-  public constructor(public readonly query: SelectStatementExpr) {
+  public constructor(public readonly query: SelectStatementExpr | CteExpr) {
     super(SubqueryExpr.type);
   }
   public override get children(): Expr[] {
@@ -1359,7 +1359,11 @@ export class SubqueryExpr extends ValueExpr {
     if (node.id !== NativeExpIds.Subquery) {
       throw new Error(`Parse node is 'node.id !== NativeExpIds.Subquery'. ${JSON.stringify(node)}`);
     }
-    return new SubqueryExpr(SelectStatementExpr.deserialize(node.query as NativeECSqlParseNode));
+    if(node.query.id === NativeExpIds.SelectStatement)
+      return new SubqueryExpr(SelectStatementExpr.deserialize(node.query as NativeECSqlParseNode));
+    if(node.query.id === NativeExpIds.CommonTable)
+      return new SubqueryExpr(CteExpr.deserialize(node.query as NativeECSqlParseNode));
+    throw new Error(`Parse query node is 'node.query.id !== NativeExpIds.SelectStatement' and 'node.query.id !== NativeExpIds.CommonTable'. ${JSON.stringify(node.query)}`);
   }
   public writeTo(writer: ECSqlWriter): void {
     writer.append("(");


### PR DESCRIPTION
This is a following PR for the imodel-native PR https://github.com/iTwin/imodel-native/pull/836