### PR TITLE
Change Planar Clip Mask test time out

### DIFF
--- a/full-stack-tests/core/src/frontend/map/PlanarClipMask.test.ts
+++ b/full-stack-tests/core/src/frontend/map/PlanarClipMask.test.ts
@@ -16,6 +16,10 @@ import { TestSnapshotConnection } from "../TestSnapshotConnection";
 describe("Planar clip mask (#integration)", () => {
   let imodel: IModelConnection;
 
+  before(function () {
+    this.timeout(480000);
+  });
+
   before(async () => {
     assert.isDefined(process.env.TEST_BING_MAPS_KEY, "The test requires that a Bing Maps key is configured.");
     assert.isDefined(process.env.TEST_MAPBOX_KEY, "The test requires that a MapBox key is configured.");


### PR DESCRIPTION
This PR doubles the planar clip mask test timeout from the default 240,000 ms to 480,000 ms to reolve this issue: https://github.com/iTwin/itwinjs-core/issues/7972

