### PR TITLE
add hydrateDefaultViewState RPC method

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3167,6 +3167,8 @@ export abstract class IModelDb extends IModel {
     // @deprecated
     query(ecsql: string, params?: QueryBinder, options?: QueryOptions): AsyncIterableIterator<any>;
     // @internal
+    queryAllSpatial3dModelIds(): Promise<Id64Array>;
+    // @internal
     queryAllUsedSpatialSubCategories(): Promise<SubCategoryResultRow[]>;
     queryEntityIds(params: EntityQueryParams): Id64Set;
     queryFilePropertyBlob(prop: FilePropertyProps): Uint8Array | undefined;

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -5100,6 +5100,8 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
     // @deprecated (undocumented)
     getViewThumbnail(_iModelToken: IModelRpcProps, _viewId: string): Promise<Uint8Array>;
     // (undocumented)
+    hydrateDefaultViewState(_iModelToken: IModelRpcProps): Promise<HydrateViewStateResponseProps>;
+    // (undocumented)
     hydrateViewState(_iModelToken: IModelRpcProps, _options: HydrateViewStateRequestProps): Promise<HydrateViewStateResponseProps>;
     static readonly interfaceName = "IModelReadRpcInterface";
     static interfaceVersion: string;

--- a/common/changes/@itwin/core-backend/nam-default-hydrate-view-state_2024-11-18-23-32.json
+++ b/common/changes/@itwin/core-backend/nam-default-hydrate-view-state_2024-11-18-23-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "add method to get all spatially located models of an iModel",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/nam-default-hydrate-view-state_2024-11-18-23-32.json
+++ b/common/changes/@itwin/core-common/nam-default-hydrate-view-state_2024-11-18-23-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "add hydrateDefaultViewState rpc method",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/CustomViewState3dCreator.ts
+++ b/core/backend/src/CustomViewState3dCreator.ts
@@ -64,22 +64,7 @@ export class CustomViewState3dCreator {
 
   /** Get the Ids of all spatially-located, non-template 3d models in the iModel. */
   private async _getAllModels(): Promise<Id64Array> {
-    // Note: IsNotSpatiallyLocated was introduced in a later version of the BisCore ECSchema.
-    // If the iModel has an earlier version, the statement will throw because the property does not exist.
-    // If the iModel was created from an earlier version and later upgraded to a newer version, the property may be NULL for models created prior to the upgrade.
-    const select = "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false";
-    const spatialCriterion = "AND (IsNotSpatiallyLocated IS NULL OR IsNotSpatiallyLocated = false)";
-
-    let models = [];
-    Logger.logInfo(loggerCategory, "Starting getAllModels query.");
-    try {
-      models = await this._executeQuery(`${select} ${spatialCriterion}`);
-    } catch {
-      models = await this._executeQuery(select);
-    }
-
-    Logger.logInfo(loggerCategory, "Finished getAllModels query.");
-    return models;
+    return this._imodel.queryAllSpatial3dModelIds();
   }
 
   private _executeQuery = async (query: string) => {

--- a/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
@@ -119,6 +119,17 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
     return viewHydrater.getHydrateResponseProps(options);
   }
 
+  public async hydrateDefaultViewState(tokenProps: IModelRpcProps): Promise<HydrateViewStateResponseProps> {
+    const iModelDb = await getIModelForRpc(tokenProps);
+    const modelIds = await iModelDb.queryAllSpatial3dModelIds();
+    const options: HydrateViewStateRequestProps = {
+      notLoadedModelSelectorStateModels: CompressedId64Set.compressArray(modelIds)
+    }
+
+    const viewHydrator = new ViewStateHydrator(iModelDb);
+    return viewHydrator.getHydrateResponseProps(options);
+  }
+
   public async queryAllUsedSpatialSubCategories(tokenProps: IModelRpcProps): Promise<SubCategoryResultRow[]> {
     const iModelDb = await getIModelForRpc(tokenProps);
     return iModelDb.queryAllUsedSpatialSubCategories();

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -811,6 +811,11 @@ describe("iModel", () => {
     });
   });
 
+  it.only("should query for all spatially located models", async () => {
+    const results = await imodel2.queryAllSpatial3dModelIds();
+    assert.isAtLeast(results.length, 1, "Expected query to find some spatially locaated models");
+  })
+
   it("should be able to query for ViewDefinitionProps", () => {
     const viewDefinitionProps: ViewDefinitionProps[] = imodel2.views.queryViewDefinitionProps(); // query for all ViewDefinitions
     assert.isAtLeast(viewDefinitionProps.length, 3);

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -811,7 +811,7 @@ describe("iModel", () => {
     });
   });
 
-  it.only("should query for all spatially located models", async () => {
+  it("should query for all spatially located models", async () => {
     const results = await imodel2.queryAllSpatial3dModelIds();
     assert.isAtLeast(results.length, 1, "Expected query to find some spatially locaated models");
   })

--- a/core/common/src/rpc/IModelReadRpcInterface.ts
+++ b/core/common/src/rpc/IModelReadRpcInterface.ts
@@ -84,7 +84,7 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
   public static readonly interfaceName = "IModelReadRpcInterface";
 
   /** The semantic version of the interface. */
-  public static interfaceVersion = "3.7.0";
+  public static interfaceVersion = "3.8.0";
 
   /*===========================================================================================
     NOTE: Any add/remove/change to the methods below requires an update of the interface version.
@@ -123,6 +123,8 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
   public async getCustomViewState3dData(_iModelToken: IModelRpcProps, _options: CustomViewState3dCreatorOptions): Promise<CustomViewState3dProps> { return this.forward(arguments); }
   @RpcOperation.allowResponseCaching(RpcResponseCacheControl.Immutable)
   public async hydrateViewState(_iModelToken: IModelRpcProps, _options: HydrateViewStateRequestProps): Promise<HydrateViewStateResponseProps> { return this.forward(arguments); }
+  @RpcOperation.allowResponseCaching(RpcResponseCacheControl.Immutable)
+  public async hydrateDefaultViewState(_iModelToken: IModelRpcProps): Promise<HydrateViewStateResponseProps> { return this.forward(arguments); }
   public async requestSnap(_iModelToken: IModelRpcProps, _sessionId: string, _props: SnapRequestProps): Promise<SnapResponseProps> { return this.forward(arguments); }
   public async cancelSnap(_iModelToken: IModelRpcProps, _sessionId: string): Promise<void> { return this.forward(arguments); }
   public async getGeometryContainment(_iModelToken: IModelRpcProps, _props: GeometryContainmentRequestProps): Promise<GeometryContainmentResponseProps> { return this.forward(arguments); }


### PR DESCRIPTION
Adds experimental rpc method, as part of default view creation refactoring. 
- Also adds a method to iModelDb to query for all spatially located models of an iModel, moving the logic from the custom view state creator file over.

This is one half of the refactoring for default view creation.