### PR TITLE
add elliptic to pnpm globalOverrides, address GHSA-vjh7-7g9h-fjfh

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -10,7 +10,8 @@
     ]
   },
   "globalOverrides": {
-    "cross-spawn": "^7.0.5" // https://github.com/advisories/GHSA-3xgq-45jj-v275 npm-run-all>cross-spawn
+    "cross-spawn": "^7.0.5", // https://github.com/advisories/GHSA-3xgq-45jj-v275 npm-run-all>cross-spawn
+    "elliptic": "^6.6.1" // https://github.com/advisories/GHSA-vjh7-7g9h-fjfh crypto-browserify>browserify-sign>elliptic
   },
   // A list of temporary advisories excluded from the High and Critical list.
   // Warning this should only be used as a temporary measure to avoid build failures

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cross-spawn: ^7.0.5
+  elliptic: ^6.6.1
 
 pnpmfileChecksum: avk5jcsa6uxo2n5cahoirjiuw4
 


### PR DESCRIPTION
Address https://github.com/advisories/GHSA-vjh7-7g9h-fjfh

full-stack-core tests still needs `crypto-browserify` to build and run tests, so can't drop. No new version of the dep has been published since, so have to override the subdeps that's the root of the audit issue.

Will manually cherry-pick to my existing bp PRs.