### PR TITLE
Use sas token from recently queried v2 checkpoint incase the one we currently have is expired

### DIFF
--- a/common/changes/@itwin/core-backend/nick-tokencloudsqlitebug_2025-01-21-19-24.json
+++ b/common/changes/@itwin/core-backend/nick-tokencloudsqlitebug_2025-01-21-19-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -199,6 +199,8 @@ export class V2CheckpointManager {
     try {
       const container = this.getContainer(v2props, checkpoint);
       const dbName = v2props.dbName;
+      // Use the new token from the recently queried v2 checkpoint just incase the one we currently have is expired.
+      container.accessToken = v2props.sasToken;
       if (!container.isConnected)
         container.connect(this.cloudCache);
       container.checkForChanges();


### PR DESCRIPTION
I believe fixes bug where:

1)Backend opens v2 checkpoint
2)Backend closes v2 checkpoint
3)time passes and token on that container expires
4) Backend opens v2 checkpoint on same container, gets 403 trying to get new manfiest because it uses the old token. Resulting in BE_SQLITE_CANTOPEN for newer checkpoints. 
