### PR TITLE
SheetViewState.computeFitRange removed internal tag

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -10942,7 +10942,7 @@ export class SheetViewState extends ViewState2d {
     collectNonTileTreeStatistics(stats: RenderMemory.Statistics): void;
     // @internal (undocumented)
     computeDisplayTransform(args: ComputeDisplayTransformArgs): Transform | undefined;
-    // @internal (undocumented)
+    // (undocumented)
     computeFitRange(): Range3d;
     // (undocumented)
     static createFromProps(viewStateData: ViewStateProps, iModel: IModelConnection): SheetViewState;

--- a/common/changes/@itwin/core-frontend/sheetVS-computeFitRange-raise_2024-10-02-16-04.json
+++ b/common/changes/@itwin/core-frontend/sheetVS-computeFitRange-raise_2024-10-02-16-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Removed Internal tag for SheetViewState.computeFitRange",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/sheetVS-computeFitRange-raise_2024-10-02-16-04.json
+++ b/common/changes/@itwin/core-frontend/sheetVS-computeFitRange-raise_2024-10-02-16-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Removed Internal tag for SheetViewState.computeFitRange",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/core/frontend/src/SheetViewState.ts
+++ b/core/frontend/src/SheetViewState.ts
@@ -553,7 +553,6 @@ export class SheetViewState extends ViewState2d {
     }
   }
 
-  /** @internal */
   public override computeFitRange(): Range3d {
     const size = this.sheetSize;
     if (0 >= size.x || 0 >= size.y)


### PR DESCRIPTION
Removes internal tag from `SheetViewState.computeFitRange`.

Resolves issue #7222 