### PR TITLE
Incremental schema loading

### DIFF
--- a/common/changes/@itwin/ecschema-editing/incremental-schema-loading_2025-03-21-11-57.json
+++ b/common/changes/@itwin/ecschema-editing/incremental-schema-loading_2025-03-21-11-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/common/changes/@itwin/ecschema-metadata/incremental-schema-loading_2025-03-21-11-03.json
+++ b/common/changes/@itwin/ecschema-metadata/incremental-schema-loading_2025-03-21-11-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "Added IncrementalSchemaLocater and IncrementalSchemaLoader",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-editing/src/test/Validation/SchemaWalker.test.ts
+++ b/core/ecschema-editing/src/test/Validation/SchemaWalker.test.ts
@@ -15,6 +15,7 @@ describe("SchemaWalker tests", () => {
     $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
     name: "TestSchema",
     version: "1.2.3",
+    alias: "ts",
   };
 
   const schemaJson = {

--- a/core/ecschema-metadata/src/Deserialization/Helper.ts
+++ b/core/ecschema-metadata/src/Deserialization/Helper.ts
@@ -84,7 +84,7 @@ export class SchemaReadHelper<T = unknown> {
 
     this._schema = schema;
 
-    const schemaInfo: SchemaInfo = { schemaKey: schema.schemaKey, references: [] };
+    const schemaInfo: SchemaInfo = { schemaKey: schema.schemaKey, alias: schema.alias, references: [] };
     for (const reference of this._parser.getReferences()) {
       const refKey = new SchemaKey(reference.name, ECVersion.fromString(reference.version));
       schemaInfo.references.push({ schemaKey: refKey });

--- a/core/ecschema-metadata/src/Deserialization/Helper.ts
+++ b/core/ecschema-metadata/src/Deserialization/Helper.ts
@@ -213,10 +213,6 @@ export class SchemaReadHelper<T = unknown> {
    * @param ref The object to read the SchemaReference's props from.
    */
   protected async loadSchemaReference(schema: Schema, refKey: SchemaKey): Promise<Schema> {
-    // const targetSchema = await this.getSchema(schema.schemaKey, SchemaMatchType.LatestWriteCompatible);
-    // if(targetSchema === undefined || targetSchema.references.find((ref) => ref.name === refKey.name) !== undefined)
-    //   return;
-
     const refSchema = await this.getSchema(refKey, SchemaMatchType.LatestWriteCompatible);
     if (undefined === refSchema)
       throw new ECObjectsError(ECObjectsStatus.UnableToLocateSchema, `Could not locate the referenced schema, ${refKey.name}.${refKey.version.toString()}, of ${schema.schemaKey.name}`);

--- a/core/ecschema-metadata/src/IncrementalSchemaLoader.ts
+++ b/core/ecschema-metadata/src/IncrementalSchemaLoader.ts
@@ -1,0 +1,270 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { SchemaInfo } from "./Interfaces";
+import type { SchemaProps } from "./Deserialization/JsonProps";
+import type { SchemaContext } from "./Context";
+import type { SchemaItem } from "./Metadata/SchemaItem";
+import { BeEvent } from "@itwin/core-bentley";
+import { Schema } from "./Metadata/Schema";
+import { SchemaItemKey, SchemaKey } from "./SchemaKey";
+import { SchemaReadHelper } from "./Deserialization/Helper";
+import { SchemaMatchType } from "./ECObjects";
+import { JsonParser } from "./Deserialization/JsonParser";
+import { ECClass } from "./Metadata/Class";
+import { ECObjectsError, ECObjectsStatus } from "./Exception";
+
+type ReadonlyBeEvent<T extends (...args: any[]) => any> = Pick<BeEvent<T>, "addListener" | "addOnce" | "removeListener">;
+
+type SchemaCompleteHandler = (schema: Schema) => void;
+type SchemaErrorHandler = (schema: Schema, error: Error) => void;
+
+/**
+ * Defines the SchemaLoader Options which informat shall initially be loaded
+ * for each incrementally loaded schema.
+ * @beta
+ */
+export interface SchemaLoaderOptions {
+  /** Loads stubs (name, type, description, label) for all items in the schema */
+  readonly includeItems?: boolean;
+  /** Loads only class stubs, including their base classes. */
+  readonly includeClasses?: boolean;
+}
+
+/**
+ * The IncrementalSchemaLoader is a base class to load EC Schemas incrementally.
+ * This is useful for large schemas that take a long time to load, but clients
+ * need a rough idea what's in the schamas as fast as possible.
+ * @beta
+ */
+export abstract class IncrementalSchemaLoader {
+  private readonly _resolvingSchemas: Map<string, Promise<Schema | undefined>>;
+  private readonly _unresolvedSchemas: Set<string>;
+  private readonly _onSchemaComplete = new BeEvent<SchemaCompleteHandler>();
+  private readonly _onSchemaError = new BeEvent<SchemaErrorHandler>();
+  private readonly _options: SchemaLoaderOptions;
+
+  /** Gets the options how the schema loader load the schemas. */
+  protected get options(): SchemaLoaderOptions {
+    return this._options;
+  }
+
+  /**
+   * Initializes a new instance of the IncrementalSchemaLoader class.
+   * @param options   The schema loaders options.
+   */
+  constructor(options?: SchemaLoaderOptions) {
+    this._options = options || {};
+    this._resolvingSchemas = new Map<string, Promise<Schema>>();
+    this._unresolvedSchemas = new Set<string>();
+  }
+
+  /** Event that gets fired when a schema has been loaded completely. */
+  public get onSchemaComplete(): ReadonlyBeEvent<SchemaCompleteHandler> {
+    return this._onSchemaComplete;
+  }
+
+  /** Event that gets fired when a schema error occured during loading it. */
+  public get onSchemaError(): ReadonlyBeEvent<SchemaErrorHandler> {
+    return this._onSchemaError;
+  }
+
+  /**
+   * Gets the schema partials for the given schema key. The first item in the array is the
+   * actual schema props of the schema to load, the following items are partial schema props
+   * of referenced schemas.
+   * @param schemaKey   The schema key of the requested schema.
+   * @param context     The schema context.
+   */
+  protected abstract getSchemaPartials(schemaKey: SchemaKey, context: SchemaContext): Promise<ReadonlyArray<Partial<SchemaProps>> | undefined>;
+
+  /**
+   * Gets the full schema json for the requested schema key.
+   * @param schemaKey   The schema key of the requested schema.
+   * @param context     The schema context.
+   */
+  protected abstract getSchemaJson(schemaKey: SchemaKey, context: SchemaContext): Promise<SchemaProps | undefined>;
+
+  /**
+   * Loads the schema info objects for the given context.
+   * @param context   The schema context to load the schema infos for.
+   * @returns         A promise that resolves to an iterable of schema infos.
+   */
+  public abstract loadSchemaInfos(context: SchemaContext): Promise<Iterable<SchemaInfo>>;
+
+  /**
+   * Start loading the schema for the given schema info incrementally. The schema is returned
+   * as soon as the schema stub is loaded while the schema fully resolves in the background.
+   * @param schemaInfo    The schema info of the schema to load.
+   * @param schemaContext The schema context to load the schema into.
+   */
+  public async loadSchema(schemaInfo: SchemaInfo, schemaContext: SchemaContext): Promise<Schema | undefined> {
+    const schemaReader = new IncrementalSchemaReader(schemaContext, true);
+
+    // Fetches the schema partials for the given schema key. The first item in the array is the
+    // actual schema props of the schema to load, the following items are schema props of referenced
+    // schema items that are needed to resolve the schema properly.
+    const schemaPartials = await this.getSchemaPartials(schemaInfo.schemaKey, schemaContext);
+    if(schemaPartials === undefined)
+      return undefined;
+
+    // Override the get schema method. While the schema reader method always look up in the
+    // schema context, we inject here to create a schema stub if the schema is not yet loaded.
+    schemaReader.getSchema = async (schemaKey, matchType) => {
+      const lookupSchemaInfo = await schemaContext.getSchemaInfo(schemaKey, matchType);
+      if(lookupSchemaInfo === undefined) {
+        return undefined;
+      }
+
+      if(schemaContext.schemaExists(lookupSchemaInfo.schemaKey)) {
+        return schemaContext.getSchema(lookupSchemaInfo.schemaKey);
+      }
+
+      const schemaStub = new Schema(schemaContext, lookupSchemaInfo.schemaKey, lookupSchemaInfo.alias);
+      await schemaContext.addSchema(schemaStub);
+
+      this._unresolvedSchemas.add(lookupSchemaInfo.schemaKey.name);
+      return schemaStub;
+    };
+
+    const schema = await schemaReader.getSchema(schemaInfo.schemaKey, SchemaMatchType.Exact);
+    if(schema === undefined)
+      return undefined;
+
+    // Start the actual schema stub loading.
+    const [schemaProps, ...referencedSchemaProps] = schemaPartials;
+    await schemaReader.readSchema(schema, schemaProps);
+    await schemaReader.loadSchema(schemaInfo, schema);
+
+    // Add the related items first that baseclasses can be resolved properly.
+    await this.loadReferencedSchemas(referencedSchemaProps, schemaReader);
+
+    // Resolves the schema stack to get fully loaded. All the schemas in the stack are loaded in parallel
+    // while the schema stub is already returned to the caller. This way the caller can start working with
+    // the schema while it is still loading. The resolver method also takes care to not load the same schema
+    // multiple times (eg if it referenced by other schemas).
+    void this.startResolveFullSchema(schema)
+      .then((completeSchema) => completeSchema && this._onSchemaComplete.raiseEvent(completeSchema))
+      .catch((error) => this._onSchemaError.raiseEvent(schema, error));
+
+    return schema;
+  }
+
+  private async loadReferencedSchemas(schemaPartials: Partial<SchemaProps>[], schemaReader: IncrementalSchemaReader) {
+    for(const schemaPartial of schemaPartials) {
+      const schema = await schemaReader.getSchema(SchemaKey.parseString(`${schemaPartial.name}.0.0.0`), SchemaMatchType.Latest);
+      if(schema === undefined || schemaPartial.items === undefined)
+        return;
+
+      for(const itemProps of Object.values(schemaPartial.items)) {
+        if(!itemProps.name || !itemProps.schemaItemType || await schema.getItem(itemProps.name) !== undefined)
+          continue;
+
+        await schemaReader.loadSchemaItem(schema, itemProps.name, itemProps.schemaItemType, itemProps);
+      }
+    }
+  }
+
+  private async startResolveFullSchema(schema: Schema): Promise<Schema | undefined> {
+    // If the schema is already resolved, return it directly.
+    if(!this._unresolvedSchemas.has(schema.schemaKey.name)) {
+      return schema;
+    }
+
+    // Since the schema relys on it's references, they get triggered to be resolved
+    // first by resursivly calling this method. After all references has been resolved
+    // the schema itself gets resolved.
+    await Promise.all(schema.references.map(async (referenceSchema) => {
+      return this.startResolveFullSchema(referenceSchema);
+    }));
+
+    // If resolving the requested schemas is already in progress, return the promise.
+    const existingResolvingPromise = this._resolvingSchemas.get(schema.schemaKey.name);
+    if(existingResolvingPromise !== undefined) {
+      return existingResolvingPromise;
+    }
+
+    const resolvingPromise = this.getSchemaJson(schema.schemaKey, schema.context)
+      .then(async (schemaProps) => this.resolveSchemaFromProps(schema, schemaProps));
+
+    this._resolvingSchemas.set(schema.schemaKey.name, resolvingPromise);
+    void resolvingPromise.finally(() => this._resolvingSchemas.delete(schema.schemaKey.name));
+
+    return resolvingPromise;
+  }
+
+  private async resolveSchemaFromProps(schema: Schema, schemaProps?: SchemaProps): Promise<Schema | undefined> {
+    if(!schemaProps || !schemaProps.items)
+      return undefined;
+
+    const reader = new IncrementalSchemaReader( schema.context, false);
+    await reader.readSchema(schema, schemaProps);
+    await reader.loadSchema(schema, schema);
+
+    this._unresolvedSchemas.delete(schema.schemaKey.name);
+
+    return schema;
+  }
+}
+
+/**
+ * Internal helper class to read schema information incrementally. It's based of the SchemaReadHelper
+ * but overrides a few methods to support the incremental schema loading case.
+ * @internal
+ */
+class IncrementalSchemaReader extends SchemaReadHelper {
+  private readonly _incremental: boolean;
+
+  constructor(schemaContext: SchemaContext, incremental: boolean) {
+    super(JsonParser, schemaContext);
+    this._incremental = incremental;
+  }
+
+  /** Override to make this method accessible in the schema loader */
+  public override async getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType): Promise<Schema | undefined> {
+    return super.getSchema(schemaKey, matchType);
+  }
+
+  /** Override to make this method accessible in the schema loader */
+  public override async getSchemaItem(schemaItemKey: SchemaItemKey): Promise<SchemaItem | undefined> {
+    return super.getSchemaItem(schemaItemKey);
+  }
+
+  /** Override to make this method accessible in the schema loader */
+  public override async loadSchema(schemaInfo: SchemaInfo, targetSchema: Schema): Promise<Schema> {
+    return super.loadSchema(schemaInfo, targetSchema);
+  }
+
+  protected override async loadSchemaReference(schema: Schema, refKey: SchemaKey): Promise<Schema> {
+    const existingReference = await schema.getReference(refKey.name);
+    if(existingReference)
+      return existingReference;
+
+    const lookupSchemaInfo = await this.context.getSchemaInfo(refKey, SchemaMatchType.Exact);
+    if(lookupSchemaInfo === undefined)
+      throw new ECObjectsError(ECObjectsStatus.UnableToLocateSchema, `Could not locate the referenced schema, ${refKey.name}.${refKey.version.toString()}, of ${schema.schemaKey.name}`);
+
+    const referencedSchema = await super.loadSchemaReference(schema, refKey);
+
+    // Also load the references of the referenced schema.
+    for(const ref of lookupSchemaInfo.references) {
+      await this.loadSchemaReference(referencedSchema, ref.schemaKey);
+    }
+
+    return referencedSchema;
+  }
+
+  public override async loadSchemaItem(schema: Schema, name: string, itemType: string, schemaItemObject: Readonly<unknown>): Promise<SchemaItem | undefined> {
+    const schemaItem = await super.loadSchemaItem(schema, name, itemType, this._incremental ? undefined : schemaItemObject);
+
+    // In incremental mode, we only load the stubs of the classes. These include the modifier and base classes.
+    // The fromJSON method of the actual class instances may complain about missing properties in the props, so
+    // calling the fromJSON on the ECClass ensures only the bare minimum is loaded.
+    if(this._incremental && schemaItemObject && schemaItem && ECClass.isECClass(schemaItem)) {
+      ECClass.prototype.fromJSONSync.call(schemaItem, schemaItemObject);
+    }
+
+    return schemaItem;
+  }
+}

--- a/core/ecschema-metadata/src/IncrementalSchemaLoader.ts
+++ b/core/ecschema-metadata/src/IncrementalSchemaLoader.ts
@@ -267,4 +267,8 @@ class IncrementalSchemaReader extends SchemaReadHelper {
 
     return schemaItem;
   }
+
+  protected override skipSchemaItem(schemaItem: SchemaItem | undefined): boolean {
+    return !this._incremental && schemaItem !== undefined;
+  }
 }

--- a/core/ecschema-metadata/src/IncrementalSchemaLocater.ts
+++ b/core/ecschema-metadata/src/IncrementalSchemaLocater.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { SchemaInfo } from "./Interfaces";
+import type { ISchemaLocater, SchemaContext } from "./Context";
+import type { IncrementalSchemaLoader } from "./IncrementalSchemaLoader";
+import type { Schema } from "./Metadata/Schema";
+import type { SchemaKey } from "./SchemaKey";
+import type { SchemaMatchType } from "./ECObjects";
+
+type LoadSchemaInfoHandler = (context: SchemaContext) => Promise<Iterable<SchemaInfo>>;
+
+/**
+ * A ISchemaLocater implementation for locating and retrieving EC Schema objects incrementially instead
+ * of all of the schema and it's references at once. This is useful for large schemas that take a long
+ * time to load, but clients need a rough scelleton of the schema as fast as possible.
+ *
+ * The IncrementalSchemaLocater is a locater around the IncrementalSchemaLoader to be used in a
+ * SchemaContext.
+ * @beta
+ */
+export class IncrementalSchemaLocater implements ISchemaLocater {
+  private readonly _schemaLoader: IncrementalSchemaLoader;
+  private readonly _schemaInfoCache: SchemaInfoCache;
+
+  /**
+   * Initializes a new instance of the IncrementalSchemaLocater class.
+   * @param schemaLoader  The schema loader instance that gets called to gather Schema Props.
+   * @param options       The options to specify what shall be loaded initially.
+   */
+  constructor(schemaLoader: IncrementalSchemaLoader) {
+    this._schemaLoader = schemaLoader;
+    this._schemaInfoCache = new SchemaInfoCache(async (context) => {
+      return schemaLoader.loadSchemaInfos(context);
+    });
+  }
+
+  /**
+   * Gets the schema info which matches the provided SchemaKey.  The schema info may be returned before the schema is fully loaded.
+   * May return the entire Schema so long as it is completely loaded as it satisfies the SchemaInfo interface.
+   * @param schemaKey   The SchemaKey to look up in the schema to get from the cache.
+   * @param matchType   The match type to match key against candidate schemas.
+   * @param context     The schema context for loading schema references.
+   */
+  public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+    return this._schemaInfoCache.lookup(schemaKey, matchType, context);
+  }
+
+  /**
+   * Attempts to get a schema from the locater. Yields undefined if no matching schema is found.
+   * For schemas that may have references, construct and call through a SchemaContext instead.
+   * @param schemaKey   The SchemaKey to look up.
+   * @param matchType   The match type to match key against candidate schemas.
+   * @param context     The schema context for loading schema references.
+   */
+  public async getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined> {
+    const schemaInfo = await this.getSchemaInfo(schemaKey, matchType, context);
+    return schemaInfo
+      ? this._schemaLoader.loadSchema(schemaInfo, context)
+      : undefined;
+  }
+
+  /**
+   * Attempts to get a schema from the locater. Yields undefined if no matching schema is found.
+   * For schemas that may have references, construct and call through a SchemaContext instead.
+   * NOT IMPLEMENTED IN THIS LOCATER.
+   * @param schemaKey   The SchemaKey to look up
+   * @param matchType   The match type to match key against candidate schemas.
+   * @param context     The schema context for loading schema references,
+   */
+  public getSchemaSync(_schemaKey: Readonly<SchemaKey>, _matchType: SchemaMatchType, _context: SchemaContext): Schema | undefined {
+    throw new Error("Incremental Schema loading does not support synchronous loading.");
+  }
+}
+
+/**
+ * Helper class to manage schema infos for a schema context.
+ */
+class SchemaInfoCache {
+  private readonly _schemaInfoCache: WeakMap<SchemaContext, Array<SchemaInfo>>;
+  private readonly _schemaInfoLoader: LoadSchemaInfoHandler;
+
+  constructor(schemaInfoLoader: LoadSchemaInfoHandler) {
+    this._schemaInfoCache = new WeakMap<SchemaContext, Array<SchemaInfo>>();
+    this._schemaInfoLoader = schemaInfoLoader;
+  }
+
+  public async lookup(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
+    if (!this._schemaInfoCache.has(context)) {
+      const schemaInfos = await this._schemaInfoLoader(context);
+      this._schemaInfoCache.set(context, Array.from(schemaInfos));
+    }
+
+    const contextSchemaInfos = this._schemaInfoCache.get(context);
+    return contextSchemaInfos
+      ? contextSchemaInfos.find((schemaInfo) => schemaInfo.schemaKey.matches(schemaKey, matchType))
+      : undefined;
+  }
+
+  public remove(schemaKey: SchemaKey, context: SchemaContext): void {
+    const contextSchemaInfos = this._schemaInfoCache.get(context);
+    if (!contextSchemaInfos)
+      return;
+
+    const index = contextSchemaInfos.findIndex((schemaInfo) => schemaInfo.schemaKey.name === schemaKey.name);
+    if (index !== -1) {
+      contextSchemaInfos.splice(index, 1);
+    }
+  }
+}

--- a/core/ecschema-metadata/src/IncrementalSchemaLocater.ts
+++ b/core/ecschema-metadata/src/IncrementalSchemaLocater.ts
@@ -70,7 +70,8 @@ export class IncrementalSchemaLocater implements ISchemaLocater {
    * @param context     The schema context for loading schema references,
    */
   public getSchemaSync(_schemaKey: Readonly<SchemaKey>, _matchType: SchemaMatchType, _context: SchemaContext): Schema | undefined {
-    throw new Error("Incremental Schema loading does not support synchronous loading.");
+    // Incremental Schema loading does not support synchronous loading, return undefined.
+    return undefined;
   }
 }
 

--- a/core/ecschema-metadata/src/Interfaces.ts
+++ b/core/ecschema-metadata/src/Interfaces.ts
@@ -7,6 +7,7 @@
  */
 
 import { DelayedPromise } from "./DelayedPromise";
+import { SchemaItemType } from "./ECObjects";
 import { ECClass, StructClass } from "./Metadata/Class";
 import { Constant } from "./Metadata/Constant";
 import { CustomAttribute, CustomAttributeContainerProps } from "./Metadata/CustomAttribute";
@@ -74,7 +75,7 @@ export type AnySchemaItem = AnyClass | Enumeration | KindOfQuantity | PropertyCa
 export type AnyECType = Schema | SchemaItem | AnyProperty | RelationshipConstraint | CustomAttributeContainerProps | CustomAttribute | OverrideFormat | AnyEnumerator;
 
 /**
- *  Holds the SchemaKeys for a schema and it's references.  Designed so that Schema fulfills this interface.
+ * Holds the SchemaKeys for a schema and it's references.  Designed so that Schema fulfills this interface.
  * @beta
  */
 export interface SchemaInfo {
@@ -94,4 +95,12 @@ export interface WithSchemaKey {
 export interface HasMixins {
   readonly mixins: LazyLoadedMixin[];
   getMixinsSync(): Iterable<Mixin>;
+}
+
+/**
+ * @internal
+ */
+export interface SchemaItemInfo {
+  readonly name: string;
+  readonly schemaItemType: SchemaItemType;
 }

--- a/core/ecschema-metadata/src/Interfaces.ts
+++ b/core/ecschema-metadata/src/Interfaces.ts
@@ -78,19 +78,20 @@ export type AnyECType = Schema | SchemaItem | AnyProperty | RelationshipConstrai
  * @beta
  */
 export interface SchemaInfo {
-  schemaKey: SchemaKey;
-  references: WithSchemaKey[];
+  readonly schemaKey: SchemaKey;
+  readonly references: WithSchemaKey[];
+  readonly alias: string;
 }
 
 /** @beta */
 export interface WithSchemaKey {
-  schemaKey: SchemaKey;
+  readonly schemaKey: SchemaKey;
 }
 
 /** This is needed to break a circular dependency between Class and EntityClass.
  * @beta
  */
 export interface HasMixins {
-  mixins: LazyLoadedMixin[];
+  readonly mixins: LazyLoadedMixin[];
   getMixinsSync(): Iterable<Mixin>;
 }

--- a/core/ecschema-metadata/src/Metadata/Schema.ts
+++ b/core/ecschema-metadata/src/Metadata/Schema.ts
@@ -959,5 +959,7 @@ export abstract class MutableSchema extends Schema {
   public abstract override deleteClassSync(name: string): void;
   public abstract override deleteSchemaItem(name: string): Promise<void>;
   public abstract override deleteSchemaItemSync(name: string): void;
+  public abstract override setDisplayLabel(displayLabel: string): void;
+  public abstract override setDescription(description: string): void;
   public abstract override setAlias(alias: string): void;
 }

--- a/core/ecschema-metadata/src/test/IncrementalSchemaLocater.test.ts
+++ b/core/ecschema-metadata/src/test/IncrementalSchemaLocater.test.ts
@@ -1,0 +1,320 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import { IncrementalSchemaLocater } from "../IncrementalSchemaLocater";
+import { IncrementalSchemaLoader } from "../IncrementalSchemaLoader";
+import { SchemaContext } from "../Context";
+import { ECVersion, SchemaKey } from "../SchemaKey";
+import { Schema, SchemaInfo, SchemaMatchType, SchemaProps } from "../ecschema-metadata";
+import * as sinon from "sinon";
+
+const $schema = "https://dev.bentley.com/json_schemas/ec/32/ecschema";
+
+class TestSchemaLoader extends IncrementalSchemaLoader {
+  public override async loadSchemaInfos(_context: SchemaContext): Promise<Iterable<SchemaInfo>> {
+    throw new Error("Implementation will be provided by the test.");
+  }
+  public override async getSchemaPartials(_schemaKey: SchemaKey): Promise<[SchemaProps, ...Partial<SchemaProps>[]] | undefined> {
+    throw new Error("Implementation will be provided by the test.");
+  }
+  public override async getSchemaJson(_schemaKey: SchemaKey, _context: SchemaContext): Promise<SchemaProps | undefined> {
+    throw new Error("Implementation will be provided by the test.");
+  }
+}
+
+describe("IncrementalSchemaLocater tests: ", () => {
+  let locater: IncrementalSchemaLocater;
+  let context: SchemaContext;
+  let schemaLoader: TestSchemaLoader;
+
+  beforeEach(() => {
+    schemaLoader = new TestSchemaLoader();
+    locater = new IncrementalSchemaLocater(schemaLoader);
+    context = new SchemaContext();
+    context.addLocater(locater);
+  });
+
+  it("get schema info, same context", async () => {
+    const schemaKeyA = new SchemaKey("SchemaA", 1, 1, 1);
+    const schemaKeyB = new SchemaKey("SchemaB", 1, 1, 1);
+    const schemaKeyC = new SchemaKey("SchemaC", 1, 1, 1);
+    const spy = sinon.stub(schemaLoader, "loadSchemaInfos").resolves([
+      { schemaKey: schemaKeyA, references: [{schemaKey: schemaKeyB}, {schemaKey: schemaKeyC}], alias: "SchemaA" },
+      { schemaKey: schemaKeyB, references: [], alias: "SchemaB" },
+      { schemaKey: schemaKeyC, references: [{schemaKey: schemaKeyB}], alias: "SchemaC" },
+    ]);
+
+    const schemaInfoA = await locater.getSchemaInfo(schemaKeyA, SchemaMatchType.Exact, context);
+    expect(schemaInfoA).to.not.be.undefined;
+    const schemaInfoB = await locater.getSchemaInfo(schemaKeyB, SchemaMatchType.Exact, context);
+    expect(schemaInfoB).to.not.be.undefined;
+
+    expect(spy.callCount).to.be.equal(1);
+  });
+
+  it("get schema info, different context", async () => {
+    const schemaKeyA = new SchemaKey("SchemaA", 1, 1, 1);
+    const schemaKeyB = new SchemaKey("SchemaB", 1, 1, 1);
+    const schemaKeyC = new SchemaKey("SchemaC", 1, 1, 1);
+    const spy = sinon.stub(schemaLoader, "loadSchemaInfos").resolves([
+      { schemaKey: schemaKeyA, references: [{schemaKey: schemaKeyB}, {schemaKey: schemaKeyC}], alias: "SchemaA" },
+      { schemaKey: schemaKeyB, references: [], alias: "SchemaB" },
+      { schemaKey: schemaKeyC, references: [{schemaKey: schemaKeyB}], alias: "SchemaC" },
+    ]);
+
+    const schemaInfoA = await locater.getSchemaInfo(schemaKeyA, SchemaMatchType.Exact, new SchemaContext());
+    expect(schemaInfoA).to.not.be.undefined;
+    const schemaInfoB = await locater.getSchemaInfo(schemaKeyB, SchemaMatchType.Exact, new SchemaContext());
+    expect(schemaInfoB).to.not.be.undefined;
+
+    expect(spy.callCount).to.be.equal(2);
+  });
+
+  it("locate valid schema with multiple references", async () => {
+    const schemaKeyA = new SchemaKey("SchemaA", 1, 1, 1);
+    const schemaKeyB = new SchemaKey("SchemaB", 1, 1, 1);
+    const schemaKeyC = new SchemaKey("SchemaC", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([
+      { schemaKey: schemaKeyA, references: [{schemaKey: schemaKeyB}, {schemaKey: schemaKeyC}], alias: "SchemaA" },
+      { schemaKey: schemaKeyB, references: [], alias: "SchemaB" },
+      { schemaKey: schemaKeyC, references: [{schemaKey: schemaKeyB}], alias: "SchemaC" },
+    ]);
+
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKeyA.name,
+      version: schemaKeyA.version.toString(),
+      alias: "SchemaA",
+      description: "Test description",
+      references: [
+        { name: schemaKeyB.name, version: schemaKeyB.version.toString() },
+        { name: schemaKeyB.name, version: schemaKeyB.version.toString() }
+      ]
+    }]);
+
+    const schema = await context.getSchema(schemaKeyA, SchemaMatchType.Exact);
+    expect(schema).to.not.be.undefined;
+    expect(schema).has.nested.property("schemaKey.name", "SchemaA");
+    expect(schema).has.nested.property("schemaKey.version").satisfies((v: ECVersion) => v.toString() ==="01.01.01");
+    expect(schema).has.nested.property("references").satisfies((refs: Schema[]) => {
+      expect(refs).satisfies(() => refs.some((ref) => Schema.isSchema(ref) && ref.schemaKey.name === "SchemaB"));
+      expect(refs).satisfies(() => refs.some((ref) => Schema.isSchema(ref) && ref.schemaKey.name === "SchemaC"));
+      return true;
+    });
+  });
+
+  it("getSchema called multiple times for same schema", async () => {
+    const schemaKey = new SchemaKey("SchemaD", 4, 4, 4);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaD" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaD"
+    }]);
+
+    // locater should not cache the schema.
+    const spy = sinon.spy(schemaLoader, "loadSchema");
+    await locater.getSchema(schemaKey, SchemaMatchType.Exact, context);
+    await locater.getSchema(schemaKey, SchemaMatchType.Exact, context);
+
+    expect(spy.callCount).to.be.equal(2);
+  });
+
+  it("getSchema, wait till resolved, succeeds", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+    sinon.stub(schemaLoader, "getSchemaJson").resolves({
+      $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+      name: "SchemaA",
+      version: "01.01.01",
+      alias: "SchemaA",
+      items: {
+        category: {
+          schemaItemType: "EntityClass",
+          label: "This is Category",
+        }
+      }
+    } as any);
+
+    const resolvePromise = new Promise<Schema>((resolve, reject) => {
+      schemaLoader.onSchemaComplete.addListener((value) => {
+        value.schemaKey.matches(schemaKey) && resolve(value);
+      });
+      schemaLoader.onSchemaError.addListener((value, error) => {
+        value.schemaKey.matches(schemaKey) && reject(error);
+      });
+    });
+
+    const schema = await locater.getSchema(schemaKey, SchemaMatchType.Exact, context);
+    expect(schema).to.not.be.undefined;
+    expect(schema).has.nested.property("schemaKey.name", "SchemaA");
+    expect(schema).has.nested.property("schemaKey.version").satisfies((v: ECVersion) => v.toString() ==="01.01.01");
+
+    const resolvedSchema = await resolvePromise;
+    expect(resolvedSchema).to.not.be.undefined;
+    expect(resolvedSchema). to.be.equal(schema);
+    await expect(resolvedSchema.getEntityClass("category")).to.be.eventually.not.undefined;
+  });
+
+  it("getSchema, wait till resolved, fails", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+    sinon.stub(schemaLoader, "getSchemaJson").resolves({
+      $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+      name: "SchemaA",
+      version: "01.01.01",
+      alias: "SchemaA",
+      items: {
+        category: {
+          schemaItemType: "EntityClass",
+          name: "Category",
+          baseClass: "SchemaA.BadBaseClass",
+        }
+      }
+    } as any);
+
+    const resolvePromise = new Promise<Schema>((resolve, reject) => {
+      schemaLoader.onSchemaComplete.addListener((value) => {
+        value.schemaKey.matches(schemaKey) && resolve(value);
+      });
+      schemaLoader.onSchemaError.addListener((value, error) => {
+        value.schemaKey.matches(schemaKey) && reject(error);
+      });
+    });
+
+    const schema = await locater.getSchema(schemaKey, SchemaMatchType.Exact, context);
+    expect(schema).to.not.be.undefined;
+    expect(schema).has.nested.property("schemaKey.name", "SchemaA");
+    expect(schema).has.nested.property("schemaKey.version").satisfies((v: ECVersion) => v.toString() ==="01.01.01");
+
+    await expect(resolvePromise).to.be.rejectedWith("Unable to locate SchemaItem SchemaA.BadBaseClass.");
+  });
+
+  it("getSchema synchronously, fails", () => {
+    const schemaKey = new SchemaKey("SchemaD", 4, 4, 4);
+    expect(() => context.getSchemaSync(schemaKey)).throws("Incremental Schema loading does not support synchronous loading.");
+  });
+
+  it("getSchema which does not exist, returns undefined", async () => {
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([]);
+
+    const schemaKey = new SchemaKey("DoesNotExist");
+    const schema = await locater.getSchema(schemaKey, SchemaMatchType.Exact, context);
+    expect(schema).to.be.undefined;
+  });
+
+  it("getSchema, full version, succeeds", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+
+    const schema = await locater.getSchema(schemaKey, SchemaMatchType.Exact, context);
+    expect(schema).to.not.be.undefined;
+    expect(schema).has.nested.property("schemaKey.name", "SchemaA");
+    expect(schema).has.nested.property("schemaKey.version").satisfies((v: ECVersion) => v.toString() ==="01.01.01");
+  });
+
+  it("getSchema, exact version, wrong minor, fails", async () => {
+    const schemaKey = new SchemaKey("SchemaD", 4, 4, 4);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaD" }]);
+
+    const schema = await locater.getSchema(new SchemaKey("SchemaD", 1, 1, 2), SchemaMatchType.Exact, context);
+    expect(schema).to.be.undefined;
+  });
+
+  it("getSchema, latest, succeeds", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 2, 0, 2);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+
+    const schema = await locater.getSchema(new SchemaKey("SchemaA", 1, 1, 0), SchemaMatchType.Latest, context);
+    expect(schema).to.not.be.undefined;
+    expect(schema).has.nested.property("schemaKey.name", "SchemaA");
+    expect(schema).has.nested.property("schemaKey.version").satisfies((v: ECVersion) => v.toString() ==="02.00.02");
+  });
+
+  it("getSchema, latest write compatible, succeeds", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+
+    const schema = await locater.getSchema(schemaKey, SchemaMatchType.LatestWriteCompatible, context);
+    expect(schema).to.not.be.undefined;
+    expect(schema).has.nested.property("schemaKey.name", "SchemaA");
+    expect(schema).has.nested.property("schemaKey.version").satisfies((v: ECVersion) => v.toString() ==="01.01.01");
+  });
+
+  it("getSchema, latest write compatible, write version wrong, fails", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+
+    const schema = await locater.getSchema(new SchemaKey("SchemaA", 1, 2, 0), SchemaMatchType.LatestWriteCompatible, context);
+    expect(schema).to.be.undefined;
+  });
+
+  it("getSchema, latest read compatible, succeeds", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+
+    const schema = await locater.getSchema(new SchemaKey("SchemaA", 1, 0, 0), SchemaMatchType.LatestReadCompatible, context);
+    expect(schema).to.not.be.undefined;
+    expect(schema).has.nested.property("schemaKey.name", "SchemaA");
+    expect(schema).has.nested.property("schemaKey.version").satisfies((v: ECVersion) => v.toString() ==="01.01.01");
+  });
+
+  it("getSchema, latest read compatible, read version wrong, fails", async () => {
+    const schemaKey = new SchemaKey("SchemaA", 1, 1, 1);
+    sinon.stub(schemaLoader, "loadSchemaInfos").resolves([{ schemaKey, references: [], alias: "SchemaA" }]);
+    sinon.stub(schemaLoader, "getSchemaPartials").resolves([{
+      $schema,
+      name: schemaKey.name,
+      version: schemaKey.version.toString(),
+      alias: "SchemaA"
+    }]);
+
+    const schema = await locater.getSchema(new SchemaKey("SchemaA", 2, 1, 1), SchemaMatchType.LatestReadCompatible, context);
+    expect(schema).to.be.undefined;
+  });
+});

