### PR TITLE
readonly schemakey change

### DIFF
--- a/common/api/ecschema-locaters.api.md
+++ b/common/api/ecschema-locaters.api.md
@@ -37,7 +37,7 @@ export abstract class SchemaFileLocater {
     fileExists(filePath: string): Promise<boolean | undefined>;
     // (undocumented)
     fileExistsSync(filePath: string): boolean | undefined;
-    protected findEligibleSchemaKeys(desiredKey: Readonly<SchemaKey>, matchType: SchemaMatchType, format: string): FileSchemaKey[];
+    protected findEligibleSchemaKeys(desiredKey: SchemaKey, matchType: SchemaMatchType, format: string): FileSchemaKey[];
     abstract getSchema(key: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
     // (undocumented)
     protected abstract getSchemaKey(data: string): SchemaKey;

--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -808,9 +808,9 @@ export interface ISchemaItemLocater {
 
 // @beta
 export interface ISchemaLocater {
-    getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
-    getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
-    getSchemaSync(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
+    getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
+    getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
+    getSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
 }
 
 // @beta
@@ -947,7 +947,7 @@ export type LazyLoadedRelationshipClass = LazyLoadedSchemaItem<RelationshipClass
 export type LazyLoadedRelationshipConstraintClass = LazyLoadedSchemaItem<EntityClass | Mixin | RelationshipClass>;
 
 // @beta (undocumented)
-export type LazyLoadedSchema = Readonly<SchemaKey> & DelayedPromise<Schema> & Promise<Schema>;
+export type LazyLoadedSchema = SchemaKey & DelayedPromise<Schema> & Promise<Schema>;
 
 // @beta (undocumented)
 export type LazyLoadedSchemaItem<T extends SchemaItem> = Readonly<SchemaItemKey> & DelayedPromise<T> & Promise<T>;
@@ -1822,11 +1822,11 @@ export class SchemaCache implements ISchemaLocater {
     // (undocumented)
     get count(): number;
     getAllSchemas(): Schema[];
-    getSchema(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Promise<Schema | undefined>;
-    getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Promise<SchemaInfo | undefined>;
+    getSchema(schemaKey: SchemaKey, matchType?: SchemaMatchType): Promise<Schema | undefined>;
+    getSchemaInfo(schemaKey: SchemaKey, matchType?: SchemaMatchType): Promise<SchemaInfo | undefined>;
     getSchemaItems(): IterableIterator<SchemaItem>;
-    getSchemaSync(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Schema | undefined;
-    schemaExists(schemaKey: Readonly<SchemaKey>): boolean;
+    getSchemaSync(schemaKey: SchemaKey, matchType?: SchemaMatchType): Schema | undefined;
+    schemaExists(schemaKey: SchemaKey): boolean;
 }
 
 // @beta
@@ -1840,12 +1840,12 @@ export class SchemaContext implements ISchemaItemLocater {
     addSchemaPromise(schemaInfo: SchemaInfo, schema: Schema, schemaPromise: Promise<Schema>): Promise<void>;
     addSchemaSync(schema: Schema): void;
     // @internal
-    getCachedSchema(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Promise<Schema | undefined>;
+    getCachedSchema(schemaKey: SchemaKey, matchType?: SchemaMatchType): Promise<Schema | undefined>;
     // @internal
-    getCachedSchemaSync(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Schema | undefined;
+    getCachedSchemaSync(schemaKey: SchemaKey, matchType?: SchemaMatchType): Schema | undefined;
     getKnownSchemas(): Schema[];
-    getSchema(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Promise<Schema | undefined>;
-    getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType): Promise<SchemaInfo | undefined>;
+    getSchema(schemaKey: SchemaKey, matchType?: SchemaMatchType): Promise<Schema | undefined>;
+    getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType): Promise<SchemaInfo | undefined>;
     getSchemaItem(schemaItemKey: SchemaItemKey): Promise<SchemaItem | undefined>;
     // (undocumented)
     getSchemaItem<T extends typeof SchemaItem>(schemaItemKey: SchemaItemKey, itemConstructor: T): Promise<InstanceType<T> | undefined>;
@@ -1856,7 +1856,7 @@ export class SchemaContext implements ISchemaItemLocater {
     getSchemaSync(schemaKey: SchemaKey, matchType?: SchemaMatchType): Schema | undefined;
     // (undocumented)
     get locaters(): ISchemaLocater[];
-    schemaExists(schemaKey: Readonly<SchemaKey>): boolean;
+    schemaExists(schemaKey: SchemaKey): boolean;
 }
 
 // @internal
@@ -1877,7 +1877,7 @@ export interface SchemaInfo {
     // (undocumented)
     references: WithSchemaKey[];
     // (undocumented)
-    schemaKey: Readonly<SchemaKey>;
+    schemaKey: SchemaKey;
 }
 
 // @beta
@@ -2031,9 +2031,9 @@ export interface SchemaItemUnitProps extends SchemaItemProps {
 // @beta
 export class SchemaJsonLocater implements ISchemaLocater {
     constructor(_getSchema: SchemaPropsGetter);
-    getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
-    getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
-    getSchemaSync(schemaKey: Readonly<SchemaKey>, _matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
+    getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
+    getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
+    getSchemaSync(schemaKey: SchemaKey, _matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
 }
 
 // @beta
@@ -2044,7 +2044,7 @@ export class SchemaKey {
     compareByVersion(rhs: SchemaKey): number;
     static fromJSON(props: SchemaKeyProps): SchemaKey;
     // (undocumented)
-    matches(rhs: Readonly<SchemaKey>, matchType?: SchemaMatchType): boolean;
+    matches(rhs: SchemaKey, matchType?: SchemaMatchType): boolean;
     // (undocumented)
     get minorVersion(): number;
     // (undocumented)
@@ -2336,7 +2336,7 @@ export type UnitSystemProps = SchemaItemProps;
 // @beta (undocumented)
 export interface WithSchemaKey {
     // (undocumented)
-    schemaKey: Readonly<SchemaKey>;
+    schemaKey: SchemaKey;
 }
 
 // @internal (undocumented)

--- a/common/api/ecschema-rpcinterface-common.api.md
+++ b/common/api/ecschema-rpcinterface-common.api.md
@@ -30,9 +30,9 @@ export abstract class ECSchemaRpcInterface extends RpcInterface {
 // @beta
 export class ECSchemaRpcLocater implements ISchemaLocater {
     constructor(token: IModelRpcProps);
-    getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
-    getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
-    getSchemaSync(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
+    getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
+    getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
+    getSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
     // (undocumented)
     readonly token: IModelRpcProps;
 }

--- a/common/changes/@itwin/ecschema-editing/stefan-readonly-schemakey-change_2025-03-06-09-23.json
+++ b/common/changes/@itwin/ecschema-editing/stefan-readonly-schemakey-change_2025-03-06-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "applied changes in ecschema-metadatas SchemaLocater interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/common/changes/@itwin/ecschema-locaters/stefan-readonly-schemakey-change_2025-03-06-09-23.json
+++ b/common/changes/@itwin/ecschema-locaters/stefan-readonly-schemakey-change_2025-03-06-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-locaters",
+      "comment": "applied changes in ecschema-metadatas SchemaLocater interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-locaters"
+}

--- a/common/changes/@itwin/ecschema-metadata/stefan-readonly-schemakey-change_2025-03-06-09-23.json
+++ b/common/changes/@itwin/ecschema-metadata/stefan-readonly-schemakey-change_2025-03-06-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "Since the properties on SchemaKey are already readonly, wrapping the type in a Readonly Utility-Type is not necessary. Changed the locater method argument from Readonly<SchemaKey> to SchemaKey and applied the change to all callers and implementations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-common/stefan-readonly-schemakey-change_2025-03-06-09-23.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-common/stefan-readonly-schemakey-change_2025-03-06-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-common",
+      "comment": "applied changes in ecschema-metadatas SchemaLocater interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-common"
+}

--- a/common/changes/@itwin/ecschema2ts/stefan-readonly-schemakey-change_2025-03-06-09-23.json
+++ b/common/changes/@itwin/ecschema2ts/stefan-readonly-schemakey-change_2025-03-06-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema2ts",
+      "comment": "applied changes in ecschema-metadatas SchemaLocater interface",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema2ts"
+}

--- a/core/ecschema-editing/src/Merging/SchemaMerger.ts
+++ b/core/ecschema-editing/src/Merging/SchemaMerger.ts
@@ -128,11 +128,11 @@ class MergingSchemaContext extends SchemaContext {
     this._nameMappings = nameMapping;
   }
 
-  public override async getCachedSchema(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Promise<Schema | undefined> {
+  public override async getCachedSchema(schemaKey: SchemaKey, matchType?: SchemaMatchType): Promise<Schema | undefined> {
     return this._internalContext.getCachedSchema(schemaKey, matchType);
   }
 
-  public override async getSchema(schemaKey: Readonly<SchemaKey>, matchType?: SchemaMatchType): Promise<Schema | undefined> {
+  public override async getSchema(schemaKey: SchemaKey, matchType?: SchemaMatchType): Promise<Schema | undefined> {
     return this._internalContext.getSchema(schemaKey, matchType);
   }
 

--- a/core/ecschema-editing/src/test/TestUtils/DeserializationHelpers.ts
+++ b/core/ecschema-editing/src/test/TestUtils/DeserializationHelpers.ts
@@ -40,7 +40,7 @@ export class ReferenceSchemaLocater implements ISchemaLocater {
     return undefined;
   }
 
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, _matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, _matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
     if (this._schemaList.has(schemaKey.name)) {
       const schemaBody = this._schemaList.get(schemaKey.name);
       const schemaInfo = this._asyncParser(schemaBody, context);

--- a/core/ecschema-locaters/src/SchemaFileLocater.ts
+++ b/core/ecschema-locaters/src/SchemaFileLocater.ts
@@ -132,7 +132,7 @@ export abstract class SchemaFileLocater {
    * @param matchType The SchemaMatchType to use when comparing the desiredKey and the keys found during the search.
    * @param format The type of file that the schema key refers to. json or xml
    */
-  private addCandidateNoExtSchemaKey(foundFiles: FileSchemaKey[], schemaPath: string, schemaName: string, desiredKey: Readonly<SchemaKey>, matchType: SchemaMatchType, format: string) {
+  private addCandidateNoExtSchemaKey(foundFiles: FileSchemaKey[], schemaPath: string, schemaName: string, desiredKey: SchemaKey, matchType: SchemaMatchType, format: string) {
     const fullPath = path.join(schemaPath, `${schemaName}.ecschema.${format}`);
 
     // If the file does not exist, end
@@ -161,7 +161,7 @@ export abstract class SchemaFileLocater {
    * @param matchType The SchemaMatchType to use when comparing the desired Key and the keys found during the search.
    * @param format The type of file that the schema key refers to. json or xml
    */
-  private addCandidateSchemaKeys(foundFiles: FileSchemaKey[], schemaPath: string, fileFilter: string, desiredKey: Readonly<SchemaKey>, matchType: SchemaMatchType, format: string) {
+  private addCandidateSchemaKeys(foundFiles: FileSchemaKey[], schemaPath: string, fileFilter: string, desiredKey: SchemaKey, matchType: SchemaMatchType, format: string) {
     const fullPath = path.join(schemaPath, fileFilter);
 
     const result = globSync(fullPath, { windowsPathsNoEscape: true });
@@ -192,7 +192,7 @@ export abstract class SchemaFileLocater {
    * @param matchType The SchemaMatchType.
    * @param format The type of file that the schema key refers to. json or xml
    */
-  protected findEligibleSchemaKeys(desiredKey: Readonly<SchemaKey>, matchType: SchemaMatchType, format: string): FileSchemaKey[] {
+  protected findEligibleSchemaKeys(desiredKey: SchemaKey, matchType: SchemaMatchType, format: string): FileSchemaKey[] {
     const foundFiles = new Array<FileSchemaKey>();
 
     let twoVersionSuffix: string;

--- a/core/ecschema-locaters/src/SchemaStringLocater.ts
+++ b/core/ecschema-locaters/src/SchemaStringLocater.ts
@@ -69,7 +69,7 @@ export abstract class SchemaStringLocater {
    * @param desiredKey The SchemaKey to match.
    * @param matchType The SchemaMatchType.
    */
-  protected findEligibleSchemaKeys(desiredKey: Readonly<SchemaKey>, matchType: SchemaMatchType): StringSchemaKey[] {
+  protected findEligibleSchemaKeys(desiredKey: SchemaKey, matchType: SchemaMatchType): StringSchemaKey[] {
     const foundStrings = new Array<StringSchemaKey>();
 
     for (const schemaString of this.schemaStrings) {

--- a/core/ecschema-metadata/src/Context.ts
+++ b/core/ecschema-metadata/src/Context.ts
@@ -40,7 +40,7 @@ export interface ISchemaLocater {
    * @param matchType how to match key against candidate schemas
    * @param context context for loading schema references
    */
-  getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
+  getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
 
   /**
   * Gets the schema info which matches the provided SchemaKey.  The schema info may be returned before the schema is fully loaded.
@@ -48,7 +48,7 @@ export interface ISchemaLocater {
   * @param schemaKey The SchemaKey describing the schema to get from the cache.
   * @param matchType The match type to use when locating the schema
   */
-  getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
+  getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
 
   /**
    * Attempts to get a schema from the locater. Yields undefined if no matching schema is found.
@@ -57,7 +57,7 @@ export interface ISchemaLocater {
    * @param matchType how to match key against candidate schemas
    * @param context context for loading schema references
    */
-  getSchemaSync(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
+  getSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
 }
 
 /**
@@ -97,25 +97,25 @@ export class SchemaCache implements ISchemaLocater {
 
   public get count() { return this._schema.length; }
 
-  private loadedSchemaExists(schemaKey: Readonly<SchemaKey>): boolean {
+  private loadedSchemaExists(schemaKey: SchemaKey): boolean {
     return undefined !== this._schema.find((entry: SchemaEntry) => entry.schemaInfo.schemaKey.matches(schemaKey, SchemaMatchType.Latest) && !entry.schemaPromise);
   }
 
-  private schemaPromiseExists(schemaKey: Readonly<SchemaKey>): boolean {
+  private schemaPromiseExists(schemaKey: SchemaKey): boolean {
     return undefined !== this._schema.find((entry: SchemaEntry) => entry.schemaInfo.schemaKey.matches(schemaKey, SchemaMatchType.Latest) && undefined !== entry.schemaPromise);
   }
 
-  private findEntry(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType): SchemaEntry | undefined {
+  private findEntry(schemaKey: SchemaKey, matchType: SchemaMatchType): SchemaEntry | undefined {
     return this._schema.find((entry: SchemaEntry) => entry.schemaInfo.schemaKey.matches(schemaKey, matchType));
   }
 
-  private removeSchemaPromise(schemaKey: Readonly<SchemaKey>) {
+  private removeSchemaPromise(schemaKey: SchemaKey) {
     const entry = this.findEntry(schemaKey, SchemaMatchType.Latest);
     if (entry)
       entry.schemaPromise = undefined;
   }
 
-  private removeEntry(schemaKey: Readonly<SchemaKey>) {
+  private removeEntry(schemaKey: SchemaKey) {
     this._schema = this._schema.filter((entry: SchemaEntry) => !entry.schemaInfo.schemaKey.matches(schemaKey));
   }
 
@@ -123,7 +123,7 @@ export class SchemaCache implements ISchemaLocater {
    * Returns true if the schema exists in either the schema cache or the promise cache.  SchemaMatchType.Latest used.
    * @param schemaKey The key to search for.
    */
-  public schemaExists(schemaKey: Readonly<SchemaKey>): boolean {
+  public schemaExists(schemaKey: SchemaKey): boolean {
     return this.loadedSchemaExists(schemaKey) || this.schemaPromiseExists(schemaKey);
   }
 
@@ -176,7 +176,7 @@ export class SchemaCache implements ISchemaLocater {
    * @param schemaKey The SchemaKey describing the schema to get from the cache.
    * @param matchType The match type to use when locating the schema
    */
-  public async getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<Schema | undefined> {
+  public async getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<Schema | undefined> {
     if (this.count === 0)
       return undefined;
 
@@ -202,7 +202,7 @@ export class SchemaCache implements ISchemaLocater {
     * @param schemaKey The SchemaKey describing the schema to get from the cache.
     * @param matchType The match type to use when locating the schema
     */
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<SchemaInfo | undefined> {
     if (this.count === 0)
       return undefined;
 
@@ -218,7 +218,7 @@ export class SchemaCache implements ISchemaLocater {
    * @param schemaKey The SchemaKey describing the schema to get from the cache.
    * @param matchType The match type to use when locating the schema
    */
-  public getSchemaSync(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Latest): Schema | undefined {
+  public getSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType = SchemaMatchType.Latest): Schema | undefined {
     if (this.count === 0)
       return undefined;
 
@@ -342,7 +342,7 @@ export class SchemaContext implements ISchemaItemLocater {
    * Returns true if the schema is already in the context.  SchemaMatchType.Latest is used to find a match.
    * @param schemaKey
    */
-  public schemaExists(schemaKey: Readonly<SchemaKey>): boolean {
+  public schemaExists(schemaKey: SchemaKey): boolean {
     return this._knownSchemas.schemaExists(schemaKey);
   }
 
@@ -363,7 +363,7 @@ export class SchemaContext implements ISchemaItemLocater {
    * @param matchType Criteria by which to identify potentially matching schemas.
    * @returns the schema matching the input criteria, or `undefined` if no such schema could be located.
    */
-  public async getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<Schema | undefined> {
+  public async getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<Schema | undefined> {
     // the first locater is _knownSchemas, so we don't have to check the cache explicitly here
     for (const locater of this._locaters) {
       const schema = await locater.getSchema(schemaKey, matchType, this);
@@ -380,7 +380,7 @@ export class SchemaContext implements ISchemaItemLocater {
    * @param schemaKey The SchemaKey describing the schema to get from the cache.
    * @param matchType The match type to use when locating the schema
    */
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType): Promise<SchemaInfo | undefined> {
     for (const locater of this._locaters) {
       const schemaInfo = await locater.getSchemaInfo(schemaKey, matchType, this);
       if (undefined !== schemaInfo)
@@ -414,7 +414,7 @@ export class SchemaContext implements ISchemaItemLocater {
    * @param matchType The SchemaMatch type to use. Default is SchemaMatchType.Latest.
    * @internal
    */
-  public async getCachedSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<Schema | undefined> {
+  public async getCachedSchema(schemaKey: SchemaKey, matchType: SchemaMatchType = SchemaMatchType.Latest): Promise<Schema | undefined> {
     return this._knownSchemas.getSchema(schemaKey, matchType);
   }
 
@@ -425,7 +425,7 @@ export class SchemaContext implements ISchemaItemLocater {
    * @param matchType The SchemaMatch type to use. Default is SchemaMatchType.Latest.
    * @internal
    */
-  public getCachedSchemaSync(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Latest): Schema | undefined {
+  public getCachedSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType = SchemaMatchType.Latest): Schema | undefined {
     return this._knownSchemas.getSchemaSync(schemaKey, matchType);
   }
 

--- a/core/ecschema-metadata/src/Deserialization/Helper.ts
+++ b/core/ecschema-metadata/src/Deserialization/Helper.ts
@@ -200,7 +200,7 @@ export class SchemaReadHelper<T = unknown> {
    * Ensures that the schema references can be located and adds them to the schema.
    * @param ref The object to read the SchemaReference's props from.
    */
-  private async loadSchemaReference(schemaInfo: SchemaInfo, refKey: Readonly<SchemaKey>): Promise<void> {
+  private async loadSchemaReference(schemaInfo: SchemaInfo, refKey: SchemaKey): Promise<void> {
     const refSchema = await this._context.getSchema(refKey, SchemaMatchType.LatestWriteCompatible);
     if (undefined === refSchema)
       throw new ECObjectsError(ECObjectsStatus.UnableToLocateSchema, `Could not locate the referenced schema, ${refKey.name}.${refKey.version.toString()}, of ${schemaInfo.schemaKey.name}`);

--- a/core/ecschema-metadata/src/Interfaces.ts
+++ b/core/ecschema-metadata/src/Interfaces.ts
@@ -29,7 +29,7 @@ import { UnitSystem } from "./Metadata/UnitSystem";
 import { SchemaItemKey, SchemaKey } from "./SchemaKey";
 
 /** @beta */
-export type LazyLoadedSchema = Readonly<SchemaKey> & DelayedPromise<Schema> & Promise<Schema>;
+export type LazyLoadedSchema = SchemaKey & DelayedPromise<Schema> & Promise<Schema>;
 
 /** @beta */
 export type LazyLoadedSchemaItem<T extends SchemaItem> = Readonly<SchemaItemKey> & DelayedPromise<T> & Promise<T>;
@@ -78,13 +78,13 @@ export type AnyECType = Schema | SchemaItem | AnyProperty | RelationshipConstrai
  * @beta
  */
 export interface SchemaInfo {
-  schemaKey: Readonly<SchemaKey>;
+  schemaKey: SchemaKey;
   references: WithSchemaKey[];
 }
 
 /** @beta */
 export interface WithSchemaKey {
-  schemaKey: Readonly<SchemaKey>;
+  schemaKey: SchemaKey;
 }
 
 /** This is needed to break a circular dependency between Class and EntityClass.

--- a/core/ecschema-metadata/src/SchemaJsonLocater.ts
+++ b/core/ecschema-metadata/src/SchemaJsonLocater.ts
@@ -31,7 +31,7 @@ export class SchemaJsonLocater implements ISchemaLocater {
    * @param context The [SchemaContext] used to facilitate schema location.
    * @throws [ECObjectsError]($ecschema-metadata) if the schema exists, but cannot be loaded.
    */
-  public async getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined> {
+  public async getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined> {
     await this.getSchemaInfo(schemaKey, matchType, context);
     return context.getCachedSchema(schemaKey, matchType);
   }
@@ -41,7 +41,7 @@ export class SchemaJsonLocater implements ISchemaLocater {
    * @param schemaKey The SchemaKey describing the schema to get from the cache.
    * @param matchType The match type to use when locating the schema
    */
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
     const schemaProps = this._getSchema(schemaKey.name);
     if (!schemaProps)
       return undefined;
@@ -59,13 +59,11 @@ export class SchemaJsonLocater implements ISchemaLocater {
    * @param context The [SchemaContext] used to facilitate schema location.
    * @throws [Error]($ecschema-metadata) if the schema exists, but cannot be loaded.
    */
-  public getSchemaSync(schemaKey: Readonly<SchemaKey>, _matchType: SchemaMatchType, context: SchemaContext): Schema | undefined {
+  public getSchemaSync(schemaKey: SchemaKey, _matchType: SchemaMatchType, context: SchemaContext): Schema | undefined {
     const schemaProps = this._getSchema(schemaKey.name);
     if (!schemaProps)
       return undefined;
 
-    context = context ? context : new SchemaContext();
-    return Schema.fromJsonSync(schemaProps, context);
+    return Schema.fromJsonSync(schemaProps, context || new SchemaContext());
   }
-
 }

--- a/core/ecschema-metadata/src/SchemaKey.ts
+++ b/core/ecschema-metadata/src/SchemaKey.ts
@@ -172,7 +172,7 @@ export class SchemaKey {
    * @param rhs The SchemaKey to compare with
    * @param matchType The match type to use for comparison.
    */
-  public matches(rhs: Readonly<SchemaKey>, matchType: SchemaMatchType = SchemaMatchType.Exact): boolean {
+  public matches(rhs: SchemaKey, matchType: SchemaMatchType = SchemaMatchType.Exact): boolean {
     switch (matchType) {
       case SchemaMatchType.Identical:
       case SchemaMatchType.Exact:

--- a/core/ecschema-metadata/src/test/TestUtils/DeserializationHelpers.ts
+++ b/core/ecschema-metadata/src/test/TestUtils/DeserializationHelpers.ts
@@ -46,7 +46,7 @@ export class ReferenceSchemaLocater implements ISchemaLocater {
     return undefined;
   }
 
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, _matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, _matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
     if (this._schemaList.has(schemaKey.name)) {
       const schemaBody = this._schemaList.get(schemaKey.name);
       const schemaInfo = this._asyncParser(schemaBody, context);

--- a/core/ecschema-metadata/src/test/TestUtils/FormatTestHelper.ts
+++ b/core/ecschema-metadata/src/test/TestUtils/FormatTestHelper.ts
@@ -22,7 +22,7 @@ export class TestSchemaLocater implements ISchemaLocater {
     return context.getCachedSchema(schemaKey, matchType);
   }
 
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
     if (!schemaKey.matches(formatsKey, matchType))
       return undefined;
 

--- a/core/ecschema-metadata/src/test/UnitProvider/UnitProvider.test.ts
+++ b/core/ecschema-metadata/src/test/UnitProvider/UnitProvider.test.ts
@@ -15,14 +15,14 @@ import { SchemaMatchType } from "../../ECObjects";
 import { SchemaKey } from "../../SchemaKey";
 
 class TestSchemaLocater implements ISchemaLocater {
-  public async getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context?: SchemaContext): Promise<Schema | undefined> {
+  public async getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context?: SchemaContext): Promise<Schema | undefined> {
     return this.getSchemaSync(schemaKey, matchType, context);
   }
 
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context?: SchemaContext | undefined): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context?: SchemaContext | undefined): Promise<SchemaInfo | undefined> {
     return this.getSchema(schemaKey, matchType, context);
   }
-  public getSchemaSync(schemaKey: Readonly<SchemaKey>, _matchType: SchemaMatchType, context?: SchemaContext): Schema | undefined {
+  public getSchemaSync(schemaKey: SchemaKey, _matchType: SchemaMatchType, context?: SchemaContext): Schema | undefined {
     if (schemaKey.name !== "Units")
       return undefined;
 

--- a/core/ecschema-metadata/src/utils/SchemaGraph.ts
+++ b/core/ecschema-metadata/src/utils/SchemaGraph.ts
@@ -28,7 +28,7 @@ export class SchemaGraph {
 
   private constructor() { }
 
-  private find(schemaKey: Readonly<SchemaKey>) {
+  private find(schemaKey: SchemaKey) {
     return this._schemas.find((info: SchemaInfo) => info.schemaKey.matches(schemaKey, SchemaMatchType.Latest));
   }
 

--- a/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
@@ -21,7 +21,7 @@ export class ECSchemaRpcLocater implements ISchemaLocater {
    * @param matchType How to match key against candidate schemas
    * @param context The SchemaContext that will control the lifetime of the schema and holds the schema's references, if they exist.
   */
-  public async getSchema(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined> {
+  public async getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined> {
     await this.getSchemaInfo(schemaKey, matchType, context);
 
     const schema = await context.getCachedSchema(schemaKey, matchType);
@@ -34,7 +34,7 @@ export class ECSchemaRpcLocater implements ISchemaLocater {
     * @param schemaKey The SchemaKey describing the schema to get from the cache.
     * @param matchType The match type to use when locating the schema
     */
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
     const schemaJson = await ECSchemaRpcInterface.getClient().getSchemaJSON(this.token, schemaKey.name);
     const schemaInfo = await Schema.startLoadingFromJson(schemaJson, context || new SchemaContext());
     if (schemaInfo !== undefined && schemaInfo.schemaKey.matches(schemaKey, matchType)) {
@@ -49,7 +49,7 @@ export class ECSchemaRpcLocater implements ISchemaLocater {
    * @param matchType How to match key against candidate schemas
    * @param context The SchemaContext that will control the lifetime of the schema and holds the schema's references, if they exist.
   */
-  public getSchemaSync(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined {
+  public getSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined {
     const schemaJson = ECSchemaRpcInterface.getClient().getSchemaJSON(this.token, schemaKey.name).then((props: SchemaProps) => {
       return props;
     });

--- a/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
+++ b/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
@@ -53,17 +53,17 @@ describe("PresentationManager", () => {
               getSchemaSync() {
                 throw new Error(`getSchemaSync not implemented`);
               },
-              async getSchemaInfo(key: Readonly<SchemaKey>, matchType: SchemaMatchType, schemaContext: SchemaContext): Promise<SchemaInfo | undefined> {
+              async getSchemaInfo(key: SchemaKey, matchType: SchemaMatchType, schemaContext: SchemaContext): Promise<SchemaInfo | undefined> {
                 const schemaInfo = await Schema.startLoadingFromJson(schemaIModel.getSchemaProps(key.name), schemaContext);
                 if (schemaInfo !== undefined && schemaInfo.schemaKey.matches(key, matchType)) {
                   return schemaInfo;
                 }
                 return undefined;
               },
-              async getSchema<T extends Schema>(key: Readonly<SchemaKey>, matchType: SchemaMatchType, schemaContext: SchemaContext): Promise<T | undefined> {
+              async getSchema(key: SchemaKey, matchType: SchemaMatchType, schemaContext: SchemaContext): Promise<Schema | undefined> {
                 await this.getSchemaInfo(key, matchType, schemaContext);
                 const schema = await schemaContext.getCachedSchema(key, matchType);
-                return schema as T;
+                return schema;
               },
             });
             return schemas;

--- a/tools/ecschema2ts/src/ecschema2ts_io.ts
+++ b/tools/ecschema2ts/src/ecschema2ts_io.ts
@@ -33,11 +33,11 @@ class SchemaBackendFileLocater extends SchemaFileLocater implements ISchemaLocat
    * @param matchType The SchemaMatchType
    * @param context The schema context used to parse schema
    */
-  public async getSchema(key: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined> {
+  public async getSchema(key: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined> {
     return this.getSchemaSync(key, matchType, context);
   }
 
-  public async getSchemaInfo(schemaKey: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
     return this.getSchema(schemaKey, matchType, context);
   }
 
@@ -47,7 +47,7 @@ class SchemaBackendFileLocater extends SchemaFileLocater implements ISchemaLocat
    * @param matchType The SchemaMatchType
    * @param context The schema context used to parse schema
    */
-  public getSchemaSync(key: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined {
+  public getSchemaSync(key: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined {
     const localPath: Set<string> = new Set<string>();
     return this.getSchemaRecursively(key, matchType, context, localPath);
   }
@@ -83,7 +83,7 @@ class SchemaBackendFileLocater extends SchemaFileLocater implements ISchemaLocat
    * @param context The schema context used to parse schema
    * @param localPath The path of the recursion is following used to detect cyclic dependency
    */
-  private getSchemaRecursively(key: Readonly<SchemaKey>, matchType: SchemaMatchType, context: SchemaContext, localPath: Set<string>): Schema | undefined {
+  private getSchemaRecursively(key: SchemaKey, matchType: SchemaMatchType, context: SchemaContext, localPath: Set<string>): Schema | undefined {
     // load the schema file
     const candidates: FileSchemaKey[] = this.findEligibleSchemaKeys(key, matchType, "xml");
     if (0 === candidates.length)


### PR DESCRIPTION
Since the properties on SchemaKey are already readonly, wrapping the type in a Readonly Utility-Type is not necessary. 
Changed the locater method argument from Readonly<SchemaKey> to SchemaKey and applied the change to all callers and implementations.