### PR TITLE
Presentation: Bump `@itwin/unified-selection` version

### DIFF
--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -590,9 +590,6 @@ export class ToolSelectionSyncHandler implements IDisposable {
     get pendingAsyncs(): Set<string>;
 }
 
-// @internal (undocumented)
-export const TRANSIENT_ELEMENT_CLASSNAME = "/TRANSIENT";
-
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/common/api/summary/presentation-frontend.exports.csv
+++ b/common/api/summary/presentation-frontend.exports.csv
@@ -55,4 +55,3 @@ public;interface;SelectionManagerProps
 public;class;SelectionScopesManager
 public;interface;SelectionScopesManagerProps
 internal;class;ToolSelectionSyncHandler
-internal;const;TRANSIENT_ELEMENT_CLASSNAME

--- a/common/changes/@itwin/presentation-common/bump_unified_selection_2024-11-06-14-52.json
+++ b/common/changes/@itwin/presentation-common/bump_unified_selection_2024-11-06-14-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "KeySet: Always store instance key class name in `Schema:Class` format.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/bump_unified_selection_2024-11-06-14-52.json
+++ b/common/changes/@itwin/presentation-frontend/bump_unified_selection_2024-11-06-14-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Bumped `@itwin/unified-selection` version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2361,7 +2361,7 @@ importers:
       '@itwin/ecschema-metadata': workspace:*
       '@itwin/eslint-plugin': 5.0.0-dev.1
       '@itwin/presentation-common': workspace:*
-      '@itwin/unified-selection': ^0.1.0
+      '@itwin/unified-selection': ^1.1.1
       '@types/chai': 4.3.1
       '@types/chai-as-promised': ^7
       '@types/chai-jest-snapshot': ^1.3.8
@@ -2393,7 +2393,7 @@ importers:
       typemoq: ^2.1.0
       typescript: ~5.6.2
     dependencies:
-      '@itwin/unified-selection': 0.1.0
+      '@itwin/unified-selection': 1.1.1
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
     devDependencies:
@@ -4204,6 +4204,10 @@ packages:
       reflect-metadata: 0.1.13
     dev: false
 
+  /@itwin/core-bentley/4.9.5:
+    resolution: {integrity: sha512-2cFqJnWKdGyNgZziqYHg4KkYVXD3+f4WQ5xhVPkEYffcOpXXz4yFh8nDOZmhgOLAmJo6KDH2x+uNJembcX6wjQ==}
+    dev: false
+
   /@itwin/core-common/4.8.1_67wltvhdskk2oee2c3z2o4tfly:
     resolution: {integrity: sha512-dIfw0ly+JFM83+mIQQ5xZ5WImazcjCBFuClTE8Fc5LMfFTe/Jtbj3nwA7aD7FcpuwtnV6kp4ykqrA5SoEz8Byg==}
     peerDependencies:
@@ -4429,6 +4433,12 @@ packages:
       - '@itwin/core-geometry'
       - supports-color
 
+  /@itwin/presentation-shared/1.1.0:
+    resolution: {integrity: sha512-H0NiWIYpxPSg4bJdQdSo4epdFUqoza/4UEbRj6nin906Mr2oKWu7Jep9OLbFXTmarMtP+q+5iSlp/eTRhTc/Cg==}
+    dependencies:
+      '@itwin/core-bentley': 4.9.5
+    dev: false
+
   /@itwin/reality-data-client/1.2.1_mdtbcqczpmeuv6yjzfaigjndwi:
     resolution: {integrity: sha512-pNpnO1tbsM1HwyZcr6UkZLyMczNcYFHqsnREmjYJ4GIeCMdrWKGbH5ar4hyajqc/ZkV9zO4FXFMYgQx3yKK1zQ==}
     peerDependencies:
@@ -4471,8 +4481,13 @@ packages:
       - '@itwin/core-geometry'
       - supports-color
 
