### PR TITLE
lock down ubuntu on integration tests

### DIFF
--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -32,7 +32,7 @@ jobs:
   - job: Node_22_x
     condition: succeeded()
     pool:
-      vmImage: ubuntu-latest
+      vmImage: ubuntu-22.04 # ubuntu-latest is 24.04, and breaks tests using sandbox
     steps:
       - checkout: self
         clean: true

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -34,7 +34,7 @@ jobs:
           imageName: ubuntu-22.04 # ubuntu-latest is 24.04, and breaks tests using sandbox
           nodeVersion: 22.x
         Windows_node_22_x:
-          imageName: macos-latest
+          imageName: windows-latest
           nodeVersion: 22.x
         MacOS_node_22_x:
           imageName: macos-latest

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         Linux_node_20_x:
-          imageName: ubuntu-latest
+          imageName: ubuntu-22.04 # ubuntu-latest is 24.04, and breaks tests using sandbox
           nodeVersion: 20.x
         Windows_node_20_x:
           imageName: windows-latest
@@ -31,7 +31,7 @@ jobs:
           imageName: macos-latest
           nodeVersion: 20.x
         Linux_node_22_x:
-          imageName: macos-latest
+          imageName: ubuntu-22.04 # ubuntu-latest is 24.04, and breaks tests using sandbox
           nodeVersion: 22.x
         Windows_node_22_x:
           imageName: macos-latest


### PR DESCRIPTION
`ubuntu-latest` is now providing ubuntu 24.02. This change is causing errors in our integrations tests

Issue showing same problem:
https://github.com/CheckerNetwork/desktop/issues/1709