### PR TITLE
Build tools: Fix `typedoc` not finding `typedoc-plugin-merge-modules` plugin when hoisting is disabled

### DIFF
--- a/common/changes/@itwin/build-tools/build-tools-provide-full-path-to-typedoc-plugin_2024-11-20-07-32.json
+++ b/common/changes/@itwin/build-tools/build-tools-provide-full-path-to-typedoc-plugin_2024-11-20-07-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Fix `typedoc` not finding `typedoc-plugin-merge-modules` plugin when hoisting is disabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/scripts/docs.js
+++ b/tools/build/scripts/docs.js
@@ -56,7 +56,7 @@ const options = [
 ];
 
 const pluginOptions = [
-  "--plugin", "typedoc-plugin-merge-modules",
+  "--plugin", require.resolve("typedoc-plugin-merge-modules"),
   "--mergeModulesMergeMode", "module",
 ];
 


### PR DESCRIPTION
The `typedoc` version that we recently started using [changed the way plugins are loaded](https://github.com/TypeStrong/typedoc/commit/f06401f51ad119da3d01b4dc5d5568a86e1f0a02#diff-cd82c66603e6129d6e4b251f231c7d7d2350784573ed9bd58221f999bfa20a90R21). Previously, it used `require(path)`, now it uses `await import(path)`. One of the differences between the two is that [`import` doesn't respect `NODE_PATH`](https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#432-removal-of-non-local-dependencies), which was one way to resolve the path to the plugin. With that gone, the only way for `typedoc` to find the plugin by name is when the plugin is [hoisted](https://pnpm.io/npmrc#dependency-hoisting-settings), since the plugin is not a dependency of `typedoc`. But hoisting is a bad practice...

On the other hand, the build tools package does have a direct dependency on the plugin, so it can resolve its full name. Passing the plugin's full path to `typedoc` fixes the issue of it not working unless hoisted.