### PR TITLE
Build tools: Bump `typedoc-plugin-merge-modules` to a version that supports `typedoc@0.26`

### DIFF
--- a/common/changes/@itwin/build-tools/build-tools-bump-typedoc-plugin-merge-modules_2024-11-14-06-58.json
+++ b/common/changes/@itwin/build-tools/build-tools-bump-typedoc-plugin-merge-modules_2024-11-14-06-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Bump `typedoc-plugin-merge-modules` dependency to a version that supports typedoc `0.26`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2899,7 +2899,7 @@ importers:
       rimraf: ^3.0.2
       tree-kill: ^1.2.2
       typedoc: ^0.26.11
-      typedoc-plugin-merge-modules: ^5.1.0
+      typedoc-plugin-merge-modules: ^6.0.3
       typescript: ~5.6.2
       wtfnode: ^0.9.1
       yargs: ^17.4.0
@@ -2915,7 +2915,7 @@ importers:
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.26.11_typescript@5.6.2
-      typedoc-plugin-merge-modules: 5.1.0_typedoc@0.26.11
+      typedoc-plugin-merge-modules: 6.0.3_typedoc@0.26.11
       typescript: 5.6.2
       wtfnode: 0.9.1
       yargs: 17.4.0
@@ -13423,10 +13423,10 @@ packages:
     dependencies:
       is-typedarray: 1.0.0
 
-  /typedoc-plugin-merge-modules/5.1.0_typedoc@0.26.11:
-    resolution: {integrity: sha512-jXH27L/wlxFjErgBXleh3opVgjVTXFEuBo68Yfl18S9Oh/IqxK6NV94jlEJ9hl4TXc9Zm2l7Rfk41CEkcCyvFQ==}
+  /typedoc-plugin-merge-modules/6.0.3_typedoc@0.26.11:
+    resolution: {integrity: sha512-66mKhcU3RqjLnFzrC4jObqKpnKg+yCyBmTYfzGHjuVlBb1ZhPyD64kLBR6ZsSx5oy99W/Kizu5xc5NBN2nY3kQ==}
     peerDependencies:
-      typedoc: 0.24.x || 0.25.x
+      typedoc: 0.26.x
     dependencies:
       typedoc: 0.26.11_typescript@5.6.2
     dev: false

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^3.0.2",
     "tree-kill": "^1.2.2",
     "typedoc": "^0.26.11",
-    "typedoc-plugin-merge-modules": "^5.1.0",
+    "typedoc-plugin-merge-modules": "^6.0.3",
     "typescript": "~5.6.2",
     "wtfnode": "^0.9.1",
     "yargs": "^17.4.0"


### PR DESCRIPTION
Should've been part of https://github.com/iTwin/itwinjs-core/pull/7353