### PR TITLE
Fix link in NextVersion.md

### DIFF
--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,7 +18,7 @@ Table of contents:
 
 At present, the sole method to reverse a defective changeset is to remove it from the iModel hub, which can lead to numerous side effects. A preferable approach would be to reverse the changeset in the timeline and introduce it as a new changeset. Although this method remains intrusive and necessitates a schema lock, it is safer because it allows for the reversal to restore previous changes, ensuring that nothing is permanently lost from the timeline.
 
-[IModelDb.revertAndPushChanges]($core-backend) Allow to push a single changeset that undo all changeset from tip to specified changeset in history.
+[BriefcaseDb.revertAndPushChanges]($backend) Allow to push a single changeset that undo all changeset from tip to specified changeset in history.
 
 Some detail and requirements are as following.
 


### PR DESCRIPTION
Fixed invalid link in NextVersion.md

@DanRod1999 @aruniverse Do you have any idea why Docs pipeline does not fail on invalid link? You can check latest run on master. It's successful but warning is logged. In Presentation repo validate docs job fails for that invalid link.