### PR TITLE
Exclude rush change artifacts from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -160,6 +160,7 @@ rush.json                                         @iTwin/itwinjs-core-admins
 
 ## Updates to the package.json should avoid requesting review by everyone
 ## If the version updates or
+/common/changes/**/*.json                         @iTwin/itwinjs-core
 /**/package.json                                  @iTwin/itwinjs-core
 /**/CHANGELOG.json                                @iTwin/itwinjs-core
 /**/CHANGELOG.md                                  @iTwin/itwinjs-core


### PR DESCRIPTION
Our CODEOWNERS file attempts to keep simple version updates from requiring all reviewers, but since `rush change` adds changelog JSON files in `common/changes`, those folks wind up being required reviewers anyway.