### PR TITLE
Remove nativeDb and IModelHost.platform

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3177,6 +3177,7 @@ export abstract class IModelDb extends IModel {
     getGeometryContainment(props: GeometryContainmentRequestProps): Promise<GeometryContainmentResponseProps>;
     getIModelCoordinatesFromGeoCoordinates(props: IModelCoordinatesRequestProps): Promise<IModelCoordinatesResponseProps>;
     getJsClass<T extends typeof Entity>(classFullName: string): T;
+    getLastError(): string;
     getMassProperties(props: MassPropertiesRequestProps): Promise<MassPropertiesResponseProps>;
     getMetaData(classFullName: string): EntityMetaData;
     getSchemaProps(name: string): ECSchemaProps;

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -5418,6 +5418,7 @@ export class SQLiteDb {
     // @deprecated
     dispose(): void;
     executeSQL(sql: string): DbResult;
+    getLastInsertRowId(): number;
     get isOpen(): boolean;
     get isReadonly(): boolean;
     openDb(dbName: string, openMode: OpenMode | SQLiteDb.OpenParams): void;

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -1776,8 +1776,6 @@ export class ECDb implements IDisposable {
     getSchemaProps(name: string): ECSchemaProps;
     importSchema(pathName: string): void;
     get isOpen(): boolean;
-    // @internal @deprecated (undocumented)
-    get nativeDb(): IModelJsNative.ECDb;
     openDb(pathName: string, openMode?: ECDbOpenMode): void;
     // @internal
     prepareSqliteStatement(sql: string, logErrors?: boolean): SqliteStatement;
@@ -3197,8 +3195,6 @@ export abstract class IModelDb extends IModel {
     static readonly maxLimit = 10000;
     // (undocumented)
     readonly models: IModelDb.Models;
-    // @internal @deprecated (undocumented)
-    get nativeDb(): IModelJsNative.DgnDb;
     // @internal (undocumented)
     notifyChangesetApplied(): void;
     readonly onBeforeClose: BeEvent<() => void>;
@@ -5422,8 +5418,6 @@ export class SQLiteDb {
     executeSQL(sql: string): DbResult;
     get isOpen(): boolean;
     get isReadonly(): boolean;
-    // @internal @deprecated (undocumented)
-    get nativeDb(): IModelJsNative.SQLiteDb;
     openDb(dbName: string, openMode: OpenMode | SQLiteDb.OpenParams): void;
     // @beta (undocumented)
     openDb(dbName: string, openMode: OpenMode | SQLiteDb.OpenParams, container?: CloudSqlite.CloudContainer): void;

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3455,8 +3455,6 @@ export class IModelHost {
     static readonly onAfterStartup: BeEvent<() => void>;
     static readonly onBeforeShutdown: BeEvent<() => void>;
     static readonly onWorkspaceStartup: BeEvent<() => void>;
-    // @internal @deprecated
-    static get platform(): typeof IModelJsNative;
     // @beta
     static get profileDir(): LocalDirName;
     // @beta

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -5892,6 +5892,7 @@ export class TxnManager {
     beginMultiTxnOperation(): DbResult;
     cancelTo(txnId: TxnIdString): IModelStatus;
     endMultiTxnOperation(): DbResult;
+    getChangeTrackingMemoryUsed(): number;
     getCurrentTxnId(): TxnIdString;
     getMultiTxnOperationDepth(): number;
     getRedoString(): string;

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -5402,6 +5402,8 @@ export class SQLiteDb {
     readonly [_nativeDb]: IModelJsNative.SQLiteDb;
     abandonChanges(): void;
     closeDb(saveChanges?: boolean): void;
+    // @beta
+    get cloudContainer(): CloudSqlite.CloudContainer | undefined;
     // @internal (undocumented)
     static createBlobIO(): SQLiteDb.BlobIO;
     createDb(dbName: string): void;

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -2509,6 +2509,13 @@ export interface ExportPartLinesInfo {
 }
 
 // @beta
+export interface ExportSchemaArgs {
+    outputDirectory: LocalFileName;
+    outputFileName?: string;
+    schemaName: string;
+}
+
+// @beta
 export class ExternalSource extends InformationReferenceElement {
     protected constructor(props: ExternalSourceProps, iModel: IModelDb);
     // @internal (undocumented)
@@ -3150,6 +3157,10 @@ export abstract class IModelDb extends IModel {
     readonly elements: IModelDb.Elements;
     exportGraphics(exportProps: ExportGraphicsOptions): DbResult;
     exportPartGraphics(exportProps: ExportPartGraphicsOptions): DbResult;
+    // @beta
+    exportSchema(args: ExportSchemaArgs): void;
+    // @beta
+    exportSchemas(outputDirectory: LocalFileName): void;
     static findByFilename(fileName: LocalFileName): IModelDb | undefined;
     static findByKey(key: string): IModelDb;
     // @deprecated (undocumented)

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3289,7 +3289,7 @@ export namespace IModelDb {
         getRootSubject(): Subject;
         hasSubModel(elementId: Id64String): boolean;
         insertAspect(aspectProps: ElementAspectProps): Id64String;
-        insertElement(elProps: ElementProps): Id64String;
+        insertElement(elProps: ElementProps, options?: InsertElementOptions): Id64String;
         // @internal
         _queryAspects(elementId: Id64String, fromClassFullName: string, excludedClassFullNames?: Set<string>): ElementAspect[];
         queryChildren(elementId: Id64String): Id64String[];
@@ -3674,6 +3674,12 @@ export abstract class InformationReferenceElement extends InformationContentElem
 
 // @internal (undocumented)
 export function initializeTracing(enableOpenTelemetry?: boolean): void;
+
+// @public
+export interface InsertElementOptions {
+    // @beta
+    forceUseId?: boolean;
+}
 
 // @beta
 export interface InstanceChange {

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -5609,6 +5609,8 @@ export enum SqliteValueType {
 // @public
 export class StandaloneDb extends BriefcaseDb {
     // @beta
+    static convertToStandalone(iModelFileName: LocalFileName): void;
+    // @beta
     createClassViews(): void;
     static createEmpty(filePath: LocalFileName, args: CreateEmptyStandaloneIModelProps): StandaloneDb;
     // (undocumented)

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3187,6 +3187,8 @@ export abstract class IModelDb extends IModel {
     importSchemaStrings(serializedXmlSchemas: string[]): Promise<void>;
     // @internal (undocumented)
     protected initializeIModelDb(): void;
+    // @beta
+    inlineGeometryParts(): InlineGeometryPartsResult;
     get isBriefcase(): boolean;
     isBriefcaseDb(): this is BriefcaseDb;
     // @internal
@@ -3254,6 +3256,8 @@ export abstract class IModelDb extends IModel {
     saveFileProperty(prop: FilePropertyProps, strValue: string | undefined, blobVal?: Uint8Array): void;
     // @beta
     saveSettingDictionary(name: string, dict: SettingsContainer): void;
+    // @beta
+    simplifyElementGeometry(args: SimplifyElementGeometryArgs): IModelStatus;
     // (undocumented)
     readonly tiles: IModelDb.Tiles;
     static tryFindByKey(key: string): IModelDb | undefined;
@@ -3685,6 +3689,13 @@ export abstract class InformationReferenceElement extends InformationContentElem
 
 // @internal (undocumented)
 export function initializeTracing(enableOpenTelemetry?: boolean): void;
+
+// @beta
+export interface InlineGeometryPartsResult {
+    numCandidateParts: number;
+    numPartsDeleted: number;
+    numRefsInlined: number;
+}
 
 // @public
 export interface InsertElementOptions {
@@ -5226,6 +5237,12 @@ export class SheetTemplate extends Document_2 {
 export class SheetViewDefinition extends ViewDefinition2d {
     // (undocumented)
     static get className(): string;
+}
+
+// @beta
+export interface SimplifyElementGeometryArgs {
+    convertBReps?: boolean;
+    id: Id64String;
 }
 
 // @public

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -168,6 +168,7 @@ public;interface;ExportPartInfo
 public;interface;ExportPartInstanceInfo
 public;type;ExportPartLinesFunction
 public;interface;ExportPartLinesInfo
+beta;interface;ExportSchemaArgs
 beta;class;ExternalSource
 public;class;ExternalSourceAspect
 public;namespace;ExternalSourceAspect

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -257,6 +257,7 @@ public;class;InformationRecordModel
 public;class;InformationRecordPartition
 public;class;InformationReferenceElement
 internal;function;initializeTracing
+public;interface;InsertElementOptions
 beta;interface;InstanceChange
 public;class;IpcHandler
 public;class;IpcHost

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -258,6 +258,7 @@ public;class;InformationRecordModel
 public;class;InformationRecordPartition
 public;class;InformationReferenceElement
 internal;function;initializeTracing
+beta;interface;InlineGeometryPartsResult
 public;interface;InsertElementOptions
 beta;interface;InstanceChange
 public;class;IpcHandler
@@ -393,6 +394,7 @@ beta;interface;SheetReferenceCreateArgs
 beta;class;SheetReferenceRefersToSheet
 public;class;SheetTemplate
 public;class;SheetViewDefinition
+beta;interface;SimplifyElementGeometryArgs
 public;class;SnapshotDb
 public;type;SnapshotDbOpenArgs
 public;class;SpatialCategory

--- a/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-23-16-54.json
+++ b/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-23-16-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Remove deprecated, @internal `nativeDb` fields.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-23-21-26.json
+++ b/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-23-21-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add StandaloneDb.convertToStandalone.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-23-21-43.json
+++ b/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-23-21-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add InsertElementOptions.forceUseId.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-14-54.json
+++ b/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-14-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add IModelDb methods for exporting ECSchemas.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-15-28.json
+++ b/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-15-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add simplifyElementGeometry and inlineGeometryParts to IModelDb.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-15-36.json
+++ b/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-15-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add IModelDb.getLastError.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-15-48.json
+++ b/common/changes/@itwin/core-backend/pmc-native-db-internal-only_2024-12-24-15-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add TxnManager.getChangeTrackingMemoryUsed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
   ../../core/backend:
     dependencies:
       '@bentley/imodeljs-native':
-        specifier: 5.0.23
-        version: 5.0.23
+        specifier: 5.0.24
+        version: 5.0.24
       '@itwin/cloud-agnostic-core':
         specifier: ^2.2.4
         version: 2.2.4(inversify@6.0.1)(reflect-metadata@0.1.13)
@@ -4722,8 +4722,8 @@ packages:
   '@bentley/icons-generic@1.0.34':
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  '@bentley/imodeljs-native@5.0.23':
-    resolution: {integrity: sha512-wbGdB27wrvZvExNEswxdpL/vh8s5OYrej8xMbppcfaq7A8FWKscegJCLG77iQ33nyAO+95jG50z/LhHC2LwccQ==}
+  '@bentley/imodeljs-native@5.0.24':
+    resolution: {integrity: sha512-8TCyOz0+s7rWeOplKGVSVlTeJLR5Qf3ywEJoEY92UnvuXY7oDaUED/yU5rK4HzWYcSsUv2xq/ZfDmtaaQTKofQ==}
 
   '@bentley/linear-referencing-schema@2.0.3':
     resolution: {integrity: sha512-2pFIEN4BS7alIDhGous6N2icKAS8ZhVBfoWB8WvSFaYnneGv5YwbbXl46qATDdPO5jUFezkW6uVxdpp1eOgUHQ==}
@@ -11201,7 +11201,7 @@ snapshots:
 
   '@bentley/icons-generic@1.0.34': {}
 
-  '@bentley/imodeljs-native@5.0.23': {}
+  '@bentley/imodeljs-native@5.0.24': {}
 
   '@bentley/linear-referencing-schema@2.0.3': {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -99,7 +99,7 @@
     "webpack": "^5.97.1"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "5.0.23",
+    "@bentley/imodeljs-native": "5.0.24",
     "@itwin/cloud-agnostic-core": "^2.2.4",
     "@itwin/core-telemetry": "workspace:*",
     "@itwin/object-storage-azure": "^2.2.5",

--- a/core/backend/src/ECDb.ts
+++ b/core/backend/src/ECDb.ts
@@ -284,11 +284,6 @@ export class ECDb implements IDisposable {
     return stmt;
   }
 
-  /** @internal
-   * @deprecated in 4.8. This internal API will be removed in 5.0. Use ECDb's public API instead.
-   */
-  public get nativeDb(): IModelJsNative.ECDb { return this[_nativeDb]; }
-
   /** @internal */
   public get [_nativeDb](): IModelJsNative.ECDb {
     assert(undefined !== this._nativeDb);

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -255,11 +255,6 @@ export abstract class IModelDb extends IModel {
     return super.iModelId;
   } // GuidString | undefined for the IModel superclass, but required for all IModelDb subclasses
 
-  /** @internal
-   * @deprecated in 4.8. This internal API will be removed in 5.0. Use IModelDb's public API instead.
-   */
-  public get nativeDb(): IModelJsNative.DgnDb { return this[_nativeDb]; }
-
   /** @internal*/
   public readonly [_nativeDb]: IModelJsNative.DgnDb;
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1542,8 +1542,7 @@ export abstract class IModelDb extends IModel {
    * @beta
    */
   public simplifyElementGeometry(args: SimplifyElementGeometryArgs): IModelStatus {
-    // ###TODO fix NativeLibraryts - it claims this returns DbResult but it returns DgnDbStatus aka IModelStatus.
-    return this[_nativeDb].simplifyElementGeometry(args) as unknown as IModelStatus;
+    return this[_nativeDb].simplifyElementGeometry(args);
   }
 
   /** Attempts to optimize all of the geometry in this iModel by identifying [[GeometryPart]]s that are referenced by exactly one
@@ -1992,9 +1991,7 @@ export namespace IModelDb {
      */
     public insertElement(elProps: ElementProps, options?: InsertElementOptions): Id64String {
       try {
-        // ###TODO: fix NativeLibrary.ts to not declare `forceUseId` as required - it's not.
-        // Then remove the spread operator below.
-        return elProps.id = this._iModel[_nativeDb].insertElement(elProps, options ? { ...options, forceUseId: !!options.forceUseId } : undefined);
+        return elProps.id = this._iModel[_nativeDb].insertElement(elProps, options);
       } catch (err: any) {
         err.message = `Error inserting element [${err.message}]`;
         err.metadata = { elProps };

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -3433,6 +3433,22 @@ export class StandaloneDb extends BriefcaseDb {
       nativeDb.closeFile();
       throw error;
     }
+  }
 
+  /** Convert an iModel stored on the local file system into a StandaloneDb, chiefly for testing purposes.
+   * The file must not be open in any application.
+   * @param iModelFileName the path to the iModel on the local file system.
+   * @beta
+   */
+  public static convertToStandalone(iModelFileName: LocalFileName): void {
+    const nativeDb = new IModelNative.platform.DgnDb();
+    nativeDb.openIModel(iModelFileName, OpenMode.ReadWrite);
+    nativeDb.setITwinId(Guid.empty); // empty iTwinId means "standalone"
+    nativeDb.saveChanges(); // save change to iTwinId
+    nativeDb.deleteAllTxns(); // necessary before resetting briefcaseId
+    nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned); // standalone iModels should always have BriefcaseId unassigned
+    nativeDb.saveLocalValue("StandaloneEdit", JSON.stringify({ txns: true }));
+    nativeDb.saveChanges(); // save change to briefcaseId
+    nativeDb.closeFile();
   }
 }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -3179,8 +3179,8 @@ export class SnapshotDb extends IModelDb {
   public static readonly onOpened = new BeEvent<(_iModelDb: SnapshotDb) => void>();
 
   private constructor(nativeDb: IModelJsNative.DgnDb, key: string) {
-    super({ nativeDb, key, changeset: nativeDb.getCurrentChangeset() }); // eslint-disable-line @typescript-eslint/no-deprecated
-    this._openMode = nativeDb.isReadonly() ? OpenMode.Readonly : OpenMode.ReadWrite; // eslint-disable-line @typescript-eslint/no-deprecated
+    super({ nativeDb, key, changeset: nativeDb.getCurrentChangeset() });  
+    this._openMode = nativeDb.isReadonly() ? OpenMode.Readonly : OpenMode.ReadWrite;  
   }
 
   public static override findByKey(key: string): SnapshotDb {

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -186,7 +186,7 @@ export interface SimplifyElementGeometryArgs {
   /** The Id of the [[GeometricElement]] or [[GeometryPart]] whose geometry is to be simplified. */
   id: Id64String;
   /** If true, simplify by converting each [BRepEntity]($common) in the element's geometry stream to a high-resolution
-   * [Polyface]($geometry) or [CurveVector]($geometry).
+   * mesh or curve geometry.
    */
   convertBReps?: boolean;
 }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -86,6 +86,18 @@ export interface UpdateModelOptions extends ModelProps {
   geometryChanged?: boolean;
 }
 
+/** Options supposed to [[IModelDb.Elements.insertElement]].
+ * @public
+ */
+export interface InsertElementOptions {
+  /** If true, instead of assigning a new, unique Id to the inserted element, the inserted element will use the Id specified by the supplied [ElementProps]($common).
+   * This is chiefly useful when applying a filtering transformation - i.e., copying some elements from a source iModel to a target iModel and adding no new elements.
+   * If this option is `true` then [ElementProps.id]($common) must be a valid Id that is not already used by an element in the iModel.
+   * @beta
+   */
+  forceUseId?: boolean;
+}
+
 /** Options supplied to [[IModelDb.computeProjectExtents]].
  * @public
  */
@@ -1884,9 +1896,9 @@ export namespace IModelDb {
      * the value of `elProps.federationGuid` is *not* updated. Generally, it is best to re-read the element after inserting (e.g. via [[getElementProps]])
      * if you intend to continue working with it. That will ensure its values reflect the persistent state.
      */
-    public insertElement(elProps: ElementProps): Id64String {
+    public insertElement(elProps: ElementProps, options?: InsertElementOptions): Id64String {
       try {
-        return elProps.id = this._iModel[_nativeDb].insertElement(elProps);
+        return elProps.id = this._iModel[_nativeDb].insertElement(elProps, options ? { ...options, forceUseId: !!options.forceUseId } : undefined);
       } catch (err: any) {
         err.message = `Error inserting element [${err.message}]`;
         err.metadata = { elProps };

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1555,6 +1555,16 @@ export abstract class IModelDb extends IModel {
   public inlineGeometryParts(): InlineGeometryPartsResult {
     return this[_nativeDb].inlineGeometryPartReferences();
   }
+
+  /** Returns a string representation of the error that most recently arose during an operation on the underlying SQLite database.
+   * If no errors have occurred, an empty string is returned.
+   * Otherwise, a string of the format `message (code)` is returned, where `message` is a human-readable diagnostic string and `code` is an integer status code.
+   * See [SQLite error codes and messages](https://www.sqlite.org/c3ref/errcode.html)
+   * @note Do not rely upon this value or its specific contents in error handling logic. It is only intended for use in debugging.
+   */
+  public getLastError(): string {
+    return this[_nativeDb].getLastError();
+  }
 }
 
 function processSchemaWriteStatus(status: SchemaWriteStatus): void {

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -12,7 +12,7 @@ import "./IModelDb"; // DO NOT REMOVE OR MOVE THIS LINE!
 import { IModelNative, loadNativePlatform } from "./internal/NativePlatform";
 import * as os from "os";
 import "reflect-metadata"; // this has to be before @itwin/object-storage-* and @itwin/cloud-agnostic-core imports because those packages contain decorators that use this polyfill.
-import { IModelJsNative, NativeLibrary } from "@bentley/imodeljs-native";
+import { NativeLibrary } from "@bentley/imodeljs-native";
 import { DependenciesConfig, Types as ExtensionTypes } from "@itwin/cloud-agnostic-core";
 import { AccessToken, assert, BeEvent, DbResult, Guid, GuidString, IModelStatus, Logger, Mutable, ProcessDetector } from "@itwin/core-bentley";
 import { AuthorizationClient, BentleyStatus, IModelError, LocalDirName, SessionProps } from "@itwin/core-common";
@@ -287,13 +287,6 @@ export class IModelHost {
   private static _cacheDir = "";
   private static _settingsSchemas?: SettingsSchemas;
   private static _appWorkspace?: OwnedWorkspace;
-
-  /** Provides access to the entirely internal, low-level, unstable APIs provided by @bentley/imodel-native.
-   * Should not be used outside of @itwin/core-backend, and certainly not outside of the itwinjs-core repository
-   * @deprecated in 4.8. This internal API will be removed in 5.0. Use IModelHost's public API instead.
-   * @internal
-   */
-  public static get platform(): typeof IModelJsNative { return IModelNative.platform; }
 
   public static configuration?: IModelHostOptions;
 

--- a/core/backend/src/SQLiteDb.ts
+++ b/core/backend/src/SQLiteDb.ts
@@ -27,11 +27,6 @@ import { _nativeDb } from "./internal/Symbols";
  * @public
  */
 export class SQLiteDb {
-  /** @internal
-   * @deprecated in 4.8. This internal API will be removed in 5.0. Use SQLiteDb's public API instead.
-   */
-  public get nativeDb(): IModelJsNative.SQLiteDb { return this[_nativeDb]; }
-
   /** @internal */
   public readonly [_nativeDb] = new IModelNative.platform.SQLiteDb();
   private _sqliteStatementCache = new StatementCache<SqliteStatement>();

--- a/core/backend/src/SQLiteDb.ts
+++ b/core/backend/src/SQLiteDb.ts
@@ -139,6 +139,13 @@ export class SQLiteDb {
     }
   }
 
+  /** The cloud container backing this SQLite database, if any.
+   * @beta
+   */
+  public get cloudContainer(): CloudSqlite.CloudContainer | undefined {
+    return this[_nativeDb].cloudContainer;
+  }
+
   /**
    * Perform an operation on a database in a CloudContainer with the write lock held.
    *

--- a/core/backend/src/SQLiteDb.ts
+++ b/core/backend/src/SQLiteDb.ts
@@ -146,6 +146,11 @@ export class SQLiteDb {
     return this[_nativeDb].cloudContainer;
   }
 
+  /** Returns the Id of the most-recently-inserted row in this database, per [sqlite3_last_insert_rowid](https://www.sqlite.org/c3ref/last_insert_rowid.html). */
+  public getLastInsertRowId(): number {
+    return this[_nativeDb].getLastInsertRowId();
+  }
+
   /**
    * Perform an operation on a database in a CloudContainer with the write lock held.
    *

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -582,5 +582,12 @@ export class TxnManager {
     }
     return this._nativeDb.getLocalChanges(args.includedClasses ?? [], args.includeUnsavedChanges ?? false);
   }
+
+  /** Query the number of bytes of memory currently allocated by SQLite to keep track of
+   * changes to the iModel, for debugging/diagnostic purposes, as reported by [sqlite3session_memory_used](https://www.sqlite.org/session/sqlite3session_memory_used.html).
+   */
+  public getChangeTrackingMemoryUsed(): number {
+    return this._iModel[_nativeDb].getChangeTrackingMemoryUsed();
+  }
 }
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -102,8 +102,9 @@ The following previously-deprecated APIs have been removed:
 | `IModelDb.nativeDb`         | N/A         |
 | `ECDb.nativeDb`             | N/A         |
 | `SQLiteDb.nativeDb`         | N/A         |
+| `IModelHost.platform`       | N/A         |
 
-All three `nativeDb` fields have always been `@internal`. Use the `@public` APIs instead. If some functionality is missing from those APIs, [let us know](https://github.com/iTwin/itwinjs-core/issues/new?template=feature_request.md).
+All three `nativeDb` fields and `IModelHost.platform` have always been `@internal`. Use the `@public` APIs instead. If some functionality is missing from those APIs, [let us know](https://github.com/iTwin/itwinjs-core/issues/new?template=feature_request.md).
 
 #### @itwin/appui-abstract
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -20,6 +20,7 @@ Table of contents:
     - [Electron](#electron)
     - [ECMAScript](#ecmascript)
   - [Deprecated API removals](#deprecated-api-removals)
+    - [@itwin/core-backend](#itwincore-backend-1)
     - [@itwin/appui-abstract](#itwinappui-abstract)
     - [@itwin/core-electron](#itwincore-electron)
   - [Packages dropped](#packages-dropped)
@@ -93,6 +94,16 @@ iTwin.js now supports only the latest Electron release (Electron 33) and has dro
 ### Deprecated API removals
 
 The following previously-deprecated APIs have been removed:
+
+#### @itwin/core-backend
+
+| Removed                     | Replacement |
+| --------------------------- | ----------- |
+| `IModelDb.nativeDb`         | N/A         |
+| `ECDb.nativeDb`             | N/A         |
+| `SQLiteDb.nativeDb`         | N/A         |
+
+All three `nativeDb` fields have always been `@internal`. Use the `@public` APIs instead. If some functionality is missing from those APIs, [let us know](https://github.com/iTwin/itwinjs-core/issues/new?template=feature_request.md).
 
 #### @itwin/appui-abstract
 

--- a/example-code/snippets/src/backend/IModelBranchingOperations.test.ts
+++ b/example-code/snippets/src/backend/IModelBranchingOperations.test.ts
@@ -181,7 +181,7 @@ namespace arbitraryEdit {
 
 // ###TODO: @itwin/imodel-transformer tries to access IModelDb.nativeDb which was removed in 5.0, test will fail
 // until that package is updated to 5.0.
-describe.only("IModelBranchingOperations", () => {
+describe.skip("IModelBranchingOperations", () => {
   const version0Path = path.join(KnownTestLocations.outputDir, "branching-ops.bim");
 
   before(async () => {

--- a/example-code/snippets/src/backend/IModelBranchingOperations.test.ts
+++ b/example-code/snippets/src/backend/IModelBranchingOperations.test.ts
@@ -179,7 +179,9 @@ namespace arbitraryEdit {
   export let editCounter = 0;
 }
 
-describe("IModelBranchingOperations", () => {
+// ###TODO: @itwin/imodel-transformer tries to access IModelDb.nativeDb which was removed in 5.0, test will fail
+// until that package is updated to 5.0.
+describe.only("IModelBranchingOperations", () => {
   const version0Path = path.join(KnownTestLocations.outputDir, "branching-ops.bim");
 
   before(async () => {

--- a/example-code/snippets/src/backend/IModelExporter.test.ts
+++ b/example-code/snippets/src/backend/IModelExporter.test.ts
@@ -41,7 +41,9 @@ class CodeExporter extends IModelExportHandler {
 import * as path from "path";
 import { IModelTestUtils } from "./IModelTestUtils";
 
-describe("IModelExporter", () => {
+// ###TODO: @itwin/imodel-transformer tries to access IModelDb.nativeDb which was removed in 5.0, test will fail
+// until that package is updated to 5.0.
+describe.skip("IModelExporter", () => {
   let iModelDb: SnapshotDb;
   before(() => {
     iModelDb = IModelTestUtils.openSnapshotFromSeed("test.bim");

--- a/example-code/snippets/src/backend/IModelExporter.test.ts
+++ b/example-code/snippets/src/backend/IModelExporter.test.ts
@@ -41,9 +41,7 @@ class CodeExporter extends IModelExportHandler {
 import * as path from "path";
 import { IModelTestUtils } from "./IModelTestUtils";
 
-// ###TODO: @itwin/imodel-transformer tries to access IModelDb.nativeDb which was removed in 5.0, test will fail
-// until that package is updated to 5.0.
-describe.skip("IModelExporter", () => {
+describe("IModelExporter", () => {
   let iModelDb: SnapshotDb;
   before(() => {
     iModelDb = IModelTestUtils.openSnapshotFromSeed("test.bim");

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:5.0.23'
+    implementation 'com.github.itwin:mobile-native-android:5.0.24'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.0.23;
+				version = 5.0.24;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.0.23;
+				version = 5.0.24;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/945

These were always @internal, always dangerous to use outside of core-backend, and deprecated in 4.x to give people fair warning that they would be removed.

Add new APIs for functionality needed by external packages.
- code-service
  - `cloudContainer` and `getLastInsertRowId` to `SQLiteDb`.
- imodel-transform
  - `StandaloneDb.convertToStandalone` - so many copies of this function floating around.
  - `IModelDb.insertElement` now takes the same options as the `NativeDgnDb` method, allowing transformer to optionally preserve element Ids during filtering transformations.
  - `IModelDb.exportSchema(s)`.
  - `IModelDb.inlineGeometryParts`.
  - `IModelDb.simplifyGeometry`.
  - `IModelDb.getLastError`.
  - `TxnManager.getChangeTrackingMemoryUsed`.

example-code-snippets has sample code + test that imports from @itwin/imodel-transformer. That test now fails because the transformer package tries to access the now non-existent `nativeDb` field. Skipping it until transformer package is updated.