### PR TITLE
Add IModelDb methods needed for solid modeling tools

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -18,6 +18,7 @@ import { BaselineShift } from '@itwin/core-common';
 import { BeDuration } from '@itwin/core-bentley';
 import { BeEvent } from '@itwin/core-bentley';
 import { BentleyError } from '@itwin/core-bentley';
+import { BentleyStatus } from '@itwin/core-bentley';
 import { BRepGeometryCreate } from '@itwin/core-common';
 import { BriefcaseId } from '@itwin/core-common';
 import { BriefcaseProps } from '@itwin/core-common';
@@ -71,6 +72,9 @@ import { ElementAlignedBox3d } from '@itwin/core-common';
 import { ElementAspectProps } from '@itwin/core-common';
 import { ElementGeometryBuilderParams } from '@itwin/core-common';
 import { ElementGeometryBuilderParamsForPart } from '@itwin/core-common';
+import { ElementGeometryCacheOperationRequestProps } from '@itwin/core-common';
+import { ElementGeometryCacheRequestProps } from '@itwin/core-common';
+import { ElementGeometryCacheResponseProps } from '@itwin/core-common';
 import { ElementGeometryRequest } from '@itwin/core-common';
 import { ElementGraphicsRequestProps } from '@itwin/core-common';
 import { ElementLoadProps } from '@itwin/core-common';
