### PR TITLE
Presentation: Don't include undefined in json

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-dont-include-undefined-in-json_2025-01-16-18-04.json
+++ b/common/changes/@itwin/presentation-backend/presentation-dont-include-undefined-in-json_2025-01-16-18-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-dont-include-undefined-in-json_2025-01-16-18-04.json
+++ b/common/changes/@itwin/presentation-common/presentation-dont-include-undefined-in-json_2025-01-16-18-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "When serializing content, don't put `undefined` values to JSON.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/backend/src/test/PresentationManager.test.snap
+++ b/presentation/backend/src/test/PresentationManager.test.snap
@@ -52,19 +52,17 @@ Object {
     "fields": Array [
       Object {
         "category": "test-category",
-        "editor": undefined,
-        "extendedData": undefined,
         "isReadonly": false,
         "label": "Simple Field",
         "name": "Uzbekistan",
         "priority": 0,
-        "renderer": undefined,
         "type": Object {
           "typeName": "string",
           "valueFormat": "Primitive",
         },
       },
     ],
+    "inputKeysHash": "",
     "selectClasses": Array [
       Object {
         "isSelectPolymorphic": false,
@@ -127,19 +125,17 @@ Object {
     "fields": Array [
       Object {
         "category": "test-category",
-        "editor": undefined,
-        "extendedData": undefined,
         "isReadonly": false,
         "label": "Simple Field",
         "name": "Investor",
         "priority": 0,
-        "renderer": undefined,
         "type": Object {
           "typeName": "string",
           "valueFormat": "Primitive",
         },
       },
     ],
+    "inputKeysHash": "",
     "selectClasses": Array [
       Object {
         "isSelectPolymorphic": false,
@@ -202,19 +198,17 @@ Object {
     "fields": Array [
       Object {
         "category": "test-category",
-        "editor": undefined,
-        "extendedData": undefined,
         "isReadonly": false,
         "label": "Simple Field",
         "name": "Virginia",
         "priority": 0,
-        "renderer": undefined,
         "type": Object {
           "typeName": "string",
           "valueFormat": "Primitive",
         },
       },
     ],
+    "inputKeysHash": "",
     "selectClasses": Array [
       Object {
         "isSelectPolymorphic": false,
@@ -275,6 +269,7 @@ Object {
     "contentFlags": 0,
     "displayType": "test",
     "fields": Array [],
+    "inputKeysHash": "",
     "selectClasses": Array [
       Object {
         "isSelectPolymorphic": false,
@@ -335,8 +330,6 @@ Object {
     "fields": Array [
       Object {
         "category": "test-category",
-        "editor": undefined,
-        "extendedData": undefined,
         "isReadonly": false,
         "label": "Properties Field",
         "name": "e-markets",
@@ -350,13 +343,13 @@ Object {
             },
           },
         ],
-        "renderer": undefined,
         "type": Object {
           "typeName": "double",
           "valueFormat": "Primitive",
         },
       },
     ],
+    "inputKeysHash": "",
     "selectClasses": Array [
       Object {
         "isSelectPolymorphic": false,
@@ -419,8 +412,6 @@ Object {
     "fields": Array [
       Object {
         "category": "test-category",
-        "editor": undefined,
-        "extendedData": undefined,
         "isReadonly": false,
         "label": "Properties Field",
         "name": "HTTP",
@@ -434,13 +425,13 @@ Object {
             },
           },
         ],
-        "renderer": undefined,
         "type": Object {
           "typeName": "double",
           "valueFormat": "Primitive",
         },
       },
     ],
+    "inputKeysHash": "",
     "selectClasses": Array [
       Object {
         "isSelectPolymorphic": false,
@@ -503,19 +494,17 @@ Object {
     "fields": Array [
       Object {
         "category": "test-category",
-        "editor": undefined,
-        "extendedData": undefined,
         "isReadonly": false,
         "label": "Not specified",
         "name": "Legacy",
         "priority": 0,
-        "renderer": undefined,
         "type": Object {
           "typeName": "string",
           "valueFormat": "Primitive",
         },
       },
     ],
+    "inputKeysHash": "",
     "selectClasses": Array [
       Object {
         "isSelectPolymorphic": false,
@@ -575,7 +564,6 @@ Object {
           "some_param": 17857,
         },
       },
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "generating",
       "name": "Primitive property field with editor",
@@ -602,7 +590,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -610,8 +597,6 @@ Object {
     },
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": true,
       "label": "bus Strategist Facilitator",
       "name": "Complex array of structs property field",
@@ -630,7 +615,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "memberType": Object {
           "members": Array [
@@ -667,21 +651,16 @@ Object {
       "autoExpand": true,
       "category": "test-category",
       "contentClassInfo": "0x1",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "24/7 Home Loan Account stable",
       "name": "Nested content field",
       "nestedFields": Array [
         Object {
           "category": "test-category",
-          "editor": undefined,
-          "extendedData": undefined,
           "isReadonly": true,
           "label": "Avon Planner Ways",
           "name": "Simple property field",
           "priority": 27093,
-          "renderer": undefined,
           "type": Object {
             "typeName": "string",
             "valueFormat": "Primitive",
@@ -700,7 +679,6 @@ Object {
       ],
       "priority": 77648,
       "relationshipMeaning": "RelatedInstance",
-      "renderer": undefined,
       "type": Object {
         "members": Array [
           Object {
@@ -1325,6 +1303,7 @@ Object {
   "contentFlags": 0,
   "displayType": "",
   "fields": Array [],
+  "inputKeysHash": "",
   "selectClasses": Array [
     Object {
       "isSelectPolymorphic": false,

--- a/presentation/common/src/presentation-common.ts
+++ b/presentation/common/src/presentation-common.ts
@@ -19,7 +19,7 @@ export * from "./presentation-common/RegisteredRuleset";
 export * from "./presentation-common/RulesetVariables";
 export * from "./presentation-common/RulesetsFactory";
 export * from "./presentation-common/Update";
-export * from "./presentation-common/Utils";
+export { DEFAULT_KEYS_BATCH_SIZE, Omit, PagedResponse, PartialBy, Subtract, ValuesDictionary, getInstancesCount } from "./presentation-common/Utils";
 export * from "./presentation-common/PresentationIpcInterface";
 export * from "./presentation-common/LocalizationHelper";
 export * from "./presentation-common/InstanceFilterDefinition";

--- a/presentation/common/src/presentation-common/Utils.ts
+++ b/presentation/common/src/presentation-common/Utils.ts
@@ -83,3 +83,20 @@ export const getInstancesCount = (keys: Readonly<KeySet>): number => {
  * @public
  */
 export const DEFAULT_KEYS_BATCH_SIZE = 5000;
+
+/**
+ * Removes all `undefined` properties from given `obj` object and returns
+ * the same (mutated) object.
+ *
+ * Example: `omitUndefined({ a: 1, b: undefined })` will return `{ a: 1 }`
+ *
+ * @internal
+ */
+export function omitUndefined<T extends object>(obj: T): T {
+  Object.entries(obj).forEach(([key, value]) => {
+    if (value === undefined) {
+      delete obj[key as keyof T];
+    }
+  });
+  return obj;
+}

--- a/presentation/common/src/presentation-common/content/Descriptor.ts
+++ b/presentation/common/src/presentation-common/content/Descriptor.ts
@@ -22,6 +22,7 @@ import { InstanceFilterDefinition } from "../InstanceFilterDefinition";
 import { Ruleset } from "../rules/Ruleset";
 import { CategoryDescription, CategoryDescriptionJSON } from "./Category";
 import { Field, FieldDescriptor, FieldJSON, getFieldByDescriptor, getFieldByName } from "./Fields";
+import { omitUndefined } from "../Utils";
 
 /**
  * Data structure that describes an ECClass in content [[Descriptor]].
@@ -427,27 +428,26 @@ export class Descriptor implements DescriptorSource {
     const classesMap: { [id: string]: CompressedClassInfoJSON } = {};
     const selectClasses: SelectClassInfoJSON<string>[] = this.selectClasses.map((selectClass) => SelectClassInfo.toCompressedJSON(selectClass, classesMap));
     const fields: FieldJSON<string>[] = this.fields.map((field) => field.toCompressedJSON(classesMap));
-    return Object.assign(
-      {
-        displayType: this.displayType,
-        contentFlags: this.contentFlags,
-        categories: this.categories.map(CategoryDescription.toJSON),
-        fields,
-        selectClasses,
-        classesMap,
-      },
-      this.connectionId !== undefined && { connectionId: this.connectionId },
-      this.inputKeysHash !== undefined && { inputKeysHash: this.inputKeysHash },
-      // istanbul ignore next
-      this.contentOptions !== undefined && { contentOptions: this.contentOptions }, // eslint-disable-line @typescript-eslint/no-deprecated
-      this.sortingField !== undefined && { sortingFieldName: this.sortingField.name },
-      this.sortDirection !== undefined && { sortDirection: this.sortDirection },
-      this.filterExpression !== undefined && { filterExpression: this.filterExpression }, // eslint-disable-line @typescript-eslint/no-deprecated
-      this.fieldsFilterExpression !== undefined && { fieldsFilterExpression: this.fieldsFilterExpression },
-      this.instanceFilter !== undefined && { instanceFilter: this.instanceFilter },
-      this.selectionInfo !== undefined && { selectionInfo: this.selectionInfo },
-      this.ruleset !== undefined && { ruleset: this.ruleset },
-    );
+    return omitUndefined({
+      displayType: this.displayType,
+      contentFlags: this.contentFlags,
+      categories: this.categories.map(CategoryDescription.toJSON),
+      fields,
+      selectClasses,
+      classesMap,
+      connectionId: this.connectionId ?? "",
+      inputKeysHash: this.inputKeysHash ?? "",
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      contentOptions: this.contentOptions,
+      sortingFieldName: this.sortingField?.name,
+      sortDirection: this.sortDirection,
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      filterExpression: this.filterExpression,
+      fieldsFilterExpression: this.fieldsFilterExpression,
+      instanceFilter: this.instanceFilter,
+      selectionInfo: this.selectionInfo,
+      ruleset: this.ruleset,
+    });
   }
 
   /** Deserialize [[Descriptor]] from JSON */
@@ -456,16 +456,27 @@ export class Descriptor implements DescriptorSource {
       return undefined;
     }
 
-    const { classesMap, ...leftOverJson } = json;
-    const categories = CategoryDescription.listFromJSON(json.categories);
-    const selectClasses = SelectClassInfo.listFromCompressedJSON(json.selectClasses, classesMap);
-    const fields = this.getFieldsFromJSON(json.fields, (fieldJson) => Field.fromCompressedJSON(fieldJson, classesMap, categories));
+    const {
+      categories: jsonCategories,
+      selectClasses: jsonSelectClasses,
+      fields: jsonFields,
+      connectionId,
+      inputKeysHash,
+      classesMap,
+      sortingFieldName,
+      ...leftOverJson
+    } = json;
+    const categories = CategoryDescription.listFromJSON(jsonCategories);
+    const selectClasses = SelectClassInfo.listFromCompressedJSON(jsonSelectClasses, classesMap);
+    const fields = this.getFieldsFromJSON(jsonFields, (fieldJson) => Field.fromCompressedJSON(fieldJson, classesMap, categories));
     return new Descriptor({
       ...leftOverJson,
+      ...(connectionId ? /* istanbul ignore next */ { connectionId } : undefined),
+      ...(inputKeysHash ? /* istanbul ignore next */ { inputKeysHash } : undefined),
       selectClasses,
       categories,
       fields,
-      sortingField: getFieldByName(fields, json.sortingFieldName, true),
+      sortingField: getFieldByName(fields, sortingFieldName, true),
     });
   }
 

--- a/presentation/common/src/presentation-common/content/Fields.ts
+++ b/presentation/common/src/presentation-common/content/Fields.ts
@@ -26,6 +26,7 @@ import { EditorDescription } from "./Editor";
 import { Property, PropertyJSON } from "./Property";
 import { RendererDescription } from "./Renderer";
 import { TypeDescription } from "./TypeDescription";
+import { omitUndefined } from "../Utils";
 
 /**
  * Data structure for a [[Field]] serialized to JSON.
@@ -40,7 +41,7 @@ export interface BaseFieldJSON {
   priority: number;
   renderer?: RendererDescription;
   editor?: EditorDescription;
-  extendedData?:  { [key: string]: unknown };
+  extendedData?: { [key: string]: unknown };
 }
 
 /**
@@ -145,7 +146,7 @@ export class Field {
   /** Property editor used to edit values of this field */
   public editor?: EditorDescription;
   /** Extended data associated with this field */
-  public extendedData?:  { [key: string]: unknown };
+  public extendedData?: { [key: string]: unknown };
   /** Parent field */
   private _parent?: NestedContentField;
 
@@ -170,7 +171,7 @@ export class Field {
     priority: number,
     editor?: EditorDescription,
     renderer?: RendererDescription,
-    extendedData?: { [key: string] : unknown }
+    extendedData?: { [key: string]: unknown },
   ) {
     this.category = category;
     this.name = name;
@@ -212,7 +213,7 @@ export class Field {
 
   /** Serialize this object to JSON */
   public toJSON(): FieldJSON {
-    return {
+    return omitUndefined({
       category: this.category.name,
       name: this.name,
       label: this.label,
@@ -221,8 +222,8 @@ export class Field {
       priority: this.priority,
       renderer: this.renderer,
       editor: this.editor,
-      extendedData: this.extendedData
-    };
+      extendedData: this.extendedData,
+    });
   }
 
   /** Serialize this object to compressed JSON */
@@ -776,7 +777,7 @@ export class NestedContentField extends Field {
       relationshipMeaning: this.relationshipMeaning,
       actualPrimaryClassIds: this.actualPrimaryClassIds,
       nestedFields: this.nestedFields.map((field: Field) => field.toJSON()),
-      autoExpand: this.autoExpand,
+      ...(this.autoExpand ? { autoExpand: true } : undefined),
     };
   }
 

--- a/presentation/common/src/presentation-common/content/Item.ts
+++ b/presentation/common/src/presentation-common/content/Item.ts
@@ -8,7 +8,7 @@
 
 import { ClassInfo, InstanceKey } from "../EC";
 import { LabelDefinition, LabelDefinitionJSON } from "../LabelDefinition";
-import { ValuesDictionary } from "../Utils";
+import { omitUndefined, ValuesDictionary } from "../Utils";
 import { DisplayValue, DisplayValueJSON, DisplayValuesMapJSON, Value, ValueJSON, ValuesMapJSON } from "./Value";
 
 /**
@@ -85,11 +85,15 @@ export class Item {
   ) {
     this.primaryKeys = primaryKeys;
     this.imageId = imageId; // eslint-disable-line @typescript-eslint/no-deprecated
-    this.classInfo = classInfo;
+    if (classInfo) {
+      this.classInfo = classInfo;
+    }
     this.values = values;
     this.displayValues = displayValues;
     this.mergedFieldNames = mergedFieldNames;
-    this.extendedData = extendedData;
+    if (extendedData) {
+      this.extendedData = extendedData;
+    }
     this.label = typeof label === "string" ? LabelDefinition.fromLabelString(label) : label;
   }
 
@@ -102,16 +106,16 @@ export class Item {
 
   /** Serialize this object to JSON */
   public toJSON(): ItemJSON {
-    const { label, ...baseItem } = this;
-    return {
+    const { label, values, displayValues, ...baseItem } = this;
+    return omitUndefined({
       ...baseItem,
       // eslint-disable-next-line @typescript-eslint/no-deprecated
-      values: Value.toJSON(this.values) as ValuesMapJSON,
+      values: Value.toJSON(values) as ValuesMapJSON,
       // eslint-disable-next-line @typescript-eslint/no-deprecated
-      displayValues: DisplayValue.toJSON(this.displayValues) as DisplayValuesMapJSON,
+      displayValues: DisplayValue.toJSON(displayValues) as DisplayValuesMapJSON,
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       labelDefinition: LabelDefinition.toJSON(label),
-    };
+    });
   }
 
   /** Deserialize [[Item]] from JSON */

--- a/presentation/common/src/test/_helpers/Content.ts
+++ b/presentation/common/src/test/_helpers/Content.ts
@@ -239,7 +239,6 @@ export function createTestNestedContentField(props: {
  */
 export function createTestContentDescriptor(props: Partial<DescriptorSource> & { fields: Field[] }) {
   return new Descriptor({
-    connectionId: "",
     displayType: "",
     contentFlags: 0,
     selectClasses: [createTestSelectClassInfo()],
@@ -252,6 +251,7 @@ export function createTestContentDescriptor(props: Partial<DescriptorSource> & {
  * @internal Used for testing only.
  */
 export function createTestContentItem(props: {
+  inputKeys?: InstanceKey[];
   primaryKeys?: InstanceKey[];
   label?: LabelDefinition | string;
   imageId?: string;
@@ -261,7 +261,7 @@ export function createTestContentItem(props: {
   mergedFieldNames?: string[];
   extendedData?: { [key: string]: any };
 }) {
-  return new Item(
+  const item = new Item(
     props.primaryKeys ?? [createTestECInstanceKey()],
     props.label ?? "",
     props.imageId ?? "",
@@ -271,4 +271,8 @@ export function createTestContentItem(props: {
     props.mergedFieldNames ?? [],
     props.extendedData,
   );
+  if (props.inputKeys) {
+    item.inputKeys = props.inputKeys;
+  }
+  return item;
 }

--- a/presentation/common/src/test/content/Descriptor.test.snap
+++ b/presentation/common/src/test/content/Descriptor.test.snap
@@ -39,13 +39,10 @@ Object {
   "fields": Array [
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Test Simple Field",
       "name": "test-simple-field",
       "priority": 0,
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -53,8 +50,6 @@ Object {
     },
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Test Properties Field",
       "name": "test-properties-field",
@@ -68,7 +63,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -76,13 +70,9 @@ Object {
     },
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "itemsField": Object {
         "category": "test-category",
-        "editor": undefined,
-        "extendedData": undefined,
         "isReadonly": false,
         "label": "Array Items Field",
         "name": "array-items-field",
@@ -96,7 +86,6 @@ Object {
             },
           },
         ],
-        "renderer": undefined,
         "type": Object {
           "typeName": "string",
           "valueFormat": "Primitive",
@@ -114,7 +103,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "memberType": Object {
           "typeName": "string",
@@ -126,15 +114,11 @@ Object {
     },
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Test Struct Properties Field",
       "memberFields": Array [
         Object {
           "category": "test-category",
-          "editor": undefined,
-          "extendedData": undefined,
           "isReadonly": false,
           "label": "Test Struct Member Field",
           "name": "test-struct-member-field",
@@ -148,7 +132,6 @@ Object {
               },
             },
           ],
-          "renderer": undefined,
           "type": Object {
             "typeName": "string",
             "valueFormat": "Primitive",
@@ -166,7 +149,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "members": Array [
           Object {
@@ -184,19 +166,14 @@ Object {
     },
     Object {
       "actualPrimaryClassIds": Array [],
-      "autoExpand": false,
       "category": "test-category",
       "contentClassInfo": "0x2",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Test Nested Content Field",
       "name": "test-nested-content-field",
       "nestedFields": Array [
         Object {
           "category": "test-category",
-          "editor": undefined,
-          "extendedData": undefined,
           "isReadonly": false,
           "label": "Test Nested Properties Field",
           "name": "test-nested-properties-field",
@@ -210,7 +187,6 @@ Object {
               },
             },
           ],
-          "renderer": undefined,
           "type": Object {
             "typeName": "string",
             "valueFormat": "Primitive",
@@ -227,7 +203,6 @@ Object {
       ],
       "priority": 0,
       "relationshipMeaning": "RelatedInstance",
-      "renderer": undefined,
       "type": Object {
         "members": Array [
           Object {
@@ -245,8 +220,6 @@ Object {
     },
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Test Properties Field With Navigation Property Info",
       "name": "test-properties-field-with-navigation-property-info",
@@ -266,7 +239,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "typeName": "navigation",
         "valueFormat": "Primitive",
@@ -363,13 +335,10 @@ Object {
   "fields": Array [
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Simple Field",
       "name": "SimpleField",
       "priority": 0,
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -377,8 +346,6 @@ Object {
     },
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Properties Field",
       "name": "PropertiesField",
@@ -392,7 +359,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -400,24 +366,18 @@ Object {
     },
     Object {
       "actualPrimaryClassIds": Array [],
-      "autoExpand": false,
       "category": "test-category",
       "contentClassInfo": "0x1",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Nested Content",
       "name": "NestedContentField",
       "nestedFields": Array [
         Object {
           "category": "test-category",
-          "editor": undefined,
-          "extendedData": undefined,
           "isReadonly": false,
           "label": "Simple Field",
           "name": "SimpleField",
           "priority": 0,
-          "renderer": undefined,
           "type": Object {
             "typeName": "string",
             "valueFormat": "Primitive",
@@ -436,7 +396,6 @@ Object {
       ],
       "priority": 0,
       "relationshipMeaning": "RelatedInstance",
-      "renderer": undefined,
       "type": Object {
         "members": Array [
           Object {
@@ -455,6 +414,7 @@ Object {
   ],
   "fieldsFilterExpression": "testFilterExpression",
   "filterExpression": "testFilterExpression",
+  "inputKeysHash": "",
   "instanceFilter": Object {
     "expression": "testExpression",
     "relatedInstances": Array [

--- a/presentation/common/src/test/content/Fields.test.snap
+++ b/presentation/common/src/test/content/Fields.test.snap
@@ -3,15 +3,12 @@
 exports[`Field fromJSON creates valid ArrayPropertiesField from valid JSON 1`] = `
 Object {
   "category": "test-category",
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "itemsField": Object {
     "category": "test-category",
     "editor": Object {
       "name": "custom-editor",
     },
-    "extendedData": undefined,
     "isReadonly": false,
     "label": "Properties Field",
     "name": "PropertiesField",
@@ -53,7 +50,6 @@ Object {
       },
     },
   ],
-  "renderer": undefined,
   "type": Object {
     "memberType": Object {
       "typeName": "string",
@@ -68,13 +64,10 @@ Object {
 exports[`Field fromJSON creates valid Field from valid JSON 1`] = `
 Object {
   "category": "test-category",
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Simple Field",
   "name": "SimpleField",
   "priority": 0,
-  "renderer": undefined,
   "type": Object {
     "typeName": "string",
     "valueFormat": "Primitive",
@@ -85,28 +78,22 @@ Object {
 exports[`Field fromJSON creates valid NestedContentField from valid JSON 1`] = `
 Object {
   "actualPrimaryClassIds": Array [],
-  "autoExpand": false,
   "category": "test-category",
   "contentClassInfo": Object {
     "id": "0x1",
     "label": "Class Label",
     "name": "SchemaName:ClassName",
   },
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Nested Content",
   "name": "NestedContentField",
   "nestedFields": Array [
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Simple Field",
       "name": "SimpleField",
       "priority": 0,
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -137,7 +124,6 @@ Object {
   ],
   "priority": 0,
   "relationshipMeaning": "RelatedInstance",
-  "renderer": undefined,
   "type": Object {
     "members": Array [
       Object {
@@ -158,8 +144,6 @@ Object {
 exports[`Field fromJSON creates valid PropertiesField from valid JSON 1`] = `
 Object {
   "category": "test-category",
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Properties Field",
   "name": "PropertiesField",
@@ -177,7 +161,6 @@ Object {
       },
     },
   ],
-  "renderer": undefined,
   "type": Object {
     "typeName": "string",
     "valueFormat": "Primitive",
@@ -188,15 +171,11 @@ Object {
 exports[`Field fromJSON creates valid StructPropertiesField from valid JSON 1`] = `
 Object {
   "category": "test-category",
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Struct Properties Field",
   "memberFields": Array [
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Properties Field",
       "name": "PropertiesField",
@@ -214,7 +193,6 @@ Object {
           },
         },
       ],
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -236,7 +214,6 @@ Object {
       },
     },
   ],
-  "renderer": undefined,
   "type": Object {
     "members": Array [
       Object {
@@ -257,28 +234,23 @@ Object {
 exports[`NestedContentField fromJSON creates valid NestedContentField from valid JSON 1`] = `
 Object {
   "actualPrimaryClassIds": Array [],
-  "autoExpand": false,
+  "autoExpand": true,
   "category": "test-category",
   "contentClassInfo": Object {
     "id": "0x1",
     "label": "Class Label",
     "name": "SchemaName:ClassName",
   },
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Nested Content",
   "name": "NestedContentField",
   "nestedFields": Array [
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Simple Field",
       "name": "SimpleField",
       "priority": 0,
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -309,7 +281,6 @@ Object {
   ],
   "priority": 0,
   "relationshipMeaning": "RelatedInstance",
-  "renderer": undefined,
   "type": Object {
     "members": Array [
       Object {
@@ -330,28 +301,22 @@ Object {
 exports[`NestedContentField fromJSON creates valid NestedContentField from valid JSON with \`relationshipMeaning\` 1`] = `
 Object {
   "actualPrimaryClassIds": Array [],
-  "autoExpand": false,
   "category": "test-category",
   "contentClassInfo": Object {
     "id": "0x1",
     "label": "Class Label",
     "name": "SchemaName:ClassName",
   },
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Nested Content",
   "name": "NestedContentField",
   "nestedFields": Array [
     Object {
       "category": "test-category",
-      "editor": undefined,
-      "extendedData": undefined,
       "isReadonly": false,
       "label": "Simple Field",
       "name": "SimpleField",
       "priority": 0,
-      "renderer": undefined,
       "type": Object {
         "typeName": "string",
         "valueFormat": "Primitive",
@@ -382,7 +347,6 @@ Object {
   ],
   "priority": 0,
   "relationshipMeaning": "SameInstance",
-  "renderer": undefined,
   "type": Object {
     "members": Array [
       Object {
@@ -403,8 +367,6 @@ Object {
 exports[`PropertiesField fromJSON creates valid PropertiesField from valid JSON 1`] = `
 Object {
   "category": "test-category",
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Properties Field",
   "name": "PropertiesField",
@@ -422,7 +384,6 @@ Object {
       },
     },
   ],
-  "renderer": undefined,
   "type": Object {
     "typeName": "string",
     "valueFormat": "Primitive",
@@ -433,8 +394,6 @@ Object {
 exports[`PropertiesField fromJSON creates valid PropertiesField from valid JSON with navigation property 1`] = `
 Object {
   "category": "test-category",
-  "editor": undefined,
-  "extendedData": undefined,
   "isReadonly": false,
   "label": "Properties Field",
   "name": "PropertiesField",
@@ -466,7 +425,6 @@ Object {
       },
     },
   ],
-  "renderer": undefined,
   "type": Object {
     "typeName": "string",
     "valueFormat": "Primitive",

--- a/presentation/common/src/test/content/Fields.test.ts
+++ b/presentation/common/src/test/content/Fields.test.ts
@@ -580,6 +580,7 @@ describe("NestedContentField", () => {
       const json = createTestNestedContentField({
         category,
         nestedFields: [createTestSimpleContentField({ category })],
+        autoExpand: true,
       }).toJSON();
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       const field = NestedContentField.fromJSON(json, [category]);

--- a/presentation/common/src/test/content/Item.test.snap
+++ b/presentation/common/src/test/content/Item.test.snap
@@ -2,11 +2,9 @@
 
 exports[`Item constructor creates valid item with label 1`] = `
 Object {
-  "classInfo": undefined,
   "displayValues": Object {
     "key": "Kina",
   },
-  "extendedData": undefined,
   "imageId": "70c6cab5-86c7-4d22-b010-6c0cf48d9662",
   "labelDefinition": Object {
     "displayValue": "pink",
@@ -23,11 +21,9 @@ Object {
 
 exports[`Item constructor creates valid item with label definition 1`] = `
 Object {
-  "classInfo": undefined,
   "displayValues": Object {
     "key": "Keyboard",
   },
-  "extendedData": undefined,
   "imageId": "0ea0e226-a243-44c2-83b1-e941fb2d30c8",
   "labelDefinition": Object {
     "displayValue": "Oregon",
@@ -171,11 +167,9 @@ Object {
 exports[`Item listFromJSON parses items from JSON 1`] = `
 Array [
   Object {
-    "classInfo": undefined,
     "displayValues": Object {
       "a": "B",
     },
-    "extendedData": undefined,
     "imageId": "",
     "labelDefinition": Object {
       "displayValue": "",
@@ -194,11 +188,9 @@ Array [
     },
   },
   Object {
-    "classInfo": undefined,
     "displayValues": Object {
       "c": "D",
     },
-    "extendedData": undefined,
     "imageId": "",
     "labelDefinition": Object {
       "displayValue": "",

--- a/presentation/common/src/test/content/Item.test.ts
+++ b/presentation/common/src/test/content/Item.test.ts
@@ -65,16 +65,23 @@ describe("Item", () => {
 
     it("creates valid Item from JSON with inputKeys", () => {
       const inputKey = createTestECInstanceKey();
-      const item = Item.fromJSON({
-        primaryKeys: [],
+      const item = createTestContentItem({
         inputKeys: [inputKey],
-        labelDefinition: createRandomLabelDefinition(),
-        imageId: "",
         values: {},
         displayValues: {},
-        mergedFieldNames: [],
       });
-      expect(item?.inputKeys).to.deep.eq([inputKey]);
+      expect(item.inputKeys).to.deep.eq([inputKey]);
+    });
+
+    it("creates valid Item from JSON with extended data", () => {
+      const item = createTestContentItem({
+        extendedData: {
+          x: 123,
+        },
+        values: {},
+        displayValues: {},
+      });
+      expect(item.extendedData).to.deep.eq({ x: 123 });
     });
 
     it("creates valid Item with null values", () => {


### PR DESCRIPTION
https://github.com/iTwin/itwinjs-core/pull/7563 highlighted that we're unnecessarily including `undefined` values to our JSONs, making our responses larger than needed. 