### PR TITLE
Reenable iOS backend unit tests for CI jobs

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -102,11 +102,10 @@ steps:
       IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
     condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
-  # The Node 22 update is causing some tests to fail, so disable until they can be fixed.
-  # - script: npm run ios:all
-  #   workingDirectory: core/backend
-  #   displayName: Build & run iOS backend unit tests in Simulator
-  #   condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
+  - script: npm run ios:all
+    workingDirectory: core/backend
+    displayName: Build & run iOS backend unit tests in Simulator
+    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: node common/scripts/install-run-rush.js lint
     displayName: rush lint


### PR DESCRIPTION
The problems that caused them to fail have been fixed in the native add-on.