### PR TITLE
Shared lock on parent implies shared lock on children

### DIFF
--- a/core/backend/src/test/standalone/ServerBasedLocks.test.ts
+++ b/core/backend/src/test/standalone/ServerBasedLocks.test.ts
@@ -25,7 +25,7 @@ const expect = chai.expect;
 const assert = chai.assert;
 chai.use(chaiAsPromised);
 
-describe("Server-based locks", () => {
+describe.only("Server-based locks", () => {
   const createVersion0 = async () => {
     const dbName = IModelTestUtils.prepareOutputFile("ServerBasedLocks", "ServerBasedLocks.bim");
     const sourceDb = SnapshotDb.createEmpty(dbName, { rootSubject: { name: "server lock test" } });

--- a/core/backend/src/test/standalone/ServerBasedLocks.test.ts
+++ b/core/backend/src/test/standalone/ServerBasedLocks.test.ts
@@ -25,7 +25,7 @@ const expect = chai.expect;
 const assert = chai.assert;
 chai.use(chaiAsPromised);
 
-describe.only("Server-based locks", () => {
+describe("Server-based locks", () => {
   const createVersion0 = async () => {
     const dbName = IModelTestUtils.prepareOutputFile("ServerBasedLocks", "ServerBasedLocks.bim");
     const sourceDb = SnapshotDb.createEmpty(dbName, { rootSubject: { name: "server lock test" } });


### PR DESCRIPTION
`ServerBasedLocks.holdsSharedLock` claims otherwise, but holding a shared lock on an owner element prevents anyone else from acquiring an exclusive lock on any of its owned elements, which is the definition of a shared lock. Nevertheless `holdsSharedLock` returns false unless the element itself is locked or one of its owners is **exclusively** locked.

@laurynas111 found this confusing and surprising.

This is a proposed change. @kabentley what am I misunderstanding?

The tests in ServerBasedLocks.test.ts fail with this change (they are counting invocations of private methods and querying the lock db directly).

