### PR TITLE
iOS tests fix

### DIFF
--- a/common/changes/@itwin/core-backend/travis-ios-tests-fix_2024-10-30-17-54.json
+++ b/common/changes/@itwin/core-backend/travis-ios-tests-fix_2024-10-30-17-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -105,7 +105,7 @@ steps:
   - script: npm run ios:all
     workingDirectory: core/backend
     displayName: Build & run iOS backend unit tests in Simulator
-    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'), false)
+    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: node common/scripts/install-run-rush.js lint
     displayName: rush lint

--- a/test-apps/display-test-app/scripts/runIosSimulator.mjs
+++ b/test-apps/display-test-app/scripts/runIosSimulator.mjs
@@ -30,11 +30,21 @@ class SimctlWithOpts extends Simctl {
    * @returns {Promise<string>}
    */
   async launchAppWithOptions(bundleId, options, args) {
-    const { stdout } = await this.exec('launch', {
+    const { stdout, stderr } = await this.exec('launch', {
       args: [...options, this.requireUdid('launch'), bundleId, ...args],
       architectures: "x86_64",
     });
-    return stdout.trim();
+    const trimmedOut = stdout.trim();
+    const trimmedErr = stderr.trim();
+    if (trimmedOut && trimmedErr) {
+      return `=========stdout=========\n${stdout.trim()}\n=========stderr=========\n${stderr.trim()}`;
+    } else if (trimmedOut) {
+      return `=========stdout=========\n${stdout.trim()}`;
+    } else if (trimmedErr) {
+      return `=========stderr=========\n${stderr.trim()}`;
+    } else {
+      return "";
+    }
   }
 
   /**

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/iTwin/mobile-native-ios",
       "state" : {
-        "revision" : "b365b0ca9fe2b16cddaf26f59e8f38148027608c",
-        "version" : "4.8.11"
+        "revision" : "c011577eed1b76b408a7d997be918b41380fb836",
+        "version" : "4.10.21"
       }
     }
   ],

--- a/tools/internal/ios/core-test-runner/core-test-runner/ViewController.swift
+++ b/tools/internal/ios/core-test-runner/core-test-runner/ViewController.swift
@@ -95,6 +95,9 @@ class ViewController: ObservableObject {
         let main = URL(fileURLWithPath: mainPath)
         log("(ios): Running tests.")
         host.loadBackend(main, withAuthClient: nil, withInspect: true) { [self] (numFailed: UInt32) in
+#if targetEnvironment(simulator)
+            log("[Mocha_Result_XML_File]: \(testResultsUrl.path)")
+#else
             log("(ios): Starting Mocha Result XML dump...")
             do {
                 let text = try String(contentsOf: testResultsUrl, encoding: .utf8)
@@ -105,6 +108,7 @@ class ViewController: ObservableObject {
                 log("(ios): Failed to read mocha test results.")
             }
             log("(ios): Mocha Result XML dump complete.")
+#endif
 
             // Indicate via UI that the tests have finished.
             self.testStatus = "Tests finished."


### PR DESCRIPTION
iOS tests fix:
* Reenable iOS backend unit tests in CI
* Copy test output XML instead of extracting from console log
* Show error output if present when running display-test-app

Hopefully this will fix the CI test failures for the backend unit tests. Unfortunately, I have no idea what was causing the failures, but I no longer execute the code that appeared to be failing, so hopefully that fixes the problem. (Specifically, instead of printing the XML file contents to the console during execution, this now prints the XML filename, and that file is then copied to the appropriate place by the script running the iOS Simulator.)