### PR TITLE
Switch from istanbul to v8 for vitest coverage provider

### DIFF
--- a/common/changes/@itwin/core-bentley/nam-vitest-v8-coverage_2024-10-09-19-51.json
+++ b/common/changes/@itwin/core-bentley/nam-vitest-v8-coverage_2024-10-09-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-common/nam-vitest-v8-coverage_2024-10-09-19-51.json
+++ b/common/changes/@itwin/core-common/nam-vitest-v8-coverage_2024-10-09-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-geometry/nam-vitest-v8-coverage_2024-10-09-19-51.json
+++ b/common/changes/@itwin/core-geometry/nam-vitest-v8-coverage_2024-10-09-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -387,8 +387,8 @@
       "allowedCategories": [ "internal" ]
     },
     {
-      "name": "@vitest/coverage-istanbul",
-      "allowedCategories": [ "backend", "common" ]
+      "name": "@vitest/coverage-v8",
+      "allowedCategories": [ "common" ]
     },
     {
       "name": "@xmldom/xmldom",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
       '@itwin/eslint-plugin': ^4.0.2
       '@opentelemetry/api': 1.0.4
       '@types/node': ~18.16.20
-      '@vitest/coverage-istanbul': ^2.1.0
+      '@vitest/coverage-v8': ^2.1.0
       eslint: ^8.56.0
       rimraf: ^3.0.2
       typescript: ~5.3.3
@@ -126,7 +126,7 @@ importers:
       '@itwin/eslint-plugin': 4.0.2_xdgzedli73k7lw4xlyzszm74om
       '@opentelemetry/api': 1.0.4
       '@types/node': 18.16.20
-      '@vitest/coverage-istanbul': 2.1.0_vitest@2.1.0
+      '@vitest/coverage-v8': 2.1.0_vitest@2.1.0
       eslint: 8.56.0
       rimraf: 3.0.2
       typescript: 5.3.3
@@ -142,7 +142,7 @@ importers:
       '@types/chai': 4.3.1
       '@types/flatbuffers': ~1.10.0
       '@types/node': ~18.16.20
-      '@vitest/coverage-istanbul': ^2.1.0
+      '@vitest/coverage-v8': ^2.1.0
       eslint: ^8.56.0
       flatbuffers: ~1.12.0
       js-base64: ^3.6.1
@@ -162,7 +162,7 @@ importers:
       '@types/chai': 4.3.1
       '@types/flatbuffers': 1.10.0
       '@types/node': 18.16.20
-      '@vitest/coverage-istanbul': 2.1.0_vitest@2.1.0
+      '@vitest/coverage-v8': 2.1.0_vitest@2.1.0
       eslint: 8.56.0
       nyc: 15.1.0
       rimraf: 3.0.2
@@ -661,7 +661,7 @@ importers:
       '@itwin/eslint-plugin': ^4.0.2
       '@types/flatbuffers': ~1.10.0
       '@types/node': ~18.16.20
-      '@vitest/coverage-istanbul': ^2.1.0
+      '@vitest/coverage-v8': ^2.1.0
       eslint: ^8.56.0
       flatbuffers: ~1.12.0
       rimraf: ^3.0.2
@@ -675,7 +675,7 @@ importers:
       '@itwin/eslint-plugin': 4.0.2_xdgzedli73k7lw4xlyzszm74om
       '@types/flatbuffers': 1.10.0
       '@types/node': 18.16.20
-      '@vitest/coverage-istanbul': 2.1.0_vitest@2.1.0
+      '@vitest/coverage-v8': 2.1.0_vitest@2.1.0
       eslint: 8.56.0
       rimraf: 3.0.2
       typescript: 5.3.3
@@ -3559,14 +3559,6 @@ packages:
       js-tokens: 4.0.0
       picocolors: 1.1.0
 
-  /@babel/parser/7.25.3:
-    resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.25.6
-    dev: true
-
   /@babel/parser/7.25.6:
     resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
     engines: {node: '>=6.0.0'}
@@ -3609,6 +3601,10 @@ packages:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  /@bcoe/v8-coverage/0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
 
   /@bentley/aec-units-schema/1.0.3:
     resolution: {integrity: sha512-Rpc+g75LZfDaapej3OBUOx67p5vOi9xF34gAhfWlmdm2cWeMZzjkjzVLR/Fn8NMdvhn/QS8HRAVLlXLSOtm6kg==}
@@ -5473,19 +5469,25 @@ packages:
   /@ungap/structured-clone/1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@vitest/coverage-istanbul/2.1.0_vitest@2.1.0:
-    resolution: {integrity: sha512-y32czqj5q+bNFOxWH0kqs/TsAx29WV2dvJr4Y/xkmHtV1CFnyphnrK0Dwx71f1+OpCicseJuHLB9jBgrqkisFQ==}
+  /@vitest/coverage-v8/2.1.0_vitest@2.1.0:
+    resolution: {integrity: sha512-yqCkr2nrV4o58VcVMxTVkS6Ggxzy7pmSD8JbTbhbH5PsQfUIES1QT716VUzo33wf2lX9EcWYdT3Vl2MMmjR59g==}
     peerDependencies:
+      '@vitest/browser': 2.1.0
       vitest: 2.1.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
     dependencies:
-      '@istanbuljs/schema': 0.1.3
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
       debug: 4.3.6
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
+      magic-string: 0.30.11
       magicast: 0.3.5
+      std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
       vitest: 2.1.0_@types+node@18.16.20
@@ -8569,7 +8571,7 @@ packages:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
     dependencies:
-      cross-spawn: 7.0.1
+      cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
   /form-data-encoder/2.1.4:
@@ -9660,19 +9662,6 @@ packages:
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /istanbul-lib-instrument/6.0.3:
-    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/parser': 7.25.3
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.2
-      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/core/bentley/package.json
+++ b/core/bentley/package.json
@@ -38,7 +38,7 @@
     "@itwin/eslint-plugin": "^4.0.2",
     "@opentelemetry/api": "1.0.4",
     "@types/node": "~18.16.20",
-    "@vitest/coverage-istanbul": "^2.1.0",
+    "@vitest/coverage-v8": "^2.1.0",
     "eslint": "^8.56.0",
     "rimraf": "^3.0.2",
     "typescript": "~5.3.3",

--- a/core/bentley/vitest.config.mts
+++ b/core/bentley/vitest.config.mts
@@ -3,7 +3,7 @@ export default defineConfig({
   test: {
     dir: "src",
     coverage: {
-      provider: "istanbul", // akin to nyc
+      provider: "v8",
       include: [
         "src/**/*"
       ],

--- a/core/common/package.json
+++ b/core/common/package.json
@@ -52,7 +52,7 @@
     "@types/chai": "4.3.1",
     "@types/flatbuffers": "~1.10.0",
     "@types/node": "~18.16.20",
-    "@vitest/coverage-istanbul": "^2.1.0",
+    "@vitest/coverage-v8": "^2.1.0",
     "eslint": "^8.56.0",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",

--- a/core/common/vitest.config.mts
+++ b/core/common/vitest.config.mts
@@ -3,7 +3,7 @@ export default defineConfig({
   test: {
     dir: "src",
     coverage: {
-      provider: "istanbul", // akin to nyc
+      provider: "v8",
       include: [
         "src/**/*"
       ],

--- a/core/geometry/package.json
+++ b/core/geometry/package.json
@@ -41,7 +41,7 @@
     "@itwin/eslint-plugin": "^4.0.2",
     "@types/flatbuffers": "~1.10.0",
     "@types/node": "~18.16.20",
-    "@vitest/coverage-istanbul": "^2.1.0",
+    "@vitest/coverage-v8": "^2.1.0",
     "eslint": "^8.56.0",
     "rimraf": "^3.0.2",
     "typescript": "~5.3.3",

--- a/core/geometry/vitest.config.mts
+++ b/core/geometry/vitest.config.mts
@@ -5,7 +5,7 @@ export default defineConfig({
     setupFiles: "./src/test/setupTests.ts",
     // include: ["**/filename.test.ts"], // to honor it/describe.only
     coverage: {
-      provider: "istanbul", // akin to nyc,
+      provider: "v8",
       include: [
         "src/**/*"
       ],


### PR DESCRIPTION
We're seeing an increase in running times for rush cover in our CI builds, in particular the subdirectories that have moved to vitest might not exit cleanly at the end of the test run, and hang. This PR aims to reduce flakiness of rush cover by switching to a more performant coverage provider for vitest. The reported coverage statistics are different - we see 10-15% improvement to coverage statistics when switching from istanbul to v8...

Locally, on an M1 Mac, comparing times from istanbul to v8 across the 3 packages that are using vitest right now, averaged across 5 runs:
- core-geometry: 108s -> 25s
- core-bentley: 2.8s -> 1.8s
- core-common: 8.6s -> 5.3s

Diving deeper into the times for core-geometry, the time vitest spent transforming and setting up the tests were significantly lower (from 370s in total across parallel workers down to 79s), because istanbul uses babel to transpile, adding extra overhead to the files, compared to v8.

A side effect of this is that `istanbul ignore` comments won't be picked up by the coverage provider, but none were found in the affected packages.