### PR TITLE
Mark readPntsColors @internal

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -9105,6 +9105,9 @@ export interface ReadPixelsArgs {
 }
 
 // @internal
+export function readPntsColors(stream: ByteStream, dataOffset: number, pnts: PntsProps): Uint8Array | undefined;
+
+// @internal
 export function readPointCloudTileContent(stream: ByteStream, iModel: IModelConnection, modelId: Id64String, _is3d: boolean, tile: RealityTile, system: RenderSystem): Promise<{
     graphic: RenderGraphic | undefined;
     rtcCenter: Point3d | undefined;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -587,6 +587,7 @@ internal;function;readImdlContent
 public;interface;ReadMeshArgs
 internal;class;ReadonlyTileUserSet
 public;interface;ReadPixelsArgs
+internal;function;readPntsColors
 internal;function;readPointCloudTileContent
 alpha;class;RealityDataError
 beta;interface;RealityDataSource

--- a/common/changes/@itwin/core-frontend/pmc-fix-extract-api_2025-04-08-19-39.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-extract-api_2025-04-08-19-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/PntsReader.ts
+++ b/core/frontend/src/tile/PntsReader.ts
@@ -82,6 +82,7 @@ type UnquantizedPntsProps = CommonPntsProps & {
 
 type PntsProps = QuantizedPntsProps | UnquantizedPntsProps;
 
+/** @internal exported strictly for tests. */
 export function readPntsColors(stream: ByteStream, dataOffset: number, pnts: PntsProps): Uint8Array | undefined {
   const nPts = pnts.POINTS_LENGTH;
   const nComponents = 3 * nPts;


### PR DESCRIPTION
#7924 exported this function; extract-api failed yet the PR auto-merged anyway. Fix the extract-api error by marking the function @internal. On master, this function is not exported from the barrel, so no release tag was needed. We seem to be missing a check on extract-api for PRs targeting release branch.