### PR TITLE
Add Condition to bump job

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -137,8 +137,10 @@ jobs:
 
   - job: Bump
     displayName: Bump Version
-    dependsOn: CreateBranch
-    condition: in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped')
+    dependsOn:
+    - CreateBranch
+    - checkPrevCommit
+    condition: and(in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'))
     variables:
       releaseBranchName: $[ dependencies.CreateBranch.outputs['getBranchName.releaseBranchName'] ]
     steps:


### PR DESCRIPTION
Recent change to this yaml file accidentally changed some of the job conditions. This caused nightly releases to be produced even if no changes were committed to itwinjs-core in that day.

Adding the condition back to the the Bump Job will skip the bump task when no commits into itwinjs-core are detected.