### PR TITLE
Deprecate `WipRpcInterface`

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -11210,7 +11210,7 @@ export class WhiteOnWhiteReversalSettings {
     toJSON(): WhiteOnWhiteReversalProps | undefined;
 }
 
-// @internal
+// @internal @deprecated
 export abstract class WipRpcInterface extends RpcInterface {
     // (undocumented)
     attachChangeCache(_iModelToken: IModelRpcProps): Promise<void>;

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -921,5 +921,6 @@ internal;class;WebAppRpcRequest
 public;interface;WhiteOnWhiteReversalProps
 public;class;WhiteOnWhiteReversalSettings
 internal;class;WipRpcInterface
+deprecated;class;WipRpcInterface
 public;class;XyzRotation
 public;interface;XyzRotationProps

--- a/common/changes/@itwin/core-backend/gytis-deprecate-WipRpcInterface_2024-09-27-12-22.json
+++ b/common/changes/@itwin/core-backend/gytis-deprecate-WipRpcInterface_2024-09-27-12-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/gytis-deprecate-WipRpcInterface_2024-09-27-12-22.json
+++ b/common/changes/@itwin/core-common/gytis-deprecate-WipRpcInterface_2024-09-27-12-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Deprecate `WipRpcInterface`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/ChangedElementsManager.ts
+++ b/core/backend/src/ChangedElementsManager.ts
@@ -8,14 +8,18 @@ import { BriefcaseManager } from "./BriefcaseManager";
 import { ChangedElementsDb } from "./ChangedElementsDb";
 import { IModelJsFs } from "./IModelJsFs";
 
+/* eslint-disable deprecation/deprecation */
+
 /** @internal */
 interface ChangedElementsDbCacheEntry {
   iModelId: GuidString;
   db: ChangedElementsDb;
 }
 
-/** Utilities for querying changed elements caches */
-/** @internal */
+/** Utilities for querying changed elements caches
+ * @internal
+ * @deprecated in 4.10. Call methods on [[IModelDb]] instance directly.
+ */
 export class ChangedElementsManager {
   /** Maintains a single entry since we will only have a cache per iModel, which means a ChangedElementsDb per backend instance */
   private static _entry: ChangedElementsDbCacheEntry | undefined;

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -488,7 +488,7 @@ export class IModelHost {
       IModelReadRpcImpl,
       IModelTileRpcImpl,
       SnapshotIModelRpcImpl,
-      WipRpcImpl,
+      WipRpcImpl, // eslint-disable-line deprecation/deprecation
       DevToolsRpcImpl,
     ].forEach((rpc) => rpc.register()); // register all of the RPC implementations
 

--- a/core/backend/src/rpc-impl/WipRpcImpl.ts
+++ b/core/backend/src/rpc-impl/WipRpcImpl.ts
@@ -6,6 +6,8 @@
  * @module RpcInterface
  */
 
+/* eslint-disable deprecation/deprecation */
+
 import { assert } from "@itwin/core-bentley";
 import { ChangedElements, IModelRpcProps, RpcInterface, RpcManager, WipRpcInterface } from "@itwin/core-common";
 import { ChangedElementsManager } from "../ChangedElementsManager";
@@ -14,8 +16,9 @@ import { BriefcaseDb } from "../IModelDb";
 
 /** The backend implementation of WipRpcInterface.
  * @internal
+ * @deprecated in 4.10. If any of these methods are needed in the frontend, they should be rewritten using IPC or HTTP protocol.
  */
-export class WipRpcImpl extends RpcInterface implements WipRpcInterface { // eslint-disable-line deprecation/deprecation
+export class WipRpcImpl extends RpcInterface implements WipRpcInterface {
 
   public static register() { RpcManager.registerImpl(WipRpcInterface, WipRpcImpl); }
   public async placeholder(_tokenProps: IModelRpcProps): Promise<string> { return "placeholder"; }

--- a/core/common/src/rpc/WipRpcInterface.ts
+++ b/core/common/src/rpc/WipRpcInterface.ts
@@ -18,10 +18,11 @@ import { RpcManager } from "../RpcManager";
  * Once stable, the goal is to move methods out to their rightful home.
  * Apps/services should understand the *flux* implied by registering this RpcInterface and should be in control of both the client and server before even considering using it.
  * @internal
+ * @deprecated in 4.10. If any of these methods are needed in the frontend, they should be rewritten using IPC or HTTP protocol.
  */
 export abstract class WipRpcInterface extends RpcInterface { // eslint-disable-line deprecation/deprecation
   /** Returns the IModelReadRpcInterface instance for the frontend. */
-  public static getClient(): WipRpcInterface { return RpcManager.getClientForInterface(WipRpcInterface); }
+  public static getClient(): WipRpcInterface { return RpcManager.getClientForInterface(WipRpcInterface); } // eslint-disable-line deprecation/deprecation
 
   /** The immutable name of the interface. */
   public static readonly interfaceName = "WipRpcInterface";

--- a/full-stack-tests/backend/src/integration/ChangedElements.test.ts
+++ b/full-stack-tests/backend/src/integration/ChangedElements.test.ts
@@ -15,6 +15,8 @@ import { HubUtility } from "../HubUtility";
 
 import "./StartupShutdown"; // calls startup/shutdown IModelHost before/after all tests
 
+/* eslint-disable deprecation/deprecation */
+
 describe("ChangedElements", () => {
   let accessToken: AccessToken;
   let testITwinId: GuidString;

--- a/full-stack-tests/core/src/common/RpcInterfaces.ts
+++ b/full-stack-tests/core/src/common/RpcInterfaces.ts
@@ -5,7 +5,6 @@
 import { AccessToken, GuidString } from "@itwin/core-bentley";
 import {
   DevToolsRpcInterface, IModelReadRpcInterface, IModelRpcProps, IModelTileRpcInterface, RpcInterface, RpcManager, SnapshotIModelRpcInterface,
-  WipRpcInterface,
 } from "@itwin/core-common";
 import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 
@@ -65,7 +64,6 @@ export const rpcInterfaces = [
   IModelTileRpcInterface,
   SnapshotIModelRpcInterface,
   TestRpcInterface,
-  WipRpcInterface,
   DevToolsRpcInterface,
   EventsTestRpcInterface,
   ECSchemaRpcInterface,


### PR DESCRIPTION
`WipRpcInterface` is internal and has no usage in core. With our intent of moving away from RPC, this is a no-brainer for removal.

While the interface is internal, this doesn’t guarantee that no one is using it. For this reason, I propose deprecating it now and removing it in 5.0.