### PR TITLE
New AccuDraw shortcut to rotate compass to closest point on an element (perpendicular).

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -697,23 +697,21 @@ export class AccuDrawRotateAxesTool extends AccuDrawShortcutsTool {
     // (undocumented)
     aboutCurrentZ: boolean;
     // (undocumented)
+    protected get allowShortcut(): boolean;
+    // (undocumented)
     doManipulation(ev: BeButtonEvent | undefined, isMotion: boolean): boolean;
-    // (undocumented)
-    doManipulationStart(): void;
-    // (undocumented)
-    protected _immediateMode: boolean;
     // (undocumented)
     static get maxArgs(): number;
     // (undocumented)
-    onInstall(): Promise<boolean>;
-    // (undocumented)
-    onManipulationComplete(): AccuDrawFlags;
-    // (undocumented)
-    onPostInstall(): Promise<void>;
+    onManipulationStart(): void;
     // (undocumented)
     parseAndRun(...args: any[]): Promise<boolean>;
     // (undocumented)
     static toolId: string;
+    // (undocumented)
+    protected get wantActivateOnStart(): boolean;
+    // (undocumented)
+    protected get wantManipulationImmediate(): boolean;
 }
 
 // @internal (undocumented)
@@ -729,17 +727,17 @@ export class AccuDrawRotateElementTool extends AccuDrawShortcutsTool {
     // (undocumented)
     doManipulation(ev: BeButtonEvent | undefined, isMotion: boolean): boolean;
     // (undocumented)
-    doManipulationStart(): void;
-    // (undocumented)
-    moveOrigin: boolean;
-    // (undocumented)
-    onInstall(): Promise<boolean>;
-    // (undocumented)
     onManipulationComplete(): AccuDrawFlags;
+    // (undocumented)
+    onManipulationStart(): void;
     // (undocumented)
     static toolId: string;
     // (undocumented)
-    updateOrientation(snap: SnapDetail, vp: Viewport): boolean;
+    updateOrientation(snap: SnapDetail, viewport: ScreenViewport, _isMotion: boolean): boolean;
+    // (undocumented)
+    protected get wantActivateOnStart(): boolean;
+    // (undocumented)
+    protected get wantManipulationImmediate(): boolean;
 }
 
 // @internal (undocumented)
@@ -748,6 +746,23 @@ export class AccuDrawRotateFrontTool extends Tool {
     run(): Promise<boolean>;
     // (undocumented)
     static toolId: string;
+}
+
+// @internal (undocumented)
+export class AccuDrawRotatePerpendicularTool extends AccuDrawRotateElementTool {
+    // (undocumented)
+    protected _location?: {
+        point: Point3d;
+        viewport: ScreenViewport;
+    };
+    // (undocumented)
+    onManipulationComplete(): AccuDrawFlags;
+    // (undocumented)
+    static toolId: string;
+    // (undocumented)
+    updateOrientation(snap: SnapDetail, viewport: ScreenViewport, isMotion: boolean): boolean;
+    // (undocumented)
+    protected get wantExitOnDataButtonUp(): boolean;
 }
 
 // @internal (undocumented)
@@ -899,6 +914,8 @@ export class AccuDrawShortcuts {
     static rotateAxesByPoint(isSnapped: boolean, aboutCurrentZ: boolean): boolean;
     // (undocumented)
     static rotateCycle(): void;
+    // (undocumented)
+    static rotatePerpendicular(): Promise<boolean>;
     // (undocumented)
     static rotateToACS(): void;
     // (undocumented)
@@ -2620,15 +2637,11 @@ export class DefaultViewTouchTool extends ViewManip implements Animator {
 // @internal (undocumented)
 export class DefineACSByElementTool extends AccuDrawShortcutsTool {
     // (undocumented)
-    activateAccuDrawOnStart(): boolean;
-    // (undocumented)
     decorate(context: DecorateContext): void;
     // (undocumented)
     doManipulation(ev: BeButtonEvent | undefined, isMotion: boolean): boolean;
     // (undocumented)
-    doManipulationStart(): void;
-    // (undocumented)
-    onManipulationComplete(): AccuDrawFlags;
+    onManipulationStart(): void;
     // (undocumented)
     static toolId: string;
     // (undocumented)
@@ -2638,15 +2651,11 @@ export class DefineACSByElementTool extends AccuDrawShortcutsTool {
 // @internal (undocumented)
 export class DefineACSByPointsTool extends AccuDrawShortcutsTool {
     // (undocumented)
-    activateAccuDrawOnStart(): boolean;
-    // (undocumented)
     decorate(context: DecorateContext): void;
     // (undocumented)
     doManipulation(ev: BeButtonEvent | undefined, isMotion: boolean): boolean;
     // (undocumented)
-    doManipulationStart(): void;
-    // (undocumented)
-    onManipulationComplete(): AccuDrawFlags;
+    onManipulationStart(): void;
     // (undocumented)
     static toolId: string;
 }

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -9,6 +9,7 @@ internal;class;AccuDrawRotateAxesTool
 internal;class;AccuDrawRotateCycleTool
 internal;class;AccuDrawRotateElementTool
 internal;class;AccuDrawRotateFrontTool
+internal;class;AccuDrawRotatePerpendicularTool
 internal;class;AccuDrawRotateSideTool
 internal;class;AccuDrawRotateTopTool
 internal;class;AccuDrawRotateViewTool

--- a/common/changes/@itwin/core-frontend/accudraw-rotate-perpendicular_2024-09-13-13-54.json
+++ b/common/changes/@itwin/core-frontend/accudraw-rotate-perpendicular_2024-09-13-13-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/public/locales/en/CoreTools.json
+++ b/core/frontend/src/public/locales/en/CoreTools.json
@@ -326,6 +326,11 @@
           "FirstPoint": "Identify element to define rotation"
         }
       },
+      "RotatePerpendicular": {
+        "keyin": "accudraw rotate perpendicular",
+        "description": "Set AccuDraw rotation perpendicular to element",
+        "flyover": "Rotate Perpendicular To Element"
+      },
       "DefineACSByElement": {
         "keyin": "define acs byelement",
         "description": "Set view ACS from element",


### PR DESCRIPTION
[Addresses:](https://dev.azure.com/bentleycs/Civil-iTwin/_workitems/edit/1377994?src=WorkItemMention&src-action=artifact_link)

Rework AccuDrawShortcutsTool base class to address issues with shortcuts no longer working correctly when run with an active Tentative or AccuSnap.