### PR TITLE
Fix iOS backend unit test crash

### DIFF
--- a/common/changes/@itwin/core-backend/travis-ios-tests-crash-fix_2024-12-18-20-41.json
+++ b/common/changes/@itwin/core-backend/travis-ios-tests-crash-fix_2024-12-18-20-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -102,11 +102,10 @@ steps:
       IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
     condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
-# Tests seem broken on ci, contacted Travis.Cobby to investigate
-#  - script: npm run ios:all
-#    workingDirectory: core/backend
-#    displayName: Build & run iOS backend unit tests in Simulator
-#    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
+  - script: npm run ios:all
+    workingDirectory: core/backend
+    displayName: Build & run iOS backend unit tests in Simulator
+    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: node common/scripts/install-run-rush.js lint
     displayName: rush lint

--- a/core/backend/scripts/runUnitTestsIosSimulator.mjs
+++ b/core/backend/scripts/runUnitTestsIosSimulator.mjs
@@ -30,11 +30,21 @@ class SimctlWithOpts extends Simctl {
    * @returns {Promise<string>}
    */
   async launchAppWithOptions(bundleId, options, args) {
-    const { stdout } = await this.exec('launch', {
+    const { stdout, stderr } = await this.exec('launch', {
       args: [...options, this.requireUdid('launch'), bundleId, ...args],
       architectures: "arm64",
     });
-    return stdout.trim();
+    const trimmedOut = stdout.trim();
+    const trimmedErr = stderr.trim();
+    if (trimmedOut && trimmedErr) {
+      return `=========stdout=========\n${stdout.trim()}\n=========stderr=========\n${stderr.trim()}`;
+    } else if (trimmedOut) {
+      return `=========stdout=========\n${stdout.trim()}`;
+    } else if (trimmedErr) {
+      return `=========stderr=========\n${stderr.trim()}`;
+    } else {
+      return "";
+    }
   }
 
   /**

--- a/tools/internal/ios/ios.webpack.config.js
+++ b/tools/internal/ios/ios.webpack.config.js
@@ -6,11 +6,15 @@
 const path = require("path");
 const { globSync } = require("glob");
 
+// const ignoredTests = [
+//   "**/node_modules/ECSqlTestRunner.test.ts",
+// ];
+
 module.exports = {
   mode: "development",
   entry: [
     path.resolve(__dirname, "scripts/configureMocha.js"),
-    ...globSync(path.resolve(__dirname, path.relative(__dirname, process.env.TESTS_GLOB))),
+    ...globSync(path.resolve(__dirname, path.relative(__dirname, process.env.TESTS_GLOB))/*, { ignore: ignoredTests }*/),
     path.resolve(__dirname, "scripts/runMocha.js")
   ],
   output: {
@@ -38,16 +42,19 @@ module.exports = {
         enforce: "pre"
       },
       {
-        test: /growl\.js$/,
-        use: 'null-loader'
-      },
-      {
-        test: /xunit\.js$/,
-        use: 'null-loader'
-      },
-      {
-        test: /bunyan/,
-        use: 'null-loader'
+        test: [
+          // The ECSqlTestParser uses marked, which includes hard-coded regular expressions that
+          // are not compatible with the mobile version of Node that lacks internationalization
+          // support. The mere presence of these regular expressions in the source code causes the
+          // JS parsing to crash. ECSqlTestRunner.test relies on ECSqlTestParser, so it must also
+          // be disabled.
+          /ECSqlTestParser.js$/,
+          /ECSqlTestRunner.test.js$/,
+          /growl\.js$/,
+          /xunit\.js$/,
+          /bunyan/,
+        ],
+        use: 'null-loader'  
       }
     ]
   },


### PR DESCRIPTION
1. Do not include ECSqlTestParser.js or ECSqlTestRunner.test.js in unit tests webpack for iOS. The former includes marked, which has at least one hard-coded regex that crashes the mobile Node due to the lack of ICU support. The latter depends on the former.
2. Update iOS simulator test runner script to show stderr output if present.
3. Reenabled iOS simulator backend unit tests in CI job.
