### PR TITLE
Don't use AxisOrder.XZY in AccuDraw.getSnapRotation as it's a left-handed matrix.

### DIFF
--- a/common/changes/@itwin/core-frontend/accudraw-snap-rotation_2025-04-09-20-21.json
+++ b/common/changes/@itwin/core-frontend/accudraw-snap-rotation_2025-04-09-20-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/AccuDrawViewportUI.ts
+++ b/core/frontend/src/tools/AccuDrawViewportUI.ts
@@ -476,10 +476,8 @@ export class AccuDrawViewportUI extends AccuDraw {
   }
 
   private async onKeyboardEvent(ev: KeyboardEvent, isDown: boolean): Promise<void> {
-    if (ev.ctrlKey || ev.altKey || ev.metaKey) {
-      ev.preventDefault(); // Ignore qualifiers other than shift...
-      return;
-    }
+    if (ev.ctrlKey || ev.altKey || ev.metaKey)
+      return; // Ignore qualifiers other than shift...
 
     switch (ev.key) {
       case "Escape":


### PR DESCRIPTION
Addresses: #7914 

Remove preventDefault for unhandled qualifiers in AccuDraw UI key event, couldn't use ctrl+shift+i when AccuDraw item field had focus.