-  /@itwin/unified-selection/0.1.0:
-    resolution: {integrity: sha512-1Pe2i3sw5dK4h394uC5wTRWvnXxeBZGv+t9LcG7tQr2L+l0Hv+Ryo5+yTN34kABEhMe2UwSHnBRU8jOGsiorIQ==}
+  /@itwin/unified-selection/1.1.1:
+    resolution: {integrity: sha512-myygzispTehbgeZBFbOipyt3AvTr9Lx+QvP5hPG3YKyEvGimAtO3Mh6unwmdCxrM9Ue9w5El63Jbr0N+f+ZdVg==}
+    dependencies:
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/presentation-shared': 1.1.0
+      rxjs: 7.8.1
+      rxjs-for-await: 1.0.0_rxjs@7.8.1
     dev: false
 
   /@jridgewell/gen-mapping/0.3.5:

--- a/presentation/common/src/presentation-common/KeySet.ts
+++ b/presentation/common/src/presentation-common/KeySet.ts
@@ -194,12 +194,13 @@ export class KeySet {
       this._nodeKeys.add(JSON.stringify(key));
     }
     for (const entry of keyset.instanceKeys) {
-      const lcClassName = normalizeClassName(entry["0"]);
+      const normalizedClassName = normalizeClassName(entry["0"]);
+      const lcClassName = normalizedClassName.toLowerCase();
       const idsJson: string | Id64String[] = entry["1"];
       const ids: Set<Id64String> =
         typeof idsJson === "string" ? (idsJson === Id64.invalid ? new Set([Id64.invalid]) : CompressedId64Set.decompressSet(idsJson)) : new Set(idsJson);
       this._instanceKeys.set(lcClassName, ids);
-      this._lowerCaseMap.set(lcClassName, entry["0"]);
+      this._lowerCaseMap.set(lcClassName, normalizedClassName);
     }
   }
 
