### PR TITLE
Empty string property tag fix

### DIFF
--- a/core/ecschema-metadata/src/Deserialization/XmlParser.ts
+++ b/core/ecschema-metadata/src/Deserialization/XmlParser.ts
@@ -1104,7 +1104,7 @@ export class XmlParser extends AbstractParser<Element> {
   }
 
   private readPrimitivePropertyValue(propElement: Element, primitiveType: PrimitiveType): PrimitiveValue {
-    if (!propElement.textContent)
+    if (propElement.textContent === undefined || propElement.textContent === null)
       throw new ECObjectsError(ECObjectsStatus.InvalidSchemaXML, `Primitive property '${propElement.tagName}' has an invalid property value.`);
 
     // TODO: Mapping all primitive types to string, number and boolean

--- a/core/ecschema-metadata/src/Deserialization/XmlParser.ts
+++ b/core/ecschema-metadata/src/Deserialization/XmlParser.ts
@@ -19,6 +19,7 @@ import {
   PrimitivePropertyProps, PropertyCategoryProps, PropertyProps, RelationshipClassProps, RelationshipConstraintProps, SchemaItemFormatProps, SchemaItemProps,
   SchemaItemUnitProps, SchemaProps, SchemaReferenceProps, StructArrayPropertyProps, StructClassProps, StructPropertyProps, UnitSystemProps,
 } from "./JsonProps";
+import { propertyTypeToString } from "../PropertyTypes";
 
 const NON_ITEM_SCHEMA_ELEMENTS = ["ECSchemaReference", "ECCustomAttributes"];
 const ECXML_URI = "http://www\\.bentley\\.com/schemas/Bentley\\.ECXML";
@@ -1104,7 +1105,10 @@ export class XmlParser extends AbstractParser<Element> {
   }
 
   private readPrimitivePropertyValue(propElement: Element, primitiveType: PrimitiveType): PrimitiveValue {
-    if (propElement.textContent === undefined || propElement.textContent === null)
+    if (undefined === propElement.textContent || null === propElement.textContent)
+      throw new ECObjectsError(ECObjectsStatus.InvalidSchemaXML, `Primitive property '${propElement.tagName}' has an invalid property value.`);
+
+    if (propElement.textContent === "" && primitiveType !== PrimitiveType.String)
       throw new ECObjectsError(ECObjectsStatus.InvalidSchemaXML, `Primitive property '${propElement.tagName}' has an invalid property value.`);
 
     // TODO: Mapping all primitive types to string, number and boolean

--- a/core/ecschema-metadata/src/test/Deserialization/XmlParser.test.ts
+++ b/core/ecschema-metadata/src/test/Deserialization/XmlParser.test.ts
@@ -1868,6 +1868,61 @@ describe("XmlParser", () => {
     });
 
     describe("Property Parsing Tests", () => {
+      describe("String Parsing Tests", () => {
+        it("With value set to valid string, CustomAttributeProvider should provide valid instance.", async () => {
+          const itemXml = `
+            <ECCustomAttributes>
+              <TestAttribute xmlns="TestSchema.1.0">
+                <TestProperty>TestString</TestProperty>
+              </TestAttribute>
+            </ECCustomAttributes>`;
+
+          const propertyJson = {
+            properties: [
+              {
+                name: "TestProperty",
+                type: "PrimitiveProperty",
+                typeName: "string",
+              },
+            ],
+          };
+
+          const testClass = await getTestCAClass(propertyJson);
+          const providers = getCAProviders(itemXml);
+
+          // Call Provider
+          const caInstance = providers[0][1](testClass!);
+
+          expect(caInstance.TestProperty).to.equal("TestString");
+        });
+
+        it("Empty property tag, CustomAttributeProvider should provide valid instance.", async () => {
+          const itemXml = `
+            <ECCustomAttributes>
+              <TestAttribute xmlns="TestSchema.1.0">
+                <TestProperty />
+              </TestAttribute>
+            </ECCustomAttributes>`;
+
+          const propertyJson = {
+            properties: [
+              {
+                name: "TestProperty",
+                type: "PrimitiveProperty",
+                typeName: "string",
+              },
+            ],
+          };
+
+          const testClass = await getTestCAClass(propertyJson);
+          const providers = getCAProviders(itemXml);
+
+          // Call Provider
+          const caInstance = providers[0][1](testClass!);
+
+          expect(caInstance.TestProperty).to.equal("");
+        });
+      });
       describe("Boolean Parsing Tests", () => {
         it("With value set to 'True', CustomAttributeProvider should provide valid instance.", async () => {
           const itemXml = `


### PR DESCRIPTION
Any null, undefined, or empty (string) values are considered invalid and exception is thrown. An exception should be made for string properties where the value is empty. 