### PR TITLE
documentation: fix link to isInUseLocksError

### DIFF
--- a/common/changes/@itwin/core-common/docs-isInUseLocksError-link-fix_2024-11-18-19-36.json
+++ b/common/changes/@itwin/core-common/docs-isInUseLocksError-link-fix_2024-11-18-19-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/ITwinError.ts
+++ b/core/common/src/ITwinError.ts
@@ -72,7 +72,7 @@ export namespace InUseLocksError {
     return ITwinError.isITwinError(error) && error.namespace === "itwinjs-core" && error.errorKey === "in-use-locks";
   }
 
-  /** throws an error which passes the [[isInUseLocksError]] type guard function */
+  /** throws an error which passes the [[InUseLocksError.isInUseLocksError]] type guard function */
   export function throwInUseLocksError(inUseLocks: InUseLock[], message?: string, metadata?: LoggingMetaData): never {
     const errorObject = new Error();
     errorObject.name = "InUseLocksError"; // optional but makes it so that when the error is thrown and not caught we see InUseLocksError: 'message' instead of Error: 'message'


### PR DESCRIPTION
Links to namespace children must be prefaced by namespace name, even when inside of the namespace. Docs link validation failed to catch this error due an oversight in easing the upgrade to TypeScript 5.3/TypeDoc 0.24.x.