### PR TITLE
Change MapLayerImageryProvider.supportsMapFeatureInfo from alpha to public

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -6416,7 +6416,7 @@ export abstract class MapLayerImageryProvider {
     protected readonly _settings: ImageMapLayerSettings;
     // @internal (undocumented)
     get status(): MapLayerImageryProviderStatus;
-    // @alpha (undocumented)
+    // (undocumented)
     get supportsMapFeatureInfo(): boolean;
     // @internal (undocumented)
     get tileSize(): number;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -6416,7 +6416,7 @@ export abstract class MapLayerImageryProvider {
     protected readonly _settings: ImageMapLayerSettings;
     // @internal (undocumented)
     get status(): MapLayerImageryProviderStatus;
-    // (undocumented)
+    // @public
     get supportsMapFeatureInfo(): boolean;
     // @internal (undocumented)
     get tileSize(): number;

--- a/common/changes/@itwin/core-frontend/wm-supportsmapfeatureinfo-beta_2024-09-09-12-49.json
+++ b/common/changes/@itwin/core-frontend/wm-supportsmapfeatureinfo-beta_2024-09-09-12-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Change MapLayerImageryProvider.supportsMapFeatureInfo from alpha to beta",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/wm-supportsmapfeatureinfo-beta_2024-09-09-12-49.json
+++ b/common/changes/@itwin/core-frontend/wm-supportsmapfeatureinfo-beta_2024-09-09-12-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Change MapLayerImageryProvider.supportsMapFeatureInfo from alpha to beta",
+      "comment": "Change MapLayerImageryProvider.supportsMapFeatureInfo from alpha to public",
       "type": "none"
     }
   ],

--- a/core/frontend/src/tile/map/MapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryProvider.ts
@@ -67,7 +67,7 @@ export abstract class MapLayerImageryProvider {
   /** @internal */
   public get status() { return this._status; }
 
-  /** @alpha */
+  /** @beta */
   public get supportsMapFeatureInfo() { return false; }
 
   public resetStatus() { this.setStatus(MapLayerImageryProviderStatus.Valid); }

--- a/core/frontend/src/tile/map/MapLayerImageryProvider.ts
+++ b/core/frontend/src/tile/map/MapLayerImageryProvider.ts
@@ -67,8 +67,12 @@ export abstract class MapLayerImageryProvider {
   /** @internal */
   public get status() { return this._status; }
 
-  /** @beta */
-  public get supportsMapFeatureInfo() { return false; }
+  /** Determine if this provider supports map feature info.
+   * For example, this can be used to show the map feature info tool only when a provider is registered to support it.
+   * @returns true if provider supports map feature info else return false.
+   * @public
+   */
+  public get supportsMapFeatureInfo(): boolean { return false; }
 
   public resetStatus() { this.setStatus(MapLayerImageryProviderStatus.Valid); }
 


### PR DESCRIPTION
This getter is needed in @itwin/map-layers package of viewer-components-react to show the map feature info tool only when a provider is registered to support it.