### PR TITLE
Throw SchemaMergingError if mergeing of two schemas failed

### DIFF
--- a/common/changes/@itwin/ecschema-editing/schemaediting-merging-error_2024-10-17-12-58.json
+++ b/common/changes/@itwin/ecschema-editing/schemaediting-merging-error_2024-10-17-12-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/core/ecschema-editing/src/Differencing/SchemaDifferenceVisitor.ts
+++ b/core/ecschema-editing/src/Differencing/SchemaDifferenceVisitor.ts
@@ -45,7 +45,7 @@ export class SchemaDifferenceWalker {
   /**
    * Calls the appropriate method on the visitor based on the schema difference type.
    */
-  private async visit(difference: AnySchemaDifference, index: number, array: AnySchemaDifference[]) {
+  protected async visit(difference: AnySchemaDifference, index: number, array: AnySchemaDifference[]) {
     switch (difference.schemaType) {
       case SchemaOtherTypes.Schema:
         return this._visitor.visitSchemaDifference(difference, index, array);

--- a/core/ecschema-editing/src/ecschema-editing.ts
+++ b/core/ecschema-editing/src/ecschema-editing.ts
@@ -23,7 +23,7 @@ export * from "./Differencing/SchemaDifference";
 export * from "./Differencing/SchemaConflicts";
 export * from "./Differencing/Errors";
 export * from "./Differencing/Utils";
-export { SchemaMerger } from "./Merging/SchemaMerger";
+export { SchemaMerger, SchemaMergingError } from "./Merging/SchemaMerger";
 export * from "./Merging/Edits/SchemaEdits";
 
 /** @docs-package-description

--- a/core/ecschema-editing/src/test/Merging/ConstantMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/ConstantMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Constant, Schema, SchemaItemType } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { SchemaOtherTypes } from "../../Differencing/SchemaDifference";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
 import { expect } from "chai";
@@ -170,8 +170,10 @@ describe("Constant merger tests", () => {
         },
       ],
     });
-    await expect(merge).to.be.rejectedWith("The Constant testConstant has an invalid 'definition' attribute.");
 
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "The Constant testConstant has an invalid 'definition' attribute.");
+    });
   });
 
   it("it should throw error if numerator conflict exist", async () => {
@@ -213,7 +215,10 @@ describe("Constant merger tests", () => {
         },
       ],
     });
-    await expect(merge).to.be.rejectedWith(Error, "Failed to merged, constant numerator conflict: 5.5 -> 4.5");
+
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Failed to merged, constant numerator conflict: 5.5 -> 4.5");
+    });
   });
 
   it("it should throw error if denominator conflict exist", async () => {
@@ -255,6 +260,9 @@ describe("Constant merger tests", () => {
         },
       ],
     });
-    await expect(merge).to.be.rejectedWith(Error, "Failed to merged, constant denominator conflict: 5.1 -> 4.2");
+
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Failed to merged, constant denominator conflict: 5.1 -> 4.2");
+    });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/CustomAttributeClassMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/CustomAttributeClassMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { CustomAttributeClass, CustomAttributeContainerType, Schema, SchemaContext, SchemaItemType } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { expect } from "chai";
 import { ECEditingStatus } from "../../Editing/Exception";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
@@ -172,7 +172,9 @@ describe("CustomAttributeClass merger tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith("Changing the class 'testCAClass' baseClass is not supported.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the class 'testCAClass' baseClass is not supported.");
+    });
   });
 
   it("should throw an error when merging custom attribute base class to one that doesn't derive from", async () => {
@@ -224,10 +226,10 @@ describe("CustomAttributeClass merger tests", () => {
       ],
     });
 
-    await expect(merge).to.be.eventually.rejected.then(function (error) {
-      expect(error).to.have.property("errorNumber", ECEditingStatus.SetBaseClass);
-      expect(error).to.have.nested.property("innerError.message", `Base class TargetSchema.TestBase must derive from TargetSchema.TargetBase.`);
-      expect(error).to.have.nested.property("innerError.errorNumber", ECEditingStatus.InvalidBaseClass);
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).to.have.nested.property("mergeError.errorNumber", ECEditingStatus.SetBaseClass);
+      expect(error).to.have.nested.property("mergeError.innerError.message", `Base class TargetSchema.TestBase must derive from TargetSchema.TargetBase.`);
+      expect(error).to.have.nested.property("mergeError.innerError.errorNumber", ECEditingStatus.InvalidBaseClass);
     });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/EntityClassMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/EntityClassMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { ECClassModifier, EntityClass, Schema, SchemaContext, SchemaItemKey, SchemaItemType } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { SchemaOtherTypes } from "../../Differencing/SchemaDifference";
 import { ECEditingStatus } from "../../Editing/Exception";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
@@ -282,7 +282,10 @@ describe("EntityClass merger tests", () => {
         },
       ],
     });
-    await expect(merge).to.be.rejectedWith("Changing the type of item 'TestClass' not supported.");
+
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the type of item 'TestClass' not supported.");
+    });
   });
 
   it("should throw an error when merging class modifier changed from Abstract to Sealed", async () => {
@@ -312,7 +315,9 @@ describe("EntityClass merger tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith("Changing the class 'TestEntity' modifier is not supported.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the class 'TestEntity' modifier is not supported.");
+    });
   });
 
   it("should throw an error when merging entity base class changed from existing one to undefined", async () => {
@@ -345,7 +350,9 @@ describe("EntityClass merger tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith("Changing the class 'TestEntity' baseClass is not supported.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the class 'TestEntity' baseClass is not supported.");
+    });
   });
 
   it("should throw an error when merging entity base class changed from undefined to existing one", async () => {
@@ -381,7 +388,9 @@ describe("EntityClass merger tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith("Changing the class 'TestEntity' baseClass is not supported.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the class 'TestEntity' baseClass is not supported.");
+    });
   });
 
   it("should throw an error when merging entity base class to one that doesn't derive from", async () => {
@@ -430,9 +439,9 @@ describe("EntityClass merger tests", () => {
     });
 
     await expect(merge).to.be.eventually.rejected.then(function (error) {
-      expect(error).to.have.property("errorNumber", ECEditingStatus.SetBaseClass);
-      expect(error).to.have.nested.property("innerError.message", `Base class TargetSchema.TestBase must derive from TargetSchema.TargetBase.`);
-      expect(error).to.have.nested.property("innerError.errorNumber", ECEditingStatus.InvalidBaseClass);
+      expect(error).to.have.nested.property("mergeError.errorNumber", ECEditingStatus.SetBaseClass);
+      expect(error).to.have.nested.property("mergeError.innerError.message", `Base class TargetSchema.TestBase must derive from TargetSchema.TargetBase.`);
+      expect(error).to.have.nested.property("mergeError.innerError.errorNumber", ECEditingStatus.InvalidBaseClass);
     });
   });
 
@@ -463,9 +472,9 @@ describe("EntityClass merger tests", () => {
     });
 
     await expect(merge).to.be.eventually.rejected.then(function (error) {
-      expect(error).to.have.property("errorNumber", ECEditingStatus.AddMixin);
-      expect(error).to.have.nested.property("innerError.message", `Mixin TargetSchema.NotExistingMixin could not be found in the schema context.`);
-      expect(error).to.have.nested.property("innerError.errorNumber", ECEditingStatus.SchemaItemNotFoundInContext);
+      expect(error).to.have.nested.property("mergeError.errorNumber", ECEditingStatus.AddMixin);
+      expect(error).to.have.nested.property("mergeError.innerError.message", `Mixin TargetSchema.NotExistingMixin could not be found in the schema context.`);
+      expect(error).to.have.nested.property("mergeError.innerError.errorNumber", ECEditingStatus.SchemaItemNotFoundInContext);
     });
   });
 
@@ -513,9 +522,9 @@ describe("EntityClass merger tests", () => {
     });
 
     await expect(merge).to.be.eventually.rejected.then(function (error) {
-      expect(error).to.have.property("errorNumber", ECEditingStatus.SetBaseClass);
-      expect(error).to.have.nested.property("innerError.message", `Base class TargetSchema.TestBase must derive from TargetSchema.BaseMixin.`);
-      expect(error).to.have.nested.property("innerError.errorNumber", ECEditingStatus.InvalidBaseClass);
+      expect(error).to.have.nested.property("mergeError.errorNumber", ECEditingStatus.SetBaseClass);
+      expect(error).to.have.nested.property("mergeError.innerError.message", `Base class TargetSchema.TestBase must derive from TargetSchema.BaseMixin.`);
+      expect(error).to.have.nested.property("mergeError.innerError.errorNumber", ECEditingStatus.InvalidBaseClass);
     });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/EnumerationMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/EnumerationMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Enumeration, Schema, SchemaItemType } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { SchemaOtherTypes } from "../../Differencing/SchemaDifference";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
 import { expect } from "chai";
@@ -290,7 +290,9 @@ describe("Enumeration merge tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith(Error, "The Enumeration TestEnumeration has an incompatible type. It must be \"string\", not \"int\".");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "The Enumeration TestEnumeration has an incompatible type. It must be \"string\", not \"int\".");
+    });
   });
 
   it("should throw an error if enumerator value attribute conflict exist", async () => {
@@ -329,6 +331,8 @@ describe("Enumeration merge tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith("Failed to merge enumerator attribute, Enumerator \"EnumeratorOne\" has different values.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Failed to merge enumerator attribute, Enumerator \"EnumeratorOne\" has different values.");
+    });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/KindOfQuantityMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/KindOfQuantityMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { KindOfQuantity, Schema, SchemaContext, SchemaItemType } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { expect } from "chai";
 import { SchemaOtherTypes } from "../../Differencing/SchemaDifference";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
@@ -504,6 +504,8 @@ describe("KindOfQuantity merge tests", () => {
       conflicts: undefined,
     });
 
-    await expect(merge).to.be.rejectedWith("Changing the kind of quantity 'TestKoq' persistenceUnit is not supported.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the kind of quantity 'TestKoq' persistenceUnit is not supported.");
+    });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/MixinMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/MixinMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Mixin, Schema, SchemaContext, SchemaItemType } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { expect } from "chai";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
 
@@ -158,6 +158,8 @@ describe("Mixin merger tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith("Changing the mixin 'TestMixin' appliesTo is not supported.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the mixin 'TestMixin' appliesTo is not supported.");
+    });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/PhenomenonMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/PhenomenonMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Phenomenon, Schema, SchemaItemType } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
 import { expect } from "chai";
 
@@ -66,7 +66,7 @@ describe("Phenomenon merger tests", () => {
     }, await BisTestHelper.getNewContext());
 
     const merger = new SchemaMerger(targetSchema.context);
-    await expect(merger.merge({
+    const merge = merger.merge({
       sourceSchemaName: "SourceSchema.01.02.03",
       targetSchemaName: "TargetSchema.01.00.00",
       differences: [
@@ -79,6 +79,10 @@ describe("Phenomenon merger tests", () => {
           },
         },
       ],
-    })).to.be.rejectedWith("The Phenomenon testPhenomenon has an invalid 'definition' attribute.");
+    });
+
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "The Phenomenon testPhenomenon has an invalid 'definition' attribute.");
+    });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/PropertyMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/PropertyMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { CustomAttributeClass, ECClass, EntityClass, Mixin, Property, Schema, SchemaContext, SchemaItemType, StructClass } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { SchemaOtherTypes } from "../../Differencing/SchemaDifference";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
 import { expect } from "chai";
@@ -1009,7 +1009,9 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestStruct.Prop' primitiveType is not supported.");
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestStruct.Prop' primitiveType is not supported.");
+      });
     });
 
     it("should throw an error when merging array properties primitive type changed from double to string", async () => {
@@ -1044,7 +1046,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestCA.ArrProp' primitiveType is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestCA.ArrProp' primitiveType is not supported.");
+      });
     });
 
     it("should throw an error when merging properties type changed from PrimitiveArrayProperty to PrimitiveProperty", async () => {
@@ -1078,7 +1083,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestEntity.Prop' type is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestEntity.Prop' type is not supported.");
+      });
     });
 
     it("should not throw an error when merging properties with changed kind of quantity but same persistence unit", async () => {
@@ -1220,7 +1228,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("KindOfQuantity can only be changed if it has the same persistence unit as the property.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "KindOfQuantity can only be changed if it has the same persistence unit as the property.");
+      });
     });
 
     it("should throw an error when merging struct properties structClass changed", async () => {
@@ -1265,7 +1276,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestEntity.StructProp' structClass is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestEntity.StructProp' structClass is not supported.");
+      });
     });
 
     it("should throw an error when merging struct array properties structClass changed", async () => {
@@ -1308,7 +1322,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestStruct.StructArrayProp' structClass is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestStruct.StructArrayProp' structClass is not supported.");
+      });
     });
 
     it("should throw an error when merging enumeration properties enumeration changed", async () => {
@@ -1361,7 +1378,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestEntity.EnumProp' enumeration is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestEntity.EnumProp' enumeration is not supported.");
+      });
     });
 
     it("should throw an error when merging enumeration array properties enumeration changed", async () => {
@@ -1423,7 +1443,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestEntity.EnumArrayProp' enumeration is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestEntity.EnumArrayProp' enumeration is not supported.");
+      });
     });
 
     it("should throw an error when merging navigation properties direction changed", async () => {
@@ -1466,7 +1489,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestEntity.NavProp' direction is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestEntity.NavProp' direction is not supported.");
+      });
     });
 
     it("should throw an error when merging navigation properties relationship class changed", async () => {
@@ -1535,7 +1561,10 @@ describe("Property merger tests", () => {
           },
         ],
       });
-      await expect(merge).to.be.rejectedWith("Changing the property 'TestEntity.NavProp' relationship class is not supported.");
+
+      await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+        expect(error).has.a.nested.property("mergeError.message", "Changing the property 'TestEntity.NavProp' relationship class is not supported.");
+      });
     });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/SchemaMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/SchemaMerger.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { Schema, SchemaContext } from "@itwin/ecschema-metadata";
 import { SchemaConflictsError } from "../../Differencing/Errors";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { AnySchemaDifference, SchemaOtherTypes } from "../../Differencing/SchemaDifference";
 import { AnySchemaDifferenceConflict, ConflictCode } from "../../Differencing/SchemaConflicts";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
@@ -57,7 +57,9 @@ describe("Schema merge tests", () => {
       differences: [],
     });
 
-    await expect(merge).to.be.rejectedWith("The target schema 'TargetSchema' could not be found in the editing context.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "The target schema 'TargetSchema' could not be found in the editing context.");
+    });
   });
 
   it("should throw an error if the target schema cannot be located", async () => {
@@ -75,7 +77,9 @@ describe("Schema merge tests", () => {
       differences: [],
     });
 
-    await expect(merge).to.be.rejectedWith("The target schema 'TargetSchema' is not dynamic. Only dynamic schemas are supported for merging.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "The target schema 'TargetSchema' is not dynamic. Only dynamic schemas are supported for merging.");
+    });
   });
 
   it("should merge label and description from schema", async () => {

--- a/core/ecschema-editing/src/test/Merging/SchemaReferenceMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/SchemaReferenceMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Schema } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { SchemaOtherTypes } from "../../Differencing/SchemaDifference";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
 import { expect } from "chai";
@@ -115,6 +115,9 @@ describe("Schema reference merging tests", () => {
         },
       }],
     });
-    await expect(merge).to.eventually.rejectedWith("Schemas references of BisCore have incompatible versions: 01.00.01 and 01.01.01");
+
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Schemas references of BisCore have incompatible versions: 01.00.01 and 01.01.01");
+    });
   });
 });

--- a/core/ecschema-editing/src/test/Merging/StructClassMerger.test.ts
+++ b/core/ecschema-editing/src/test/Merging/StructClassMerger.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Schema, SchemaContext, SchemaItemType, StructClass } from "@itwin/ecschema-metadata";
-import { SchemaMerger } from "../../Merging/SchemaMerger";
+import { SchemaMerger, SchemaMergingError } from "../../Merging/SchemaMerger";
 import { BisTestHelper } from "../TestUtils/BisTestHelper";
 import { expect } from "chai";
 
@@ -169,6 +169,8 @@ describe("StructClass merger tests", () => {
       ],
     });
 
-    await expect(merge).to.be.rejectedWith("Changing the class 'TestStruct' baseClass is not supported.");
+    await expect(merge).to.be.eventually.rejectedWith(SchemaMergingError).then((error) => {
+      expect(error).has.a.nested.property("mergeError.message", "Changing the class 'TestStruct' baseClass is not supported.");
+    });
   });
 });


### PR DESCRIPTION
Additionally, SchemaMergingError provides a list of differences that has been merged until the error happend.