### PR TITLE
fix core-frontend tests using fetch stub on node 22

### DIFF
--- a/common/changes/@itwin/core-frontend/frontend-fetch-stubs_2024-12-09-15-57.json
+++ b/common/changes/@itwin/core-frontend/frontend-fetch-stubs_2024-12-09-15-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/test/tile/map/ArcGISImageryProvider.test.ts
+++ b/core/frontend/src/test/tile/map/ArcGISImageryProvider.test.ts
@@ -33,13 +33,7 @@ describe("ArcGISImageryProvider", () => {
 
     const provider = new TestArcGISProvider(settings, true);
 
-    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async function (_input: NodeJS.fetch.RequestInfo, _init?: RequestInit) {
-      return Promise.resolve({
-        status: 200,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({}),
-      } as Response);
-    });
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());;
 
     const testUrl = `${settings.url}?testParam=test`;
     await provider.fetch(new URL(testUrl), { method: "GET" });

--- a/core/frontend/src/test/tile/map/ArcGISMapLayerImageryProvider.test.ts
+++ b/core/frontend/src/test/tile/map/ArcGISMapLayerImageryProvider.test.ts
@@ -199,13 +199,7 @@ describe("ArcGISMapLayerImageryProvider", () => {
     await provider.initialize();
     const resolveChildren = (_childIds: QuadId[]) => {};
 
-    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async function (_input: NodeJS.fetch.RequestInfo, _init?: RequestInit) {
-      return Promise.resolve({
-        status: 200,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => {},
-      } as unknown as Response);
-    });
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
 
     await (provider as any)._generateChildIds(QuadId.createFromContentId("1_0_0"), resolveChildren);
     expect(fetchStub).toHaveBeenCalledOnce();

--- a/core/frontend/src/test/tile/map/ArcGisUtilities.test.ts
+++ b/core/frontend/src/test/tile/map/ArcGisUtilities.test.ts
@@ -111,12 +111,7 @@ describe("ArcGisUtilities", () => {
 
   it("should validate by invoking getServiceJson with proper parameters ", async () => {
     const source = getSampleSourceWithQueryParamsAndCreds();
-    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async function (_input: NodeJS.fetch.RequestInfo, _init?: RequestInit) {
-      return Promise.resolve({
-        status: 200,
-        json: async () => {return {};},
-      } as unknown as Response);
-    });
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
     await ArcGisUtilities.getServiceJson({ url: source.url, formatId: source.formatId, userName: source.userName, password: source.password, queryParams: source.collectQueryParams() });
 
     expect(fetchStub).toHaveBeenCalledOnce();


### PR DESCRIPTION
should resolve the following for those on node 22.12.0

```
==[ FAILURE: 1 operation ]=====================================================

--[ FAILURE: @itwin/core-frontend ]--------------------------[ 9.48 seconds ]--

src/test/tile/map/ArcGISImageryProvider.test.ts(36,103): error TS2694: Namespace 'NodeJS' has no exported member 'fetch'.
src/test/tile/map/ArcGISMapLayerImageryProvider.test.ts(202,103): error TS2694: Namespace 'NodeJS' has no exported member 'fetch'.
src/test/tile/map/ArcGisUtilities.test.ts(114,103): error TS2694: Namespace 'NodeJS' has no exported member 'fetch'.
Returned error code: 2


Operations failed.
```