### PR TITLE
add setup node to finalize-release.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 
 * @iTwin/itwinjs-core-admins
 
-.github/workflows                                 @aruniverse @calebmshafer @wgoehrig @ColinKerr
+.github/workflows                                 @aruniverse @calebmshafer @wgoehrig @ColinKerr @ben-polinsky
 .github/CODEOWNERS                                @iTwin/itwinjs-core-admins
 
 .gitattributes                                    @iTwin/itwinjs-core-admins

--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure git
         run: |

--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -29,7 +29,7 @@ jobs:
           git config --local user.name imodeljs-admin
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
 

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -29,7 +29,7 @@ jobs:
           git config --local user.name imodeljs-admin
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
 

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -27,6 +27,12 @@ jobs:
         run: |
           git config --local user.email 38288322+imodeljs-admin@users.noreply.github.com
           git config --local user.name imodeljs-admin
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "22"
+
       - name: Run update-changelogs.mjs
         run: |
           sudo npm install -g @microsoft/rush


### PR DESCRIPTION
Add setup node step to pipeline. Otherwise we run the risk of a vm not using a supported version of node.

This caused an error in another pipeline, so we should use node setup or nodeTool whenever possible to avoid this problem