### PR TITLE
Presentation: Stop using `Object.create` and `Object.assign`

### DIFF
--- a/common/changes/@itwin/presentation-common/presentation-object-create_2025-01-29-07-11.json
+++ b/common/changes/@itwin/presentation-common/presentation-object-create_2025-01-29-07-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Stop using `Object.create` and `Object.assign` and use proper constructors and operators instead.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/presentation-object-create_2025-01-29-07-11.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-object-create_2025-01-29-07-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/presentation/common/src/presentation-common/content/ContentTraverser.ts
+++ b/presentation/common/src/presentation-common/content/ContentTraverser.ts
@@ -7,6 +7,7 @@
  */
 
 import { assert } from "@itwin/core-bentley";
+import { LabelDefinition } from "../LabelDefinition";
 import { CategoryDescription } from "./Category";
 import { Content } from "./Content";
 import { Descriptor } from "./Descriptor";
@@ -22,7 +23,6 @@ import {
   ValuesArray as PresentationValuesArray,
   ValuesMap as PresentationValuesMap,
 } from "./Value";
-import { LabelDefinition } from "../LabelDefinition";
 
 const NESTED_CONTENT_LABEL_SYMBOL = Symbol();
 
@@ -355,7 +355,7 @@ function traverseContentItemFields(visitor: IContentVisitor, fieldHierarchies: F
 
   try {
     fieldHierarchies.forEach((fieldHierarchy) => {
-      using res = new VisitedCategories(visitor, fieldHierarchy.field.category)
+      using res = new VisitedCategories(visitor, fieldHierarchy.field.category);
       if (res.shouldContinue) {
         traverseContentItemField(visitor, fieldHierarchy, item);
       }
@@ -407,13 +407,15 @@ function traverseContentItemField(visitor: IContentVisitor, fieldHierarchy: Fiel
     } else if (pathUpToField.length > 0) {
       fieldHierarchy = {
         ...fieldHierarchy,
-        field: Object.assign(fieldHierarchy.field.clone(), {
-          type: {
+        field: (function () {
+          const clone = fieldHierarchy.field.clone();
+          clone.type = {
             valueFormat: PropertyValueFormat.Array,
             typeName: `${fieldHierarchy.field.type.typeName}[]`,
             memberType: fieldHierarchy.field.type,
-          },
-        }),
+          };
+          return clone;
+        })(),
       };
     }
 
@@ -506,14 +508,14 @@ function traverseContentItemStructFieldValue(
         // Not finding a member field means we're traversing an ECStruct. We still need to carry member information, so we
         // create a fake field to represent the member
         memberField = {
-          field: new Field(
-            fieldHierarchy.field.category,
-            memberDescription.name,
-            memberDescription.label,
-            memberDescription.type,
-            fieldHierarchy.field.isReadonly,
-            0,
-          ),
+          field: new Field({
+            category: fieldHierarchy.field.category,
+            name: memberDescription.name,
+            label: memberDescription.label,
+            type: memberDescription.type,
+            isReadonly: fieldHierarchy.field.isReadonly,
+            priority: 0,
+          }),
           childFields: [],
         };
       }
@@ -730,16 +732,11 @@ function convertNestedContentItemToStructArrayItem(item: Readonly<Item>, field: 
       nextFieldValues.display.push(nextDisplayValue);
     }
   });
-  const convertedItem = new Item(
-    item.primaryKeys,
-    item.label,
-    item.imageId, // eslint-disable-line @typescript-eslint/no-deprecated
-    item.classInfo,
-    { [nextField.name]: nextFieldValues.raw },
-    { [nextField.name]: nextFieldValues.display },
-    item.mergedFieldNames,
-    item.extendedData,
-  );
+  const convertedItem = new Item({
+    ...item,
+    values: { [nextField.name]: nextFieldValues.raw },
+    displayValues: { [nextField.name]: nextFieldValues.display },
+  });
   return { emptyNestedItem: false, convertedItem };
 }
 
@@ -752,8 +749,9 @@ function convertNestedContentFieldHierarchyToStructArrayHierarchy(fieldHierarchy
     return child;
   });
   const convertedFieldHierarchy: FieldHierarchy = {
-    field: Object.assign(fieldHierarchy.field.clone(), {
-      type: {
+    field: (function () {
+      const clone = fieldHierarchy.field.clone();
+      clone.type = {
         valueFormat: PropertyValueFormat.Array,
         typeName: `${fieldHierarchy.field.type.typeName}[]`,
         memberType: {
@@ -765,8 +763,9 @@ function convertNestedContentFieldHierarchyToStructArrayHierarchy(fieldHierarchy
             type: member.field.type,
           })),
         },
-      } as TypeDescription,
-    }),
+      };
+      return clone;
+    })(),
     childFields: convertedChildFieldHierarchies,
   };
   return convertedFieldHierarchy;
@@ -815,15 +814,11 @@ function convertNestedContentFieldHierarchyItemToStructArrayItem(item: Readonly<
   }
 
   const converted = convertNestedContentValuesToStructArrayValuesRecursive(fieldHierarchy, rawValue);
-  const convertedItem = new Item(
-    item.primaryKeys,
-    item.label,
-    item.imageId, // eslint-disable-line @typescript-eslint/no-deprecated
-    item.classInfo,
-    { [fieldName]: converted.raw },
-    { [fieldName]: converted.display },
-    converted.mergedFieldNames,
-    item.extendedData,
-  );
+  const convertedItem = new Item({
+    ...item,
+    values: { [fieldName]: converted.raw },
+    displayValues: { [fieldName]: converted.display },
+    mergedFieldNames: converted.mergedFieldNames,
+  });
   return { emptyNestedItem: false, convertedItem };
 }

--- a/presentation/common/src/presentation-common/content/Fields.ts
+++ b/presentation/common/src/presentation-common/content/Fields.ts
@@ -21,12 +21,12 @@ import {
 } from "../EC";
 import { PresentationError, PresentationStatus } from "../Error";
 import { RelationshipMeaning } from "../rules/content/modifiers/RelatedPropertiesSpecification";
+import { omitUndefined } from "../Utils";
 import { CategoryDescription } from "./Category";
 import { EditorDescription } from "./Editor";
 import { Property, PropertyJSON } from "./Property";
 import { RendererDescription } from "./Renderer";
 import { TypeDescription } from "./TypeDescription";
