### PR TITLE
Remove `ElectronHost.getWindowSizeSetting` and `ElectronApp.callDialog`

### DIFF
--- a/common/api/core-electron.api.md
+++ b/common/api/core-electron.api.md
@@ -12,17 +12,15 @@ import { IpcHandler } from '@itwin/core-backend';
 import { NativeAppOpts } from '@itwin/core-frontend';
 import { NativeHostOpts } from '@itwin/core-backend';
 import { PickAsyncMethods } from '@itwin/core-bentley';
-import { PromiseReturnType } from '@itwin/core-bentley';
 import { RpcConfiguration } from '@itwin/core-common';
 import { RpcInterfaceDefinition } from '@itwin/core-common';
+import type { WebPreferences } from 'electron';
 
 // @beta
 export type DialogModuleMethod = AsyncMethodsOf<Electron.Dialog>;
 
 // @beta
 export class ElectronApp {
-    // @deprecated
-    static callDialog<T extends DialogModuleMethod>(methodName: T, ...args: Parameters<Electron.Dialog[T]>): Promise<PromiseReturnType<Electron.Dialog[T]>>;
     static dialogIpc: PickAsyncMethods<Electron.Dialog>;
     // (undocumented)
     static get isValid(): boolean;
@@ -46,8 +44,6 @@ export class ElectronHost {
     static frontendURL: string;
     static getWindowMaximizedSetting(windowName: string): boolean | undefined;
     static getWindowSizeAndPositionSetting(windowName: string): WindowSizeAndPositionProps | undefined;
-    // @deprecated
-    static getWindowSizeSetting(windowName: string): WindowSizeAndPositionProps | undefined;
     // (undocumented)
     static get ipcMain(): Electron.IpcMain;
     // (undocumented)
@@ -80,9 +76,9 @@ export interface ElectronHostOpts extends NativeHostOpts {
 
 // @beta (undocumented)
 export interface ElectronHostWindowOptions extends BrowserWindowConstructorOptions {
-    // (undocumented)
     storeWindowName?: string;
     titleBarStyle?: ("default" | "hidden" | "hiddenInset" | "customButtonsOnHover");
+    webPreferences?: Omit<WebPreferences, "preload" | "experimentalFeatures" | "nodeIntegration" | "contextIsolation" | "sandbox" | "nodeIntegrationInWorker" | "nodeIntegrationInSubFrames">;
 }
 
 // @internal (undocumented)

--- a/common/changes/@itwin/core-electron/gytis-remove-deprecated-electron-apis_2024-11-11-13-17.json
+++ b/common/changes/@itwin/core-electron/gytis-remove-deprecated-electron-apis_2024-11-11-13-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Removed `ElectronHost.getWindowSizeSetting` and `ElectronApp.callDialog` methods",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/core/electron/src/backend/ElectronHost.ts
+++ b/core/electron/src/backend/ElectronHost.ts
@@ -68,9 +68,12 @@ export interface ElectronHostOpts extends NativeHostOpts {
 
 /** @beta */
 export interface ElectronHostWindowOptions extends BrowserWindowConstructorOptions {
+  /** Name used to construct key for saving window size, position and maximize status to the settings store */
   storeWindowName?: string;
   /** The style of window title bar. Default is `default`. */
   titleBarStyle?: ("default" | "hidden" | "hiddenInset" | "customButtonsOnHover");
+  /** Web page settings */
+  webPreferences?: Omit<WebPreferences, "preload" | "experimentalFeatures" | "nodeIntegration" | "contextIsolation" | "sandbox" | "nodeIntegrationInWorker" | "nodeIntegrationInSubFrames">;
 }
 
 /** the size and position of a window as stored in the settings file.

--- a/core/electron/src/frontend/ElectronApp.ts
+++ b/core/electron/src/frontend/ElectronApp.ts
@@ -7,11 +7,11 @@
  * @module Renderer
  */
 
-import { ProcessDetector, PromiseReturnType } from "@itwin/core-bentley";
+import { ProcessDetector } from "@itwin/core-bentley";
 import { IpcListener, IpcSocketFrontend } from "@itwin/core-common";
 import { _callIpcChannel, IpcApp, NativeApp, NativeAppOpts } from "@itwin/core-frontend";
 import type { IpcRenderer } from "electron";
-import { DialogModuleMethod, electronIpcStrings } from "../common/ElectronIpcInterface";
+import { electronIpcStrings } from "../common/ElectronIpcInterface";
 import { ElectronRpcManager } from "../common/ElectronRpcManager";
 import type { ITwinElectronApi } from "../common/ITwinElectronApi";
 
@@ -77,16 +77,6 @@ export class ElectronApp {
     this._ipc = undefined;
     await NativeApp.shutdown();
     ElectronRpcManager.terminateFrontend();
-  }
-
-  /**
-   * Call an asynchronous method in the [Electron.Dialog](https://www.electronjs.org/docs/api/dialog) interface from a previously initialized ElectronFrontend.
-   * @param methodName the name of the method to call
-   * @param args arguments to method
-   * @deprecated in 3.x. use [[dialogIpc]]
-   */
-  public static async callDialog<T extends DialogModuleMethod>(methodName: T, ...args: Parameters<Electron.Dialog[T]>) {
-    return IpcApp[_callIpcChannel](electronIpcStrings.dialogChannel, "callDialog", methodName, ...args) as PromiseReturnType<Electron.Dialog[T]>;
   }
 
   /** Proxy object for calling methods of `Electron.Dialog` */

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -40,5 +40,5 @@ The following previously-deprecated APIs have been removed:
 
 **@itwin/core-electron**:
 
-- `ElectronApp.callDialog`
-- `ElectronHost.getWindowSizeSetting`
+- `ElectronApp.callDialog` - replaced by [ElectronApp.dialogIpc]($electron)
+- `ElectronHost.getWindowSizeSetting` - replaced by [ElectronHost.getWindowSizeAndPositionSetting]($electron)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -10,6 +10,7 @@ Table of contents:
   - [@itwin/presentation-common](#itwinpresentation-common)
 - [Breaking Changes](#breaking-changes)
   - [Opening connection to local snapshot requires IPC](#opening-connection-to-local-snapshot-requires-ipc)
+  - [Deprecated API removals](#deprecated-api-removals)
 
 ## API deprecations
 
@@ -22,3 +23,12 @@ Table of contents:
 ### Opening connection to local snapshot requires IPC
 
 [SnapshotConnection.openFile]($frontend) now requires applications to have set up a valid IPC communication. If you're using this API in an Electron or Mobile application, no additional action is needed as long as you call `ElectronHost.startup` or `MobileHost.startup` respectively. This API shouldn't be used in Web applications, so it has no replacement there.
+
+### Deprecated API removals
+
+The following previously-deprecated APIs have been removed:
+
+**@itwin/core-electron**:
+
+- `ElectronApp.callDialog`
+- `ElectronHost.getWindowSizeSetting`


### PR DESCRIPTION
Both methods are in beta, have been deprecated since 3.x and have 1:1 replacement.

Also, fixed `ElectronHostWindowOptions.webPreferences` type. We override values of some of the properties in `webPreferences` before passing it to the Electron. New `Omit<WebPreferences, "preload" | ...>` type omits those properties as to not confuse API callers.