### PR TITLE
Presentation: Add `getElementProperties` overload for specifying elements by id

### DIFF
--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1719,11 +1719,14 @@ export interface LocalizationHelperProps {
 }
 
 // @public
-export interface MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> extends RequestOptions<TIModel> {
-    batchSize?: number;
+export type MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> = RequestOptions<TIModel> & {
     contentParser?: (descriptor: Descriptor, item: Item) => TParsedContent;
+    batchSize?: number;
+} & ({
     elementClasses?: string[];
-}
+} | {
+    elementIds?: Id64String[];
+});
 
 // @public
 export interface MultiSchemaClassesSpecification {

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -1719,14 +1719,23 @@ export interface LocalizationHelperProps {
 }
 
 // @public
-export type MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> = RequestOptions<TIModel> & {
-    contentParser?: (descriptor: Descriptor, item: Item) => TParsedContent;
+export interface MultiElementPropertiesBaseRequestOptions<TIModel, TParsedContent = ElementProperties> extends RequestOptions<TIModel> {
     batchSize?: number;
-} & ({
+    contentParser?: (descriptor: Descriptor, item: Item) => TParsedContent;
+}
+
+// @public
+export interface MultiElementPropertiesByClassRequestOptions<TIModel, TParsedContent = ElementProperties> extends MultiElementPropertiesBaseRequestOptions<TIModel, TParsedContent> {
     elementClasses?: string[];
-} | {
+}
+
+// @public
+export interface MultiElementPropertiesByIdsRequestOptions<TIModel, TParsedContent = ElementProperties> extends MultiElementPropertiesBaseRequestOptions<TIModel, TParsedContent> {
     elementIds?: Id64String[];
-});
+}
+
+// @public
+export type MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> = MultiElementPropertiesByClassRequestOptions<TIModel, TParsedContent> | MultiElementPropertiesByIdsRequestOptions<TIModel, TParsedContent>;
 
 // @public
 export interface MultiSchemaClassesSpecification {

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -250,6 +250,9 @@ public;type;LabelRawValueJSON
 deprecated;type;LabelRawValueJSON
 internal;class;LocalizationHelper
 internal;interface;LocalizationHelperProps
+public;interface;MultiElementPropertiesBaseRequestOptions
+public;interface;MultiElementPropertiesByClassRequestOptions
+public;interface;MultiElementPropertiesByIdsRequestOptions
 public;type;MultiElementPropertiesRequestOptions
 public;interface;MultiSchemaClassesSpecification
 public;interface;NamedFieldDescriptor

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -250,7 +250,7 @@ public;type;LabelRawValueJSON
 deprecated;type;LabelRawValueJSON
 internal;class;LocalizationHelper
 internal;interface;LocalizationHelperProps
-public;interface;MultiElementPropertiesRequestOptions
+public;type;MultiElementPropertiesRequestOptions
 public;interface;MultiSchemaClassesSpecification
 public;interface;NamedFieldDescriptor
 public;interface;NavigationPropertyInfo

--- a/common/changes/@itwin/presentation-backend/presentation-getElementProperties-with-elementIds_2024-11-27-12-05.json
+++ b/common/changes/@itwin/presentation-backend/presentation-getElementProperties-with-elementIds_2024-11-27-12-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Add `PresentationManager.getElementProperties` overload for specifying elements by id rather than class name.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-getElementProperties-with-elementIds_2024-11-27-12-05.json
+++ b/common/changes/@itwin/presentation-common/presentation-getElementProperties-with-elementIds_2024-11-27-12-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Extend `MultiElementPropertiesRequestOptions` to support specifying input element either through `elementClasses` or `elementIds` arrays.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/full-stack-tests/presentation/src/backend/PresentationManager.test.snap
+++ b/full-stack-tests/presentation/src/backend/PresentationManager.test.snap
@@ -948,3 +948,980 @@ Array [
   },
 ]
 `;
+
+exports[`PresentationManager getElementProperties returns properties of specific elements by element ID 1`] = `
+Array [
+  Object {
+    "class": "Subject",
+    "id": "0x1",
+    "items": Object {
+      "Selected Item(s)": Object {
+        "items": Object {
+          "Code": Object {
+            "type": "primitive",
+            "value": "DgnV8Bridge",
+          },
+          "Description": Object {
+            "type": "primitive",
+            "value": "",
+          },
+          "Model": Object {
+            "type": "primitive",
+            "value": "DgnV8Bridge",
+          },
+          "User Label": Object {
+            "type": "primitive",
+            "value": "",
+          },
+        },
+        "type": "category",
+      },
+    },
+    "label": "DgnV8Bridge",
+  },
+  Object {
+    "class": "Physical Object",
+    "id": "0x74",
+    "items": Object {
+      "Selected Item(s)": Object {
+        "items": Object {
+          "Category": Object {
+            "type": "primitive",
+            "value": "Uncategorized",
+          },
+          "Code": Object {
+            "type": "primitive",
+            "value": "",
+          },
+          "Model": Object {
+            "type": "primitive",
+            "value": "Properties_60InstancesWithUrl2",
+          },
+          "User Label": Object {
+            "type": "primitive",
+            "value": "",
+          },
+          "area": Object {
+            "items": Object {
+              "area": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "Acres": Object {
+                      "type": "primitive",
+                      "value": "150.1235 acres",
+                    },
+                    "cm2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 cm²",
+                    },
+                    "ft ft": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ft·ft",
+                    },
+                    "ft mi": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ft·mi",
+                    },
+                    "ft2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ft²",
+                    },
+                    "ha": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ha",
+                    },
+                    "in ft": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in·ft",
+                    },
+                    "in m": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in·m",
+                    },
+                    "in mi": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in·mi",
+                    },
+                    "in2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in²",
+                    },
+                    "km2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 km²",
+                    },
+                    "m km": Object {
+                      "type": "primitive",
+                      "value": "150.1235 m·km",
+                    },
+                    "m m": Object {
+                      "type": "primitive",
+                      "value": "150.1235 mm·m",
+                    },
+                    "m2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 m²",
+                    },
+                    "mi2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 mi²",
+                    },
+                    "mm km": Object {
+                      "type": "primitive",
+                      "value": "150.1235 mm·km",
+                    },
+                    "thousand ft2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 thousand ft²",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "firstTry": Object {
+            "items": Object {
+              "firstTry": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "email": Object {
+                      "type": "primitive",
+                      "value": "justas.lauzadis@bentley.com",
+                    },
+                    "full URL": Object {
+                      "type": "primitive",
+                      "value": "http://www.google.lt",
+                    },
+                    "mailto": Object {
+                      "type": "primitive",
+                      "value": "mailto:justas.lauzadis@bentley.com",
+                    },
+                    "without http": Object {
+                      "type": "primitive",
+                      "value": "www.bbc.co.uk",
+                    },
+                    "without www": Object {
+                      "type": "primitive",
+                      "value": "gmail.com",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "workingUnitsProp": Object {
+            "items": Object {
+              "workingUnitsProp": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "Angle": Object {
+                      "type": "primitive",
+                      "value": "2.62",
+                    },
+                    "Area": Object {
+                      "type": "primitive",
+                      "value": "150.12",
+                    },
+                    "Distance": Object {
+                      "type": "primitive",
+                      "value": "150.12",
+                    },
+                    "Volume": Object {
+                      "type": "primitive",
+                      "value": "150.12",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+        },
+        "type": "category",
+      },
+    },
+    "label": "Physical Object [0-38]",
+  },
+  Object {
+    "class": "Physical Object",
+    "id": "0x75",
+    "items": Object {
+      "Selected Item(s)": Object {
+        "items": Object {
+          "Category": Object {
+            "type": "primitive",
+            "value": "Uncategorized",
+          },
+          "Code": Object {
+            "type": "primitive",
+            "value": "",
+          },
+          "Model": Object {
+            "type": "primitive",
+            "value": "Properties_60InstancesWithUrl2",
+          },
+          "User Label": Object {
+            "type": "primitive",
+            "value": "",
+          },
+          "area": Object {
+            "items": Object {
+              "area": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "Acres": Object {
+                      "type": "primitive",
+                      "value": "150.1235 acres",
+                    },
+                    "cm2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 cm²",
+                    },
+                    "ft ft": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ft·ft",
+                    },
+                    "ft mi": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ft·mi",
+                    },
+                    "ft2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ft²",
+                    },
+                    "ha": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ha",
+                    },
+                    "in ft": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in·ft",
+                    },
+                    "in m": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in·m",
+                    },
+                    "in mi": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in·mi",
+                    },
+                    "in2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 in²",
+                    },
+                    "km2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 km²",
+                    },
+                    "m km": Object {
+                      "type": "primitive",
+                      "value": "150.1235 m·km",
+                    },
+                    "m m": Object {
+                      "type": "primitive",
+                      "value": "150.1235 mm·m",
+                    },
+                    "m2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 m²",
+                    },
+                    "mi2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 mi²",
+                    },
+                    "mm km": Object {
+                      "type": "primitive",
+                      "value": "150.1235 mm·km",
+                    },
+                    "thousand ft2": Object {
+                      "type": "primitive",
+                      "value": "150.1235 thousand ft²",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "area per time": Object {
+            "items": Object {
+              "area per time": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "cSt": Object {
+                      "type": "primitive",
+                      "value": "150.1235 cSt",
+                    },
+                    "ft2 s": Object {
+                      "type": "primitive",
+                      "value": "150.1235 ft²/s",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "area per time squared": Object {
+            "items": Object {
+              "Btu/lb [Btu per pound mass]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1475.699 Btu/lb",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "area per time squared temperature": Object {
+            "items": Object {
+              "Btu/(lbm·Δ°R) [btu per pound mass per delta degree rankine]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "14759.0 Btu/(lbm·Δ°R)",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "cube root length per time": Object {
+            "items": Object {
+              "ft^(1/3)/s [ft^(1/3)/s]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "14758.99",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "dimensionless": Object {
+            "items": Object {
+              "$ [dollar]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "15845.0 $",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "electric current": Object {
+            "items": Object {
+              "KA [kiloampere]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1475.65 KA",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "length": Object {
+            "items": Object {
+              "µin [microinch]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1475.96 µin",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "length per plane angle": Object {
+            "items": Object {
+              "in/deg [inch per degree]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "123654.47 in/degree",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "length per time": Object {
+            "items": Object {
+              "ft³/(ft²·min) [Foot cubed per foot squared per minute]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "15896.698 ft³/(ft²·min)",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "length time squared per mass": Object {
+            "items": Object {
+              "length time squared per mass": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "1/Bar [1/Bar]": Object {
+                      "type": "primitive",
+                      "value": "14851.00",
+                    },
+                    "Untitled": Object {
+                      "type": "primitive",
+                      "value": "",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "length to the six power": Object {
+            "items": Object {
+              "mm⁶ [millimeter to the sixth]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "14758.964 mm⁶",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "lenic mass": Object {
+            "items": Object {
+              "lb/ft [pound per foot]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "147.158 lb/ft",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "luminous flux": Object {
+            "items": Object {
+              "lm [lumen]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1589.741 lm",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "luminous flux per area": Object {
+            "items": Object {
+              "lm/ft² [lumen per foot squared]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1485.9 lm/ft²",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass": Object {
+            "items": Object {
+              "µg [microgram]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "14785.5896 µg",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass area per time cubed electric current": Object {
+            "items": Object {
+              "KV [kilovolt]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1478.5 KV",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass area per time squared plane angle": Object {
+            "items": Object {
+              "N·m/deg [newton meter per degree]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "14758.36 N·m/deg",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass area per time squared temperature mole": Object {
+            "items": Object {
+              "Btu/(lb-mol·Δ°R) [btu per pound mole per delta degree rankine]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "14758.5 Btu/(lb-mol·Δ°R)",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass length per time cubed temperature": Object {
+            "items": Object {
+              "(in·lbf)/(s·in·°F) [inch pound force per second inch fahrenheit]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "123456799.00",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass per time squared": Object {
+            "items": Object {
+              "lbf/in [pound force per inch]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1232584.897489 lbf/in",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass per volume": Object {
+            "items": Object {
+              "µg/L [micrograms per liter]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "45896318.0 µg/L",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mass volume per time squared": Object {
+            "items": Object {
+              "lbf·ft² [pound force foot squared]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "15789.46",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "molar volume": Object {
+            "items": Object {
+              "ft³/lb-mol [foot cubed per pound mole]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "0.5689 ft³/lb-mol",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mole per time": Object {
+            "items": Object {
+              "kmol/s [kilomole per second]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "123456.78 kmol/s",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "mole per volume": Object {
+            "items": Object {
+              "lb-mol/ft³ [pound mole per foot cubed]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "0.12",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "plane angle": Object {
+            "items": Object {
+              "quadrants [quadrants]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "0.01233 quadrants",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "plane angle per time": Object {
+            "items": Object {
+              "cycle/sec [cycle per second]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "0.02 cycle/sec",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "quartic length": Object {
+            "items": Object {
+              "ft⁴ [foot to the fourth]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "123456789.12345 ft⁴",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "reciprocal area": Object {
+            "items": Object {
+              "p/ft² [person per foot squared]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1234567.89 p/ft²",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "reciprocal length": Object {
+            "items": Object {
+              "1/mile [1/mile]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "12345.6789 1/mile",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "reciprocal mass": Object {
+            "items": Object {
+              "1/tn(short) [one per short ton]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "123.46",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "reciprocal temperature": Object {
+            "items": Object {
+              "1/Δ°R [reciprocal delta degree rankine]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "0.0 1/Δ°R",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "reciprocal time": Object {
+            "items": Object {
+              "grf/(h·ft²·inHg) [Grain mass per hour per foot squared per inch Mercury conventional]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "123456.79",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "reciprocal volume": Object {
+            "items": Object {
+              "1/ million gal": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1.23",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "square root length per time": Object {
+            "items": Object {
+              "ft^(1/2)/s [ft^(1/2)/s]": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1234.57",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "square root length to the seventh power per square root mass": Object {
+            "items": Object {
+              "Gallon per minute per square root pounds per inch squared": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1.23",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "temperature": Object {
+            "items": Object {
+              "Delta celsius": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "0.0 Δ°C",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "temperature per length": Object {
+            "items": Object {
+              "delta degree Kelvin per meter": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "123.456789 ΔK/m",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "time": Object {
+            "items": Object {
+              "days": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1234.56789 days",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "time cubed per mass area": Object {
+            "items": Object {
+              "one per kilowat": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1234.57",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "time cubed temperature": Object {
+            "items": Object {
+              "foot squared hour delta degree Fahrenheit per Btu": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1.2346 ft²·h·Δ°F/Btu",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "time squared per length": Object {
+            "items": Object {
+              "kg/kW h": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1.23",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "time squared per mass": Object {
+            "items": Object {
+              "1/Btu": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1.23",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "volume": Object {
+            "items": Object {
+              "thousand gal": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1.2346 thousand gal",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "volume per Time": Object {
+            "items": Object {
+              "volume per Time": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "L/min": Object {
+                      "type": "primitive",
+                      "value": "123456.789 L/min",
+                    },
+                    "ML/day": Object {
+                      "type": "primitive",
+                      "value": "1234567.89",
+                    },
+                    "acre ft/day": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 acre·ft/day",
+                    },
+                    "acre ft/h": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 acre·ft/h",
+                    },
+                    "acre ft/min": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 acre·ft/min",
+                    },
+                    "acre in/h": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 acre·in/h",
+                    },
+                    "acre in/min": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 acre·in/min",
+                    },
+                    "ft3/day": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 ft³/day",
+                    },
+                    "ft3/min": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 ft³/min",
+                    },
+                    "ft3/s": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 ft³/s",
+                    },
+                    "gal(imp)/day": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 gal (imp)/day",
+                    },
+                    "gal(imp)/s": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 gal (imp)/s",
+                    },
+                    "gal/s": Object {
+                      "type": "primitive",
+                      "value": "123456789.0 gal/s",
+                    },
+                    "gpd/capita": Object {
+                      "type": "primitive",
+                      "value": "123.46",
+                    },
+                    "m3/min": Object {
+                      "type": "primitive",
+                      "value": "12345.6789 m³/min",
+                    },
+                    "million gal(impl)/day": Object {
+                      "type": "primitive",
+                      "value": "123456.79",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "volume per mass": Object {
+            "items": Object {
+              "ft3/lm": Object {
+                "type": "array",
+                "valueType": "primitive",
+                "values": Array [
+                  "1.234568 ft³/lm",
+                ],
+              },
+            },
+            "type": "category",
+          },
+          "workingUnitsProp": Object {
+            "items": Object {
+              "workingUnitsProp": Object {
+                "type": "array",
+                "valueType": "struct",
+                "values": Array [
+                  Object {
+                    "Angle": Object {
+                      "type": "primitive",
+                      "value": "2.62",
+                    },
+                    "Area": Object {
+                      "type": "primitive",
+                      "value": "150.12",
+                    },
+                    "Distance": Object {
+                      "type": "primitive",
+                      "value": "150.12",
+                    },
+                    "Volume": Object {
+                      "type": "primitive",
+                      "value": "150.12",
+                    },
+                  },
+                ],
+              },
+            },
+            "type": "category",
+          },
+        },
+        "type": "category",
+      },
+    },
+    "label": "Physical Object [0-39]",
+  },
+]
+`;

--- a/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
+++ b/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
@@ -179,6 +179,17 @@ describe("PresentationManager", () => {
         expect(properties).to.matchSnapshot();
       });
     });
+
+    it("returns properties of specific elements by element ID", async () => {
+      await using(new PresentationManager(), async (manager) => {
+        const properties: ElementProperties[] = [];
+        const { iterator } = await manager.getElementProperties({ imodel, elementIds: ["0x74", "0x1", "0x75"] });
+        for await (const items of iterator()) {
+          properties.push(...items);
+        }
+        expect(properties).to.matchSnapshot();
+      });
+    });
   });
 
   describe("Cancel request", () => {

--- a/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
+++ b/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
@@ -6,24 +6,21 @@
  * @module Core
  */
 
-import { from, mergeAll, mergeMap, Observable, reduce } from "rxjs";
+import { bufferCount, defer, from, groupBy, map, mergeMap, Observable, ObservedValueOf, of, range, reduce } from "rxjs";
 import { ECSqlStatement, IModelDb } from "@itwin/core-backend";
-import { DbResult, Id64String } from "@itwin/core-bentley";
-import { PresentationError, PresentationStatus } from "@itwin/presentation-common";
-
-/** @internal */
-export function getElementsCount(db: IModelDb, classNames?: string[]) {
-  const filter = createElementsFilter("e", classNames);
-  const query = `
-    SELECT COUNT(e.ECInstanceId)
-    FROM bis.Element e
-    ${filter ? `WHERE ${filter}` : ""}
-  `;
-
-  return db.withPreparedStatement(query, (stmt: ECSqlStatement) => {
-    return stmt.step() === DbResult.BE_SQLITE_ROW ? stmt.getValue(0).getInteger() : 0;
-  });
-}
+import { DbResult, Id64, Id64Array, Id64String, OrderedId64Iterable } from "@itwin/core-bentley";
+import { QueryRowProxy } from "@itwin/core-common";
+import {
+  ContentDescriptorRequestOptions,
+  ContentRequestOptions,
+  Descriptor,
+  Item,
+  KeySet,
+  PresentationError,
+  PresentationStatus,
+  Ruleset,
+  RulesetVariable,
+} from "@itwin/presentation-common";
 
 /** @internal */
 export function parseFullClassName(fullClassName: string): [string, string] {
@@ -37,70 +34,285 @@ function getECSqlName(fullClassName: string) {
 }
 
 /** @internal */
-export function getClassesWithInstances(imodel: IModelDb, fullClassNames: string[]): Observable<string> {
-  return from(fullClassNames).pipe(
-    mergeMap((fullClassName) => {
-      const reader = imodel.createQueryReader(`
-        SELECT s.Name, c.Name
-        FROM ${getECSqlName(fullClassName)} e
-        JOIN meta.ECClassDef c ON c.ECInstanceId = e.ECClassId
-        JOIN meta.ECSchemaDef s on s.ECInstanceId = c.Schema.Id
-        GROUP BY c.ECInstanceId
-      `);
-      return from(reader.toArray() as Promise<[string, string][]>);
+export function getContentItemsObservableFromElementIds(
+  imodel: IModelDb,
+  contentDescriptorGetter: (
+    partialProps: Pick<ContentDescriptorRequestOptions<IModelDb, KeySet, RulesetVariable>, "rulesetOrId" | "keys">,
+  ) => Promise<Descriptor | undefined>,
+  contentSetGetter: (
+    partialProps: Pick<ContentRequestOptions<IModelDb, Descriptor, KeySet, RulesetVariable>, "rulesetOrId" | "keys" | "descriptor">,
+  ) => Promise<Item[]>,
+  elementIds: Id64String[],
+  classParallelism: number,
+  batchesParallelism: number,
+  batchSize: number,
+): { itemBatches: Observable<{ descriptor: Descriptor; items: Item[] }>; count: Observable<number> } {
+  return {
+    itemBatches: getElementClassesFromIds(imodel, elementIds).pipe(
+      mergeMap(
+        ({ classFullName, ids }) =>
+          getBatchedClassContentItems(
+            classFullName,
+            contentDescriptorGetter,
+            contentSetGetter,
+            () => createIdBatches(OrderedId64Iterable.sortArray(ids), batchSize),
+            batchesParallelism,
+          ),
+        classParallelism,
+      ),
+    ),
+    count: of(elementIds.length),
+  };
+}
+
+/** @internal */
+export function getContentItemsObservableFromClassNames(
+  imodel: IModelDb,
+  contentDescriptorGetter: (
+    partialProps: Pick<ContentDescriptorRequestOptions<IModelDb, KeySet, RulesetVariable>, "rulesetOrId" | "keys">,
+  ) => Promise<Descriptor | undefined>,
+  contentSetGetter: (
+    partialProps: Pick<ContentRequestOptions<IModelDb, Descriptor, KeySet, RulesetVariable>, "rulesetOrId" | "keys" | "descriptor">,
+  ) => Promise<Item[]>,
+  elementClasses: string[],
+  classParallelism: number,
+  batchesParallelism: number,
+  batchSize: number,
+): { itemBatches: Observable<{ descriptor: Descriptor; items: Item[] }>; count: Observable<number> } {
+  return {
+    itemBatches: getClassesWithInstances(imodel, elementClasses).pipe(
+      mergeMap(
+        (classFullName) =>
+          getBatchedClassContentItems(
+            classFullName,
+            contentDescriptorGetter,
+            contentSetGetter,
+            () => getBatchedClassElementIds(imodel, classFullName, batchSize),
+            batchesParallelism,
+          ),
+        classParallelism,
+      ),
+    ),
+    count: of(getElementsCount(imodel, elementClasses)),
+  };
+}
+
+function getBatchedClassContentItems(
+  classFullName: string,
+  contentDescriptorGetter: (
+    partialProps: Pick<ContentDescriptorRequestOptions<IModelDb, KeySet, RulesetVariable>, "rulesetOrId" | "keys">,
+  ) => Promise<Descriptor | undefined>,
+  contentSetGetter: (
+    partialProps: Pick<ContentRequestOptions<IModelDb, Descriptor, KeySet, RulesetVariable>, "rulesetOrId" | "keys" | "descriptor">,
+  ) => Promise<Item[]>,
+  batcher: () => Observable<Array<{ from: Id64String; to: Id64String }>>,
+  batchesParallelism: number,
+): Observable<{ descriptor: Descriptor; items: Item[] }> {
+  return of({
+    ruleset: createClassContentRuleset(classFullName),
+    keys: new KeySet(),
+  }).pipe(
+    mergeMap(({ ruleset, keys }) =>
+      defer(async () => {
+        const descriptor = await contentDescriptorGetter({ rulesetOrId: ruleset, keys });
+        if (!descriptor) {
+          throw new PresentationError(PresentationStatus.Error, `Failed to get descriptor for class ${classFullName}`);
+        }
+        return descriptor;
+      }).pipe(
+        // create elements' id batches
+        mergeMap((descriptor) => batcher().pipe(map((batch) => ({ descriptor, batch })))),
+        // request content for each batch, filter by IDs for performance
+        mergeMap(
+          ({ descriptor, batch }) =>
+            defer(async () => {
+              const filteringDescriptor = new Descriptor(descriptor);
+              filteringDescriptor.instanceFilter = {
+                selectClassName: classFullName,
+                expression: createElementIdsECExpressionFilter(batch),
+              };
+              return contentSetGetter({
+                rulesetOrId: ruleset,
+                keys,
+                descriptor: filteringDescriptor,
+              });
+            }).pipe(map((items) => ({ descriptor, items }))),
+          batchesParallelism,
+        ),
+      ),
+    ),
+  );
+}
+
+function createElementIdsECExpressionFilter(batch: Array<{ from: Id64String; to: Id64String }>): string {
+  let filter = "";
+  function appendCondition(cond: string) {
+    if (filter.length > 0) {
+      filter += " OR ";
+    }
+    filter += cond;
+  }
+  for (const item of batch) {
+    if (item.from === item.to) {
+      appendCondition(`this.ECInstanceId = ${item.from}`);
+    } else {
+      appendCondition(`this.ECInstanceId >= ${item.from} AND this.ECInstanceId <= ${item.to}`);
+    }
+  }
+  return filter;
+}
+
+function createClassContentRuleset(fullClassName: string): Ruleset {
+  const [schemaName, className] = parseFullClassName(fullClassName);
+  return {
+    id: `content/class-descriptor/${fullClassName}`,
+    rules: [
+      {
+        ruleType: "Content",
+        specifications: [
+          {
+            specType: "ContentInstancesOfSpecificClasses",
+            classes: {
+              schemaName,
+              classNames: [className],
+              arePolymorphic: false,
+            },
+            handlePropertiesPolymorphically: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** Given a list of element ids, group them by class name. */
+function getElementClassesFromIds(imodel: IModelDb, elementIds: string[]): Observable<{ classFullName: string; ids: Id64Array }> {
+  const elementIdsBatchSize = 5000;
+  return range(0, elementIds.length / elementIdsBatchSize).pipe(
+    mergeMap((batchIndex) => {
+      const idsFrom = batchIndex * elementIdsBatchSize;
+      const idsTo = Math.min(idsFrom + elementIdsBatchSize, elementIds.length);
+      let idsFilter = "";
+      for (let i = idsFrom; i < idsTo; i++) {
+        idsFilter += `${elementIds[i]}`;
+        if (i < idsTo - 1) {
+          idsFilter += ",";
+        }
+      }
+      return from(
+        imodel.createQueryReader(
+          `
+            SELECT ec_classname(e.ECClassId) className, GROUP_CONCAT(IdToHex(e.ECInstanceId)) ids
+            FROM bis.Element e
+            WHERE e.ECInstanceId IN (${idsFilter})
+            GROUP BY e.ECClassId
+          `,
+        ),
+      );
     }),
-    mergeAll(),
-    reduce<[string, string], Set<string>>((set, [schemaName, className]) => {
-      set.add(`${schemaName}.${className}`);
-      return set;
-    }, new Set()),
-    mergeMap((set) => [...set]),
+    map((row: QueryRowProxy): { className: string; ids: Id64Array } => ({ className: row.className, ids: row.ids.split(",") })),
+    groupBy(({ className }) => className),
+    mergeMap((groups) =>
+      groups.pipe(
+        reduce<ObservedValueOf<typeof groups>, { classFullName: string; ids: Id64Array }>(
+          (acc, g) => {
+            g.ids.forEach((id) => acc.ids.push(id));
+            return {
+              classFullName: g.className,
+              ids: acc.ids,
+            };
+          },
+          { classFullName: "", ids: [] },
+        ),
+      ),
+    ),
+  );
+}
+
+/** Given a list of full class names, get a stream of actual class names that have instances. */
+function getClassesWithInstances(imodel: IModelDb, fullClassNames: string[]): Observable<string> {
+  return from(fullClassNames).pipe(
+    mergeMap((fullClassName) =>
+      from(
+        imodel.createQueryReader(
+          `
+            SELECT ec_classname(e.ECClassId, 's.c') className
+            FROM ${getECSqlName(fullClassName)} e
+            GROUP BY e.ECClassId
+          `,
+        ),
+      ),
+    ),
+    map((row: QueryRowProxy): string => row.className),
+  );
+}
+
+/**
+ * Given a sorted list of ECInstanceIds and a batch size, create a stream of batches. Because the IDs won't necessarily
+ * be sequential, a batch is defined a list of from-to pairs.
+ * @internal
+ */
+export function createIdBatches(sortedIds: Id64String[], batchSize: number): Observable<Array<{ from: Id64String; to: Id64String }>> {
+  return range(0, sortedIds.length / batchSize).pipe(
+    map((batchIndex) => {
+      const sequences = new Array<{ from: Id64String; to: Id64String }>();
+      const startIndex = batchIndex * batchSize;
+      const endIndex = Math.min((batchIndex + 1) * batchSize, sortedIds.length) - 1;
+      let fromId = sortedIds[startIndex];
+      let to = {
+        id: sortedIds[startIndex],
+        localId: Id64.getLocalId(sortedIds[startIndex]),
+      };
+      for (let i = startIndex + 1; i <= endIndex; ++i) {
+        const currLocalId = Id64.getLocalId(sortedIds[i]);
+        if (currLocalId !== to.localId + 1) {
+          sequences.push({ from: fromId, to: sortedIds[i - 1] });
+          fromId = sortedIds[i];
+        }
+        to = { id: sortedIds[i], localId: currLocalId };
+      }
+      sequences.push({ from: fromId, to: sortedIds[endIndex] });
+      return sequences;
+    }),
+  );
+}
+
+/**
+ * Query all ECInstanceIds from given class and stream from-to pairs that batch the items into batches of `batchSize` size.
+ * @internal
+ */
+export function getBatchedClassElementIds(imodel: IModelDb, fullClassName: string, batchSize: number): Observable<Array<{ from: Id64String; to: Id64String }>> {
+  return from(imodel.createQueryReader(`SELECT IdToHex(ECInstanceId) id FROM ${getECSqlName(fullClassName)} ORDER BY ECInstanceId`)).pipe(
+    map((row): Id64String => row.id),
+    bufferCount(batchSize),
+    map((batch) => [{ from: batch[0], to: batch[batch.length - 1] }]),
   );
 }
 
 /** @internal */
-export async function getBatchedClassElementIds(
-  imodel: IModelDb,
-  fullClassName: string,
-  batchSize: number,
-): Promise<Array<{ from: Id64String; to: Id64String }>> {
-  const batches = [];
-  const reader = imodel.createQueryReader(`SELECT ECInstanceId id FROM ${getECSqlName(fullClassName)} ORDER BY ECInstanceId`);
-  let currId: Id64String | undefined;
-  let fromId: Id64String | undefined;
-  let count = 0;
-  while (await reader.step()) {
-    currId = reader.current.toRow().id as Id64String;
-    if (!fromId) {
-      fromId = currId;
+export function getElementsCount(db: IModelDb, classNames: string[]) {
+  const whereClause = (() => {
+    if (classNames === undefined || classNames.length === 0) {
+      return undefined;
     }
-    if (++count >= batchSize) {
-      batches.push({ from: fromId, to: currId });
-      fromId = undefined;
-      count = 0;
+    // check if list contains only valid class names
+    const classNameRegExp = new RegExp(/^[\w]+[.:][\w]+$/);
+    const invalidName = classNames.find((name) => !name.match(classNameRegExp));
+    if (invalidName) {
+      throw new PresentationError(
+        PresentationStatus.InvalidArgument,
+        `Encountered invalid class name - ${invalidName}.
+        Valid class name formats: "<schema name or alias>.<class name>", "<schema name or alias>:<class name>"`,
+      );
     }
-  }
-  if (fromId && currId) {
-    batches.push({ from: fromId, to: currId });
-  }
-  return batches;
-}
-
-function createElementsFilter(elementAlias: string, classNames?: string[]) {
-  if (classNames === undefined || classNames.length === 0) {
-    return undefined;
-  }
-
-  // check if list contains only valid class names
-  const classNameRegExp = new RegExp(/^[\w]+[.:][\w]+$/);
-  const invalidName = classNames.find((name) => !name.match(classNameRegExp));
-  if (invalidName) {
-    throw new PresentationError(
-      PresentationStatus.InvalidArgument,
-      `Encountered invalid class name - ${invalidName}.
-      Valid class name formats: "<schema name or alias>.<class name>", "<schema name or alias>:<class name>"`,
-    );
-  }
-
-  return `${elementAlias}.ECClassId IS (${classNames.join(",")})`;
+    return `e.ECClassId IS (${classNames.join(",")})`;
+  })();
+  const query = `
+    SELECT COUNT(e.ECInstanceId)
+    FROM bis.Element e
+    ${whereClause ? `WHERE ${whereClause}` : ""}
+  `;
+  return db.withPreparedStatement(query, (stmt: ECSqlStatement) => {
+    return stmt.step() === DbResult.BE_SQLITE_ROW ? stmt.getValue(0).getInteger() : 0;
+  });
 }

--- a/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
+++ b/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
@@ -189,19 +189,12 @@ function getElementClassesFromIds(imodel: IModelDb, elementIds: string[]): Obser
     mergeMap((batchIndex) => {
       const idsFrom = batchIndex * elementIdsBatchSize;
       const idsTo = Math.min(idsFrom + elementIdsBatchSize, elementIds.length);
-      let idsFilter = "";
-      for (let i = idsFrom; i < idsTo; i++) {
-        idsFilter += `${elementIds[i]}`;
-        if (i < idsTo - 1) {
-          idsFilter += ",";
-        }
-      }
       return from(
         imodel.createQueryReader(
           `
             SELECT ec_classname(e.ECClassId) className, GROUP_CONCAT(IdToHex(e.ECInstanceId)) ids
             FROM bis.Element e
-            WHERE e.ECInstanceId IN (${idsFilter})
+            WHERE e.ECInstanceId IN (${elementIds.slice(idsFrom, idsTo).join(",")})
             GROUP BY e.ECClassId
           `,
         ),

--- a/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
+++ b/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
@@ -108,37 +108,35 @@ function getBatchedClassContentItems(
   batcher: () => Observable<Array<{ from: Id64String; to: Id64String }>>,
   batchesParallelism: number,
 ): Observable<{ descriptor: Descriptor; items: Item[] }> {
-  return defer(() => {
+  return defer(async () => {
     const ruleset = createClassContentRuleset(classFullName);
     const keys = new KeySet();
-    return defer(async () => {
-      const descriptor = await contentDescriptorGetter({ rulesetOrId: ruleset, keys });
-      if (!descriptor) {
-        throw new PresentationError(PresentationStatus.Error, `Failed to get descriptor for class ${classFullName}`);
-      }
-      return descriptor;
-    }).pipe(
-      // create elements' id batches
-      mergeMap((descriptor) => batcher().pipe(map((batch) => ({ descriptor, batch })))),
-      // request content for each batch, filter by IDs for performance
-      mergeMap(
-        ({ descriptor, batch }) =>
-          defer(async () => {
-            const filteringDescriptor = new Descriptor(descriptor);
-            filteringDescriptor.instanceFilter = {
-              selectClassName: classFullName,
-              expression: createElementIdsECExpressionFilter(batch),
-            };
-            return contentSetGetter({
-              rulesetOrId: ruleset,
-              keys,
-              descriptor: filteringDescriptor,
-            });
-          }).pipe(map((items) => ({ descriptor, items }))),
-        batchesParallelism,
-      ),
-    );
-  });
+    const descriptor = await contentDescriptorGetter({ rulesetOrId: ruleset, keys });
+    if (!descriptor) {
+      throw new PresentationError(PresentationStatus.Error, `Failed to get descriptor for class ${classFullName}`);
+    }
+    return { descriptor, keys, ruleset };
+  }).pipe(
+    // create elements' id batches
+    mergeMap((x) => batcher().pipe(map((batch) => ({ ...x, batch })))),
+    // request content for each batch, filter by IDs for performance
+    mergeMap(
+      ({ descriptor, keys, ruleset, batch }) =>
+        defer(async () => {
+          const filteringDescriptor = new Descriptor(descriptor);
+          filteringDescriptor.instanceFilter = {
+            selectClassName: classFullName,
+            expression: createElementIdsECExpressionFilter(batch),
+          };
+          return contentSetGetter({
+            rulesetOrId: ruleset,
+            keys,
+            descriptor: filteringDescriptor,
+          });
+        }).pipe(map((items) => ({ descriptor, items }))),
+      batchesParallelism,
+    ),
+  );
 }
 
 function createElementIdsECExpressionFilter(batch: Array<{ from: Id64String; to: Id64String }>): string {

--- a/presentation/backend/src/test/ElementPropertiesHelper.test.ts
+++ b/presentation/backend/src/test/ElementPropertiesHelper.test.ts
@@ -3,11 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
+import { firstValueFrom, toArray } from "rxjs";
 import * as moq from "typemoq";
 import { ECSqlStatement, ECSqlValue, IModelDb } from "@itwin/core-backend";
 import { DbResult } from "@itwin/core-bentley";
 import { PresentationError } from "@itwin/presentation-common";
-import { getBatchedClassElementIds, getClassesWithInstances, getElementsCount } from "../presentation-backend/ElementPropertiesHelper";
+import { createIdBatches, getBatchedClassElementIds, getElementsCount } from "../presentation-backend/ElementPropertiesHelper";
 import { stubECSqlReader } from "./Helpers";
 
 describe("getElementsCount", () => {
@@ -24,7 +25,7 @@ describe("getElementsCount", () => {
         statementMock.setup((x) => x.step()).returns(() => DbResult.BE_SQLITE_DONE);
         return cb(statementMock.object);
       });
-    expect(getElementsCount(imodelMock.object)).to.be.eq(0);
+    expect(getElementsCount(imodelMock.object, [])).to.be.eq(0);
   });
 
   it("returns count when statement has row", () => {
@@ -39,7 +40,7 @@ describe("getElementsCount", () => {
         statementMock.setup((x) => x.getValue(0)).returns(() => valueMock.object);
         return cb(statementMock.object);
       });
-    expect(getElementsCount(imodelMock.object)).to.be.eq(elementCount);
+    expect(getElementsCount(imodelMock.object, [])).to.be.eq(elementCount);
   });
 
   it("adds WHERE clause when class list is defined and not empty", () => {
@@ -63,6 +64,58 @@ describe("getElementsCount", () => {
   });
 });
 
+describe("createIdBatches", () => {
+  it("returns empty list when given no ids", async () => {
+    expect(await firstValueFrom(createIdBatches([], 2).pipe(toArray()))).to.be.deep.eq([]);
+  });
+
+  it("creates a batch larger than element ids count, when there's one element id", async () => {
+    expect(await firstValueFrom(createIdBatches(["0x3"], 10).pipe(toArray()))).to.be.deep.eq([[{ from: "0x3", to: "0x3" }]]);
+  });
+
+  it("creates a batch larger than element ids count, when element ids are in sequence", async () => {
+    expect(await firstValueFrom(createIdBatches(["0x1", "0x2", "0x3", "0x4", "0x5"], 10).pipe(toArray()))).to.be.deep.eq([[{ from: "0x1", to: "0x5" }]]);
+  });
+
+  it("creates a batch larger than element ids count, when element ids are not in sequence", async () => {
+    expect(await firstValueFrom(createIdBatches(["0x1", "0x3", "0x5", "0x7", "0x9"], 10).pipe(toArray()))).to.be.deep.eq([
+      [
+        { from: "0x1", to: "0x1" },
+        { from: "0x3", to: "0x3" },
+        { from: "0x5", to: "0x5" },
+        { from: "0x7", to: "0x7" },
+        { from: "0x9", to: "0x9" },
+      ],
+    ]);
+  });
+
+  it("creates a batch with last sequence consisting of more than 1 element", async () => {
+    expect(await firstValueFrom(createIdBatches(["0x1", "0x2", "0x3", "0x5", "0x6"], 10).pipe(toArray()))).to.be.deep.eq([
+      [
+        { from: "0x1", to: "0x3" },
+        { from: "0x5", to: "0x6" },
+      ],
+    ]);
+  });
+
+  it("creates a batch with last sequence consisting of 1 element", async () => {
+    expect(await firstValueFrom(createIdBatches(["0x1", "0x2", "0x9"], 10).pipe(toArray()))).to.be.deep.eq([
+      [
+        { from: "0x1", to: "0x2" },
+        { from: "0x9", to: "0x9" },
+      ],
+    ]);
+  });
+
+  it("creates multiple batches", async () => {
+    expect(await firstValueFrom(createIdBatches(["0x1", "0x2", "0x3", "0x4", "0x5"], 2).pipe(toArray()))).to.be.deep.eq([
+      [{ from: "0x1", to: "0x2" }],
+      [{ from: "0x3", to: "0x4" }],
+      [{ from: "0x5", to: "0x5" }],
+    ]);
+  });
+});
+
 describe("getBatchedClassElementIds", () => {
   const imodelMock = moq.Mock.ofType<IModelDb>();
   beforeEach(() => {
@@ -71,39 +124,16 @@ describe("getBatchedClassElementIds", () => {
 
   it("returns empty list when statement has no rows", async () => {
     imodelMock.setup((x) => x.createQueryReader(moq.It.isAnyString())).returns(() => stubECSqlReader([]));
-    expect(await getBatchedClassElementIds(imodelMock.object, "x.y", 2)).to.be.deep.eq([]);
+    expect(await firstValueFrom(getBatchedClassElementIds(imodelMock.object, "x.y", 2).pipe(toArray()))).to.be.deep.eq([]);
   });
 
   it("returns batches", async () => {
     const elements = [{ id: "0x1" }, { id: "0x2" }, { id: "0x3" }, { id: "0x4" }, { id: "0x5" }];
     imodelMock.setup((x) => x.createQueryReader(moq.It.isAnyString())).returns(() => stubECSqlReader(elements));
-    expect(await getBatchedClassElementIds(imodelMock.object, "x.y", 2)).to.be.deep.eq([
-      { from: "0x1", to: "0x2" },
-      { from: "0x3", to: "0x4" },
-      { from: "0x5", to: "0x5" },
+    expect(await firstValueFrom(getBatchedClassElementIds(imodelMock.object, "x.y", 2).pipe(toArray()))).to.be.deep.eq([
+      [{ from: "0x1", to: "0x2" }],
+      [{ from: "0x3", to: "0x4" }],
+      [{ from: "0x5", to: "0x5" }],
     ]);
-  });
-});
-
-describe("getClassesWithInstances", () => {
-  const imodelMock = moq.Mock.ofType<IModelDb>();
-  beforeEach(() => {
-    imodelMock.reset();
-  });
-
-  it("returns unique class names by running a query", async () => {
-    imodelMock
-      .setup((x) => x.createQueryReader(moq.It.isAnyString()))
-      .returns(() =>
-        stubECSqlReader([
-          ["schema", "classA"],
-          ["schema", "classB"],
-          ["schema", "classA"],
-          ["schema", "classB"],
-        ]),
-      );
-    const result = new Array<string>();
-    await getClassesWithInstances(imodelMock.object, ["x"]).forEach((value) => result.push(value));
-    expect(result).to.deep.eq(["schema.classA", "schema.classB"]);
   });
 });

--- a/presentation/backend/src/test/ElementPropertiesHelper.test.ts
+++ b/presentation/backend/src/test/ElementPropertiesHelper.test.ts
@@ -69,15 +69,15 @@ describe("createIdBatches", () => {
     expect(await firstValueFrom(createIdBatches([], 2).pipe(toArray()))).to.be.deep.eq([]);
   });
 
-  it("creates a batch larger than element ids count, when there's one element id", async () => {
+  it("creates a batch from one element id", async () => {
     expect(await firstValueFrom(createIdBatches(["0x3"], 10).pipe(toArray()))).to.be.deep.eq([[{ from: "0x3", to: "0x3" }]]);
   });
 
-  it("creates a batch larger than element ids count, when element ids are in sequence", async () => {
+  it("creates a batch from sequential element ids, when `batchSize` is larger than the number of ids", async () => {
     expect(await firstValueFrom(createIdBatches(["0x1", "0x2", "0x3", "0x4", "0x5"], 10).pipe(toArray()))).to.be.deep.eq([[{ from: "0x1", to: "0x5" }]]);
   });
 
-  it("creates a batch larger than element ids count, when element ids are not in sequence", async () => {
+  it("creates a batch of non-sequential element ids, when `batchSize` is larger than the number of ids", async () => {
     expect(await firstValueFrom(createIdBatches(["0x1", "0x3", "0x5", "0x7", "0x9"], 10).pipe(toArray()))).to.be.deep.eq([
       [
         { from: "0x1", to: "0x1" },

--- a/presentation/backend/src/test/Helpers.ts
+++ b/presentation/backend/src/test/Helpers.ts
@@ -3,16 +3,45 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { ECSqlReader } from "@itwin/core-common";
+import { ECSqlReader, QueryRowProxy } from "@itwin/core-common";
 
-export function stubECSqlReader<TRow extends object>(rows: TRow[]) {
+export function stubECSqlReader<TRow extends object>(rows: TRow[]): ECSqlReader {
   let stepsCount = -1;
-  return {
-    async step() {
-      return ++stepsCount < rows.length;
+  const step = async () => {
+    return ++stepsCount < rows.length;
+  };
+  const getCurrent = (): QueryRowProxy => {
+    if (stepsCount < 0 || stepsCount >= rows.length) {
+      throw new Error("No current row");
+    }
+    return {
+      ...rows[stepsCount],
+      toRow: () => rows[stepsCount],
+    } as unknown as QueryRowProxy;
+  };
+  const next = async (): Promise<IteratorResult<QueryRowProxy, any>> => {
+    if (await step()) {
+      return {
+        done: false,
+        value: getCurrent(),
+      };
+    }
+    return {
+      done: true,
+      value: undefined,
+    };
+  };
+  const iterator: AsyncIterableIterator<QueryRowProxy> = {
+    next,
+    [Symbol.asyncIterator](): AsyncIterableIterator<QueryRowProxy> {
+      return iterator;
     },
+  };
+  return {
+    ...iterator,
+    step,
     get current() {
-      return stepsCount >= 0 && stepsCount < rows.length ? { toRow: () => rows[stepsCount] } : undefined;
+      return getCurrent();
     },
     async toArray() {
       return rows;

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { ECSqlStatement, ECSqlValue, IModelDb, IModelHost, IModelJsNative, IModelNative, IpcHost } from "@itwin/core-backend";
-import { DbResult, Id64String, using } from "@itwin/core-bentley";
+import { DbResult, Id64, Id64String, using } from "@itwin/core-bentley";
 import { SchemaContext } from "@itwin/ecschema-metadata";
 import {
   ArrayTypeDescription,
@@ -116,7 +116,7 @@ describe("PresentationManager", () => {
       try {
         IModelNative.platform;
         isLoaded = true;
-      } catch { }
+      } catch {}
       if (!isLoaded) {
         throw e; // re-throw if startup() failed to set up NativePlatform
       }
@@ -2564,25 +2564,25 @@ describe("PresentationManager", () => {
         expect(result).to.deep.eq(expectedResponse);
       });
 
-      function setupIModelForElementIds(imodel: moq.IMock<IModelDb>, ids: string[]) {
+      function setupIModelForBatchedElementIdsQuery(imodel: moq.IMock<IModelDb>, ids: Id64String[]) {
         imodel.setup((x) => x.withPreparedStatement(moq.It.isAnyString(), moq.It.isAny())).returns(() => ids.length);
         imodel
-          .setup((x) => x.createQueryReader(moq.It.is((query) => query.startsWith("SELECT ECInstanceId"))))
+          .setup((x) => x.createQueryReader(moq.It.is((query) => query.startsWith("SELECT IdToHex(ECInstanceId)"))))
           .returns(() => stubECSqlReader(ids.map((id) => ({ id }))));
       }
 
-      it("returns multiple elements properties", async () => {
+      it("returns multiple elements properties by class name", async () => {
         // what the addon receives
         imodelMock
           .setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM [TestSchema].[TestClass]`))))
-          .returns(() => stubECSqlReader([["TestSchema", "TestClass"]]));
-        setupIModelForElementIds(imodelMock, ["0x123", "0x124"]);
+          .returns(() => stubECSqlReader([{ className: "TestSchema.TestClass" }]));
+        setupIModelForBatchedElementIdsQuery(imodelMock, ["0x123", "0x124"]);
 
         const expectedContentParams = {
           requestId: NativePlatformRequestTypes.GetContentSet,
           params: {
             rulesetId: manager.getRulesetId({
-              id: `content/TestSchema.TestClass`,
+              id: `content/class-descriptor/TestSchema.TestClass`,
               rules: [
                 {
                   ruleType: "Content",
@@ -2605,7 +2605,7 @@ describe("PresentationManager", () => {
               contentFlags: ContentFlags.ShowLabels,
               instanceFilter: {
                 selectClassName: `TestSchema.TestClass`,
-                expression: `this.ECInstanceId >= ${Number.parseInt("0x123", 16).toString(10)} AND this.ECInstanceId <= ${Number.parseInt("0x124", 16).toString(10)}`,
+                expression: `this.ECInstanceId >= 0x123 AND this.ECInstanceId <= 0x124`,
               },
             },
             keys: new KeySet(),
@@ -2701,18 +2701,17 @@ describe("PresentationManager", () => {
         }
       });
 
-      it("returns localized multiple elements properties", async () => {
-        // what the addon receives
+      it("returns multiple elements properties by element id", async () => {
+        const elementIds = [Id64.fromLocalAndBriefcaseIds(123, 1), Id64.fromLocalAndBriefcaseIds(124, 1), Id64.fromLocalAndBriefcaseIds(333, 1)];
         imodelMock
-          .setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM [TestSchema].[TestClass]`))))
-          .returns(() => stubECSqlReader([["TestSchema", "TestClass"]]));
-        setupIModelForElementIds(imodelMock, ["0x123", "0x124"]);
+          .setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM bis.Element`))))
+          .returns(() => stubECSqlReader([{ className: "TestSchema.TestClass", ids: elementIds.join(",") }]));
 
         const expectedContentParams = {
           requestId: NativePlatformRequestTypes.GetContentSet,
           params: {
             rulesetId: manager.getRulesetId({
-              id: `content/TestSchema.TestClass`,
+              id: `content/class-descriptor/TestSchema.TestClass`,
               rules: [
                 {
                   ruleType: "Content",
@@ -2735,7 +2734,164 @@ describe("PresentationManager", () => {
               contentFlags: ContentFlags.ShowLabels,
               instanceFilter: {
                 selectClassName: `TestSchema.TestClass`,
-                expression: `this.ECInstanceId >= ${Number.parseInt("0x123", 16).toString(10)} AND this.ECInstanceId <= ${Number.parseInt("0x124", 16).toString(10)}`,
+                expression: `this.ECInstanceId >= ${elementIds[0]} AND this.ECInstanceId <= ${elementIds[1]} OR this.ECInstanceId = ${elementIds[2]}`,
+              },
+            },
+            keys: new KeySet(),
+          },
+        };
+
+        // what the addon returns
+        setup(
+          createTestContentDescriptor({
+            displayType: DefaultContentDisplayTypes.Grid,
+            contentFlags: ContentFlags.ShowLabels,
+            fields: [
+              createTestSimpleContentField({
+                name: "test",
+                label: "Test Field",
+                category: createTestCategoryDescription({ label: "Test Category" }),
+              }),
+            ],
+          }).toJSON(),
+        );
+        setup(
+          [
+            createTestContentItem({
+              label: "test label 1",
+              classInfo: createTestECClassInfo({ label: "Test Class" }),
+              primaryKeys: [{ className: "TestSchema:TestClass", id: elementIds[0] }],
+              values: {
+                test: "test value 1",
+              },
+              displayValues: {
+                test: "test display value 1",
+              },
+            }),
+            createTestContentItem({
+              label: "test label 2",
+              classInfo: createTestECClassInfo({ label: "Test Class" }),
+              primaryKeys: [{ className: "TestSchema:TestClass", id: elementIds[1] }],
+              values: {
+                test: "test value 2",
+              },
+              displayValues: {
+                test: "test display value 2",
+              },
+            }),
+            createTestContentItem({
+              label: "test label 3",
+              classInfo: createTestECClassInfo({ label: "Test Class" }),
+              primaryKeys: [{ className: "TestSchema:TestClass", id: elementIds[2] }],
+              values: {
+                test: "test value 3",
+              },
+              displayValues: {
+                test: "test display value 3",
+              },
+            }),
+          ].map((item) => item.toJSON()),
+        );
+
+        // test
+        const options: MultiElementPropertiesRequestOptions<IModelDb> = {
+          imodel: imodelMock.object,
+          elementIds,
+        };
+        const expectedResponse = [
+          {
+            class: "Test Class",
+            id: elementIds[0],
+            label: "test label 1",
+            items: {
+              ["Test Category"]: {
+                type: "category",
+                items: {
+                  ["Test Field"]: {
+                    type: "primitive",
+                    value: "test display value 1",
+                  },
+                },
+              },
+            },
+          },
+          {
+            class: "Test Class",
+            id: elementIds[1],
+            label: "test label 2",
+            items: {
+              ["Test Category"]: {
+                type: "category",
+                items: {
+                  ["Test Field"]: {
+                    type: "primitive",
+                    value: "test display value 2",
+                  },
+                },
+              },
+            },
+          },
+          {
+            class: "Test Class",
+            id: elementIds[2],
+            label: "test label 3",
+            items: {
+              ["Test Category"]: {
+                type: "category",
+                items: {
+                  ["Test Field"]: {
+                    type: "primitive",
+                    value: "test display value 3",
+                  },
+                },
+              },
+            },
+          },
+        ];
+        const { total, iterator } = await manager.getElementProperties(options);
+
+        expect(total).to.be.eq(3);
+        for await (const items of iterator()) {
+          verifyMockRequest(expectedContentParams);
+          expect(items).to.deep.eq(expectedResponse);
+        }
+      });
+
+      it("returns localized multiple elements properties", async () => {
+        // what the addon receives
+        imodelMock
+          .setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM [TestSchema].[TestClass]`))))
+          .returns(() => stubECSqlReader([{ className: "TestSchema.TestClass" }]));
+        setupIModelForBatchedElementIdsQuery(imodelMock, ["0x123", "0x124"]);
+
+        const expectedContentParams = {
+          requestId: NativePlatformRequestTypes.GetContentSet,
+          params: {
+            rulesetId: manager.getRulesetId({
+              id: `content/class-descriptor/TestSchema.TestClass`,
+              rules: [
+                {
+                  ruleType: "Content",
+                  specifications: [
+                    {
+                      specType: "ContentInstancesOfSpecificClasses",
+                      classes: {
+                        schemaName: "TestSchema",
+                        classNames: ["TestClass"],
+                        arePolymorphic: false,
+                      },
+                      handlePropertiesPolymorphically: true,
+                    },
+                  ],
+                },
+              ],
+            }),
+            descriptorOverrides: {
+              displayType: DefaultContentDisplayTypes.Grid,
+              contentFlags: ContentFlags.ShowLabels,
+              instanceFilter: {
+                selectClassName: `TestSchema.TestClass`,
+                expression: `this.ECInstanceId >= 0x123 AND this.ECInstanceId <= 0x124`,
               },
             },
             keys: new KeySet(),
@@ -2835,14 +2991,14 @@ describe("PresentationManager", () => {
         // what the addon receives
         imodelMock
           .setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM [TestSchema].[TestClass]`))))
-          .returns(() => stubECSqlReader([["TestSchema", "TestClass"]]));
-        setupIModelForElementIds(imodelMock, ["0x123", "0x124"]);
+          .returns(() => stubECSqlReader([{ className: "TestSchema.TestClass" }]));
+        setupIModelForBatchedElementIdsQuery(imodelMock, ["0x123", "0x124"]);
 
         const expectedContentParams = {
           requestId: NativePlatformRequestTypes.GetContentSet,
           params: {
             rulesetId: manager.getRulesetId({
-              id: `content/TestSchema.TestClass`,
+              id: `content/class-descriptor/TestSchema.TestClass`,
               rules: [
                 {
                   ruleType: "Content",
@@ -2865,7 +3021,7 @@ describe("PresentationManager", () => {
               contentFlags: ContentFlags.ShowLabels,
               instanceFilter: {
                 selectClassName: `TestSchema.TestClass`,
-                expression: `this.ECInstanceId >= ${Number.parseInt("0x123", 16).toString(10)} AND this.ECInstanceId <= ${Number.parseInt("0x124", 16).toString(10)}`,
+                expression: `this.ECInstanceId >= 0x123 AND this.ECInstanceId <= 0x124`,
               },
             },
             keys: new KeySet(),
@@ -2919,6 +3075,24 @@ describe("PresentationManager", () => {
           verifyMockRequest(expectedContentParams);
           expect(items).to.deep.eq(expectedResponse);
         }
+      });
+
+      it("throws when descriptor is undefined", async () => {
+        const elementIds = [Id64.fromLocalAndBriefcaseIds(123, 1)];
+        imodelMock
+          .setup((x) => x.createQueryReader(moq.It.is((query) => query.includes(`FROM bis.Element`))))
+          .returns(() => stubECSqlReader([{ className: "TestSchema.TestClass", ids: elementIds.join(",") }]));
+
+        // what the addon returns
+        setup(undefined);
+
+        // test
+        const options: MultiElementPropertiesRequestOptions<IModelDb> = {
+          imodel: imodelMock.object,
+          elementIds,
+        };
+        const { iterator } = await manager.getElementProperties(options);
+        await expect(iterator().next()).to.eventually.be.rejectedWith(PresentationError);
       });
     });
 

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -208,10 +208,10 @@ export interface SingleElementPropertiesRequestOptions<TIModel, TParsedContent =
 }
 
 /**
- * Request type for multiple elements properties requests.
+ * Base request type for multiple elements properties requests.
  * @public
  */
-export type MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> = RequestOptions<TIModel> & {
+export interface MultiElementPropertiesBaseRequestOptions<TIModel, TParsedContent = ElementProperties> extends RequestOptions<TIModel> {
   /**
    * Content parser that creates a result item based on given content descriptor and content item. Defaults
    * to a parser that creates [[ElementProperties]] objects.
@@ -224,22 +224,38 @@ export type MultiElementPropertiesRequestOptions<TIModel, TParsedContent = Eleme
    * Defaults to `1000`.
    */
   batchSize?: number;
-} & (
-    | {
-        /**
-         * Classes of the elements to get properties for. If [[elementClasses]] is `undefined`, all classes
-         * are used. Classes should be specified in one of these formats: "<schema name or alias>.<class_name>" or
-         * "<schema name or alias>:<class_name>".
-         */
-        elementClasses?: string[];
-      }
-    | {
-        /**
-         * A list of `bis.Element` IDs to get properties for.
-         */
-        elementIds?: Id64String[];
-      }
-  );
+}
+/**
+ * Request type for multiple elements properties requests, where elements are specified by class.
+ * @public
+ */
+export interface MultiElementPropertiesByClassRequestOptions<TIModel, TParsedContent = ElementProperties>
+  extends MultiElementPropertiesBaseRequestOptions<TIModel, TParsedContent> {
+  /**
+   * Classes of the elements to get properties for. If [[elementClasses]] is `undefined`, all classes
+   * are used. Classes should be specified in one of these formats: "<schema name or alias>.<class_name>" or
+   * "<schema name or alias>:<class_name>".
+   */
+  elementClasses?: string[];
+}
+/**
+ * Request type for multiple elements properties requests, where elements are specified by element id.
+ * @public
+ */
+export interface MultiElementPropertiesByIdsRequestOptions<TIModel, TParsedContent = ElementProperties>
+  extends MultiElementPropertiesBaseRequestOptions<TIModel, TParsedContent> {
+  /**
+   * A list of `bis.Element` IDs to get properties for.
+   */
+  elementIds?: Id64String[];
+}
+/**
+ * Request type for multiple elements properties requests.
+ * @public
+ */
+export type MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> =
+  | MultiElementPropertiesByClassRequestOptions<TIModel, TParsedContent>
+  | MultiElementPropertiesByIdsRequestOptions<TIModel, TParsedContent>;
 
 /**
  * Request type for content instance keys' requests.

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -211,14 +211,7 @@ export interface SingleElementPropertiesRequestOptions<TIModel, TParsedContent =
  * Request type for multiple elements properties requests.
  * @public
  */
-export interface MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> extends RequestOptions<TIModel> {
-  /**
-   * Classes of the elements to get properties for. If [[elementClasses]] is `undefined`, all classes
-   * are used. Classes should be specified in one of these formats: "<schema name or alias>.<class_name>" or
-   * "<schema name or alias>:<class_name>".
-   */
-  elementClasses?: string[];
-
+export type MultiElementPropertiesRequestOptions<TIModel, TParsedContent = ElementProperties> = RequestOptions<TIModel> & {
   /**
    * Content parser that creates a result item based on given content descriptor and content item. Defaults
    * to a parser that creates [[ElementProperties]] objects.
@@ -231,7 +224,22 @@ export interface MultiElementPropertiesRequestOptions<TIModel, TParsedContent = 
    * Defaults to `1000`.
    */
   batchSize?: number;
-}
+} & (
+    | {
+        /**
+         * Classes of the elements to get properties for. If [[elementClasses]] is `undefined`, all classes
+         * are used. Classes should be specified in one of these formats: "<schema name or alias>.<class_name>" or
+         * "<schema name or alias>:<class_name>".
+         */
+        elementClasses?: string[];
+      }
+    | {
+        /**
+         * A list of `bis.Element` IDs to get properties for.
+         */
+        elementIds?: Id64String[];
+      }
+  );
 
 /**
  * Request type for content instance keys' requests.


### PR DESCRIPTION
Closes https://github.com/iTwin/itwinjs-core/issues/7403.

Performance numbers on a specific test iModel with 688452 geometric elements (ran each test 3 times on my local box):

```
## Original implementation

Loaded 688452 elements properties in 94.01 s
Loaded 688452 elements properties in 99.85 s
Loaded 688452 elements properties in 93.98 s

## Modified implementation, by class

Loaded 688452 elements properties in 81.74 s
Loaded 688452 elements properties in 84.52 s
Loaded 688452 elements properties in 85.40 s

## Modified implementation, by element ids

Loaded 688452 elements properties in 79.83 s
Loaded 688452 elements properties in 70.09 s
Loaded 688452 elements properties in 73.82 s
```