### PR TITLE
Forward error metadata to Frontend

### DIFF
--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -176,8 +176,6 @@ export abstract class IpcHandler {
       } catch (err: any) {
         let ret: IpcInvokeReturn;
         if (ITwinError.isITwinError(err)) {
-          // TODO: Should metadata be left out? It is left out in the original error implementation..
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { namespace, errorKey, message, stack, metadata, ...rest } = err;
           ret = {
             iTwinError:
@@ -185,6 +183,7 @@ export abstract class IpcHandler {
               namespace,
               errorKey,
               message,
+              ...(metadata && { metadata }), // Include metadata only when defined
               ...rest,
             },
           };

--- a/core/common/src/ipc/IpcSocket.ts
+++ b/core/common/src/ipc/IpcSocket.ts
@@ -6,6 +6,8 @@
  * @module IpcSocket
  */
 
+import { LoggingMetaData } from "@itwin/core-bentley";
+
 /**
  * The prefix for all IpcSocket channels to disambiguate from system channels.
  * @internal
@@ -32,7 +34,7 @@ export type RemoveFunction = () => void;
  * Otherwise the `result` member holds the response.
  * @internal */
 export type IpcInvokeReturn = { result: any, error?: never, iTwinError?: never } | { result?: never, iTwinError?: never, error: { name: string, message: string, errorNumber: number, stack?: string } } |
-{ result?: never, error?: never, iTwinError: {namespace: string, errorKey: string, message: string, stack?: string, [key: string]: any} };
+{ result?: never, error?: never, iTwinError: {namespace: string, errorKey: string, message: string, stack?: string, metadata?: LoggingMetaData, [key: string]: any } };
 /**
  * An inter-process socket connection between a single [IModelHost]($backend) on the backend (the node process), and an [IModelApp]($frontend) on
  * the frontend (the browser process.) Each side will implement this interface to form a two way connection. The frontend and backend

--- a/full-stack-tests/core/src/frontend/standalone/Error.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/Error.test.ts
@@ -33,7 +33,7 @@ if (ProcessDetector.isElectronAppFrontend) {
           expect(err.stack?.includes("core\\backend") || err.stack?.includes("core/backend"), `Expected ${err.stack} to have mention of 'core\\backend' or 'core/backend'`).to.be.true;
           expect(err.message).to.equal(message);
           expect(err.inUseLocks).to.deep.equal(inUseLocks);
-          expect(ITwinError.getMetaData(err)).to.be.undefined; // Currently not propagating metadata.
+          expect(ITwinError.getMetaData(err)).to.deep.equal(metadata);
         }
       }
       expect(caughtError).to.be.true;


### PR DESCRIPTION
We currently do not send error metadata to the frontend via IPC. However, this change would enable error metadata to be sent for further processing.

- Added metadata property to IpcInvokeReturn.

- Modified test to now check for metadata.