### PR TITLE
Enable `useDefineForClassFields` TS flag

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -290,14 +290,14 @@ export abstract class AuxCoordSystem extends DefinitionElement {
     // (undocumented)
     description?: string;
     // (undocumented)
-    type: number;
+    type?: number;
 }
 
 // @public
 export class AuxCoordSystem2d extends AuxCoordSystem {
     constructor(props: AuxCoordSystem2dProps, iModel: IModelDb);
     // (undocumented)
-    angle: number;
+    angle?: number;
     // (undocumented)
     static get className(): string;
     static createCode(iModel: IModelDb, scopeModelId: CodeScopeProps, codeValue: string): Code;
@@ -314,11 +314,11 @@ export class AuxCoordSystem3d extends AuxCoordSystem {
     // (undocumented)
     origin?: Point3d;
     // (undocumented)
-    pitch: number;
+    pitch?: number;
     // (undocumented)
-    roll: number;
+    roll?: number;
     // (undocumented)
-    yaw: number;
+    yaw?: number;
 }
 
 // @public
@@ -3811,7 +3811,7 @@ export class LightLocation extends SpatialLocationElement {
     protected constructor(props: LightLocationProps, iModel: IModelDb);
     // (undocumented)
     static get className(): string;
-    enabled: boolean;
+    enabled?: boolean;
 }
 
 // @public
@@ -4246,7 +4246,7 @@ export class Model extends Entity {
     // @beta
     protected static onUpdateElement(_arg: OnElementInModelPropsArg): void;
     // (undocumented)
-    readonly parentModel: Id64String;
+    readonly parentModel?: Id64String;
     // @internal (undocumented)
     static get protectedOperations(): string[];
     removeUserProperties(nameSpace: string): void;

--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -1416,8 +1416,6 @@ export class RelationshipClass extends ECClass {
     // (undocumented)
     fromJSONSync(relationshipClassProps: RelationshipClassProps): void;
     // (undocumented)
-    readonly schema: Schema;
-    // (undocumented)
     readonly schemaItemType = SchemaItemType.RelationshipClass;
     // @alpha
     protected setSourceConstraint(source: RelationshipConstraint): void;

--- a/common/changes/@itwin/build-tools/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
+++ b/common/changes/@itwin/build-tools/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "Enabled `useDefineForClassFields` TypeScript config flag",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/common/changes/@itwin/core-backend/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
+++ b/common/changes/@itwin/core-backend/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Changed `Model.parentModel`, `LightLocation.enabled` and some of the `AuxCoordSystem` properties to be optional",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-bentley/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
+++ b/common/changes/@itwin/core-bentley/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-common/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
+++ b/common/changes/@itwin/core-common/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/ecschema-metadata/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
+++ b/common/changes/@itwin/ecschema-metadata/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/common/changes/@itwin/presentation-common/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
+++ b/common/changes/@itwin/presentation-common/gytis-enable-useDefineForClassFields-ts-flag_2025-01-16-11-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -477,6 +477,7 @@ export abstract class GeometricElement extends Element {
     super(props, iModel);
     this.category = Id64.fromJSON(props.category);
     this.geom = props.geom;
+    this.elementGeometryBuilderParams = props.elementGeometryBuilderParams;
   }
 
   /** Type guard for instanceof [[GeometricElement3d]] */
@@ -707,7 +708,10 @@ export abstract class InformationReferenceElement extends InformationContentElem
 export class Subject extends InformationReferenceElement {
   public static override get className(): string { return "Subject"; }
   public description?: string;
-  protected constructor(props: SubjectProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: SubjectProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.description = props.description;
+  }
 
   public override toJSON(): SubjectProps { // This override only specializes the return type
     return super.toJSON() as SubjectProps; // Entity.toJSON takes care of auto-handled properties
@@ -880,7 +884,11 @@ export class SheetBorderTemplate extends Document {
   public static override get className(): string { return "SheetBorderTemplate"; }
   public height?: number;
   public width?: number;
-  protected constructor(props: SheetBorderTemplateProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: SheetBorderTemplateProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.height = props.height;
+    this.width = props.width;
+  }
 }
 
 /** The template for a [[Sheet]]
@@ -892,7 +900,12 @@ export class SheetTemplate extends Document {
   public width?: number;
   public border?: Id64String;
 
-  protected constructor(props: SheetTemplateProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: SheetTemplateProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.height = props.height;
+    this.width = props.width;
+    this.border = props.border;
+  }
 
   protected override collectReferenceIds(referenceIds: EntityReferenceSet): void {
     super.collectReferenceIds(referenceIds);
@@ -1053,7 +1066,10 @@ export abstract class TypeDefinitionElement extends DefinitionElement {
   public static override get className(): string { return "TypeDefinitionElement"; }
   public recipe?: RelatedElement;
 
-  protected constructor(props: TypeDefinitionElementProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: TypeDefinitionElementProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.recipe = this.recipe;
+  }
 
   protected override collectReferenceIds(referenceIds: EntityReferenceSet): void {
     super.collectReferenceIds(referenceIds);
@@ -1252,7 +1268,10 @@ export abstract class InformationPartitionElement extends InformationContentElem
   /** A human-readable string describing the intent of the partition. */
   public description?: string;
 
-  protected constructor(props: InformationPartitionElementProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: InformationPartitionElementProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.description = props.description;
+  }
 
   public override toJSON(): InformationPartitionElementProps { // This override only specializes the return type
     return super.toJSON() as InformationPartitionElementProps; // Entity.toJSON takes care of auto-handled properties
@@ -1483,9 +1502,13 @@ export class GeometryPart extends DefinitionElement {
 export class LineStyle extends DefinitionElement {
   public static override get className(): string { return "LineStyle"; }
   public description?: string;
-  public data!: string;
+  public data: string;
 
-  protected constructor(props: LineStyleProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: LineStyleProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.description = props.description;
+    this.data = props.data;
+  }
 
   /** Create a Code for a LineStyle definition given a name that is meant to be unique within the scope of the specified model.
    * @param iModel The IModel

--- a/core/backend/src/Model.ts
+++ b/core/backend/src/Model.ts
@@ -69,16 +69,18 @@ export class Model extends Entity {
   public static override get className(): string { return "Model"; }
   /** @internal */
   public static override get protectedOperations() { return ["onInsert", "onUpdate", "onDelete"]; }
-  public readonly modeledElement!: RelatedElement;
+  public readonly modeledElement: RelatedElement;
   public readonly name: string;
-  public readonly parentModel!: Id64String;
+  public readonly parentModel?: Id64String;
   public readonly jsonProperties: { [key: string]: any };
   public isPrivate: boolean;
   public isTemplate: boolean;
 
   protected constructor(props: ModelProps, iModel: IModelDb) {
     super(props, iModel);
+    this.modeledElement = new RelatedElement(props.modeledElement);
     this.name = props.name ? props.name : ""; // NB this isn't really a property of Model (it's the code.value of the modeled element), but it comes in ModelProps because it's often needed
+    this.parentModel = props.parentModel;
     this.isPrivate = JsonUtils.asBool(props.isPrivate);
     this.isTemplate = JsonUtils.asBool(props.isTemplate);
     this.jsonProperties = { ...props.jsonProperties }; // make sure we have our own copy
@@ -233,11 +235,14 @@ export class Model extends Entity {
  * @public
  */
 export class GeometricModel extends Model {
-  public geometryGuid?: GuidString; // Initialized by the Entity constructor
+  public geometryGuid?: GuidString;
 
   public static override get className(): string { return "GeometricModel"; }
 
-  protected constructor(props: GeometricModelProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: GeometricModelProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.geometryGuid = props.geometryGuid;
+  }
 
   /** Query for the union of the extents of the elements contained by this model.
    * @note This function blocks the JavaScript event loop. Consider using [[queryRange]] instead.
@@ -293,10 +298,13 @@ export abstract class GeometricModel3d extends GeometricModel {
  */
 export abstract class GeometricModel2d extends GeometricModel {
   /** The actual coordinates of (0,0) in modeling coordinates. An offset applied to all modeling coordinates. */
-  public globalOrigin?: Point2d; // Initialized by the Entity constructor
+  public globalOrigin?: Point2d;
   public static override get className(): string { return "GeometricModel2d"; }
 
-  protected constructor(props: GeometricModel2dProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: GeometricModel2dProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.globalOrigin = props.globalOrigin ? Point2d.fromJSON(props.globalOrigin) : undefined;
+  }
 
   public override toJSON(): GeometricModel2dProps {
     const val = super.toJSON() as GeometricModel2dProps;

--- a/core/backend/src/ViewDefinition.ts
+++ b/core/backend/src/ViewDefinition.ts
@@ -614,9 +614,13 @@ export class TemplateViewDefinition3d extends ViewDefinition3d {
  */
 export abstract class AuxCoordSystem extends DefinitionElement {
   public static override get className(): string { return "AuxCoordSystem"; }
-  public type!: number;
+  public type?: number;
   public description?: string;
-  public constructor(props: AuxCoordSystemProps, iModel: IModelDb) { super(props, iModel); }
+  public constructor(props: AuxCoordSystemProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.type = props.type;
+    this.description = props.description;
+  }
 }
 
 /** A 2d auxiliary coordinate system.
@@ -625,8 +629,12 @@ export abstract class AuxCoordSystem extends DefinitionElement {
 export class AuxCoordSystem2d extends AuxCoordSystem {
   public static override get className(): string { return "AuxCoordSystem2d"; }
   public origin?: Point2d;
-  public angle!: number;
-  public constructor(props: AuxCoordSystem2dProps, iModel: IModelDb) { super(props, iModel); }
+  public angle?: number;
+  public constructor(props: AuxCoordSystem2dProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.origin = props.origin ? Point2d.fromJSON(props.origin) : undefined;
+    this.angle = props.angle ? Angle.fromJSON(props.angle).degrees : undefined;
+  }
 
   /** Create a Code for a AuxCoordSystem2d element given a name that is meant to be unique within the scope of the specified DefinitionModel.
    * @param iModel  The IModelDb
@@ -645,10 +653,16 @@ export class AuxCoordSystem2d extends AuxCoordSystem {
 export class AuxCoordSystem3d extends AuxCoordSystem {
   public static override get className(): string { return "AuxCoordSystem3d"; }
   public origin?: Point3d;
-  public yaw!: number;
-  public pitch!: number;
-  public roll!: number;
-  public constructor(props: AuxCoordSystem3dProps, iModel: IModelDb) { super(props, iModel); }
+  public yaw?: number;
+  public pitch?: number;
+  public roll?: number;
+  public constructor(props: AuxCoordSystem3dProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.origin = props.origin ? Point3d.fromJSON(props.origin) : undefined;
+    this.yaw = props.yaw ? Angle.fromJSON(props.yaw).degrees : undefined;
+    this.pitch = props.pitch ? Angle.fromJSON(props.pitch).degrees : undefined;
+    this.roll = props.roll ? Angle.fromJSON(props.roll).degrees : undefined;
+  }
 
   /** Create a Code for a AuxCoordSystem3d element given a name that is meant to be unique within the scope of the specified DefinitionModel.
    * @param iModel  The IModelDb
@@ -700,7 +714,10 @@ export class ViewAttachment extends GraphicalElement2d {
 export class LightLocation extends SpatialLocationElement {
   public static override get className(): string { return "LightLocation"; }
   /** Whether this light is currently turned on. */
-  public enabled!: boolean;
+  public enabled?: boolean;
 
-  protected constructor(props: LightLocationProps, iModel: IModelDb) { super(props, iModel); }
+  protected constructor(props: LightLocationProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.enabled = props.enabled;
+  }
 }

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -60,7 +60,7 @@ export interface TestRelationshipProps extends RelationshipProps {
 }
 export class TestElementDrivesElement extends ElementDrivesElement {
   public static override get className(): string { return "TestElementDrivesElement"; }
-  public property1!: string;
+  declare public property1: string;
   public static rootChanged = new BeEvent<(props: RelationshipProps, imodel: IModelDb) => void>();
   public static deletedDependency = new BeEvent<(props: RelationshipProps, imodel: IModelDb) => void>();
   public static override onRootChanged(props: RelationshipProps, imodel: IModelDb): void { this.rootChanged.raiseEvent(props, imodel); }
@@ -71,7 +71,7 @@ export interface TestPhysicalObjectProps extends PhysicalElementProps {
 }
 export class TestPhysicalObject extends PhysicalElement {
   public static override get className(): string { return "TestPhysicalObject"; }
-  public intProperty!: number;
+  declare public intProperty: number;
   public static beforeOutputsHandled = new BeEvent<(id: Id64String, imodel: IModelDb) => void>();
   public static allInputsHandled = new BeEvent<(id: Id64String, imodel: IModelDb) => void>();
   public static override onBeforeOutputsHandled(id: Id64String, imodel: IModelDb): void { this.beforeOutputsHandled.raiseEvent(id, imodel); }

--- a/core/bentley/src/test/LRUMap.test.ts
+++ b/core/bentley/src/test/LRUMap.test.ts
@@ -179,12 +179,12 @@ describe("LRUMap", () => {
     c.set("a", 4);
     assert.equal(c.size, 1);
     assert.equal(c.newest, c.oldest);
-    assert.deepEqual(c.newest, { key: "a", value: 4 });
+    assert.deepEqual(c.newest, { key: "a", value: 4, newer: undefined, older: undefined });
 
     c.set("a", 5);
     assert.equal(c.size, 1);
     assert.equal(c.newest, c.oldest);
-    assert.deepEqual(c.newest, { key: "a", value: 5 });
+    assert.deepEqual(c.newest, { key: "a", value: 5, newer: undefined, older: undefined });
 
     c.set("b", 6);
     assert.equal(c.size, 2);

--- a/core/common/src/RpcInterface.ts
+++ b/core/common/src/RpcInterface.ts
@@ -122,7 +122,7 @@ export abstract class RpcInterface {
   }
 
   /** @internal */
-  public configurationSupplier: RpcConfigurationSupplier | undefined;
+  declare public configurationSupplier: RpcConfigurationSupplier | undefined;
 }
 
 RpcInterface.prototype.configurationSupplier = undefined;

--- a/core/ecschema-metadata/src/Metadata/RelationshipClass.ts
+++ b/core/ecschema-metadata/src/Metadata/RelationshipClass.ts
@@ -32,7 +32,6 @@ type AnyConstraintClass = EntityClass | Mixin | RelationshipClass;
  * @beta
  */
 export class RelationshipClass extends ECClass {
-  public override readonly schema!: Schema;
   public override readonly schemaItemType = SchemaItemType.RelationshipClass;
   protected _strength: StrengthType;
   protected _strengthDirection: StrengthDirection;
@@ -122,7 +121,7 @@ export class RelationshipClass extends ECClass {
 
     let strength = parseStrength(relationshipClassProps.strength);
     if (undefined === strength) {
-      if (SchemaReadHelper.isECSpecVersionNewer({readVersion: relationshipClassProps.originalECSpecMajorVersion, writeVersion: relationshipClassProps.originalECSpecMinorVersion} as ECSpecVersion))
+      if (SchemaReadHelper.isECSpecVersionNewer({ readVersion: relationshipClassProps.originalECSpecMajorVersion, writeVersion: relationshipClassProps.originalECSpecMinorVersion } as ECSpecVersion))
         strength = StrengthType.Referencing;
       else
         throw new ECObjectsError(ECObjectsStatus.InvalidStrength, `The RelationshipClass ${this.fullName} has an invalid 'strength' attribute. '${relationshipClassProps.strength}' is not a valid StrengthType.`);
@@ -241,11 +240,11 @@ export class RelationshipConstraint implements CustomAttributeContainerProps {
     if (undefined === this._constraintClasses)
       return;
 
-    this._constraintClasses.forEach( (item, index) => {
+    this._constraintClasses.forEach((item, index) => {
       const constraintName = item.fullName;
-      if(constraintName === constraint.fullName)
+      if (constraintName === constraint.fullName)
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this._constraintClasses?.splice(index,1);
+        this._constraintClasses?.splice(index, 1);
     });
   }
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -25,6 +25,7 @@ Table of contents:
     - [@itwin/core-electron](#itwincore-electron)
   - [API removals](#api-removals)
   - [Packages dropped](#packages-dropped)
+  - [TypeScript configuration changes](#typescript-configuration-changes)
 - [Change to pull/merge method](#change-to-pullmerge)
 
 ## Selection set
@@ -151,13 +152,65 @@ As of iTwin.js 5.0, the following packages have been removed and are no longer a
 | `@itwin/core-webpack-tools`    | We no longer recommend using [webpack](https://webpack.js.org/) and instead recommend using [Vite](https://vite.dev/). |
 | `@itwin/backend-webpack-tools` | We no longer recommend webpack-ing backends, which was previously recommended to shrink the size of backends. |
 
+### TypeScript configuration changes
+
+There are number of changes made to base TypeScript configuration available in `@itwin/build-tools` package.
+
+#### `target`
+
+[`target`](https://www.typescriptlang.org/tsconfig/#target) is now set to `ES2023` instead of `ES2021`.
+
+#### `useDefineForClassFields`
+
+Starting `ES2022`, Typescript compile flag [`useDefineForClassFields`](https://www.typescriptlang.org/tsconfig/#useDefineForClassFields) defaults to `true` ([TypeScript release notes on `useDefineForClassFields` flag](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier)).
+
+This may cause issues for classes which have [Entity]($backend) class as an ancestor and initialize their properties using [Entity]($backend) constructor (note: example uses simplified [Element]($backend) class):
+```ts
+interface MyElementProps extends ElementProps {
+  property: string;
+}
+
+class MyElement extends Element {
+  public property!: string;
+
+  constructor(props: MyElementProps) {
+    super(props);
+  }
+}
+
+const myElement = new MyElement({ property: "value" });
+console.log(myElement.property); // undefined
+```
+
+To fix this, you can either initialize your properties in your class constructor:
+
+```ts
+class MyElement extends Element {
+  public property: string;
+
+  constructor(props: MyElementProps) {
+    super(props);
+    property = props.property;
+  }
+}
+```
+
+or just define your properties using `declare` keyword:
+
+```ts
+class MyElement extends Element {
+  declare public property: string;
+  ...
+}
+```
+
 ### Change to pullMerge
 
 Starting from version 5.x, iTwin.js has transitioned from using the merge method to using the rebase + fastforward method for merging changes. This change is transparent to users and is enabled by default.
 
 #### No pending/local changes
 
-- Incomming changes are applied using "fast-forward" method.
+- Incoming changes are applied using "fast-forward" method.
 
 #### With pending/local changes
 

--- a/presentation/common/src/test/content/Item.test.snap
+++ b/presentation/common/src/test/content/Item.test.snap
@@ -8,6 +8,7 @@ Object {
   },
   "extendedData": undefined,
   "imageId": "70c6cab5-86c7-4d22-b010-6c0cf48d9662",
+  "inputKeys": undefined,
   "labelDefinition": Object {
     "displayValue": "pink",
     "rawValue": "pink",
@@ -29,6 +30,7 @@ Object {
   },
   "extendedData": undefined,
   "imageId": "0ea0e226-a243-44c2-83b1-e941fb2d30c8",
+  "inputKeys": undefined,
   "labelDefinition": Object {
     "displayValue": "Oregon",
     "rawValue": "Toys",
@@ -177,6 +179,7 @@ Array [
     },
     "extendedData": undefined,
     "imageId": "",
+    "inputKeys": undefined,
     "labelDefinition": Object {
       "displayValue": "",
       "rawValue": "",
@@ -200,6 +203,7 @@ Array [
     },
     "extendedData": undefined,
     "imageId": "",
+    "inputKeys": undefined,
     "labelDefinition": Object {
       "displayValue": "",
       "rawValue": "",

--- a/tools/build/tsconfig-base.json
+++ b/tools/build/tsconfig-base.json
@@ -23,7 +23,6 @@
     "strict": true,
     "strictNullChecks": true,
     "stripInternal": false,
-    "useDefineForClassFields": false,
     "target": "ES2023"
   }
 }


### PR DESCRIPTION
TypeScript recommends setting `useDefineForClassFields` to `true` (default value starting ES2022). However, enabling this flag caused several issues. More info: https://github.com/iTwin/itwinjs-core/issues/7474

Additionally, noticed that some TypeScript types are incorrectly defined (e.g. `AuxCoordSystem2d.angle` is defined as `number`, but in reality it can be a `number`, `object` or `undefined`). This PR fixes some of these.