### PR TITLE
Presentation Set up test assets once for the whole test suite rather than for each test

### DIFF
--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -9,10 +9,9 @@
   },
   "private": true,
   "scripts": {
-    "build": "npm run -s copy:locale && tsc 1>&2",
+    "build": "tsc 1>&2",
     "build:watch": "npm run build -- -w",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
-    "copy:locale": "cpx \"./public/**/*\" ./lib/public",
     "docs": "npm run -s extract",
     "extract": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=../../generated-docs/extract",
     "lint": "eslint \"./src/**/*.ts\" 1>&2",

--- a/full-stack-tests/presentation/scripts/setup-tests.js
+++ b/full-stack-tests/presentation/scripts/setup-tests.js
@@ -4,13 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 const chai = require("chai");
+const cpx = require("cpx2");
 const faker = require("faker");
+const fs = require("fs");
 const chaiJestSnapshot = require("chai-jest-snapshot");
 const chaiAsPromised = require("chai-as-promised");
 const sinonChai = require("sinon-chai");
 const chaiSubset = require("chai-subset");
 const jsdom = require("jsdom");
 const sourceMapSupport = require("source-map-support");
+const path = require("path");
 
 console.log(`Backend PID: ${process.pid}`);
 
@@ -30,6 +33,40 @@ chai.use(sinonChai);
 chai.use(chaiSubset);
 
 faker.seed(1);
+
+// Set up assets
+cpx.copySync(`assets/**/*`, "lib/assets");
+cpx.copySync(`public/**/*`, "lib/public");
+copyITwinBackendAssets("lib/assets");
+copyITwinFrontendAssets("lib/public");
+function copyITwinBackendAssets(outputDir) {
+  const iTwinPackagesPath = "node_modules/@itwin";
+  fs.readdirSync(iTwinPackagesPath)
+    .map((packageName) => {
+      const packagePath = path.resolve(iTwinPackagesPath, packageName);
+      return path.join(packagePath, "lib", "cjs", "assets");
+    })
+    .filter((assetsPath) => {
+      return fs.existsSync(assetsPath);
+    })
+    .forEach((src) => {
+      cpx.copySync(`${src}/**/*`, outputDir);
+    });
+}
+function copyITwinFrontendAssets(outputDir) {
+  const iTwinPackagesPath = "node_modules/@itwin";
+  fs.readdirSync(iTwinPackagesPath)
+    .map((packageName) => {
+      const packagePath = path.resolve(iTwinPackagesPath, packageName);
+      return path.join(packagePath, "lib", "public");
+    })
+    .filter((assetsPath) => {
+      return fs.existsSync(assetsPath);
+    })
+    .forEach((src) => {
+      cpx.copySync(`${src}/**/*`, outputDir);
+    });
+}
 
 beforeEach(function () {
   const currentTest = this.currentTest;

--- a/full-stack-tests/presentation/src/IntegrationTests.ts
+++ b/full-stack-tests/presentation/src/IntegrationTests.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import * as cpx from "cpx2";
 import * as fs from "fs";
 import Backend from "i18next-http-backend";
 import * as path from "path";
@@ -46,43 +45,10 @@ function loadEnv(envFile: string) {
 
 loadEnv(path.join(__dirname, "..", ".env"));
 
-const copyITwinBackendAssets = (outputDir: string) => {
-  const iTwinPackagesPath = "node_modules/@itwin";
-  fs.readdirSync(iTwinPackagesPath)
-    .map((packageName) => {
-      const packagePath = path.resolve(iTwinPackagesPath, packageName);
-      return path.join(packagePath, "lib", "cjs", "assets");
-    })
-    .filter((assetsPath) => {
-      return fs.existsSync(assetsPath);
-    })
-    .forEach((src) => {
-      cpx.copySync(`${src}/**/*`, outputDir);
-    });
-};
-
-const copyITwinFrontendAssets = (outputDir: string) => {
-  const iTwinPackagesPath = "node_modules/@itwin";
-  fs.readdirSync(iTwinPackagesPath)
-    .map((packageName) => {
-      const packagePath = path.resolve(iTwinPackagesPath, packageName);
-      return path.join(packagePath, "lib", "public");
-    })
-    .filter((assetsPath) => {
-      return fs.existsSync(assetsPath);
-    })
-    .forEach((src) => {
-      cpx.copySync(`${src}/**/*`, outputDir);
-    });
-};
-
 class IntegrationTestsApp extends NoRenderApp {
   public static override async startup(opts?: IModelAppOptions): Promise<void> {
     await NoRenderApp.startup(opts);
     await IModelApp.localization.changeLanguage("en-PSEUDO");
-    cpx.copySync(`assets/**/*`, "lib/assets");
-    copyITwinBackendAssets("lib/assets");
-    copyITwinFrontendAssets("lib/public");
   }
 }
 


### PR DESCRIPTION
Should reduce test flakiness related to tests attempting to overwrite files that aren't yet released by the OS.