### PR TITLE
Add `roundingError` to `GenericInstanceFilterRuleValue` and `PrimitiveValue`

### DIFF
--- a/common/api/appui-abstract.api.md
+++ b/common/api/appui-abstract.api.md
@@ -881,6 +881,7 @@ export namespace Primitives {
 export interface PrimitiveValue extends BasePropertyValue {
     // (undocumented)
     displayValue?: string;
+    roundingError?: number;
     // (undocumented)
     value?: Primitives.Value;
     // (undocumented)

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -3538,12 +3538,7 @@ export type GenericInstanceFilterRuleGroupOperator = "and" | "or";
 export type GenericInstanceFilterRuleOperator = "is-equal" | "is-not-equal" | "is-null" | "is-not-null" | "is-true" | "is-false" | "less" | "less-or-equal" | "greater" | "greater-or-equal" | "like";
 
 // @beta
-export interface GenericInstanceFilterRuleValue {
-    // (undocumented)
-    displayValue: string;
-    // (undocumented)
-    rawValue: GenericInstanceFilterRuleValue.Values;
-}
+export type GenericInstanceFilterRuleValue = GenericInstanceFilterRuleNumericValue | GenericInstanceFilterRuleNonNumericValue;
 
 // @beta (undocumented)
 export namespace GenericInstanceFilterRuleValue {

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -294,7 +294,7 @@ beta;interface;GenericInstanceFilterRule
 beta;interface;GenericInstanceFilterRuleGroup
 beta;type;GenericInstanceFilterRuleGroupOperator
 beta;type;GenericInstanceFilterRuleOperator
-beta;interface;GenericInstanceFilterRuleValue
+beta;type;GenericInstanceFilterRuleValue
 beta;namespace;GenericInstanceFilterRuleValue
 public;class;GeocentricTransform
 public;interface;GeocentricTransformProps

--- a/common/changes/@itwin/appui-abstract/rounding_errors_2024-09-16-10-01.json
+++ b/common/changes/@itwin/appui-abstract/rounding_errors_2024-09-16-10-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-abstract",
+      "comment": "Added `roundingError` to `PrimitiveValue`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-abstract"
+}

--- a/common/changes/@itwin/core-common/rounding_errors_2024-09-16-10-01.json
+++ b/common/changes/@itwin/core-common/rounding_errors_2024-09-16-10-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Added `roundingError` to numeric `GenericInstanceFilterRuleValue`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -57,8 +57,10 @@ interface GenericInstanceFilterRuleNumericValue {
   displayValue: string;
   rawValue: number;
   /**
-   * Rounding error that should be taken into consideration when comparing values. This is useful
-   * when value should match values that can be rounded to the same value.
+   * Rounding error that should be taken into consideration when comparing numeric values. This is useful
+   * when numeric display value is rounded and displayed with less precision than actual value.
+   *
+   * Example: entered value is 0.12 but it should match values like 0.12345. In that case `roundingError` can be set to `0.005` and comparison should be done in `0.115` to `0.125` range.
    */
   roundingError?: number;
 }

--- a/core/common/src/GenericInstanceFilter.ts
+++ b/core/common/src/GenericInstanceFilter.ts
@@ -50,15 +50,36 @@ export type GenericInstanceFilterRuleOperator =
   | "like";
 
 /**
+ * Type definition that describes numeric values of [[GenericInstanceFilterRule]].
+ * @beta
+ */
+interface GenericInstanceFilterRuleNumericValue {
+  displayValue: string;
+  rawValue: number;
+  /**
+   * Rounding error that should be taken into consideration when comparing values. This is useful
+   * when value should match values that can be rounded to the same value.
+   */
+  roundingError?: number;
+}
+
+/**
+ * Type definition that describes non-numeric values of [[GenericInstanceFilterRule]].
+ * @beta
+ */
+interface GenericInstanceFilterRuleNonNumericValue {
+  displayValue: string;
+  rawValue: Exclude<GenericInstanceFilterRuleValue.Values, number>;
+}
+
+/**
  * Type definition that describes value of [[GenericInstanceFilterRule]].
  * @beta
  */
-export interface GenericInstanceFilterRuleValue {
-  displayValue: string;
-  rawValue: GenericInstanceFilterRuleValue.Values;
-}
+export type GenericInstanceFilterRuleValue = GenericInstanceFilterRuleNumericValue | GenericInstanceFilterRuleNonNumericValue;
 
 /** @beta */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
 export namespace GenericInstanceFilterRuleValue {
   export interface Point2d {
     x: number;

--- a/ui/appui-abstract/src/appui-abstract/properties/Value.ts
+++ b/ui/appui-abstract/src/appui-abstract/properties/Value.ts
@@ -33,6 +33,13 @@ export interface PrimitiveValue extends BasePropertyValue {
   valueFormat: PropertyValueFormat.Primitive;
   value?: Primitives.Value;
   displayValue?: string;
+  /**
+   * Rounding error that should be taken into consideration when comparing numeric values. This is useful
+   * when numeric display value is rounded and displayed with less precision than actual value.
+   *
+   * Example: entered value is 0.12 but it should match values like 0.12345. In that case `roundingError` can be set to `0.005` and comparison should be done in `0.115` to `0.125` range.
+   */
+  roundingError?: number;
 }
 
 /** Struct property value


### PR DESCRIPTION
Type changes required for https://github.com/iTwin/appui/issues/990