### PR TITLE
Sending metadata for bentley error over ipc

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -5315,6 +5315,7 @@ export type IpcInvokeReturn = {
         message: string;
         errorNumber: number;
         stack?: string;
+        metadata?: LoggingMetaData;
     };
 } | {
     result?: never;

--- a/common/changes/@itwin/core-backend/pankhur94-forward-error-metadata_2025-03-05-01-58.json
+++ b/common/changes/@itwin/core-backend/pankhur94-forward-error-metadata_2025-03-05-01-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Sending metadata for bentley error over ipc & checking function is not sent as metadata ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/pankhur94-forward-error-metadata_2025-03-05-01-58.json
+++ b/common/changes/@itwin/core-common/pankhur94-forward-error-metadata_2025-03-05-01-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Adding metadata for bentley error in  IpcInvokeReturn ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -7,7 +7,7 @@
  */
 
 import { IModelJsNative } from "@bentley/imodeljs-native";
-import { assert, BentleyError, IModelStatus, Logger, LogLevel, OpenMode } from "@itwin/core-bentley";
+import { assert, BentleyError, GetMetaDataFunction, IModelStatus, Logger, LoggingMetaData, LogLevel, OpenMode } from "@itwin/core-bentley";
 import {
   ChangesetIndex, ChangesetIndexAndId, EditingScopeNotifications, getPullChangesIpcChannel, IModelConnectionProps, IModelError, IModelNotFoundResponse, IModelRpcProps,
   ipcAppChannels, IpcAppFunctions, IpcAppNotifications, IpcInvokeReturn, IpcListener, IpcSocketBackend, iTwinChannel,
@@ -175,27 +175,33 @@ export abstract class IpcHandler {
         return { result: await func.call(impl, ...args) };
       } catch (err: any) {
         let ret: IpcInvokeReturn;
+        let metadata: Exclude<LoggingMetaData, GetMetaDataFunction>;
         if (ITwinError.isITwinError(err)) {
-          const { namespace, errorKey, message, stack, metadata, ...rest } = err;
+          const { namespace, errorKey, message, stack, ...rest } = err;
+          if(rest.metadata)
+            metadata = ITwinError.getMetaData(err);
+
           ret = {
             iTwinError:
             {
               namespace,
               errorKey,
               message,
-              ...(metadata && { metadata }), // Include metadata only when defined
-              ...rest,
+              ...(metadata && { metadata }), // Include metadata only when defined.
             },
           };
           if (!IpcHost.noStack)
             ret.iTwinError.stack = stack;
         } else {
+          metadata = BentleyError.getErrorMetadata(err);
+
           ret = {
             error:
             {
               name: err.hasOwnProperty("name") ? err.name : err.constructor?.name ?? "Unknown Error",
               message: err.message ?? BentleyError.getErrorMessage(err),
               errorNumber: err.errorNumber ?? 0,
+              ...(metadata && { metadata }), // Include metadata only when defined.
             },
           };
           if (!IpcHost.noStack)

--- a/core/common/src/ipc/IpcSocket.ts
+++ b/core/common/src/ipc/IpcSocket.ts
@@ -33,7 +33,7 @@ export type RemoveFunction = () => void;
  * The presence of iTwinError indicates that the backend threw an exception of type [[ITwinError]] and the frontend will re-throw that same error.
  * Otherwise the `result` member holds the response.
  * @internal */
-export type IpcInvokeReturn = { result: any, error?: never, iTwinError?: never } | { result?: never, iTwinError?: never, error: { name: string, message: string, errorNumber: number, stack?: string } } |
+export type IpcInvokeReturn = { result: any, error?: never, iTwinError?: never } | { result?: never, iTwinError?: never, error: { name: string, message: string, errorNumber: number, stack?: string, metadata?: LoggingMetaData } } |
 { result?: never, error?: never, iTwinError: {namespace: string, errorKey: string, message: string, stack?: string, metadata?: LoggingMetaData, [key: string]: any } };
 /**
  * An inter-process socket connection between a single [IModelHost]($backend) on the backend (the node process), and an [IModelApp]($frontend) on


### PR DESCRIPTION
- Fix: [issue](https://github.com/iTwin/itwinjs-backlog/issues/1402)
- Add metadata for Bentley error.
- Confirm function is not returned for metadata
