### PR TITLE
Fix image names in integration-validation.yaml

### DIFF
--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -32,7 +32,7 @@ jobs:
   - job: Node_22_x
     condition: succeeded()
     pool:
-      vmImage: ubuntu-latest
+      vmImage: ubuntu-22.04 # ubuntu-latest is 24.04, and breaks tests using sandbox
     steps:
       - checkout: self
         clean: true

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -31,10 +31,10 @@ jobs:
           imageName: macos-latest
           nodeVersion: 20.x
         Linux_node_22_x:
-          imageName: macos-latest
+          imageName: ubuntu-latest
           nodeVersion: 22.x
         Windows_node_22_x:
-          imageName: macos-latest
+          imageName: windows-latest
           nodeVersion: 22.x
         MacOS_node_22_x:
           imageName: macos-latest

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -23,23 +23,30 @@ jobs:
       matrix:
         Linux_node_20_x:
           imageName: ubuntu-latest
+          poolName:
           nodeVersion: 20.x
         Windows_node_20_x:
           imageName: windows-latest
+          poolName:
           nodeVersion: 20.x
         MacOS_node_20_x:
           imageName: macos-latest
+          poolName: "iModelTechMacArm"
           nodeVersion: 20.x
         Linux_node_22_x:
           imageName: ubuntu-latest
+          poolName:
           nodeVersion: 22.x
         Windows_node_22_x:
           imageName: windows-latest
+          poolName:
           nodeVersion: 22.x
         MacOS_node_22_x:
           imageName: macos-latest
+          poolName: "iModelTechMacArm"
           nodeVersion: 22.x
     pool:
+      name: $(poolName)
       vmImage: $(imageName)
     steps:
       - checkout: self

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         Linux_node_20_x:
-          imageName: ubuntu-latest
+          imageName: ubuntu-22.04 # ubuntu-latest is 24.04, and breaks tests using sandbox
           poolName:
           nodeVersion: 20.x
         Windows_node_20_x:
@@ -34,7 +34,7 @@ jobs:
           poolName: "iModelTechMacArm"
           nodeVersion: 20.x
         Linux_node_22_x:
-          imageName: ubuntu-latest
+          imageName: ubuntu-22.04 # ubuntu-latest is 24.04, and breaks tests using sandbox
           poolName:
           nodeVersion: 22.x
         Windows_node_22_x:


### PR DESCRIPTION
Node 22 Windows and Linux were incorrectly run on MacOS machines.