### PR TITLE
Fix ArcGIS Feature request failures on specific server

### DIFF
--- a/common/changes/@itwin/map-layers-formats/geo-fixFeatureFormatCase_2024-10-25-19-20.json
+++ b/common/changes/@itwin/map-layers-formats/geo-fixFeatureFormatCase_2024-10-25-19-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-formats",
+      "comment": "Fix ArcGIS Feature request failures on specific server",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-formats"
+}

--- a/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureProvider.ts
+++ b/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureProvider.ts
@@ -7,7 +7,7 @@ import { Cartographic, ImageMapLayerSettings, ImageSource, ImageSourceFormat, Se
 import { base64StringToUint8Array, IModelStatus, Logger } from "@itwin/core-bentley";
 import { Matrix4d, Point3d, Range2d, Transform } from "@itwin/core-geometry";
 import { ArcGisErrorCode, ArcGISImageryProvider, ArcGISServiceMetadata, ArcGisUtilities, FeatureGraphicsRenderer, HitDetail, ImageryMapTileTree, MapCartoRectangle, MapFeatureInfoOptions, MapLayerFeatureInfo, MapLayerImageryProviderStatus, QuadId, setRequestTimeout } from "@itwin/core-frontend";
-import { ArcGisExtent, ArcGisFeatureFormat, ArcGisFeatureQuery, ArcGisFeatureResultType, ArcGisGeometry, FeatureQueryQuantizationParams } from "./ArcGisFeatureQuery";
+import { ArcGisExtent, ArcGisFeatureFormat, arcgisFeatureFormats, ArcGisFeatureQuery, ArcGisFeatureResultType, ArcGisGeometry, FeatureQueryQuantizationParams } from "./ArcGisFeatureQuery";
 import { ArcGisPbfFeatureReader } from "./ArcGisPbfFeatureReader";
 import { ArcGisJsonFeatureReader } from "./ArcGisJsonFeatureReader";
 import { ArcGisFeatureResponse, ArcGisResponseData } from "./ArcGisFeatureResponse";
@@ -215,11 +215,11 @@ export class ArcGisFeatureProvider extends ArcGISImageryProvider {
     // Note: needs to be checked on the layer metadata, service metadata advertises a different set of formats
     //       Also, since PBF format does not support floating points, there is no point using this format if supportsCoordinatesQuantization is not available.
     if (this._layerMetadata.supportedQueryFormats) {
-      const formats: string[] = this._layerMetadata.supportedQueryFormats.split(", ");
-      if (formats.includes("PBF") && this._supportsCoordinatesQuantization) {
-        this._format = "PBF";
-      } else if (formats.includes("JSON")) {
-        this._format = "JSON";
+      const formats: string[] = this._layerMetadata.supportedQueryFormats.split(",").map((s: string) => s.trim().toLowerCase());
+      if (formats.includes(arcgisFeatureFormats.pbf) && this._supportsCoordinatesQuantization) {
+        this._format = arcgisFeatureFormats.pbf;
+      } else if (formats.includes(arcgisFeatureFormats.json)) {
+        this._format = arcgisFeatureFormats.json;
       }
     }
 
@@ -281,7 +281,7 @@ export class ArcGisFeatureProvider extends ArcGISImageryProvider {
     tmpUrl.searchParams.append("where", "1=1");
     tmpUrl.searchParams.append("outSR", "3857");
     tmpUrl.searchParams.append("returnExtentOnly", "true");
-    tmpUrl.searchParams.append("f", "json");
+    tmpUrl.searchParams.append("f", arcgisFeatureFormats.json);
     const cached = ArcGisFeatureProvider._extentCache.get(tmpUrl.toString());
     if (cached) {
       extentJson = cached;
@@ -433,12 +433,12 @@ export class ArcGisFeatureProvider extends ArcGISImageryProvider {
 
     if (this._debugFeatureGeom) {
       try {
-        let responseData = await doFeatureInfoQuery("PBF", "", true);
+        let responseData = await doFeatureInfoQuery(arcgisFeatureFormats.pbf, "", true);
         if (responseData) {
           const json = JSON.stringify(responseData.data.toObject());
           Logger.logInfo(loggerCategory, json);
         }
-        responseData = await doFeatureInfoQuery("JSON", "", true);
+        responseData = await doFeatureInfoQuery(arcgisFeatureFormats.json, "", true);
         if (responseData) {
           const json = JSON.stringify(responseData.data);
           Logger.logInfo(loggerCategory, json);
@@ -450,7 +450,7 @@ export class ArcGisFeatureProvider extends ArcGISImageryProvider {
 
     try {
       // Feature Info requests are always made in JSON for now.
-      const responseData = await doFeatureInfoQuery("JSON", "*", true);
+      const responseData = await doFeatureInfoQuery(arcgisFeatureFormats.json, "*", true);
       if (!responseData) {
         Logger.logError(loggerCategory, `Could not get feature info data`);
         return;
@@ -556,7 +556,9 @@ export class ArcGisFeatureProvider extends ArcGISImageryProvider {
       }
 
       const renderer = new FeatureCanvasRenderer(ctx, this._symbologyRenderer, transfo);
-      const featureReader: ArcGisFeatureReader = this.format === "PBF" ? new ArcGisPbfFeatureReader(this._settings, this._layerMetadata) : new ArcGisJsonFeatureReader(this._settings, this._layerMetadata);
+      const featureReader: ArcGisFeatureReader = this.format === arcgisFeatureFormats.pbf
+      ? new ArcGisPbfFeatureReader(this._settings, this._layerMetadata)
+      : new ArcGisJsonFeatureReader(this._settings, this._layerMetadata);
 
       const getSubEnvelopes = (envelope: ArcGisExtent): ArcGisExtent[] => {
         const dx = (envelope.xmax - envelope.xmin) * 0.5;

--- a/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureQuery.ts
+++ b/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureQuery.ts
@@ -70,12 +70,12 @@ export interface FeatureQueryQuantizationParams {
 
 /** @internal */
 export type ArcGisFeatureFormat = "json" | "pbf";
+
 /**
 * @internal
 */
-
 export const arcgisFeatureFormats = {
-  json:  "json" as ArcGisFeatureFormat,
+  json: "json" as ArcGisFeatureFormat,
   pbf: "pbf"  as ArcGisFeatureFormat,
 }
 

--- a/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureQuery.ts
+++ b/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureQuery.ts
@@ -69,7 +69,15 @@ export interface FeatureQueryQuantizationParams {
 }
 
 /** @internal */
-export type ArcGisFeatureFormat = "JSON" | "PBF";
+export type ArcGisFeatureFormat = "json" | "pbf";
+/**
+* @internal
+*/
+
+export const arcgisFeatureFormats = {
+  json:  "json" as ArcGisFeatureFormat,
+  pbf: "pbf"  as ArcGisFeatureFormat,
+}
 
 // Based on official documentation:
 // https://developers.arcgis.com/rest/services-reference/query-feature-service-layer-.htm

--- a/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureResponse.ts
+++ b/extensions/map-layers-formats/src/ArcGisFeature/ArcGisFeatureResponse.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { ArcGisExtent, ArcGisFeatureFormat } from "./ArcGisFeatureQuery";
+import { ArcGisExtent, ArcGisFeatureFormat, arcgisFeatureFormats } from "./ArcGisFeatureQuery";
 import { esriPBuffer } from "./esriPBuffer.gen";
 
 /** @internal */
@@ -48,7 +48,7 @@ export class ArcGisFeatureResponse {
       if (tileResponse === undefined || tileResponse.status !== 200  )
         return undefined;
 
-      if (this.format === "PBF") {
+      if (this.format === arcgisFeatureFormats.pbf) {
         const byteArray: Uint8Array = new Uint8Array(await tileResponse.arrayBuffer());
         if (!byteArray || (byteArray.length === 0))
           return undefined;

--- a/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureProvider.test.ts
+++ b/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureProvider.test.ts
@@ -93,16 +93,16 @@ function stubGetLayerMetadata(sandbox: sinon.SinonSandbox) {
   });
 }
 
-function stubGetServiceJson(sandbox: sinon.SinonSandbox, json: any ) {
+function stubGetServiceJson(sandbox: sinon.SinonSandbox, getContent: ()=>any ) {
   return sandbox.stub(ArcGisUtilities, "getServiceJson").callsFake(async function _(_args: ArcGisGetServiceJsonArgs) {
-    return json;
+    return getContent();
   });
 }
 
-function getDefaultLayerMetadata() {
+function getDefaultLayerMetadata(supportedFormats?: string) {
   return {
     defaultVisibility: true,
-    supportedQueryFormats: "PBF, JSON",
+    supportedQueryFormats: supportedFormats?? "PBF, JSON",
     supportsCoordinatesQuantization: true,
     minScale: 600000,
     maxScale: 5000,
@@ -122,7 +122,7 @@ async function testGetFeatureInfoGeom(sandbox: sinon.SinonSandbox, fetchStub: an
   fetchStub.restore();  // fetch is always stubbed by default, restore and provide our own stub
 
   stubGetLayerMetadata(sandbox);
-  stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } });
+  stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } }});
   stubJsonFetch(JSON.stringify(dataset));
   const provider = new ArcGisFeatureProvider(settings);
   await provider.initialize();
@@ -175,7 +175,7 @@ describe("ArcGisFeatureProvider", () => {
 
   it("should initialize with valid service metadata", async () => {
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: NewYorkDataset.serviceCapabilities });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: NewYorkDataset.serviceCapabilities }});
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "getLayerMetadata" as any).callsFake(async function _(_layerId: unknown) {
       return NewYorkDataset.streetsLayerCapabilities;
@@ -191,7 +191,7 @@ describe("ArcGisFeatureProvider", () => {
 
   it("should initialize and set cartoRange without making extra extent request", async () => {
 
-    stubGetServiceJson(sandbox, {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities});
+    stubGetServiceJson(sandbox, () => {return {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities}});
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "getLayerMetadata" as any).callsFake(async function _(_layerId: unknown) {
       return NewYorkDataset.streetsLayerCapabilities;
@@ -212,7 +212,7 @@ describe("ArcGisFeatureProvider", () => {
 
   it("should make an extra extent request when none available in layer metadata", async () => {
 
-    stubGetServiceJson(sandbox, {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities});
+    stubGetServiceJson(sandbox, () => {return {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities}});
     const setCartoSpy = sandbox.spy(ArcGisFeatureProvider.prototype, "setCartoRangeFromExtentJson" as any);
 
     const layerExtent = {...NewYorkDataset.streetsLayerCapabilities.extent};
@@ -236,7 +236,7 @@ describe("ArcGisFeatureProvider", () => {
 
   it("should make an extra extent request when none available in layer metadata", async () => {
 
-    stubGetServiceJson(sandbox, {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities});
+    stubGetServiceJson(sandbox, () => {return {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities}});
 
     const setCartoSpy = sandbox.spy(ArcGisFeatureProvider.prototype, "setCartoRangeFromExtentJson" as any);
 
@@ -286,7 +286,7 @@ describe("ArcGisFeatureProvider", () => {
   it("should compose proper request to get extent", async () => {
 
     fetchStub.restore();  // fetch is always stubbed by default, restore and provide our own stub
-    stubGetServiceJson(sandbox, {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities});
+    stubGetServiceJson(sandbox, () => {return {accessTokenRequired: false, content:NewYorkDataset.serviceCapabilities}});
 
     const layerCapabilitiesNoExtent = {...NewYorkDataset.streetsLayerCapabilities};
     sandbox.stub(ArcGisFeatureProvider.prototype, "getLayerMetadata" as any).callsFake(async function _(_layerId: unknown) {
@@ -347,7 +347,7 @@ describe("ArcGisFeatureProvider", () => {
   });
 
   it("should not initialize with no service metadata", async () => {
-    stubGetServiceJson(sandbox, undefined);
+    stubGetServiceJson(sandbox, ()=>undefined);
     const settings = ImageMapLayerSettings.fromJSON(esriFeatureSampleSource);
     const provider = new ArcGisFeatureProvider(settings);
 
@@ -357,7 +357,7 @@ describe("ArcGisFeatureProvider", () => {
 
   it("should update status when invalid token error from service", async () => {
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { error: { code: 499 } } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { error: { code: 499 } } }});
     const settings = ImageMapLayerSettings.fromJSON(esriFeatureSampleSource);
     const provider = new ArcGisFeatureProvider(settings);
     const raiseEventSpy = sandbox.spy(provider.onStatusChanged, "raiseEvent");
@@ -368,7 +368,7 @@ describe("ArcGisFeatureProvider", () => {
   });
 
   it("should throw    query capability not supported", async () => {
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Test" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Test" } }});
 
     const settings = ImageMapLayerSettings.fromJSON(esriFeatureSampleSource);
     const provider = new ArcGisFeatureProvider(settings);
@@ -376,7 +376,7 @@ describe("ArcGisFeatureProvider", () => {
   });
 
   it("should pick the first visible sub-layer when multiple visible sub-layers", async () => {
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
       return getDefaultLayerMetadata();
@@ -395,7 +395,7 @@ describe("ArcGisFeatureProvider", () => {
 
   it("should pick sub-layers from service metadata if none provided on layer settings", async () => {
 
-    stubGetServiceJson(sandbox, {
+    stubGetServiceJson(sandbox, () => {return {
       accessTokenRequired: false, content: {
         capabilities: "Query",
         layers: [
@@ -408,7 +408,7 @@ describe("ArcGisFeatureProvider", () => {
           },
         ],
       },
-    });
+    }});
 
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (id: unknown) {
       if (id === 1) {
@@ -426,7 +426,7 @@ describe("ArcGisFeatureProvider", () => {
   });
 
   it("should throw error if no layers in capabilities", async () => {
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query", layers: [] } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query", layers: [] } }});
 
     const settings = ImageMapLayerSettings.fromJSON(esriFeatureSampleSource);
     const provider = new ArcGisFeatureProvider(settings);
@@ -441,7 +441,7 @@ describe("ArcGisFeatureProvider", () => {
     },
     );
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
       return undefined;
@@ -463,7 +463,7 @@ describe("ArcGisFeatureProvider", () => {
       return getDefaultLayerMetadata();
     });
 
-    let getServiceJsonStub = stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    let getServiceJsonStub = stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     let provider = new ArcGisFeatureProvider(settings);
     await provider.initialize();
@@ -471,7 +471,7 @@ describe("ArcGisFeatureProvider", () => {
 
     // PBF requires 'supportsCoordinatesQuantization'
     getServiceJsonStub.restore();
-    getServiceJsonStub = stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } });
+    getServiceJsonStub = stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } }});
 
     getLayerMetadataStub.restore();
     getLayerMetadataStub = sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
@@ -493,7 +493,7 @@ describe("ArcGisFeatureProvider", () => {
     });
 
     getServiceJsonStub.restore();
-    getServiceJsonStub = stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { currentVersion: 10.91, capabilities: "Query", supportsCoordinatesQuantization: true } });
+    getServiceJsonStub = stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion: 10.91, capabilities: "Query", supportsCoordinatesQuantization: true } }});
 
     provider = new ArcGisFeatureProvider(settings);
     await provider.initialize();
@@ -520,7 +520,7 @@ describe("ArcGisFeatureProvider", () => {
       return getDefaultLayerMetadata();
     });
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     const provider = new ArcGisFeatureProvider(settings);
     await provider.initialize();
@@ -554,7 +554,7 @@ describe("ArcGisFeatureProvider", () => {
       };
     });
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } }});
 
     const provider = new ArcGisFeatureProvider(settings);
     await provider.initialize();
@@ -644,7 +644,7 @@ describe("ArcGisFeatureProvider", () => {
       return getDefaultLayerMetadata();
     });
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } }});
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "constructFeatureUrl").callsFake(function _(_row: number, _column: number, _zoomLevel: number, _format: ArcGisFeatureFormat, _resultType: ArcGisFeatureResultType, _geomOverride?: ArcGisGeometry, _outFields?: string, _tolerance?: number, _returnGeometry?: boolean) {
       return undefined;
@@ -681,7 +681,7 @@ describe("ArcGisFeatureProvider", () => {
       };
     });
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } }});
 
     fetchStub.restore();  // fetch is always stubbed by default, restore and provide our own stub
     sandbox.stub((ArcGISImageryProvider.prototype as any), "fetch").callsFake(async function _(_url: unknown, _options?: unknown) {
@@ -736,7 +736,7 @@ describe("ArcGisFeatureProvider", () => {
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
       return getDefaultLayerMetadata();
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
     sandbox.stub((ArcGisFeatureResponse.prototype as any), "getResponseData").callsFake(async function _() {
       return { exceedTransferLimit: true, data: undefined };
     });
@@ -763,7 +763,7 @@ describe("ArcGisFeatureProvider", () => {
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
       return getDefaultLayerMetadata();
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub((ArcGisFeatureResponse.prototype as any), "getResponseData").callsFake(async function _() {
       throw new Error();
@@ -790,7 +790,7 @@ describe("ArcGisFeatureProvider", () => {
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
       return getDefaultLayerMetadata();
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub((ArcGisFeatureResponse.prototype as any), "getResponseData").callsFake(async function _() {
       return {
@@ -876,7 +876,7 @@ describe("ArcGisFeatureProvider", () => {
         drawingInfo: PhillyLandmarksDataset.phillySimplePolyDrawingInfo.drawingInfo,
       };
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion: 11, capabilities: "Query" } }});
 
     sandbox.stub(HTMLCanvasElement.prototype, "getContext").callsFake(function _(_contextId: any, _options?: any) {
       return {} as RenderingContext;
@@ -922,7 +922,7 @@ describe("ArcGisFeatureProvider", () => {
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
       return getDefaultLayerMetadata();
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub(HTMLCanvasElement.prototype, "getContext").callsFake(function _(_contextId: any, _options?: any) {
       return {} as RenderingContext;
@@ -971,7 +971,7 @@ describe("ArcGisFeatureProvider", () => {
         drawingInfo: PhillyLandmarksDataset.phillySimplePolyDrawingInfo.drawingInfo,
       };
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub(HTMLCanvasElement.prototype, "getContext").callsFake(function _(_contextId: any, _options?: any) {
       return {} as RenderingContext;
@@ -1074,7 +1074,7 @@ describe("ArcGisFeatureProvider", () => {
         drawingInfo: PhillyLandmarksDataset.phillySimpleLineDrawingInfo.drawingInfo,
       };
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "constructFeatureUrl").callsFake(function _(_row: number, _column: number, _zoomLevel: number, _format: ArcGisFeatureFormat, _resultType: ArcGisFeatureResultType, _geomOverride?: ArcGisGeometry, _outFields?: string, _tolerance?: number, _returnGeometry?: boolean) {
       return { url: settings.url };
@@ -1105,7 +1105,7 @@ describe("ArcGisFeatureProvider", () => {
         drawingInfo: PhillyLandmarksDataset.phillySimpleLineDrawingInfo.drawingInfo,
       };
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "constructFeatureUrl").callsFake(function _(_row: number, _column: number, _zoomLevel: number, _format: ArcGisFeatureFormat, _resultType: ArcGisFeatureResultType, _geomOverride?: ArcGisGeometry, _outFields?: string, _tolerance?: number, _returnGeometry?: boolean) {
       return { url: settings.url };
@@ -1132,7 +1132,7 @@ describe("ArcGisFeatureProvider", () => {
       drawingInfo: PhillyLandmarksDataset.phillySimpleLineDrawingInfo.drawingInfo,
     };
 
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "constructFeatureUrl").callsFake(function _(_row: number, _column: number, _zoomLevel: number, _format: ArcGisFeatureFormat, _resultType: ArcGisFeatureResultType, _geomOverride?: ArcGisGeometry, _outFields?: string, _tolerance?: number, _returnGeometry?: boolean) {
       return { url: settings.url };
@@ -1199,7 +1199,7 @@ describe("ArcGisFeatureProvider", () => {
     sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
       return {...layerMetadata, geometryType : "esriGeometryPoint" };
     });
-    stubGetServiceJson(sandbox, { accessTokenRequired: false, content: { capabilities: "Query" } });
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { capabilities: "Query" } }});
 
     sandbox.stub(ArcGisFeatureProvider.prototype, "constructFeatureUrl").callsFake(function _(_row: number, _column: number, _zoomLevel: number, _format: ArcGisFeatureFormat, _resultType: ArcGisFeatureResultType, _geomOverride?: ArcGisGeometry, _outFields?: string, _tolerance?: number, _returnGeometry?: boolean) {
       return { url: settings.url };
@@ -1211,6 +1211,43 @@ describe("ArcGisFeatureProvider", () => {
     await provider.initialize();
     const nbMarkerToLoad = layerMetadata.drawingInfo.renderer.uniqueValueInfos.length + 1; // +1 for provider's default symbol
     expect (loadImageSpy.getCalls().length).to.equals(nbMarkerToLoad);
+  });
+
+  it("should pick the first visible sub-layer when multiple visible sub-layers", async () => {
+    let currentVersion = 11;
+    stubGetServiceJson(sandbox, () => {return { accessTokenRequired: false, content: { currentVersion, capabilities: "Query" } }});
+
+    let supportedQueryFormats = "JSON,PBF";
+    sandbox.stub((ArcGisFeatureProvider.prototype as any), "getLayerMetadata").callsFake(async function (_id: unknown) {
+      return getDefaultLayerMetadata(supportedQueryFormats);
+    });
+
+    const settings = ImageMapLayerSettings.fromJSON({
+      ...esriFeatureSampleSource,
+      subLayers: [{ id: 0, name: "layer1", visible: true }, { id: 2, name: "layer2", visible: true }],
+    },
+    );
+    let provider = new ArcGisFeatureProvider(settings);
+    await provider.initialize();
+    expect((provider as any)._format).to.equals(arcgisFeatureFormats.pbf);
+
+    supportedQueryFormats = "JSON"
+    provider = new ArcGisFeatureProvider(settings);
+    await provider.initialize();
+    expect((provider as any)._format).to.equals(arcgisFeatureFormats.json);
+
+    supportedQueryFormats = "PBF";
+    provider = new ArcGisFeatureProvider(settings);
+    await provider.initialize();
+    expect((provider as any)._format).to.equals(arcgisFeatureFormats.pbf);
+
+    // Should default to JSON because PBF is not supported in version 10
+    currentVersion = 10;
+    supportedQueryFormats = "JSON,PBF";
+    provider = new ArcGisFeatureProvider(settings);
+    await provider.initialize();
+    expect((provider as any)._format).to.equals(arcgisFeatureFormats.json);
+
   });
 
 });

--- a/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureQuery.test.ts
+++ b/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureQuery.test.ts
@@ -5,7 +5,7 @@
 
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { ArcGisExtent, ArcGisFeatureQuery } from "../../ArcGisFeature/ArcGisFeatureQuery";
+import { ArcGisExtent, arcgisFeatureFormats, ArcGisFeatureQuery } from "../../ArcGisFeature/ArcGisFeatureQuery";
 
 describe("ArcGisFeatureQuery", () => {
 
@@ -20,7 +20,7 @@ describe("ArcGisFeatureQuery", () => {
 
   it("should not apply different switches if not needed", async () => {
 
-    const query = new ArcGisFeatureQuery("https://test.com/rest/",0, "JSON", 3857);
+    const query = new ArcGisFeatureQuery("https://test.com/rest/",0, arcgisFeatureFormats.json, 3857);
     const queryUrl = query.toString();
     expect(queryUrl).to.not.contains("resultRecordCount");
     expect(queryUrl).to.not.contains("resultOffset");
@@ -47,7 +47,7 @@ describe("ArcGisFeatureQuery", () => {
         wkid : 102100,
         latestWkid : 3857,
       }};
-    const query = new ArcGisFeatureQuery("https://test.com/rest/",0, "JSON", 3857,
+    const query = new ArcGisFeatureQuery("https://test.com/rest/",0, arcgisFeatureFormats.json, 3857,
       {
         resultRecordCount: 10,
         resultOffset: 11,
@@ -95,7 +95,7 @@ describe("ArcGisFeatureQuery", () => {
         wkid : 102100,
         latestWkid : 3857,
       }};
-    const query = new ArcGisFeatureQuery("https://test.com/rest/",0, "JSON", 3857,
+    const query = new ArcGisFeatureQuery("https://test.com/rest/",0, arcgisFeatureFormats.json, 3857,
       {
         spatialRel: "esriSpatialRelIntersects",
       });

--- a/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureResponse.test.ts
+++ b/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureResponse.test.ts
@@ -20,7 +20,7 @@ describe("ArcGisFeatureResponse", () => {
     sandbox.restore();
   });
 
-  it("should return undefined if http error", async () => {
+  it("should return undefined if http error ", async () => {
     const response = new ArcGisFeatureResponse(arcgisFeatureFormats.pbf, Promise.resolve({status: 404} as Response));
     const data = await response.getResponseData();
     expect(data).to.be.undefined;

--- a/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureResponse.test.ts
+++ b/extensions/map-layers-formats/src/test/ArcGisFeature/ArcGisFeatureResponse.test.ts
@@ -10,6 +10,7 @@ import * as sinon from "sinon";
 import { ArcGisFeatureResponse } from "../../ArcGisFeature/ArcGisFeatureResponse";
 import { esriPBuffer } from "../../ArcGisFeature/esriPBuffer.gen";
 import { PhillyLandmarksDataset } from "./PhillyLandmarksDataset";
+import { arcgisFeatureFormats } from "../../ArcGisFeature/ArcGisFeatureQuery";
 
 describe("ArcGisFeatureResponse", () => {
 
@@ -20,13 +21,13 @@ describe("ArcGisFeatureResponse", () => {
   });
 
   it("should return undefined if http error", async () => {
-    const response = new ArcGisFeatureResponse("PBF", Promise.resolve({status: 404} as Response));
+    const response = new ArcGisFeatureResponse(arcgisFeatureFormats.pbf, Promise.resolve({status: 404} as Response));
     const data = await response.getResponseData();
     expect(data).to.be.undefined;
   });
 
   it("should return undefined if invalid PBF data", async () => {
-    const response = new ArcGisFeatureResponse("PBF", Promise.resolve({
+    const response = new ArcGisFeatureResponse(arcgisFeatureFormats.pbf, Promise.resolve({
       status: 404,
       arrayBuffer: async () => {
         return Promise.resolve(undefined);
@@ -39,7 +40,7 @@ describe("ArcGisFeatureResponse", () => {
   it("should create FeatureCollectionPBuffer from PBF data", async () => {
 
     const fakeResponse  = {
-      headers: { "content-type" : "pbf"},
+      headers: { "content-type" : arcgisFeatureFormats.pbf},
       arrayBuffer: async () => {
         const byteArray = Base64EncodedString.toUint8Array(PhillyLandmarksDataset.phillyTransportationGetFeatureInfoQueryEncodedPbf);
         return Promise.resolve(byteArray ? ByteStream.fromUint8Array(byteArray).arrayBuffer : undefined);
@@ -47,7 +48,7 @@ describe("ArcGisFeatureResponse", () => {
       status: 200,
     } as unknown;
 
-    const response = new ArcGisFeatureResponse("PBF", Promise.resolve(fakeResponse as Response));
+    const response = new ArcGisFeatureResponse(arcgisFeatureFormats.pbf, Promise.resolve(fakeResponse as Response));
     const data = await response.getResponseData();
     expect(data?.exceedTransferLimit).to.be.false;
     expect(data?.data instanceof esriPBuffer.FeatureCollectionPBuffer).to.be.true;
@@ -58,7 +59,7 @@ describe("ArcGisFeatureResponse", () => {
     const collection = esriPBuffer.FeatureCollectionPBuffer.fromObject(PhillyLandmarksDataset.phillyExceededTransferLimitPbf);
 
     const fakeResponse  = {
-      headers: { "content-type" : "pbf"},
+      headers: { "content-type" : arcgisFeatureFormats.pbf},
       arrayBuffer: async () => {
         const byteArray = collection.serialize();
         return Promise.resolve(byteArray ? ByteStream.fromUint8Array(byteArray).arrayBuffer : undefined);
@@ -66,14 +67,14 @@ describe("ArcGisFeatureResponse", () => {
       status: 200,
     } as unknown;
 
-    const response = new ArcGisFeatureResponse("PBF", Promise.resolve(fakeResponse as Response));
+    const response = new ArcGisFeatureResponse(arcgisFeatureFormats.pbf, Promise.resolve(fakeResponse as Response));
     const data = await response.getResponseData();
     expect(data?.exceedTransferLimit).to.be.true;
     expect(data?.data instanceof esriPBuffer.FeatureCollectionPBuffer).to.be.true;
   });
 
   it("should return undefined if invalid JSON", async () => {
-    const response = new ArcGisFeatureResponse("JSON", Promise.resolve({
+    const response = new ArcGisFeatureResponse(arcgisFeatureFormats.json, Promise.resolve({
       status: 404,
       json: async () => {
         return undefined;
@@ -84,7 +85,7 @@ describe("ArcGisFeatureResponse", () => {
   });
 
   it("should return JSON data", async () => {
-    const response = new ArcGisFeatureResponse("JSON", Promise.resolve({
+    const response = new ArcGisFeatureResponse(arcgisFeatureFormats.json, Promise.resolve({
       status: 200,
       json: async () => {
         return {exceededTransferLimit: false};
@@ -96,7 +97,7 @@ describe("ArcGisFeatureResponse", () => {
   });
 
   it("should report exceededTransferLimit from JSON object", async () => {
-    const response = new ArcGisFeatureResponse("JSON", Promise.resolve({
+    const response = new ArcGisFeatureResponse(arcgisFeatureFormats.json, Promise.resolve({
       status: 200,
       json: async () => {
         return {exceededTransferLimit: true};


### PR DESCRIPTION
This PR solves 2 issues:

1. Capabilities parsing issue of the `supportedQueryFormats`:
  Typically, the capabilities response contains the following:
  `"supportedQueryFormats": "JSON, PBF",`
  Turns out some server, do no include a whitespace after the comma separator, like this:
   `"supportedQueryFormats": "JSON,PBF",`

3. The `f` (i.e. format) query parameter, must have its value set in lower case, even though the `supportedQueryFormats` capability indicates the formats in upper case.
This is confirmed by the [ArcGIS documentation](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/):
![image](https://github.com/user-attachments/assets/c9dd0063-8e8b-4a49-a450-c0a0557459aa)



