### PR TITLE
Presentation: Internal APIs cleanup

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -197,6 +197,8 @@ export enum PresentationBackendNativeLoggerCategory {
 
 // @public
 export class PresentationManager {
+    // @internal (undocumented)
+    get [_presentation_manager_detail](): PresentationManagerDetail;
     [Symbol.dispose](): void;
     constructor(props?: PresentationManagerProps);
     get activeUnitSystem(): UnitSystemKey | undefined;
@@ -211,28 +213,23 @@ export class PresentationManager {
     getContentSet(requestOptions: WithCancelEvent<Prioritized<Paged<ContentRequestOptions<IModelDb, Descriptor, KeySet, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Item[]>;
     getContentSetSize(requestOptions: WithCancelEvent<Prioritized<ContentRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<number>;
     getContentSources(requestOptions: WithCancelEvent<Prioritized<ContentSourcesRequestOptions<IModelDb>>> & BackendDiagnosticsAttribute): Promise<SelectClassInfo[]>;
-    // @internal (undocumented)
-    getDetail(): PresentationManagerDetail;
     getDisplayLabelDefinition(requestOptions: WithCancelEvent<Prioritized<DisplayLabelRequestOptions<IModelDb, InstanceKey>>> & BackendDiagnosticsAttribute): Promise<LabelDefinition>;
     getDisplayLabelDefinitions(requestOptions: WithCancelEvent<Prioritized<Paged<DisplayLabelsRequestOptions<IModelDb, InstanceKey>>>> & BackendDiagnosticsAttribute): Promise<LabelDefinition[]>;
     getElementProperties<TParsedContent = ElementProperties>(requestOptions: WithCancelEvent<Prioritized<SingleElementPropertiesRequestOptions<IModelDb, TParsedContent>>> & BackendDiagnosticsAttribute): Promise<TParsedContent | undefined>;
     getElementProperties<TParsedContent = ElementProperties>(requestOptions: WithCancelEvent<Prioritized<MultiElementPropertiesRequestOptions<IModelDb, TParsedContent>>> & BackendDiagnosticsAttribute): Promise<MultiElementPropertiesResponse<TParsedContent>>;
     getFilteredNodePaths(requestOptions: WithCancelEvent<Prioritized<FilterByTextHierarchyRequestOptions<IModelDb, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<NodePathElement[]>;
-    // @internal (undocumented)
-    getNativePlatform: () => NativePlatformDefinition;
     getNodePaths(requestOptions: WithCancelEvent<Prioritized<FilterByInstancePathsHierarchyRequestOptions<IModelDb, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<NodePathElement[]>;
     getNodes(requestOptions: WithCancelEvent<Prioritized<Paged<HierarchyRequestOptions<IModelDb, NodeKey, RulesetVariable>>>> & BackendDiagnosticsAttribute): Promise<Node_2[]>;
     getNodesCount(requestOptions: WithCancelEvent<Prioritized<HierarchyRequestOptions<IModelDb, NodeKey, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<number>;
     getNodesDescriptor(requestOptions: WithCancelEvent<Prioritized<HierarchyLevelDescriptorRequestOptions<IModelDb, NodeKey, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<Descriptor | undefined>;
     getPagedDistinctValues(requestOptions: WithCancelEvent<Prioritized<DistinctValuesRequestOptions<IModelDb, Descriptor | DescriptorOverrides, KeySet, RulesetVariable>>> & BackendDiagnosticsAttribute): Promise<PagedResponse<DisplayValueGroup>>;
-    // @internal (undocumented)
+    // (undocumented)
     getRulesetId(rulesetOrId: Ruleset | string): string;
     // @deprecated
     getSelectionScopes(_requestOptions: SelectionScopeRequestOptions<IModelDb> & BackendDiagnosticsAttribute): Promise<SelectionScope[]>;
+    get onUsed(): BeEvent<() => void>;
     get props(): PresentationManagerProps;
     rulesets(): RulesetManager;
-    // @internal (undocumented)
-    setOnManagerUsedHandler(handler: () => void): void;
     vars(rulesetId: string): RulesetVariablesManager;
 }
 
@@ -245,15 +242,11 @@ export interface PresentationManagerCachingConfig {
 
 // @public
 export interface PresentationManagerProps {
-    // @internal (undocumented)
-    addon?: NativePlatformDefinition;
     caching?: PresentationManagerCachingConfig;
     defaultFormats?: FormatsMap;
     defaultUnitSystem?: UnitSystemKey;
     diagnostics?: BackendDiagnosticsOptions;
     getLocalizedString?: (key: string) => string;
-    // @internal
-    id?: string;
     // @deprecated
     presentationAssetsRoot?: string | PresentationAssetsRootConfig;
     rulesetDirectories?: string[];
@@ -267,8 +260,6 @@ export interface PresentationManagerProps {
 
 // @public
 export interface PresentationProps extends Omit<PresentationManagerProps, "enableSchemasPreload"> {
-    // @internal
-    clientManagerFactory?: (clientId: string, props: PresentationManagerProps) => PresentationManager;
     enableSchemasPreload?: boolean;
     requestTimeout?: number;
     unusedClientLifetime?: number;
@@ -323,7 +314,7 @@ export interface RulesetVariablesManager {
 }
 
 // @public @deprecated
-export type SingleManagerPresentationProps = Omit<PresentationProps, "clientManagerFactory" | "unusedClientLifetime">;
+export type SingleManagerPresentationProps = Omit<PresentationProps, "unusedClientLifetime">;
 
 // @public @deprecated
 export type UnitSystemFormat = UnitSystemFormat_2;

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -254,8 +254,6 @@ export type ContentDescriptorRpcRequestOptions = PresentationRpcRequestOptions<C
 
 // @public
 export enum ContentFlags {
-    // @internal
-    DescriptorOnly = 512,
     DistinctValues = 16,
     IncludeInputKeys = 256,
     KeysOnly = 1,
@@ -1303,8 +1301,6 @@ export interface LabelDefinition {
 
 // @public (undocumented)
 export namespace LabelDefinition {
-    const // @internal (undocumented)
-    COMPOSITE_DEFINITION_TYPENAME = "composite";
     export function fromLabelString(label: string): LabelDefinition;
     export function isCompositeDefinition(def: LabelDefinition): def is LabelDefinition & {
         rawValue: LabelCompositeValue;
@@ -2129,8 +2125,6 @@ export interface RepeatableRelationshipStepSpecification extends RelationshipSte
 export interface RequestOptions<TIModel> {
     imodel: TIModel;
     locale?: string;
-    // @internal
-    transport?: "unparsed-json";
     unitSystem?: UnitSystemKey;
 }
 

--- a/common/changes/@itwin/presentation-backend/presentation-internal-cleanup-2_2025-03-31-11-22.json
+++ b/common/changes/@itwin/presentation-backend/presentation-internal-cleanup-2_2025-03-31-11-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/presentation-internal-cleanup-2_2025-03-31-11-22.json
+++ b/common/changes/@itwin/presentation-common/presentation-internal-cleanup-2_2025-03-31-11-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/presentation-internal-cleanup-2_2025-03-31-11-22.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-internal-cleanup-2_2025-03-31-11-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/full-stack-tests/presentation/src/IntegrationTests.ts
+++ b/full-stack-tests/presentation/src/IntegrationTests.ts
@@ -76,6 +76,7 @@ export const initialize = async (props?: {
   const outputRoot = setupTestsOutputDirectory();
 
   const backendInitProps: PresentationBackendProps = {
+    // @ts-expect-error internal prop
     id: `test-${Guid.createValue()}`,
     requestTimeout: DEFAULT_BACKEND_TIMEOUT,
     rulesetDirectories: [path.join(path.resolve("lib"), "assets", "rulesets")],

--- a/full-stack-tests/presentation/src/frontend/content/Infrastructure.test.ts
+++ b/full-stack-tests/presentation/src/frontend/content/Infrastructure.test.ts
@@ -13,6 +13,7 @@ import { initialize } from "../../IntegrationTests.js";
 import { collect } from "../../Utils.js";
 import { createContentTestSuite } from "./Utils.js";
 import { createTestContentDescriptor, createTestContentItem, ResolvablePromise } from "@itwin/presentation-common/test-utils";
+import { _presentation_manager_detail } from "@itwin/presentation-backend/internal";
 
 createContentTestSuite({ skipInitialize: true })("Error handling", ({ getDefaultSuiteIModel }) => {
   const frontendTimeout = 50;
@@ -40,9 +41,9 @@ createContentTestSuite({ skipInitialize: true })("Error handling", ({ getDefault
       [Symbol.dispose]: () => void resolvablePromise.resolve(""),
     };
     sinon.stub(PresentationBackend, "getManager").returns({
-      getDetail: () => ({
+      [_presentation_manager_detail]: {
         getContentDescriptor: async () => resolvablePromise,
-      }),
+      },
     } as unknown as PresentationManager);
 
     const start = BeTimePoint.now();
@@ -65,13 +66,13 @@ createContentTestSuite({ skipInitialize: true })("Error handling", ({ getDefault
     };
     sinon.stub(PresentationBackend, "getManager").returns({
       getContentSetSize: async () => 2,
-      getDetail: () => ({
+      [_presentation_manager_detail]: {
         getContent: async ({ paging }: { paging?: PageOptions }) =>
           new Content(
             createTestContentDescriptor({ fields: [] }),
             (paging?.start ?? 0) === 0 ? [createTestContentItem({ values: {}, displayValues: {} })] : await resolvableItemsPromise,
           ),
-      }),
+      },
     } as unknown as PresentationManager);
 
     const result = await PresentationFrontend.presentation.getContentIterator({

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -29,6 +29,10 @@
       "import": "./lib/esm/presentation-backend.js",
       "require": "./lib/cjs/presentation-backend.js"
     },
+    "./internal": {
+      "import": "./lib/esm/presentation-backend-internal.js",
+      "require": "./lib/cjs/presentation-backend-internal.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/presentation/backend/src/presentation-backend-internal.ts
+++ b/presentation/backend/src/presentation-backend-internal.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+// WARNING: This barrel file exports internal APIs only for use by Presentation packages.
+// They should not be used outside of these packages. These APIs may be broken or removed at any time without notice.
+
+export { _presentation_manager_detail } from "./presentation-backend/InternalSymbols.js";

--- a/presentation/backend/src/presentation-backend/InternalSymbols.ts
+++ b/presentation/backend/src/presentation-backend/InternalSymbols.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable @typescript-eslint/naming-convention */
+
+function sym(name: string): string {
+  return `${name}_presentation-backend_INTERNAL_ONLY_DO_NOT_USE`;
+}
+
+export const _presentation_manager_detail = Symbol.for(sym("presentation_manager_detail"));

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -69,6 +69,13 @@ import bisSupplementalRuleset from "./supplemental-presentation-rules/BisCore.Pr
 import funcSupplementalRuleset from "./supplemental-presentation-rules/Functional.PresentationRuleSet.json" with { type: "json" };
 import { BackendDiagnosticsAttribute, BackendDiagnosticsOptions, combineDiagnosticsOptions, getElementKey, reportDiagnostics } from "./Utils.js";
 
+/**
+ * Produce content descriptor that is not intended for querying content. Allows the implementation to omit certain
+ * operations to make obtaining content descriptor faster.
+ * @internal
+ */
+export const DESCRIPTOR_ONLY_CONTENT_FLAG = 1 << 9;
+
 /** @internal */
 export class PresentationManagerDetail implements Disposable {
   private _disposed: boolean;
@@ -195,7 +202,7 @@ export class PresentationManagerDetail implements Disposable {
       requestId: NativePlatformRequestTypes.GetContentDescriptor,
       rulesetId: this.registerRuleset(rulesetOrId),
       ...strippedOptions,
-      contentFlags: contentFlags ?? ContentFlags.DescriptorOnly, // only set "descriptor only" flag if there are no flags provided
+      contentFlags: contentFlags ?? DESCRIPTOR_ONLY_CONTENT_FLAG, // only set "descriptor only" flag if there are no flags provided
       keys: getKeysForContentRequest(requestOptions.keys, (map) => bisElementInstanceKeysProcessor(requestOptions.imodel, map)),
     };
     return this.request(params);

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -61,7 +61,7 @@ import packageJson from "../../../package.json" with { type: "json" };
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory.js";
 import { Presentation } from "./Presentation.js";
 import { PresentationManager } from "./PresentationManager.js";
-import { getRulesetIdObject } from "./PresentationManagerDetail.js";
+import { DESCRIPTOR_ONLY_CONTENT_FLAG, getRulesetIdObject } from "./PresentationManagerDetail.js";
 import { TemporaryStorage } from "./TemporaryStorage.js";
 
 const packageJsonVersion = packageJson.version;
@@ -317,18 +317,12 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     return this.makeRequest(token, "getContentDescriptor", requestOptions, async (options) => {
       options = {
         ...options,
-        contentFlags: (options.contentFlags ?? 0) | ContentFlags.DescriptorOnly, // always append the "descriptor only" flag when handling request from the frontend
+        contentFlags: (options.contentFlags ?? 0) | DESCRIPTOR_ONLY_CONTENT_FLAG, // always append the "descriptor only" flag when handling request from the frontend
         keys: KeySet.fromJSON(options.keys),
       };
-      if (options.transport === "unparsed-json") {
-        // Here we send a plain JSON string but we will parse it to DescriptorJSON on the frontend. This way we are
-        // bypassing unnecessary deserialization and serialization.
-        return Presentation.getManager(requestOptions.clientId).getDetail().getContentDescriptor(options) as unknown as DescriptorJSON | undefined;
-      } else {
-        // Support for older frontends that still expect a parsed descriptor
-        const descriptor = await Presentation.getManager(requestOptions.clientId).getContentDescriptor(options);
-        return descriptor?.toJSON();
-      }
+      // Here we send a plain JSON string but we will parse it to DescriptorJSON on the frontend. This way we are
+      // bypassing unnecessary deserialization and serialization.
+      return Presentation.getManager(requestOptions.clientId).getDetail().getContentDescriptor(options) as unknown as DescriptorJSON | undefined;
     });
   }
 

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -63,6 +63,7 @@ import { Presentation } from "./Presentation.js";
 import { PresentationManager } from "./PresentationManager.js";
 import { DESCRIPTOR_ONLY_CONTENT_FLAG, getRulesetIdObject } from "./PresentationManagerDetail.js";
 import { TemporaryStorage } from "./TemporaryStorage.js";
+import { _presentation_manager_detail } from "./InternalSymbols.js";
 
 const packageJsonVersion = packageJson.version;
 
@@ -260,7 +261,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     return this.makeRequest(token, "getPagedNodes", requestOptions, async (options) => {
       options = enforceValidPageSize(options);
       const [serializedHierarchyLevel, count] = await Promise.all([
-        this.getManager(requestOptions.clientId).getDetail().getNodes(options),
+        this.getManager(requestOptions.clientId)[_presentation_manager_detail].getNodes(options),
         this.getManager(requestOptions.clientId).getNodesCount(options),
       ]);
       const hierarchyLevel: HierarchyLevel = deepReplaceNullsToUndefined(JSON.parse(serializedHierarchyLevel));
@@ -276,7 +277,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: HierarchyLevelDescriptorRpcRequestOptions,
   ): PresentationRpcResponse<string | DescriptorJSON | undefined> {
     return this.makeRequest(token, "getNodesDescriptor", requestOptions, async (options) => {
-      return this.getManager(requestOptions.clientId).getDetail().getNodesDescriptor(options);
+      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getNodesDescriptor(options);
     });
   }
 
@@ -285,7 +286,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: FilterByInstancePathsHierarchyRpcRequestOptions,
   ): PresentationRpcResponse<NodePathElement[]> {
     return this.makeRequest(token, "getNodePaths", requestOptions, async (options) => {
-      return this.getManager(requestOptions.clientId).getDetail().getNodePaths(options);
+      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getNodePaths(options);
     });
   }
 
@@ -294,7 +295,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: FilterByTextHierarchyRpcRequestOptions,
   ): PresentationRpcResponse<NodePathElement[]> {
     return this.makeRequest(token, "getFilteredNodePaths", requestOptions, async (options) => {
-      return this.getManager(requestOptions.clientId).getDetail().getFilteredNodePaths(options);
+      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getFilteredNodePaths(options);
     });
   }
 
@@ -322,7 +323,9 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
       };
       // Here we send a plain JSON string but we will parse it to DescriptorJSON on the frontend. This way we are
       // bypassing unnecessary deserialization and serialization.
-      return Presentation.getManager(requestOptions.clientId).getDetail().getContentDescriptor(options) as unknown as DescriptorJSON | undefined;
+      return Presentation.getManager(requestOptions.clientId)[_presentation_manager_detail].getContentDescriptor(options) as unknown as
+        | DescriptorJSON
+        | undefined;
     });
   }
 
@@ -348,7 +351,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
 
       const [size, content] = await Promise.all([
         this.getManager(requestOptions.clientId).getContentSetSize(options),
-        this.getManager(requestOptions.clientId).getDetail().getContent(options),
+        this.getManager(requestOptions.clientId)[_presentation_manager_detail].getContent(options),
       ]);
 
       if (!content) {
@@ -390,7 +393,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     return this.makeRequest(token, "getElementProperties", { ...requestOptions }, async (options) => {
       const manager = this.getManager(requestOptions.clientId);
       const { elementId, ...optionsNoElementId } = options;
-      const content = await manager.getDetail().getContent({
+      const content = await manager[_presentation_manager_detail].getContent({
         ...optionsNoElementId,
         descriptor: {
           displayType: DefaultContentDisplayTypes.PropertyPane,
@@ -415,7 +418,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
         ...options,
         keys: KeySet.fromJSON(options.keys),
       });
-      return this.getManager(requestOptions.clientId).getDetail().getPagedDistinctValues(options);
+      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getPagedDistinctValues(options);
     });
   }
 
@@ -439,7 +442,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
 
       const [size, content] = await Promise.all([
         this.getManager(requestOptions.clientId).getContentSetSize(options),
-        this.getManager(requestOptions.clientId).getDetail().getContent(options),
+        this.getManager(requestOptions.clientId)[_presentation_manager_detail].getContent(options),
       ]);
 
       if (size === 0 || !content) {
@@ -458,7 +461,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: DisplayLabelRpcRequestOptions,
   ): PresentationRpcResponse<LabelDefinition> {
     return this.makeRequest(token, "getDisplayLabelDefinition", requestOptions, async (options) => {
-      const label = await this.getManager(requestOptions.clientId).getDetail().getDisplayLabelDefinition(options);
+      const label = await this.getManager(requestOptions.clientId)[_presentation_manager_detail].getDisplayLabelDefinition(options);
       return label;
     });
   }
@@ -472,9 +475,10 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
       requestOptions.keys.splice(pageOpts.paging.size);
     }
     return this.makeRequest(token, "getPagedDisplayLabelDefinitions", requestOptions, async (options) => {
-      const labels = await this.getManager(requestOptions.clientId)
-        .getDetail()
-        .getDisplayLabelDefinitions({ ...options, keys: options.keys });
+      const labels = await this.getManager(requestOptions.clientId)[_presentation_manager_detail].getDisplayLabelDefinitions({
+        ...options,
+        keys: options.keys,
+      });
       return {
         total: options.keys.length,
         items: labels,

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -94,7 +94,12 @@ import {
   PresentationNativePlatformResponseError,
 } from "../presentation-backend/NativePlatform.js";
 import { HierarchyCacheMode, HybridCacheConfig, PresentationManager, PresentationManagerProps } from "../presentation-backend/PresentationManager.js";
-import { getKeysForContentRequest, ipcUpdatesHandler, noopUpdatesHandler } from "../presentation-backend/PresentationManagerDetail.js";
+import {
+  DESCRIPTOR_ONLY_CONTENT_FLAG,
+  getKeysForContentRequest,
+  ipcUpdatesHandler,
+  noopUpdatesHandler,
+} from "../presentation-backend/PresentationManagerDetail.js";
 import { RulesetManagerImpl } from "../presentation-backend/RulesetManager.js";
 import { RulesetVariablesManagerImpl } from "../presentation-backend/RulesetVariablesManager.js";
 import { SelectionScopesHelper } from "../presentation-backend/SelectionScopesHelper.js";
@@ -1325,7 +1330,7 @@ describe("PresentationManager", () => {
             keys: getKeysForContentRequest(keys),
             selection: testData.selectionInfo,
             rulesetId: manager.getRulesetId(testData.rulesetOrId),
-            contentFlags: ContentFlags.DescriptorOnly,
+            contentFlags: DESCRIPTOR_ONLY_CONTENT_FLAG,
           },
         };
 

--- a/presentation/backend/src/test/PresentationManager.test.ts
+++ b/presentation/backend/src/test/PresentationManager.test.ts
@@ -104,6 +104,7 @@ import { RulesetManagerImpl } from "../presentation-backend/RulesetManager.js";
 import { RulesetVariablesManagerImpl } from "../presentation-backend/RulesetVariablesManager.js";
 import { SelectionScopesHelper } from "../presentation-backend/SelectionScopesHelper.js";
 import { stubECSqlReader } from "./Helpers.js";
+import { _presentation_manager_detail } from "../presentation-backend/InternalSymbols.js";
 
 describe("PresentationManager", () => {
   before(async () => {
@@ -153,7 +154,7 @@ describe("PresentationManager", () => {
       it("creates without props", () => {
         const constructorSpy = sinon.spy(IModelNative.platform, "ECPresentationManager");
         using manager = new PresentationManager();
-        expect((manager.getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
+        expect((manager[_presentation_manager_detail].getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
         expect(constructorSpy).to.be.calledOnceWithExactly({
           id: "",
           taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
@@ -184,6 +185,7 @@ describe("PresentationManager", () => {
           uomSeparator: "",
         };
         const props: PresentationManagerProps = {
+          // @ts-expect-error internal prop
           id: "test-id",
           presentationAssetsRoot: "/test",
           workerThreadsCount: testThreadsCount,
@@ -204,9 +206,9 @@ describe("PresentationManager", () => {
           mode: HierarchyCacheMode.Memory,
         };
         using manager = new PresentationManager(props);
-        expect((manager.getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
+        expect((manager[_presentation_manager_detail].getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
         expect(constructorSpy).to.be.calledOnceWithExactly({
-          id: props.id,
+          id: "test-id",
           taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 999 },
           updateCallback: noopUpdatesHandler,
           cacheConfig: expectedCacheConfig,
@@ -224,7 +226,7 @@ describe("PresentationManager", () => {
         const constructorSpy = sinon.spy(IModelNative.platform, "ECPresentationManager");
         {
           using manager = new PresentationManager({ caching: { hierarchies: { mode: HierarchyCacheMode.Disk } } });
-          expect((manager.getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
+          expect((manager[_presentation_manager_detail].getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
@@ -245,7 +247,7 @@ describe("PresentationManager", () => {
         const expectedConfig = { ...cacheConfig, directory: path.resolve(cacheConfig.directory) };
         {
           using manager = new PresentationManager({ caching: { hierarchies: cacheConfig } });
-          expect((manager.getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
+          expect((manager[_presentation_manager_detail].getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
@@ -263,7 +265,7 @@ describe("PresentationManager", () => {
         const constructorSpy = sinon.spy(IModelNative.platform, "ECPresentationManager");
         {
           using manager = new PresentationManager({ caching: { hierarchies: { mode: HierarchyCacheMode.Hybrid } } });
-          expect((manager.getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
+          expect((manager[_presentation_manager_detail].getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
@@ -290,7 +292,7 @@ describe("PresentationManager", () => {
         };
         {
           using manager = new PresentationManager({ caching: { hierarchies: cacheConfig } });
-          expect((manager.getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
+          expect((manager[_presentation_manager_detail].getNativePlatform() as any)._nativeAddon).instanceOf(IModelNative.platform.ECPresentationManager);
           expect(constructorSpy).to.be.calledOnceWithExactly({
             id: "",
             taskAllocationsMap: { [Number.MAX_SAFE_INTEGER]: 2 },
@@ -314,8 +316,11 @@ describe("PresentationManager", () => {
 
     it("uses addon implementation supplied through props", () => {
       const nativePlatformMock = moq.Mock.ofType<NativePlatformDefinition>();
-      using manager = new PresentationManager({ addon: nativePlatformMock.object });
-      expect(manager.getNativePlatform()).eq(nativePlatformMock.object);
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: nativePlatformMock.object,
+      });
+      expect(manager[_presentation_manager_detail].getNativePlatform()).eq(nativePlatformMock.object);
     });
 
     describe("addon setup based on props", () => {
@@ -328,7 +333,11 @@ describe("PresentationManager", () => {
         const dirs = ["test1", "test2", "test2"];
         const addonDirs = ["test1", "test2"];
         addon.setup((x) => x.setupRulesetDirectories(addonDirs)).verifiable();
-        using _pm = new PresentationManager({ addon: addon.object, rulesetDirectories: dirs });
+        using _pm = new PresentationManager({
+          // @ts-expect-error internal prop
+          addon: addon.object,
+          rulesetDirectories: dirs,
+        });
         addon.verifyAll();
       });
 
@@ -337,7 +346,11 @@ describe("PresentationManager", () => {
         const addonDirs = ["test1", "test2"];
         addon.setup((x) => x.setupSupplementalRulesetDirectories(addonDirs)).verifiable();
         {
-          using _pm = new PresentationManager({ addon: addon.object, supplementalRulesetDirectories: dirs });
+          using _pm = new PresentationManager({
+            // @ts-expect-error internal prop
+            addon: addon.object,
+            supplementalRulesetDirectories: dirs,
+          });
         }
         addon.verifyAll();
       });
@@ -367,7 +380,10 @@ describe("PresentationManager", () => {
       const imodelMock = moq.Mock.ofType<IModelDb>();
       const rulesetId = "test-ruleset-id";
       const unitSystem = "metric";
-      using manager = new PresentationManager({ addon: addonMock.object });
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addonMock.object,
+      });
       addonMock
         .setup(async (x) =>
           x.handleRequest(
@@ -389,7 +405,11 @@ describe("PresentationManager", () => {
       const imodelMock = moq.Mock.ofType<IModelDb>();
       const rulesetId = "test-ruleset-id";
       const unitSystem = "usSurvey";
-      using manager = new PresentationManager({ addon: addonMock.object, defaultUnitSystem: unitSystem });
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addonMock.object,
+        defaultUnitSystem: unitSystem,
+      });
       addonMock
         .setup(async (x) =>
           x.handleRequest(
@@ -411,7 +431,11 @@ describe("PresentationManager", () => {
       const imodelMock = moq.Mock.ofType<IModelDb>();
       const rulesetId = "test-ruleset-id";
       const unitSystem = "usCustomary";
-      using manager = new PresentationManager({ addon: addonMock.object, defaultUnitSystem: "metric" });
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addonMock.object,
+        defaultUnitSystem: "metric",
+      });
       expect(manager.activeUnitSystem).to.not.eq(unitSystem);
       addonMock
         .setup(async (x) =>
@@ -431,18 +455,21 @@ describe("PresentationManager", () => {
     });
   });
 
-  describe("setOnManagerUsedHandler", () => {
+  describe("`onUsed` event", () => {
     it("invokes when making presentation requests", async () => {
       const addonMock = moq.Mock.ofType<NativePlatformDefinition>();
       const imodelMock = moq.Mock.ofType<IModelDb>();
-      const manager = new PresentationManager({ addon: addonMock.object });
-      const managerUsedSpy = sinon.spy();
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addonMock.object,
+      });
 
       addonMock.setup(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAnyString(), undefined)).returns(async () => ({ result: `{"nodes":[]}` }));
-
       addonMock.setup(async (x) => x.handleRequest(moq.It.isAny(), moq.It.isAnyString(), undefined)).returns(async () => ({ result: "{}" }));
 
-      manager.setOnManagerUsedHandler(managerUsedSpy);
+      const managerUsedSpy = sinon.spy();
+      manager.onUsed.addListener(managerUsedSpy);
+
       await manager.getNodes({ imodel: imodelMock.object, rulesetOrId: "RulesetId" });
       expect(managerUsedSpy).to.be.calledOnce;
       await manager.getContent({ imodel: imodelMock.object, rulesetOrId: "RulesetId", keys: new KeySet([]), descriptor: {} });
@@ -454,7 +481,10 @@ describe("PresentationManager", () => {
     const addon = moq.Mock.ofType<NativePlatformDefinition>();
 
     it("returns variables manager", () => {
-      const manager = new PresentationManager({ addon: addon.object });
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addon.object,
+      });
       const vars = manager.vars("test-ruleset-id");
       expect(vars).to.be.instanceOf(RulesetVariablesManagerImpl);
     });
@@ -464,7 +494,10 @@ describe("PresentationManager", () => {
     const addon = moq.Mock.ofType<NativePlatformDefinition>();
 
     it("returns rulesets manager", () => {
-      const manager = new PresentationManager({ addon: addon.object });
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addon.object,
+      });
       expect(manager.rulesets()).to.be.instanceOf(RulesetManagerImpl);
     });
   });
@@ -472,7 +505,10 @@ describe("PresentationManager", () => {
   describe("dispose", () => {
     it("calls native platform dispose when manager is disposed", () => {
       const nativePlatformMock = moq.Mock.ofType<NativePlatformDefinition>();
-      const manager = new PresentationManager({ addon: nativePlatformMock.object });
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: nativePlatformMock.object,
+      });
       manager[Symbol.dispose]();
       manager[Symbol.dispose]();
       // note: verify native platform's `dispose` called only once
@@ -481,9 +517,12 @@ describe("PresentationManager", () => {
 
     it("throws when attempting to use native platform after disposal", () => {
       const nativePlatformMock = moq.Mock.ofType<NativePlatformDefinition>();
-      const manager = new PresentationManager({ addon: nativePlatformMock.object });
+      using manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: nativePlatformMock.object,
+      });
       manager[Symbol.dispose]();
-      expect(() => manager.getNativePlatform()).to.throw(Error);
+      expect(() => manager[_presentation_manager_detail].getNativePlatform()).to.throw(Error);
     });
   });
 
@@ -492,7 +531,10 @@ describe("PresentationManager", () => {
 
     beforeEach(() => {
       const addon = moq.Mock.ofType<NativePlatformDefinition>();
-      manager = new PresentationManager({ addon: addon.object });
+      manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addon.object,
+      });
     });
 
     afterEach(() => {
@@ -512,7 +554,10 @@ describe("PresentationManager", () => {
     it("returns correct id when input is a ruleset and in one-backend-one-frontend mode", async () => {
       sinon.stub(IpcHost, "isValid").get(() => true);
       sinon.stub(IpcHost, "handle");
-      manager = new PresentationManager({ addon: moq.Mock.ofType<NativePlatformDefinition>().object });
+      manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: moq.Mock.ofType<NativePlatformDefinition>().object,
+      });
       const ruleset: Ruleset = { id: "test", rules: [] };
       expect(manager.getRulesetId(ruleset)).to.eq(ruleset.id);
     });
@@ -524,7 +569,10 @@ describe("PresentationManager", () => {
     let manager: PresentationManager;
 
     beforeEach(() => {
-      manager = new PresentationManager({ addon: addonMock.object });
+      manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addonMock.object,
+      });
       addonMock.reset();
     });
 
@@ -596,6 +644,7 @@ describe("PresentationManager", () => {
       const diagnosticsCallback = sinon.spy();
       const diagnosticsContext = {};
       manager = new PresentationManager({
+        // @ts-expect-error internal prop
         addon: addonMock.object,
         diagnostics: {
           perf: true,
@@ -633,6 +682,7 @@ describe("PresentationManager", () => {
       const diagnosticsCallback = sinon.spy();
       const diagnosticsContext = {};
       manager = new PresentationManager({
+        // @ts-expect-error internal prop
         addon: addonMock.object,
         diagnostics: {
           perf: true,
@@ -680,6 +730,7 @@ describe("PresentationManager", () => {
       const managerDiagnosticsCallback = sinon.spy();
       const managerDiagnosticsContext = {};
       manager = new PresentationManager({
+        // @ts-expect-error internal prop
         addon: addonMock.object,
         diagnostics: {
           perf: true,
@@ -805,10 +856,11 @@ describe("PresentationManager", () => {
     function recreateManager(props?: Partial<PresentationManagerProps>) {
       manager && manager[Symbol.dispose]();
       manager = new PresentationManager({
+        // @ts-expect-error internal prop
         addon: nativePlatformMock.object,
         ...props,
       });
-      sinon.stub(manager.getDetail(), "rulesets").value(
+      sinon.stub(manager[_presentation_manager_detail], "rulesets").value(
         sinon.createStubInstance(RulesetManagerImpl, {
           add: sinon.stub<[Ruleset], RegisteredRuleset>().callsFake((ruleset) => new RegisteredRuleset(ruleset, "", () => {})),
         }),
@@ -3366,8 +3418,12 @@ describe("PresentationManager", () => {
     describe("getLocalizedString", () => {
       it("Passes getLocalizedString to manager and uses it", async () => {
         const getLocalizedStringSpy = sinon.spy();
-        manager = new PresentationManager({ addon: nativePlatformMock.object, getLocalizedString: getLocalizedStringSpy });
-        sinon.stub(manager.getDetail(), "rulesets").value(
+        manager = new PresentationManager({
+          // @ts-expect-error internal prop
+          addon: nativePlatformMock.object,
+          getLocalizedString: getLocalizedStringSpy,
+        });
+        sinon.stub(manager[_presentation_manager_detail], "rulesets").value(
           sinon.createStubInstance(RulesetManagerImpl, {
             add: sinon.stub<[Ruleset], RegisteredRuleset>().callsFake((ruleset) => new RegisteredRuleset(ruleset, "", () => {})),
           }),
@@ -3409,7 +3465,10 @@ describe("PresentationManager", () => {
     beforeEach(() => {
       addon.reset();
       imodel.reset();
-      manager = new PresentationManager({ addon: addon.object });
+      manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addon.object,
+      });
     });
 
     afterEach(() => {
@@ -3433,7 +3492,10 @@ describe("PresentationManager", () => {
     beforeEach(() => {
       addon.reset();
       imodel.reset();
-      manager = new PresentationManager({ addon: addon.object });
+      manager = new PresentationManager({
+        // @ts-expect-error internal prop
+        addon: addon.object,
+      });
     });
 
     afterEach(() => {

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -83,6 +83,7 @@ import { DESCRIPTOR_ONLY_CONTENT_FLAG, PresentationManagerDetail } from "../pres
 import { MAX_ALLOWED_KEYS_PAGE_SIZE, MAX_ALLOWED_PAGE_SIZE, PresentationRpcImpl } from "../presentation-backend/PresentationRpcImpl.js";
 import { RulesetManager } from "../presentation-backend/RulesetManager.js";
 import { RulesetVariablesManager } from "../presentation-backend/RulesetVariablesManager.js";
+import { _presentation_manager_detail } from "../presentation-backend/InternalSymbols.js";
 
 /* eslint-disable @typescript-eslint/no-deprecated -- PresentationRpcInterface methods are deprecated */
 
@@ -101,6 +102,7 @@ describe("PresentationRpcImpl", () => {
 
   it("uses default PresentationManager implementation if not overridden", () => {
     Presentation.initialize({
+      // @ts-expect-error internal prop
       addon: moq.Mock.ofType<NativePlatformDefinition>().object,
     });
     using impl = new PresentationRpcImpl();
@@ -123,9 +125,11 @@ describe("PresentationRpcImpl", () => {
     const rulesetsMock = moq.Mock.ofType<RulesetManager>();
     const variablesMock = moq.Mock.ofType<RulesetVariablesManager>();
     const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
+    presentationManagerMock.setup((x) => x.onUsed).returns(() => new BeEvent());
     presentationManagerMock.setup((x) => x.rulesets()).returns(() => rulesetsMock.object);
     presentationManagerMock.setup((x) => x.vars(moq.It.isAnyString())).returns(() => variablesMock.object);
     Presentation.initialize({
+      // @ts-expect-error internal prop
       clientManagerFactory: () => presentationManagerMock.object,
     });
 
@@ -161,9 +165,11 @@ describe("PresentationRpcImpl", () => {
     const rulesetsMock = moq.Mock.ofType<RulesetManager>();
     const variablesMock = moq.Mock.ofType<RulesetVariablesManager>();
     const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
+    presentationManagerMock.setup((x) => x.onUsed).returns(() => new BeEvent());
     presentationManagerMock.setup((x) => x.rulesets()).returns(() => rulesetsMock.object);
     presentationManagerMock.setup((x) => x.vars(moq.It.isAnyString())).returns(() => variablesMock.object);
     Presentation.initialize({
+      // @ts-expect-error internal prop
       clientManagerFactory: () => presentationManagerMock.object,
     });
 
@@ -194,9 +200,11 @@ describe("PresentationRpcImpl", () => {
     const rulesetsMock = moq.Mock.ofType<RulesetManager>();
     const variablesMock = moq.Mock.ofType<RulesetVariablesManager>();
     const presentationManagerMock = moq.Mock.ofType<PresentationManager>();
+    presentationManagerMock.setup((x) => x.onUsed).returns(() => new BeEvent());
     presentationManagerMock.setup((x) => x.rulesets()).returns(() => rulesetsMock.object);
     presentationManagerMock.setup((x) => x.vars(moq.It.isAnyString())).returns(() => variablesMock.object);
     Presentation.initialize({
+      // @ts-expect-error internal prop
       clientManagerFactory: () => presentationManagerMock.object,
     });
 
@@ -249,12 +257,15 @@ describe("PresentationRpcImpl", () => {
     const variablesMock = moq.Mock.ofType<RulesetVariablesManager>();
 
     beforeEach(() => {
+      const onManagerUsed = new BeEvent();
       rulesetsMock.reset();
       variablesMock.reset();
       presentationManagerMock.reset();
       presentationManagerMock.setup((x) => x.vars(moq.It.isAnyString())).returns(() => variablesMock.object);
       presentationManagerMock.setup((x) => x.rulesets()).returns(() => rulesetsMock.object);
+      presentationManagerMock.setup((x) => x.onUsed).returns(() => onManagerUsed);
       Presentation.initialize({
+        // @ts-expect-error internal prop
         clientManagerFactory: () => presentationManagerMock.object,
       });
       testData = {
@@ -566,9 +577,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getNodes: sinon.spy(async () => JSON.stringify(getRootNodesResult)),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getNodes(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getNodes(managerOptions))
           .returns(async () => JSON.stringify(getRootNodesResult))
           .verifiable();
         presentationManagerMock
@@ -606,9 +619,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getNodes: sinon.spy(async () => JSON.stringify(getChildNodesResult)),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getNodes(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getNodes(managerOptions))
           .returns(async () => JSON.stringify(getChildNodesResult))
           .verifiable();
         presentationManagerMock
@@ -642,7 +657,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getNodes: sinon.fake(async () => JSON.stringify(getRootNodesResult)),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
           .setup(async (x) => x.getNodesCount(managerOptions))
           .returns(async () => getRootNodesCountResult)
@@ -670,7 +687,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getNodes: sinon.spy(async () => JSON.stringify(getRootNodesResult)),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
           .setup(async (x) => x.getNodesCount(managerOptions))
           .returns(async () => getRootNodesCountResult)
@@ -698,7 +717,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getNodes: sinon.spy(async () => JSON.stringify(getRootNodesResult)),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
           .setup(async (x) => x.getNodesCount(managerOptions))
           .returns(async () => getRootNodesCountResult)
@@ -726,7 +747,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getNodesDescriptor: sinon.spy(async () => JSON.stringify(result.toJSON())),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getNodesDescriptor(testData.imodelToken, rpcOptions);
         expect(presentationManagerDetailStub.getNodesDescriptor).to.be.calledOnceWith(managerOptions);
         expect(actualResult.result).to.eq(JSON.stringify(result.toJSON()));
@@ -750,7 +773,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getFilteredNodePaths: sinon.spy(async () => result),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getFilteredNodePaths(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
 
@@ -778,7 +803,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getNodePaths: sinon.spy(async () => result),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getNodePaths(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
 
@@ -835,7 +862,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContentDescriptor: sinon.spy(async () => JSON.stringify(descriptor.toJSON())),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getContentDescriptor(testData.imodelToken, rpcOptions);
         expect(presentationManagerDetailStub.getContentDescriptor).to.have.been.calledOnceWithExactly(managerOptions);
         expect(actualResult.result).to.be.equal(JSON.stringify(descriptor.toJSON()));
@@ -860,7 +889,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContentDescriptor: sinon.spy(async () => undefined),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getContentDescriptor(testData.imodelToken, rpcOptions);
         expect(presentationManagerDetailStub.getContentDescriptor).to.have.been.calledOnceWithExactly(managerOptions);
         presentationManagerMock.verifyAll();
@@ -920,9 +951,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -965,9 +998,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => undefined),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => undefined)
           .verifiable();
         presentationManagerMock
@@ -1002,9 +1037,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1045,9 +1082,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1088,9 +1127,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1133,9 +1174,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1219,9 +1262,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1259,9 +1304,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1299,9 +1346,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1354,7 +1403,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getPagedDistinctValues: sinon.spy(async () => distinctValues),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);
@@ -1396,7 +1447,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getPagedDistinctValues: sinon.spy(async () => distinctValues),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);
@@ -1439,7 +1492,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getPagedDistinctValues: sinon.spy(async () => distinctValues),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);
@@ -1481,7 +1536,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getPagedDistinctValues: sinon.spy(async () => distinctValues),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getPagedDistinctValues(testData.imodelToken, rpcOptions);
         presentationManagerMock.verifyAll();
         expect(actualResult.result).to.deep.eq(distinctValues);
@@ -1494,7 +1551,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => undefined),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getElementProperties(testData.imodelToken, {
           ...defaultRpcParams,
           elementId,
@@ -1553,7 +1612,9 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => managerResponse),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         const actualResult = await impl.getElementProperties(testData.imodelToken, {
           ...defaultRpcParams,
           elementId,
@@ -1590,9 +1651,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1630,9 +1693,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => undefined),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => undefined)
           .verifiable();
         presentationManagerMock
@@ -1674,9 +1739,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1718,9 +1785,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1761,9 +1830,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getContent: sinon.spy(async () => content),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getContent(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getContent(managerOptions))
           .returns(async () => content)
           .verifiable();
         presentationManagerMock
@@ -1798,9 +1869,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getDisplayLabelDefinition: sinon.spy(async () => result),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getDisplayLabelDefinition(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getDisplayLabelDefinition(managerOptions))
           .returns(async () => result)
           .verifiable();
         const actualResult = await impl.getDisplayLabelDefinition(testData.imodelToken, rpcOptions);
@@ -1826,9 +1899,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getDisplayLabelDefinitions: sinon.spy(async () => result),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getDisplayLabelDefinitions(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getDisplayLabelDefinitions(managerOptions))
           .returns(async () => result)
           .verifiable();
         const actualResult = await impl.getPagedDisplayLabelDefinitions(testData.imodelToken, rpcOptions);
@@ -1852,9 +1927,11 @@ describe("PresentationRpcImpl", () => {
         const presentationManagerDetailStub = {
           getDisplayLabelDefinitions: sinon.spy(async () => result),
         };
-        presentationManagerMock.setup((x) => x.getDetail()).returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
         presentationManagerMock
-          .setup(async (x) => x.getDetail().getDisplayLabelDefinitions(managerOptions))
+          .setup((x) => x[_presentation_manager_detail])
+          .returns(() => presentationManagerDetailStub as unknown as PresentationManagerDetail);
+        presentationManagerMock
+          .setup(async (x) => x[_presentation_manager_detail].getDisplayLabelDefinitions(managerOptions))
           .returns(async () => result)
           .verifiable();
         const actualResult = await impl.getPagedDisplayLabelDefinitions(testData.imodelToken, rpcOptions);

--- a/presentation/common/src/presentation-common/LabelDefinition.ts
+++ b/presentation/common/src/presentation-common/LabelDefinition.ts
@@ -34,17 +34,17 @@ export interface LabelDefinition {
   typeName: string;
 }
 
+/** @internal */
+export const COMPOSITE_LABEL_DEFINITION_TYPENAME = "composite";
+
 /** @public */
 export namespace LabelDefinition {
-  /** @internal */
-  export const COMPOSITE_DEFINITION_TYPENAME = "composite";
-
   /**
    * Checks if provided [[LabelDefinition]] has raw value of type [[LabelCompositeValue]].
    * @public
    */
   export function isCompositeDefinition(def: LabelDefinition): def is LabelDefinition & { rawValue: LabelCompositeValue } {
-    return def.typeName === COMPOSITE_DEFINITION_TYPENAME;
+    return def.typeName === COMPOSITE_LABEL_DEFINITION_TYPENAME;
   }
 
   /**

--- a/presentation/common/src/presentation-common/LocalizationHelper.ts
+++ b/presentation/common/src/presentation-common/LocalizationHelper.ts
@@ -15,7 +15,7 @@ import { DisplayValue, DisplayValueGroup, Value } from "./content/Value.js";
 import { ElementProperties } from "./ElementProperties.js";
 import { Node } from "./hierarchy/Node.js";
 import { NodePathElement } from "./hierarchy/NodePathElement.js";
-import { LabelCompositeValue, LabelDefinition } from "./LabelDefinition.js";
+import { COMPOSITE_LABEL_DEFINITION_TYPENAME, LabelCompositeValue, LabelDefinition } from "./LabelDefinition.js";
 
 const KEY_PATTERN = /@[\w\d\-_]+:[\w\d\-\._]+?@/g;
 
@@ -60,7 +60,7 @@ export class LocalizationHelper {
       values: compositeValue.values.map((value) => this.getLocalizedLabelDefinition(value)),
     });
 
-    if (labelDefinition.typeName === LabelDefinition.COMPOSITE_DEFINITION_TYPENAME) {
+    if (labelDefinition.typeName === COMPOSITE_LABEL_DEFINITION_TYPENAME) {
       return {
         ...labelDefinition,
         rawValue: getLocalizedComposite(labelDefinition.rawValue as LabelCompositeValue),

--- a/presentation/common/src/presentation-common/PresentationManagerOptions.ts
+++ b/presentation/common/src/presentation-common/PresentationManagerOptions.ts
@@ -34,13 +34,6 @@ export interface RequestOptions<TIModel> {
    * unit is used if unit system is not specified.
    */
   unitSystem?: UnitSystemKey;
-
-  /**
-   * Expected form of response. This property is set automatically on newer frontends.
-   * `unparsed-json` — deliver response from native addon without parsing it.
-   * @internal
-   */
-  transport?: "unparsed-json";
 }
 
 /**

--- a/presentation/common/src/presentation-common/PresentationRpcInterface.ts
+++ b/presentation/common/src/presentation-common/PresentationRpcInterface.ts
@@ -237,12 +237,11 @@ export class PresentationRpcInterface extends RpcInterface {
 
   /** @deprecated in 4.10. Use [PresentationManager]($presentation-frontend) instead of calling the RPC interface directly. */
   public async getContentDescriptor(_token: IModelRpcProps, _options: ContentDescriptorRpcRequestOptions): PresentationRpcResponse<DescriptorJSON | undefined> {
-    arguments[1] = { ...arguments[1], transport: "unparsed-json" };
-    const response: PresentationRpcResponseData<DescriptorJSON | string | undefined> = await this.forward(arguments);
-    if (response.statusCode === PresentationStatus.Success && typeof response.result === "string") {
-      response.result = JSON.parse(response.result);
-    }
-    return response as PresentationRpcResponseData<DescriptorJSON | undefined>;
+    const response: PresentationRpcResponseData<string | undefined> = await this.forward(arguments);
+    return {
+      ...response,
+      ...(response.result ? { result: JSON.parse(response.result) } : {}),
+    };
   }
 
   /** @deprecated in 4.10. Use [PresentationManager]($presentation-frontend) instead of calling the RPC interface directly. */

--- a/presentation/common/src/presentation-common/content/Descriptor.ts
+++ b/presentation/common/src/presentation-common/content/Descriptor.ts
@@ -147,13 +147,6 @@ export enum ContentFlags {
    * given input key at the cost of performance creating those items.
    */
   IncludeInputKeys = 1 << 8,
-
-  /**
-   * Produce content descriptor that is not intended for querying content. Allows the implementation to omit certain
-   * operations to make obtaining content descriptor faster.
-   * @internal
-   */
-  DescriptorOnly = 1 << 9,
 }
 
 /**

--- a/presentation/common/src/test/LabelDefinition.test.ts
+++ b/presentation/common/src/test/LabelDefinition.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { LabelDefinition } from "../presentation-common/LabelDefinition.js";
+import { COMPOSITE_LABEL_DEFINITION_TYPENAME, LabelDefinition } from "../presentation-common/LabelDefinition.js";
 
 describe("LabelDefinition", () => {
   describe("fromLabelString", () => {
@@ -22,7 +22,7 @@ describe("LabelDefinition", () => {
     it("returns correct values", () => {
       const stringDefinition = LabelDefinition.fromLabelString("Test String");
       const compositeDefinition: LabelDefinition = {
-        typeName: LabelDefinition.COMPOSITE_DEFINITION_TYPENAME,
+        typeName: COMPOSITE_LABEL_DEFINITION_TYPENAME,
         displayValue: "Composite-Value",
         rawValue: {
           separator: "-",

--- a/presentation/common/src/test/LocalizationHelper.test.ts
+++ b/presentation/common/src/test/LocalizationHelper.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { ArrayPropertiesField, NestedContentField, NodePathElement, StructPropertiesField } from "../presentation-common.js";
 import { Content } from "../presentation-common/content/Content.js";
 import { DisplayValueGroup, NavigationPropertyValue } from "../presentation-common/content/Value.js";
-import { LabelCompositeValue, LabelDefinition } from "../presentation-common/LabelDefinition.js";
+import { COMPOSITE_LABEL_DEFINITION_TYPENAME, LabelCompositeValue, LabelDefinition } from "../presentation-common/LabelDefinition.js";
 import { LocalizationHelper } from "../presentation-common/LocalizationHelper.js";
 import {
   createTestArrayPropertiesContentField,
@@ -363,7 +363,7 @@ describe("LocalizationHelper", () => {
             createTestLabelDefinition({ rawValue: "@namespace:LocalizedValue@" }),
           ],
         },
-        typeName: LabelDefinition.COMPOSITE_DEFINITION_TYPENAME,
+        typeName: COMPOSITE_LABEL_DEFINITION_TYPENAME,
       };
       const result = localizationHelper.getLocalizedLabelDefinition(labelDefinition);
       (result.rawValue as LabelCompositeValue).values.forEach((value) => {

--- a/presentation/common/src/test/PresentationRpcInterface.test.ts
+++ b/presentation/common/src/test/PresentationRpcInterface.test.ts
@@ -151,12 +151,6 @@ describe("PresentationRpcInterface", () => {
         keys: new KeySet().toJSON(),
       };
 
-      it("forwards call without modifying options", async () => {
-        await rpcInterface.getContentDescriptor(token, options);
-        expect(spy).to.be.calledOnceWith([token, { ...options, transport: "unparsed-json" }]);
-        expect(options.transport).to.be.undefined;
-      });
-
       it("parses string response into DescriptorJSON", async () => {
         const descriptorJson = createTestContentDescriptor({ fields: [] }).toJSON();
         const presentationResponse: PresentationRpcResponseData<string> = {
@@ -167,6 +161,17 @@ describe("PresentationRpcInterface", () => {
 
         const response = await rpcInterface.getContentDescriptor(token, options);
         expect(response.result).to.be.deep.equal(descriptorJson);
+      });
+
+      it("returns undefined result", async () => {
+        const presentationResponse: PresentationRpcResponseData<string> = {
+          statusCode: PresentationStatus.Success,
+          result: undefined,
+        };
+        spy.returns(Promise.resolve(presentationResponse));
+
+        const response = await rpcInterface.getContentDescriptor(token, options);
+        expect(response.result).to.be.be.undefined;
       });
     });
 

--- a/presentation/frontend/src/presentation-frontend/IModelConnectionInitialization.ts
+++ b/presentation/frontend/src/presentation-frontend/IModelConnectionInitialization.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IModelConnection } from "@itwin/core-frontend";
+
+/** @internal */
+export interface IModelConnectionInitializationHandler {
+  startInitialization: (imodel: IModelConnection) => void;
+  ensureInitialized: (imodel: IModelConnection) => Promise<void>;
+}
+
+/** @internal */
+export const imodelInitializationHandlers = new Set<IModelConnectionInitializationHandler>();
+
+/** @internal */
+export function startIModelInitialization(imodel: IModelConnection) {
+  for (const { startInitialization } of imodelInitializationHandlers) {
+    startInitialization(imodel);
+  }
+}
+
+/** @internal */
+export async function ensureIModelInitialized(imodel: IModelConnection) {
+  await Promise.all([...imodelInitializationHandlers].map(async ({ ensureInitialized }) => ensureInitialized(imodel)));
+}

--- a/presentation/frontend/src/presentation-frontend/InternalSymbols.ts
+++ b/presentation/frontend/src/presentation-frontend/InternalSymbols.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable @typescript-eslint/naming-convention */
+
+function sym(name: string): string {
+  return `${name}_presentation-frontend_INTERNAL_ONLY_DO_NOT_USE`;
+}
+
+export const _presentation_manager_rpcRequestsHandler = Symbol.for(sym("presentation_manager_rpcRequestsHandler"));
+export const _presentation_manager_ipcRequestsHandler = Symbol.for(sym("presentation_manager_ipcRequestsHandler"));

--- a/presentation/frontend/src/presentation-frontend/Presentation.ts
+++ b/presentation/frontend/src/presentation-frontend/Presentation.ts
@@ -15,6 +15,8 @@ import { FrontendLocalizationHelper } from "./LocalizationHelper.js";
 import { PresentationManager, PresentationManagerProps } from "./PresentationManager.js";
 import { SelectionManager, SelectionManagerProps } from "./selection/SelectionManager.js";
 import { SelectionScopesManager } from "./selection/SelectionScopesManager.js";
+import { imodelInitializationHandlers } from "./IModelConnectionInitialization.js";
+import { _presentation_manager_rpcRequestsHandler } from "./InternalSymbols.js";
 
 let localization: Localization | undefined;
 let presentationManager: PresentationManager | undefined;
@@ -89,7 +91,7 @@ export class Presentation {
         scopes:
           props?.selection?.scopes ??
           new SelectionScopesManager({
-            rpcRequestsHandler: presentationManager.rpcRequestsHandler,
+            rpcRequestsHandler: presentationManager[_presentation_manager_rpcRequestsHandler],
             localeProvider: () => this.presentation.activeLocale,
           }),
       });
@@ -100,9 +102,6 @@ export class Presentation {
         storage: props?.favorites ? props.favorites.storage : createFavoritePropertiesStorage(DefaultFavoritePropertiesStorageTypes.Noop),
       });
     }
-
-    presentationManager.startIModelInitialization = (imodel) => favoritePropertiesManager?.startConnectionInitialization(imodel);
-    presentationManager.ensureIModelInitialized = async (imodel) => favoritePropertiesManager?.ensureInitialized(imodel);
 
     await FrontendLocalizationHelper.registerNamespaces();
     for (const handler of initializationHandlers) {
@@ -120,6 +119,8 @@ export class Presentation {
   public static terminate(): void {
     terminationHandlers.forEach((handler) => handler());
     terminationHandlers.length = 0;
+
+    imodelInitializationHandlers.clear();
 
     if (localization) {
       FrontendLocalizationHelper.unregisterNamespaces();
@@ -158,14 +159,6 @@ export class Presentation {
     return presentationManager;
   }
 
-  /** @internal */
-  public static setPresentationManager(value: PresentationManager) {
-    if (presentationManager) {
-      presentationManager[Symbol.dispose]();
-    }
-    presentationManager = value;
-  }
-
   /**
    * The singleton [[SelectionManager]].
    *
@@ -180,29 +173,14 @@ export class Presentation {
     return selectionManager;
   }
 
-  /** @internal */
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  public static setSelectionManager(value: SelectionManager) {
-    selectionManager = value;
-  }
-
   /**
    * The singleton [[FavoritePropertiesManager]]
-   * @public
    */
   public static get favoriteProperties(): FavoritePropertiesManager {
     if (!favoritePropertiesManager) {
       throw new Error("Favorite Properties must be first initialized by calling Presentation.initialize");
     }
     return favoritePropertiesManager;
-  }
-
-  /** @internal */
-  public static setFavoritePropertiesManager(value: FavoritePropertiesManager) {
-    if (favoritePropertiesManager) {
-      favoritePropertiesManager[Symbol.dispose]();
-    }
-    favoritePropertiesManager = value;
   }
 
   /**
@@ -213,10 +191,5 @@ export class Presentation {
       throw new Error("Presentation must be first initialized by calling Presentation.initialize");
     }
     return localization;
-  }
-
-  /** @internal */
-  public static setLocalization(value: Localization) {
-    localization = value;
   }
 }

--- a/presentation/frontend/src/presentation-frontend/RulesetVariablesManager.ts
+++ b/presentation/frontend/src/presentation-frontend/RulesetVariablesManager.ts
@@ -83,9 +83,7 @@ export interface RulesetVariablesManager {
   /** Unsets variable with given id. */
   unset(variableId: string): Promise<void>;
 
-  /** Retrieves all variables.
-   * @internal
-   */
+  /** Retrieves all variables. */
   getAllVariables(): RulesetVariable[];
 }
 
@@ -103,8 +101,8 @@ export class RulesetVariablesManagerImpl implements RulesetVariablesManager {
 
   public getAllVariables(): RulesetVariable[] {
     const variables: RulesetVariable[] = [];
-    for (const entry of this._clientValues) {
-      variables.push(entry[1]);
+    for (const [_, variable] of this._clientValues) {
+      variables.push(variable);
     }
     return variables;
   }

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionManager.ts
@@ -127,12 +127,6 @@ export class SelectionManager implements ISelectionProvider, Disposable {
     }
   }
 
-  /** @internal */
-  /* c8 ignore next 3 */
-  public getToolSelectionSyncHandler(imodel: IModelConnection) {
-    return this._imodelToolSelectionSyncHandlers.get(imodel)?.handler;
-  }
-
   /**
    * Request the manager to sync with imodel's tool selection (see `IModelConnection.selectionSet`).
    */

--- a/presentation/frontend/src/presentation-frontend/selection/SelectionScopesManager.ts
+++ b/presentation/frontend/src/presentation-frontend/selection/SelectionScopesManager.ts
@@ -8,8 +8,18 @@
  */
 
 import { Id64Arg } from "@itwin/core-bentley";
+import { IModelRpcProps } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
-import { DEFAULT_KEYS_BATCH_SIZE, KeySet, SelectionScope, SelectionScopeProps } from "@itwin/presentation-common";
+import {
+  ClientDiagnosticsAttribute,
+  ComputeSelectionRequestOptions,
+  DEFAULT_KEYS_BATCH_SIZE,
+  KeySet,
+  KeySetJSON,
+  SelectionScope,
+  SelectionScopeProps,
+  SelectionScopeRequestOptions,
+} from "@itwin/presentation-common";
 import { RpcRequestsHandler } from "@itwin/presentation-common/internal";
 
 /**
@@ -19,7 +29,12 @@ import { RpcRequestsHandler } from "@itwin/presentation-common/internal";
  */
 export interface SelectionScopesManagerProps {
   /** RPC handler to use for requesting selection scopes */
-  rpcRequestsHandler: RpcRequestsHandler;
+  rpcRequestsHandler: {
+    /** Requests available selection scopes */
+    getSelectionScopes: (args: SelectionScopeRequestOptions<IModelRpcProps> & ClientDiagnosticsAttribute) => Promise<SelectionScope[]>;
+    /** Requests keys to be added to logical selection based on provided element IDs and selection scope */
+    computeSelection: (args: ComputeSelectionRequestOptions<IModelRpcProps> & ClientDiagnosticsAttribute) => Promise<KeySetJSON>;
+  };
 
   /** Provider of active locale to use for localizing scopes */
   localeProvider?: () => string | undefined;
@@ -33,7 +48,7 @@ export interface SelectionScopesManagerProps {
  * @deprecated in 5.0. Use `computeSelection` from [@itwin/unified-selection](https://github.com/iTwin/presentation/blob/master/packages/unified-selection/README.md#selection-scopes) package instead.
  */
 export class SelectionScopesManager {
-  private _rpcRequestsHandler: RpcRequestsHandler;
+  private _rpcRequestsHandler: Pick<RpcRequestsHandler, "getSelectionScopes" | "computeSelection">;
   private _getLocale: () => string | undefined;
   private _activeScope: SelectionScopeProps | SelectionScope | string | undefined;
 

--- a/presentation/frontend/src/test/PresentationManager.test.ts
+++ b/presentation/frontend/src/test/PresentationManager.test.ts
@@ -70,6 +70,8 @@ import {
 } from "../presentation-frontend/PresentationManager.js";
 import { RulesetManagerImpl } from "../presentation-frontend/RulesetManager.js";
 import { RulesetVariablesManagerImpl } from "../presentation-frontend/RulesetVariablesManager.js";
+import { imodelInitializationHandlers } from "../presentation-frontend/IModelConnectionInitialization.js";
+import { _presentation_manager_ipcRequestsHandler, _presentation_manager_rpcRequestsHandler } from "../presentation-frontend/InternalSymbols.js";
 
 /* eslint-disable @typescript-eslint/no-deprecated */
 
@@ -112,6 +114,7 @@ describe("PresentationManager", () => {
   function recreateManager(props?: Partial<PresentationManagerProps>) {
     manager && manager[Symbol.dispose]();
     manager = PresentationManager.create({
+      // @ts-expect-error internal prop
       rpcRequestsHandler: rpcRequestsHandlerMock.object,
       ...props,
     });
@@ -119,7 +122,7 @@ describe("PresentationManager", () => {
 
   const mockI18N = () => {
     i18nMock.reset();
-    Presentation.setLocalization(i18nMock.object);
+    sinon.replaceGetter(Presentation, "localization", () => i18nMock.object);
     const resolvedPromise = new Promise<void>((resolve) => resolve());
     i18nMock.setup(async (x) => x.registerNamespace(moq.It.isAny())).returns(async () => resolvedPromise);
     i18nMock.setup((x) => x.getLocalizedString(moq.It.isAny(), moq.It.isAny())).returns((stringId) => stringId);
@@ -170,37 +173,41 @@ describe("PresentationManager", () => {
 
     it("sets custom RpcRequestsHandler if supplied with props", async () => {
       const handler = moq.Mock.ofType<RpcRequestsHandler>();
-      const props = { rpcRequestsHandler: handler.object };
-      const mgr = PresentationManager.create(props);
-      expect(mgr.rpcRequestsHandler).to.eq(handler.object);
+      const mgr = PresentationManager.create({
+        // @ts-expect-error internal prop
+        rpcRequestsHandler: handler.object,
+      });
+      expect(mgr[_presentation_manager_rpcRequestsHandler]).to.eq(handler.object);
     });
 
     it("sets RpcRequestsHandler clientId if supplied with props", async () => {
       const props = { clientId: "some client id" };
       const mgr = PresentationManager.create(props);
-      expect(mgr.rpcRequestsHandler.clientId).to.eq(props.clientId);
+      expect(mgr[_presentation_manager_rpcRequestsHandler].clientId).to.eq(props.clientId);
     });
 
     it("sets RpcRequestsHandler timeout if supplied with props", async () => {
       const props = { requestTimeout: 123 };
       const mgr = PresentationManager.create(props);
-      expect(mgr.rpcRequestsHandler.timeout).to.eq(props.requestTimeout);
+      expect(mgr[_presentation_manager_rpcRequestsHandler].timeout).to.eq(props.requestTimeout);
     });
 
     it("sets custom IpcRequestsHandler if supplied with props", async () => {
       sinon.stub(IpcApp, "isValid").get(() => true);
       sinon.stub(IpcApp, "addListener");
       const handler = moq.Mock.ofType<IpcRequestsHandler>();
-      const props = { ipcRequestsHandler: handler.object };
-      const mgr = PresentationManager.create(props);
-      expect(mgr.ipcRequestsHandler).to.eq(handler.object);
+      const mgr = PresentationManager.create({
+        // @ts-expect-error internal prop
+        ipcRequestsHandler: handler.object,
+      });
+      expect(mgr[_presentation_manager_ipcRequestsHandler]).to.eq(handler.object);
     });
 
     it("creates RpcRequestsHandler and IpcRequestsHandler with same client id", async () => {
       sinon.stub(IpcApp, "isValid").get(() => true);
       sinon.stub(IpcApp, "addListener");
       const mgr = PresentationManager.create();
-      expect(mgr.rpcRequestsHandler.clientId).to.eq(mgr.ipcRequestsHandler?.clientId);
+      expect(mgr[_presentation_manager_rpcRequestsHandler].clientId).to.eq(mgr[_presentation_manager_ipcRequestsHandler]?.clientId);
     });
 
     it("starts listening to update events", async () => {
@@ -217,8 +224,9 @@ describe("PresentationManager", () => {
   });
 
   describe("onConnection", () => {
-    it("calls `startiModelInitialization`", async () => {
-      const spy = sinon.stub(manager, "startIModelInitialization");
+    it("calls `startIModelInitialization`", async () => {
+      const spy = sinon.spy();
+      imodelInitializationHandlers.add({ startInitialization: spy, ensureInitialized: async () => {} });
       const onCloseEvent = new BeEvent();
       const imodelMock = moq.Mock.ofType<IModelConnection>();
       imodelMock.setup((x) => x.onClose).returns(() => onCloseEvent);
@@ -411,6 +419,7 @@ describe("PresentationManager", () => {
       sinon.stub(IpcApp, "addListener");
       manager[Symbol.dispose]();
       manager = PresentationManager.create({
+        // @ts-expect-error internal prop
         rpcRequestsHandler: rpcRequestsHandlerMock.object,
       });
       await manager.getNodesCount({
@@ -639,7 +648,7 @@ describe("PresentationManager", () => {
 
     it("calls `ensureIModelInitialized`", async () => {
       const stub = sinon.fake.returns(Promise.resolve());
-      manager.ensureIModelInitialized = stub;
+      imodelInitializationHandlers.add({ startInitialization: () => {}, ensureInitialized: stub });
 
       const result = createTestContentDescriptor({ fields: [] });
       const options = createTestOptions();
@@ -756,7 +765,7 @@ describe("PresentationManager", () => {
 
     it("calls `ensureIModelInitialized`", async () => {
       const stub = sinon.fake.returns(Promise.resolve());
-      manager.ensureIModelInitialized = stub;
+      imodelInitializationHandlers.add({ startInitialization: () => {}, ensureInitialized: stub });
       const testOptions = createTestOptions();
       await manager.getContentDescriptor(testOptions);
       expect(stub).to.be.calledOnce;
@@ -846,7 +855,7 @@ describe("PresentationManager", () => {
   describe("getContent", () => {
     it("calls `ensureIModelInitialized`", async () => {
       const stub = sinon.fake.returns(Promise.resolve());
-      manager.ensureIModelInitialized = stub;
+      imodelInitializationHandlers.add({ startInitialization: () => {}, ensureInitialized: stub });
       const keyset = new KeySet();
       const descriptor = createTestContentDescriptor({ fields: [] });
       const result = {
@@ -1032,7 +1041,7 @@ describe("PresentationManager", () => {
   describe("getContentAndContentSize", () => {
     it("calls `ensureIModelInitialized`", async () => {
       const stub = sinon.fake.returns(Promise.resolve());
-      manager.ensureIModelInitialized = stub;
+      imodelInitializationHandlers.add({ startInitialization: () => {}, ensureInitialized: stub });
       const keyset = new KeySet();
       const descriptor = createTestContentDescriptor({ fields: [] });
       const result = {

--- a/presentation/frontend/src/test/favorite-properties/FavoritePropertiesManager.test.ts
+++ b/presentation/frontend/src/test/favorite-properties/FavoritePropertiesManager.test.ts
@@ -25,6 +25,7 @@ import {
   PropertyFullName,
 } from "../../presentation-frontend/favorite-properties/FavoritePropertiesManager.js";
 import { IFavoritePropertiesStorage } from "../../presentation-frontend/favorite-properties/FavoritePropertiesStorage.js";
+import { ensureIModelInitialized, startIModelInitialization } from "../../presentation-frontend/IModelConnectionInitialization.js";
 
 describe("FavoritePropertiesManager", () => {
   let manager: FavoritePropertiesManager;
@@ -157,13 +158,17 @@ describe("FavoritePropertiesManager", () => {
   });
   /* eslint-enable @typescript-eslint/no-deprecated */
 
-  describe("startConnectionInitialization", () => {
-    it("calls initializeConnection once", () => {
-      const s = sinon.spy(manager, "initializeConnection");
-      manager.startConnectionInitialization(imodelMock.object);
-      manager.startConnectionInitialization(imodelMock.object);
-      expect(s).to.be.calledOnce;
-    });
+  it("initializes connection when `startIModelInitialization` is called", () => {
+    const spy = sinon.spy(manager, "initializeConnection");
+    startIModelInitialization(imodelMock.object);
+    startIModelInitialization(imodelMock.object);
+    expect(spy).to.be.calledOnce;
+  });
+
+  it("initializes connection when `ensureInitialized` is called", async () => {
+    const spy = sinon.spy(manager, "initializeConnection");
+    await ensureIModelInitialized(imodelMock.object);
+    expect(spy).to.be.calledOnce;
   });
 
   describe("has", () => {
@@ -248,7 +253,7 @@ describe("FavoritePropertiesManager", () => {
 
   describe("add", () => {
     it("calls `ensureInitialized`", async () => {
-      const spy = sinon.spy(manager, "ensureInitialized");
+      const spy = sinon.spy(manager, "initializeConnection");
       await manager.add(propertyField1, imodelMock.object, FavoritePropertiesScope.Global);
       expect(spy).to.be.calledOnce;
     });
@@ -286,7 +291,7 @@ describe("FavoritePropertiesManager", () => {
 
   describe("remove", () => {
     it("calls `ensureInitialized`", async () => {
-      const spy = sinon.spy(manager, "ensureInitialized");
+      const spy = sinon.spy(manager, "initializeConnection");
       await manager.remove(propertyField1, imodelMock.object, FavoritePropertiesScope.Global);
       expect(spy).to.be.calledOnce;
     });
@@ -364,8 +369,8 @@ describe("FavoritePropertiesManager", () => {
   });
 
   describe("clear", () => {
-    it("calls `ensureInitialized`", async () => {
-      const spy = sinon.spy(manager, "ensureInitialized");
+    it("initializes connection", async () => {
+      const spy = sinon.spy(manager, "initializeConnection");
       await manager.clear(imodelMock.object, FavoritePropertiesScope.Global);
       expect(spy).to.be.calledOnce;
     });

--- a/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
+++ b/presentation/frontend/src/test/selection/HiliteSetProvider.test.ts
@@ -23,14 +23,15 @@ describe("HiliteSetProvider", () => {
     Promise<{ descriptor: Descriptor; total: number; items: AsyncIterableIterator<Item> } | undefined>
   >();
 
-  before(() => {
+  beforeEach(() => {
     const managerMock = sinon.createStubInstance(PresentationManager, {
       getContentIterator: fakeGetContentIterator,
     });
-    Presentation.setPresentationManager(managerMock);
+    sinon.replaceGetter(Presentation, "presentation", () => managerMock);
   });
 
-  beforeEach(() => {
+  afterEach(() => {
+    sinon.restore();
     imodelMock.reset();
     fakeGetContentIterator.reset();
   });


### PR DESCRIPTION
Closes https://github.com/iTwin/itwinjs-core/issues/7879.

There's already a section in `NextVersion.md` regarding removal of internal Presentation APIs, so didn't add anything there.