### PR TITLE
update express to resolve GHSA-rhx6-c78j-4q9w

### DIFF
--- a/common/changes/@itwin/certa/cve-GHSA-rhx6-c78j-4q9w_2025-01-27-14-21.json
+++ b/common/changes/@itwin/certa/cve-GHSA-rhx6-c78j-4q9w_2025-01-27-14-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/changes/@itwin/express-server/cve-GHSA-rhx6-c78j-4q9w_2025-01-27-14-21.json
+++ b/common/changes/@itwin/express-server/cve-GHSA-rhx6-c78j-4q9w_2025-01-27-14-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/express-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/express-server"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -690,11 +690,11 @@ importers:
   ../../core/express-server:
     dependencies:
       express:
-        specifier: ^4.20.0
-        version: 4.20.0
+        specifier: ^4.21.2
+        version: 4.21.2
       express-ws:
         specifier: ^5.0.2
-        version: 5.0.2(express@4.20.0)
+        version: 5.0.2(express@4.21.2)
     devDependencies:
       '@itwin/build-tools':
         specifier: workspace:*
@@ -2867,8 +2867,8 @@ importers:
         specifier: ^33.0.0
         version: 33.0.0
       express:
-        specifier: ^4.20.0
-        version: 4.20.0
+        specifier: ^4.21.2
+        version: 4.21.2
       semver:
         specifier: ^7.5.2
         version: 7.5.2
@@ -3580,8 +3580,8 @@ importers:
         specifier: ^9.13.0
         version: 9.13.0
       express:
-        specifier: ^4.20.0
-        version: 4.20.0
+        specifier: ^4.21.2
+        version: 4.21.2
       internal-tools:
         specifier: workspace:*
         version: link:../../tools/internal
@@ -3767,11 +3767,11 @@ importers:
         specifier: ^9.13.0
         version: 9.13.0
       express:
-        specifier: ^4.20.0
-        version: 4.20.0
+        specifier: ^4.21.2
+        version: 4.21.2
       express-ws:
         specifier: ^5.0.2
-        version: 5.0.2(express@4.20.0)
+        version: 5.0.2(express@4.21.2)
       fs-extra:
         specifier: ^8.1.0
         version: 8.1.0
@@ -4124,8 +4124,8 @@ importers:
         specifier: ~1.3.0
         version: 1.3.0
       express:
-        specifier: ^4.20.0
-        version: 4.20.0
+        specifier: ^4.21.2
+        version: 4.21.2
       jsonc-parser:
         specifier: ~2.0.3
         version: 2.0.3
@@ -6712,10 +6712,6 @@ packages:
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
-
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
@@ -7390,10 +7386,6 @@ packages:
     peerDependencies:
       express: ^4.0.0 || ^5.0.0-alpha.1
 
-  express@4.20.0:
-    resolution: {integrity: sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==}
-    engines: {node: '>= 0.10.0'}
-
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
@@ -7468,10 +7460,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  finalhandler@1.2.0:
-    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
-    engines: {node: '>= 0.8'}
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
@@ -9131,9 +9119,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
-
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
@@ -9312,10 +9297,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
-    engines: {node: '>=0.6'}
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -9636,10 +9617,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.18.0:
-    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
-    engines: {node: '>= 0.8.0'}
-
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -9693,10 +9670,6 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
-
-  serve-static@1.16.0:
-    resolution: {integrity: sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==}
-    engines: {node: '>= 0.8.0'}
 
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
@@ -13450,8 +13423,6 @@ snapshots:
 
   cookie-signature@1.0.6: {}
 
-  cookie@0.6.0: {}
-
   cookie@0.7.1: {}
 
   cookie@0.7.2: {}
@@ -14289,47 +14260,13 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  express-ws@5.0.2(express@4.20.0):
+  express-ws@5.0.2(express@4.21.2):
     dependencies:
-      express: 4.20.0
+      express: 4.21.2
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  express@4.20.0:
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.3
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.6.0
-      cookie-signature: 1.0.6
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.2.0
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.10
-      proxy-addr: 2.0.7
-      qs: 6.11.0
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.0
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
 
   express@4.21.2:
     dependencies:
@@ -14434,16 +14371,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  finalhandler@1.2.0:
-    dependencies:
-      debug: 2.6.9
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.1
-      unpipe: 1.0.0
 
   finalhandler@1.3.1:
     dependencies:
@@ -16318,8 +16245,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-to-regexp@0.1.10: {}
-
   path-to-regexp@0.1.12: {}
 
   path-to-regexp@6.3.0: {}
@@ -16472,10 +16397,6 @@ snapshots:
   punycode@1.3.2: {}
 
   punycode@2.3.1: {}
-
-  qs@6.11.0:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.13.0:
     dependencies:
@@ -16830,22 +16751,6 @@ snapshots:
 
   semver@7.6.3: {}
 
-  send@0.18.0:
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -16902,13 +16807,6 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
-
-  serve-static@1.16.0:
-    dependencies:
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 0.18.0
 
   serve-static@1.16.2:
     dependencies:

--- a/core/express-server/package.json
+++ b/core/express-server/package.json
@@ -61,7 +61,7 @@
     "@itwin/core-common": "workspace:*"
   },
   "dependencies": {
-    "express": "^4.20.0",
+    "express": "^4.21.2",
     "express-ws": "^5.0.2"
   },
   "nyc": {

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -27,7 +27,7 @@
     "@itwin/core-mobile": "workspace:*",
     "@itwin/express-server": "workspace:*",
     "electron": "^33.0.0",
-    "express": "^4.20.0",
+    "express": "^4.21.2",
     "semver": "^7.5.2",
     "spdy": "^4.0.1"
   },

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -75,7 +75,7 @@
     "dotenv-expand": "^5.1.0",
     "electron": "^33.0.0",
     "eslint": "^9.13.0",
-    "express": "^4.20.0",
+    "express": "^4.21.2",
     "internal-tools": "workspace:*",
     "npm-run-all": "^4.1.5",
     "null-loader": "^4.0.1",

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -92,7 +92,7 @@
     "dotenv-expand": "^5.1.0",
     "electron": "^33.0.0",
     "eslint": "^9.13.0",
-    "express": "^4.20.0",
+    "express": "^4.21.2",
     "express-ws": "^5.0.2",
     "fs-extra": "^8.1.0",
     "internal-tools": "workspace:*",

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "canonical-path": "^1.0.0",
     "detect-port": "~1.3.0",
-    "express": "^4.20.0",
+    "express": "^4.21.2",
     "jsonc-parser": "~2.0.3",
     "lodash": "^4.17.21",
     "mocha": "^10.2.0",


### PR DESCRIPTION
resolves the following
```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ Unpatched `path-to-regexp` ReDoS in 0.1.x              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ path-to-regexp                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <0.1.12                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=0.1.12                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ ../../core/electron >                                  │
│                     │ @itwin/certa@link:../../tools/certa > express@4.20.0 > │
│                     │ path-to-regexp@0.1.10                                  │
│                     │                                                        │
│                     │ ../../core/express-server > express@4.20.0 >           │
│                     │ path-to-regexp@0.1.10                                  │
│                     │                                                        │
│                     │ ../../core/express-server > express-ws@5.0.2 >         │
│                     │ express@4.20.0 > path-to-regexp@0.1.10                 │
│                     │                                                        │
│                     │ ... Found 27 paths, run `pnpm why path-to-regexp` for  │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-rhx6-c78j-4q9w      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```