### PR TITLE
Optionally return world CRS

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -3218,6 +3218,7 @@ export function getAvailableCoordinateReferenceSystems(args: GetAvailableCoordin
 // @beta
 export interface GetAvailableCoordinateReferenceSystemsArgs {
     extent?: Range2dProps;
+    includeWorld?: boolean;
 }
 
 // @beta

--- a/common/changes/@itwin/core-backend/benpo-return-world-crs_2025-05-02-20-06.json
+++ b/common/changes/@itwin/core-backend/benpo-return-world-crs_2025-05-02-20-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "optionally return world CRS from getAvailableCoordinateReferenceSystems",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   ../../core/backend:
     dependencies:
       '@bentley/imodeljs-native':
-        specifier: 5.1.14
-        version: 5.1.14
+        specifier: 5.1.15
+        version: 5.1.15
       '@itwin/cloud-agnostic-core':
         specifier: ^2.2.4
         version: 2.2.4(inversify@6.0.1)(reflect-metadata@0.1.13)
@@ -4623,8 +4623,8 @@ packages:
   '@bentley/icons-generic@1.0.34':
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  '@bentley/imodeljs-native@5.1.14':
-    resolution: {integrity: sha512-btuk5eMSl51Oz+1TJfu30/icJhCMQyz7hSpk0Sw94xNU38ZGXZZUhE67JBJtbDeH3N7z90G2edaWXJQkI1pm4Q==}
+  '@bentley/imodeljs-native@5.1.15':
+    resolution: {integrity: sha512-mbGw/8S4ahL78pamMVR4AVGPo594oSZEixVjXOoWfx1w08KMdxJLNuSiB8AlVsgLAWm/ckE1SujHEabweEDudA==}
 
   '@bentley/linear-referencing-schema@2.0.3':
     resolution: {integrity: sha512-2pFIEN4BS7alIDhGous6N2icKAS8ZhVBfoWB8WvSFaYnneGv5YwbbXl46qATDdPO5jUFezkW6uVxdpp1eOgUHQ==}
@@ -11014,7 +11014,7 @@ snapshots:
 
   '@bentley/icons-generic@1.0.34': {}
 
-  '@bentley/imodeljs-native@5.1.14': {}
+  '@bentley/imodeljs-native@5.1.15': {}
 
   '@bentley/linear-referencing-schema@2.0.3': {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -106,7 +106,7 @@
     "webpack": "^5.97.1"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "5.1.14",
+    "@bentley/imodeljs-native": "5.1.15",
     "@itwin/cloud-agnostic-core": "^2.2.4",
     "@itwin/object-storage-azure": "^2.3.0",
     "@itwin/object-storage-core": "^2.3.0",

--- a/core/backend/src/GeographicCRSServices.ts
+++ b/core/backend/src/GeographicCRSServices.ts
@@ -38,6 +38,9 @@ export interface GetAvailableCoordinateReferenceSystemsArgs {
    * Maximum longitude and latitude correspond to extent.high.x and extent.high.y, respectively.
    */
   extent?: Range2dProps;
+  /** If true, returns additional CRS with extents spanning the entire Earth's surface.
+   * @default false
+   */
   includeWorld?: boolean
 }
 

--- a/core/backend/src/GeographicCRSServices.ts
+++ b/core/backend/src/GeographicCRSServices.ts
@@ -38,6 +38,7 @@ export interface GetAvailableCoordinateReferenceSystemsArgs {
    * Maximum longitude and latitude correspond to extent.high.x and extent.high.y, respectively.
    */
   extent?: Range2dProps;
+  includeWorld?: boolean
 }
 
 /** Get a list of Geographic Coordinate Reference Systems.
@@ -46,5 +47,5 @@ export interface GetAvailableCoordinateReferenceSystemsArgs {
  * @beta
  */
 export async function getAvailableCoordinateReferenceSystems(args: GetAvailableCoordinateReferenceSystemsArgs): Promise<AvailableCoordinateReferenceSystemProps[]> {
-  return IModelNative.platform.GeoServices.getListOfCRS(args.extent);
+  return IModelNative.platform.GeoServices.getListOfCRS(args.extent, args.includeWorld);
 }

--- a/core/backend/src/GeographicCRSServices.ts
+++ b/core/backend/src/GeographicCRSServices.ts
@@ -9,7 +9,7 @@
 import { Range2dProps } from "@itwin/core-geometry";
 import { IModelNative } from "./internal/NativePlatform";
 
-/** Describes a geographic coordinate reference system produced by [[getAvailableCoordinateReferenceSystems]].
+/** Describes a coordinate reference system produced by [[getAvailableCoordinateReferenceSystems]].
  * @beta
  */
 export interface AvailableCoordinateReferenceSystemProps {
@@ -34,11 +34,11 @@ export interface AvailableCoordinateReferenceSystemProps {
  * @beta
  */
 export interface GetAvailableCoordinateReferenceSystemsArgs {
-  /** If provided, only return CRS's that contain the given extent. Minimum longitude and latitude correspond to extent.low.x and extent.low.y, respectively.
+  /** If provided, only return coordinate reference systems that contain the given extent. Minimum longitude and latitude correspond to extent.low.x and extent.low.y, respectively.
    * Maximum longitude and latitude correspond to extent.high.x and extent.high.y, respectively.
    */
   extent?: Range2dProps;
-  /** If true, returns additional CRS with extents spanning the entire Earth's surface.
+  /** If true, returns additional coordinate reference systems with extents spanning the entire Earth's surface.
    * @default false
    */
   includeWorld?: boolean

--- a/core/backend/src/test/misc/GeoServices.test.ts
+++ b/core/backend/src/test/misc/GeoServices.test.ts
@@ -870,7 +870,7 @@ describe("GeoServices", () => {
     it("should return CRS that are in the specified range (3)", async () => {
       const extent: Range2dProps = { low: { x: 0.3, y: 2.4 }, high: { x: 1.6, y: 3.77 } };
       await validateCRSList({expectedCount: 62, allowedRange: validationRangeSmall, extent});
-      await validateCRSList({expectedCount: 422, allowedRange: validationRangeSmall, extent, includeWorld: true});
+      await validateCRSList({expectedCount: 419, allowedRange: validationRangeSmall, extent, includeWorld: true});
     });
 
     it("should retrieve the whole list of CRS and validate the properties for a few selected CRS.", async () => {

--- a/core/backend/src/test/misc/GeoServices.test.ts
+++ b/core/backend/src/test/misc/GeoServices.test.ts
@@ -869,10 +869,8 @@ describe("GeoServices", () => {
 
     it("should return CRS that are in the specified range (3)", async () => {
       const extent: Range2dProps = { low: { x: 0.3, y: 2.4 }, high: { x: 1.6, y: 3.77 } };
-      const expectationPromises = []
-      expectationPromises.push(validateCRSList({expectedCount: 62, allowedRange: validationRangeSmall, extent}));
-      expectationPromises.push(validateCRSList({expectedCount: 422, allowedRange: validationRangeSmall, extent, includeWorld: true}));
-      await Promise.all(expectationPromises);
+      await validateCRSList({expectedCount: 62, allowedRange: validationRangeSmall, extent});
+      await validateCRSList({expectedCount: 422, allowedRange: validationRangeSmall, extent, includeWorld: true});
     });
 
     it("should retrieve the whole list of CRS and validate the properties for a few selected CRS.", async () => {

--- a/core/backend/src/test/misc/GeoServices.test.ts
+++ b/core/backend/src/test/misc/GeoServices.test.ts
@@ -820,20 +820,20 @@ describe("GeoServices", () => {
       const { expectedCount, allowedRange, extent, includeWorld } = options;
       const listOfCRS = await getAvailableCoordinateReferenceSystems({ extent, includeWorld });
 
-      // Check fields of returned CRS's
+      // Check fields of returned coordinate reference systems
       const extentRange: Range2d = Range2d.fromJSON(extent);
       for (const crs of listOfCRS) {
-      // Validate extent
-      if (extent !== undefined) {
-        const crsExtentRange: Range2d = Range2d.fromJSON(crs.crsExtent);
-        const intersects = extentRange.intersectsRange(crsExtentRange);
-        assert.isTrue(intersects);
-      }
+        // Validate extent
+        if (extent !== undefined) {
+          const crsExtentRange: Range2d = Range2d.fromJSON(crs.crsExtent);
+          const intersects = extentRange.intersectsRange(crsExtentRange);
+          assert.isTrue(intersects);
+        }
 
-      // These fields should always be present
-      assert.isTrue(crs.name !== undefined);
-      assert.isTrue(crs.description !== undefined);
-      assert.isTrue(crs.deprecated === true || crs.deprecated === false);
+        // These fields should always be present
+        assert.isTrue(crs.name !== undefined);
+        assert.isTrue(crs.description !== undefined);
+        assert.isTrue(crs.deprecated === true || crs.deprecated === false);
       }
 
       assert.isTrue(listOfCRS.length > expectedCount - allowedRange && listOfCRS.length < expectedCount + allowedRange);

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:5.1.14'
+    implementation 'com.github.itwin:mobile-native-android:5.1.15'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.1.14;
+				version = 5.1.15;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.1.14;
+				version = 5.1.15;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/1103

There are a number of critical "world" CRS ("EPSG:4326" for example) which are not available from [getAvailableCoordinateReferenceSystems](https://github.com/iTwin/itwinjs-core/blob/06313ff2dc8671959008c377d92437e3bbe2f57a/core/backend/src/GeographicCRSServices.ts#L48). This is because [GeoServicesInterop::GetListOfGCS](https://github.com/iTwin/imodel-native/blob/644642cf7a86d9926c7c64aee51f4491045cca97/iModelJsNodeAddon/GeoServicesInterop.cpp#L75) filters out CRS without extents or those with extents spanning the globe.

This PR exposes an optional includeWorld argument to circumvent the above check.
