### PR TITLE
Presentation: Fix Presentation RPC returning details contained within thrown errors

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-fix-backend-returning-error-details_2025-01-16-09-38.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix-backend-returning-error-details_2025-01-16-09-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fix Presentation RPC returning details contained within thrown errors. Instead of doing that, we now re-throw the error and let RPC system handle it (by re-throwing a generic error instead).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/full-stack-tests/presentation/src/frontend/content/Infrastructure.test.ts
+++ b/full-stack-tests/presentation/src/frontend/content/Infrastructure.test.ts
@@ -33,8 +33,8 @@ describeContentTestSuite("Error handling", ({ getDefaultSuiteIModel }) => {
     const realRace = Promise.race;
     // mock `Promise.race` to always reject
     const raceStub = sinon.stub(Promise, "race").callsFake(async (values) => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      (values as Array<Promise<any>>).splice(0, 0, Promise.reject(new Error()));
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises, @typescript-eslint/prefer-promise-reject-errors
+      (values as Array<Promise<any>>).splice(0, 0, Promise.reject("timeout"));
       return realRace.call(Promise, values);
     });
     try {

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -36,9 +36,7 @@ import {
   NodePathElement,
   Paged,
   PagedResponse,
-  PresentationError,
   PresentationIpcEvents,
-  PresentationStatus,
   Prioritized,
   Ruleset,
   RulesetVariable,
@@ -106,9 +104,8 @@ export class PresentationManagerDetail implements IDisposable {
 
   public getNativePlatform(): NativePlatformDefinition {
     if (this._disposed) {
-      throw new PresentationError(PresentationStatus.NotInitialized, "Attempting to use Presentation manager after disposal");
+      throw new Error("Attempting to use Presentation manager after disposal");
     }
-
     return this._nativePlatform!;
   }
 

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -7,7 +7,7 @@
  */
 
 import { IModelDb, RpcTrace } from "@itwin/core-backend";
-import { assert, BeEvent, Id64String, IDisposable, Logger } from "@itwin/core-bentley";
+import { BeEvent, Id64String, IDisposable, Logger } from "@itwin/core-bentley";
 import { IModelRpcProps } from "@itwin/core-common";
 import {
   buildElementProperties,
@@ -151,14 +151,9 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
   }
 
   private async getIModel(token: IModelRpcProps): Promise<IModelDb> {
-    let imodel: IModelDb;
-    try {
-      imodel = IModelDb.findByKey(token.key);
-      // call refreshContainer, just in case this is a V2 checkpoint whose sasToken is about to expire, or its default transaction is about to be restarted.
-      await imodel.refreshContainerForRpc(RpcTrace.expectCurrentActivity.accessToken);
-    } catch {
-      throw new PresentationError(PresentationStatus.InvalidArgument, "IModelRpcProps doesn't point to a valid iModel");
-    }
+    const imodel = IModelDb.findByKey(token.key);
+    // call refreshContainer, just in case this is a V2 checkpoint whose sasToken is about to expire, or its default transaction is about to be restarted.
+    await imodel.refreshContainerForRpc(RpcTrace.expectCurrentActivity.accessToken);
     return imodel;
   }
 
@@ -170,13 +165,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
 
     Logger.logInfo(PresentationBackendLoggerCategory.Rpc, `Received '${requestId}' request. Params: ${requestKey}`);
 
-    let imodel: IModelDb;
-    try {
-      imodel = await this.getIModel(token);
-    } catch (e) {
-      assert(e instanceof Error);
-      return this.errorResponse(PresentationStatus.InvalidArgument, e.message);
-    }
+    const imodel = await this.getIModel(token);
 
     let resultPromise = this._pendingRequests.getValue(requestKey);
     if (resultPromise) {
@@ -225,7 +214,12 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
       // initiate request
       resultPromise = request(managerRequestOptions)
         .then((result) => this.successResponse(result, diagnostics))
-        .catch((e: PresentationError) => this.errorResponse(e.errorNumber, e.message, diagnostics));
+        .catch((e: unknown) => {
+          if (e instanceof PresentationError) {
+            return this.errorResponse(e.errorNumber, e.message, diagnostics);
+          }
+          throw e;
+        });
 
       // store the request promise
       this._pendingRequests.addValue(requestKey, resultPromise);
@@ -243,25 +237,32 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements IDi
     let timeout: NodeJS.Timeout;
     const timeoutPromise = new Promise<any>((_resolve, reject) => {
       timeout = setTimeout(() => {
-        reject(new Error());
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+        reject("timeout");
       }, this._requestTimeout);
     });
 
     Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Returning a promise with a timeout of ${this._requestTimeout}.`);
     return Promise.race([resultPromise, timeoutPromise])
-      .catch<PresentationRpcResponseData>(() => {
-        // note: error responses from the manager get handled when creating `resultPromise`, so we can only get here due
-        // to a timeout exception
-        Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request timeout, returning "BackendTimeout" status.`);
-        return this.errorResponse(PresentationStatus.BackendTimeout);
+      .catch<PresentationRpcResponseData>((e: unknown) => {
+        if (e === "timeout") {
+          // note: error responses from the manager get handled when creating `resultPromise`, so we can only get here due
+          // to a timeout exception
+          Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request timeout, returning "BackendTimeout" status.`);
+          return this.errorResponse(PresentationStatus.BackendTimeout);
+        }
+        // ...or an error that we don't want to reveal - let RPC system handle it.
+        throw e;
       })
       .then((response: PresentationRpcResponseData<TResult>) => {
         if (response.statusCode !== PresentationStatus.BackendTimeout) {
           Logger.logTrace(PresentationBackendLoggerCategory.Rpc, `Request completed, returning result.`);
           this._pendingRequests.deleteValue(requestKey);
         }
-        clearTimeout(timeout);
         return response;
+      })
+      .finally(() => {
+        clearTimeout(timeout);
       });
   }
 

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -497,7 +497,7 @@ describe("PresentationManager", () => {
       const nativePlatformMock = moq.Mock.ofType<NativePlatformDefinition>();
       const manager = new PresentationManager({ addon: nativePlatformMock.object });
       manager.dispose();
-      expect(() => manager.getNativePlatform()).to.throw(PresentationError);
+      expect(() => manager.getNativePlatform()).to.throw(Error);
     });
   });
 


### PR DESCRIPTION
For security reasons we don't want the backend's error response to contain any details about the error. The RPC implementation was converting all errors to a 200 response containing the error message. Now we only do that for `PresentationError` errors, which contain errors that we want to return (e.g. "invalid element id", or "unknown presentation rule", etc.). The generic `Error` errors are just re-thrown to the RPC system, where they can be handled in a generic way.