### PR TITLE
re enable oneAtATime test

### DIFF
--- a/common/changes/@itwin/core-bentley/master_2025-01-31-18-34.json
+++ b/common/changes/@itwin/core-bentley/master_2025-01-31-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/core/bentley/src/test/OneAtATime.test.ts
+++ b/core/bentley/src/test/OneAtATime.test.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { AbandonedError, OneAtATimeAction } from "../OneAtATimeAction";
 import { BeDuration } from "../Time";
 
@@ -42,6 +42,8 @@ describe("OneAtATime test", () => {
     void expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // aborts previous, becomes pending
     count = await operation.request(200, "hello");
     expect(count).toBe(3);
-    process.removeListener("unhandledRejection", unhandledRejectionHandler);
+    onTestFinished(() => {
+      process.removeListener("unhandledRejection", unhandledRejectionHandler)
+    });
   });
 });

--- a/core/bentley/src/test/OneAtATime.test.ts
+++ b/core/bentley/src/test/OneAtATime.test.ts
@@ -16,6 +16,10 @@ describe("OneAtATime test", () => {
     };
 
     process.on("unhandledRejection", unhandledRejectionHandler);
+    onTestFinished(() => {
+      process.removeListener("unhandledRejection", unhandledRejectionHandler)
+    });
+
     let calls = 0;
     const operation = new OneAtATimeAction(async (a: number, b: string) => {
       if (a === 10)
@@ -42,8 +46,5 @@ describe("OneAtATime test", () => {
     void expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // aborts previous, becomes pending
     count = await operation.request(200, "hello");
     expect(count).toBe(3);
-    onTestFinished(() => {
-      process.removeListener("unhandledRejection", unhandledRejectionHandler)
-    });
   });
 });

--- a/core/bentley/src/test/OneAtATime.test.ts
+++ b/core/bentley/src/test/OneAtATime.test.ts
@@ -2,51 +2,44 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
-// import * as chai from "chai";
-// import * as chaiAsPromised from "chai-as-promised";
-import { assert, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { AbandonedError, OneAtATimeAction } from "../OneAtATimeAction";
 import { BeDuration } from "../Time";
 
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
-// const assert = chai.assert;
-// const expect = chai.expect;
-
-// chai.use(chaiAsPromised);
 describe("OneAtATime test", () => {
 
-  it.skip("OneAtATime", async () => {
+  it("OneAtATime", async () => {
+    const unhandledRejectionHandler = (_reason: any) => {
+      expect(_reason).toBeInstanceOf(Error);
+    };
+
+    process.on("unhandledRejection", unhandledRejectionHandler);
     let calls = 0;
     const operation = new OneAtATimeAction(async (a: number, b: string) => {
       if (a === 10)
         throw new Error("cancelled");
 
-      assert.equal(a, 200);
-      assert.equal(b, "hello");
+      expect(a).toBe(200);
+      expect(b).toBe("hello");
       await BeDuration.wait(100);
       return ++calls;
     }, "testAbandon");
 
-    // expect(operation.request(200, "hello")).to.be.eventually.fulfilled; // is started immediately
-    // expect(operation.request(200, "hello")). ; // is started immediately
-    // operation.request(200, "hello");
     const abandonedError = new AbandonedError("testAbandon");
     const cancelled = new AbandonedError("cancelled");
 
-    expect(operation.request(200, "hello")).rejects.with.toBeInstanceOf(AbandonedError); // becomes pending, doesn't abort previous because its already started
+    void expect(operation.request(200, "hello")).rejects.with.toBeInstanceOf(AbandonedError); // becomes pending, doesn't abort previous because its already started
 
-    expect(operation.request(200, "hello")).rejects.with.toBeInstanceOf(AbandonedError); // aborts previous, becomes pending
+    void expect(operation.request(200, "hello")).rejects.with.toBeInstanceOf(AbandonedError); // aborts previous, becomes pending
     let count = await operation.request(200, "hello"); // aborts previous, becomes pending, eventually is run
-    assert.equal(count, 2); // only the first and last complete
-    // console.log(await operation.request(10, "hello"));
+    expect(count).toBe(2); // only the first and last complete
     // then, just try the whole thing again
-    expect(operation.request(10, "hello")).rejects; // try calling a function that throws
-    expect(operation.request(10, "hello")).rejects.with.toEqual(cancelled); // try calling a function that throws
-    expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // becomes pending, doesn't abort previous because its already started
-    expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // aborts previous, becomes pending
+    void expect(operation.request(10, "hello")).rejects; // try calling a function that throws
+    void expect(operation.request(10, "hello")).rejects.with.toEqual(cancelled); // try calling a function that throws
+    void expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // becomes pending, doesn't abort previous because its already started
+    void expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // aborts previous, becomes pending
     count = await operation.request(200, "hello");
-    assert.equal(count, 3);
+    expect(count).toBe(3);
+    process.removeListener("unhandledRejection", unhandledRejectionHandler);
   });
 });


### PR DESCRIPTION
Closes #7200 

Handling of vitest where:
1. We expect an error to be thrown
2. We expect those errors to be thrown as promise rejections (i.e run as non awaited promises) 

Can cause wonky behaviors, with vitest's runner identifying those errors to be 'uncaught'. We can listen to these uncaught exception events raised to suppress that behavior.