### PR TITLE
Fixed issue with arc-arc intersection returning invalid intersections

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -4885,7 +4885,7 @@ export class PolylineOps {
 
 // @internal
 export class PowerPolynomial {
-    static accumulate(coffP: Float64Array, coffQ: Float64Array, scale: number): number;
+    static accumulate(coffP: Float64Array, coffQ: Float64Array, scaleQ: number): number;
     static degreeKnownEvaluate(coff: Float64Array, degree: number, x: number): number;
     static evaluate(coff: Float64Array, x: number): number;
     static zero(coff: Float64Array): void;

--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -4885,7 +4885,7 @@ export class PolylineOps {
 
 // @internal
 export class PowerPolynomial {
-    static accumulate(coffP: Float64Array, coffQ: Float64Array, scaleQ: number): number;
+    static accumulate(coffP: Float64Array, coffQ: Float64Array, scale: number): number;
     static degreeKnownEvaluate(coff: Float64Array, degree: number, x: number): number;
     static evaluate(coff: Float64Array, x: number): number;
     static zero(coff: Float64Array): void;
@@ -6150,7 +6150,7 @@ export class TrigPolynomial {
     static solveAngles(coff: Float64Array, nominalDegree: number, referenceCoefficient: number, radians: number[]): boolean;
     static solveUnitCircleEllipseIntersection(cx: number, cy: number, ux: number, uy: number, vx: number, vy: number, ellipseRadians: number[], circleRadians: number[]): boolean;
     static solveUnitCircleHomogeneousEllipseIntersection(cx: number, cy: number, cw: number, ux: number, uy: number, uw: number, vx: number, vy: number, vw: number, ellipseRadians: number[], circleRadians: number[]): boolean;
-    static solveUnitCircleImplicitQuadricIntersection(axx: number, axy: number, ayy: number, ax: number, ay: number, a1: number, radians: number[]): boolean;
+    static solveUnitCircleImplicitQuadricIntersection(axx: number, axy: number, ayy: number, ax: number, ay: number, a: number, radians: number[]): boolean;
     static readonly SS: Float64Array;
     static readonly SW: Float64Array;
     static readonly W: Float64Array;

--- a/common/changes/@itwin/core-geometry/saeed-torabi-arcArcIntersection_2024-10-02-16-09.json
+++ b/common/changes/@itwin/core-geometry/saeed-torabi-arcArcIntersection_2024-10-02-16-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/internaldocs/unitCircleEllipseIntersection.md
+++ b/core/geometry/internaldocs/unitCircleEllipseIntersection.md
@@ -74,7 +74,7 @@ The first matrix of scalars encapsulates the Bezier coefficients of the $C$, $S$
 - **Curves and Surfaces for CAGD: A Practical Guide**, Gerald Farin, 4th Edition, Section 13.8 (Control Vectors)
 
 The transformation of equation $(1)$ from trigonometric basis to power polynomial basis is performed by the substitution:
-$$\begin{equation}x(t) := \cos\theta = \frac{C(t)}{W(t)},\space\space\space y(t) := \sin\theta = \frac{S(t)}{W(t)}\end{equation}$$
+$$\begin{equation}\cos\theta = \frac{C(t)}{W(t)} := x(t),\space\space\space \sin\theta = \frac{S(t)}{W(t)} := y(t)\end{equation}$$
 
 The method `TrigPolynomial.solveUnitCircleImplicitQuadricIntersection` takes the coefficients of the trigonometric polynomial in $(1)$, and internally applies the transformation $(2)$ to compute its power basis coefficients. The transformed polynomial $P(t)$ has degree at most 4. We currently prefer the power basis because we have polynomial root finders for degrees 2, 3, and 4 implemented by classical formulae. In the future we may use a Bezier polynomial solver that handles any degree, and has the advantage of superior numerical stability of the Bernstein-Bezier basis.
 

--- a/core/geometry/internaldocs/unitCircleEllipseIntersection.md
+++ b/core/geometry/internaldocs/unitCircleEllipseIntersection.md
@@ -74,7 +74,7 @@ The first matrix of scalars encapsulates the Bezier coefficients of the $C$, $S$
 - **Curves and Surfaces for CAGD: A Practical Guide**, Gerald Farin, 4th Edition, Section 13.8 (Control Vectors)
 
 The transformation of equation $(1)$ from trigonometric basis to power polynomial basis is performed by the substitution:
-$$\begin{equation}\cos\theta = \frac{C(t)}{W(t)} := x(t),\space\space\space \sin\theta = \frac{S(t)}{W(t)} := y(t)\end{equation}$$
+$$\begin{equation}\cos\theta = \frac{C(t)}{W(t)} =: x(t),\space\space\space \sin\theta = \frac{S(t)}{W(t)} =: y(t)\end{equation}$$
 
 The method `TrigPolynomial.solveUnitCircleImplicitQuadricIntersection` takes the coefficients of the trigonometric polynomial in $(1)$, and internally applies the transformation $(2)$ to compute its power basis coefficients. The transformed polynomial $P(t)$ has degree at most 4. We currently prefer the power basis because we have polynomial root finders for degrees 2, 3, and 4 implemented by classical formulae. In the future we may use a Bezier polynomial solver that handles any degree, and has the advantage of superior numerical stability of the Bernstein-Bezier basis.
 

--- a/core/geometry/internaldocs/unitCircleEllipseIntersection.md
+++ b/core/geometry/internaldocs/unitCircleEllipseIntersection.md
@@ -1,0 +1,94 @@
+# Intersection of Unit Circle and General Ellipse
+
+We want to find intersections of the homogeneous unit circle $x^2 + y^2 = w^2$ and the general ellipse
+$$
+\begin{bmatrix}
+x(\theta) \\
+y(\theta)  \\
+w(\theta)
+\end{bmatrix} =
+\begin{bmatrix}
+u_x & v_x & c_x \\
+u_y & v_y & c_y \\
+u_w & v_w & c_w
+\end{bmatrix}
+\begin{bmatrix}
+\cos\theta \\
+\sin\theta  \\
+1
+\end{bmatrix}
+$$
+
+By substitution ellipse equation into unit circle equation, we get
+
+$a_{cc} \cos\theta \cos\theta + a_{cs} \cos\theta \sin\theta + a_{ss} \sin\theta \sin\theta + a_c \cos\theta + a_s \sin\theta + a = 0 $ **(*)**
+
+where
+
+$a_{cc} = u_x u_x + u_y u_y - u_w u_w\\$
+$a_{cs} = 2 (u_x v_x + u_y v_y - u_w v_w)\\$
+$a_{ss} = v_x v_x + v_y v_y - v_w v_w\\$
+$a_c = 2 (u_x c_x + u_y c_y - u_w c_w)\\$
+$a_s = 2 (v_x c_x + v_y c_y - v_w c_w)\\$
+$a = c_x c_x + c_y c_y - c_w c_w\\$
+
+Above is used in `TrigPolynomial.solveUnitCircleHomogeneousEllipseIntersection`.
+
+This is the equation we want to solve for $\theta$ to get the angles of intersections. However, trigonometry equations are not easy to solve. Therefor, we look to change the basis of equation from $(1, \cos\theta$, $\sin\theta, ...)$ to $(1,t,t^2,...)$ to make the problem easier.
+
+Note that as $\theta$ traverses from 0 to $\pi$, $\begin{bmatrix}\cos\theta \\ \sin\theta \end{bmatrix}$
+traverses the top half of the unit circle. There is a rational formula that traverses the same path:
+$\begin{bmatrix}\frac{C(t)}{W(t)} \\ \frac{S(t)}{W(t)}\end{bmatrix}$ as $t$ goes from $0$ to $1$ where $C$, $S$, and $W$ are defined using Bernstein basis:
+
+$$
+\begin{bmatrix}
+C(t) \\
+S(t)  \\
+W(t)
+\end{bmatrix} =
+\begin{bmatrix}
+1 & 0 & -1 \\
+0 & 1 & 0 \\
+1 & 0 & 1
+\end{bmatrix}
+\begin{bmatrix}
+(1-t)^2 \\
+2t(1-t)  \\
+t^2
+\end{bmatrix}
+$$
+
+For more info see
+- https://en.wikipedia.org/wiki/Bernstein_polynomial
+- **Curves and Surfaces for CAGD: A Practical Guide**, Gerald Farin, 4th Edition, Section 13.8 (Control Vectors)
+
+Now we have
+
+$C(t) = (1-t)^2 - t^2 = 1 - 2t \\$
+$S(t) = 2t(1-t) = 2t - 2t^2 \\$
+$W(t) = (1-t)^2 + t^2 = 1 - 2t + 2t^2$
+
+so if we choose basis to be $1,t,t^2,...$ we get
+
+$C = [1, -2]\\$
+$S = [0, 2, -2]\\$
+$W = [1, -2, 2]$
+
+
+So by the substitution $\cos\theta=\frac{C(t)}{W(t)}$ and $\sin\theta = \frac{S(t)}{W(t)}$ we can re-parametrize equation **(*)** to below equation which is more numerically stable for root-finding:
+
+$a_{xx} \frac{CC}{WW} + a_{xy} \frac{CS}{WW} + a_{yy} \frac{SS}{WW} + a_x \frac{C}{W} + a_y \frac{S}{W} + a = 0$
+
+or
+
+$a_{xx} CC + a_{xy} CS + a_{yy} SS + a_x CW + a_y SW + aWW = 0$
+
+Above equation is at most a degree 4 polynomial in $t$ and easy to solve. In particular, if $a_{xx}$, $a_{xy}$, and $a_{yy}$ are zero (meaning both arcs are circular), this equation reduces to the degree 2:
+
+$a_x CW + a_y SW + aWW = 0$
+
+Above formulas are used in `TrigPolynomial.solveUnitCircleImplicitQuadricIntersection`.
+
+Since $\sin(\theta) =\frac{S(t)}{W(t)} $ and $\cos(\theta) =\frac{C(t)}{W(t)}$, after $t$ is found, it can be converted to $\theta$ using
+
+$$\theta = \arctan(\frac{S(t)}{C(t)})$$

--- a/core/geometry/internaldocs/unitCircleEllipseIntersection.md
+++ b/core/geometry/internaldocs/unitCircleEllipseIntersection.md
@@ -4,7 +4,7 @@ We want to find intersections of the homogeneous unit circle $x^2 + y^2 = w^2$ a
 $$
 \begin{bmatrix}
 x(\theta) \\
-y(\theta)  \\
+y(\theta) \\
 w(\theta)
 \end{bmatrix} =
 \begin{bmatrix}
@@ -14,31 +14,32 @@ u_w & v_w & c_w
 \end{bmatrix}
 \begin{bmatrix}
 \cos\theta \\
-\sin\theta  \\
+\sin\theta \\
 1
 \end{bmatrix}
 $$
 
-By substitution ellipse equation into unit circle equation, we get
+By substituting the ellipse equation into the unit circle equation, we get
 
-$a_{cc} \cos\theta \cos\theta + a_{cs} \cos\theta \sin\theta + a_{ss} \sin\theta \sin\theta + a_c \cos\theta + a_s \sin\theta + a = 0 $ **(*)**
+$$\begin{equation}a_{cc} \cos\theta \cos\theta + a_{cs} \cos\theta \sin\theta + a_{ss} \sin\theta \sin\theta + a_c \cos\theta + a_s \sin\theta + a = 0\end{equation}$$
 
 where
 
-$a_{cc} = u_x u_x + u_y u_y - u_w u_w\\$
-$a_{cs} = 2 (u_x v_x + u_y v_y - u_w v_w)\\$
-$a_{ss} = v_x v_x + v_y v_y - v_w v_w\\$
-$a_c = 2 (u_x c_x + u_y c_y - u_w c_w)\\$
-$a_s = 2 (v_x c_x + v_y c_y - v_w c_w)\\$
-$a = c_x c_x + c_y c_y - c_w c_w\\$
+$$\begin{align}
+\nonumber{}a_{cc} &= u_x u_x + u_y u_y - u_w u_w\\
+\nonumber{}a_{cs} &= 2 (u_x v_x + u_y v_y - u_w v_w)\\
+\nonumber{}a_{ss} &= v_x v_x + v_y v_y - v_w v_w\\
+\nonumber{}a_c &= 2 (u_x c_x + u_y c_y - u_w c_w)\\
+\nonumber{}a_s &= 2 (v_x c_x + v_y c_y - v_w c_w)\\
+\nonumber{}a &= c_x c_x + c_y c_y - c_w c_w
+\end{align}$$
 
-Above is used in `TrigPolynomial.solveUnitCircleHomogeneousEllipseIntersection`.
+These formulas are used in `TrigPolynomial.solveUnitCircleHomogeneousEllipseIntersection`.
 
-This is the equation we want to solve for $\theta$ to get the angles of intersections. However, trigonometry equations are not easy to solve. Therefor, we look to change the basis of equation from $(1, \cos\theta$, $\sin\theta, ...)$ to $(1,t,t^2,...)$ to make the problem easier.
+Equation $(1)$ is what we want to solve to get the ellipse angles $\theta$ of the intersections. To take advantage of polynomial root finders tailored to other bases, we make a change of basis from the trigonometric basis $(1, \cos\theta, \sin\theta, \cos\theta\sin\theta, ...)$ to another polynomial basis as follows.
 
-Note that as $\theta$ traverses from 0 to $\pi$, $\begin{bmatrix}\cos\theta \\ \sin\theta \end{bmatrix}$
-traverses the top half of the unit circle. There is a rational formula that traverses the same path:
-$\begin{bmatrix}\frac{C(t)}{W(t)} \\ \frac{S(t)}{W(t)}\end{bmatrix}$ as $t$ goes from $0$ to $1$ where $C$, $S$, and $W$ are defined using Bernstein basis:
+First, note that as $\theta$ traverses from 0 to $\pi$, $\begin{bmatrix}\cos\theta \\ \sin\theta \end{bmatrix}$
+traverses the top half of the unit circle. There is a rational homogeneous parameterization for the same path as $t$ goes from $0$ to $1$:
 
 $$
 \begin{bmatrix}
@@ -55,40 +56,30 @@ W(t)
 (1-t)^2 \\
 2t(1-t)  \\
 t^2
+\end{bmatrix} =
+\begin{bmatrix}
+1 & -2 & 0 \\
+0 & 2 & -2 \\
+1 & -2 & 2
+\end{bmatrix}
+\begin{bmatrix}
+1 \\
+t \\
+t^2
 \end{bmatrix}
 $$
 
-For more info see
+The first matrix of scalars encapsulates the Bezier coefficients of the $C$, $S$, and $W$ polynomials in the degree-2 Bernstein-Bezier polynomial basis; the second matrix of scalars, the coefficients in the standard power basis. For more info see:
 - https://en.wikipedia.org/wiki/Bernstein_polynomial
 - **Curves and Surfaces for CAGD: A Practical Guide**, Gerald Farin, 4th Edition, Section 13.8 (Control Vectors)
 
-Now we have
+The transformation of equation $(1)$ from trigonometric basis to power polynomial basis is performed by the substitution:
+$$\begin{equation}x(t) := \cos\theta = \frac{C(t)}{W(t)},\space\space\space y(t) := \sin\theta = \frac{S(t)}{W(t)}\end{equation}$$
 
-$C(t) = (1-t)^2 - t^2 = 1 - 2t \\$
-$S(t) = 2t(1-t) = 2t - 2t^2 \\$
-$W(t) = (1-t)^2 + t^2 = 1 - 2t + 2t^2$
+The method `TrigPolynomial.solveUnitCircleImplicitQuadricIntersection` takes the coefficients of the trigonometric polynomial in $(1)$, and internally applies the transformation $(2)$ to compute its power basis coefficients. The transformed polynomial $P(t)$ has degree at most 4. We currently prefer the power basis because we have polynomial root finders for degrees 2, 3, and 4 implemented by classical formulae. In the future we may use a Bezier polynomial solver that handles any degree, and has the advantage of superior numerical stability of the Bernstein-Bezier basis.
 
-so if we choose basis to be $1,t,t^2,...$ we get
+Note that if both arcs are circular, then $a_{cc} = a_{cs} = a_{ss} = 0$, and the quartic reduces to a quadratic.
 
-$C = [1, -2]\\$
-$S = [0, 2, -2]\\$
-$W = [1, -2, 2]$
+Once a solution to $P(t) = 0$ is found, the inverse of the substitution $(2)$ yields an ellipse angle $\theta$ of the intersection of the ellipse and the unit circle:
 
-
-So by the substitution $\cos\theta=\frac{C(t)}{W(t)}$ and $\sin\theta = \frac{S(t)}{W(t)}$ we can re-parametrize equation **(*)** to below equation which is more numerically stable for root-finding:
-
-$a_{xx} \frac{CC}{WW} + a_{xy} \frac{CS}{WW} + a_{yy} \frac{SS}{WW} + a_x \frac{C}{W} + a_y \frac{S}{W} + a = 0$
-
-or
-
-$a_{xx} CC + a_{xy} CS + a_{yy} SS + a_x CW + a_y SW + aWW = 0$
-
-Above equation is at most a degree 4 polynomial in $t$ and easy to solve. In particular, if $a_{xx}$, $a_{xy}$, and $a_{yy}$ are zero (meaning both arcs are circular), this equation reduces to the degree 2:
-
-$a_x CW + a_y SW + aWW = 0$
-
-Above formulas are used in `TrigPolynomial.solveUnitCircleImplicitQuadricIntersection`.
-
-Since $\sin(\theta) =\frac{S(t)}{W(t)} $ and $\cos(\theta) =\frac{C(t)}{W(t)}$, after $t$ is found, it can be converted to $\theta$ using
-
-$$\theta = \arctan(\frac{S(t)}{C(t)})$$
+$$\theta = \arctan(\frac{S(t)}{C(t)}).$$

--- a/core/geometry/src/curve/Arc3d.ts
+++ b/core/geometry/src/curve/Arc3d.ts
@@ -1076,7 +1076,9 @@ export class Arc3d extends CurvePrimitive implements BeJSONFunctions {
     };
   }
   /** Return the arc definition with center, two vectors, and angle sweep, optionally transformed. */
-  public toTransformedVectors(transform?: Transform): { center: Point3d, vector0: Vector3d, vector90: Vector3d, sweep: AngleSweep } {
+  public toTransformedVectors(
+    transform?: Transform,
+  ): { center: Point3d, vector0: Vector3d, vector90: Vector3d, sweep: AngleSweep } {
     return transform ? {
       center: transform.multiplyPoint3d(this._center),
       vector0: transform.multiplyVector(this._matrix.columnX()),
@@ -1091,7 +1093,9 @@ export class Arc3d extends CurvePrimitive implements BeJSONFunctions {
       };
   }
   /** Return the arc definition with center, two vectors, and angle sweep, transformed to 4d points. */
-  public toTransformedPoint4d(matrix: Matrix4d): { center: Point4d, vector0: Point4d, vector90: Point4d, sweep: AngleSweep } {
+  public toTransformedPoint4d(
+    matrix: Matrix4d,
+  ): { center: Point4d, vector0: Point4d, vector90: Point4d, sweep: AngleSweep } {
     return {
       center: matrix.multiplyPoint3d(this._center, 1.0),
       vector0: matrix.multiplyPoint3d(this._matrix.columnX(), 0.0),
@@ -1223,11 +1227,19 @@ export class Arc3d extends CurvePrimitive implements BeJSONFunctions {
   /** Compute the center and vectors of another arc as local coordinates within this arc's frame. */
   public otherArcAsLocalVectors(other: Arc3d): ArcVectors | undefined {
     const otherOrigin = this._matrix.multiplyInverseXYZAsPoint3d(
-      other.center.x - this.center.x, other.center.y - this.center.y, other.center.z - this.center.z);
+      other.center.x - this.center.x,
+      other.center.y - this.center.y,
+      other.center.z - this.center.z,
+    );
     const otherVector0 = this._matrix.multiplyInverse(other.vector0);
     const otherVector90 = this._matrix.multiplyInverse(other.vector90);
     if (otherOrigin && otherVector0 && otherVector90) {
-      return { center: otherOrigin, vector0: otherVector0, vector90: otherVector90, sweep: this.sweep.clone() };
+      return {
+        center: otherOrigin,
+        vector0: otherVector0,
+        vector90: otherVector90,
+        sweep: this.sweep.clone(),
+      };
     }
     return undefined;
   }

--- a/core/geometry/src/curve/internalContexts/CurveCurveIntersectXY.ts
+++ b/core/geometry/src/curve/internalContexts/CurveCurveIntersectXY.ts
@@ -459,7 +459,7 @@ export class CurveCurveIntersectXY extends RecurseToCurvesGeometryHandler {
     extendB1: boolean,
     reversed: boolean,
   ): void {
-    // inverseA transforms arcA to its local coordinates, where it is the unit xy-circle.
+    // inverseA transforms arcA to its local coordinates, where it is the unit xy-circle
     const inverseA = matrixA.inverse();
     if (inverseA) {
       // localB defines the arc formed by transforming arcB into the local coordinates of arcA

--- a/core/geometry/src/geometry3d/Matrix3d.ts
+++ b/core/geometry/src/geometry3d/Matrix3d.ts
@@ -852,14 +852,19 @@ export class Matrix3d implements BeJSONFunctions {
         result,
       );
   }
-  /** Create a matrix with each column's _x,y_ parts given `XAndY` and separate numeric z values.
+  /**
+   * Create a matrix with each column's _x,y_ parts given `XAndY` and separate numeric z values.
    * ```
    * equation
    * \begin{bmatrix}U_x & V_x & W_x \\ U_y & V_y & W_y \\ u & v & w \end{bmatrix}
    * ```
    */
-  public static createColumnsXYW(vectorU: XAndY, u: number, vectorV: XAndY, v: number,
-    vectorW: XAndY, w: number, result?: Matrix3d): Matrix3d {
+  public static createColumnsXYW(
+    vectorU: XAndY, u: number,
+    vectorV: XAndY, v: number,
+    vectorW: XAndY, w: number,
+    result?: Matrix3d,
+  ): Matrix3d {
     return Matrix3d.createRowValues
       (
         vectorU.x, vectorV.x, vectorW.x,

--- a/core/geometry/src/geometry3d/Point3dVector3d.ts
+++ b/core/geometry/src/geometry3d/Point3dVector3d.ts
@@ -1091,8 +1091,8 @@ export class Vector3d extends XYZ {
    * the plane of this vector and the target vector.
    * @param target Second vector which defines the plane of rotation.
    * @param result optional preallocated vector for result.
-   * @returns rotated vector, or undefined if the cross product of this and
-   *          the the target cannot be normalized (i.e. if the target and this are colinear)
+   * @returns rotated vector, or undefined if the cross product of this and the the
+   * target cannot be normalized (i.e. if the target and this are colinear).
    */
   public rotate90Towards(target: Vector3d, result?: Vector3d): Vector3d | undefined {
     const normal = this.crossProduct(target).normalize();
@@ -1244,7 +1244,7 @@ export class Vector3d extends XYZ {
   }
   /**
    * Compute the cross product of this vector with `vectorB` and normalize it.
-   * * If length is zero normalize using given xyz as default.
+   * * If length is zero, return the vector given by x, y, z.
    * @param vectorB second vector of cross product
    * @param x x value for default result
    * @param y y value for default result

--- a/core/geometry/src/geometry3d/Point3dVector3d.ts
+++ b/core/geometry/src/geometry3d/Point3dVector3d.ts
@@ -1091,8 +1091,8 @@ export class Vector3d extends XYZ {
    * the plane of this vector and the target vector.
    * @param target Second vector which defines the plane of rotation.
    * @param result optional preallocated vector for result.
-   * @returns rotated vector, or undefined if the cross product of this and the the
-   * target cannot be normalized (i.e. if the target and this are colinear).
+   * @returns rotated vector, or undefined if the cross product of this and the target
+   * cannot be normalized (i.e. if the target and this are colinear).
    */
   public rotate90Towards(target: Vector3d, result?: Vector3d): Vector3d | undefined {
     const normal = this.crossProduct(target).normalize();

--- a/core/geometry/src/geometry3d/Point3dVector3d.ts
+++ b/core/geometry/src/geometry3d/Point3dVector3d.ts
@@ -1243,7 +1243,8 @@ export class Vector3d extends XYZ {
     return this.crossProduct(vectorB, result).normalize(result);
   }
   /**
-   * Compute the cross product of this vector with `vectorB`. Normalize it, using given xyz as default if length is zero.
+   * Compute the cross product of this vector with `vectorB` and normalize it.
+   * * If length is zero normalize using given xyz as default.
    * @param vectorB second vector of cross product
    * @param x x value for default result
    * @param y y value for default result

--- a/core/geometry/src/numerics/Polynomials.ts
+++ b/core/geometry/src/numerics/Polynomials.ts
@@ -1130,7 +1130,7 @@ export class TrigPolynomial {
   public static readonly W = Float64Array.from([1.0, -2.0, 2.0]);
   /** Standard Basis coefficients for C(t) * W(t). */
   public static readonly CW = Float64Array.from([1.0, -4.0, 6.0, -4.0]);
-  /** Standard Basis coefficients forS(t) * W(t). */
+  /** Standard Basis coefficients for S(t) * W(t). */
   public static readonly SW = Float64Array.from([0.0, 2.0, -6.0, 8.0, -4.0]);
   /** Standard Basis coefficients for S(t) * C(t). */
   public static readonly SC = Float64Array.from([0.0, 2.0, -6.0, 4.0]);

--- a/core/geometry/src/numerics/Polynomials.ts
+++ b/core/geometry/src/numerics/Polynomials.ts
@@ -1092,15 +1092,15 @@ export class PowerPolynomial {
     return this.degreeKnownEvaluate(coff, degree, x);
   }
   /**
-   * Accumulate `coffQ*scale` into `coffP`.
-   * * Both are treated as full degree (the length of `coffP` must be at least length of `coffQ`).
+   * Accumulate `coffQ*scaleQ` into `coffP`.
+   * * The length of `coffP` must be at least length of `coffQ`.
    * * Returns degree of result as determined by comparing trailing coefficients to zero.
    */
-  public static accumulate(coffP: Float64Array, coffQ: Float64Array, scale: number): number {
+  public static accumulate(coffP: Float64Array, coffQ: Float64Array, scaleQ: number): number {
     let degreeP = coffP.length - 1;
     const degreeQ = coffQ.length - 1;
     for (let i = 0; i <= degreeQ; i++)
-      coffP[i] += scale * coffQ[i];
+      coffP[i] += scaleQ * coffQ[i];
     while (degreeP >= 0 && coffP[degreeP] === 0.0)
       degreeP--;
     return degreeP;
@@ -1122,25 +1122,25 @@ export class TrigPolynomial {
 
   // see itwinjs-core\core\geometry\internaldocs\unitCircleEllipseIntersection.md
   // on how below variables are derived.
-  /** Standard Basis coefficients for rational sine numerator. */
+  /** Standard Basis coefficients for the numerator of the y-coordinate y(t) = S(t)/W(t) in the rational semicircle parameterization. */
   public static readonly S = Float64Array.from([0.0, 2.0, -2.0]);
-  /** Standard Basis coefficients for rational cosine numerator. */
+  /** Standard Basis coefficients for the numerator of the x-coordinate x(t) = C(t)/W(t) in the rational semicircle parameterization. */
   public static readonly C = Float64Array.from([1.0, -2.0]);
-  /** Standard Basis coefficients for rational weight denominator. */
+  /** Standard Basis coefficients for the denominator of x(t) and y(t) in the rational semicircle parameterization. */
   public static readonly W = Float64Array.from([1.0, -2.0, 2.0]);
-  /** Standard Basis coefficients for cosine*weight numerator. */
+  /** Standard Basis coefficients for C(t) * W(t). */
   public static readonly CW = Float64Array.from([1.0, -4.0, 6.0, -4.0]);
-  /** Standard Basis coefficients for sine*weight numerator. */
+  /** Standard Basis coefficients forS(t) * W(t). */
   public static readonly SW = Float64Array.from([0.0, 2.0, -6.0, 8.0, -4.0]);
-  /** Standard Basis coefficients for sine*cosine numerator. */
+  /** Standard Basis coefficients for S(t) * C(t). */
   public static readonly SC = Float64Array.from([0.0, 2.0, -6.0, 4.0]);
-  /** Standard Basis coefficients for sine^2 numerator. */
+  /** Standard Basis coefficients for S(t) * S(t). */
   public static readonly SS = Float64Array.from([0.0, 0.0, 4.0, -8.0, 4.0]);
-  /** Standard Basis coefficients for cosine^2 numerator. */
+  /** Standard Basis coefficients for C(t) * C(t). */
   public static readonly CC = Float64Array.from([1.0, -4.0, 4.0]);
-  /** Standard Basis coefficients for weight^2 denominator. */
+  /** Standard Basis coefficients for W(t) * W(t). */
   public static readonly WW = Float64Array.from([1.0, -4.0, 8.0, -8.0, 4.0]);
-  /** Standard Basis coefficients for cosine^2 - sine^2 numerator. */
+  /** Standard Basis coefficients for C(t) * C(t) - S(t) * S(t). */
   public static readonly CCminusSS = Float64Array.from([1.0, -4.0, 0.0, 8.0, -4.0]);
 
   /**
@@ -1178,7 +1178,6 @@ export class TrigPolynomial {
     if (degree === -1) {
       // Umm. Dunno. Nothing there.
     } else {
-      // status = true;
       if (degree === 0) {
         // p(t) is a nonzero constant
         // No roots, but not degenerate.
@@ -1295,7 +1294,7 @@ export class TrigPolynomial {
     return status;
   }
   /**
-   * Compute intersections of unit circle `x^2 + y^2 = w^2` (in homogenous coordinates) with the ellipse
+   * Compute intersections of unit circle `x^2 + y^2 = w^2` (in homogeneous coordinates) with the ellipse
    * `F(t) = (cx + ux cos(t) + vx sin(t), cy + uy cos(t) + vy sin(t)) / (cw + uw cos(t) + vw sin(t))`.
    * @param cx center x
    * @param cy center y
@@ -1893,5 +1892,4 @@ export class ImplicitLineXY {
     this.ax += scale * ax;
     this.ay += scale * ay;
   }
-
 }

--- a/core/geometry/src/test/curve/CurveCurveIntersectXY.test.ts
+++ b/core/geometry/src/test/curve/CurveCurveIntersectXY.test.ts
@@ -1589,6 +1589,57 @@ describe("CurveCurveIntersectXY", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectXY", "intersectionCurveChainVsCurveChain");
     expect(ck.getNumErrors()).equals(0);
   });
+  it("intersectionArcVsArc1", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    const arc1 = Arc3d.create(
+      Point3d.create(0, 0), Vector3d.create(1, 0), Vector3d.create(0, 2), AngleSweep.createStartEndDegrees(-90, 90),
+    );
+    const arc2 = Arc3d.create(
+      Point3d.create(0, 10), Vector3d.create(5, 0), Vector3d.create(0, 3), AngleSweep.createStartEndDegrees(-90, 90),
+    );
+    captureAndTestIntersection(allGeometry, ck, 0, 0, arc1, arc2, false, false, 0);
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectXY", "intersectionArcVsArc1");
+    expect(ck.getNumErrors()).toBe(0);
+  });
+  it("intersectionArcVsArc2", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    const arc1 = Arc3d.create(
+      Point3d.create(97, 5), Vector3d.create(1, 0), Vector3d.create(0, 2), AngleSweep.createStartEndDegrees(90, -90),
+    );
+    const arc2 = Arc3d.create(
+      Point3d.create(97, 15), Vector3d.create(4, 0), Vector3d.create(0, 1), AngleSweep.createStartEndDegrees(-90, 90),
+    );
+    captureAndTestIntersection(allGeometry, ck, 0, 0, arc1, arc2, false, false, 0);
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectXY", "intersectionArcVsArc2");
+    expect(ck.getNumErrors()).toBe(0);
+  });
+  it("intersectionArcVsArc3", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    const arc1 = Arc3d.create(
+      Point3d.create(539965.1282729112, 101215.56042805065),
+      Vector3d.create(1.3462994039129226, -1.4790124796713886),
+      Vector3d.create(-1.4790124796713886, -1.346299403912922),
+      AngleSweep.createStartEndDegrees(-43.31588330628889, 43.31588330628889),
+    );
+    const arc2 = Arc3d.create(
+      Point3d.create(540142.5176908899, 101091.35101865641),
+      Vector3d.create(-0.862104587620478, 0.8621045876247996),
+      Vector3d.create(0.8621045876247995, 0.862104587620478),
+      AngleSweep.createStartEndDegrees(-44.99999999980853, 44.99999999980853),
+    );
+    captureAndTestIntersection(allGeometry, ck, 0, 0, arc1, arc2, false, false, 0);
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectXY", "intersectionArcVsArc3");
+    expect(ck.getNumErrors()).toBe(0);
+  });
   it("intersectionSingleChild", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];

--- a/core/geometry/src/test/curve/CurveCurveIntersectXYZ.test.ts
+++ b/core/geometry/src/test/curve/CurveCurveIntersectXYZ.test.ts
@@ -2065,4 +2065,34 @@ describe("CurveCurveIntersectXYZChains", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectXYZChains", "intersectionXyzCurveChainCoPlanarVsCurveChainPlanar2");
     expect(ck.getNumErrors()).equals(0);
   });
+  it("intersectionArcVsArc1", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    const arc1 = Arc3d.create(
+      Point3d.create(77, 10), Vector3d.create(1, 0), Vector3d.create(0, 2), AngleSweep.createStartEndDegrees(-90, 90),
+    );
+    const arc2 = Arc3d.create(
+      Point3d.create(77, 20), Vector3d.create(5, 0), Vector3d.create(0, 3), AngleSweep.createStartEndDegrees(-90, 90),
+    );
+    captureAndTestIntersection(allGeometry, ck, 0, 0, arc2, arc1, false, false, 0);
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectXYZ", "intersectionArcVsArc1");
+    expect(ck.getNumErrors()).toBe(0);
+  });
+  it("intersectionArcVsArc2", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    const arc1 = Arc3d.create(
+      Point3d.create(97, 5), Vector3d.create(1, 0), Vector3d.create(0, 2), AngleSweep.createStartEndDegrees(90, -90),
+    );
+    const arc2 = Arc3d.create(
+      Point3d.create(97, 15), Vector3d.create(4, 0), Vector3d.create(0, 1), AngleSweep.createStartEndDegrees(-90, 90),
+    );
+    captureAndTestIntersection(allGeometry, ck, 0, 0, arc1, arc2, false, false, 0);
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectXYZ", "intersectionArcVsArc2");
+    expect(ck.getNumErrors()).toBe(0);
+  });
 });

--- a/core/geometry/src/test/curve/RegionBoolean.test.ts
+++ b/core/geometry/src/test/curve/RegionBoolean.test.ts
@@ -740,7 +740,7 @@ describe("RegionBoolean", () => {
   it("SelfIntersectingPolygon", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
-    const bowTie = Loop.createPolygon([Point3d.create(0,0), Point3d.create(10,0), Point3d.create(0,10), Point3d.create(10,10)]);
+    const bowTie = Loop.createPolygon([Point3d.create(0, 0), Point3d.create(10, 0), Point3d.create(0, 10), Point3d.create(10, 10)]);
     const signedLoops = RegionOps.constructAllXYRegionLoops(bowTie);
     ck.testExactNumber(1, signedLoops.length, "only one connected component");
     if (ck.testExactNumber(2, signedLoops[0].positiveAreaLoops.length, "two constituent ccw loops from intersections"))


### PR DESCRIPTION
Code was returning imaginary roots for one of the quadratics derived from the quartic by way of the resolvent cubic. Now no roots are returned for this case. This was apparently a fat-finger from the native port.