### PR TITLE
point master to 5.0.0-dev

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,7 +2,7 @@
   {
     "policyName": "prerelease-monorepo-lockStep",
     "definitionName": "lockStepVersion",
-    "version": "4.11.0-dev.0",
+    "version": "5.0.0-dev",
     "nextBump": "prerelease"
   }
 ]


### PR DESCRIPTION
Manually modify `version-policies.json` to version `5.0.0-dev`.
When the nightly version bump runs, itll increment version to `5.0.0-dev.x`