@@ -222,12 +223,12 @@ export class KeySet {
       if (Key.isEntityProps(value)) {
         this.add({ className: value.classFullName, id: Id64.fromJSON(value.id) } as InstanceKey);
       } else if (Key.isInstanceKey(value)) {
-        const lcClassName = normalizeClassName(value.className);
+        const normalizedClassName = normalizeClassName(value.className);
+        const lcClassName = normalizedClassName.toLowerCase();
         if (!this._instanceKeys.has(lcClassName)) {
           this._instanceKeys.set(lcClassName, new Set());
-          this._lowerCaseMap.set(lcClassName, value.className);
         }
-        this._lowerCaseMap.set(lcClassName, value.className);
+        this._lowerCaseMap.set(lcClassName, normalizedClassName);
         this._instanceKeys.get(lcClassName)!.add(value.id);
       } else if (Key.isNodeKey(value)) {
         this._nodeKeys.add(JSON.stringify(value));
@@ -274,7 +275,8 @@ export class KeySet {
     } else if (Key.isEntityProps(value)) {
       this.delete({ className: value.classFullName, id: value.id! } as InstanceKey);
     } else if (Key.isInstanceKey(value)) {
-      const set = this._instanceKeys.get(normalizeClassName(value.className));
+      const normalizedClassName = normalizeClassName(value.className);
+      const set = this._instanceKeys.get(normalizedClassName.toLowerCase());
       if (set) {
         set.delete(value.id);
       }
@@ -301,7 +303,8 @@ export class KeySet {
       return this.has({ className: value.classFullName, id: value.id! } as InstanceKey);
     }
     if (Key.isInstanceKey(value)) {
-      const set = this._instanceKeys.get(normalizeClassName(value.className));
+      const normalizedClassName = normalizeClassName(value.className);
+      const set = this._instanceKeys.get(normalizedClassName.toLowerCase());
       return !!(set && set.has(value.id));
     }
     if (Key.isNodeKey(value)) {
@@ -504,7 +507,7 @@ export class KeySet {
 }
 
 function normalizeClassName(className: string) {
-  return className.replace(".", ":").toLowerCase();
+  return className.replace(".", ":");
 }
 
 const some = <TItem>(set: Set<TItem>, cb: (item: TItem) => boolean) => {

--- a/presentation/common/src/test/KeySet.test.ts
+++ b/presentation/common/src/test/KeySet.test.ts
@@ -280,6 +280,15 @@ describe("KeySet", () => {
       expect(set.guid).to.not.eq(guidBefore);
     });
 
+    it("converts instance key class name into `Schema:Class` format", () => {
+      const set = new KeySet([{ className: "Schema.Class", id: "0x1" }]);
+      const key = { className: "Schema.Class", id: "0x2" };
+      set.add(key);
+      expect(set.instanceKeysCount).to.eq(2);
+      expect(set.has(key)).to.be.true;
+      set.instanceKeys.forEach((_, className) => expect(className).to.eq("Schema:Class"));
+    });
+
     it("doesn't add the same instance key", () => {
       const key = createRandomECInstanceKey();
       const set = new KeySet([key]);

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -42,7 +42,7 @@
     "prettier:fix": "prettier --write ."
   },
   "dependencies": {
-    "@itwin/unified-selection": "^0.1.0",
+    "@itwin/unified-selection": "^1.1.1",
     "rxjs": "^7.8.1",
     "rxjs-for-await": "^1.0.0"
   },

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -62,8 +62,8 @@ import { IpcRequestsHandler } from "./IpcRequestsHandler";
 import { FrontendLocalizationHelper } from "./LocalizationHelper";
 import { RulesetManager, RulesetManagerImpl } from "./RulesetManager";
 import { RulesetVariablesManager, RulesetVariablesManagerImpl } from "./RulesetVariablesManager";
-import { TRANSIENT_ELEMENT_CLASSNAME } from "./selection/SelectionManager";
 import { StreamedResponseGenerator } from "./StreamedResponseGenerator";
+import { TRANSIENT_ELEMENT_CLASSNAME } from "@itwin/unified-selection";
 
 /**
  * Data structure that describes IModel hierarchy change event arguments.

--- a/presentation/frontend/src/presentation-frontend/selection/HiliteSetProvider.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/HiliteSetProvider.ts
@@ -12,8 +12,8 @@ import { Id64String } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
 import { ContentFlags, DEFAULT_KEYS_BATCH_SIZE, DefaultContentDisplayTypes, DescriptorOverrides, Item, Key, KeySet, Ruleset } from "@itwin/presentation-common";
 import { Presentation } from "../Presentation";
-import { TRANSIENT_ELEMENT_CLASSNAME } from "./SelectionManager";
 import hiliteRuleset from "./HiliteRules.json";
+import { TRANSIENT_ELEMENT_CLASSNAME } from "@itwin/unified-selection";
 
 const HILITE_RULESET = hiliteRuleset as Ruleset;
 

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -18,6 +18,7 @@ import {
   SelectionStorage,
   StorageSelectionChangeEventArgs,
   StorageSelectionChangeType,
+  TRANSIENT_ELEMENT_CLASSNAME,
 } from "@itwin/unified-selection";
 import { Presentation } from "../Presentation";
 import { HiliteSet, HiliteSetProvider } from "./HiliteSetProvider";
@@ -370,10 +371,10 @@ export class SelectionManager implements ISelectionProvider {
     return this._selectionChanges
       .pipe(
         mergeMap((args) => {
-          const currentSelectables = this._selectionStorage.getSelection({ iModelKey: args.iModelKey, level: args.level });
-          return this._currentSelection.computeSelection(args.iModelKey, args.level, currentSelectables, args.selectables).pipe(
+          const currentSelectables = this._selectionStorage.getSelection({ iModelKey: args.imodelKey, level: args.level });
+          return this._currentSelection.computeSelection(args.imodelKey, args.level, currentSelectables, args.selectables).pipe(
             mergeMap(({ level, changedSelection }): Observable<SelectionChangeEventArgs> => {
-              const imodel = this._knownIModels.get(args.iModelKey);
+              const imodel = this._knownIModels.get(args.imodelKey);
               // istanbul ignore if
               if (!imodel) {
                 return EMPTY;
@@ -397,9 +398,6 @@ export class SelectionManager implements ISelectionProvider {
       });
   }
 }
-
-/** @internal */
-export const TRANSIENT_ELEMENT_CLASSNAME = "/TRANSIENT";
 
 /** @internal */
 export class ToolSelectionSyncHandler implements IDisposable {

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -77,7 +77,7 @@ import {
 } from "../presentation-frontend/PresentationManager";
 import { RulesetManagerImpl } from "../presentation-frontend/RulesetManager";
 import { RulesetVariablesManagerImpl } from "../presentation-frontend/RulesetVariablesManager";
-import { TRANSIENT_ELEMENT_CLASSNAME } from "../presentation-frontend/selection/SelectionManager";
+import { TRANSIENT_ELEMENT_CLASSNAME } from "@itwin/unified-selection";
 
 /* eslint-disable @typescript-eslint/no-deprecated */
 

--- a/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
+++ b/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
@@ -9,10 +9,10 @@ import { IModelConnection } from "@itwin/core-frontend";
 import { Content, DEFAULT_KEYS_BATCH_SIZE, Descriptor, Item, KeySet } from "@itwin/presentation-common";
 import { createRandomECInstanceKey, createRandomTransientId, createTestContentDescriptor } from "@itwin/presentation-common/lib/cjs/test";
 import { HiliteSetProvider } from "../../presentation-frontend/selection/HiliteSetProvider";
-import { TRANSIENT_ELEMENT_CLASSNAME } from "../../presentation-frontend/selection/SelectionManager";
 import sinon from "sinon";
 import { Presentation } from "../../presentation-frontend/Presentation";
 import { GetContentRequestOptions, MultipleValuesRequestOptions, PresentationManager } from "../../presentation-frontend";
+import { TRANSIENT_ELEMENT_CLASSNAME } from "@itwin/unified-selection";
 
 describe("HiliteSetProvider", () => {
   const imodelMock = moq.Mock.ofType<IModelConnection>();

--- a/presentation/frontend/src/test/selection/SelectionManager.test.ts
+++ b/presentation/frontend/src/test/selection/SelectionManager.test.ts
@@ -17,12 +17,12 @@ import {
   ResolvablePromise,
   waitForPendingAsyncs,
 } from "@itwin/presentation-common/lib/cjs/test";
-import { createStorage, CustomSelectable, SelectionStorage } from "@itwin/unified-selection";
+import { createStorage, CustomSelectable, SelectionStorage, TRANSIENT_ELEMENT_CLASSNAME } from "@itwin/unified-selection";
 import { Presentation } from "../../presentation-frontend/Presentation";
 import { PresentationManager } from "../../presentation-frontend/PresentationManager";
 import { HiliteSetProvider } from "../../presentation-frontend/selection/HiliteSetProvider";
 import { SelectionChangeEventArgs, SelectionChangesListener } from "../../presentation-frontend/selection/SelectionChangeEvent";
-import { SelectionManager, ToolSelectionSyncHandler, TRANSIENT_ELEMENT_CLASSNAME } from "../../presentation-frontend/selection/SelectionManager";
+import { SelectionManager, ToolSelectionSyncHandler } from "../../presentation-frontend/selection/SelectionManager";
 import { SelectionScopesManager } from "../../presentation-frontend/selection/SelectionScopesManager";
 
 const generateSelection = (): InstanceKey[] => {


### PR DESCRIPTION
Bumped `@itwin/unified-selection` version.
Updated `KeySet` to always store instance key class names in `Schema:Class` format.