### PR TITLE
Deprecate `GeoServiceStatus.Pending` and `GeoCoordStatus.Pending`

### DIFF
--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -571,7 +571,7 @@ export enum GeoServiceStatus {
     OutOfMathematicalDomain = 147458,
     // (undocumented)
     OutOfUsefulRange = 147457,
-    // (undocumented)
+    // @deprecated (undocumented)
     Pending = 147462,
     // (undocumented)
     Success = 0,

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -3724,6 +3724,7 @@ export enum GeoCoordStatus {
     NoGCSDefined = 100,
     OutOfMathematicalDomain = 2,
     OutOfUsefulRange = 1,
+    // @deprecated
     Pending = -41556,
     Success = 0,
     VerticalDatumConvertError = 26

--- a/common/changes/@itwin/core-bentley/master_2025-02-19-14-14.json
+++ b/common/changes/@itwin/core-bentley/master_2025-02-19-14-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Deprecated `GeoServiceStatus.Pending`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-common/master_2025-02-19-14-14.json
+++ b/common/changes/@itwin/core-common/master_2025-02-19-14-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Deprecated `GeoCoordStatus.Pending`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/bentley/src/BentleyError.ts
+++ b/core/bentley/src/BentleyError.ts
@@ -288,6 +288,9 @@ export enum GeoServiceStatus {
   NoDatumConverter = GEOSERVICESTATUS_BASE + 3,
   VerticalDatumConvertError = GEOSERVICESTATUS_BASE + 4,
   CSMapError = GEOSERVICESTATUS_BASE + 5,
+  /**
+   * @deprecated in 5.0. Pending is no longer a valid status.
+   */
   Pending = GEOSERVICESTATUS_BASE + 6,
 }
 
@@ -623,7 +626,7 @@ export class BentleyError extends Error {
       case GeoServiceStatus.NoDatumConverter: return "No datum converter";
       case GeoServiceStatus.VerticalDatumConvertError: return "Vertical datum convert error";
       case GeoServiceStatus.CSMapError: return "CSMap error";
-      case GeoServiceStatus.Pending: return "Pending";
+      case GeoServiceStatus.Pending: return "Pending"; // eslint-disable-line @typescript-eslint/no-deprecated
       case RealityDataStatus.InvalidData: return "Invalid or unknown data";
       case DbResult.BE_SQLITE_OK:
       case DbResult.BE_SQLITE_ROW:

--- a/core/bentley/src/BentleyError.ts
+++ b/core/bentley/src/BentleyError.ts
@@ -289,7 +289,7 @@ export enum GeoServiceStatus {
   VerticalDatumConvertError = GEOSERVICESTATUS_BASE + 4,
   CSMapError = GEOSERVICESTATUS_BASE + 5,
   /**
-   * @deprecated in 5.0. Pending is no longer a valid status.
+   * @deprecated in 5.0. This status is never returned.
    */
   Pending = GEOSERVICESTATUS_BASE + 6,
 }

--- a/core/bentley/src/StatusCategory.ts
+++ b/core/bentley/src/StatusCategory.ts
@@ -342,7 +342,7 @@ function lookupHttpStatusCategory(statusCode: number): StatusCategory {
     case GeoServiceStatus.NoDatumConverter: return new OperationFailed();
     case GeoServiceStatus.VerticalDatumConvertError: return new OperationFailed();
     case GeoServiceStatus.CSMapError: return new InternalError();
-    case GeoServiceStatus.Pending: return new Pending();
+    case GeoServiceStatus.Pending: return new Pending(); // eslint-disable-line @typescript-eslint/no-deprecated
 
     case RealityDataStatus.Success: return new Success();
     case RealityDataStatus.InvalidData: return new InvalidData();

--- a/core/common/src/GeoCoordinateServices.ts
+++ b/core/common/src/GeoCoordinateServices.ts
@@ -59,6 +59,7 @@ export enum GeoCoordStatus {
   /** This temporary status is used to mark coordinates for which the conversion has not yet been processed by the backend
    *  as opposed to other coordinate conversions that may have been resolved otherwise (typically a cache).
    *  At the completion of the conversion promise no coordinates should have this status.
+   * @deprecated in 5.0. Pending is no longer returned as a status for coordinate conversions.
    */
   Pending = -41556,
 }
@@ -75,7 +76,7 @@ export function mapToGeoServiceStatus(s: GeoCoordStatus): GeoServiceStatus {
     case GeoCoordStatus.NoDatumConverter: return GeoServiceStatus.NoDatumConverter;
     case GeoCoordStatus.VerticalDatumConvertError: return GeoServiceStatus.VerticalDatumConvertError;
     case GeoCoordStatus.CSMapError: return GeoServiceStatus.CSMapError;
-    case GeoCoordStatus.Pending: return GeoServiceStatus.Pending;
+    case GeoCoordStatus.Pending: return GeoServiceStatus.Pending; // eslint-disable-line @typescript-eslint/no-deprecated
     default:
       throw new Error("GeoCoordStatus -> GeoServiceStatus - Missing enum conversion");
   }


### PR DESCRIPTION
`GeoCoordStatus` and `GeoServiceStatus` seem to be only used to indicate coordinate conversion status. After going through the code it doesn't seem like `Pending` will be ever returned (last usage in core was removed in https://github.com/iTwin/itwinjs-core/pull/5098 and [`ReprojectStatus`](https://github.com/iTwin/imodel-native/blob/daa66a0a45de96f8e8153d4265edc7c153d8f5e1/iModelCore/GeomLibs/PublicAPI/Geom/GeoPoint.h#L49) in native does not contain `Pending` type either).