### PR TITLE
Improve error message when deleting element that is a definition element

### DIFF
--- a/common/changes/@itwin/core-backend/affank-fix-errmsg-delete-def-el_2025-05-02-16-29.json
+++ b/common/changes/@itwin/core-backend/affank-fix-errmsg-delete-def-el_2025-05-02-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add test for improved error message for when deleting definition element",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/categories/Category.test.ts
+++ b/core/backend/src/test/categories/Category.test.ts
@@ -54,5 +54,6 @@ describe("Category", () => {
     expect(subCat.appearance.priority).to.equal(100);
     expect(subCat.appearance.transparency).to.equal(0.75);
     expect(subCat.appearance.materialId).to.equal(materialId);
+    expect(() => imodel.elements.deleteElement(priCategoryId)).throws(Error, "DefinitionElements cannot be deleted directly. Use deleteDefinitionElements() instead.");
   });
 });


### PR DESCRIPTION
closes https://github.com/iTwin/itwinjs-core/issues/8029

This pull request enhances the error message displayed when trying to delete a definition element. Instead of a generic error, it now provides a specific message indicating that definition elements cannot be deleted directly. Developers are advised to use the `deleteDefinitionElements()` method instead. This change offers clearer guidance and helps prevent accidental deletions of crucial elements.