### PR TITLE
Remove @iTwin/itwinjs-core team as owner for all changelog files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -157,8 +157,7 @@ rush.json                                         @iTwin/itwinjs-core-admins
 # These are at the end to override all previous reviews
 
 ## Updates to the package.json should avoid requesting review by everyone
-## If the version updates or
-/common/changes/**/*.json                         @iTwin/itwinjs-core
+/common/changes/**/*.json
 /**/package.json                                  @iTwin/itwinjs-core
 /**/CHANGELOG.json                                @iTwin/itwinjs-core
 /**/CHANGELOG.md                                  @iTwin/itwinjs-core

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -17,7 +17,7 @@ jobs:
       # Checks-out your repository, which is validated in the next step
       - uses: actions/checkout@v4
       - name: GitHub CODEOWNERS Validator
-        uses: mszostok/codeowners-validator@v0.5.0
+        uses: mszostok/codeowners-validator@v0.7.0
         with:
           checks: "duppatterns,syntax"
           experimental_checks: "notowned"


### PR DESCRIPTION
I added this line in #7292 with the hopes of not requiring reviews from everyone for package.json-only updates.  An unintentional side-effect of this has been that now @iTwin/itwinjs-core is required to review every single PR, even when a smaller set of codeowners would otherwise be sufficient, leading to a lot of notification noise.

Since changelog files are never expected to be added on their own, let's just not require anyone as a reviewer for those.