### PR TITLE
Tweak contour tooltip

### DIFF
--- a/common/changes/@itwin/frontend-devtools/pmc-contour-tooltip_2025-04-29-19-23.json
+++ b/common/changes/@itwin/frontend-devtools/pmc-contour-tooltip_2025-04-29-19-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/frontend-devtools/src/tools/ToolTipProvider.ts
+++ b/core/frontend-devtools/src/tools/ToolTipProvider.ts
@@ -32,7 +32,11 @@ class DebugToolTipProvider implements ToolTipProvider {
 
     if (hit.contour) {
       const actualZ = hit.hitPoint.z;
-      const contourInfo = `${hit.contour.isMajor ? "Major" : "Minor"} contour ${hit.contour.elevation}m (z=${actualZ})`;
+      const elev = hit.contour.elevation;
+      const type = hit.contour.isMajor ? "Major" : "Minor";
+      const group = hit.contour.group.name ? ` (${hit.contour.group.name})` : "";
+
+      const contourInfo = `${type} contour${group}<br>Elevation: ${elev} (z=${actualZ})`;
       html = `${html}${contourInfo}<br>`;
     }
 


### PR DESCRIPTION
#7986 added contour line information to the tooltips produced by `fdt tooltips` keyin. Slightly tweak the formatting and include the group name, for demo purposes.