### PR TITLE
More sensible work around for appui keyboard shortcuts only working on Home.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -974,7 +974,6 @@ export class AccuDrawViewportUI extends AccuDraw {
             shadow: string;
         };
     };
-    protected doProcessUnhandledKey(ev: KeyboardEvent, _isDown: boolean): Promise<void>;
     grabInputFocus(): void;
     get hasInputFocus(): boolean;
     onCompassDisplayChange(state: "show" | "hide"): void;

--- a/common/changes/@itwin/core-frontend/accudraw-appui-focus-one-home_2025-01-22-13-17.json
+++ b/common/changes/@itwin/core-frontend/accudraw-appui-focus-one-home_2025-01-22-13-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/AccuDrawViewportUI.ts
+++ b/core/frontend/src/tools/AccuDrawViewportUI.ts
@@ -292,18 +292,7 @@ export class AccuDrawViewportUI extends AccuDraw {
     }
   }
 
-  /**
-   * Provided as a work around to appui keyboard shortcuts currently requiring focus on home.
-   * A sub-class can override of this method to explicity process the shortcuts.
-   * by overriding as follows...
-   * ```ts
-   * super.doProcessUnhandledKey(ev, isDown);
-   * if (isDown)
-   *   UiFramework.keyboardShortcuts.processKey(ev.key, ev.altKey, ev.ctrlKey, ev.shiftKey);
-   * ```
-   * @see [[ToolAdmin.processShortcutKey]]
-   */
-  protected async doProcessUnhandledKey(ev: KeyboardEvent, _isDown: boolean): Promise<void> {
+  private async doProcessUnhandledKey(ev: KeyboardEvent, _isDown: boolean): Promise<void> {
     ev.preventDefault();
   }
 

--- a/docs/learning/frontend/AccuDrawUI.md
+++ b/docs/learning/frontend/AccuDrawUI.md
@@ -204,11 +204,27 @@ For applications that wish to include a settings dialog for the user, a helper m
 
 ### Keyboard Shortcuts
 
+Keyboard shortcuts are essential to using AccuDraw effectively and efficiently. Refer [here](./AccuDrawShortcuts) for information regarding available shortcuts and what they do.
+
 When AccuDraw has input focus and does not handle a KeyboardEvent, the event will be propagated first to the active interactive tool, and then to [ToolAdmin.processShortcutKey]($frontend). This is where applications should test for and run their desired keyboard shortcuts.
 
-Refer [here](./AccuDrawShortcuts) for information regarding available shortcuts and what they do.
+> NOTE: When using keyboard shortcuts from the appui package, they currently requires focus on Home and as such will not work out of the box with [AccuDrawViewportUI]($frontend) when AccuDraw has input focus. To work around this limitation in the appui package, applications should override the implementation of [ToolAdmin.processShortcutKey] from the appui package to remove the focus location check.
 
-> NOTE: When using keyboard shortcuts from the appui package, it currently requires focus on Home and as such will not work out of the box with [AccuDrawViewportUI]($frontend) when AccuDraw has input focus. To work around this limitation in the appui package, refer to the documentation for [AccuDrawViewportUI.doProcessUnhandledKey]($frontend).
+```ts
+export class MyToolAdmin extends FrameworkToolAdmin {
+  public override async processShortcutKey(e: KeyboardEvent, wentDown: boolean): Promise<boolean> {
+    if (!wentDown || UiFramework.isContextMenuOpen || "Escape" === e.key)
+      return false;
+    UiFramework.keyboardShortcuts.processKey(e.key, e.altKey, e.ctrlKey, e.shiftKey);
+    return true;
+  }
+}
+
+iModelApp: {
+  accuDraw: new AccuDrawViewportUI(),
+  toolAdmin: new MyToolAdmin(),
+},
+```
 
 ### Known Issues
 


### PR DESCRIPTION
Actually overriding the problematic method is much better than having a protected method on AccuDraw. Once FrameworkToolAdmin is fixed the app override can just be removed.