### PR TITLE
deprecate SchemaMatchType.Identical because it is the same as Exact. …

### DIFF
--- a/common/changes/@itwin/ecschema-metadata/deprecate-SchemaMatchType.Identical_2024-11-01-15-01.json
+++ b/common/changes/@itwin/ecschema-metadata/deprecate-SchemaMatchType.Identical_2024-11-01-15-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "Deprecate SchemaMatchType.Identical and switch to Exact as default",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-metadata/src/ECObjects.ts
+++ b/core/ecschema-metadata/src/ECObjects.ts
@@ -89,15 +89,18 @@ export enum CustomAttributeContainerType {
  * @beta
  */
 export enum SchemaMatchType {
-  // Find exact VersionRead, VersionWrite, VersionMinor match as well as Data
+  /*
+  * Find exact VersionRead, VersionWrite, VersionMinor match as well as Data. NOTE data is not yet matched
+  * @deprecated in 4.10 Use Exact instead.
+  */
   Identical,
-  // Find exact VersionRead, VersionWrite, VersionMinor match.
+  /* Find exact VersionRead, VersionWrite, VersionMinor match. */
   Exact,
-  // Find latest version with matching VersionRead and VersionWrite
+  /* Find latest version with matching VersionRead and VersionWrite */
   LatestWriteCompatible,
-  // Find latest version.
+  /* Find latest version. */
   Latest,
-  // Find latest version with matching VersionRead
+  /* Find latest version with matching VersionRead */
   LatestReadCompatible,
 }
 

--- a/core/ecschema-metadata/src/SchemaKey.ts
+++ b/core/ecschema-metadata/src/SchemaKey.ts
@@ -165,13 +165,9 @@ export class SchemaKey {
    * @param rhs The SchemaKey to compare with
    * @param matchType The match type to use for comparison.
    */
-  public matches(rhs: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Identical): boolean {
+  public matches(rhs: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Exact): boolean {
     switch (matchType) {
       case SchemaMatchType.Identical:
-        // TODO: if (this.checksum && rhs.checksum)
-        // TODO:   return this.checksum === rhs.checksum;
-        return this.compareByName(rhs.name) && this.readVersion === rhs.readVersion &&
-          this.writeVersion === rhs.writeVersion && this.minorVersion === rhs.minorVersion;
       case SchemaMatchType.Exact:
         return this.compareByName(rhs.name) && this.readVersion === rhs.readVersion &&
           this.writeVersion === rhs.writeVersion && this.minorVersion === rhs.minorVersion;

--- a/core/ecschema-metadata/src/test/SchemaKey.test.ts
+++ b/core/ecschema-metadata/src/test/SchemaKey.test.ts
@@ -90,22 +90,22 @@ describe("SchemaKey", () => {
 
     describe("matches", () => {
       it("should correctly handle SchemaMatchType.Identical", () => {
+        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 1, 0, 0), SchemaMatchType.Identical)).true;
+        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 1, 0, 0), SchemaMatchType.Identical)).false;
+        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 2, 0, 0), SchemaMatchType.Identical)).false;
+        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 1, 0, 1), SchemaMatchType.Identical)).false;
+      });
+
+      it("should correctly handle SchemaMatchType.Exact", () => {
         expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 1, 0, 0))).true;
         expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 1, 0, 0))).false;
         expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 2, 0, 0))).false;
         expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 1, 0, 1))).false;
 
-        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 1, 0, 0), SchemaMatchType.Identical)).true;
-        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 1, 0, 0), SchemaMatchType.Identical)).false;
-        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 2, 0, 0), SchemaMatchType.Identical)).false;
-        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 1, 0, 1), SchemaMatchType.Identical)).false;
-      });
-
-      it("should correctly handle SchemaMatchType.Exact", () => {
         expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 1, 0, 0), SchemaMatchType.Exact)).true;
         expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 1, 0, 0), SchemaMatchType.Exact)).false;
-        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 2, 0, 0), SchemaMatchType.Exact)).false;
-        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaNotTest", 1, 0, 1), SchemaMatchType.Exact)).false;
+        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 2, 0, 0), SchemaMatchType.Exact)).false;
+        expect(new SchemaKey("SchemaTest", 1, 0, 0).matches(new SchemaKey("SchemaTest", 1, 0, 1), SchemaMatchType.Exact)).false;
       });
 
       it("should correctly handle SchemaMatchType.Latest", () => {


### PR DESCRIPTION
… Switch default match type to Exact