### PR TITLE
ElementSetTool still needs to support option to clear an unsupported selection when it's models and/or sub-categories.

### DIFF
--- a/common/changes/@itwin/core-frontend/element-set-tool-preferred-source_2024-12-12-13-53.json
+++ b/common/changes/@itwin/core-frontend/element-set-tool-preferred-source_2024-12-12-13-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ElementSetTool.ts
+++ b/core/frontend/src/tools/ElementSetTool.ts
@@ -412,13 +412,19 @@ export abstract class ElementSetTool extends PrimitiveTool {
   */
   protected setPreferredElementSource(): void {
     this._useSelectionSet = false;
-    if (this.iModel.selectionSet.elements.size === 0) {
-      if (this.iModel.selectionSet.isActive) {
-        IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, CoreTools.translate("ElementSet.Error.ActiveSSWithoutElems")));
-      }
+    if (!this.iModel.selectionSet.isActive)
       return;
-    }
-    if (this.allowSelectionSet && this.iModel.selectionSet.elements.size >= this.requiredElementCount)
+
+    const isSelectionSetValid = (): boolean => {
+      if (0 === this.iModel.selectionSet.elements.size) {
+        IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, CoreTools.translate("ElementSet.Error.ActiveSSWithoutElems")));
+        return false;
+      }
+
+      return (this.iModel.selectionSet.elements.size >= this.requiredElementCount);
+    };
+
+    if (this.allowSelectionSet && isSelectionSetValid())
       this._useSelectionSet = true;
     else if (this.clearSelectionSet)
       this.iModel.selectionSet.emptyAll();


### PR DESCRIPTION
Missed the early return here when reviewing #7478.