### PR TITLE
Fix for ECClass.getProperties() which returns empty list in 4.10.2 when called multiple times

### DIFF
--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -263,7 +263,7 @@ export abstract class ECClass extends SchemaItem implements CustomAttributeConta
     // (undocumented)
     protected _baseClass?: LazyLoadedECClass;
     // (undocumented)
-    protected buildPropertyCache(result: Property[], existingValues?: Map<string, number>, resetBaseCaches?: boolean): Promise<void>;
+    protected buildPropertyCache(resetBaseCaches?: boolean): Promise<Property[]>;
     // (undocumented)
     protected buildPropertyCacheSync(result: Property[], existingValues?: Map<string, number>, resetBaseCaches?: boolean): void;
     protected createPrimitiveArrayProperty(name: string, primitiveType: PrimitiveType): Promise<PrimitiveArrayProperty>;
@@ -504,7 +504,7 @@ export class EntityClass extends ECClass {
     // (undocumented)
     protected addMixin(mixin: Mixin): void;
     // (undocumented)
-    protected buildPropertyCache(result: Property[], existingValues?: Map<string, number>, resetBaseCaches?: boolean): Promise<void>;
+    protected buildPropertyCache(resetBaseCaches?: boolean): Promise<Property[]>;
     // (undocumented)
     protected buildPropertyCacheSync(result: Property[], existingValues?: Map<string, number>, resetBaseCaches?: boolean): void;
     // (undocumented)

--- a/common/changes/@itwin/analytical-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/analytical-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/analytical-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/analytical-backend"
+}

--- a/common/changes/@itwin/appui-abstract/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/appui-abstract/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-abstract",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-abstract"
+}

--- a/common/changes/@itwin/backend-webpack-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/backend-webpack-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/backend-webpack-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/backend-webpack-tools"
+}

--- a/common/changes/@itwin/build-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/build-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/common/changes/@itwin/certa/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/certa/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/changes/@itwin/core-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-bentley/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-bentley/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/common/changes/@itwin/core-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/changes/@itwin/core-electron/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-electron/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/changes/@itwin/core-extension/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-extension/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-extension",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-extension"
+}

--- a/common/changes/@itwin/core-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-geometry/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-geometry/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/common/changes/@itwin/core-i18n/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-i18n/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-i18n",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-i18n"
+}

--- a/common/changes/@itwin/core-markup/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-markup/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-markup",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-markup"
+}

--- a/common/changes/@itwin/core-mobile/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-mobile/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/common/changes/@itwin/core-orbitgt/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-orbitgt/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-orbitgt",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-orbitgt"
+}

--- a/common/changes/@itwin/core-quantity/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-quantity/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-quantity",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-quantity"
+}

--- a/common/changes/@itwin/core-telemetry/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-telemetry/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-telemetry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-telemetry"
+}

--- a/common/changes/@itwin/core-webpack-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/core-webpack-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-webpack-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-webpack-tools"
+}

--- a/common/changes/@itwin/ecschema-editing/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecschema-editing/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/common/changes/@itwin/ecschema-locaters/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecschema-locaters/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-locaters",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-locaters"
+}

--- a/common/changes/@itwin/ecschema-metadata/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecschema-metadata/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "buildPropertyCache is now return Property[] instead of being a void, it merge properties into a local result[] and then return the final result rather than just mutating mutating the _mergePropertyCache input.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-common"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-impl/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-impl/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-impl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-impl"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-tests/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-tests/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-tests"
+}

--- a/common/changes/@itwin/ecschema2ts/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecschema2ts/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema2ts",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema2ts"
+}

--- a/common/changes/@itwin/ecsql-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/ecsql-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecsql-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecsql-common"
+}

--- a/common/changes/@itwin/editor-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/editor-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-backend"
+}

--- a/common/changes/@itwin/editor-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/editor-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-common"
+}

--- a/common/changes/@itwin/editor-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/editor-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/editor-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/editor-frontend"
+}

--- a/common/changes/@itwin/express-server/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/express-server/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/express-server",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/express-server"
+}

--- a/common/changes/@itwin/frontend-devtools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/frontend-devtools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/common/changes/@itwin/frontend-tiles/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/frontend-tiles/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/common/changes/@itwin/hypermodeling-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/hypermodeling-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/hypermodeling-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/hypermodeling-frontend"
+}

--- a/common/changes/@itwin/linear-referencing-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/linear-referencing-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/linear-referencing-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-backend"
+}

--- a/common/changes/@itwin/linear-referencing-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/linear-referencing-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/linear-referencing-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-common"
+}

--- a/common/changes/@itwin/map-layers-auth/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/map-layers-auth/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-auth",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-auth"
+}

--- a/common/changes/@itwin/map-layers-formats/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/map-layers-formats/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-formats",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-formats"
+}

--- a/common/changes/@itwin/perf-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/perf-tools/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/perf-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/perf-tools"
+}

--- a/common/changes/@itwin/physical-material-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/physical-material-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/physical-material-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/physical-material-backend"
+}

--- a/common/changes/@itwin/presentation-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/presentation-backend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/presentation-common/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/presentation-frontend/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/common/changes/@itwin/rpcinterface-full-stack-tests/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/rpcinterface-full-stack-tests/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/rpcinterface-full-stack-tests"
+}

