### PR TITLE
Account for changes for bearing format conventions

### DIFF
--- a/common/changes/@itwin/core-frontend/accudraw-bearing-mode_2025-02-20-23-48.json
+++ b/common/changes/@itwin/core-frontend/accudraw-bearing-mode_2025-02-20-23-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}


### PR DESCRIPTION
When the "angle" input field is being used with a bearing direction formatter/parser, update the logic that adjusts the angle (which is measured from the AccuDraw compass X axis) for the current bearing format conventions. Now design X wants 90 for "N90E" instead of 0, and design Y wants 0 for "N0E" instead of 90, which was the old convention.