### PR TITLE
Add yAxisUp to ReadGltfGraphicsArgs

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -9041,6 +9041,7 @@ export interface ReadGltfGraphicsArgs {
     pickableOptions?: PickableGraphicOptions;
     // @alpha (undocumented)
     transform?: Transform;
+    yAxisUp?: boolean;
 }
 
 // @beta

--- a/common/changes/@itwin/core-frontend/andremig-render-instances_2025-02-04-17-04.json
+++ b/common/changes/@itwin/core-frontend/andremig-render-instances_2025-02-04-17-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "add yAxisUp to ReadGltfGraphicsArgs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -2134,6 +2134,8 @@ export interface ReadGltfGraphicsArgs {
   hasChildren?: boolean;
   /** @internal */
   idMap?: BatchedTileIdMap;
+  /** Specify the axis orientation. If true, y will be up. */
+  yAxisUp?: boolean;
 }
 
 /** The output of [[readGltf]].
@@ -2178,7 +2180,7 @@ export async function readGltfGraphics(args: ReadGltfGraphicsArgs): Promise<Rend
  */
 export async function readGltfTemplate(args: ReadGltfGraphicsArgs): Promise<GltfTemplate | undefined> {
   const baseUrl = typeof args.baseUrl === "string" ? new URL(args.baseUrl) : args.baseUrl;
-  const props = GltfReaderProps.create(args.gltf, true, baseUrl); // glTF supports exactly one coordinate system with y axis up.
+  const props = GltfReaderProps.create(args.gltf, args.yAxisUp, baseUrl); // glTF supports exactly one coordinate system with y axis up.
   const reader = props ? new GltfGraphicsReader(props, args) : undefined;
   if (!reader)
     return undefined;

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -2180,7 +2180,8 @@ export async function readGltfGraphics(args: ReadGltfGraphicsArgs): Promise<Rend
  */
 export async function readGltfTemplate(args: ReadGltfGraphicsArgs): Promise<GltfTemplate | undefined> {
   const baseUrl = typeof args.baseUrl === "string" ? new URL(args.baseUrl) : args.baseUrl;
-  const props = GltfReaderProps.create(args.gltf, args.yAxisUp, baseUrl); // glTF supports exactly one coordinate system with y axis up.
+  const yAxisUp = args.yAxisUp ?? true; // default to true
+  const props = GltfReaderProps.create(args.gltf, yAxisUp, baseUrl); // glTF supports exactly one coordinate system with y axis up.
   const reader = props ? new GltfGraphicsReader(props, args) : undefined;
   if (!reader)
     return undefined;


### PR DESCRIPTION
This PR addresses this issue: https://github.com/iTwin/itwinjs-core/issues/7454

When calling `ReadGltf()`, `ReadGltfGraphics()`, or `ReadGltfTemplate()`, there is currently no option to specify the `yAxisUp` option of the `GltfGraphicsReader` when it is created as a part of these functions. Instead, `yAxisUp` is forced true. This leads to situations like the one outlined in the above issue, where a call to `ReadGltfTemplate()` may create misplaced graphics due to axis orientation issues. To solve this, an optional `yAxisUp` flag was added to `ReadGltfGraphicsArgs`, and can now be passed in to any of the above function calls if desired. If `ReadGltfGraphicsArgs.yAxisUp` is `undefined`, the flag defaults to true.