### PR TITLE
Manual backport 2 fixes from master (Column Infos)

### DIFF
--- a/common/changes/@itwin/core-backend/rob-manual-column-fix-backport_2025-01-13-14-43.json
+++ b/common/changes/@itwin/core-backend/rob-manual-column-fix-backport_2025-01-13-14-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
 
   ../../core/backend:
     specifiers:
-      '@bentley/imodeljs-native': 4.11.8
+      '@bentley/imodeljs-native': 4.11.11
       '@itwin/build-tools': workspace:*
       '@itwin/cloud-agnostic-core': ^2.2.4
       '@itwin/core-bentley': workspace:*
@@ -60,7 +60,7 @@ importers:
       webpack: ^5.76.0
       ws: ^7.5.10
     dependencies:
-      '@bentley/imodeljs-native': 4.11.8
+      '@bentley/imodeljs-native': 4.11.11
       '@itwin/cloud-agnostic-core': 2.2.4_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/core-telemetry': link:../telemetry
       '@itwin/object-storage-azure': 2.2.5_scz6qrwecfbbxg4vskopkl3a7u
@@ -3700,8 +3700,8 @@ packages:
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
     dev: false
 
-  /@bentley/imodeljs-native/4.11.8:
-    resolution: {integrity: sha512-p1qKRSk/gqC7Xz+eUx/mj0lXA4nzvBackWzUB6Ohy5y2siWGrunTQaJaJlS/abxTNo+ufsdlbxdH9/1POQD7Bw==}
+  /@bentley/imodeljs-native/4.11.11:
+    resolution: {integrity: sha512-E8JtgTLdvmxfuy8rpt5j4IPpiu99xoSllfqcie/PyLI+sQdllzUUiKA/7Iw8resteSuZ9HUI2efLpprWo32p8Q==}
     requiresBuild: true
     dev: false
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -97,7 +97,7 @@
     "webpack": "^5.76.0"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "4.11.8",
+    "@bentley/imodeljs-native": "4.11.11",
     "@itwin/cloud-agnostic-core": "^2.2.4",
     "@itwin/core-telemetry": "workspace:*",
     "@itwin/object-storage-azure": "^2.2.5",

--- a/core/backend/src/test/ecdb/ECSqlReader.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlReader.test.ts
@@ -595,16 +595,16 @@ describe("ECSqlReader", (() => {
       it("Geometric type column with alias", async () => {
         reader = iModel.createQueryReader("select GeometryStream A from bis.GeometricElement3d LIMIT 1");
         const metaData = await reader.getMetaData();
-        assert.equal("Json", metaData[0].extendedType);
-        assert.equal("Json", metaData[0].extendType);   // eslint-disable-line @typescript-eslint/no-deprecated
+        assert.equal("GeometryStream", metaData[0].extendedType);
+        assert.equal("GeometryStream", metaData[0].extendType);   // eslint-disable-line @typescript-eslint/no-deprecated
         assert.equal(metaData[0].extendedType, metaData[0].extendType);   // eslint-disable-line @typescript-eslint/no-deprecated
       });
 
       it("Geometric type column without alias", async () => {
         reader = iModel.createQueryReader("select GeometryStream from bis.GeometricElement3d LIMIT 1");
         const metaData = await reader.getMetaData();
-        assert.equal("Json", metaData[0].extendedType);
-        assert.equal("Json", metaData[0].extendType);   // eslint-disable-line @typescript-eslint/no-deprecated
+        assert.equal("GeometryStream", metaData[0].extendedType);
+        assert.equal("GeometryStream", metaData[0].extendType);   // eslint-disable-line @typescript-eslint/no-deprecated
         assert.equal(metaData[0].extendedType, metaData[0].extendType);   // eslint-disable-line @typescript-eslint/no-deprecated
       });
 

--- a/core/backend/src/test/standalone/DisplayStyle.test.ts
+++ b/core/backend/src/test/standalone/DisplayStyle.test.ts
@@ -6,7 +6,7 @@
 import { expect } from "chai";
 import { CompressedId64Set, Guid } from "@itwin/core-bentley";
 import { DisplayStyle3dSettingsProps, DisplayStyleSettingsProps, IModel, SkyBoxImageType, SkyBoxProps } from "@itwin/core-common";
-import { DisplayStyle3d, IModelElementCloneContext, StandaloneDb } from "../../core-backend";
+import { DisplayStyle3d, IModelElementCloneContext, SpatialCategory, StandaloneDb, SubCategory } from "../../core-backend";
 import { IModelTestUtils } from "../IModelTestUtils";
 
 describe("DisplayStyle", () => {
@@ -121,16 +121,21 @@ describe("DisplayStyle", () => {
 
     it("remaps subCategory overrides when cloning", () => {
       const cloneContext = new IModelElementCloneContext(db, db2);
+      const categoryId = SpatialCategory.insert(db, IModel.dictionaryId, "testCat", {});
+      const subCategoryId1 = SubCategory.insert(db, categoryId, "subC1", {});
+      const subCategoryId2 = SubCategory.insert(db, categoryId, "subC2", {});
+      const subCategoryId3 = SubCategory.insert(db, categoryId, "subC3", {});
+      const subCategoryId4 = SubCategory.insert(db, categoryId, "subC4", {});
       const displayStyleJsonProps: DisplayStyleSettingsProps = {subCategoryOvr: [
-        {subCategory: "0x1", weight: 5},
-        {subCategory: "0x2", weight: 3},
-        {subCategory: "0x3", invisible: false},
-        {subCategory: "0x4", invisible: true},
+        {subCategory: subCategoryId1, weight: 5},
+        {subCategory: subCategoryId2, weight: 3},
+        {subCategory: subCategoryId3, invisible: false},
+        {subCategory: subCategoryId4, invisible: true},
       ]};
       const displayStyleId = DisplayStyle3d.insert(db, IModel.dictionaryId, "TestStyle", displayStyleJsonProps);
 
-      cloneContext.remapElement("0x1", "0xa");
-      cloneContext.remapElement("0x4", "0xd");
+      cloneContext.remapElement(subCategoryId1, "0xa");
+      cloneContext.remapElement(subCategoryId4, "0xd");
       const displayStyle = db.elements.getElement<DisplayStyle3d>(displayStyleId);
       const displayStyleClone = cloneContext.cloneElement(displayStyle);
 

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:4.11.8'
+    implementation 'com.github.itwin:mobile-native-android:4.11.11'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.11.8;
+				version = 4.11.11;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.11.8;
+				version = 4.11.11;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/965

backport from PR https://github.com/iTwin/imodel-native/pull/965

The automatic backport would do too much as this fix was bundled with the new ECSql test suite which we do not want to backport.
So this includes only the test adjustments that are needed with the fix.