### PR TITLE
Improve error message when deleting element that is a definition element

### DIFF
--- a/common/changes/@itwin/core-backend/affank-improve-error-msg_2025-05-01-17-11.json
+++ b/common/changes/@itwin/core-backend/affank-improve-error-msg_2025-05-01-17-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Improve error message when deleting definition element",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2205,8 +2205,14 @@ export namespace IModelDb {
     public deleteElement(ids: Id64Arg): void {
       const iModel = this._iModel;
       Id64.toIdSet(ids).forEach((id) => {
+        this[_cache].delete({ id });
+        const key = iModel[_nativeDb].resolveInstanceKey({ partialKey: { id, baseClassName: "BisCore:Element" } });
+        const isDefinitionElement = iModel[_nativeDb].isSubClassOf(key.classFullName, "BisCore:DefinitionElement");
+        if (isDefinitionElement) {
+          throw new IModelError(IModelStatus.DeletionProhibited, "DefinitionElements cannot be deleted directly. Use deleteDefinitionElements() instead.");
+        }
+        
         try {
-          this[_cache].delete({ id });
           iModel[_nativeDb].deleteElement(id);
         } catch (err: any) {
           err.message = `Error deleting element [${err.message}], id: ${id}`;

--- a/core/backend/src/test/categories/Category.test.ts
+++ b/core/backend/src/test/categories/Category.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import { Guid, Id64 } from "@itwin/core-bentley";
-import { SubCategoryAppearance } from "@itwin/core-common";
+import { IModelError, SubCategoryAppearance } from "@itwin/core-common";
 import {
   IModelDb, RenderMaterialElement, RenderMaterialElementParams, SpatialCategory, StandaloneDb, SubCategory,
 } from "../../core-backend";
@@ -54,5 +54,7 @@ describe("Category", () => {
     expect(subCat.appearance.priority).to.equal(100);
     expect(subCat.appearance.transparency).to.equal(0.75);
     expect(subCat.appearance.materialId).to.equal(materialId);
+    expect(() => imodel.elements.deleteElement(priCategoryId)).throws(IModelError, "DefinitionElements cannot be deleted directly. Use deleteDefinitionElements() instead.");
+
   });
 });


### PR DESCRIPTION
closes https://github.com/iTwin/itwinjs-core/issues/8029

This pull request improves the error message when attempting to delete an element that is a definition element. Instead of a generic error, a specific error message is thrown indicating that definition elements cannot be deleted directly and that the `deleteDefinitionElements()` method should be used instead. This provides clearer guidance to developers and helps prevent accidental deletions of important elements.