### PR TITLE
Deprecate `DialogModuleMethod` in core-electron

### DIFF
--- a/common/api/core-electron.api.md
+++ b/common/api/core-electron.api.md
@@ -16,7 +16,7 @@ import { RpcConfiguration } from '@itwin/core-common';
 import { RpcInterfaceDefinition } from '@itwin/core-common';
 import type { WebPreferences } from 'electron';
 
-// @beta
+// @beta @deprecated
 export type DialogModuleMethod = AsyncMethodsOf<Electron.Dialog>;
 
 // @beta

--- a/common/changes/@itwin/core-electron/gytis-deprecate-unused-electron-type_2025-04-08-13-43.json
+++ b/common/changes/@itwin/core-electron/gytis-deprecate-unused-electron-type_2025-04-08-13-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Deprecate `DialogModuleMethod` ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/core/electron/src/backend/ElectronHost.ts
+++ b/core/electron/src/backend/ElectronHost.ts
@@ -13,11 +13,11 @@ import type * as ElectronModule from "electron";
 
 import * as fs from "fs";
 import * as path from "path";
-import { BeDuration, IModelStatus, ProcessDetector } from "@itwin/core-bentley";
+import { AsyncMethodsOf, BeDuration, IModelStatus, ProcessDetector } from "@itwin/core-bentley";
 import { IpcHandler, IpcHost, NativeHost, NativeHostOpts } from "@itwin/core-backend";
 import { IModelError, IpcListener, IpcSocketBackend, RemoveFunction, RpcConfiguration, RpcInterfaceDefinition } from "@itwin/core-common";
 import { ElectronRpcConfiguration, ElectronRpcManager } from "../common/ElectronRpcManager";
-import { DialogModuleMethod, electronIpcStrings } from "../common/ElectronIpcInterface";
+import { electronIpcStrings } from "../common/ElectronIpcInterface";
 
 // cSpell:ignore signin devserver webcontents copyfile unmaximize eopt
 
@@ -289,7 +289,7 @@ export class ElectronHost {
 
 class ElectronDialogHandler extends IpcHandler {
   public get channelName() { return electronIpcStrings.dialogChannel; }
-  public async callDialog(method: DialogModuleMethod, ...args: any) {
+  public async callDialog(method: AsyncMethodsOf<Electron.Dialog>, ...args: any) {
     const dialog = ElectronHost.electron.dialog;
     const dialogMethod = dialog[method] as (...args: any[]) => any;
     if (typeof dialogMethod !== "function")

--- a/core/electron/src/common/ElectronIpcInterface.ts
+++ b/core/electron/src/common/ElectronIpcInterface.ts
@@ -15,5 +15,6 @@ export const electronIpcStrings = {
 
 /** Asynchronous methods of dialog module in an Electron app.
  * @beta
+ * @deprecated in 5.0. Use `Electron.Dialog` from `electron` instead.
  */
 export type DialogModuleMethod = AsyncMethodsOf<Electron.Dialog>;


### PR DESCRIPTION
All methods using this were deprecated in https://github.com/iTwin/itwinjs-core/pull/4533 and removed recently.