### PR TITLE
try to add logging for flaky test "briefcasetxns writable connection receives events from TxnManager"

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -147,7 +147,6 @@ describe("BriefcaseTxns", () => {
         ]);
 
         await rwConn.txns.reinstateTxn();
-        Logger.logTrace("Nick", "BeforeAllRedo");
         await expectRedo([
           "onElementsChanged", "onChangesApplied",
           "onElementsChanged", "onModelsChanged", "onChangesApplied",

--- a/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/BriefcaseTxns.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import * as path from "path";
-import { Guid, OpenMode, ProcessDetector } from "@itwin/core-bentley";
+import { Guid, Logger, LogLevel, OpenMode, ProcessDetector } from "@itwin/core-bentley";
 import { Transform } from "@itwin/core-geometry";
 import { BriefcaseConnection, TxnEntityChanges, TxnEntityChangeType } from "@itwin/core-frontend";
 import { addAllowedChannel, coreFullStackTestIpc, deleteElements, initializeEditTools, insertLineElement, makeModelCode, transformElements } from "../Editing";
@@ -56,11 +56,18 @@ describe("BriefcaseTxns", () => {
         for (const additionalEvent of additionalEvents)
           expected.push(additionalEvent);
 
+        let timesWaited = 0;
         const wait = async (): Promise<void> => {
           if (received.length >= expected.length)
             return;
 
+          if (timesWaited > 300) { // 10 timesWaited is 1 second. 100 is 10 seconds. 300 is 30 seconds.
+            timesWaited = 0;
+            Logger.logTrace("TestCategory", `Waited for 30 seconds. Received: ${received.length}, Expected: ${expected.length}
+              \tReceived: ${received.map((evt) => evt).join(", ")}\n\tExpected: ${expected.map((evt) => evt).join(", ")}`);
+          }
           await new Promise<void>((resolve: any) => setTimeout(resolve, 100));
+          timesWaited++;
           return wait();
         };
 
@@ -75,7 +82,8 @@ describe("BriefcaseTxns", () => {
     describe("writable connection", () => {
       it("receives events from TxnManager", async () => {
         const expectEvents = installListeners(rwConn);
-
+        Logger.initializeToConsole();
+        Logger.setLevel("TestCategory", LogLevel.Trace);
         const expectCommit = async (...evts: TxnEvent[]) => expectEvents(["onCommit", ...evts, "onCommitted"]);
 
         const dictModelId = await rwConn.models.getDictionaryModel();
@@ -139,6 +147,7 @@ describe("BriefcaseTxns", () => {
         ]);
 
         await rwConn.txns.reinstateTxn();
+        Logger.logTrace("Nick", "BeforeAllRedo");
         await expectRedo([
           "onElementsChanged", "onChangesApplied",
           "onElementsChanged", "onModelsChanged", "onChangesApplied",
@@ -146,6 +155,8 @@ describe("BriefcaseTxns", () => {
           "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
           "onElementsChanged", "onChangesApplied", "onModelGeometryChanged",
         ]);
+
+        Logger.initialize(); // Reset the logger since we initialized it to console above.
       });
 
       it("receives events including entity Id and class name", async () => {


### PR DESCRIPTION
Over the last 14 days this test has failed the most times than any other test at 13 times. Adding logging in hopes that it might give some clarity. I also considered doing a log message before and after each expectEvents call, but wasn't sure if that would be too much.
![image](https://github.com/user-attachments/assets/7e550650-49d2-474d-9b9f-aaf145fba244)