-import { omitUndefined } from "../Utils";
 
 /**
  * Data structure for a [[Field]] serialized to JSON.
@@ -123,6 +123,31 @@ function isNestedContentField(field: FieldJSON | Field) {
 }
 
 /**
+ * Props for creating [[Field]].
+ * @public
+ */
+interface FieldProps {
+  /** Category information */
+  category: CategoryDescription;
+  /** Unique name */
+  name: string;
+  /** Display label */
+  label: string;
+  /** Description of this field's values data type */
+  type: TypeDescription;
+  /** Are values in this field read-only */
+  isReadonly: boolean;
+  /** Priority of the field */
+  priority: number;
+  /** Property editor used to edit values of this field */
+  editor?: EditorDescription;
+  /** Property renderer used to render values of this field */
+  renderer?: RendererDescription;
+  /** Extended data associated with this field */
+  extendedData?: { [key: string]: unknown };
+}
+
+/**
  * Describes a single content field. A field is usually represented as a grid column
  * or a property pane row.
  *
@@ -151,7 +176,7 @@ export class Field {
   private _parent?: NestedContentField;
 
   /**
-   * Creates an instance of Field.
+   * Creates an instance of [[Field]].
    * @param category Category information
    * @param name Unique name
    * @param label Display label
@@ -161,6 +186,7 @@ export class Field {
    * @param editor Property editor used to edit values of this field
    * @param renderer Property renderer used to render values of this field
    * @param extendedData Extended data associated with this field
+   * @deprecated in 5.0. Use an overload with [[FieldProps]] instead.
    */
   public constructor(
     category: CategoryDescription,
@@ -172,16 +198,44 @@ export class Field {
     editor?: EditorDescription,
     renderer?: RendererDescription,
     extendedData?: { [key: string]: unknown },
+  );
+  /** Creates an instance of [[Field]]. */
+  public constructor(props: FieldProps);
+  public constructor(
+    categoryOrProps: CategoryDescription | FieldProps,
+    name?: string,
+    label?: string,
+    type?: TypeDescription,
+    isReadonly?: boolean,
+    priority?: number,
+    editor?: EditorDescription,
+    renderer?: RendererDescription,
+    extendedData?: { [key: string]: unknown },
   ) {
-    this.category = category;
-    this.name = name;
-    this.label = label;
-    this.type = type;
-    this.isReadonly = isReadonly;
-    this.priority = priority;
-    this.editor = editor;
-    this.renderer = renderer;
-    this.extendedData = extendedData;
+    /* istanbul ignore next */
+    const props =
+      "category" in categoryOrProps
+        ? categoryOrProps
+        : {
+            category: categoryOrProps,
+            name: name!,
+            label: label!,
+            type: type!,
+            isReadonly: isReadonly!,
+            priority: priority!,
+            editor,
+            renderer,
+            extendedData,
+          };
+    this.category = props.category;
+    this.name = props.name;
+    this.label = props.label;
+    this.type = props.type;
+    this.isReadonly = props.isReadonly;
+    this.priority = props.priority;
+    this.editor = props.editor;
+    this.renderer = props.renderer;
+    this.extendedData = props.extendedData;
   }
 
   /**
@@ -206,7 +260,7 @@ export class Field {
   }
 
   public clone() {
-    const clone = new Field(this.category, this.name, this.label, this.type, this.isReadonly, this.priority, this.editor, this.renderer, this.extendedData);
+    const clone = new Field(this);
     clone.rebuildParentship(this.parent);
     return clone;
   }
@@ -243,8 +297,8 @@ export class Field {
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       return NestedContentField.fromJSON(json, categories);
     }
-    const field = Object.create(Field.prototype);
-    return Object.assign(field, json, {
+    return new Field({
+      ...json,
       category: Field.getCategoryFromFieldJson(json, categories),
     });
   }
@@ -258,17 +312,14 @@ export class Field {
     if (!json) {
       return undefined;
     }
-
     if (isPropertiesField(json)) {
       return PropertiesField.fromCompressedJSON(json, classesMap, categories);
     }
-
     if (isNestedContentField(json)) {
       return NestedContentField.fromCompressedJSON(json, classesMap, categories);
     }
-
-    const field = Object.create(Field.prototype);
-    return Object.assign(field, json, {
+    return new Field({
+      ...json,
       category: Field.getCategoryFromFieldJson(json, categories),
     });
   }
@@ -312,6 +363,15 @@ export class Field {
 }
 
 /**
+ * Props for creating [[PropertiesField]].
+ * @public
+ */
+interface PropertiesFieldProps extends FieldProps {
+  /** A list of properties this field is created from */
+  properties: Property[];
+}
+
+/**
  * Describes a content field that's based on one or more similar
  * EC properties.
  *
@@ -322,7 +382,7 @@ export class PropertiesField extends Field {
   public properties: Property[];
 
   /**
-   * Creates an instance of PropertiesField.
+   * Creates an instance of [[PropertiesField]].
    * @param category Category information
    * @param name Unique name
    * @param label Display label
@@ -332,20 +392,49 @@ export class PropertiesField extends Field {
    * @param properties A list of properties this field is created from
    * @param editor Property editor used to edit values of this field
    * @param renderer Property renderer used to render values of this field
+   * @deprecated in 5.0. Use an overload with [[PropertiesFieldProps]] instead.
    */
   public constructor(
     category: CategoryDescription,
     name: string,
     label: string,
-    description: TypeDescription,
+    type: TypeDescription,
     isReadonly: boolean,
     priority: number,
     properties: Property[],
     editor?: EditorDescription,
     renderer?: RendererDescription,
+  );
+  /** Creates an instance of [[PropertiesField]]. */
+  public constructor(props: PropertiesFieldProps);
+  public constructor(
+    categoryOrProps: CategoryDescription | PropertiesFieldProps,
+    name?: string,
+    label?: string,
+    type?: TypeDescription,
+    isReadonly?: boolean,
+    priority?: number,
+    properties?: Property[],
+    editor?: EditorDescription,
+    renderer?: RendererDescription,
   ) {
-    super(category, name, label, description, isReadonly, priority, editor, renderer);
-    this.properties = properties;
+    /* istanbul ignore next */
+    const props =
+      "category" in categoryOrProps
+        ? categoryOrProps
+        : {
+            category: categoryOrProps,
+            name: name!,
+            label: label!,
+            type: type!,
+            isReadonly: isReadonly!,
+            priority: priority!,
+            editor,
+            renderer,
+            properties: properties!,
+          };
+    super(props);
+    this.properties = props.properties;
   }
 
   /** Is this a an array property field */
@@ -358,17 +447,7 @@ export class PropertiesField extends Field {
   }
 
   public override clone() {
-    const clone = new PropertiesField(
-      this.category,
-      this.name,
-      this.label,
-      this.type,
-      this.isReadonly,
-      this.priority,
-      this.properties,
-      this.editor,
-      this.renderer,
-    );
+    const clone = new PropertiesField(this);
     clone.rebuildParentship(this.parent);
     return clone;
   }
@@ -394,16 +473,14 @@ export class PropertiesField extends Field {
     if (!json) {
       return undefined;
     }
-
     if (isArrayPropertiesField(json)) {
       return ArrayPropertiesField.fromJSON(json, categories);
     }
     if (isStructPropertiesField(json)) {
       return StructPropertiesField.fromJSON(json, categories);
     }
-
-    const field = Object.create(PropertiesField.prototype);
-    return Object.assign(field, json, {
+    return new PropertiesField({
+      ...json,
       category: this.getCategoryFromFieldJson(json, categories),
     });
   }
@@ -423,8 +500,8 @@ export class PropertiesField extends Field {
     if (isStructPropertiesField(json)) {
       return StructPropertiesField.fromCompressedJSON(json, classesMap, categories);
     }
-    const field = Object.create(PropertiesField.prototype);
-    return Object.assign(field, json, {
+    return new PropertiesField({
+      ...json,
       category: this.getCategoryFromFieldJson(json, categories),
       properties: json.properties.map((propertyJson) => fromCompressedPropertyJSON(propertyJson, classesMap)),
     });
@@ -492,26 +569,68 @@ export class PropertiesField extends Field {
 }
 
 /**
+ * Props for creating [[ArrayPropertiesField]].
+ * @public
+ */
+interface ArrayPropertiesFieldProps extends PropertiesFieldProps {
+  itemsField: PropertiesField;
+}
+
+/**
  * Describes a content field that's based on one or more similar EC array properties.
  * @public
  */
 export class ArrayPropertiesField extends PropertiesField {
   public itemsField: PropertiesField;
 
+  /**
+   * Creates an instance of [[ArrayPropertiesField]].
+   * @deprecated in 5.0. Use an overload with [[ArrayPropertiesFieldProps]] instead.
+   */
   public constructor(
     category: CategoryDescription,
     name: string,
     label: string,
-    description: TypeDescription,
+    type: TypeDescription,
     itemsField: PropertiesField,
     isReadonly: boolean,
     priority: number,
     properties: Property[],
     editor?: EditorDescription,
     renderer?: RendererDescription,
+  );
+  /** Creates an instance of [[ArrayPropertiesField]]. */
+  public constructor(props: ArrayPropertiesFieldProps);
+  public constructor(
+    categoryOrProps: CategoryDescription | ArrayPropertiesFieldProps,
+    name?: string,
+    label?: string,
+    type?: TypeDescription,
+    itemsField?: PropertiesField,
+    isReadonly?: boolean,
+    priority?: number,
+    properties?: Property[],
+    editor?: EditorDescription,
+    renderer?: RendererDescription,
   ) {
-    super(category, name, label, description, isReadonly, priority, properties, editor, renderer);
-    this.itemsField = itemsField;
+    /* istanbul ignore next */
+    const props =
+      "category" in categoryOrProps
+        ? categoryOrProps
+        : {
+            category: categoryOrProps,
+            name: name!,
+            label: label!,
+            type: type!,
+            isReadonly: isReadonly!,
+            priority: priority!,
+            editor,
+            renderer,
+            properties: properties!,
+            itemsField: itemsField!,
+          };
+    super(props);
+    this.itemsField = props.itemsField;
   }
 
   public override isArrayPropertiesField(): this is ArrayPropertiesField {
@@ -519,18 +638,7 @@ export class ArrayPropertiesField extends PropertiesField {
   }
 
   public override clone() {
-    const clone = new ArrayPropertiesField(
-      this.category,
-      this.name,
-      this.label,
-      this.type,
-      this.itemsField.clone(),
-      this.isReadonly,
-      this.priority,
-      this.properties,
-      this.editor,
-      this.renderer,
-    );
+    const clone = new ArrayPropertiesField(this);
     clone.rebuildParentship(this.parent);
     return clone;
   }
@@ -553,10 +661,10 @@ export class ArrayPropertiesField extends PropertiesField {
 
   /** Deserialize [[ArrayPropertiesField]] from JSON */
   public static override fromJSON(json: ArrayPropertiesFieldJSON, categories: CategoryDescription[]): ArrayPropertiesField {
-    const field = Object.create(ArrayPropertiesField.prototype);
-    return Object.assign(field, json, {
+    return new ArrayPropertiesField({
+      ...json,
       category: this.getCategoryFromFieldJson(json, categories),
-      itemsField: PropertiesField.fromJSON(json.itemsField, categories),
+      itemsField: PropertiesField.fromJSON(json.itemsField, categories)!,
     });
   }
 
@@ -569,13 +677,21 @@ export class ArrayPropertiesField extends PropertiesField {
     classesMap: { [id: string]: CompressedClassInfoJSON },
     categories: CategoryDescription[],
   ): ArrayPropertiesField {
-    const field = Object.create(ArrayPropertiesField.prototype);
-    return Object.assign(field, json, {
+    return new ArrayPropertiesField({
+      ...json,
       category: this.getCategoryFromFieldJson(json, categories),
       properties: json.properties.map((propertyJson) => fromCompressedPropertyJSON(propertyJson, classesMap)),
-      itemsField: PropertiesField.fromCompressedJSON(json.itemsField, classesMap, categories),
+      itemsField: PropertiesField.fromCompressedJSON(json.itemsField, classesMap, categories)!,
     });
   }
+}
+
+/**
+ * Props for creating [[StructPropertiesField]].
+ * @public
+ */
+interface StructPropertiesFieldProps extends PropertiesFieldProps {
+  memberFields: PropertiesField[];
 }
 
 /**
@@ -585,20 +701,54 @@ export class ArrayPropertiesField extends PropertiesField {
 export class StructPropertiesField extends PropertiesField {
   public memberFields: PropertiesField[];
 
+  /**
+   * Creates an instance of [[StructPropertiesField]].
+   * @deprecated in 5.0. Use an overload with [[StructPropertiesFieldProps]] instead.
+   */
   public constructor(
     category: CategoryDescription,
     name: string,
     label: string,
-    description: TypeDescription,
+    type: TypeDescription,
     memberFields: PropertiesField[],
     isReadonly: boolean,
     priority: number,
     properties: Property[],
     editor?: EditorDescription,
     renderer?: RendererDescription,
+  );
+  /** Creates an instance of [[StructPropertiesField]]. */
+  public constructor(props: StructPropertiesFieldProps);
+  public constructor(
+    categoryOrProps: CategoryDescription | StructPropertiesFieldProps,
+    name?: string,
+    label?: string,
+    type?: TypeDescription,
+    memberFields?: PropertiesField[],
+    isReadonly?: boolean,
+    priority?: number,
+    properties?: Property[],
+    editor?: EditorDescription,
+    renderer?: RendererDescription,
   ) {
-    super(category, name, label, description, isReadonly, priority, properties, editor, renderer);
-    this.memberFields = memberFields;
+    /* istanbul ignore next */
+    const props =
+      "category" in categoryOrProps
+        ? categoryOrProps
+        : {
+            category: categoryOrProps,
+            name: name!,
+            label: label!,
+            type: type!,
+            isReadonly: isReadonly!,
+            priority: priority!,
+            editor,
+            renderer,
+            properties: properties!,
+            memberFields: memberFields!,
+          };
+    super(props);
+    this.memberFields = props.memberFields;
   }
 
   public override isStructPropertiesField(): this is StructPropertiesField {
@@ -606,18 +756,7 @@ export class StructPropertiesField extends PropertiesField {
   }
 
   public override clone() {
-    const clone = new StructPropertiesField(
-      this.category,
-      this.name,
-      this.label,
-      this.type,
-      this.memberFields.map((m) => m.clone()),
-      this.isReadonly,
-      this.priority,
-      this.properties,
-      this.editor,
-      this.renderer,
-    );
+    const clone = new StructPropertiesField(this);
     clone.rebuildParentship(this.parent);
     return clone;
   }
@@ -640,10 +779,10 @@ export class StructPropertiesField extends PropertiesField {
 
   /** Deserialize [[StructPropertiesField]] from JSON */
   public static override fromJSON(json: StructPropertiesFieldJSON, categories: CategoryDescription[]): StructPropertiesField {
-    const field = Object.create(StructPropertiesField.prototype);
-    return Object.assign(field, json, {
+    return new StructPropertiesField({
+      ...json,
       category: this.getCategoryFromFieldJson(json, categories),
-      memberFields: json.memberFields.map((m) => PropertiesField.fromJSON(m, categories)),
+      memberFields: json.memberFields.map((m) => PropertiesField.fromJSON(m, categories)!),
     });
   }
 
@@ -656,13 +795,47 @@ export class StructPropertiesField extends PropertiesField {
     classesMap: { [id: string]: CompressedClassInfoJSON },
     categories: CategoryDescription[],
   ): StructPropertiesField {
-    const field = Object.create(StructPropertiesField.prototype);
-    return Object.assign(field, json, {
+    return new StructPropertiesField({
+      ...json,
       category: this.getCategoryFromFieldJson(json, categories),
       properties: json.properties.map((propertyJson) => fromCompressedPropertyJSON(propertyJson, classesMap)),
-      memberFields: json.memberFields.map((m) => PropertiesField.fromCompressedJSON(m, classesMap, categories)),
+      memberFields: json.memberFields.map((m) => PropertiesField.fromCompressedJSON(m, classesMap, categories)!),
     });
   }
+}
+
+/**
+ * Props for creating [[NestedContentField]].
+ * @public
+ */
+interface NestedContentFieldProps extends FieldProps {
+  /** Information about an ECClass whose properties are nested inside this field */
+  contentClassInfo: ClassInfo;
+  /** Relationship path to [Primary class]($docs/presentation/content/Terminology#primary-class) */
+  pathToPrimaryClass: RelationshipPath;
+  /**
+   * Meaning of the relationship between the [primary class]($docs/presentation/content/Terminology#primary-class)
+   * and content class of this field.
+   *
+   * The value is set up through [[RelatedPropertiesSpecification.relationshipMeaning]] attribute when setting up
+   * presentation rules for creating the content.
+   */
+  relationshipMeaning?: RelationshipMeaning;
+  /**
+   * When content descriptor is requested in a polymorphic fashion, fields get created if at least one of the concrete classes
+   * has it. In certain situations it's necessary to know which concrete classes caused that and this attribute is
+   * here to help.
+   *
+   * **Example:** There's a base class `A` and it has two derived classes `B` and `C` and class `B` has a relationship to class `D`.
+   * When content descriptor is requested for class `A` polymorphically, it's going to contain fields for all properties of class `B`,
+   * class `C` and a nested content field for the `B -> D` relationship. The nested content field's `actualPrimaryClassIds` attribute
+   * will contain ID of class `B`, identifying that only this specific class has the relationship.
+   */
+  actualPrimaryClassIds?: Id64String[];
+  /** Contained nested fields */
+  nestedFields: Field[];
+  /** Flag specifying whether field should be expanded */
+  autoExpand?: boolean;
 }
 
 /**
@@ -700,7 +873,7 @@ export class NestedContentField extends Field {
   public autoExpand?: boolean;
 
   /**
-   * Creates an instance of NestedContentField.
+   * Creates an instance of [[NestedContentField]].
    * @param category Category information
    * @param name Unique name
    * @param label Display label
@@ -714,12 +887,13 @@ export class NestedContentField extends Field {
    * @param autoExpand Flag specifying whether field should be expanded
    * @param relationshipMeaning RelationshipMeaning of the field
    * @param renderer Property renderer used to render values of this field
+   * @deprecated in 5.0. Use an overload with [[NestedContentFieldProps]] instead.
    */
   public constructor(
     category: CategoryDescription,
     name: string,
     label: string,
-    description: TypeDescription,
+    type: TypeDescription,
     isReadonly: boolean,
     priority: number,
     contentClassInfo: ClassInfo,
@@ -728,33 +902,55 @@ export class NestedContentField extends Field {
     editor?: EditorDescription,
     autoExpand?: boolean,
     renderer?: RendererDescription,
+  );
+  /** Creates an instance of [[NestedContentField]]. */
+  public constructor(props: NestedContentFieldProps);
+  public constructor(
+    categoryOrProps: CategoryDescription | NestedContentFieldProps,
+    name?: string,
+    label?: string,
+    type?: TypeDescription,
+    isReadonly?: boolean,
+    priority?: number,
+    contentClassInfo?: ClassInfo,
+    pathToPrimaryClass?: RelationshipPath,
+    nestedFields?: Field[],
+    editor?: EditorDescription,
+    autoExpand?: boolean,
+    renderer?: RendererDescription,
   ) {
-    super(category, name, label, description, isReadonly, priority, editor, renderer);
-    this.contentClassInfo = contentClassInfo;
-    this.pathToPrimaryClass = pathToPrimaryClass;
-    this.relationshipMeaning = RelationshipMeaning.RelatedInstance;
-    this.nestedFields = nestedFields;
-    this.autoExpand = autoExpand;
-    this.actualPrimaryClassIds = [];
+    /* istanbul ignore next */
+    const props =
+      "category" in categoryOrProps
+        ? categoryOrProps
+        : {
+            category: categoryOrProps,
+            name: name!,
+            label: label!,
+            type: type!,
+            isReadonly: isReadonly!,
+            priority: priority!,
+            editor,
+            renderer,
+            contentClassInfo: contentClassInfo!,
+            pathToPrimaryClass: pathToPrimaryClass!,
+            nestedFields: nestedFields!,
+            autoExpand,
+          };
+    super(props);
+    this.contentClassInfo = props.contentClassInfo;
+    this.pathToPrimaryClass = props.pathToPrimaryClass;
+    this.relationshipMeaning = props.relationshipMeaning ?? RelationshipMeaning.RelatedInstance;
+    this.nestedFields = props.nestedFields;
+    this.autoExpand = props.autoExpand;
+    this.actualPrimaryClassIds = props.actualPrimaryClassIds ?? [];
   }
 
   public override clone() {
-    const clone = new NestedContentField(
-      this.category,
-      this.name,
-      this.label,
-      this.type,
-      this.isReadonly,
-      this.priority,
-      this.contentClassInfo,
-      this.pathToPrimaryClass,
-      this.nestedFields.map((n) => n.clone()),
-      this.editor,
-      this.autoExpand,
-      this.renderer,
-    );
-    clone.actualPrimaryClassIds = this.actualPrimaryClassIds;
-    clone.relationshipMeaning = this.relationshipMeaning;
+    const clone = new NestedContentField({
+      ...this,
+      nestedFields: this.nestedFields.map((n) => n.clone()),
+    });
     clone.rebuildParentship(this.parent);
     return clone;
   }
@@ -801,9 +997,9 @@ export class NestedContentField extends Field {
     if (!json) {
       return undefined;
     }
-
-    const field = Object.create(NestedContentField.prototype);
-    return Object.assign(field, json, this.fromCommonJSON(json, categories), {
+    return new NestedContentField({
+      ...json,
+      ...this.fromCommonJSON(json, categories),
       nestedFields: json.nestedFields
         .map((nestedFieldJson: FieldJSON) => Field.fromJSON(nestedFieldJson, categories))
         .filter((nestedField): nestedField is Field => !!nestedField),
@@ -817,8 +1013,9 @@ export class NestedContentField extends Field {
     categories: CategoryDescription[],
   ) {
     assert(classesMap.hasOwnProperty(json.contentClassInfo));
-    const field = Object.create(NestedContentField.prototype);
-    return Object.assign(field, json, this.fromCommonJSON(json, categories), {
+    return new NestedContentField({
+      ...json,
+      ...this.fromCommonJSON(json, categories),
       category: this.getCategoryFromFieldJson(json, categories),
       nestedFields: json.nestedFields
         .map((nestedFieldJson: FieldJSON) => Field.fromCompressedJSON(nestedFieldJson, classesMap, categories))
@@ -829,7 +1026,7 @@ export class NestedContentField extends Field {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated
-  private static fromCommonJSON(json: NestedContentFieldJSON<ClassInfoJSON | string>, categories: CategoryDescription[]): Partial<NestedContentField> {
+  private static fromCommonJSON(json: NestedContentFieldJSON<ClassInfoJSON | string>, categories: CategoryDescription[]) {
     return {
       category: this.getCategoryFromFieldJson(json, categories),
       relationshipMeaning: json.relationshipMeaning ?? RelationshipMeaning.RelatedInstance,

--- a/presentation/common/src/presentation-common/content/Item.ts
+++ b/presentation/common/src/presentation-common/content/Item.ts
@@ -9,7 +9,7 @@
 import { ClassInfo, InstanceKey } from "../EC";
 import { LabelDefinition, LabelDefinitionJSON } from "../LabelDefinition";
 import { omitUndefined, ValuesDictionary } from "../Utils";
-import { DisplayValue, DisplayValueJSON, DisplayValuesMapJSON, Value, ValueJSON, ValuesMapJSON } from "./Value";
+import { DisplayValue, DisplayValueJSON, DisplayValuesMap, DisplayValuesMapJSON, Value, ValueJSON, ValuesMap, ValuesMapJSON } from "./Value";
 
 /**
  * Serialized [[Item]] JSON representation.
@@ -28,6 +28,21 @@ export interface ItemJSON {
   values: ValuesDictionary<ValueJSON>;
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   displayValues: ValuesDictionary<DisplayValueJSON>;
+  mergedFieldNames: string[];
+  extendedData?: { [key: string]: any };
+}
+
+/**
+ * Props for creating [[Item]].
+ * @public
+ */
+interface ItemProps {
+  inputKeys?: InstanceKey[];
+  primaryKeys: InstanceKey[];
+  label: LabelDefinition;
+  classInfo?: ClassInfo;
+  values: ValuesDictionary<Value>;
+  displayValues: ValuesDictionary<DisplayValue>;
   mergedFieldNames: string[];
   extendedData?: { [key: string]: any };
 }
@@ -72,6 +87,7 @@ export class Item {
    * @param displayValues Display values dictionary
    * @param mergedFieldNames List of field names whose values are merged (see [Merging values]($docs/presentation/content/Terminology#value-merging))
    * @param extendedData Extended data injected into this content item
+   * @deprecated in 5.0. Use an overload with [[ItemProps]] instead.
    */
   public constructor(
     primaryKeys: InstanceKey[],
@@ -82,19 +98,44 @@ export class Item {
     displayValues: ValuesDictionary<DisplayValue>,
     mergedFieldNames: string[],
     extendedData?: { [key: string]: any },
+  );
+  public constructor(props: ItemProps);
+  public constructor(
+    primaryKeysOrProps: ItemProps | InstanceKey[],
+    label?: string | LabelDefinition,
+    imageId?: string,
+    classInfo?: ClassInfo | undefined,
+    values?: ValuesDictionary<Value>,
+    displayValues?: ValuesDictionary<DisplayValue>,
+    mergedFieldNames?: string[],
+    extendedData?: { [key: string]: any },
   ) {
-    this.primaryKeys = primaryKeys;
-    this.imageId = imageId; // eslint-disable-line @typescript-eslint/no-deprecated
-    if (classInfo) {
-      this.classInfo = classInfo;
+    /* istanbul ignore next */
+    const props = Array.isArray(primaryKeysOrProps)
+      ? {
+          primaryKeys: primaryKeysOrProps,
+          label: typeof label === "string" ? LabelDefinition.fromLabelString(label) : label!,
+          imageId: imageId!,
+          classInfo,
+          values: values!,
+          displayValues: displayValues!,
+          mergedFieldNames: mergedFieldNames!,
+          extendedData,
+        }
+      : primaryKeysOrProps;
+
+    if ("inputKeys" in props) {
+      this.inputKeys = props.inputKeys;
     }
-    this.values = values;
-    this.displayValues = displayValues;
-    this.mergedFieldNames = mergedFieldNames;
-    if (extendedData) {
-      this.extendedData = extendedData;
-    }
-    this.label = typeof label === "string" ? LabelDefinition.fromLabelString(label) : label;
+    this.primaryKeys = props.primaryKeys;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    this.imageId = "imageId" in props ? props.imageId : "";
+    this.classInfo = props.classInfo;
+    this.values = props.values;
+    this.displayValues = props.displayValues;
+    this.mergedFieldNames = props.mergedFieldNames;
+    this.extendedData = props.extendedData;
+    this.label = props.label;
   }
 
   /**
@@ -126,16 +167,17 @@ export class Item {
     if (typeof json === "string") {
       return JSON.parse(json, (key, value) => Item.reviver(key, value));
     }
-    const item = Object.create(Item.prototype);
-    const { labelDefinition, ...baseJson } = json;
-    return Object.assign(item, baseJson, {
+    const { labelDefinition, values, displayValues, ...baseJson } = json;
+
+    return new Item({
+      ...baseJson,
       // eslint-disable-next-line @typescript-eslint/no-deprecated
-      values: Value.fromJSON(json.values),
+      values: Value.fromJSON(values) as ValuesMap,
       // eslint-disable-next-line @typescript-eslint/no-deprecated
-      displayValues: DisplayValue.fromJSON(json.displayValues),
+      displayValues: DisplayValue.fromJSON(displayValues) as DisplayValuesMap,
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       label: LabelDefinition.fromJSON(labelDefinition),
-    } as Partial<Item>);
+    });
   }
 
   /**

--- a/presentation/common/src/test/ElementProperties.test.ts
+++ b/presentation/common/src/test/ElementProperties.test.ts
@@ -97,7 +97,7 @@ describe("buildElementProperties", () => {
     ).to.deep.eq({
       class: "",
       id: "0x1",
-      label: "",
+      label: "test display value",
       items: {
         ["Parent Category"]: {
           type: "category",
@@ -150,7 +150,7 @@ describe("buildElementProperties", () => {
     ).to.deep.eq({
       class: "",
       id: "0x1",
-      label: "",
+      label: "test display value",
       items: {
         ["Test Category"]: {
           type: "category",
@@ -194,7 +194,7 @@ describe("buildElementProperties", () => {
     ).to.deep.eq({
       class: "",
       id: "0x1",
-      label: "",
+      label: "test display value",
       items: {},
     });
   });
@@ -221,7 +221,7 @@ describe("buildElementProperties", () => {
     ).to.deep.eq({
       class: "",
       id: "0x1",
-      label: "",
+      label: "test display value",
       items: {
         ["Test Category"]: {
           type: "category",
@@ -291,7 +291,7 @@ describe("buildElementProperties", () => {
     ).to.deep.eq({
       class: "",
       id: "0x1",
-      label: "",
+      label: "test display value",
       items: {
         ["Test Category"]: {
           type: "category",
@@ -350,7 +350,7 @@ describe("buildElementProperties", () => {
     ).to.deep.eq({
       class: "",
       id: "0x1",
-      label: "",
+      label: "test display value",
       items: {
         ["Test Category"]: {
           type: "category",
@@ -424,7 +424,7 @@ describe("buildElementProperties", () => {
     ).to.deep.eq({
       class: "",
       id: "0x1",
-      label: "",
+      label: "test display value",
       items: {
         ["Test Category"]: {
           type: "category",

--- a/presentation/common/src/test/LocalizationHelper.test.ts
+++ b/presentation/common/src/test/LocalizationHelper.test.ts
@@ -6,7 +6,6 @@
 import { expect } from "chai";
 import { ArrayPropertiesField, NestedContentField, NodePathElement, StructPropertiesField } from "../presentation-common";
 import { Content } from "../presentation-common/content/Content";
-import { Item } from "../presentation-common/content/Item";
 import { DisplayValueGroup, NavigationPropertyValue } from "../presentation-common/content/Value";
 import { LabelCompositeValue, LabelDefinition } from "../presentation-common/LabelDefinition";
 import { LocalizationHelper } from "../presentation-common/LocalizationHelper";
@@ -268,8 +267,12 @@ describe("LocalizationHelper", () => {
     });
 
     it("does not translate content item non-translatable value", () => {
-      const contentItem = new Item([], createTestLabelDefinition(), "", undefined, {}, {}, []);
-      contentItem.values.property = 10;
+      const contentItem = createTestContentItem({
+        values: {
+          property: 10,
+        },
+        displayValues: {},
+      });
       const content = new Content(createTestContentDescriptor({ fields: [] }), [contentItem]);
       const result = localizationHelper.getLocalizedContent(content);
       expect(result.contentSet[0].values.property).to.be.eq(10);
@@ -326,7 +329,7 @@ describe("LocalizationHelper", () => {
     });
 
     it("translates content descriptor category label & description", () => {
-      const contentItem = new Item([], createTestLabelDefinition(), "", undefined, {}, {}, []);
+      const contentItem = createTestContentItem({ values: {}, displayValues: {} });
       const testCategory = createTestCategoryDescription({
         label: "@namespace:LocalizedLabel@",
         description: "@namespace:LocalizedDescription@",

--- a/presentation/common/src/test/RulesetsFactory.test.ts
+++ b/presentation/common/src/test/RulesetsFactory.test.ts
@@ -9,12 +9,7 @@ import {
   ArrayTypeDescription,
   ClassInfo,
   ContentSpecificationTypes,
-  Field,
-  Item,
-  NestedContentField,
-  NestedContentValue,
   PrimitiveTypeDescription,
-  PropertiesField,
   Property,
   PropertyValueFormat,
   RelatedClassInfo,
@@ -24,8 +19,9 @@ import {
   RuleTypes,
   StructTypeDescription,
 } from "../presentation-common";
-import { createTestCategoryDescription } from "./_helpers/Content";
-import { createRandomECClassInfo, createRandomId } from "./_helpers/random";
+import { createTestPropertyInfo } from "./_helpers";
+import { createTestContentItem, createTestNestedContentField, createTestPropertiesContentField, createTestSimpleContentField } from "./_helpers/Content";
+import { createRandomId } from "./_helpers/random";
 
 describe("RulesetsFactory", () => {
   let factory: RulesetsFactory;
@@ -88,16 +84,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createStringTypeDescription(), true, 1, [property]);
-      const record = new Item(
-        [],
-        faker.random.word(),
-        "",
-        recordClass,
-        { ["MyProperty"]: `test value with double "quotes"` },
-        { ["MyProperty"]: "test display value" },
-        [],
-      );
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createStringTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: `test value with double "quotes"` },
+        displayValues: { ["MyProperty"]: "test display value" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -129,8 +126,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createBooleanTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: true }, { ["MyProperty"]: "True" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createBooleanTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: true },
+        displayValues: { ["MyProperty"]: "True" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -162,8 +168,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createBooleanTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: false }, { ["MyProperty"]: "False" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createBooleanTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: false },
+        displayValues: { ["MyProperty"]: "False" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -195,8 +210,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createIntTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: 123 }, { ["MyProperty"]: "123" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createIntTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: 123 },
+        displayValues: { ["MyProperty"]: "123" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -228,8 +252,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createDoubleTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: 123.456 }, { ["MyProperty"]: "123.46" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createDoubleTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: 123.456 },
+        displayValues: { ["MyProperty"]: "123.46" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -261,16 +294,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createDateTimeTypeDescription(), true, 1, [property]);
-      const record = new Item(
-        [],
-        faker.random.word(),
-        "",
-        recordClass,
-        { ["MyProperty"]: "2007-07-13T07:18:07.000" },
-        { ["MyProperty"]: "633199078870000000" },
-        [],
-      );
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createDateTimeTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: "2007-07-13T07:18:07.000" },
+        displayValues: { ["MyProperty"]: "633199078870000000" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -302,8 +336,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createPoint2dTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: { x: 1, y: 2 } }, { ["MyProperty"]: "1, 2" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createPoint2dTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: { x: 1, y: 2 } },
+        displayValues: { ["MyProperty"]: "1, 2" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -335,8 +378,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createPoint2dTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: { x: 0, y: 0 } }, { ["MyProperty"]: "0, 0" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createPoint2dTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: { x: 0, y: 0 } },
+        displayValues: { ["MyProperty"]: "0, 0" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -368,8 +420,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createPoint3dTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: { x: 1, y: 2, z: 3 } }, { ["MyProperty"]: "1, 2, 3" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createPoint3dTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: { x: 1, y: 2, z: 3 } },
+        displayValues: { ["MyProperty"]: "1, 2, 3" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -401,8 +462,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createPoint3dTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: { x: 1, y: 2, z: 0 } }, { ["MyProperty"]: "1, 2, 0" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createPoint3dTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: { x: 1, y: 2, z: 0 } },
+        displayValues: { ["MyProperty"]: "1, 2, 0" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -434,8 +504,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createStringTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: undefined }, { ["MyProperty"]: "" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createStringTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: undefined },
+        displayValues: { ["MyProperty"]: "" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -467,18 +546,17 @@ describe("RulesetsFactory", () => {
           name: "MyProperty",
         },
       };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createNavigationPropertyTypeDescription(), true, 1, [
-        property,
-      ]);
-      const record = new Item(
-        [],
-        faker.random.word(),
-        "",
-        recordClass,
-        { ["MyProperty"]: { className: "MySchema:MyClass", id: "0x16" } },
-        { ["MyProperty"]: "test display value" },
-        [],
-      );
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createNavigationPropertyTypeDescription(),
+        properties: [property],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: { className: "MySchema:MyClass", id: "0x16" } },
+        displayValues: { ["MyProperty"]: "test display value" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -522,48 +600,44 @@ describe("RulesetsFactory", () => {
           isPolymorphicTargetClass: true,
         },
       ];
-      const property: Property = {
-        property: {
-          classInfo: propertyClass,
-          type: "string",
-          name: "MyProperty",
-        },
-      };
-      const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), "Related Property", createStringTypeDescription(), true, 1, [
-        property,
-      ]);
-      const parentField = new NestedContentField(
-        createTestCategoryDescription(),
-        faker.random.word(),
-        faker.random.words(),
-        createStringTypeDescription(),
-        faker.random.boolean(),
-        faker.random.number(),
-        createRandomECClassInfo(),
-        relationshipPath,
-        [field],
-        undefined,
-        faker.random.boolean(),
-      );
-      field.rebuildParentship(parentField);
-      const values = {
-        [parentField.name]: [
+      const field = createTestPropertiesContentField({
+        name: "RelatedProperty",
+        label: "Related Property",
+        type: createStringTypeDescription(),
+        properties: [
           {
-            primaryKeys: [],
-            values: {
-              [field.name]: "test value",
+            property: {
+              classInfo: propertyClass,
+              type: "string",
+              name: "MyProperty",
             },
-            displayValues: {
-              [field.name]: "test display value",
-            },
-            mergedFieldNames: [],
           },
-        ] as NestedContentValue[],
-      };
-      const displayValues = {
-        [field.name]: undefined,
-      };
-      const record = new Item([], faker.random.words(), "", recordClass, values, displayValues, []);
+        ],
+      });
+      const parentField = createTestNestedContentField({
+        pathToPrimaryClass: relationshipPath,
+        nestedFields: [field],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: {
+          [parentField.name]: [
+            {
+              primaryKeys: [],
+              values: {
+                [field.name]: "test value",
+              },
+              displayValues: {
+                [field.name]: "test display value",
+              },
+              mergedFieldNames: [],
+            },
+          ],
+        },
+        displayValues: {
+          [field.name]: undefined,
+        },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -619,48 +693,45 @@ describe("RulesetsFactory", () => {
           isPolymorphicTargetClass: true,
         },
       ];
-      const property: Property = {
-        property: {
-          classInfo: propertyClass,
-          type: "string",
-          name: "RelatedProperty",
-        },
-      };
-      const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), "Related Property", createStringTypeDescription(), true, 1, [
-        property,
-      ]);
-      const parentField = new NestedContentField(
-        createTestCategoryDescription(),
-        faker.random.word(),
-        faker.random.words(),
-        createStringTypeDescription(),
-        faker.random.boolean(),
-        faker.random.number(),
-        createRandomECClassInfo(),
-        relationshipPath,
-        [field],
-        undefined,
-        faker.random.boolean(),
-      );
-      field.rebuildParentship(parentField);
-      const values = {
-        [parentField.name]: [
+
+      const field = createTestPropertiesContentField({
+        name: "RelatedProperty",
+        label: "Related Property",
+        type: createStringTypeDescription(),
+        properties: [
           {
-            primaryKeys: [],
-            values: {
-              [field.name]: "test value",
+            property: {
+              classInfo: propertyClass,
+              type: "string",
+              name: "RelatedProperty",
             },
-            displayValues: {
-              [field.name]: "test display value",
-            },
-            mergedFieldNames: [],
           },
-        ] as NestedContentValue[],
-      };
-      const displayValues = {
-        [field.name]: undefined,
-      };
-      const record = new Item([], faker.random.words(), "", recordClass, values, displayValues, []);
+        ],
+      });
+      const parentField = createTestNestedContentField({
+        pathToPrimaryClass: relationshipPath,
+        nestedFields: [field],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: {
+          [parentField.name]: [
+            {
+              primaryKeys: [],
+              values: {
+                [field.name]: "test value",
+              },
+              displayValues: {
+                [field.name]: "test display value",
+              },
+              mergedFieldNames: [],
+            },
+          ],
+        },
+        displayValues: {
+          [field.name]: undefined,
+        },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -733,48 +804,45 @@ describe("RulesetsFactory", () => {
           isPolymorphicRelationship: true,
         },
       ];
-      const property: Property = {
-        property: {
-          classInfo: propertyClass,
-          type: "string",
-          name: "MyProperty",
-        },
-      };
-      const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), "Related Property", createStringTypeDescription(), true, 1, [
-        property,
-      ]);
-      const parentField = new NestedContentField(
-        createTestCategoryDescription(),
-        faker.random.word(),
-        faker.random.words(),
-        createStringTypeDescription(),
-        faker.random.boolean(),
-        faker.random.number(),
-        createRandomECClassInfo(),
-        relationshipPath,
-        [field],
-        undefined,
-        faker.random.boolean(),
-      );
-      field.rebuildParentship(parentField);
-      const values = {
-        [parentField.name]: [
+
+      const field = createTestPropertiesContentField({
+        name: "RelatedProperty",
+        label: "Related Property",
+        type: createStringTypeDescription(),
+        properties: [
           {
-            primaryKeys: [],
-            values: {
-              [field.name]: "test value",
+            property: {
+              classInfo: propertyClass,
+              type: "string",
+              name: "MyProperty",
             },
-            displayValues: {
-              [field.name]: "test display value",
-            },
-            mergedFieldNames: [],
           },
-        ] as NestedContentValue[],
-      };
-      const displayValues = {
-        [field.name]: undefined,
-      };
-      const record = new Item([], faker.random.words(), "", selectClass, values, displayValues, []);
+        ],
+      });
+      const parentField = createTestNestedContentField({
+        pathToPrimaryClass: relationshipPath,
+        nestedFields: [field],
+      });
+      const record = createTestContentItem({
+        classInfo: selectClass,
+        values: {
+          [parentField.name]: [
+            {
+              primaryKeys: [],
+              values: {
+                [field.name]: "test value",
+              },
+              displayValues: {
+                [field.name]: "test display value",
+              },
+              mergedFieldNames: [],
+            },
+          ],
+        },
+        displayValues: {
+          [field.name]: undefined,
+        },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       const expectedRules: Rule[] = [
         {
@@ -816,15 +884,25 @@ describe("RulesetsFactory", () => {
         name: "MySchema:MyClass",
         label: "My Class",
       };
-      const property: Property = {
-        property: {
-          classInfo: recordClass,
-          type: "string",
-          name: "MyProperty",
-        },
-      };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createStringTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: "test value" }, { ["MyProperty"]: "test display value" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createStringTypeDescription(),
+        properties: [
+          {
+            property: {
+              classInfo: recordClass,
+              type: "string",
+              name: "MyProperty",
+            },
+          },
+        ],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: "test value" },
+        displayValues: { ["MyProperty"]: "test display value" },
+      });
       const callback = sinon.fake(async () => "TEST");
       const result = await factory.createSimilarInstancesRuleset(field, record, callback);
       expect(callback).to.be.calledOnceWithExactly(field.type.typeName, "test value", "test display value");
@@ -837,15 +915,25 @@ describe("RulesetsFactory", () => {
         name: "MySchema:MyClass",
         label: "My Class",
       };
-      const property: Property = {
-        property: {
-          classInfo: recordClass,
-          type: "string",
-          name: "MyProperty",
-        },
-      };
-      const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createStringTypeDescription(), true, 1, [property]);
-      const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: "test value" }, { ["MyProperty"]: "test display value" }, []);
+      const field = createTestPropertiesContentField({
+        name: "MyProperty",
+        label: "My Property",
+        type: createStringTypeDescription(),
+        properties: [
+          {
+            property: {
+              classInfo: recordClass,
+              type: "string",
+              name: "MyProperty",
+            },
+          },
+        ],
+      });
+      const record = createTestContentItem({
+        classInfo: recordClass,
+        values: { ["MyProperty"]: "test value" },
+        displayValues: { ["MyProperty"]: "test display value" },
+      });
       const result = await factory.createSimilarInstancesRuleset(field, record);
       expect(result.description).to.eq(`[My Class].[My Property] = test display value`);
     });
@@ -858,17 +946,25 @@ describe("RulesetsFactory", () => {
             name: "MySchema:MyClass",
             label: "My Class",
           };
-          const property: Property = {
-            property: {
-              classInfo: recordClass,
-              type: "boolean",
-              name: "MyProperty",
-            },
-          };
-          const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", faker.random.word(), createBooleanTypeDescription(), true, 1, [
-            property,
-          ]);
-          const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: invalidValue }, { ["MyProperty"]: "" }, []);
+          const field = createTestPropertiesContentField({
+            name: "MyProperty",
+            label: "My Property",
+            type: createStringTypeDescription(),
+            properties: [
+              {
+                property: {
+                  classInfo: recordClass,
+                  type: "string",
+                  name: "MyProperty",
+                },
+              },
+            ],
+          });
+          const record = createTestContentItem({
+            classInfo: recordClass,
+            values: { ["MyProperty"]: invalidValue },
+            displayValues: { ["MyProperty"]: "" },
+          });
           await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith(
             "Can only create 'similar instances' ruleset for primitive values",
           );
@@ -881,8 +977,17 @@ describe("RulesetsFactory", () => {
           name: "MySchema:MyClass",
           label: "My Class",
         };
-        const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", faker.random.word(), createBooleanTypeDescription(), true, 1, []);
-        const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: "test value" }, { ["MyProperty"]: "test display value" }, []);
+        const field = createTestPropertiesContentField({
+          name: "MyProperty",
+          label: "My Property",
+          type: createStringTypeDescription(),
+          properties: [],
+        });
+        const record = createTestContentItem({
+          classInfo: recordClass,
+          values: { ["MyProperty"]: "test value" },
+          displayValues: { ["MyProperty"]: "test display value" },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith("Invalid properties' field with no properties");
       });
 
@@ -911,37 +1016,31 @@ describe("RulesetsFactory", () => {
             isPolymorphicTargetClass: true,
           },
         ];
-        const property: Property = {
-          property: {
-            classInfo: propertyClass,
-            type: "string",
-            name: "MyProperty",
+        const field = createTestPropertiesContentField({
+          type: createStringTypeDescription(),
+          properties: [
+            {
+              property: {
+                classInfo: propertyClass,
+                type: "string",
+                name: "MyProperty",
+              },
+            },
+          ],
+        });
+        const parentField = createTestNestedContentField({
+          pathToPrimaryClass: relationshipPath,
+          nestedFields: [field],
+        });
+        const record = createTestContentItem({
+          classInfo: recordClass,
+          values: {
+            [parentField.name]: "invalid",
           },
-        };
-        const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), faker.random.word(), createStringTypeDescription(), true, 1, [
-          property,
-        ]);
-        const parentField = new NestedContentField(
-          createTestCategoryDescription(),
-          faker.random.word(),
-          faker.random.words(),
-          createStringTypeDescription(),
-          faker.random.boolean(),
-          faker.random.number(),
-          createRandomECClassInfo(),
-          relationshipPath,
-          [field],
-          undefined,
-          faker.random.boolean(),
-        );
-        field.rebuildParentship(parentField);
-        const values = {
-          [parentField.name]: "invalid",
-        };
-        const displayValues = {
-          [field.name]: undefined,
-        };
-        const record = new Item([], faker.random.words(), "", recordClass, values, displayValues, []);
+          displayValues: {
+            [field.name]: undefined,
+          },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith("Invalid record value");
       });
 
@@ -951,62 +1050,70 @@ describe("RulesetsFactory", () => {
           name: "MySchema:MyClass",
           label: "My Class",
         };
-        const property: Property = {
-          property: {
-            classInfo: recordClass,
-            type: "point2d",
-            name: "MyProperty",
-          },
-        };
-        const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", "My Property", createPoint2dTypeDescription(), true, 1, [property]);
-        const record = new Item([], faker.random.word(), "", recordClass, { ["MyProperty"]: "should be {x,y} object" }, { ["MyProperty"]: "1, 2" }, []);
+        const field = createTestPropertiesContentField({
+          name: "MyProperty",
+          label: "My Property",
+          type: createPoint2dTypeDescription(),
+          properties: [
+            {
+              property: {
+                classInfo: recordClass,
+                type: "point2d",
+                name: "MyProperty",
+              },
+            },
+          ],
+        });
+        const record = createTestContentItem({
+          classInfo: recordClass,
+          values: { ["MyProperty"]: "should be {x,y} object" },
+          displayValues: { ["MyProperty"]: "1, 2" },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith("Expecting point values to be supplied as objects");
       });
     });
 
     describe("unsupported conditions", () => {
       it("throws when field is not a properties field", async () => {
-        const field = new Field(createTestCategoryDescription(), faker.random.word(), faker.random.word(), createStringTypeDescription(), true, 1);
-        const record = new Item([], faker.random.word(), "", undefined, {}, {}, []);
+        const field = createTestSimpleContentField({
+          name: "MyProperty",
+          label: "My Property",
+          type: createPoint2dTypeDescription(),
+        });
+        const record = createTestContentItem({
+          values: { ["MyProperty"]: undefined },
+          displayValues: { ["MyProperty"]: "" },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith(
           "Can only create 'similar instances' ruleset for properties-based records",
         );
       });
 
       it("throws when properties field is of array type", async () => {
-        const property: Property = {
-          property: {
-            classInfo: createRandomECClassInfo(),
-            name: faker.random.word(),
-            type: faker.database.type(),
-          },
-        };
-        const typeDescription: ArrayTypeDescription = {
-          valueFormat: PropertyValueFormat.Array,
-          typeName: faker.random.word(),
-          memberType: createStringTypeDescription(),
-        };
-        const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), faker.random.word(), typeDescription, true, 1, [property]);
-        const values = {
-          [field.name]: ["some value 1", "some value 2"],
-        };
-        const displayValues = {
-          [field.name]: ["some display value 1", "some display value 2"],
-        };
-        const record = new Item([], faker.random.word(), "", undefined, values, displayValues, []);
+        const field = createTestPropertiesContentField({
+          name: "MyProperty",
+          label: "My Property",
+          type: {
+            valueFormat: PropertyValueFormat.Array,
+            typeName: faker.random.word(),
+            memberType: createStringTypeDescription(),
+          } satisfies ArrayTypeDescription,
+          properties: [
+            {
+              property: createTestPropertyInfo(),
+            },
+          ],
+        });
+        const record = createTestContentItem({
+          values: { ["MyProperty"]: ["some value 1", "some value 2"] },
+          displayValues: { ["MyProperty"]: ["some display value 1", "some display value 2"] },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith(
           "Can only create 'similar instances' ruleset for primitive properties",
         );
       });
 
       it("throws when properties field is of struct type", async () => {
-        const property: Property = {
-          property: {
-            classInfo: createRandomECClassInfo(),
-            name: faker.random.word(),
-            type: faker.database.type(),
-          },
-        };
         const typeDescription: StructTypeDescription = {
           valueFormat: PropertyValueFormat.Struct,
           typeName: faker.random.word(),
@@ -1018,68 +1125,78 @@ describe("RulesetsFactory", () => {
             },
           ],
         };
-        const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), faker.random.word(), typeDescription, true, 1, [property]);
-        const values = {
-          [field.name]: {
-            [typeDescription.members[0].name]: "some value",
+        const field = createTestPropertiesContentField({
+          name: "MyProperty",
+          label: "My Property",
+          type: typeDescription,
+          properties: [
+            {
+              property: createTestPropertyInfo(),
+            },
+          ],
+        });
+        const record = createTestContentItem({
+          values: {
+            ["MyProperty"]: {
+              [typeDescription.members[0].name]: "some value",
+            },
           },
-        };
-        const displayValues = {
-          [field.name]: {
-            [typeDescription.members[0].name]: "some display value",
+          displayValues: {
+            ["MyProperty"]: {
+              [typeDescription.members[0].name]: "some value",
+            },
           },
-        };
-        const record = new Item([], faker.random.word(), "", undefined, values, displayValues, []);
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith(
           "Can only create 'similar instances' ruleset for primitive properties",
         );
       });
 
       it("throws when record is merged", async () => {
-        const property: Property = {
-          property: {
-            classInfo: {
-              id: createRandomId(),
-              name: "MySchema:MyClass",
-              label: "My Class",
+        const field = createTestPropertiesContentField({
+          name: "MyProperty",
+          label: "My Property",
+          type: createStringTypeDescription(),
+          properties: [
+            {
+              property: createTestPropertyInfo(),
             },
-            type: "string",
-            name: "MyProperty",
+          ],
+        });
+        const record = createTestContentItem({
+          values: {
+            ["MyProperty"]: "test value",
           },
-        };
-        const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", faker.random.word(), createStringTypeDescription(), true, 1, [
-          property,
-        ]);
-        const record = new Item([], faker.random.word(), "", undefined, { ["MyProperty"]: "test value" }, { ["MyProperty"]: "test value" }, ["MyProperty"]);
+          displayValues: {
+            ["MyProperty"]: "test display value",
+          },
+          mergedFieldNames: ["MyProperty"],
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith(
           "Can't create 'similar instances' ruleset for merged values",
         );
       });
 
       it("throws when record is based on different classes", async () => {
-        const property: Property = {
-          property: {
-            classInfo: {
-              id: createRandomId(),
-              name: "MySchema:MyClass",
-              label: "My Class",
+        const field = createTestPropertiesContentField({
+          name: "MyProperty",
+          label: "My Property",
+          type: createStringTypeDescription(),
+          properties: [
+            {
+              property: createTestPropertyInfo(),
             },
-            type: "string",
-            name: "MyProperty",
+          ],
+        });
+        const record = createTestContentItem({
+          classInfo: undefined /* this `undefined` means that record is based on multiple different classes */,
+          values: {
+            ["MyProperty"]: "test value",
           },
-        };
-        const field = new PropertiesField(createTestCategoryDescription(), "MyProperty", faker.random.word(), createStringTypeDescription(), true, 1, [
-          property,
-        ]);
-        const record = new Item(
-          [],
-          faker.random.word(),
-          "",
-          undefined /* this `undefined` means that record is based on multiple different classes */,
-          { ["MyProperty"]: "test value" },
-          { ["MyProperty"]: "test display value" },
-          [],
-        );
+          displayValues: {
+            ["MyProperty"]: "test display value",
+          },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith(
           "Can't create 'similar instances' for records based on multiple different ECClass instances",
         );
@@ -1110,58 +1227,52 @@ describe("RulesetsFactory", () => {
             isPolymorphicTargetClass: true,
           },
         ];
-        const property: Property = {
-          property: {
-            classInfo: propertyClass,
-            type: "string",
-            name: "MyProperty",
+        const field = createTestPropertiesContentField({
+          type: createStringTypeDescription(),
+          properties: [
+            {
+              property: {
+                classInfo: propertyClass,
+                type: "string",
+                name: "MyProperty",
+              },
+            },
+          ],
+        });
+        const parentField = createTestNestedContentField({
+          pathToPrimaryClass: relationshipPath,
+          nestedFields: [field],
+        });
+        const record = createTestContentItem({
+          classInfo: recordClass,
+          values: {
+            [parentField.name]: [
+              {
+                primaryKeys: [],
+                values: {
+                  [field.name]: "test value 1",
+                },
+                displayValues: {
+                  [field.name]: "test display value 1",
+                },
+                mergedFieldNames: [],
+              },
+              {
+                primaryKeys: [],
+                values: {
+                  [field.name]: "test value 2",
+                },
+                displayValues: {
+                  [field.name]: "test display value 2",
+                },
+                mergedFieldNames: [],
+              },
+            ],
           },
-        };
-        const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), faker.random.word(), createStringTypeDescription(), true, 1, [
-          property,
-        ]);
-        const parentField = new NestedContentField(
-          createTestCategoryDescription(),
-          faker.random.word(),
-          faker.random.words(),
-          createStringTypeDescription(),
-          faker.random.boolean(),
-          faker.random.number(),
-          createRandomECClassInfo(),
-          relationshipPath,
-          [field],
-          undefined,
-          faker.random.boolean(),
-        );
-        field.rebuildParentship(parentField);
-        const values = {
-          [parentField.name]: [
-            {
-              primaryKeys: [],
-              values: {
-                [field.name]: "test value 1",
-              },
-              displayValues: {
-                [field.name]: "test display value 1",
-              },
-              mergedFieldNames: [],
-            },
-            {
-              primaryKeys: [],
-              values: {
-                [field.name]: "test value 2",
-              },
-              displayValues: {
-                [field.name]: "test display value 2",
-              },
-              mergedFieldNames: [],
-            },
-          ] as NestedContentValue[],
-        };
-        const displayValues = {
-          [field.name]: undefined,
-        };
-        const record = new Item([], faker.random.words(), "", recordClass, values, displayValues, []);
+          displayValues: {
+            [field.name]: undefined,
+          },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejected;
       });
 
@@ -1190,48 +1301,42 @@ describe("RulesetsFactory", () => {
             isPolymorphicTargetClass: true,
           },
         ];
-        const property: Property = {
-          property: {
-            classInfo: propertyClass,
-            type: "string",
-            name: "MyProperty",
-          },
-        };
-        const field = new PropertiesField(createTestCategoryDescription(), faker.random.word(), faker.random.word(), createStringTypeDescription(), true, 1, [
-          property,
-        ]);
-        const parentField = new NestedContentField(
-          createTestCategoryDescription(),
-          faker.random.word(),
-          faker.random.words(),
-          createStringTypeDescription(),
-          faker.random.boolean(),
-          faker.random.number(),
-          createRandomECClassInfo(),
-          relationshipPath,
-          [field],
-          undefined,
-          faker.random.boolean(),
-        );
-        field.rebuildParentship(parentField);
-        const values = {
-          [parentField.name]: [
+        const field = createTestPropertiesContentField({
+          type: createStringTypeDescription(),
+          properties: [
             {
-              primaryKeys: [],
-              values: {
-                [field.name]: "test value",
+              property: {
+                classInfo: propertyClass,
+                type: "string",
+                name: "MyProperty",
               },
-              displayValues: {
-                [field.name]: "test display value",
-              },
-              mergedFieldNames: [field.name],
             },
-          ] as NestedContentValue[],
-        };
-        const displayValues = {
-          [field.name]: undefined,
-        };
-        const record = new Item([], faker.random.words(), "", recordClass, values, displayValues, []);
+          ],
+        });
+        const parentField = createTestNestedContentField({
+          pathToPrimaryClass: relationshipPath,
+          nestedFields: [field],
+        });
+        const record = createTestContentItem({
+          classInfo: recordClass,
+          values: {
+            [parentField.name]: [
+              {
+                primaryKeys: [],
+                values: {
+                  [field.name]: "test value",
+                },
+                displayValues: {
+                  [field.name]: "test display value",
+                },
+                mergedFieldNames: [field.name],
+              },
+            ],
+          },
+          displayValues: {
+            [field.name]: undefined,
+          },
+        });
         await expect(factory.createSimilarInstancesRuleset(field, record)).to.eventually.be.rejectedWith(
           "Can't create 'similar instances' ruleset for merged values",
         );

--- a/presentation/common/src/test/_helpers/Content.ts
+++ b/presentation/common/src/test/_helpers/Content.ts
@@ -73,16 +73,15 @@ export function createTestSimpleContentField(props?: {
   editor?: EditorDescription;
   renderer?: RendererDescription;
 }) {
-  return new Field(
-    props?.category ?? createTestCategoryDescription(),
-    props?.name ?? "SimpleField",
-    props?.label ?? "Simple Field",
-    props?.type ?? { valueFormat: PropertyValueFormat.Primitive, typeName: "string" },
-    props?.isReadonly ?? false,
-    props?.priority ?? 0,
-    props?.editor,
-    props?.renderer,
-  );
+  return new Field({
+    category: createTestCategoryDescription(),
+    name: "SimpleField",
+    label: "Simple Field",
+    type: { valueFormat: PropertyValueFormat.Primitive, typeName: "string" },
+    isReadonly: false,
+    priority: 0,
+    ...props,
+  });
 }
 
 /**
@@ -99,17 +98,15 @@ export function createTestPropertiesContentField(props: {
   editor?: EditorDescription;
   renderer?: RendererDescription;
 }) {
-  return new PropertiesField(
-    props.category ?? createTestCategoryDescription(),
-    props.name ?? "PropertiesField",
-    props.label ?? "Properties Field",
-    props.type ?? { valueFormat: PropertyValueFormat.Primitive, typeName: "string" },
-    props.isReadonly ?? false,
-    props.priority ?? 0,
-    props.properties,
-    props.editor,
-    props.renderer,
-  );
+  return new PropertiesField({
+    category: createTestCategoryDescription(),
+    name: "PropertiesField",
+    label: "Properties Field",
+    type: { valueFormat: PropertyValueFormat.Primitive, typeName: "string" },
+    isReadonly: false,
+    priority: 0,
+    ...props,
+  });
 }
 
 /**
@@ -127,11 +124,11 @@ export function createTestArrayPropertiesContentField(props: {
   editor?: EditorDescription;
   renderer?: RendererDescription;
 }) {
-  return new ArrayPropertiesField(
-    props.category ?? createTestCategoryDescription(),
-    props.name ?? "ArrayPropertiesField",
-    props.label ?? "Array Properties Field",
-    props.type ?? {
+  return new ArrayPropertiesField({
+    category: createTestCategoryDescription(),
+    name: "ArrayPropertiesField",
+    label: "Array Properties Field",
+    type: {
       valueFormat: PropertyValueFormat.Array,
       typeName: "string[]",
       memberType: {
@@ -139,13 +136,11 @@ export function createTestArrayPropertiesContentField(props: {
         typeName: "string",
       },
     },
-    props.itemsField ?? createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo() }] }),
-    props.isReadonly ?? false,
-    props.priority ?? 0,
-    props.properties,
-    props.editor,
-    props.renderer,
-  );
+    itemsField: createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo() }] }),
+    isReadonly: false,
+    priority: 0,
+    ...props,
+  });
 }
 
 /**
@@ -163,11 +158,11 @@ export function createTestStructPropertiesContentField(props: {
   editor?: EditorDescription;
   renderer?: RendererDescription;
 }) {
-  return new StructPropertiesField(
-    props.category ?? createTestCategoryDescription(),
-    props.name ?? "StructPropertiesField",
-    props.label ?? "Struct Properties Field",
-    props.type ?? {
+  return new StructPropertiesField({
+    category: createTestCategoryDescription(),
+    name: "StructPropertiesField",
+    label: "Struct Properties Field",
+    type: {
       valueFormat: PropertyValueFormat.Struct,
       typeName: "TestStruct",
       members: [
@@ -178,13 +173,11 @@ export function createTestStructPropertiesContentField(props: {
         },
       ],
     },
-    props.memberFields ?? [createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ name: "member1", type: "string" }) }] })],
-    props.isReadonly ?? false,
-    props.priority ?? 0,
-    props.properties,
-    props.editor,
-    props.renderer,
-  );
+    memberFields: [createTestPropertiesContentField({ properties: [{ property: createTestPropertyInfo({ name: "member1", type: "string" }) }] })],
+    isReadonly: false,
+    priority: 0,
+    ...props,
+  });
 }
 
 /**
@@ -213,23 +206,17 @@ export function createTestNestedContentField(props: {
       type: f.type,
     })),
   };
-  const field = new NestedContentField(
-    props.category ?? createTestCategoryDescription(),
-    props.name ?? "NestedContentField",
-    props.label ?? "Nested Content",
-    nestedContentFieldType,
-    props.isReadonly ?? false,
-    props.priority ?? 0,
-    props.contentClassInfo ?? createTestECClassInfo(),
-    props.pathToPrimaryClass ?? createTestRelationshipPath(1),
-    props.nestedFields,
-    props.editor,
-    !!props.autoExpand,
-    props.renderer,
-  );
-  if (props.relationshipMeaning) {
-    field.relationshipMeaning = props.relationshipMeaning;
-  }
+  const field = new NestedContentField({
+    category: createTestCategoryDescription(),
+    name: "NestedContentField",
+    label: "Nested Content",
+    type: nestedContentFieldType,
+    isReadonly: false,
+    priority: 0,
+    contentClassInfo: createTestECClassInfo(),
+    pathToPrimaryClass: createTestRelationshipPath(1),
+    ...props,
+  });
   field.rebuildParentship();
   return field;
 }
@@ -261,18 +248,15 @@ export function createTestContentItem(props: {
   mergedFieldNames?: string[];
   extendedData?: { [key: string]: any };
 }) {
-  const item = new Item(
-    props.primaryKeys ?? [createTestECInstanceKey()],
-    props.label ?? "",
-    props.imageId ?? "",
-    props.classInfo,
-    props.values,
-    props.displayValues,
-    props.mergedFieldNames ?? [],
-    props.extendedData,
-  );
-  if (props.inputKeys) {
-    item.inputKeys = props.inputKeys;
-  }
+  const item = new Item({
+    ...props,
+    primaryKeys: props.primaryKeys ?? [createTestECInstanceKey()],
+    label: props.label
+      ? typeof props.label === "string"
+        ? createTestLabelDefinition({ displayValue: props.label })
+        : props.label
+      : createTestLabelDefinition(),
+    mergedFieldNames: props.mergedFieldNames ?? [],
+  });
   return item;
 }

--- a/presentation/common/src/test/content/Item.test.snap
+++ b/presentation/common/src/test/content/Item.test.snap
@@ -21,20 +21,17 @@ Object {
 
 exports[`Item constructor creates valid item with label definition 1`] = `
 Object {
-  "displayValues": Object {
-    "key": "Keyboard",
-  },
-  "imageId": "0ea0e226-a243-44c2-83b1-e941fb2d30c8",
-  "labelDefinition": Object {
-    "displayValue": "Oregon",
-    "rawValue": "Toys",
-    "typeName": "string",
-  },
-  "mergedFieldNames": Array [],
-  "primaryKeys": Array [],
-  "values": Object {
-    "key": "Savings Account",
-  },
+  "displayValue": "test display value",
+  "rawValue": "test raw value",
+  "typeName": "string",
+}
+`;
+
+exports[`Item constructor creates valid item with label string 1`] = `
+Object {
+  "displayValue": "test",
+  "rawValue": "test raw value",
+  "typeName": "string",
 }
 `;
 
@@ -172,8 +169,8 @@ Array [
     },
     "imageId": "",
     "labelDefinition": Object {
-      "displayValue": "",
-      "rawValue": "",
+      "displayValue": "test display value",
+      "rawValue": "test raw value",
       "typeName": "string",
     },
     "mergedFieldNames": Array [],
@@ -193,8 +190,8 @@ Array [
     },
     "imageId": "",
     "labelDefinition": Object {
-      "displayValue": "",
-      "rawValue": "",
+      "displayValue": "test display value",
+      "rawValue": "test raw value",
       "typeName": "string",
     },
     "mergedFieldNames": Array [],
@@ -219,8 +216,8 @@ Array [
     },
     "imageId": "",
     "labelDefinition": Object {
-      "displayValue": "",
-      "rawValue": "",
+      "displayValue": "test display value",
+      "rawValue": "test raw value",
       "typeName": "string",
     },
     "mergedFieldNames": Array [],
@@ -240,8 +237,8 @@ Array [
     },
     "imageId": "",
     "labelDefinition": Object {
-      "displayValue": "",
-      "rawValue": "",
+      "displayValue": "test display value",
+      "rawValue": "test raw value",
       "typeName": "string",
     },
     "mergedFieldNames": Array [],

--- a/presentation/common/src/test/content/Item.test.ts
+++ b/presentation/common/src/test/content/Item.test.ts
@@ -6,28 +6,27 @@ import { expect } from "chai";
 import * as faker from "faker";
 import { Item, ItemJSON } from "../../presentation-common/content/Item";
 import { NestedContentValueJSON } from "../../presentation-common/content/Value";
+import { createTestContentItem, createTestLabelDefinition } from "../_helpers";
 import { createTestECInstanceKey } from "../_helpers/EC";
 import { createRandomECClassInfo, createRandomECInstanceKey, createRandomLabelDefinition } from "../_helpers/random";
-import { createTestContentItem } from "../_helpers";
 
 describe("Item", () => {
   describe("constructor", () => {
-    it("creates valid item with label", () => {
-      const item = new Item([], faker.random.word(), faker.random.uuid(), undefined, { key: faker.random.word() }, { key: faker.random.word() }, []);
-      expect(item).to.matchSnapshot();
+    it("creates valid item with label string", () => {
+      const item = createTestContentItem({ label: "test", values: {}, displayValues: {} });
+      expect(item.label).to.matchSnapshot();
     });
 
     it("creates valid item with label definition", () => {
-      const item = new Item([], createRandomLabelDefinition(), faker.random.uuid(), undefined, { key: faker.random.word() }, { key: faker.random.word() }, []);
-      expect(item).to.matchSnapshot();
+      const item = createTestContentItem({ label: createTestLabelDefinition(), values: {}, displayValues: {} });
+      expect(item.label).to.matchSnapshot();
     });
   });
 
   describe("toJSON", () => {
     it("serializes inputKeys", () => {
       const inputKey = createTestECInstanceKey();
-      const item = new Item([], "", "", undefined, {}, {}, []);
-      item.inputKeys = [inputKey];
+      const item = createTestContentItem({ inputKeys: [inputKey], values: {}, displayValues: {} });
       const json = item.toJSON();
       expect(json.inputKeys).to.deep.eq([inputKey]);
     });
@@ -137,12 +136,12 @@ describe("Item", () => {
 
   describe("isFieldMerged", () => {
     it("returns false for unmerged field", () => {
-      const item = new Item([], faker.random.word(), faker.random.uuid(), undefined, { key: faker.random.word() }, { key: faker.random.word() }, []);
+      const item = createTestContentItem({ values: {}, displayValues: {}, mergedFieldNames: [] });
       expect(item.isFieldMerged("key")).to.be.false;
     });
 
     it("returns true for merged field", () => {
-      const item = new Item([], faker.random.word(), faker.random.uuid(), undefined, { key: faker.random.word() }, { key: faker.random.word() }, ["key"]);
+      const item = createTestContentItem({ values: {}, displayValues: {}, mergedFieldNames: ["key"] });
       expect(item.isFieldMerged("key")).to.be.true;
     });
   });

--- a/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
+++ b/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
@@ -4,15 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
+import sinon from "sinon";
 import * as moq from "typemoq";
 import { IModelConnection } from "@itwin/core-frontend";
 import { Content, DEFAULT_KEYS_BATCH_SIZE, Descriptor, Item, KeySet } from "@itwin/presentation-common";
-import { createRandomECInstanceKey, createRandomTransientId, createTestContentDescriptor } from "@itwin/presentation-common/lib/cjs/test";
-import { HiliteSetProvider } from "../../presentation-frontend/selection/HiliteSetProvider";
-import sinon from "sinon";
-import { Presentation } from "../../presentation-frontend/Presentation";
-import { GetContentRequestOptions, MultipleValuesRequestOptions, PresentationManager } from "../../presentation-frontend";
+import {
+  createRandomECInstanceKey,
+  createRandomTransientId,
+  createTestContentDescriptor,
+  createTestContentItem,
+} from "@itwin/presentation-common/lib/cjs/test";
 import { TRANSIENT_ELEMENT_CLASSNAME } from "@itwin/unified-selection";
+import { GetContentRequestOptions, MultipleValuesRequestOptions, PresentationManager } from "../../presentation-frontend";
+import { Presentation } from "../../presentation-frontend/Presentation";
+import { HiliteSetProvider } from "../../presentation-frontend/selection/HiliteSetProvider";
 
 describe("HiliteSetProvider", () => {
   const imodelMock = moq.Mock.ofType<IModelConnection>();
@@ -49,9 +54,7 @@ describe("HiliteSetProvider", () => {
     });
 
     it("memoizes result", async () => {
-      const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
-        new Item([createRandomECInstanceKey()], "", "", undefined, {}, {}, [], {}), // element
-      ]);
+      const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [createTestContentItem({ values: {}, displayValues: {} })]);
       fakeGetContentIterator.callsFake(async () => ({ total: 1, descriptor: resultContent.descriptor, items: iterate(resultContent.contentSet) }));
       const keys = new KeySet([createRandomECInstanceKey()]);
 
@@ -88,7 +91,7 @@ describe("HiliteSetProvider", () => {
       const persistentKey = createRandomECInstanceKey();
       const resultKey = createRandomECInstanceKey();
       const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
-        new Item([resultKey], "", "", undefined, {}, {}, [], {}), // element
+        createTestContentItem({ primaryKeys: [resultKey], values: {}, displayValues: {} }), // element
       ]);
 
       fakeGetContentIterator
@@ -105,7 +108,9 @@ describe("HiliteSetProvider", () => {
     it("creates result for model keys", async () => {
       const persistentKey = createRandomECInstanceKey();
       const resultKey = createRandomECInstanceKey();
-      const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [new Item([resultKey], "", "", undefined, {}, {}, [], { isModel: true })]);
+      const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
+        createTestContentItem({ primaryKeys: [resultKey], values: {}, displayValues: {}, extendedData: { isModel: true } }),
+      ]);
 
       fakeGetContentIterator
         .onFirstCall()
@@ -122,7 +127,7 @@ describe("HiliteSetProvider", () => {
       const persistentKey = createRandomECInstanceKey();
       const resultKey = createRandomECInstanceKey();
       const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
-        new Item([resultKey], "", "", undefined, {}, {}, [], { isSubCategory: true }),
+        createTestContentItem({ primaryKeys: [resultKey], values: {}, displayValues: {}, extendedData: { isSubCategory: true } }),
       ]);
       fakeGetContentIterator
         .onFirstCall()
@@ -143,9 +148,9 @@ describe("HiliteSetProvider", () => {
       const resultSubCategoryKey = createRandomECInstanceKey();
       const resultElementKey = createRandomECInstanceKey();
       const resultContent = new Content(createTestContentDescriptor({ fields: [] }), [
-        new Item([resultModelKey], "", "", undefined, {}, {}, [], { isModel: true }),
-        new Item([resultSubCategoryKey], "", "", undefined, {}, {}, [], { isSubCategory: true }),
-        new Item([resultElementKey], "", "", undefined, {}, {}, [], {}), // element
+        createTestContentItem({ primaryKeys: [resultModelKey], values: {}, displayValues: {}, extendedData: { isModel: true } }),
+        createTestContentItem({ primaryKeys: [resultSubCategoryKey], values: {}, displayValues: {}, extendedData: { isSubCategory: true } }),
+        createTestContentItem({ primaryKeys: [resultElementKey], values: {}, displayValues: {}, extendedData: {} }),
       ]);
       fakeGetContentIterator
         .onFirstCall()
@@ -168,7 +173,7 @@ describe("HiliteSetProvider", () => {
       // first request returns content with an element key
       const elementKey = createRandomECInstanceKey();
       const resultContent1 = new Content(createTestContentDescriptor({ fields: [] }), [
-        new Item([elementKey], "", "", undefined, {}, {}, [], {}), // element
+        createTestContentItem({ primaryKeys: [elementKey], values: {}, displayValues: {} }),
       ]);
       fakeGetContentIterator
         .withArgs(sinon.match((opts: GetContentRequestOptions) => opts.keys.size === DEFAULT_KEYS_BATCH_SIZE))
@@ -182,8 +187,8 @@ describe("HiliteSetProvider", () => {
       const subCategoryKey = createRandomECInstanceKey();
       const modelKey = createRandomECInstanceKey();
       const resultContent2 = new Content(createTestContentDescriptor({ fields: [] }), [
-        new Item([subCategoryKey], "", "", undefined, {}, {}, [], { isSubCategory: true }),
-        new Item([modelKey], "", "", undefined, {}, {}, [], { isModel: true }),
+        createTestContentItem({ primaryKeys: [subCategoryKey], values: {}, displayValues: {}, extendedData: { isSubCategory: true } }),
+        createTestContentItem({ primaryKeys: [modelKey], values: {}, displayValues: {}, extendedData: { isModel: true } }),
       ]);
       fakeGetContentIterator
         .withArgs(sinon.match((opts: GetContentRequestOptions) => opts.keys.size === 1))
@@ -205,7 +210,7 @@ describe("HiliteSetProvider", () => {
 
     it("iterates over content items in pages", async () => {
       const elementKeys = new Array(1001).fill(0).map((_, i) => ({ id: `0x${i}`, className: "TestElement" }));
-      const items = elementKeys.map((key) => new Item([key], "", "", undefined, {}, {}, [], {}));
+      const items = elementKeys.map((key) => createTestContentItem({ primaryKeys: [key], values: {}, displayValues: {} }));
 
       const resultContent1 = new Content(createTestContentDescriptor({ fields: [] }), items.slice(0, 1000));
       const resultContent2 = new Content(createTestContentDescriptor({ fields: [] }), items.slice(1000));


### PR DESCRIPTION
`Object.create` was causing trouble for @GytisCepk. In addition, `Object.assign` breaks type safety.