### PR TITLE
Clarify documentation related to saving and pushing Txns

### DIFF
--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -803,7 +803,7 @@ export abstract class IModelDb extends IModel {
     this[_nativeDb].updateIModelProps(this.toJSON());
   }
 
-  /** Commit unsaved changes in memory as a Txn to the iModelDb.
+  /** Commit unsaved changes in memory as a Txn to this iModelDb.
    * @param description Optional description of the changes
    * @throws [[IModelError]] if there is a problem saving changes or if there are pending, un-processed lock or code requests.
    * @note This will not push changes to the iModelHub.
@@ -818,7 +818,9 @@ export abstract class IModelDb extends IModel {
       throw new IModelError(stat, `Could not save changes (${description})`);
   }
 
-  /** Abandon pending changes in this iModel. */
+  /** Abandon changes in memory that have not been saved as a Txn to this iModelDb. 
+   * @note This will not delete Txns that have already been saved, even if they have not yet been pushed.
+  */
   public abandonChanges(): void {
     this[_nativeDb].abandonChanges();
   }

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -803,9 +803,11 @@ export abstract class IModelDb extends IModel {
     this[_nativeDb].updateIModelProps(this.toJSON());
   }
 
-  /** Commit pending changes to this iModel.
+  /** Commit unsaved changes in memory as a Txn to the iModelDb.
    * @param description Optional description of the changes
    * @throws [[IModelError]] if there is a problem saving changes or if there are pending, un-processed lock or code requests.
+   * @note This will not push changes to the iModelHub.
+   * @see [[IModelDb.pushChanges]] to push changes to the iModelHub.
    */
   public saveChanges(description?: string): void {
     if (this.openMode === OpenMode.Readonly)

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -732,13 +732,22 @@ export class TxnManager {
   /** Test if a TxnId is valid */
   public isTxnIdValid(txnId: TxnIdString): boolean { return this._nativeDb.isTxnIdValid(txnId); }
 
-  /** Query if there are any pending Txns in this IModelDb that are waiting to be pushed.  */
+  /** Query if there are any pending Txns in this IModelDb that are waiting to be pushed.
+   * @see [[IModelDb.pushChanges]]
+   */
   public get hasPendingTxns(): boolean { return this._nativeDb.hasPendingTxns(); }
 
-  /** Query if there are any changes in memory that have yet to be saved to the IModelDb. */
+  /**
+   * Query if there are any changes in memory that have yet to be saved to the IModelDb.
+   * @see [[IModelDb.saveChanges]]
+   */
   public get hasUnsavedChanges(): boolean { return this._nativeDb.hasUnsavedChanges(); }
 
-  /** Query if there are un-saved or un-pushed local changes. */
+  /**
+   * Query if there are changes in memory that have not been saved to the iModelDb or if there are Txns that are waiting to be pushed.
+   * @see [[IModelDb.saveChanges]]
+   * @see [[IModelDb.pushChanges]]
+   */
   public get hasLocalChanges(): boolean { return this.hasUnsavedChanges || this.hasPendingTxns; }
 
   /** Destroy the record of all local changes that have yet to be saved and/or pushed.


### PR DESCRIPTION
Follow up to #7712

Clarify whether functions apply to changes that have not yet been saved as a Txn to the iModelDb, versus those that apply to Txns that have not yet been pushed to iModel hub