@@ -3082,6 +3086,8 @@ export abstract class IModelDb extends IModel {
     // @beta
     deleteSettingDictionary(name: string): void;
     // @beta
+    elementGeometryCacheOperation(requestProps: ElementGeometryCacheOperationRequestProps): BentleyStatus;
+    // @beta
     elementGeometryRequest(requestProps: ElementGeometryRequest): IModelStatus;
     // (undocumented)
     readonly elements: IModelDb.Elements;
@@ -3186,6 +3192,8 @@ export abstract class IModelDb extends IModel {
     tryGetMetaData(classFullName: string): EntityMetaData | undefined;
     tryPrepareStatement(sql: string): ECSqlStatement | undefined;
     updateEcefLocation(ecef: EcefLocation): void;
+    // @beta
+    updateElementGeometryCache(requestProps: ElementGeometryCacheRequestProps): Promise<ElementGeometryCacheResponseProps>;
     updateIModelProps(): void;
     updateProjectExtents(newExtents: AxisAlignedBox3d): void;
     static validateSchemas(filePath: LocalFileName, forReadWrite: boolean): SchemaState;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2743,6 +2743,30 @@ export interface ElementGeometryBuilderParamsForPart {
     is2dPart?: boolean;
 }
 
+// @beta
+export interface ElementGeometryCacheOperationRequestProps {
+    id: Id64String;
+    onGeometry?: ElementGeometryFunction;
+    op: number;
+    params?: any;
+}
+
+// @beta
+export interface ElementGeometryCacheRequestProps {
+    id?: Id64String;
+}
+
+// @beta
+export interface ElementGeometryCacheResponseProps {
+    numCurve?: number;
+    numGeom?: number;
+    numOther?: number;
+    numPart?: number;
+    numSolid?: number;
+    numSurface?: number;
+    status: BentleyStatus;
+}
+
 // @public (undocumented)
 export type ElementGeometryChange = ExtantElementGeometryChange | DeletedElementGeometryChange;
 

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -223,6 +223,9 @@ public;interface;ElementAspectProps
 beta;namespace;ElementGeometry
 public;interface;ElementGeometryBuilderParams
 public;interface;ElementGeometryBuilderParamsForPart
+beta;interface;ElementGeometryCacheOperationRequestProps
+beta;interface;ElementGeometryCacheRequestProps
+beta;interface;ElementGeometryCacheResponseProps
 public;type;ElementGeometryChange
 public;namespace;ElementGeometryChange
 public;interface;ElementGeometryDataEntry

--- a/common/changes/@itwin/core-backend/backend-geometry-cache_2024-09-18-15-30.json
+++ b/common/changes/@itwin/core-backend/backend-geometry-cache_2024-09-18-15-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/backend-geometry-cache_2024-09-18-15-30.json
+++ b/common/changes/@itwin/core-common/backend-geometry-cache_2024-09-18-15-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -17,7 +17,7 @@ import {
 import {
   AxisAlignedBox3d, BRepGeometryCreate, BriefcaseId, BriefcaseIdValue, CategorySelectorProps, ChangesetIdWithIndex, ChangesetIndexAndId, Code,
   CodeProps, CreateEmptySnapshotIModelProps, CreateEmptyStandaloneIModelProps, CreateSnapshotIModelProps, DbQueryRequest, DisplayStyleProps,
-  DomainOptions, EcefLocation, ECJsNames, ECSchemaProps, ECSqlReader, ElementAspectProps, ElementGeometryRequest, ElementGraphicsRequestProps,
+  DomainOptions, EcefLocation, ECJsNames, ECSchemaProps, ECSqlReader, ElementAspectProps, ElementGeometryCacheOperationRequestProps, ElementGeometryCacheRequestProps, ElementGeometryCacheResponseProps, ElementGeometryRequest, ElementGraphicsRequestProps,
   ElementLoadProps, ElementProps, EntityMetaData, EntityProps, EntityQueryParams, FilePropertyProps, FontId, FontMap, FontType,
   GeoCoordinatesRequestProps, GeoCoordinatesResponseProps, GeometryContainmentRequestProps, GeometryContainmentResponseProps, IModel,
   IModelCoordinatesRequestProps, IModelCoordinatesResponseProps, IModelError, IModelNotFoundResponse, IModelTileTreeProps, LocalFileName,
@@ -1344,6 +1344,22 @@ export abstract class IModelDb extends IModel {
    */
   public elementGeometryRequest(requestProps: ElementGeometryRequest): IModelStatus {
     return this[_nativeDb].processGeometryStream(requestProps);
+  }
+
+  /** Request the creation of a backend geometry cache for the specified geometric element.
+   * @returns ElementGeometryCacheResponseProps
+   * @beta
+   */
+  public async updateElementGeometryCache(requestProps: ElementGeometryCacheRequestProps): Promise<ElementGeometryCacheResponseProps> {
+    return this[_nativeDb].updateElementGeometryCache(requestProps);
+  }
+
+  /** Request operation using the backend geometry cache populated by first calling elementGeometryRequest.
+ * @returns SUCCESS if requested operation could be applied.
+ * @beta
+ */
+  public elementGeometryCacheOperation(requestProps: ElementGeometryCacheOperationRequestProps): BentleyStatus {
+    return this[_nativeDb].elementGeometryCacheOperation(requestProps);
   }
 
   /** Create brep geometry for inclusion in an element's geometry stream.

--- a/core/common/src/geometry/ElementGeometry.ts
+++ b/core/common/src/geometry/ElementGeometry.ts
@@ -6,7 +6,7 @@
  * @module Geometry
  */
 import { flatbuffers } from "flatbuffers";
-import { Id64, Id64String } from "@itwin/core-bentley";
+import { BentleyStatus, Id64, Id64String } from "@itwin/core-bentley";
 import { Angle, AngleSweep, Arc3d, BentleyGeometryFlatBuffer, CurveCollection, FrameBuilder, GeometryQuery, LineSegment3d, LineString3d, Loop, Matrix3d, Plane3dByOriginAndUnitNormal, Point2d, Point3d, Point3dArray, PointString3d, Polyface, PolyfaceQuery, Range2d, Range3d, SolidPrimitive, Transform, Vector3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { EGFBAccessors } from "./ElementGeometryFB";
 import { Base64EncodedString } from "../Base64EncodedString";
@@ -150,6 +150,48 @@ export interface ElementGeometryBuilderParamsForPart {
   entryArray: ElementGeometryDataEntry[];
   /** If true, create geometry part with 2d geometry */
   is2dPart?: boolean;
+}
+
+/** Request parameters for [IModelDb.updateElementGeometryCache]($core-backend)
+ * @beta
+ */
+export interface ElementGeometryCacheRequestProps {
+  /** Geometric element to populate geometry cache for. Clear cache for all elements when undefined. */
+  id?: Id64String;
+}
+
+/** Response parameters for [IModelDb.updateElementGeometryCache]($core-backend)
+ * @beta
+ */
+export interface ElementGeometryCacheResponseProps {
+  /** Cache creation status */
+  status: BentleyStatus;
+  /** Count of displayable entries in element's geometry stream */
+  numGeom?: number;
+  /** Count of part references in element's geometry stream */
+  numPart?: number;
+  /** Count of solid/volumetric geometry in element's geometry stream */
+  numSolid?: number;
+  /** Count of surface/region geometry in element's geometry stream */
+  numSurface?: number;
+  /** Count of curve/path geometry in element's geometry stream */
+  numCurve?: number;
+  /** Count of text/image/non-geometric displayable entries in element's geometry stream */
+  numOther?: number;
+}
+
+/** Request parameters for [IModelDb.elementGeometryCacheOperation]($core-backend)
+ * @beta
+ */
+export interface ElementGeometryCacheOperationRequestProps {
+  /** Target element id, tool element ids can be supplied by parameters... */
+  id: Id64String;
+  /** Requested operation */
+  op: number;
+  /** Parameters for operation */
+  params?: any;
+  /** Callback for result when element's geometry stream is requested in flatbuffer or graphic formats */
+  onGeometry?: ElementGeometryFunction;
 }
 
 /** Values for [[BRepGeometryCreate.operation]]


### PR DESCRIPTION
requiring backend native libraries to perform their operation.
Replacement for using internal/deprecated nativeDb directly in EditCommand in editing package.