### PR TITLE
Cancel tile magnification in children if they no longer meet the magnification criterion

### DIFF
--- a/core/common/src/tile/TileMetadata.ts
+++ b/core/common/src/tile/TileMetadata.ts
@@ -39,6 +39,7 @@ export interface TileContentMetadata {
   readonly contentRange: Range3d;
   readonly isLeaf: boolean;
   readonly sizeMultiplier?: number;
+  readonly disallowMagnification?: boolean;
   readonly emptySubRangeMask: number;
 }
 
@@ -773,7 +774,7 @@ export function computeChildTileProps(parent: TileMetadata, idProvider: ContentI
     return { children, numEmpty };
 
   // One child, same volume as parent, but higher-resolution.
-  if (undefined !== parent.sizeMultiplier) {
+  if (!parent.disallowMagnification && undefined !== parent.sizeMultiplier) {
     const sizeMultiplier = parent.sizeMultiplier * 2;
     const contentId = idProvider.idFromParentAndMultiplier(parent.contentId, sizeMultiplier);
     children.push({
@@ -926,6 +927,7 @@ export function decodeTileContentDescription(args: DecodeTileContentDescriptionA
     isLeaf,
     sizeMultiplier,
     emptySubRangeMask: header.emptySubRanges,
+    disallowMagnification: 0 !== (header.flags & ImdlFlags.DisallowMagnification),
   };
 }
 
@@ -978,6 +980,7 @@ export class TileMetadataReader {
       emptySubRangeMask: content.emptySubRangeMask,
       range: Range3d.fromJSON(props.range),
       contentId: props.contentId,
+      disallowMagnification: content.disallowMagnification,
     };
   }
 }

--- a/core/frontend/src/tile/ImdlReader.ts
+++ b/core/frontend/src/tile/ImdlReader.ts
@@ -132,6 +132,7 @@ export async function readImdlContent(args: ImdlReaderCreateArgs & { parseDocume
     readStatus: TileReadStatus.Success,
     isLeaf: content.isLeaf,
     sizeMultiplier: content.sizeMultiplier,
+    disallowMagnification: content.disallowMagnification,
     contentRange: content.contentRange.isNull ? undefined : content.contentRange,
     graphic,
     emptySubRangeMask: content.emptySubRangeMask,


### PR DESCRIPTION
Proposition to fix issue [1094](https://github.com/iTwin/itwinjs-backlog/issues/1094)

Prior to this change, a tile was candidate for magnification if the number of elements was lower than 100, however in certain cases, the number of elements does not reflect the actual complexity of the geometries contained inside a tile.

This could result in the production of overly large tiles, if the tile contains line style symbols that were not stroked initially if the tolerance was too high.

We propose to cancel the tile magnification if symbols start appearing in magificied child tiles and if the number of symbols exceed the maximum geometry count (100).

/*****/

Below is the evolution of the magnification for the model linked with issue 1094, and although it may not be the case for other models, here it would have been reasonable to "revert" the magnification decision as soon as the symbols were added. A alternative solution would be to disallow magnification if a tile contains stroke line styles, but this is perhaps a bit too conservative as it could restrict magnification for tiles that would have actually been valid candidates
 
-b-5-0-0-0-1:2199023256120, primitive count:77, quantized:1, allow magnification: 1, num included elements:28, num excluded elements: 0, info: estimated triangle count: 0, geometry count: 28, 

-b-5-0-0-0-2:2199023256120, primitive count:67201, quantized:1, allow magnification: 0, num included elements:28, num excluded elements: 0, info: estimated triangle count: 0, geometry count: 4605, 
// Here some elements start appearing, but since the primitive count is not yet too high, we can still mitigate the issue by opting for subdivision instead of magnification

-b-5-0-0-0-4:2199023256120, primitive count:125856, quantized:1, allow magnification: 0, num included elements:28, num excluded elements: 0, info: estimated triangle count: 0, geometry count: 8157, 

-b-5-0-0-0-400:2199023256120, primitive count:3662729, quantized:0, allow magnification: 0, num included elements:28, num excluded elements: 0, info: estimated triangle count: 0, geometry count: 18482,
 
