### PR TITLE
New workflow for creating release branches

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -9,13 +9,6 @@ on:
       releaseBranch:
         description: 'The name of the release branch to create'
         required: true
-        default: 'TEST/0.0.x' # FIXME temp default while testing. Otherwise it will create protected branches
-  pull_request:
-    types: [opened, synchronize]
-
-# FIXME FOR TESTING PURPOSES ONLY
-env:
-  RELEASE_BRANCH: 'TEST/0.0.x'
 
 jobs:
   create-release-branch:
@@ -40,7 +33,7 @@ jobs:
 
       - name: Create Release Branch
         run: |
-          git checkout -b ${{ env.RELEASE_BRANCH }}
+          git checkout -b ${{ inputs.releaseBranch }}
         shell: bash {0}
 
       - name: Update 'gather-docs.yaml'
@@ -116,6 +109,6 @@ jobs:
           git add .
           newVersion=$(node -pe "require('./common/config/rush/version-policies.json')[0].version.trim()") && echo $newVersion
           # FIXME temp commit message while testing. Otherwise I might trigger a new build
-          git commit -m "TEST COMMIT" --author="imodeljs-admin <imodeljs-admin@users.noreply.github.com>"
-          git push origin ${{ env.RELEASE_BRANCH }}
+          git commit -m "$newVersion" --author="imodeljs-admin <imodeljs-admin@users.noreply.github.com>"
+          git push origin ${{ inputs.releaseBranch }}
         shell: bash {0}


### PR DESCRIPTION
New workflow only for creating release branches off of already existing release branches. This is intended only to use when master is on a different minor branch then the one we are currently using. This will be needed for new 4.x minors while 5.0 is currently in development.

Related issue: https://github.com/iTwin/itwinjs-backlog/issues/1316

The purpose of a new workflow is to avoid changing the logic of the currently existing bump version pipeline. I believe re working the current scripts (here and in native) would be more difficult and would risk breaking what already works.

I will admit there are already a few parts of the current scripts I don't like, so maybe it would be worth while to rework in the future (I have an issue already created for it). So if anyone does work on that script, it might be better to address everything in one large change instead of multiple (most likely still large) changes.