### PR TITLE
Update BlobContainer.TokenProps interface

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -446,6 +446,7 @@ export namespace BlobContainer {
         ownerGuid?: GuidString;
     }
     export interface TokenProps {
+        baseUri?: string;
         expiration: Date;
         metadata: Metadata;
         provider: Provider;

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -446,7 +446,7 @@ export namespace BlobContainer {
         ownerGuid?: GuidString;
     }
     export interface TokenProps {
-        baseUri?: string;
+        baseUri: string;
         expiration: Date;
         metadata: Metadata;
         provider: Provider;

--- a/common/changes/@itwin/core-backend/update-tokenProps-interface_2024-09-09-17-51.json
+++ b/common/changes/@itwin/core-backend/update-tokenProps-interface_2024-09-09-17-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Optional base uri added to TokenProps interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/update-tokenProps-interface_2024-09-09-19-26.json
+++ b/common/changes/@itwin/core-backend/update-tokenProps-interface_2024-09-09-19-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "base uri added to BlobContainer.TokenProps interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/BlobContainerService.ts
+++ b/core/backend/src/BlobContainerService.ts
@@ -84,7 +84,7 @@ export namespace BlobContainer {
     /** Metadata of the container. */
     metadata: Metadata;
     /** Base URI of container */
-    baseUri?: string;
+    baseUri: string;
   }
 
   /** The URI and Id of the container. */

--- a/core/backend/src/BlobContainerService.ts
+++ b/core/backend/src/BlobContainerService.ts
@@ -83,6 +83,8 @@ export namespace BlobContainer {
     expiration: Date;
     /** Metadata of the container. */
     metadata: Metadata;
+    /** Base URI of container */
+    baseUri?: string;
   }
 
   /** The URI and Id of the container. */

--- a/example-code/snippets/src/backend/AzuriteTest.ts
+++ b/example-code/snippets/src/backend/AzuriteTest.ts
@@ -219,6 +219,7 @@ export namespace AzuriteTest {
         token: sasUrl.split("?")[1],
         provider: "azure",
         expiration: expiresOn,
+        baseUri: azCont.url,
       };
     },
   };

--- a/full-stack-tests/backend/src/integration/AzuriteTest.ts
+++ b/full-stack-tests/backend/src/integration/AzuriteTest.ts
@@ -239,6 +239,7 @@ export namespace AzuriteTest {
         token: sasUrl.split("?")[1],
         provider: "azure",
         expiration: expiresOn,
+        baseUri:azCont.url,
       };
     },
   };

--- a/full-stack-tests/core/src/backend/AzuriteTest.ts
+++ b/full-stack-tests/core/src/backend/AzuriteTest.ts
@@ -219,6 +219,7 @@ export namespace AzuriteTest {
         token: sasUrl.split("?")[1],
         provider: "azure",
         expiration: expiresOn,
+        baseUri: azCont.url,
       };
     },
   };


### PR DESCRIPTION
ContainerService.requestToken() returns TokenProps, inside the TokenProps, base uri seems to be missing. 

base uri points to the location where the actual workspace container lives, it is required for every operation. Internal api (storage-container) also return base uri, we just need to expose it through interface and add it to response. 