### PR TITLE
[ci] fix filter to run ECSQL tests in markdown

### DIFF
--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -28,7 +28,8 @@ pr:
       - release/*
   paths:
     exclude:
-      - "**.md"
+      - "**/README.md"
+      - "**.api.md"
       - docs/**
       - .github/CODEOWNERS
       - common/changes/**/*.json


### PR DESCRIPTION
PR validation pipelines (fast-ci.yml) currently ignore all .md files, so we don't build and test code just for docs changes.
ECSQL uses md files for tests, so "**.md" was too broad of a filter iTwin.js pipeline.
These two filters should still skip CI for all relevant md files, but now include CI for ECSQL md tests

example pr where we currently skip CI, but should not
https://github.com/iTwin/itwinjs-core/pull/7522