### PR TITLE
Regression 4.9.2 where aliased ECClassId switch from returning classId to className

### DIFF
--- a/common/changes/@itwin/core-backend/affanK-regression_classid_2024-10-18-19-55.json
+++ b/common/changes/@itwin/core-backend/affanK-regression_classid_2024-10-18-19-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Comply with 4.8.x ECSql row format",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   ../../core/backend:
     specifiers:
-      '@bentley/imodeljs-native': 4.10.13
+      '@bentley/imodeljs-native': 4.10.14
       '@itwin/build-tools': workspace:*
       '@itwin/cloud-agnostic-core': ^2.2.4
       '@itwin/core-bentley': workspace:*
@@ -58,7 +58,7 @@ importers:
       webpack: ^5.76.0
       ws: ^7.5.10
     dependencies:
-      '@bentley/imodeljs-native': 4.10.13
+      '@bentley/imodeljs-native': 4.10.14
       '@itwin/cloud-agnostic-core': 2.2.4_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/core-telemetry': link:../telemetry
       '@itwin/object-storage-azure': 2.2.5_scz6qrwecfbbxg4vskopkl3a7u
@@ -3693,8 +3693,8 @@ packages:
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
     dev: false
 
-  /@bentley/imodeljs-native/4.10.13:
-    resolution: {integrity: sha512-BVM85YYIHqI42UhimwXVAQlLr5RqjI8bVdrnA+iyenmCWEFr7RdWEcLXXhG7vqA85waXpMc+qvbtKSjeXa4THw==}
+  /@bentley/imodeljs-native/4.10.14:
+    resolution: {integrity: sha512-BWSxjcpkCKFZm4vWN9rXH/hDdR/PxWQW5L4nHEyPRlvhPls6kfV6BE3OaN/yk62d/drN+SKpJmlMzmzYCTakwg==}
     requiresBuild: true
     dev: false
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -98,7 +98,7 @@
     "webpack": "^5.76.0"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "4.10.13",
+    "@bentley/imodeljs-native": "4.10.14",
     "@itwin/cloud-agnostic-core": "^2.2.4",
     "@itwin/core-telemetry": "workspace:*",
     "@itwin/object-storage-azure": "^2.2.5",

--- a/core/backend/src/test/ecdb/ECSqlStatement.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlStatement.test.ts
@@ -2297,7 +2297,7 @@ describe("ECSqlStatement", () => {
         assert.equal(row["parent.id"], parentId);
         assert.equal(row["parent.relClassName"], "Test.ParentHasChildren");
         assert.equal(row.myParentId, parentId);
-        assert.isFalse(Id64.isValidId64(row.myParentRelClassId));
+        assert.isTrue(Id64.isValidId64(row.myParentRelClassId));
       }), 2);
 
       const childId: Id64String = childIds[0];
@@ -2337,11 +2337,11 @@ describe("ECSqlStatement", () => {
       assert.equal(await query(ecdb, "SELECT ECInstanceId as MyId,ECClassId as MyClassId,SourceECInstanceId As MySourceId,SourceECClassId As MySourceClassId,TargetECInstanceId As MyTargetId,TargetECClassId As MyTargetClassId FROM test.ParentHasChildren WHERE TargetECInstanceId=?", QueryBinder.from([childId]), undefined, (row: any) => {
         rowCount++;
         assert.equal(row.myId, childId);
-        assert.isFalse(Id64.isValidId64(row.myClassId));
+        assert.isTrue(Id64.isValidId64(row.myClassId));
         assert.equal(row.mySourceId, parentId);
-        assert.isFalse(Id64.isValidId64(row.mySourceClassId));
+        assert.isTrue(Id64.isValidId64(row.mySourceClassId));
         assert.equal(row.myTargetId, childId);
-        assert.isFalse(Id64.isValidId64(row.myTargetClassId));
+        assert.isTrue(Id64.isValidId64(row.myTargetClassId));
       }), 1);
 
     });

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:4.10.13'
+    implementation 'com.github.itwin:mobile-native-android:4.10.14'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.10.13;
+				version = 4.10.14;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.10.13;
+				version = 4.10.14;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
1. CTE query returning classid switch from className to classId in `4.9.x`. This broke a user. 
2. [PR 7235](https://github.com/iTwin/itwinjs-core/pull/7238) Fix CTE, but this requires properly handling extendType information. This result in another break in behavior where aliased classid property was return as className. In 4.8.x/ 4.9.0 it used to return Id not class name. This break only happens for Concurrent Query for ECSqlStatement was fine as it set a flag called `DoNotConvertClassIdsToClassNamesWhenAliased` to reproduce previous behavior.
3. This PR also set `DoNotConvertClassIdsToClassNamesWhenAliased` for concurrent query to reproduce behavior of classId returning class name when aliased to be compilable with 4.8.x


First query that broke user is following 
```sql
SELECT t(aClassId) AS (SELECT ECClassId FROM Bis.Element) SELECT * FROM t
-- 4.8.x return className
-- 4.9.0 return classId
```
```sql
SELECT ECClassId AS aClassId FROM Bis.Element
--4.9.0 returned classId
--4.9.2 return className
```

After current fix

```sql
SELECT t(aClassId) AS (SELECT ECClassId FROM Bis.Element) SELECT * FROM t
-- return className as in 4.8.x
```
```sql
SELECT ECClassId AS aClassId FROM Bis.Element
-- returned classId  as in 4.8.x
```

imodel-native: https://github.com/iTwin/imodel-native/pull/891