### PR TITLE
Revert BackendTypes to Public

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -468,10 +468,10 @@ export class BackendError extends IModelError {
     constructor(errorNumber: number, name: string, message: string, getMetaData?: LoggingMetaData);
 }
 
-// @internal @deprecated (undocumented)
+// @public @deprecated (undocumented)
 export type BackendReadable = Readable;
 
-// @internal @deprecated (undocumented)
+// @public @deprecated (undocumented)
 export type BackendWritable = Writable;
 
 // @public

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -31,9 +31,9 @@ internal;class;B3dmHeader
 internal;type;BackendBuffer
 deprecated;type;BackendBuffer
 public;class;BackendError
-internal;type;BackendReadable
+public;type;BackendReadable
 deprecated;type;BackendReadable
-internal;type;BackendWritable
+public;type;BackendWritable
 deprecated;type;BackendWritable
 public;enum;BackgroundFill
 public;interface;BackgroundMapProps

--- a/common/changes/@itwin/core-common/mike-fix-extract_2025-02-07-16-14.json
+++ b/common/changes/@itwin/core-common/mike-fix-extract_2025-02-07-16-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Revert BackendTypes to Public",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/internal/BackendTypes.ts
+++ b/core/common/src/internal/BackendTypes.ts
@@ -16,7 +16,7 @@ Do not add any new types to this file.
 All types here will be removed in 4.0
 */
 
-/** BackendReadable and BackendWritable are tagged public for depreciated public RPC APIs which reference these types. */
+/** BackendReadable and BackendWritable are tagged public for deprecated public RPC APIs which reference these types. */
 /** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendReadable = Readable;
 

--- a/core/common/src/internal/BackendTypes.ts
+++ b/core/common/src/internal/BackendTypes.ts
@@ -16,10 +16,11 @@ Do not add any new types to this file.
 All types here will be removed in 4.0
 */
 
-/** @internal @deprecated in 3.x. This type was mistakenly made public in the common scope. */
+/** BackendReadable and BackendWritable are tagged public for depreciated public RPC APIs which reference these types. */
+/** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendReadable = Readable;
 
-/** @internal @deprecated in 3.x. This type was mistakenly made public in the common scope. */
+/** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendWritable = Writable;
 
 /** @internal @deprecated in 3.x. This type was mistakenly made public in the common scope. */

--- a/core/common/src/internal/BackendTypes.ts
+++ b/core/common/src/internal/BackendTypes.ts
@@ -17,10 +17,10 @@ All types here will be removed in 4.0
 */
 
 /** BackendReadable and BackendWritable are not tagged internal for deprecated public RPC APIs which reference these types. */
-/** @deprecated in 3.x. This type was mistakenly made public in the common scope. */
+/** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendReadable = Readable;
 
-/** @deprecated in 3.x. This type was mistakenly made public in the common scope. */
+/** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendWritable = Writable;
 
 /** @internal @deprecated in 3.x. This type was mistakenly made public in the common scope. */

--- a/core/common/src/internal/BackendTypes.ts
+++ b/core/common/src/internal/BackendTypes.ts
@@ -17,7 +17,7 @@ All types here will be removed in 4.0
 */
 
 /** BackendReadable and BackendWritable are tagged public for deprecated public RPC APIs which reference these types. */
-/** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */
+/** @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendReadable = Readable;
 
 /** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */

--- a/core/common/src/internal/BackendTypes.ts
+++ b/core/common/src/internal/BackendTypes.ts
@@ -16,11 +16,11 @@ Do not add any new types to this file.
 All types here will be removed in 4.0
 */
 
-/** BackendReadable and BackendWritable are tagged public for deprecated public RPC APIs which reference these types. */
+/** BackendReadable and BackendWritable are not tagged internal for deprecated public RPC APIs which reference these types. */
 /** @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendReadable = Readable;
 
-/** @public @deprecated in 3.x. This type was mistakenly made public in the common scope. */
+/** @deprecated in 3.x. This type was mistakenly made public in the common scope. */
 export type BackendWritable = Writable;
 
 /** @internal @deprecated in 3.x. This type was mistakenly made public in the common scope. */


### PR DESCRIPTION
In https://github.com/iTwin/itwinjs-core/pull/7572#issuecomment-2642292035 BackendTypes referenced by `HttpServerRequest` were converted to internal. These types need to remain public to match `HttpServerRequest`.

Both the BackendTypes and `HttpServerRequest` function are deprecated, and should be removed by the upcoming RPC refactor. 