--- a/common/changes/@itwin/webgl-compatibility/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/webgl-compatibility/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}

--- a/common/changes/@itwin/workspace-editor/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
+++ b/common/changes/@itwin/workspace-editor/abhi-ecclass-getproperties-issue_2025-04-11-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/workspace-editor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/workspace-editor"
+}

--- a/core/ecschema-metadata/src/Metadata/EntityClass.ts
+++ b/core/ecschema-metadata/src/Metadata/EntityClass.ts
@@ -106,10 +106,10 @@ export class EntityClass extends ECClass {
     return undefined;
   }
 
-  protected override async buildPropertyCache(result: Property[], existingValues?: Map<string, number>, resetBaseCaches: boolean = false): Promise<void> {
-    if (!existingValues) {
-      existingValues = new Map<string, number>();
-    }
+  protected override async buildPropertyCache(resetBaseCaches: boolean = false): Promise<Property[]> {
+    const result: Property[] = [];
+    const existingValues = new Map<string, number>();
+
 
     if (this.baseClass) {
       ECClass.mergeProperties(result, existingValues, await (await this.baseClass).getProperties(resetBaseCaches), false);
@@ -119,10 +119,10 @@ export class EntityClass extends ECClass {
       ECClass.mergeProperties(result, existingValues, await (await mixin).getProperties(resetBaseCaches), false);
     }
 
-    if (!this.properties)
-      return;
+    if (this.properties)
+      ECClass.mergeProperties(result, existingValues, [...this.properties], true);
 
-    ECClass.mergeProperties(result, existingValues, [...this.properties], true);
+    return result;
   }
 
   protected override buildPropertyCacheSync(result: Property[], existingValues?: Map<string, number>, resetBaseCaches: boolean = false): void {

--- a/core/ecschema-metadata/src/test/Metadata/Class.test.ts
+++ b/core/ecschema-metadata/src/test/Metadata/Class.test.ts
@@ -52,11 +52,40 @@ describe("ECClass", () => {
       await (entityClass as ECClass as MutableClass).createPrimitiveProperty("PrimProp");
       entityClass.baseClass = new DelayedPromiseWithProps(baseClass.key, async () => baseClass);
 
+      const [res1,res2] = await Promise.all([entityClass.getProperties().then((x)=>[...x]), entityClass.getProperties().then((x)=>[...x])]);
+      expect(res1).to.have.length(2);
+      expect(res2).to.have.length(2);
+
       expect(await entityClass.getProperty("BasePrimProp")).to.be.undefined;
       expect(await entityClass.getProperty("BasePrimProp", false)).to.be.undefined;
       expect(await entityClass.getProperty("BasePrimProp", true)).equal(basePrimProp);
       expect(await entityClass.getInheritedProperty("BasePrimProp")).equal(basePrimProp);
       expect(await entityClass.getInheritedProperty("PrimProp")).to.be.undefined;
+    });
+
+    it("successfully executes multiples calls to ", async() => {
+      const baseClass = new EntityClass(schema, "Parent");
+      await (baseClass as ECClass as MutableClass).createPrimitiveProperty("ParentPrimProp");
+      await (baseClass as ECClass as MutableClass).createPrimitiveProperty("ParentPrimProp2");
+      await (baseClass as ECClass as MutableClass).createPrimitiveProperty("ParentPrimProp3");
+
+      const entityClass = new EntityClass(schema, "Child");
+      await (entityClass as ECClass as MutableClass).createPrimitiveProperty("ChildPrimProp");
+      await (entityClass as ECClass as MutableClass).createPrimitiveProperty("ChildPrimProp2");
+      await (entityClass as ECClass as MutableClass).createPrimitiveProperty("ChildPrimProp3");
+      entityClass.baseClass = new DelayedPromiseWithProps(baseClass.key, async () => baseClass);
+
+      const [res1,res2] = await Promise.all([entityClass.getProperties().then((x)=>[...x]), entityClass.getProperties().then((x)=>[...x]), entityClass.getProperties().then((x)=>[...x])]);
+      expect(res1).to.have.length(6);
+      expect(res2).to.have.length(6);
+
+      const [res3,res4] = await Promise.all([entityClass.getProperties().then((x)=>[...x]), entityClass.getProperties(true).then((x)=>[...x]), entityClass.getProperties(true).then((x)=>[...x])]);
+      expect(res3).to.have.length(6);
+      expect(res4).to.have.length(6);
+
+      const [res5,res6] = await Promise.all([entityClass.getProperties(true).then((x)=>[...x]), entityClass.getProperties().then((x)=>[...x]), entityClass.getProperties(true).then((x)=>[...x])]);
+      expect(res5).to.have.length(6);
+      expect(res6).to.have.length(6);
     });
 
     it("inherited properties from base class synchronously", () => {


### PR DESCRIPTION
Issue Link: https://github.com/iTwin/itwinjs-core/issues/7919

- Introduced a _propertyCachePromise field to track ongoing cache builds
- buildPropertyCache() now builds the merged property list in isolation and returns it instead of mutating _mergedPropertyCache
- Final result is only assigned to _mergedPropertyCache after a successful build
- Ensures that only one build processes run at a time