### PR TITLE
[ci] Use pipeline to update gather-docs.yaml during releases

### DIFF
--- a/.github/workflows/automation-scripts/update-changelogs.mjs
+++ b/.github/workflows/automation-scripts/update-changelogs.mjs
@@ -108,17 +108,6 @@ if (targetBranch === `origin/${currentBranch}`) {
 // copy all changelogs from the current branch to ./temp-incoming-changelogs, the files will be named: package_name_CHANGELOG.json
 await $`find ./ -type f -name "CHANGELOG.json" -not -path "*/node_modules/*" -exec sh -c 'cp "{}" "./temp-incoming-changelogs/$(echo "{}" | sed "s/^.\\///; s/\\//_/g")"' \\;`;
 
-// before checking out to target branch
-// if it is a major or minor release, we need to update `gather-docs.yaml`'s branchName value to be the release branch
-if (commitMessage.endsWith(".0")) {
-  const docsYamlPath = "common/config/azure-pipelines/templates/gather-docs.yaml";
-  editFileInPlaceSynchronously(docsYamlPath, /release\/\d+\.\d+\.\w+/g, currentBranch);
-  // commit these changes to our release branch
-  await $`git add ${docsYamlPath}`;
-  await $`git commit -m "Update gather-docs.yaml's branch name to the release branch"`;
-  await $`git push origin HEAD:${currentBranch}`;
-}
-
 targetBranch = targetBranch.replace("origin/", "");
 await $`git checkout ${targetBranch}`;
 // copy all changelogs from the target branch to ./temp-target-changelogs, the files will be named: package_name_CHANGELOG.json

--- a/common/config/azure-pipelines/jobs/check-gather-docs.yaml
+++ b/common/config/azure-pipelines/jobs/check-gather-docs.yaml
@@ -1,0 +1,38 @@
+name: check-gather-docs
+trigger: none
+
+resources:
+  pipelines:
+  - pipeline: 'itwinjs'
+    source: iTwin.js/iTwin.js
+    trigger:
+      enabled: true
+      branches:
+        include:
+          - release/*
+      tags:
+        - 'package-release'
+
+jobs:
+  - job: check-gather-docs
+    displayName: 'Check and update gather-docs.yaml branch'
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    variables:
+      - group: imodel-native-secret-variables
+
+    steps:
+      - checkout: self
+        persistCredentials: true
+        clean: true
+
+      - script: |
+          node common/scripts/check_gather_docs.mjs
+          git add .
+          git commit -m "Update gather-docs.yaml"
+          git push --set-upstream https://$(GH_TOKEN)@github.com/iTwin/itwinjs-core $(Build.SourceBranchName)
+        displayName: 'Check gather-docs.yaml branch'
+        env:
+          GITHUB_TOKEN: $(GH_TOKEN)
+          CURRENT_BRANCH: $(Build.SourceBranch)

--- a/common/config/azure-pipelines/jobs/check-gather-docs.yaml
+++ b/common/config/azure-pipelines/jobs/check-gather-docs.yaml
@@ -1,38 +1,38 @@
-name: check-gather-docs
-trigger: none
+# name: check-gather-docs
+# trigger: none
 
-resources:
-  pipelines:
-  - pipeline: 'itwinjs'
-    source: iTwin.js/iTwin.js
-    trigger:
-      enabled: true
-      branches:
-        include:
-          - release/*
-      tags:
-        - 'package-release'
+# resources:
+#   pipelines:
+#   - pipeline: 'itwinjs'
+#     source: iTwin.js/iTwin.js
+#     trigger:
+#       enabled: true
+#       branches:
+#         include:
+#           - release/*
+#       tags:
+#         - 'package-release'
 
-jobs:
-  - job: check-gather-docs
-    displayName: 'Check and update gather-docs.yaml branch'
-    pool:
-      vmImage: 'ubuntu-latest'
+# jobs:
+#   - job: check-gather-docs
+#     displayName: 'Check and update gather-docs.yaml branch'
+#     pool:
+#       vmImage: 'ubuntu-latest'
 
-    variables:
-      - group: imodel-native-secret-variables
+#     variables:
+#       - group: imodel-native-secret-variables
 
-    steps:
-      - checkout: self
-        persistCredentials: true
-        clean: true
+#     steps:
+#       - checkout: self
+#         persistCredentials: true
+#         clean: true
 
-      - script: |
-          node common/scripts/check_gather_docs.mjs
-          git add .
-          git commit -m "Update gather-docs.yaml"
-          git push --set-upstream https://$(GH_TOKEN)@github.com/iTwin/itwinjs-core $(Build.SourceBranchName)
-        displayName: 'Check gather-docs.yaml branch'
-        env:
-          GITHUB_TOKEN: $(GH_TOKEN)
-          CURRENT_BRANCH: $(Build.SourceBranch)
+#       - script: |
+#           node common/scripts/check_gather_docs.mjs
+#           git add .
+#           git commit -m "Update gather-docs.yaml"
+#           git push --set-upstream https://$(GH_TOKEN)@github.com/iTwin/itwinjs-core $(Build.SourceBranchName)
+#         displayName: 'Check gather-docs.yaml branch'
+#         env:
+#           GITHUB_TOKEN: $(GH_TOKEN)
+#           CURRENT_BRANCH: $(Build.SourceBranch)

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -38,3 +38,14 @@ steps:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)/imodeljs/packages'
     ArtifactName: packages
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
+
+- script: |
+    node common/scripts/check_gather_docs.mjs
+    git add .
+    git commit -m "Update gather-docs.yaml"
+    git push --set-upstream https://$(GH_TOKEN)@github.com/iTwin/itwinjs-core $(Build.SourceBranchName)
+  displayName: 'Check gather-docs.yaml branch'
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
+  env:
+    GITHUB_TOKEN: $(GH_TOKEN)
+    CURRENT_BRANCH: $(Build.SourceBranch)

--- a/common/config/azure-pipelines/templates/publish.yaml
+++ b/common/config/azure-pipelines/templates/publish.yaml
@@ -45,7 +45,7 @@ steps:
     git commit -m "Update gather-docs.yaml"
     git push --set-upstream https://$(GH_TOKEN)@github.com/iTwin/itwinjs-core $(Build.SourceBranchName)
   displayName: 'Check gather-docs.yaml branch'
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'))
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['ShouldPublish'], 'True'), ne(variables['Build.SourceBranchName'], 'master'))
   env:
     GITHUB_TOKEN: $(GH_TOKEN)
     CURRENT_BRANCH: $(Build.SourceBranch)

--- a/common/scripts/check_gather_docs.mjs
+++ b/common/scripts/check_gather_docs.mjs
@@ -1,0 +1,70 @@
+import fs from "fs";
+import path from "path";
+
+function checkFile(filePath, currentBranch) {
+  // const filePath = path.normalize("./common/config/azure-pipelines/templates/gather-docs.yaml")
+  if (!fs.existsSync(filePath)) {
+    console.error("File not found.");
+    process.exit(1);
+  }
+
+  const fileContent = fs.readFileSync(filePath, "utf8");
+
+  const textToFind = /branchName: refs\/heads\/release\/\d+\.\d+\.x/gi;
+  const branchInFile = fileContent.match(textToFind);
+
+  if (!branchInFile) {
+    console.error("No match for branch name found");
+    process.exit(1);
+  }
+
+  if (branchInFile[0] === `branchName: ${currentBranch}`) {
+    console.log("The current branch  matches the branch in gather-docs.yaml. No update Needed.");
+    return false;
+  }
+  else {
+    const newContent = fileContent.replace(textToFind, `branchName: ${currentBranch}`);
+    fs.writeFileSync(filePath, newContent, "utf8");
+    console.log("Updated gather-docs.yaml with the current branch.");
+    return true;
+  }
+}
+
+function main() {
+  const filePath = path.normalize("./common/config/azure-pipelines/templates/gather-docs.yaml")
+  const currentBranch = process.env.CURRENT_BRANCH;
+  checkFile(filePath, currentBranch);
+}
+main();
+
+// Tests
+function createTempFile(name, content) {
+  const tempFilePath = path.join('./', `${name}`);
+
+  fs.writeFileSync(tempFilePath, content, "utf8");
+  console.log(`Temporary file created at: ${tempFilePath}`);
+
+  return tempFilePath;
+}
+
+function deleteTempFile(filePath) {
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+    console.log(`Temporary file deleted: ${filePath}`);
+  } else {
+    console.log(`File not found: ${filePath}`);
+  }
+}
+
+function tests() {
+  const currentBranch = "refs/heads/release/1.2.x";
+  // Test for when file needs to be updated
+  let filePath = createTempFile("should-change.txt", "branchName: refs/heads/release/0.0.x");
+  console.assert(checkFile(filePath, currentBranch) === true, "File should be updated");
+  deleteTempFile(filePath);
+
+  filePath = createTempFile("should-not-change.txt", "branchName: refs/heads/release/1.2.x");
+  console.assert(checkFile(filePath, currentBranch) === false, "File should not be updated");
+  deleteTempFile(filePath);
+}
+// tests();

--- a/common/scripts/check_gather_docs.mjs
+++ b/common/scripts/check_gather_docs.mjs
@@ -33,6 +33,13 @@ function checkFile(filePath, currentBranch) {
 function main() {
   const filePath = path.normalize("./common/config/azure-pipelines/templates/gather-docs.yaml")
   const currentBranch = process.env.CURRENT_BRANCH;
+
+  const textToFind = /refs\/heads\/release\/\d+\.\d+\.x/gi;
+  if (!currentBranch.match(textToFind)) {
+    console.error("Invalid branch name.");
+    process.exit(1);
+  }
+
   checkFile(filePath, currentBranch);
 }
 main();


### PR DESCRIPTION
Use a script to find and replace the branchName in gather-docs.ymal file. 

We would want to run this script whenever we publish build artifacts on a release branch, this is because the first time we build on a new release branch we target the previous release branch. Once that build publishes artifacts we want to update the yml file to the current release branch.

I created a new yaml file to trigger this, which runs every time we publish an artifact during the itwin.js builds. Don't know if this is the best way to call the script. Maybe just putting it at the end of the release pipeline which has a similar trigger, however that lives in the imodeljs-build-pipeline-scripts repo.