### PR TITLE
Update `extract-api` to support custom `entry` paths

### DIFF
--- a/common/changes/@itwin/build-tools/extract-api-dir_2024-10-22-09-50.json
+++ b/common/changes/@itwin/build-tools/extract-api-dir_2024-10-22-09-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Allow specifying a relative directory for the `entry` argument in the `extract-api` command.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/scripts/extract-api.js
+++ b/tools/build/scripts/extract-api.js
@@ -15,8 +15,14 @@ if (argv.entry === undefined) {
   return;
 }
 
+function getEntryPointDirName(){
+  const dirname = path.dirname(argv.entry);
+  return dirname === "." ? "./lib/cjs" : dirname;
+};
+
 const isCI = (process.env.TF_BUILD);
-const entryPointFileName = argv.entry;
+const entryPointFileName = path.basename(argv.entry);
+const entryPointDirName = getEntryPointDirName();
 const ignoreMissingTags = argv.ignoreMissingTags;
 const includeUnexportedApis = argv.includeUnexportedApis;
 
@@ -43,9 +49,11 @@ const apiReportFolder = argv.apiReportFolder ?? path.join(rushCommon(), "/api");
 const apiReportTempFolder = argv.apiReportTempFolder ?? path.join(rushCommon(), "/temp/api");
 const apiSummaryFolder = argv.apiSummaryFolder ?? path.join(rushCommon(), "/api/summary");
 
+const appDir = path.join(paths.appSrc, "..");
+const projectFolder = path.relative(entryPointDirName, appDir);
 const config = {
   $schema: "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  projectFolder: "../../",
+  projectFolder,
   compiler: {
     tsconfigFilePath: "<projectFolder>/tsconfig.json"
   },
@@ -104,12 +112,12 @@ const config = {
   }
 };
 
-if (!fs.existsSync("lib")) {
-  process.stderr.write("`lib` folder not found. Build the package(s) before running `extract-api`");
+if (!fs.existsSync(entryPointDirName)) {
+  process.stderr.write(`\`${entryPointDirName}\` folder not found. Build the package(s) before running \`extract-api\``);
   process.exit(1);
 }
 
-const configFileName = `lib/cjs/${entryPointFileName}.json`;
+const configFileName = path.format({ dir: entryPointDirName, name: entryPointFileName, ext: ".json" });
 fs.writeFileSync(configFileName, JSON.stringify(config, null, 2));
 
 const args = [


### PR DESCRIPTION
This PR updates the `extract-api` script to allow the specification of a relative directory for the `entry` argument.
This might be useful for packages that do not deliver `cjs` modules or have a different module structure. 
I.e. extract the API from the `lib` directory: `betools extract-api --entry=./lib/core-frontend`.

Current usage is not affected by this change - if the `entry` argument specifies only a file name w/o a directory name, the `./lib/cjs` directory is used. I.e. `betools extract-api --entry=core-frontend` continues to extract the API from `lib/cjs` directory.