### PR TITLE
Ignore 'file already exists' errors when recursively making directories

### DIFF
--- a/common/changes/@itwin/core-backend/simi-mkdir-race_2024-12-05-22-02.json
+++ b/common/changes/@itwin/core-backend/simi-mkdir-race_2024-12-05-22-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Resolve race condition when recursively creating folders.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelJsFs.ts
+++ b/core/backend/src/IModelJsFs.ts
@@ -143,7 +143,14 @@ export class IModelJsFs {
     const parentPath = path.dirname(dirPath);
     if (parentPath !== dirPath)
       IModelJsFs.recursiveMkDirSync(parentPath);
-    IModelJsFs.mkdirSync(dirPath);
+    try {
+      IModelJsFs.mkdirSync(dirPath);
+    } catch (error) {
+      // Ignore the error if the folder has been created since the existence check
+      if (error.code !== 'EEXIST') {
+      throw error;
+      }
+    }
   }
 
   /** Remove a directory, recursively */

--- a/core/backend/src/IModelJsFs.ts
+++ b/core/backend/src/IModelJsFs.ts
@@ -147,9 +147,8 @@ export class IModelJsFs {
       IModelJsFs.mkdirSync(dirPath);
     } catch (err: any) {
       // Ignore the error if the folder has been created since the existence check
-      if (err?.code !== 'EEXIST') {
-      throw err;
-      }
+      if (err?.code !== "EEXIST")
+        throw err;
     }
   }
 

--- a/core/backend/src/IModelJsFs.ts
+++ b/core/backend/src/IModelJsFs.ts
@@ -145,10 +145,10 @@ export class IModelJsFs {
       IModelJsFs.recursiveMkDirSync(parentPath);
     try {
       IModelJsFs.mkdirSync(dirPath);
-    } catch (error) {
+    } catch (err: any) {
       // Ignore the error if the folder has been created since the existence check
-      if (error.code !== 'EEXIST') {
-      throw error;
+      if (err?.code !== 'EEXIST') {
+      throw err;
       }
     }
   }


### PR DESCRIPTION
Addresses issue: Race condition in iModelHost.startup #7452 

Ignore when a folder was already created between the existence check and the attempt to create it.
This would typically only happen if the folder was created out-of-process or in a multi-threaded environment.