### PR TITLE
Fixed Ray3d flaky test

### DIFF
--- a/common/changes/@itwin/core-geometry/saeed-torabi-ray3d-flaky-test_2025-02-14-15-52.json
+++ b/common/changes/@itwin/core-geometry/saeed-torabi-ray3d-flaky-test_2025-02-14-15-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/geometry3d/Ray3d.ts
+++ b/core/geometry/src/geometry3d/Ray3d.ts
@@ -464,9 +464,8 @@ export class Ray3d implements BeJSONFunctions {
         v = 0.0;
       else
         return undefined;  // ray does not intersect the triangle
-    } else if (u + v > 1.0) {
-      if (u + v > 1.0 + parameterTol)
-        return undefined;  // ray does not intersect the triangle
+    } else if (u + v > 1.0 + parameterTol) {
+      return undefined;  // ray does not intersect the triangle
     }
     // at this stage, we know the line (parameterized as the ray) intersects the triangle
     const t = f * edge2.dotProduct(q);

--- a/core/geometry/src/geometry3d/Ray3d.ts
+++ b/core/geometry/src/geometry3d/Ray3d.ts
@@ -388,8 +388,8 @@ export class Ray3d implements BeJSONFunctions {
    * @param vertex2 third vertex of the triangle
    * @param distanceTol optional tolerance used to check if ray is parallel to the triangle or if we have line
    * intersection but not ray intersection (if tolerance is not provided, Geometry.smallMetricDistance is used)
-   * @param parameterTol optional tolerance used to snap barycentric coordinates of the intersection point to
-   * a triangle edge or vertex (if tolerance is not provided, Geometry.smallFloatingPoint is used)
+   * @param parameterTol optional tolerance used to allow intersections just beyond an edge/vertex in barycentric
+   * coordinate space (if tolerance is not provided, Geometry.smallFloatingPoint is used)
    * @param result optional pre-allocated object to fill and return
    * @returns the intersection point if ray intersects the triangle. Otherwise, return undefined.
   */
@@ -447,12 +447,12 @@ export class Ray3d implements BeJSONFunctions {
     const s = Ray3d._workVector3 = Vector3d.createStartEnd(vertex0, this.origin, Ray3d._workVector3);
     let u = f * s.dotProduct(h);
     if (u < 0.0) {
-      if (u > -parameterTol)
+      if (u >= -parameterTol)
         u = 0.0;
       else
         return undefined; // ray does not intersect the triangle
     } else if (u > 1.0) {
-      if (u < 1.0 + parameterTol)
+      if (u <= 1.0 + parameterTol)
         u = 1.0;
       else
         return undefined; // ray does not intersect the triangle
@@ -460,19 +460,17 @@ export class Ray3d implements BeJSONFunctions {
     const q = Ray3d._workVector4 = s.crossProduct(edge1, Ray3d._workVector4);
     let v = f * this.direction.dotProduct(q);
     if (v < 0.0) {
-      if (v > -parameterTol)
+      if (v >= -parameterTol)
         v = 0.0;
       else
         return undefined;  // ray does not intersect the triangle
     } else if (u + v > 1.0) {
-      if (u + v < 1.0 + parameterTol)
-        v = 1.0 - u;
-      else
+      if (u + v > 1.0 + parameterTol)
         return undefined;  // ray does not intersect the triangle
     }
     // at this stage, we know the line (parameterized as the ray) intersects the triangle
     const t = f * edge2.dotProduct(q);
-    if (t <= distanceTol) // line intersection but not ray intersection
+    if (t < -distanceTol) // line intersection but not ray intersection
       return undefined;
     return this.origin.plusScaled(this.direction, t, result); // ray intersection
   }

--- a/core/geometry/src/test/geometry3d/Ray3d.test.ts
+++ b/core/geometry/src/test/geometry3d/Ray3d.test.ts
@@ -482,7 +482,7 @@ describe("Ray3d.IntersectionWithTriangle", () => {
     intersectionPoint = ray.intersectionWithTriangle(triangle.points[0], triangle.points[1], triangle.points[2]);
     ck.testUndefined(intersectionPoint, "expect no intersection when ray direction is (0,0,0)");
 
-    origin = Point3d.create(10, 0, 0);
+    origin = Point3d.create(11, 0, 0);
     direction = Vector3d.create(1, 1, 1);
     ray = Ray3d.create(origin, direction);
     intersectionPoint = ray.intersectionWithTriangle(triangle.points[0], triangle.points[1], triangle.points[2]);
@@ -629,6 +629,43 @@ describe("Ray3d.IntersectionWithTriangle", () => {
       )) {
         expect(ck.getNumErrors()).toBe(0);
       }
+    }
+    expect(ck.getNumErrors()).toBe(0);
+  });
+
+  it("Ray3d.IntersectRayOriginOnTriangle", () => {
+    const ck = new Checker();
+
+    const numSamples = 6;
+    const origins = [
+      new Point3d(-2, 40, 82), new Point3d(2, 70, 0), new Point3d(-32, 6, -43),
+      new Point3d(13, -59, 2), new Point3d(47, 0, -85), new Point3d(-61, -79, 48),
+    ];
+    const directions = [
+      new Vector3d(-5, 41, -2), new Vector3d(31, 90, 66), new Vector3d(-93, -82, -12),
+      new Vector3d(-6, 0, 23), new Vector3d(-38, -74, 51), new Vector3d(61, 61, 64),
+    ];
+    const triangles: BarycentricTriangle[] = [
+      BarycentricTriangle.create(new Point3d(9, -26, 93), new Point3d(75, 36, 93), new Point3d(-87, 92, 63)),
+      BarycentricTriangle.create(new Point3d(-17, 39, 5), new Point3d(73, 84, -30), new Point3d(-55, 94, 28)),
+      BarycentricTriangle.create(new Point3d(-58, -28, -82), new Point3d(-20, 4, -23), new Point3d(-50, 9, -73)),
+      BarycentricTriangle.create(new Point3d(56, -29, -90), new Point3d(6, -1, 89), new Point3d(13, -59, 2)),
+      BarycentricTriangle.create(new Point3d(64, -39, -84), new Point3d(-50, -100, 17), new Point3d(-47, -10, -16)),
+      BarycentricTriangle.create(new Point3d(57, 10, -92), new Point3d(-10, -28, -85), new Point3d(-42, -60, 79)),
+    ];
+
+    for (let i = 0; i < numSamples; i++) {
+      const ray = Ray3d.create(origins[i], directions[i])
+      const intersectionPointFast = ray.intersectionWithTriangle(
+        triangles[i].points[0], triangles[i].points[1], triangles[i].points[2],
+      )!;
+      const intersectionPointSlow = triangles[i].intersectRay3d(ray).world;
+
+      ck.testPoint3d(
+        intersectionPointFast,
+        intersectionPointSlow,
+        "intersection points calculated by Ray3d and BarycentricTriangle classes are equal",
+      );
     }
     expect(ck.getNumErrors()).toBe(0);
   });


### PR DESCRIPTION
Ray3d.intersectionWithTriangle was not finding intersection of a Ray3d into a triangle if ray origin was on the triangle.