--- a/core/ecschema-metadata/src/test/Metadata/Class.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Class.test.ts
@@ -289,6 +289,7 @@ describe("ECClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           TestFirstBaseCAClass0: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyClass" },
           TestFirstBaseCAClass1: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyClass" },
@@ -359,6 +360,7 @@ describe("ECClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           TestCAClass0: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyClass" },
           TestCAClass1: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyClass" },
@@ -493,6 +495,7 @@ describe("ECClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           testBaseClass: {
             schemaItemType: "EntityClass",
@@ -525,6 +528,7 @@ describe("ECClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         references: [
           {
             name: "RefSchema",
@@ -578,6 +582,7 @@ describe("ECClass", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
       items: {
         TestCAClass: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyClass" },
         testClass: {
@@ -615,6 +620,7 @@ describe("ECClass", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
       items: {
         TestCAClassA: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyClass" },
         TestCAClassB: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyClass" },
@@ -654,6 +660,7 @@ describe("ECClass", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
       items: {
         testClass: {
           schemaItemType: "EntityClass",
@@ -715,6 +722,7 @@ describe("ECClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           testStruct: {
             schemaItemType: "StructClass",
@@ -905,6 +913,7 @@ describe("ECClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           testBaseClass: {
             schemaItemType: "EntityClass",
@@ -1026,6 +1035,7 @@ describe("ECClass", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
       items: {
         TestCAClassA: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyProperty" },
         TestCAClassB: { schemaItemType: "CustomAttributeClass", appliesTo: "AnyProperty" },
@@ -1090,6 +1100,7 @@ describe("ECClass", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
       items: {
         testBaseClass: {
           schemaItemType: "EntityClass",

--- a/core/ecschema-metadata/src/test/Metadata/Deserialization.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Deserialization.test.ts
@@ -28,6 +28,7 @@ describe("Full Schema Deserialization", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         description: "This is a test description",
         label: "This is a test label",
       });
@@ -45,6 +46,7 @@ describe("Full Schema Deserialization", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         description: "This is a test description",
         label: "This is a test label",
       });
@@ -63,6 +65,7 @@ describe("Full Schema Deserialization", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         description: "This is a test description",
         label: "This is a test label",
       };
@@ -111,7 +114,7 @@ describe("Full Schema Deserialization", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
-
+      alias: "ts",
     };
     const validSchemaJson = {
       ...baseJson,
@@ -481,6 +484,7 @@ describe("Full Schema Deserialization", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
     };
 
     it("should throw for invalid items attribute", async () => {
@@ -572,6 +576,7 @@ describe("Full Schema Deserialization", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
     };
     type Mock<T> = { readonly [P in keyof T]: sinon.SinonSpy; };
     let mockVisitor: Mock<ISchemaPartVisitor>;

--- a/core/ecschema-metadata/src/test/Metadata/InvertedUnit.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/InvertedUnit.test.ts
@@ -94,6 +94,7 @@ describe("Inverted Unit tests", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         version: "1.0.0",
         name: "TestSchema",
+        alias: "ts",
         items: {
           HORIZONTAL_PER_VERTICAL: {
             schemaItemType: "InvertedUnit",
@@ -132,6 +133,7 @@ describe("Inverted Unit tests", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         version: "1.0.0",
         name: "TestSchema",
+        alias: "ts",
         items: {
           HORIZONTAL_PER_VERTICAL: {
             schemaItemType: "InvertedUnit",
@@ -171,6 +173,7 @@ describe("Inverted Unit tests", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         version: "1.0.0",
         name: "TestSchema",
+        alias: "ts",
         items: {
           HORIZONTAL_PER_VERTICAL: {
             schemaItemType: "InvertedUnit",
@@ -201,6 +204,7 @@ describe("Inverted Unit tests", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         version: "1.0.0",
         name: "TestSchema",
+        alias: "ts",
         items: {
           HORIZONTAL_PER_VERTICAL: {
             schemaItemType: "InvertedUnit",
@@ -394,6 +398,7 @@ describe("Inverted Unit tests", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       version: "1.0.0",
       name: "TestSchema",
+      alias: "ts",
       items: {
         HORIZONTAL_PER_VERTICAL: {
           schemaItemType: "InvertedUnit",
@@ -471,6 +476,7 @@ describe("Inverted Unit tests", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       version: "1.0.0",
       name: "TestSchema",
+      alias: "ts",
       items: {
         HORIZONTAL_PER_VERTICAL: {
           schemaItemType: "InvertedUnit",

--- a/core/ecschema-metadata/src/test/Metadata/Phenomenon.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Phenomenon.test.ts
@@ -20,6 +20,7 @@ describe("Phenomenon tests", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
       items: {
         testPhenomenon: {
           schemaItemType: "Phenomenon",

--- a/core/ecschema-metadata/src/test/Metadata/Property.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Property.test.ts
@@ -369,6 +369,7 @@ describe("Property", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           ...customAttributeJson,
           testClass: {

--- a/core/ecschema-metadata/src/test/Metadata/Relationship.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Relationship.test.ts
@@ -183,6 +183,7 @@ describe("RelationshipClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           TestRelationship: {
             schemaItemType: "RelationshipClass",
@@ -454,6 +455,7 @@ describe("RelationshipClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           TestRelationship: {
             schemaItemType: "RelationshipClass",
@@ -689,6 +691,7 @@ describe("RelationshipClass", () => {
         $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
         name: "TestSchema",
         version: "1.2.3",
+        alias: "ts",
         items: {
           ...customAttributeJson,
           TestRelationship: {

--- a/core/ecschema-metadata/src/test/Metadata/UnitSystem.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/UnitSystem.test.ts
@@ -29,6 +29,7 @@ describe("UnitSystem tests", () => {
       $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
       name: "TestSchema",
       version: "1.2.3",
+      alias: "ts",
       items: {
         testUnitSystem: {
           schemaItemType: "UnitSystem",

--- a/core/ecschema-metadata/src/test/TestUtils/DeserializationHelpers.ts
+++ b/core/ecschema-metadata/src/test/TestUtils/DeserializationHelpers.ts
@@ -17,6 +17,7 @@ export function createSchemaJsonWithItems(itemsJson: any, referenceJson?: any): 
     $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
     name: "TestSchema",
     version: "1.2.3",
+    alias: "ts",
     items: {
       ...itemsJson,
     },

--- a/core/ecschema-metadata/src/test/Validation/SchemaWalker.test.ts
+++ b/core/ecschema-metadata/src/test/Validation/SchemaWalker.test.ts
@@ -22,6 +22,7 @@ describe("SchemaWalker tests", () => {
     $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
     name: "TestSchema",
     version: "1.2.3",
+    alias: "ts",
   };
 
   const schemaJson = {


### PR DESCRIPTION
Added incremental schema loading:

To locate schemas incrementally, the IncrementalSchemaLocater was added. Clients that want to load their schemas incrementally should add this locater to their context.

The actual schema loading happens in an abstract IncrementalSchemaLoader class. Derived classes may add their own handling to fetch the data before the loader loads them.

Also included:
- SchemaInfo now also holds the schemas alias. This affected a couple of tests that has to be adjusted.
- In SchemaReadHelper a few methods went from private to protected, that they can be overridden when needed.