### PR TITLE
Fix for ACS plane snap lock.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -450,6 +450,7 @@ export class AccuDraw {
     indexed: LockedStates;
     // @internal (undocumented)
     protected _indexToleranceInches: number;
+    is3dCompass(viewport: Viewport): boolean;
     get isActive(): boolean;
     get isBearingMode(): boolean;
     get isDeactivated(): boolean;

--- a/common/changes/@itwin/core-frontend/accudraw-force-2d-layout_2025-02-22-15-02.json
+++ b/common/changes/@itwin/core-frontend/accudraw-force-2d-layout_2025-02-22-15-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/AccuDraw.ts
+++ b/core/frontend/src/AccuDraw.ts
@@ -429,6 +429,16 @@ export class AccuDraw {
       this.currentState = CurrentState.Deactivated;
   }
 
+  /** Whether to show Z input field in 3d. Sub-classes can override to restrict AccuDraw to 2d input when working in overlays where
+   * depth is not important.
+   * @note Intended to be used in conjunction with ViewState.allow3dManipulations returning false to also disable 3d rotation and
+   * ToolAdmin.acsPlaneSnapLock set to true for projecting snapped points to the view's ACS plane.
+   * @see [[ViewState.allow3dManipulations]][[ToolAdmin.acsPlaneSnapLock]]
+   */
+  public is3dCompass(viewport: Viewport): boolean {
+    return viewport.view.is3d();
+  }
+
   /** Change current compass input mode to either polar or rectangular */
   public setCompassMode(mode: CompassMode): void {
     if (mode === this.compassMode)
@@ -622,7 +632,7 @@ export class AccuDraw {
   public isZLocked(vp: Viewport): boolean {
     if (this._fieldLocked[ItemField.Z_Item])
       return true;
-    if (vp.isSnapAdjustmentRequired) //  && TentativeOrAccuSnap.isHot())
+    if (vp.isSnapAdjustmentRequired && TentativeOrAccuSnap.isHot)
       return true;
 
     return false;

--- a/core/frontend/src/tools/AccuDrawTool.ts
+++ b/core/frontend/src/tools/AccuDrawTool.ts
@@ -191,7 +191,7 @@ export class AccuDrawShortcuts {
     }
 
     const vp = accudraw.currentView;
-    const is3d = vp ? vp.view.is3d() : false;
+    const is3d = vp ? accudraw.is3dCompass(vp) : false;
     const isPolar = (CompassMode.Polar === accudraw.compassMode);
     switch (index) {
       case ItemField.DIST_Item:

--- a/core/frontend/src/tools/AccuDrawViewportUI.ts
+++ b/core/frontend/src/tools/AccuDrawViewportUI.ts
@@ -685,7 +685,7 @@ export class AccuDrawViewportUI extends AccuDraw {
     if (undefined === this._controls) {
       const overlay = vp.addNewDiv("accudraw-overlay", true, 35);
       const div = this.createControlDiv();
-      const is3dLayout = vp.view.is3d();
+      const is3dLayout = this.is3dCompass(vp);
       const isHorizontalLayout = props.horizontalArrangement;
 
       overlay.appendChild(div);
@@ -739,7 +739,7 @@ export class AccuDrawViewportUI extends AccuDraw {
       div.style.height = isHorizontalLayout ? `${itemHeight * props.rowSpacingFactor}px` : `${rowOffset}px`;
 
       this._controls = { overlay, div, itemFields, itemLocks };
-      this.updateControlVisibility(CompassMode.Polar === this.compassMode, vp.view.is3d());
+      this.updateControlVisibility(CompassMode.Polar === this.compassMode, this.is3dCompass(vp));
       this.setFocusItem(this._focusItem);
       this.suspendToolTips();
 


### PR DESCRIPTION
Added is3dCompass for SiteOps to use 2d UI in 3d. [Issue](https://github.com/iTwin/itwinjs-core/issues/7757)