### PR TITLE
Deprecate `getSchemaSync` method in `ECSchemaRpcLocater` and enforce async usage

### DIFF
--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -1443,7 +1443,7 @@ export enum PropertyType {
 }
 
 // @internal (undocumented)
-export function propertyTypeToString(type: PropertyType): "PrimitiveProperty" | "StructProperty" | "StructArrayProperty" | "NavigationProperty" | "PrimitiveArrayProperty";
+export function propertyTypeToString(type: PropertyType): "PrimitiveArrayProperty" | "PrimitiveProperty" | "StructArrayProperty" | "StructProperty" | "NavigationProperty";
 
 // @internal (undocumented)
 export namespace PropertyTypeUtils {

--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -1443,7 +1443,7 @@ export enum PropertyType {
 }
 
 // @internal (undocumented)
-export function propertyTypeToString(type: PropertyType): "PrimitiveArrayProperty" | "PrimitiveProperty" | "StructArrayProperty" | "StructProperty" | "NavigationProperty";
+export function propertyTypeToString(type: PropertyType): "PrimitiveProperty" | "StructProperty" | "StructArrayProperty" | "NavigationProperty" | "PrimitiveArrayProperty";
 
 // @internal (undocumented)
 export namespace PropertyTypeUtils {

--- a/common/api/ecschema-rpc-interface.api.md
+++ b/common/api/ecschema-rpc-interface.api.md
@@ -32,7 +32,8 @@ export class ECSchemaRpcLocater implements ISchemaLocater {
     constructor(token: IModelRpcProps);
     getSchema(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<Schema | undefined>;
     getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined>;
-    getSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined;
+    // @deprecated
+    getSchemaSync(_schemaKey: SchemaKey, _matchType: SchemaMatchType, _context: SchemaContext): Schema | undefined;
     // @internal (undocumented)
     readonly token: IModelRpcProps;
 }

--- a/common/changes/@itwin/ecschema-rpcinterface-common/deprecate-getSchemaSync-Rpc-Locater_2025-05-05-06-38.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-common/deprecate-getSchemaSync-Rpc-Locater_2025-05-05-06-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-common",
+      "comment": "Deprecated `getSchemaSync` method from ECSchemaRpcLocater.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-common"
+}

--- a/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { ISchemaLocater, Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType, SchemaProps } from "@itwin/ecschema-metadata";
+import { ISchemaLocater, Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
 import { IModelRpcProps } from "@itwin/core-common";
 import { ECSchemaRpcInterface } from "./ECSchemaRpcInterface";
 
@@ -45,19 +45,15 @@ export class ECSchemaRpcLocater implements ISchemaLocater {
   }
 
   /**
-   * Attempts to get a schema from the schema rpc locater. Yields undefined if no matching schema is found.
-   * @param schemaKey Key to look up
-   * @param matchType How to match key against candidate schemas
-   * @param context The SchemaContext that will control the lifetime of the schema and holds the schema's references, if they exist.
+   * This method is not supported for locating schemas over RPC/HTTP.
+   * Use the asynchronous `getSchema` method instead.
+   * @param _schemaKey Key to look up
+   * @param _matchType How to match key against candidate schemas
+   * @param _context The SchemaContext that will control the lifetime of the schema and holds the schema's references, if they exist.
+   * @throws Error Always throws an error indicating this method is not supported.
+   * @deprecated in 5.0 Use the asynchronous `getSchema` method for schema retrieval.
   */
-  public getSchemaSync(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Schema | undefined {
-    const schemaJson = ECSchemaRpcInterface.getClient().getSchemaJSON(this.token, schemaKey.name).then((props: SchemaProps) => {
-      return props;
-    });
-    const schema = Schema.fromJsonSync(schemaJson, context || new SchemaContext());
-    if (schema !== undefined && schema.schemaKey.matches(schemaKey, matchType)) {
-      return schema;
-    }
-    return undefined;
+  public getSchemaSync(_schemaKey: SchemaKey, _matchType: SchemaMatchType, _context: SchemaContext): Schema | undefined {
+    throw new Error("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
   }
 }

--- a/full-stack-tests/core/src/frontend/standalone/SchemaLocator.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/SchemaLocator.test.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { IModelConnection } from "@itwin/core-frontend";
+import { TestUtility } from "../TestUtility";
+import { SchemaContext } from "@itwin/ecschema-metadata";
+import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
+import * as EC from "@itwin/ecschema-metadata";
+import { assert, expect } from "chai";
+import { TestSnapshotConnection } from "../TestSnapshotConnection";
+
+describe("Schema Locater tests: ", () => {
+  let context = new SchemaContext();
+  let imodel: IModelConnection;
+
+  beforeEach(async () => {
+    await TestUtility.startFrontend();
+    imodel = await TestSnapshotConnection.openFile("testImodel.bim"); // relative path resolved by BackendTestAssetResolver
+    const schemaLocater = new ECSchemaRpcLocater(imodel);
+    context = new SchemaContext();
+    context.addLocater(schemaLocater);
+  });
+
+  afterEach(async () => {
+    if (undefined !== imodel)
+      await imodel.close();
+
+    await TestUtility.shutdownFrontend();
+  });
+
+  it("locate valid schema Async", async () => {
+    const schemaKey = new EC.SchemaKey("Gist", 1, 0, 0);
+    const schema = await context.getSchema(schemaKey, EC.SchemaMatchType.Exact);
+
+    assert.isDefined(schema);
+    assert.strictEqual(schema!.schemaKey.name, "Gist");
+    assert.strictEqual(schema!.schemaKey.version.toString(), "01.00.00");
+  });
+
+  it("locate valid schema Sync", () => {
+    const schemaKey = new EC.SchemaKey("Gist", 1, 0, 0);
+    let schema: EC.Schema | undefined;
+    expect(() => schema = context.getSchemaSync(schemaKey, EC.SchemaMatchType.Exact)).to.throw("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
+    assert.isUndefined(schema);
+  });
+});

--- a/full-stack-tests/core/src/frontend/standalone/SchemaLocator.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/SchemaLocator.test.ts
@@ -4,13 +4,12 @@
 *--------------------------------------------------------------------------------------------*/
 import { IModelConnection } from "@itwin/core-frontend";
 import { TestUtility } from "../TestUtility";
-import { SchemaContext } from "@itwin/ecschema-metadata";
+import { EntityClass, Schema, SchemaContext, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
-import * as EC from "@itwin/ecschema-metadata";
 import { assert, expect } from "chai";
 import { TestSnapshotConnection } from "../TestSnapshotConnection";
 
-describe("Schema Locater tests: ", () => {
+describe("Schema Locater Tests", () => {
   let context = new SchemaContext();
   let imodel: IModelConnection;
 
@@ -29,19 +28,59 @@ describe("Schema Locater tests: ", () => {
     await TestUtility.shutdownFrontend();
   });
 
-  it("locate valid schema Async", async () => {
-    const schemaKey = new EC.SchemaKey("Gist", 1, 0, 0);
-    const schema = await context.getSchema(schemaKey, EC.SchemaMatchType.Exact);
+  it("should locate a valid schema asynchronously", async () => {
+    const schemaKey = new SchemaKey("Gist", 1, 0, 0);
+    const schema = await context.getSchema(schemaKey, SchemaMatchType.Exact);
 
     assert.isDefined(schema);
     assert.strictEqual(schema!.schemaKey.name, "Gist");
     assert.strictEqual(schema!.schemaKey.version.toString(), "01.00.00");
+
+    // Check that the schema is cached in the context
+    // Even though getSchemaSync is not supported for locating schemas over RPC/HTTP,
+    // it will return the schema if it has already been cached by a previous async getSchema call.
+    const schemaSync = context.getSchemaSync(schemaKey, SchemaMatchType.Exact);
+    assert.isDefined(schemaSync);
+    assert.strictEqual(schemaSync!.schemaKey.name, "Gist");
+    assert.strictEqual(schemaSync!.schemaKey.version.toString(), "01.00.00");
   });
 
-  it("locate valid schema Sync", () => {
-    const schemaKey = new EC.SchemaKey("Gist", 1, 0, 0);
-    let schema: EC.Schema | undefined;
-    expect(() => schema = context.getSchemaSync(schemaKey, EC.SchemaMatchType.Exact)).to.throw("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
+  it("should throw an exception when locating a schema synchronously without caching", () => {
+    const schemaKey = new SchemaKey("Gist", 1, 0, 0);
+    let schema: Schema | undefined;
+    expect(() => schema = context.getSchemaSync(schemaKey, SchemaMatchType.Exact)).to.throw("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
     assert.isUndefined(schema);
+  });
+
+  it("should retrieve schema items asynchronously", async () => {
+    const toyPart = await context.getSchemaItem("Gist.ToyPart", EntityClass);
+    expect(toyPart?.name).to.eql("ToyPart");
+    const rod = await context.getSchemaItem("Gist.Rod", EntityClass);
+    expect(rod?.name).to.eql("Rod");
+    const hub = await context.getSchemaItem("Gist.Hub", EntityClass);
+    expect(hub?.name).to.eql("Hub");
+    const gistPhysicalElement = await context.getSchemaItem("Gist.GistPhysicalElement", EntityClass);
+    expect(gistPhysicalElement?.name).to.eql("GistPhysicalElement");
+  });
+
+  it("should throw an exception when retrieving schema items synchronously over RPC/HTTP", () => {
+    expect(() => context.getSchemaItemSync("Gist.ToyPart", EntityClass)).to.throw("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
+    expect(() => context.getSchemaItemSync("Gist.Rod", EntityClass)).to.throw("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
+    expect(() => context.getSchemaItemSync("Gist.Hub", EntityClass)).to.throw("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
+    expect(() => context.getSchemaItemSync("Gist.GistPhysicalElement", EntityClass)).to.throw("getSchemaSync is not supported. Use the asynchronous getSchema method instead.");
+  });
+
+  it("should cache schema items in the context after asynchronous retrieval", async () => {
+    // Retrieve a schema item asynchronously, which caches the schema in the context
+    const toyPart = await context.getSchemaItem("Gist.ToyPart", EntityClass);
+    expect(toyPart?.name).to.eql("ToyPart");
+
+    // Retrieve other schema items synchronously, which works because the schema is now cached
+    const rod = context.getSchemaItemSync("Gist.Rod", EntityClass);
+    expect(rod?.name).to.eql("Rod");
+    const hub = context.getSchemaItemSync("Gist.Hub", EntityClass);
+    expect(hub?.name).to.eql("Hub");
+    const gistPhysicalElement = context.getSchemaItemSync("Gist.GistPhysicalElement", EntityClass);
+    expect(gistPhysicalElement?.name).to.eql("GistPhysicalElement");
   });
 });


### PR DESCRIPTION
**What’s Changed:**

- Deprecated the `getSchemaSync` method in `ECSchemaRpcLocater`.
- Updated its implementation to always throw an error, clearly stating that synchronous schema loading over RPC is not supported.

**New Behavior:**

Calling `getSchemaSync` will now immediately throw:
```typescript
Error: getSchemaSync is not supported. Use the asynchronous getSchema method instead.
```