### PR TITLE
Fix reading of KHR compressed meshes

### DIFF
--- a/common/changes/@itwin/core-frontend/man-khr-mesh-compression-fix_2024-10-31-14-07.json
+++ b/common/changes/@itwin/core-frontend/man-khr-mesh-compression-fix_2024-10-31-14-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fixed reading of KHR compressed meshes in GLTF reader.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1342,9 +1342,9 @@ export abstract class GltfReader {
           // Assume KHR_mesh_quantization...
           min = [0, 0, 0];
           if (GltfDataType.UnsignedShort === posView.type)
-            max = [65535, 65535, 65535];
+            max = [0xFFFF, 0xFFFF, 0xFFFF];
           else
-            max = [255, 255, 255];
+            max = [0xFF, 0xFF, 0xFF];
           }
 
         if (undefined === min || undefined === max) {
@@ -1550,7 +1550,7 @@ export abstract class GltfReader {
       } else {
         // Assume KHR_mesh_quantization...
         rangeMin = [0, 0, 0];
-        rangeMax = [65535, 65535, 65535];
+        rangeMax = [0xFFFF, 0xFFFF, 0xFFFF];
       }
 
       if (undefined === rangeMin || undefined === rangeMax) // required by spec...

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1341,7 +1341,10 @@ export abstract class GltfReader {
         } else {
           // Assume KHR_mesh_quantization...
           min = [0, 0, 0];
-          max = [65535, 65535, 65535];
+          if (GltfDataType.UnsignedShort === posView.type)
+            max = [65535, 65535, 65535];
+          else
+            max = [255, 255, 255];
           }
 
         if (undefined === min || undefined === max) {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1340,9 +1340,9 @@ export abstract class GltfReader {
           max = ext.decodedMax;
         } else {
           // Assume KHR_mesh_quantization...
-          min = posView.accessor.min;
-          max = posView.accessor.max;
-        }
+          min = [0, 0, 0];
+          max = [65535, 65535, 65535];
+          }
 
         if (undefined === min || undefined === max) {
           return undefined;
@@ -1546,8 +1546,8 @@ export abstract class GltfReader {
         rangeMax = quantized.decodedMax;
       } else {
         // Assume KHR_mesh_quantization...
-        rangeMin = view.accessor.min;
-        rangeMax = view.accessor.max;
+        rangeMin = [0, 0, 0];
+        rangeMax = [65535, 65535, 65535];
       }
 
       if (undefined === rangeMin || undefined === rangeMax) // required by spec...


### PR DESCRIPTION
Fixes the reading of KHR compressed meshes.  This makes it possible to read in the meshes that we export with the cesium option which were in many cases not scaling properly when attached back into the original iModel.

Partially fixes issue [#420](https://github.com/iTwin/itwin-graphics-backlog/issues/420)