### PR TITLE
Revert "Added test cases to test support for boolean exps in select statements"

### DIFF
--- a/common/changes/@itwin/core-backend/revert-7150-Soham-booleanExpsInSelect_2024-09-25-06-10.json
+++ b/common/changes/@itwin/core-backend/revert-7150-Soham-booleanExpsInSelect_2024-09-25-06-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Removed added tests for boolean exps in select statement",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/ecdb/ECSqlAst.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlAst.test.ts
@@ -475,26 +475,6 @@ describe("ECSql Abstract Syntax Tree", () => {
       assert.equal(test.expectedECSql, await toNormalizeECSql(test.expectedECSql));
     }
   });
-  it("parse Boolean Exp in Select statements", async () => {
-    const tests = [
-      {
-        orignalECSql: "select 1 < true",
-        expectedECSql: "SELECT (1 < TRUE)",
-      },
-      {
-        orignalECSql: "select 2 IN(2,7)",
-        expectedECSql: "SELECT 2 IN (2, 7)",
-      },
-      {
-        orignalECSql: "SELECT p.ECInstanceId=k.s FROM meta.ECClassDef p, (SELECT 1 s) k",
-        expectedECSql: "SELECT ([p].[ECInstanceId] = [k].[s]) FROM [ECDbMeta].[ECClassDef] [p], (SELECT 1 [s]) [k]",
-      },
-    ];
-    for (const test of tests) {
-      assert.equal(test.expectedECSql, await toNormalizeECSql(test.orignalECSql));
-      assert.equal(test.expectedECSql, await toNormalizeECSql(test.expectedECSql));
-    }
-  });
   it("parse $, $->prop", async () => {
     const tests = [
       {


### PR DESCRIPTION
Reverts iTwin/itwinjs-core#7150

imodel-native: https://github.com/iTwin/imodel-native/pull/868