### PR TITLE
Change Schemas getItems method to be consistent with other item calls

### DIFF
--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -1464,7 +1464,6 @@ export enum PropertyType {
 // @beta (undocumented)
 export function propertyTypeToString(type: PropertyType): "PrimitiveProperty" | "StructProperty" | "StructArrayProperty" | "NavigationProperty" | "PrimitiveArrayProperty";
 
-
 // @beta (undocumented)
 export namespace PropertyTypeUtils {
     // (undocumented)
@@ -1693,7 +1692,7 @@ export class Schema implements CustomAttributeContainerProps {
     // (undocumented)
     protected createInvertedUnitSync(name: string): InvertedUnit;
     // @alpha (undocumented)
-    protected createItem<T extends AnySchemaItem>(type: (new (_schema: Schema, _name: string) => T), name: string): T;
+    protected createItem<T extends SchemaItem>(type: (new (_schema: Schema, _name: string) => T), name: string): T;
     protected createKindOfQuantity(name: string): Promise<KindOfQuantity>;
     // (undocumented)
     protected createKindOfQuantitySync(name: string): KindOfQuantity;
@@ -1742,7 +1741,6 @@ export class Schema implements CustomAttributeContainerProps {
     fromJSONSync(schemaProps: SchemaProps): void;
     static fromJsonSync(jsonObj: object | string, context: SchemaContext): Schema;
     get fullName(): string;
-    getClasses(): IterableIterator<ECClass>;
     getConstant(name: string): Promise<Constant | undefined>;
     getCustomAttributeClass(name: string): Promise<CustomAttributeClass | undefined>;
     getEntityClass(name: string): Promise<EntityClass | undefined>;
@@ -1752,7 +1750,9 @@ export class Schema implements CustomAttributeContainerProps {
     getItem(name: string): Promise<SchemaItem | undefined>;
     // (undocumented)
     getItem<T extends typeof SchemaItem>(name: string, itemConstructor: T): Promise<InstanceType<T> | undefined>;
-    getItems<T extends AnySchemaItem>(): IterableIterator<T>;
+    getItems(): IterableIterator<SchemaItem>;
+    // (undocumented)
+    getItems<T extends typeof SchemaItem>(itemConstructor: T): IterableIterator<InstanceType<T>>;
     getItemSync(name: string): SchemaItem | undefined;
     // (undocumented)
     getItemSync<T extends typeof SchemaItem>(name: string, itemConstructor: T): InstanceType<T> | undefined;

--- a/common/changes/@itwin/ecschema-editing/stefan-schema-getItems-method_2025-02-13-14-13.json
+++ b/common/changes/@itwin/ecschema-editing/stefan-schema-getItems-method_2025-02-13-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/common/changes/@itwin/ecschema-metadata/stefan-schema-getItems-method_2025-02-13-14-13.json
+++ b/common/changes/@itwin/ecschema-metadata/stefan-schema-getItems-method_2025-02-13-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "EC Schemas getItems was using a generic to specify the type of item to be removed, the items were never validated though if the schema items really match the given type. With this change, callers can make sure that if they use the overload with the item type (analog to getItem) only items of that type get's returned.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-editing/src/test/Editing/mvp.test.ts
+++ b/core/ecschema-editing/src/test/Editing/mvp.test.ts
@@ -185,7 +185,7 @@ describe("SchemaEditor tests", () => {
       await testEditor.entities.delete(result);
       element = await testSchema!.getItem("testElements");
       expect(element).to.be.undefined;
-      const classes = testSchema!.getClasses();
+      const classes = testSchema!.getItems(ECClass);
       for (const _class of classes) {
         expect(false, "Expected no classes in the schema.").to.be.true;
       }

--- a/core/ecschema-metadata/src/test/Metadata/Schema.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Schema.test.ts
@@ -602,23 +602,21 @@ describe("Schema", () => {
         expect(schemaItems.next().value.schemaItemType).to.equal(SchemaItemType.Format);
         expect(schemaItems.next().done).to.equal(true);
       });
-    });
-
-    describe("getClasses", () => {
-      let schemaClasses: IterableIterator<ECClass>;
-
-      before(() => {
-        schemaClasses = testSchema.getClasses();
-      });
 
       it("should return only class items in schema", async () => {
-        const classArray = Array.from(testSchema.getClasses());
+        const classArray = Array.from(testSchema.getItems(ECClass));
         expect(classArray.length).to.eql(3);
 
-        expect(schemaClasses.next().value.schemaItemType).to.eql(SchemaItemType.EntityClass);
-        expect(schemaClasses.next().value.schemaItemType).to.eql(SchemaItemType.Mixin);
-        expect(schemaClasses.next().value.schemaItemType).to.eql(SchemaItemType.StructClass);
-        expect(schemaClasses.next().done).to.eql(true);
+        expect(classArray[0].schemaItemType).to.eql(SchemaItemType.EntityClass);
+        expect(classArray[1].schemaItemType).to.eql(SchemaItemType.Mixin);
+        expect(classArray[2].schemaItemType).to.eql(SchemaItemType.StructClass);
+      });
+
+      it("should return only enumeration items in schema", async () => {
+        const classArray = Array.from(testSchema.getItems(Enumeration));
+        expect(classArray.length).to.eql(1);
+
+        expect(classArray[0].schemaItemType).to.eql(SchemaItemType.Enumeration);
       });
     });
   });


### PR DESCRIPTION
**What**
After changing the signature of getItem and lookup item in a previous issue (#7577), the getItems method still had the old signature with a generic that could not verify the items type before returning them.

This changes the method signature to be consistent with the other calls. It also ensures the returned items are all of the requested type, items of other types will be ignored and not returned.
```ts
schema.getItems() // Return iterable of Schema Items
schema.getItems(EntityClass) // Returns iterable of EntityClasses
schema.getItems(ECClass) // Returns iterable of all class items in this schema (Entities, Structs, Mixins,...)
```