### PR TITLE
Nelrod/sheetindex in registery

### DIFF
--- a/common/changes/@itwin/core-backend/master_2025-02-06-15-37.json
+++ b/common/changes/@itwin/core-backend/master_2025-02-06-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added SheetIndex classes to Class Registery",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/BisCoreSchema.ts
+++ b/core/backend/src/BisCoreSchema.ts
@@ -21,6 +21,7 @@ import * as textureMod from "./Texture";
 import * as viewMod from "./ViewDefinition";
 import * as displayStyleMod from "./DisplayStyle";
 import * as annotationsMod from "./TextAnnotationElement";
+import * as sheetIndex from "./SheetIndex";
 
 /**
  * The [BisCore]($docs/bis/guide/fundamentals/schemas-domains.md) schema is the lowest level Schema in an iModel.
@@ -58,6 +59,7 @@ export class BisCoreSchema extends Schema {
       externalSourceMod,
       displayStyleMod,
       annotationsMod,
+      sheetIndex
     ].forEach((module) => ClassRegistry.registerModule(module, this));
   }
 }


### PR DESCRIPTION
When Sheet Index Typescript classes were introduced, I forgot to added them to the class registry.  This fixes that.