### PR TITLE
Update minimum supported Node 20 to 20.11.0

### DIFF
--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -28,21 +28,21 @@ jobs:
 
     strategy:
       matrix:
-        "Windows_Node_22_11_0":
+        "Windows_Node_20_11_0":
           OS: windows-latest
           platform: Windows_NT
           name: $(win_pool)
-          node_version: 22.11.0
-        "Linux_Node_22_11_0":
+          node_version: 20.11.0
+        "Linux_Node_20_11_0":
           OS: ubuntu-latest
           platform: Linux
           name: $(linux_pool)
-          node_version: 22.11.0
-        "MacOS_Node_22_11_0":
+          node_version: 20.11.0
+        "MacOS_Node_20_11_0":
           OS: macOS-latest
           platform: Darwin
           name: $(mac_pool)
-          node_version: 22.11.0
+          node_version: 20.11.0
       maxParallel: 3
 
     pool:

--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -28,21 +28,21 @@ jobs:
 
     strategy:
       matrix:
-        "Windows_Node_20_9_0":
+        "Windows_Node_22_11_0":
           OS: windows-latest
           platform: Windows_NT
           name: $(win_pool)
-          node_version: 20.9.0
-        "Linux_Node_20_9_0":
+          node_version: 22.11.0
+        "Linux_Node_22_11_0":
           OS: ubuntu-latest
           platform: Linux
           name: $(linux_pool)
-          node_version: 20.9.0
-        "MacOS_Node_20_9_0":
+          node_version: 22.11.0
+        "MacOS_Node_22_11_0":
           OS: macOS-latest
           platform: Darwin
           name: $(mac_pool)
-          node_version: 20.9.0
+          node_version: 22.11.0
       maxParallel: 3
 
     pool:

--- a/common/config/azure-pipelines/jobs/regression-testing.yaml
+++ b/common/config/azure-pipelines/jobs/regression-testing.yaml
@@ -2,7 +2,7 @@
 #
 # Tests all supported versions of iTwin.js on latest versions of 3 main supported platforms; Windows, Ubuntu, and MacOS.
 #
-# Starts with the minimum Node version (currently 20.9.0) and then follows the tip of each subsequent major LTS (even-numbered) version.
+# Uses minimum supported Node version (currently 20.11.0) documented in SupportedPlatforms.md.
 #
 # The current LTS is tested in all normal CI/PR builds so no need to test it here.
 

--- a/docs/learning/SupportedPlatforms.md
+++ b/docs/learning/SupportedPlatforms.md
@@ -18,7 +18,7 @@ The following Node.js versions are officially supported by the iTwin.js backend 
 | iTwin.js - Node Support | iTwin.js 3.x | iTwin.js 4.x | iTwin.js 5.x |
 | ----------------------- | ------------ | ------------ | ------------ |
 | Node 22 (>=22.11)       | ❌           | ✅ (>= 4.10) | ✅          |
-| Node 20 (>=20.9)        | ❌           | ✅ (>= 4.3)  | ✅          |
+| Node 20 (>=20.11)        | ❌           | ✅ (>= 4.3)  | ✅          |
 | Node 18 (>=18.12)       | ✅ (>= 3.5)  | ✅           | ❌          |
 | Node 16 (>=16.13)       | ✅           | ❌           | ❌          |
 | Node 14 (>=14.17)       | ✅           | ❌           | ❌          |

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.147.0",
   "pnpmVersion": "9.15.0",
-  "nodeSupportedVersionRange": "^20.9.0 || ^22.11.0",
+  "nodeSupportedVersionRange": "^20.11.0 || ^22.11.0",
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,
   "ensureConsistentVersions": true,


### PR DESCRIPTION
Closes #8009 

- Updates node 20 version used in regression tests.
- Update documented minimum supported node version from 20.9.0 to 20.11.0 to accomodate [some new features used](https://github.com/iTwin/itwinjs-core/issues/8009#issuecomment-2834064116).

Update NextVersion.md in backport PR later