### PR TITLE
Metadata: Add a minimum ECSpecVersion check in Schema (backport #7884) [release/4.10.x]

### DIFF
--- a/common/changes/@itwin/ecschema-metadata/rohitptnkr-add-minimum-ecspecversion-check_2025-03-27-08-13.json
+++ b/common/changes/@itwin/ecschema-metadata/rohitptnkr-add-minimum-ecspecversion-check_2025-03-27-08-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-metadata/src/Metadata/Schema.ts
+++ b/core/ecschema-metadata/src/Metadata/Schema.ts
@@ -126,6 +126,12 @@ export class Schema implements CustomAttributeContainerProps {
   public static get currentECSpecMajorVersion(): number { return parseInt(Schema._currentECSpecVersion.split(".")[0], 10); }
   public static get currentECSpecMinorVersion(): number { return parseInt(Schema._currentECSpecVersion.split(".")[1], 10); }
 
+  private get _isECSpecVersionUnsupported(): boolean {
+    return (this.originalECSpecMajorVersion !== 3 || this.originalECSpecMinorVersion === undefined
+      || (this.originalECSpecMinorVersion < 2 || this.originalECSpecMinorVersion > Schema.currentECSpecMinorVersion))
+  }
+
+
   public get alias() {
     if (this._alias === undefined || this._alias === null) {
       throw new ECObjectsError(ECObjectsStatus.InvalidECJson, `The Schema ${this.name} does not have the required 'alias' attribute.`);
@@ -549,7 +555,7 @@ export class Schema implements CustomAttributeContainerProps {
    * Save this Schema's properties to an object for serializing to JSON.
    */
   public toJSON(): SchemaProps {
-    if (!this.isECSpecVersionSupported())
+    if (this._isECSpecVersionUnsupported)
       throw new ECObjectsError(ECObjectsStatus.NewerECSpecVersion, `The Schema '${this.name}' has an unsupported ECSpecVersion and cannot be serialized.`);
 
     const schemaJson: { [value: string]: any } = {};
@@ -581,7 +587,7 @@ export class Schema implements CustomAttributeContainerProps {
    * @param schemaXml An empty DOM document to which the schema will be written
    */
   public async toXml(schemaXml: Document): Promise<Document> {
-    if (!this.isECSpecVersionSupported())
+    if (this._isECSpecVersionUnsupported)
       throw new ECObjectsError(ECObjectsStatus.NewerECSpecVersion, `The Schema '${this.name}' has an unsupported ECSpecVersion and cannot be serialized.`);
 
     const schemaMetadata = schemaXml.createElement("ECSchema");
@@ -624,36 +630,6 @@ export class Schema implements CustomAttributeContainerProps {
     return schemaXml;
   }
 
-  // Check if the ECSpecVersion read-version is greater than the current ECSpecVersion supported.
-  // If a specific ECSpecVersion is given, check against that version.
-  // If no argument is given, check against the original ECSpecVersion of the schema.
-  private isECSpecMajorVersionSupported(ecSpecMajorVersionToCheck?: number): boolean {
-    // If argument is supplied, check the argument against the current ECSpecVersion supported
-    if (ecSpecMajorVersionToCheck !== undefined)
-      return (Schema.currentECSpecMajorVersion >= ecSpecMajorVersionToCheck);
-
-    // If argument is not supplied, check against the original ECSpecVersion of the schema
-    if (this.originalECSpecMajorVersion === undefined)
-      return false;
-    return (Schema.currentECSpecMajorVersion >= this.originalECSpecMajorVersion);
-  }
-
-  // Check if the full ECSpecVersion is greater than the current ECSpecVersion supported.
-  // If a specific ECSpecVersion is given, check against that version.
-  // If no argument is given, check against the original ECSpecVersion of the schema.
-  private isECSpecVersionSupported(ecSpecMajorVersionToCheck?: number, ecSpecMinorVersionToCheck?: number): boolean {
-    // If arguments are supplied, check the arguments against the current ECSpecVersion supported
-    if (ecSpecMajorVersionToCheck !== undefined && ecSpecMinorVersionToCheck !== undefined) {
-      if (!this.isECSpecMajorVersionSupported(ecSpecMajorVersionToCheck))
-        return false;
-      return (Schema.currentECSpecMinorVersion >= ecSpecMinorVersionToCheck);
-    }
-    // If arguments are not supplied, check against the original ECSpecVersion of the schema
-    if (!this.isECSpecMajorVersionSupported() || this.originalECSpecMinorVersion === undefined)
-      return false;
-    return (Schema.currentECSpecMinorVersion >= this.originalECSpecMinorVersion);
-  }
-
   /**
    * Loads the schema header (name, version alias, label and description) from the input SchemaProps
    */
@@ -680,11 +656,11 @@ export class Schema implements CustomAttributeContainerProps {
       ecVersion = { readVersion: schemaProps.ecSpecMajorVersion, writeVersion: schemaProps.ecSpecMinorVersion } as ECSpecVersion;
     }
 
-    this._originalECSpecMajorVersion = ecVersion?.readVersion;
-    this._originalECSpecMinorVersion = ecVersion?.writeVersion;
+    this._originalECSpecMajorVersion = ecVersion.readVersion;
+    this._originalECSpecMinorVersion = ecVersion.writeVersion;
 
-    if (!this.isECSpecMajorVersionSupported(ecVersion?.readVersion))
-      throw new ECObjectsError(ECObjectsStatus.NewerECSpecVersion, `The Schema '${this.name}' has an unsupported ECVersion and cannot be loaded.`);
+    if (ecVersion.readVersion !== 3 || (ecVersion.readVersion === 3 && ecVersion.writeVersion < 2))
+      throw new ECObjectsError(ECObjectsStatus.InvalidECVersion, `The Schema '${this.name}' has an unsupported ECVersion ${ecVersion.readVersion}.${ecVersion.writeVersion} and cannot be loaded.`);
 
     if (ECName.validate(schemaProps.alias)) {
       this._alias = schemaProps.alias;

--- a/core/ecschema-metadata/src/test/Metadata/Schema.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Schema.test.ts
@@ -628,7 +628,8 @@ describe("Schema", () => {
 
     type TestCase = [ xmlVersionMajor: number, xmlVersionMinor: number, deserializtionStatus: boolean, serializationStatus: boolean ];
     const testCases: TestCase[] = [
-      [Schema.currentECSpecMajorVersion, Schema.currentECSpecMinorVersion - 1, true, true],
+      // [3, 1, false, false], // Will have to be uncommented and the test below updated when the ECSpec Version gets incremented next.
+      [Schema.currentECSpecMajorVersion, Schema.currentECSpecMinorVersion - 1, false, false],
       [Schema.currentECSpecMajorVersion, Schema.currentECSpecMinorVersion, true, true],
       [Schema.currentECSpecMajorVersion, Schema.currentECSpecMinorVersion + 1, true, false],
       [Schema.currentECSpecMajorVersion + 1, Schema.currentECSpecMinorVersion, false, false],
@@ -638,11 +639,11 @@ describe("Schema", () => {
     async function testSerialization(schema: Schema, serializationStatus: boolean, expectedError: string) {
       const xmlDoc = new DOMParser().parseFromString(`<?xml version="1.0" encoding="UTF-8"?>`, "application/xml");
       if (serializationStatus) {
-        await expect(schema.toXml(xmlDoc)).to.not.be.rejectedWith(ECObjectsError, expectedError);
-        expect(() => schema.toJSON()).to.not.throw(ECObjectsError, expectedError);
+        await expect(schema.toXml(xmlDoc)).to.not.be.rejectedWith(ECObjectsError, expectedError, `Serialization failed for ECXML version ${schema.originalECSpecMajorVersion}.${schema.originalECSpecMinorVersion}`);
+        expect(() => schema.toJSON()).to.not.throw(ECObjectsError, expectedError, `Serialization failed for ECXML version ${schema.originalECSpecMajorVersion}.${schema.originalECSpecMinorVersion}`);
       } else {
-        await expect(schema.toXml(xmlDoc)).to.be.rejectedWith(ECObjectsError, expectedError);
-        expect(() => schema.toJSON()).to.throw(ECObjectsError, expectedError);
+        await expect(schema.toXml(xmlDoc)).to.be.rejectedWith(ECObjectsError, expectedError, `Serialization failed for ECXML version ${schema.originalECSpecMajorVersion}.${schema.originalECSpecMinorVersion}`);
+        expect(() => schema.toJSON()).to.throw(ECObjectsError, expectedError, `Serialization failed for ECXML version ${schema.originalECSpecMajorVersion}.${schema.originalECSpecMinorVersion}`);
       }
     }
 
@@ -662,15 +663,15 @@ describe("Schema", () => {
         try {
           reader.readSchemaSync(schema, document);
         } catch (err: any) {
-          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion and cannot be loaded.`);
-          assert.isFalse(deserializtionStatus);
+          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion ${xmlVersionMajor}.${xmlVersionMinor} and cannot be loaded.`);
+          assert.isFalse(deserializtionStatus, `Deserialization check failed for ECXML version ${xmlVersionMajor}.${xmlVersionMinor}`);
 
           // Schema serialization should fail if the major ECXml version is newer
           await testSerialization(schema, serializationStatus, unsupportedVersionError);
           continue;
         }
 
-        assert.isTrue(deserializtionStatus);
+        assert.isTrue(deserializtionStatus, `Deserialization check failed for ECXML version ${xmlVersionMajor}.${xmlVersionMinor}`);
         expect(schema.originalECSpecMajorVersion).to.equal(xmlVersionMajor);
         expect(schema.originalECSpecMinorVersion).to.equal(xmlVersionMinor);
         expect(schema.getItemSync("testClass") !== undefined).to.equal(deserializtionStatus);
@@ -694,7 +695,7 @@ describe("Schema", () => {
         try {
           await reader.readSchema(schema, new DOMParser().parseFromString(schemaXml));
         } catch (err: any) {
-          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion and cannot be loaded.`);
+          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion ${xmlVersionMajor}.${xmlVersionMinor} and cannot be loaded.`);
           assert.isFalse(deserializtionStatus);
 
           // Schema serialization should fail if the major ECXml version is newer
@@ -713,8 +714,7 @@ describe("Schema", () => {
     });
 
     it("Deserialize and serialize newer JS schemas - sync", async () => {
-      // eslint-disable-next-line prefer-const
-      for (let [ecMajorVersion, ecMinorVersion, deserializtionStatus, serializationStatus] of testCases) {
+      for (const [ecMajorVersion, ecMinorVersion, deserializtionStatus, serializationStatus] of testCases) {
         const schemaJson = {
           $schema: `https://dev.bentley.com/json_schemas/ec/${ecMajorVersion}${ecMinorVersion}/ecschema`,
           name: "TestSchema",
@@ -735,15 +735,12 @@ describe("Schema", () => {
         try {
           schema = Schema.fromJsonSync(schemaJson, new SchemaContext());
         } catch (err: any) {
-          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion and cannot be loaded.`);
+          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion ${ecMajorVersion}.${ecMinorVersion} and cannot be loaded.`);
           assert.isFalse(deserializtionStatus);
 
-          // When the ECXML major version is newer, deserialization will throw an error and the schema object will never get updated and the ECXMl version will remain the deafult latest supported.
-          // Hence serialization should succeed in this case.
-          if (ecMajorVersion > Schema.currentECSpecMajorVersion || (ecMajorVersion === Schema.currentECSpecMajorVersion && ecMinorVersion > Schema.currentECSpecMinorVersion))
-            serializationStatus = true;
-
-          await testSerialization(schema, serializationStatus, unsupportedVersionError);
+          // When the ECXML major version is newer, deserialization will throw an error and the schema object will never get updated. The ECXMl version will then remain the default latest supported.
+          // Hence, serialization should succeed in this case.
+          await testSerialization(schema, true, unsupportedVersionError);
           continue;
         }
 
@@ -758,8 +755,7 @@ describe("Schema", () => {
     });
 
     it("Deserialize and serialize newer JS schemas - async", async () => {
-      // eslint-disable-next-line prefer-const
-      for (let [ecMajorVersion, ecMinorVersion, deserializtionStatus, serializationStatus] of testCases) {
+      for (const [ecMajorVersion, ecMinorVersion, deserializtionStatus, serializationStatus] of testCases) {
         const schemaJson = {
           $schema: `https://dev.bentley.com/json_schemas/ec/${ecMajorVersion}${ecMinorVersion}/ecschema`,
           name: "TestSchema",
@@ -779,15 +775,12 @@ describe("Schema", () => {
         try {
           schema = await Schema.fromJson(schemaJson, new SchemaContext());
         } catch (err: any) {
-          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion and cannot be loaded.`);
+          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion ${ecMajorVersion}.${ecMinorVersion} and cannot be loaded.`);
           assert.isFalse(deserializtionStatus);
 
-          // When the ECXML major version is newer, deserialization will throw an error and the schema object will never get updated and the ECXMl version will remain the deafult latest supported.
-          // Hence serialization should succeed in this case.
-          if (ecMajorVersion > Schema.currentECSpecMajorVersion || (ecMajorVersion === Schema.currentECSpecMajorVersion && ecMinorVersion > Schema.currentECSpecMinorVersion))
-            serializationStatus = true;
-
-          await testSerialization(schema, serializationStatus, unsupportedVersionError);
+          // When the ECXML major version is newer, deserialization will throw an error and the schema object will never get updated. The ECXMl version will then remain the default latest supported.
+          // Hence, serialization should succeed in this case.
+          await testSerialization(schema, true, unsupportedVersionError);
           continue;
         }
 
@@ -814,7 +807,7 @@ describe("Schema", () => {
         try {
           schema.fromJSONSync(schemaJson);
         } catch (err: any) {
-          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion and cannot be loaded.`);
+          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion ${ecMajorVersion}.${ecMinorVersion} and cannot be loaded.`);
           assert.isFalse(deserializtionStatus);
 
           // Schema serialization should fail if the major ECXml version is newer
@@ -844,7 +837,7 @@ describe("Schema", () => {
         try {
           await schema.fromJSON(schemaJson);
         } catch (err: any) {
-          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion and cannot be loaded.`);
+          assert.equal(err.message, `The Schema 'TestSchema' has an unsupported ECVersion ${ecMajorVersion}.${ecMinorVersion} and cannot be loaded.`);
           assert.isFalse(deserializtionStatus);
 
           // Schema serialization should fail if the major ECXml version is newer


### PR DESCRIPTION
Backported from PR https://github.com/iTwin/itwinjs-core/pull/7884