### PR TITLE
Fix `error` metadata being overwritten in logs

### DIFF
--- a/common/changes/@itwin/core-backend/master_2024-08-23-11-20.json
+++ b/common/changes/@itwin/core-backend/master_2024-08-23-11-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/rpc/web/response.ts
+++ b/core/backend/src/rpc/web/response.ts
@@ -157,7 +157,7 @@ function logResponse(request: SerializedRpcRequest, statusCode: number, resultOb
     path: request.path,
     operation: request.operation,
     statusCode,
-    error: resultObj instanceof Error ? resultObj : undefined,
+    errorObj: resultObj instanceof Error ? resultObj : undefined,
   };
 
   if (statusCode < 400)


### PR DESCRIPTION
At some point, the value of the `error` metadata property is being overwritten to `true`, and as a result, the original value is not available in telemetry.