### PR TITLE
Fix display-test-app not polyfilling `using` statements

### DIFF
--- a/test-apps/display-performance-test-app/vite.config.mts
+++ b/test-apps/display-performance-test-app/vite.config.mts
@@ -46,7 +46,7 @@ Object.keys(packageJson.dependencies).forEach((pkgName) => {
         .replace("\\lib\\cjs\\", "\\src\\")
         .replace("/lib/cjs/", "/src/")
         .replace(".js", ".ts");
-    } catch { }
+    } catch {}
   }
 });
 
@@ -91,14 +91,14 @@ export default defineConfig(() => {
         plugins: [
           ...(process.env.OUTPUT_STATS !== undefined
             ? [
-              rollupVisualizer({
-                open: true,
-                filename: "stats.html",
-                template: "treemap",
-                sourcemap: true,
-              }),
-              webpackStats(), // needs to be the last plugin
-            ]
+                rollupVisualizer({
+                  open: true,
+                  filename: "stats.html",
+                  template: "treemap",
+                  sourcemap: true,
+                }),
+                webpackStats(), // needs to be the last plugin
+              ]
             : []),
           externalGlobals({
             // allow global `window` object to access electron as external global

--- a/test-apps/display-performance-test-app/vite.config.mts
+++ b/test-apps/display-performance-test-app/vite.config.mts
@@ -46,7 +46,7 @@ Object.keys(packageJson.dependencies).forEach((pkgName) => {
         .replace("\\lib\\cjs\\", "\\src\\")
         .replace("/lib/cjs/", "/src/")
         .replace(".js", ".ts");
-    } catch {}
+    } catch { }
   }
 });
 
@@ -68,6 +68,9 @@ export default defineConfig(() => {
     envPrefix: "IMJS_",
     publicDir: ".static-assets",
     logLevel: process.env.VITE_CI ? "error" : "warn",
+    esbuild: {
+      target: "es2022",
+    },
     build: {
       outDir: "./lib",
       sourcemap: !process.env.VITE_CI, // append to the resulting output file if not running in CI.
@@ -88,14 +91,14 @@ export default defineConfig(() => {
         plugins: [
           ...(process.env.OUTPUT_STATS !== undefined
             ? [
-                rollupVisualizer({
-                  open: true,
-                  filename: "stats.html",
-                  template: "treemap",
-                  sourcemap: true,
-                }),
-                webpackStats(), // needs to be the last plugin
-              ]
+              rollupVisualizer({
+                open: true,
+                filename: "stats.html",
+                template: "treemap",
+                sourcemap: true,
+              }),
+              webpackStats(), // needs to be the last plugin
+            ]
             : []),
           externalGlobals({
             // allow global `window` object to access electron as external global

--- a/test-apps/display-test-app/vite.config.mts
+++ b/test-apps/display-test-app/vite.config.mts
@@ -45,7 +45,7 @@ Object.keys(packageJson.dependencies).forEach((pkgName) => {
         .replace("\\lib\\cjs\\", "\\src\\")
         .replace("/lib/cjs/", "/src/")
         .replace(".js", ".ts");
-    } catch {}
+    } catch { }
   }
 });
 
@@ -67,11 +67,14 @@ export default defineConfig(() => {
     envPrefix: "IMJS_",
     publicDir: ".static-assets",
     logLevel: process.env.VITE_CI ? "error" : "warn",
+    esbuild: {
+      target: "es2022",
+    },
     build: {
       outDir: "./lib",
       sourcemap: !process.env.VITE_CI, // append to the resulting output file if not running in CI.
       minify: false, // disable compaction of source code
-      target: browserslistToEsbuild(), // for browserslist in package.json
+      target: console.log(browserslistToEsbuild()) || browserslistToEsbuild(), // for browserslist in package.json
       commonjsOptions: {
         // plugin to convert CommonJS modules to ESM, so they can be included in bundle
         include: [
@@ -87,14 +90,14 @@ export default defineConfig(() => {
         plugins: [
           ...(process.env.OUTPUT_STATS !== undefined
             ? [
-                rollupVisualizer({
-                  open: true,
-                  filename: "stats.html",
-                  template: "treemap",
-                  sourcemap: true,
-                }),
-                webpackStats(), // needs to be the last plugin
-              ]
+              rollupVisualizer({
+                open: true,
+                filename: "stats.html",
+                template: "treemap",
+                sourcemap: true,
+              }),
+              webpackStats(), // needs to be the last plugin
+            ]
             : []),
           externalGlobals({
             // allow global `window` object to access electron as external global

--- a/test-apps/display-test-app/vite.config.mts
+++ b/test-apps/display-test-app/vite.config.mts
@@ -45,7 +45,7 @@ Object.keys(packageJson.dependencies).forEach((pkgName) => {
         .replace("\\lib\\cjs\\", "\\src\\")
         .replace("/lib/cjs/", "/src/")
         .replace(".js", ".ts");
-    } catch { }
+    } catch {}
   }
 });
 
@@ -74,7 +74,7 @@ export default defineConfig(() => {
       outDir: "./lib",
       sourcemap: !process.env.VITE_CI, // append to the resulting output file if not running in CI.
       minify: false, // disable compaction of source code
-      target: console.log(browserslistToEsbuild()) || browserslistToEsbuild(), // for browserslist in package.json
+      target: browserslistToEsbuild(), // for browserslist in package.json
       commonjsOptions: {
         // plugin to convert CommonJS modules to ESM, so they can be included in bundle
         include: [
@@ -90,14 +90,14 @@ export default defineConfig(() => {
         plugins: [
           ...(process.env.OUTPUT_STATS !== undefined
             ? [
-              rollupVisualizer({
-                open: true,
-                filename: "stats.html",
-                template: "treemap",
-                sourcemap: true,
-              }),
-              webpackStats(), // needs to be the last plugin
-            ]
+                rollupVisualizer({
+                  open: true,
+                  filename: "stats.html",
+                  template: "treemap",
+                  sourcemap: true,
+                }),
+                webpackStats(), // needs to be the last plugin
+              ]
             : []),
           externalGlobals({
             // allow global `window` object to access electron as external global


### PR DESCRIPTION
Looks like #7309 broke display-test-app because Vite was not configured to polyfill `using` statements in dev mode.

CC: @pmconne 