### PR TITLE
Deprecate some replaced metadata methods

### DIFF
--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -398,7 +398,10 @@ export class Element extends Entity {
     model: ConcreteEntityTypes.Model,
   };
 
-  /** Get the class metadata for this element. */
+  /** Get the class metadata for this element.
+   * @deprecated in 5.0. Use [[Entity.getMetaData]] instead.
+   */
+   
   public getClassMetaData(): EntityMetaData | undefined { return this.iModel.classMetaDataRegistry.find(this.classFullName); }
 
   private getAllUserProperties(): any {

--- a/core/backend/src/Entity.ts
+++ b/core/backend/src/Entity.ts
@@ -71,6 +71,7 @@ export class Entity {
     this.iModel = iModel;
     this.id = Id64.fromJSON(props.id);
     // copy all auto-handled properties from input to the object being constructed
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.forEachProperty((propName: string, meta: PropertyMetaData) => (this as any)[propName] = meta.createProperty((props as any)[propName]), false);
   }
 
@@ -89,6 +90,7 @@ export class Entity {
     val.classFullName = this.classFullName;
     if (Id64.isValid(this.id))
       val.id = this.id;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.forEachProperty((propName: string) => val[propName] = (this as any)[propName], false);
     return val;
   }
@@ -97,8 +99,10 @@ export class Entity {
    * @param func The callback to be invoked on each property
    * @param includeCustom If true (default), include custom-handled properties in the iteration. Otherwise, skip custom-handled properties.
    * @note Custom-handled properties are core properties that have behavior enforced by C++ handlers.
+   * @deprecated in 5.0. Use [[getMetaData]] to get the metadata and iterate over the properties
    */
   public forEachProperty(func: PropertyCallback, includeCustom: boolean = true) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this.iModel.forEachMetaData(this.classFullName, true, func, includeCustom);
   }
 

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -818,7 +818,7 @@ export abstract class IModelDb extends IModel {
       throw new IModelError(stat, `Could not save changes (${description})`);
   }
 
-  /** Abandon changes in memory that have not been saved as a Txn to this iModelDb. 
+  /** Abandon changes in memory that have not been saved as a Txn to this iModelDb.
    * @note This will not delete Txns that have already been saved, even if they have not yet been pushed.
   */
   public abandonChanges(): void {
@@ -1154,6 +1154,7 @@ export abstract class IModelDb extends IModel {
 
   /** Get metadata for a class. This method will load the metadata from the iModel into the cache as a side-effect, if necessary.
    * @throws [[IModelError]] if the metadata cannot be found nor loaded.
+   * @deprecated in 5.0. Use [schemaContext] instead.
    */
   public getMetaData(classFullName: string): EntityMetaData {
     let metadata = this.classMetaDataRegistry.find(classFullName);
@@ -1166,9 +1167,12 @@ export abstract class IModelDb extends IModel {
     return metadata;
   }
 
-  /** Identical to [[getMetaData]], except it returns `undefined` instead of throwing an error if the metadata cannot be found nor loaded. */
+  /** Identical to [[getMetaData]], except it returns `undefined` instead of throwing an error if the metadata cannot be found nor loaded.
+   * @deprecated in 5.0. Use [schemaContext] instead.
+   */
   public tryGetMetaData(classFullName: string): EntityMetaData | undefined {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       return this.getMetaData(classFullName);
     } catch {
       return undefined;
@@ -1182,8 +1186,10 @@ export abstract class IModelDb extends IModel {
    * @param func The callback to be invoked on each property
    * @param includeCustom If true (default), include custom-handled properties in the iteration. Otherwise, skip custom-handled properties.
    * @note Custom-handled properties are core properties that have behavior enforced by C++ handlers.
+   * @deprecated in 5.0. Use [schemaContext] instead.
    */
   public static forEachMetaData(iModel: IModelDb, classFullName: string, wantSuper: boolean, func: PropertyCallback, includeCustom: boolean = true) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     iModel.forEachMetaData(classFullName, wantSuper, func, includeCustom);
   }
 
@@ -1193,8 +1199,10 @@ export abstract class IModelDb extends IModel {
    * @param func The callback to be invoked on each property
    * @param includeCustom If true (default), include custom-handled properties in the iteration. Otherwise, skip custom-handled properties.
    * @note Custom-handled properties are core properties that have behavior enforced by C++ handlers.
+   * @deprecated in 5.0. Use [schemaContext] instead.
    */
   public forEachMetaData(classFullName: string, wantSuper: boolean, func: PropertyCallback, includeCustom: boolean = true) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const meta = this.getMetaData(classFullName); // will load if necessary
     for (const propName in meta.properties) { // eslint-disable-line guard-for-in
       const propMeta = meta.properties[propName];
@@ -1203,6 +1211,7 @@ export abstract class IModelDb extends IModel {
     }
 
     if (wantSuper && meta.baseClasses && meta.baseClasses.length > 0)
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       meta.baseClasses.forEach((baseClass) => this.forEachMetaData(baseClass, true, func, includeCustom));
   }
 

--- a/core/backend/src/IModelElementCloneContext.ts
+++ b/core/backend/src/IModelElementCloneContext.ts
@@ -151,6 +151,7 @@ export class IModelElementCloneContext {
   public cloneElement(sourceElement: Element, cloneOptions?: IModelJsNative.CloneElementOptions): ElementProps {
     const targetElementProps: ElementProps = this._nativeContext.cloneElement(sourceElement.id, cloneOptions);
     // Ensure that all NavigationProperties in targetElementProps have a defined value so "clearing" changes will be part of the JSON used for update
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     sourceElement.forEachProperty((propertyName: string, meta: PropertyMetaData) => {
       if ((meta.isNavigation) && (undefined === (sourceElement as any)[propertyName])) {
         (targetElementProps as any)[propertyName] = RelatedElement.none;

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -164,6 +164,7 @@ class ChangedEntitiesProc {
       db.withPreparedSqliteStatement(sql, (stmt) => {
         while (stmt.step() === DbResult.BE_SQLITE_ROW) {
           const classFullName = `${stmt.getValueString(2)}:${stmt.getValueString(0)}`;
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           db.tryGetMetaData(classFullName);
         }
       });
@@ -182,6 +183,7 @@ class ChangedEntitiesProc {
       const bases: number[] = [];
       result[index] = { name, bases };
 
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const meta = db.tryGetMetaData(name);
       if (!meta) {
         return;

--- a/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
+++ b/core/backend/src/rpc-impl/IModelReadRpcImpl.ts
@@ -233,6 +233,7 @@ export class IModelReadRpcImpl extends RpcInterface implements IModelReadRpcInte
     const iModelDb = await getIModelForRpc(tokenProps);
     const classArray: string[] = [];
     while (true) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const classMetaData: EntityMetaData = iModelDb.getMetaData(classFullName);
       classArray.push(classFullName);
       if (!classMetaData.baseClasses || classMetaData.baseClasses.length === 0)

--- a/core/backend/src/test/element/ElementRoundTrip.test.ts
+++ b/core/backend/src/test/element/ElementRoundTrip.test.ts
@@ -565,6 +565,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
       }
     } as unknown as TestElement;
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const relClassId = imodel.getMetaData("BisCore:ModelContainsElements").classId;
 
     // verify inserted element properties
@@ -596,6 +597,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     let reader = imodel.createQueryReader("SELECT ECInstanceId, ECClassId, Model.Id, Model.RelECClassId FROM ts.TestElement", undefined, { rowFormat: QueryRowFormat.UseECSqlPropertyNames });
     assert.isTrue(await reader.step());
     assert.equal(reader.current.ECInstanceId, id);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.equal(reader.current.ECClassId, geomElement.getClassMetaData()?.classId);
     assert.equal(reader.current.Id, newModelId);
     assert.equal(reader.current.RelECClassId, relClassId);
@@ -642,6 +644,7 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     reader = imodel.createQueryReader("SELECT ECInstanceId, ECClassId, Model.Id, Model.RelECClassId FROM ts.TestElement", undefined, { rowFormat: QueryRowFormat.UseECSqlPropertyNames });
     assert.isTrue(await reader.step());
     assert.equal(reader.current.ECInstanceId, id);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.equal(reader.current.ECClassId, geomElement.getClassMetaData()?.classId);
     assert.equal(reader.current.Id, newModelId);
     assert.equal(reader.current.RelECClassId, relClassId);
@@ -684,8 +687,10 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
     const reader = iModel.createQueryReader("SELECT ECInstanceId, ECClassId, Element.Id, Element.RelECClassId FROM ts.TestElementAspect", undefined, { rowFormat: QueryRowFormat.UseECSqlPropertyNames });
     assert.isTrue(await reader.step());
     assert.equal(reader.current.ECInstanceId, elementAspectId);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.equal(reader.current.ECClassId, iModel.getMetaData("ElementRoundTripTest:TestElementAspect").classId);
     assert.equal(reader.current.Id, elementId);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.equal(reader.current.RelECClassId, iModel.getMetaData("BisCore:ElementOwnsUniqueAspect").classId);
     assert.isFalse(await reader.step());
 
@@ -811,7 +816,9 @@ describe("Element and ElementAspect roundtrip test for all type of properties", 
       targetClassName: `ElementRoundTripTest.TestElement`,
     } as unknown as TestElementRefersToElements;
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const classId = imodel.getMetaData("ElementRoundTripTest:TestElementRefersToElements").classId;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const testElementId = imodel.getMetaData("ElementRoundTripTest:TestElement").classId;
 
     // verify system properties via concurrent query

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1060,6 +1060,7 @@ describe("iModel", () => {
   }
 
   it("should get metadata for class", () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const metaData: EntityMetaData = imodel1.getMetaData(Element.classFullName);
     assert.exists(metaData);
     checkElementMetaData(metaData);
@@ -1146,12 +1147,14 @@ describe("iModel", () => {
   }
 
   it("should get metadata for CA class just as well (and we'll see a array-typed property)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const metaData: EntityMetaData = imodel1.getMetaData("BisCore:ClassHasHandler");
     assert.exists(metaData);
     checkClassHasHandlerMetaData(metaData);
   });
 
   it("should get metadata for CA class just as well (and we'll see a array-typed property)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const metaData = imodel1.getMetaData("BisCore:ClassHasHandler");
     assert.exists(metaData);
     checkClassHasHandlerMetaData(metaData);
@@ -1357,6 +1360,7 @@ describe("iModel", () => {
   });
 
   it("should import schemas", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const classMetaData = imodel1.getMetaData("TestBim:TestDocument"); // will throw on failure
     assert.isDefined(classMetaData.properties.testDocumentProperty);
     assert.isTrue(classMetaData.properties.testDocumentProperty.primitiveType === PrimitiveTypeCode.Integer);
@@ -1397,6 +1401,7 @@ describe("iModel", () => {
   it("should create model with custom relationship to modeled element", async () => {
     const testImodel = imodel1;
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.isDefined(testImodel.getMetaData("TestBim:TestModelModelsElement"), "TestModelModelsElement is expected to be defined in TestBim.ecschema.xml");
 
     let newModelId1: Id64String;
@@ -1523,6 +1528,7 @@ describe("iModel", () => {
   it("should set EC properties of various types", async () => {
 
     const testImodel = imodel1;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     testImodel.getMetaData("TestBim:TestPhysicalObject");
 
     // Create a new physical model

--- a/core/backend/src/test/imodel/SchemaXmlImport.test.ts
+++ b/core/backend/src/test/imodel/SchemaXmlImport.test.ts
@@ -35,6 +35,7 @@ describe("Schema XML Import Tests", () => {
 
     await imodel.importSchemaStrings([schemaString]); // will throw an exception if import fails
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const testDomainClass = imodel.getMetaData("Test3:Test3Element"); // will throw on failure
 
     assert.equal(testDomainClass.baseClasses.length, 1);

--- a/core/backend/src/test/schema/ClassRegistry.test.ts
+++ b/core/backend/src/test/schema/ClassRegistry.test.ts
@@ -39,6 +39,7 @@ describe("Class Registry", () => {
     const el = imodel.elements.getElement(code1);
     assert.exists(el);
     if (el) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const metaData: EntityMetaData | undefined = el.getClassMetaData();
       assert.exists(metaData);
       if (undefined === metaData)
@@ -60,6 +61,7 @@ describe("Class Registry", () => {
     const el2 = imodel.elements.getElement("0x34");
     assert.exists(el2);
     if (el2) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const metaData = el2.getClassMetaData();
       assert.exists(metaData);
       if (undefined === metaData)
@@ -80,6 +82,7 @@ describe("Class Registry", () => {
     const schemaPathname = path.join(KnownTestLocations.assetsDir, "TestDomain.ecschema.xml");
     await imodel.importSchemas([schemaPathname]); // will throw an exception if import fails
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const testDomainClass = imodel.getMetaData("TestDomain:TestDomainClass"); // will throw on failure
 
     assert.equal(testDomainClass.baseClasses.length, 2);
@@ -92,6 +95,7 @@ describe("Class Registry", () => {
     // Verify that the forEach method which is called when constructing an entity
     // is picking up all expected properties.
     const testData: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     IModelDb.forEachMetaData(imodel, "TestDomain:TestDomainClass", true, (propName) => {
       testData.push(propName);
     }, false);

--- a/core/backend/src/test/standalone/ChangesetReader.test.ts
+++ b/core/backend/src/test/standalone/ChangesetReader.test.ts
@@ -617,6 +617,7 @@ describe("Changeset Reader API", async () => {
     assert.isUndefined(findEl(el2));
     assert.isDefined(findEl(el3));
     assert.isDefined(findEl(el4));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(rwIModel.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2"]);
     // 6. Revert to timeline 2
     await rwIModel.revertAndPushChanges({ toIndex: 2, description: "revert to timeline 2" });
@@ -626,6 +627,7 @@ describe("Changeset Reader API", async () => {
     assert.isUndefined(findEl(el2));
     assert.isUndefined(findEl(el3));
     assert.isUndefined(findEl(el4));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(rwIModel.getMetaData("TestDomain:Test2dElement").properties), ["p1"]);
 
     await rwIModel.revertAndPushChanges({ toIndex: 6, description: "reinstate last reverted changeset" });
@@ -634,6 +636,7 @@ describe("Changeset Reader API", async () => {
     assert.isUndefined(findEl(el2));
     assert.isDefined(findEl(el3));
     assert.isDefined(findEl(el4));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(rwIModel.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2"]);
 
     await addPropertyAndImportSchema();
@@ -641,6 +644,7 @@ describe("Changeset Reader API", async () => {
     await updateEl(el1, { p1: "test12", p2: "test13", p3: "test114" });
     rwIModel.saveChanges();
     await rwIModel.pushChanges({ description: "import schema, insert element 5 & update element 1" });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(rwIModel.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
 
     // skip schema changes & auto generated comment
@@ -651,6 +655,7 @@ describe("Changeset Reader API", async () => {
     assert.isUndefined(findEl(el3));
     assert.isUndefined(findEl(el4));
     assert.isUndefined(findEl(el5));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(rwIModel.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
 
     await rwIModel.revertAndPushChanges({ toIndex: 9 });
@@ -660,6 +665,7 @@ describe("Changeset Reader API", async () => {
     assert.isDefined(findEl(el3));
     assert.isDefined(findEl(el4));
     assert.isDefined(findEl(el5));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(rwIModel.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
     rwIModel.close();
   });

--- a/core/backend/src/test/standalone/TxnManager.test.ts
+++ b/core/backend/src/test/standalone/TxnManager.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../core-backend";
 import { IModelTestUtils, TestElementDrivesElement, TestPhysicalObject, TestPhysicalObjectProps } from "../IModelTestUtils";
 import { IModelNative } from "../../internal/NativePlatform";
+import { EntityClass, SchemaItemKey, SchemaKey } from "@itwin/ecschema-metadata";
 
 /// cspell:ignore accum
 
@@ -104,7 +105,7 @@ describe("TxnManager", () => {
     let model = models.getModel<PhysicalModel>(modelId);
     assert.isUndefined(model.geometryGuid, "geometryGuid starts undefined");
 
-    assert.isDefined(imodel.getMetaData("TestBim:TestPhysicalObject"), "TestPhysicalObject is present");
+    assert.isDefined(await imodel.schemaContext.getSchemaItem(new SchemaItemKey("TestPhysicalObject", new SchemaKey("TestBim", 1,0,0)), EntityClass), "TestPhysicalObject is present");
 
     const txns = imodel.txns;
     assert.isFalse(txns.hasPendingTxns);

--- a/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
+++ b/domains/analytical/backend/src/test/AnalyticalSchema.test.ts
@@ -12,7 +12,7 @@ import {
   Schemas, SnapshotDb, SpatialCategory, SubjectOwnsPartitionElements,
 } from "@itwin/core-backend";
 import {
-  CategoryProps, Code, ColorDef, GeometricElement3dProps, IModel, InformationPartitionElementProps, ModelProps, PropertyMetaData, RelatedElement,
+  CategoryProps, Code, ColorDef, GeometricElement3dProps, IModel, InformationPartitionElementProps, ModelProps, RelatedElement,
   TypeDefinitionElementProps,
 } from "@itwin/core-common";
 import { AnalyticalElement, AnalyticalModel, AnalyticalPartition, AnalyticalSchema } from "../analytical-backend";
@@ -123,22 +123,15 @@ describe("AnalyticalSchema", () => {
     const elementId: Id64String = iModelDb.elements.insertElement(elementProps);
     // test forEachProperty and PropertyMetaData.isNavigation
     const element: GeometricElement3d = iModelDb.elements.getElement(elementId);
-    element.forEachProperty((propertyName: string, meta: PropertyMetaData) => {
-      switch (propertyName) {
+    const metadata = await element.getMetaData();
+    (await metadata.getProperties()).forEach((property) => {
+      switch (property.name) {
         case "model":
-          assert.isTrue(meta.isNavigation);
-          break;
         case "category":
-          assert.isTrue(meta.isNavigation);
-          break;
         case "typeDefinition":
-          assert.isTrue(meta.isNavigation);
-          break;
         case "codeValue":
-          assert.isFalse(meta.isNavigation);
-          break;
         case "userLabel":
-          assert.isFalse(meta.isNavigation);
+        assert.isTrue(property.isNavigation());
           break;
       }
     });

--- a/full-stack-tests/backend/src/integration/SchemaSync.test.ts
+++ b/full-stack-tests/backend/src/integration/SchemaSync.test.ts
@@ -70,9 +70,10 @@ const tinySchemaToXml = (s: TinySchema) => {
   xml.push(`</ECSchema>`);
   return xml.join(EOL);
 };
-const queryPropNames = (b: BriefcaseDb, className: string) => {
+const queryPropNames = (b: BriefcaseDb, classFullName: string) => {
   try {
-    return Object.getOwnPropertyNames(b.getMetaData(className).properties);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    return Object.getOwnPropertyNames(b.getMetaData(classFullName).properties);
   } catch { return []; }
 };
 const assertChangesetTypeAndDescr = async (b: BriefcaseDb, changesetType: ChangesetType, description: string) => {
@@ -186,6 +187,7 @@ describe("Schema synchronization", function (this: Suite) {
     b1.saveChanges();
 
     // ensure b1 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2"], Object.getOwnPropertyNames(b1.getMetaData("TestSchema1:Pipe1").properties));
 
     // pull schema change into b2 from shared schema channel
@@ -193,6 +195,7 @@ describe("Schema synchronization", function (this: Suite) {
     b2.saveChanges();
 
     // ensure b2 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2"], Object.getOwnPropertyNames(b2.getMetaData("TestSchema1:Pipe1").properties));
 
     // add new properties in b2
@@ -211,6 +214,7 @@ describe("Schema synchronization", function (this: Suite) {
     b2.saveChanges();
 
     // ensure b2 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2", "p3", "p4"], Object.getOwnPropertyNames(b2.getMetaData("TestSchema1:Pipe1").properties));
 
     // pull schema change into b1 from shared schema channel
@@ -218,6 +222,7 @@ describe("Schema synchronization", function (this: Suite) {
     b1.saveChanges();
 
     // ensure b1 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2", "p3", "p4"], Object.getOwnPropertyNames(b1.getMetaData("TestSchema1:Pipe1").properties));
 
     // push changes
@@ -228,6 +233,7 @@ describe("Schema synchronization", function (this: Suite) {
     await b3.pullChanges({ accessToken: user3AccessToken });
 
     // ensure b3 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2", "p3", "p4"], Object.getOwnPropertyNames(b3.getMetaData("TestSchema1:Pipe1").properties));
 
     b1.close();
@@ -284,6 +290,7 @@ describe("Schema synchronization", function (this: Suite) {
     b1.saveChanges();
 
     // ensure b1 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2"], Object.getOwnPropertyNames(b1.getMetaData("TestSchema1:Pipe1").properties));
 
     // pull schema change into b2 from shared schema channel
@@ -291,6 +298,7 @@ describe("Schema synchronization", function (this: Suite) {
     b2.saveChanges();
 
     // ensure b2 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2"], Object.getOwnPropertyNames(b2.getMetaData("TestSchema1:Pipe1").properties));
 
     // import same schema from another briefcase
@@ -298,6 +306,7 @@ describe("Schema synchronization", function (this: Suite) {
     b2.saveChanges();
 
     // ensure b2 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2"], Object.getOwnPropertyNames(b2.getMetaData("TestSchema1:Pipe1").properties));
 
     // pull schema change into b1 from shared schema channel
@@ -305,6 +314,7 @@ describe("Schema synchronization", function (this: Suite) {
     b1.saveChanges();
 
     // ensure b1 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2"], Object.getOwnPropertyNames(b1.getMetaData("TestSchema1:Pipe1").properties));
 
     // push changes
@@ -315,6 +325,7 @@ describe("Schema synchronization", function (this: Suite) {
     await b3.pullChanges({ accessToken: user3AccessToken });
 
     // ensure b3 have class and its properties
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.sameOrderedMembers(["p1", "p2"], Object.getOwnPropertyNames(b3.getMetaData("TestSchema1:Pipe1").properties));
 
     b1.close();
@@ -1505,6 +1516,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isUndefined(findEl(el2));
     assert.isDefined(findEl(el3));
     assert.isDefined(findEl(el4));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2"]);
     // 6. Revert to timeline 2
     await b2.revertAndPushChanges({ toIndex: 3, description: "revert to timeline 2" });
@@ -1515,6 +1527,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isUndefined(findEl(el2));
     assert.isUndefined(findEl(el3));
     assert.isUndefined(findEl(el4));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2"]);
 
     await b2.revertAndPushChanges({ toIndex: 7, description: "reinstate last reverted changeset" });
@@ -1524,6 +1537,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isUndefined(findEl(el2));
     assert.isDefined(findEl(el3));
     assert.isDefined(findEl(el4));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2"]);
 
     await addPropertyAndImportSchema(b1);
@@ -1531,6 +1545,7 @@ describe("Schema synchronization", function (this: Suite) {
     await updateEl(el1, { p1: "test12", p2: "test13", p3: "test114" });
     b1.saveChanges();
     await b1.pushChanges({ description: "import schema, insert element 5 & update element 1" });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
 
     // skip schema changes & auto generated comment
@@ -1541,6 +1556,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isUndefined(findEl(el3));
     assert.isUndefined(findEl(el4));
     assert.isUndefined(findEl(el5));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
 
     await b1.revertAndPushChanges({ toIndex: 10 });
@@ -1550,6 +1566,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isDefined(findEl(el3));
     assert.isDefined(findEl(el4));
     assert.isDefined(findEl(el5));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
 
     // schema sync should be skip for revert
@@ -1558,16 +1575,20 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isTrue(SchemaSync.isEnabled(b3));
 
     await addPropertyAndImportSchema(b1);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3", "p4"]);
 
     // b3 should get new property via schema sync
     await b3.pullChanges();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b3.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3", "p4"]);
 
     // b2 should not see new property even after revert
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b2.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
     await b2.revertAndPushChanges({ toIndex: 11 });
     assert.equal((await getChanges()).at(-1)!.description, "Reverted changes from 11 to 11 (schema changes skipped)");
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b2.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3"]);
 
     await b1.pullChanges();
@@ -1579,6 +1600,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isUndefined(findEl(el3, b1));
     assert.isUndefined(findEl(el4, b1));
     assert.isUndefined(findEl(el5, b1));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b1.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3", "p4"]);
 
     assert.isUndefined(findEl(el1, b2));
@@ -1586,6 +1608,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isUndefined(findEl(el3, b2));
     assert.isUndefined(findEl(el4, b2));
     assert.isUndefined(findEl(el5, b2));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b2.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3", "p4"]);
 
     assert.isUndefined(findEl(el1, b3));
@@ -1593,6 +1616,7 @@ describe("Schema synchronization", function (this: Suite) {
     assert.isUndefined(findEl(el3, b3));
     assert.isUndefined(findEl(el4, b3));
     assert.isUndefined(findEl(el5, b3));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     assert.deepEqual(Object.getOwnPropertyNames(b3.getMetaData("TestDomain:Test2dElement").properties), ["p1", "p2", "p3", "p4"]);
 
     b1.close();

--- a/full-stack-tests/backend/src/perftest/ECSqlRow.test.ts
+++ b/full-stack-tests/backend/src/perftest/ECSqlRow.test.ts
@@ -142,6 +142,7 @@ describe("ECSqlRowPerformanceTests", () => {
         const testSchemaName = path.join(KnownTestLocations.assetsDir, "PerfTestDomain.ecschema.xml");
         await seedIModel.importSchemas([testSchemaName]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData(`PerfTestDomain:${name}`), `${name}is present in iModel.`);
 
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
@@ -212,6 +213,7 @@ describe("ECSqlRowPerformanceTests2d", () => {
         const testSchemaName = path.join(KnownTestLocations.assetsDir, "PerfTestDomain.ecschema.xml");
         await seedIModel.importSchemas([testSchemaName]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData(`PerfTestDomain:${name}`), `${name}is present in iModel.`);
 
         const codeProps = Code.createEmpty();

--- a/full-stack-tests/backend/src/perftest/ElementCRUD.test.ts
+++ b/full-stack-tests/backend/src/perftest/ElementCRUD.test.ts
@@ -143,6 +143,7 @@ describe("PerformanceElementsTests", () => {
         const testSchemaName = path.join(KnownTestLocations.assetsDir, "PerfTestDomain.ecschema.xml");
         await seedIModel.importSchemas([testSchemaName]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData(`PerfTestDomain:${name}`), `${name}is present in iModel.`);
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");
@@ -353,6 +354,7 @@ describe("PerformanceElementsTests2d", () => {
         const testSchemaName = path.join(KnownTestLocations.assetsDir, "PerfTestDomain.ecschema.xml");
         await seedIModel.importSchemas([testSchemaName]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData(`PerfTestDomain:${name}`), `${name}is present in iModel.`);
 
         const codeProps = Code.createEmpty();

--- a/full-stack-tests/backend/src/perftest/MixinImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/MixinImpact.test.ts
@@ -130,6 +130,7 @@ describe("SchemaDesignPerf Impact of Mixins", () => {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("MixinPerformance", `mixin_${hCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData("TestMixinSchema:MixinElement"), "Mixin Class is not present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");

--- a/full-stack-tests/backend/src/perftest/PerfTestUtils.ts
+++ b/full-stack-tests/backend/src/perftest/PerfTestUtils.ts
@@ -29,6 +29,7 @@ export class PerfTestDataMgr {
     if (this.db) {
       await this.db.importSchemas([schemaPath]);
       if (testCName)
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(this.db.getMetaData(testCName), `Class Name ${testCName}is not present in iModel.`);
       this.db.saveChanges();
     }

--- a/full-stack-tests/backend/src/perftest/PolymorphicQuery.test.ts
+++ b/full-stack-tests/backend/src/perftest/PolymorphicQuery.test.ts
@@ -138,6 +138,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
         if (undefined === spatialCategoryId)
           spatialCategoryId = SpatialCategory.insert(seedIModel, IModel.dictionaryId, "MySpatialCategory", new SubCategoryAppearance({ color: ColorDef.fromString("rgb(255,0,0)").toJSON() }));
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData("TestPolySchema:TestElement"), "Base Class is not present in iModel.");
         // create base class elements
         for (let i = 0; i < flatSeedCount; ++i) {
@@ -177,6 +178,7 @@ describe("SchemaDesignPerf Polymorphic query", () => {
       if (undefined === spatialCategoryId)
         spatialCategoryId = SpatialCategory.insert(seedIModel2, IModel.dictionaryId, "MySpatialCategory", new SubCategoryAppearance({ color: ColorDef.fromString("rgb(255,0,0)").toJSON() }));
       seedIModel2[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       assert.isDefined(seedIModel2.getMetaData("TestPolySchema:TestElement"), "Base Class is not present in iModel.");
       // create base class elements
       for (let i = 0; i < multiSeedCount; ++i) {

--- a/full-stack-tests/backend/src/perftest/PropertiesImpact.test.ts
+++ b/full-stack-tests/backend/src/perftest/PropertiesImpact.test.ts
@@ -98,6 +98,7 @@ describe("SchemaDesignPerf Impact of Properties", () => {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("PropPerformance", `props_${pCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData("TestPropsSchema:PropElement"), "PropsClass is present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");
@@ -359,6 +360,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("IndexPerformance", `index_${iCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData("TestIndexSchema:PropElement"), "PropsClass is present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");
@@ -388,6 +390,7 @@ describe("SchemaDesignPerf Number of Indices", () => {
         const seedIModel = SnapshotDb.createEmpty(IModelTestUtils.prepareOutputFile("IndexPerformance", `index_perclass_${iCount}.bim`), { rootSubject: { name: "PerfTest" } });
         await seedIModel.importSchemas([st]);
         seedIModel[_nativeDb].resetBriefcaseId(BriefcaseIdValue.Unassigned);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         assert.isDefined(seedIModel.getMetaData("TestIndexSchema:PropElement0"), "PropsClass is present in iModel.");
         const [, newModelId] = IModelTestUtils.createAndInsertPhysicalPartitionAndModel(seedIModel, Code.createEmpty(), true);
         let spatialCategoryId = SpatialCategory.queryCategoryIdByName(seedIModel, IModel.dictionaryId, "MySpatialCategory");

--- a/presentation/backend/src/test/SelectionScopesHelper.test.ts
+++ b/presentation/backend/src/test/SelectionScopesHelper.test.ts
@@ -159,6 +159,7 @@ describe("SelectionScopesHelper", () => {
       imodelMock.setup((x) => x.elements).returns(() => elementsMock.object);
       imodelMock.setup((x) => x.models).returns(() => modelsMock.object);
       imodelMock
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         .setup((x) => x.getMetaData(moq.It.isAnyString()))
         .returns(
           (className: string) =>


### PR DESCRIPTION
WIP
I replaced some callers with the new calls, and ignored the deprecation warning on others. Eventually we will want to replace them all.

Fixes: https://github.com/iTwin/itwinjs-backlog/issues/1415