### PR TITLE
Update BaseURI Comment and Test

### DIFF
--- a/common/changes/@itwin/core-backend/mike-update-baseUri_2025-01-15-19-02.json
+++ b/common/changes/@itwin/core-backend/mike-update-baseUri_2025-01-15-19-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Update BlobContainerService Comments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/BlobContainerService.ts
+++ b/core/backend/src/BlobContainerService.ts
@@ -78,19 +78,19 @@ export namespace BlobContainer {
   /** Properties returned by `Service.requestToken` */
   export interface TokenProps {
     /**
-     * expiring token that provides the requested access to the container. Should be used in all subsequent requests for blobs within the container,
+     * Expiring token that provides the requested access to the container. Should be used in all subsequent requests for blobs within the container,
      * and must be refreshed before it expires
      */
     token: ContainerToken;
-    /** scope of the container. */
+    /** Scope of the container. */
     scope: Scope;
-    /** name of the blob storage provider. */
+    /** Name of the blob storage provider. */
     provider: Provider;
     /** Time at which the token will expire. The token should be refreshed (that is, a new token should be requested) before this time. */
     expiration: Date;
     /** Metadata of the container. */
     metadata: Metadata;
-    /** Base URI of container */
+    /** Base URI of the storage account that hosts the container */
     baseUri: string;
   }
 

--- a/full-stack-tests/backend/src/integration/AzuriteTest.ts
+++ b/full-stack-tests/backend/src/integration/AzuriteTest.ts
@@ -242,7 +242,7 @@ export namespace AzuriteTest {
         token: sasUrl.split("?")[1],
         provider: "azure",
         expiration: expiresOn,
-        baseUri: `${azContUrl.protocol}//${azContUrl.host}`, // remove container and optional params from URL to isolate the baseURI
+        baseUri
       };
     },
   };

--- a/full-stack-tests/backend/src/integration/AzuriteTest.ts
+++ b/full-stack-tests/backend/src/integration/AzuriteTest.ts
@@ -232,7 +232,6 @@ export namespace AzuriteTest {
       if (metadata?.itwinid === undefined)
         throw new Error("invalid container");
 
-      const azContUrl = new URL(azCont.url);
       return {
         scope: {
           iTwinId: metadata.itwinid,

--- a/full-stack-tests/backend/src/integration/AzuriteTest.ts
+++ b/full-stack-tests/backend/src/integration/AzuriteTest.ts
@@ -232,6 +232,7 @@ export namespace AzuriteTest {
       if (metadata?.itwinid === undefined)
         throw new Error("invalid container");
 
+      const azContUrl = new URL(azCont.url);
       return {
         scope: {
           iTwinId: metadata.itwinid,
@@ -241,7 +242,7 @@ export namespace AzuriteTest {
         token: sasUrl.split("?")[1],
         provider: "azure",
         expiration: expiresOn,
-        baseUri: azCont.url,
+        baseUri: `${azContUrl.protocol}//${azContUrl.host}`, // remove container and optional params from URL to isolate the baseURI
       };
     },
   };


### PR DESCRIPTION
Updates the baseURI comment in BlobContainerService to correctly reflect what should be returned by the service. 

The baseURI does not contain the containerId, only the url of the storage account hosting the container. 

Updates AzuriteTest to correctly reflect this behavior as well.