### PR TITLE
Fixed a few spots where extendedType was misnamed as extendType

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -7513,7 +7513,7 @@ export enum QueryParamType {
 export interface QueryPropertyMetaData {
     accessString?: string;
     className: string;
-    extendType: string;
+    extendedType: string;
     generated: boolean;
     index: number;
     jsonName: string;

--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -61,8 +61,8 @@ export interface QueryPropertyMetaData {
   jsonName: string;
   /** The name is the property's alias if the property is a generated one, otherwise, it is the name of the property. */
   name: string;
-  /** If this property is a PrimitiveECProperty, extend type is the extended type name of this property, if it is not defined locally will be inherited from base property if one exists, otherwise extended type is set to an empty string. */
-  extendType: string;
+  /** If this property is a PrimitiveECProperty, extended type is the extended type name of this property, if it is not defined locally will be inherited from base property if one exists, otherwise extended type is set to an empty string. */
+  extendedType: string;
   /** The type name is set to 'navigation' if the property is a navigation property, otherwise, it is the type name for the property. */
   typeName: string;
 }

--- a/core/ecschema-editing/src/Editing/Properties.ts
+++ b/core/ecschema-editing/src/Editing/Properties.ts
@@ -316,10 +316,10 @@ class PrimitiveOrEnumProperties extends Properties {
   }
 
   /**
-   * Sets the extendTypeName attribute value.
+   * Sets the extendedTypeName attribute value.
    * @param classKey The SchemaItemKey of the class.
    * @param propertyName The name of the property.
-   * @param extendTypeName The extended type name of the property.
+   * @param extendedTypeName The extended type name of the property.
    */
   public async setExtendedTypeName(classKey: SchemaItemKey, propertyName: string, extendedTypeName: string) {
     const property = await this.getProperty<MutablePrimitiveOrEnumPropertyBase>(classKey, propertyName)

--- a/docs/learning/ECSqlReference/InstanceQuery.md
+++ b/docs/learning/ECSqlReference/InstanceQuery.md
@@ -242,7 +242,7 @@ SELECT *
 1. Only top level property is allowed.
 2. Only primitive type values can be accessed in the filter directly. Any composite type will require `JSON_EXTRACT()` to extract child value before it can be used in a query. Refer [Accessing Composite Properties](#accessing-composite-properties)
 3. Currently indexes are not supported on instance properties.
-4. MetaData a.k.a `ColumnInfo` is dynamically updated only for primitive properties selected for output. All other properties will get generic `ColumnInfo` with a string property and `extendType=JSON`.
+4. MetaData a.k.a `ColumnInfo` is dynamically updated only for primitive properties selected for output. All other properties will get generic `ColumnInfo` with a string property and `extendedType=JSON`.
 
 ## Performance
 


### PR DESCRIPTION
closes #7361 

Fixed the above issue in [ConcurrentQuery.ts](https://github.com/iTwin/itwinjs-core/blob/d8b4364092ea7f00c0340179a51ff1ae126395f8/core/common/src/ConcurrentQuery.ts#L4) and a few other files.