### PR TITLE
fix output variable referencing in version bump pipeline

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -93,12 +93,12 @@ jobs:
         displayName: Get Branch Name
         name: getBranchName
 
-      - bash: git checkout -b $(releaseBranchName)
+      - bash: git checkout -b $(getBranchName.releaseBranchName)
         displayName: Create release branch and checkout
 
       - bash: |
           docsYamlPath="common/config/azure-pipelines/templates/gather-docs.yaml"
-          releaseBranch=$(releaseBranchName)
+          releaseBranch=$(getBranchName.releaseBranchName)
 
           # delimiter
           IFS="."
@@ -132,7 +132,7 @@ jobs:
           fi
         displayName: Update 'gather-docs.yaml' and commit to release branch
 
-      - bash: git push --set-upstream https://$(GITHUBTOKEN)@github.com/iTwin/itwinjs-core $(releaseBranchName) -q
+      - bash: git push --set-upstream https://$(GITHUBTOKEN)@github.com/iTwin/itwinjs-core $(getBranchName.releaseBranchName) -q
         displayName: Publish the release branch
 
   - job: Bump


### PR DESCRIPTION
Fixes an issue with creating a new release branch. The issue stems from [here](https://github.com/iTwin/itwinjs-core/pull/7174/files#diff-5a3184c3fd1e071ed4f30f98a6738e716142b89ff0fd9bb155fa15c78d4a9fbfR94) - setting the `isOutput` flag requires the stepName to be used as a prefix when referencing the variable - [source](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash#set-an-output-variable-for-use-in-the-same-job).