### PR TITLE
Don't fail test when Android emulator output includes invalid UTF-8

### DIFF
--- a/test-apps/display-test-app/scripts/runAndroidEmulator.py
+++ b/test-apps/display-test-app/scripts/runAndroidEmulator.py
@@ -232,7 +232,7 @@ def wait_for_first_render(wait_minutes: float) -> bool:
     log('Waiting for first render to finish...')
     start_time = time.time()
     while True:
-        result = subprocess.run([env.adb, '-e', 'logcat', '-d'], capture_output=True, text=True)
+        result = subprocess.run([env.adb, '-e', 'logcat', '-d'], capture_output=True, encoding='utf-8', errors='replace')
         if result.stdout.find('com.bentley.display_test_app: First render finished.') != -1:
             log('Success!')
             return True


### PR DESCRIPTION
While I don't know what causes invalid UTF-8 to sometimes show up in the emulator output, we don't really care about it, so instead of generating an error, replace the invalid output with the Unicode Replacement Character (�).