### PR TITLE
Docs: workaround for typedoc issue #2802

### DIFF
--- a/common/changes/@itwin/build-tools/docs-residual-typedoc0.26-issues_2024-12-09-20-45.json
+++ b/common/changes/@itwin/build-tools/docs-residual-typedoc0.26-issues_2024-12-09-20-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "add temporary fix for typedoc@0.26 issue #2802",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -45,8 +45,6 @@ parameters:
     type: boolean
     default: false
 
-
-
 jobs:
   - job: DocsBuild
     displayName: Docs Build
@@ -117,7 +115,7 @@ jobs:
           useCurrentConnectorFrameworkDocsArtifact: ${{ parameters.useCurrentConnectorFrameworkDocsArtifact }}
 
       # Currently BeMetalsmith is an internal only tool
-      - script: npm install @bentley/bemetalsmith@5.4.x
+      - script: npm install @bentley/bemetalsmith@5.5.x
         displayName: Install BeMetalsmith
         workingDirectory: ${{ parameters.workingDir }}
 

--- a/tools/build/scripts/docs.js
+++ b/tools/build/scripts/docs.js
@@ -52,7 +52,9 @@ const readmeOption = (argv.readme === undefined) ? "none" : argv.readme;
 const options = [
   "--hideGenerator",
   "--logLevel",
-  "Error"
+  "Error",
+  "--cascadedModifierTags", // workaround for https://github.com/TypeStrong/typedoc/issues/2802
+  "@experimental"
 ];
 
 const pluginOptions = [


### PR DESCRIPTION
TypeDoc 0.26 introduced a [defect](https://github.com/TypeStrong/typedoc/issues/2802) which caused modifier tags (`@alpha`, `@beta`, etc...) to be absent in certain type reflections - causing various issues with linking. While the bug has been identified and fixed, we need to update our docs build system to ESM (in progress) to consume the new version of TypeDoc. In the meantime, a workaround for the issue is to override the default `cascadedModifierTags`.