### PR TITLE
Calculate correct area and centroid for union and parity regions

### DIFF
--- a/common/changes/@itwin/core-geometry/saeed-torabi-parity-union-centroid_2025-05-06-19-47.json
+++ b/common/changes/@itwin/core-geometry/saeed-torabi-parity-union-centroid_2025-05-06-19-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/bspline/BSplineSurface.ts
+++ b/core/geometry/src/bspline/BSplineSurface.ts
@@ -160,12 +160,12 @@ export interface BSplineSurface3dQuery {
 export abstract class BSpline2dNd extends GeometryQuery {
   /** String name for schema properties */
   public readonly geometryCategory = "bsurf";
-
   /** Array of (exactly 2) knot vectors for the u, v directions */
   public knots: KnotVector[];
   /** flat array of coordinate data, blocked by poleDimension and row */
   public coffs: Float64Array;
-  /** Number of components per pole.
+  /**
+   * Number of components per pole.
    * * 3 for conventional xyz surface
    * * 4 for weighted (wx, wy, wz, w) surface.
    */

--- a/core/geometry/src/curve/RegionMomentsXY.ts
+++ b/core/geometry/src/curve/RegionMomentsXY.ts
@@ -17,12 +17,14 @@ import { Point3d } from "../geometry3d/Point3dVector3d";
 import { MomentData } from "../geometry4d/MomentData";
 import { Arc3d } from "./Arc3d";
 import { CurvePrimitive } from "./CurvePrimitive";
+import { AnyRegion } from "./CurveTypes";
 import { LineSegment3d } from "./LineSegment3d";
 import { LineString3d } from "./LineString3d";
 import { Loop } from "./Loop";
 import { ParityRegion } from "./ParityRegion";
-import { StrokeOptions } from "./StrokeOptions";
+import { RegionBinaryOpType, RegionOps } from "./RegionOps";
 import { TransitionSpiral3d } from "./spiral/TransitionSpiral3d";
+import { StrokeOptions } from "./StrokeOptions";
 import { UnionRegion } from "./UnionRegion";
 
 /**
@@ -91,49 +93,30 @@ export class RegionMomentsXY extends NullGeometryHandler {
     this._activeMomentData = undefined;
     return momentData;
   }
+  private handleAnyRegion(region: AnyRegion): MomentData | undefined {
+    const summedMoments = MomentData.create();
+    // guarantee there is no overlapping children
+    const merged = RegionOps.regionBooleanXY(region, undefined, RegionBinaryOpType.Union);
+    if (merged) {
+      for (const child of merged.children) {
+        const childMoments = child.dispatchToGeometryHandler(this);
+        if (childMoments) {
+          const sign0 = childMoments.signFactor(1.0);
+          summedMoments.accumulateProducts(childMoments, sign0);
+        }
+      }
+    } else {
+      return undefined;
+    }
+    return summedMoments;
+  }
   /** Accumulate integrals from origin to the components of the parity region. */
   public override handleParityRegion(region: ParityRegion): MomentData | undefined {
-    const allChildMoments: MomentData[] = [];
-    let maxAbsArea = 0.0;
-    let largestChildMoments: MomentData | undefined;
-    for (const child of region.children) {
-      if (child instanceof Loop) {
-        const childMoments = this.handleLoop(child);
-        if (childMoments) {
-          allChildMoments.push(childMoments);
-          const q = Math.abs(childMoments.quantitySum);
-          if (q > maxAbsArea) {
-            maxAbsArea = q;
-            largestChildMoments = childMoments;
-          }
-        }
-      }
-    }
-    if (largestChildMoments) {
-      const summedMoments = MomentData.create();
-      const sign0 = largestChildMoments.signFactor(1.0);
-      summedMoments.accumulateProducts(largestChildMoments, sign0);
-      for (const childMoments of allChildMoments) {
-        if (childMoments !== largestChildMoments) {
-          const sign1 = childMoments.signFactor(-1.0);
-          summedMoments.accumulateProducts(childMoments, sign1);
-        }
-      }
-      return summedMoments;
-    }
-    return undefined;
+    return this.handleAnyRegion(region);
   }
   /** Accumulate integrals from origin to the components of the union region. */
   public override handleUnionRegion(region: UnionRegion): MomentData | undefined {
-    const summedMoments = MomentData.create();
-    for (const child of region.children) {
-      const childMoments = child.dispatchToGeometryHandler(this);
-      if (childMoments) {
-        const sign0 = childMoments.signFactor(1.0);
-        summedMoments.accumulateProducts(childMoments, sign0);
-      }
-    }
-    return summedMoments;
+    return this.handleAnyRegion(region);
   }
   private _strokeOptions?: StrokeOptions;
   private getStrokeOptions(): StrokeOptions {

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -729,9 +729,7 @@ export class RegionOps {
     curvesAndRegions: AnyCurve | AnyCurve[], tolerance: number = Geometry.smallMetricDistance,
   ): SignedLoops[] {
     let primitives = RegionOps.collectCurvePrimitives(curvesAndRegions, undefined, true, true);
-    const bagOfCurves = BagOfCurves.create(...primitives);
-    const transferredBagOfCurves = TransferWithSplitArcs.clone(bagOfCurves);
-    primitives = transferredBagOfCurves.children as CurvePrimitive[];
+    primitives = TransferWithSplitArcs.clone(BagOfCurves.create(...primitives)).children as CurvePrimitive[];
     const range = this.curveArrayRange(primitives);
     const areaTol = this.computeXYAreaTolerance(range, tolerance);
     const intersections = CurveCurve.allIntersectionsAmongPrimitivesXY(primitives, tolerance);

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -338,8 +338,8 @@ export class RegionOps {
     operation: RegionBinaryOpType,
     mergeTolerance: number = Geometry.smallMetricDistance,
   ): AnyRegion | undefined {
-    // Always return UnionRegion for now. But keep return type as AnyRegion:
-    // in the future, we might return the *simplest* region type.
+    // always return UnionRegion for now, but keep return type as AnyRegion
+    // in the future, we might return the *simplest* region type
     const result = UnionRegion.create();
     const context = RegionBooleanContext.create(RegionGroupOpType.Union, RegionGroupOpType.Union);
     context.addMembers(loopsA, loopsB);

--- a/core/geometry/src/curve/internalContexts/TransferWithSplitArcs.ts
+++ b/core/geometry/src/curve/internalContexts/TransferWithSplitArcs.ts
@@ -14,6 +14,7 @@ import { CloneCurvesContext } from "./CloneCurvesContext";
 
 /**
  * Algorithmic class for shallow-copying a CurveCollection with each full-sweep arc replaced by two half-sweep arcs.
+ * * Often useful for building graphs from loops.
  * @internal
  */
 export class TransferWithSplitArcs extends CloneCurvesContext {

--- a/core/geometry/src/curve/internalContexts/TransferWithSplitArcs.ts
+++ b/core/geometry/src/curve/internalContexts/TransferWithSplitArcs.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+/** @packageDocumentation
+ * @module Curve
+ */
+
+import { Arc3d } from "../Arc3d";
+import { CurveCollection } from "../CurveCollection";
+import { CurvePrimitive } from "../CurvePrimitive";
+import { CloneCurvesContext } from "./CloneCurvesContext";
+
+/**
+ * Algorithmic class for shallow-copying a CurveCollection with each full-sweep arc replaced by two half-sweep arcs.
+ * @internal
+ */
+export class TransferWithSplitArcs extends CloneCurvesContext {
+  public constructor() {
+    super(undefined);
+  }
+  protected override doClone(primitive: CurvePrimitive): CurvePrimitive | CurvePrimitive[] {
+    if (primitive instanceof Arc3d && primitive.sweep.isFullCircle) // replace full arc with two half arcs
+      return [primitive.clonePartialCurve(0.0, 0.5), primitive.clonePartialCurve(0.5, 1)];
+    return primitive;
+  }
+  public static override clone(target: CurveCollection): CurveCollection {
+    const context = new TransferWithSplitArcs();
+    target.announceToCurveProcessor(context);
+    return context._result as CurveCollection;
+  }
+}

--- a/core/geometry/src/test/curve/RegionBoolean.test.ts
+++ b/core/geometry/src/test/curve/RegionBoolean.test.ts
@@ -1351,7 +1351,7 @@ describe("GeneralSweepBooleans", () => {
     expect(ck.getNumErrors()).toBe(0);
   });
   it("FullCircle", () => {
-    const ck = new Checker(true, true);
+    const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
     let x0 = 0;
 

--- a/core/geometry/src/test/curve/RegionBoolean.test.ts
+++ b/core/geometry/src/test/curve/RegionBoolean.test.ts
@@ -1351,7 +1351,7 @@ describe("GeneralSweepBooleans", () => {
     expect(ck.getNumErrors()).toBe(0);
   });
   it("FullCircle", () => {
-    const ck = new Checker();
+    const ck = new Checker(true, true);
     const allGeometry: GeometryQuery[] = [];
     let x0 = 0;
 
@@ -1467,8 +1467,15 @@ describe("GeneralSweepBooleans", () => {
   });
 });
 
-function exerciseAreaBooleans(dataA: AnyRegion[], dataB: AnyRegion[],
-  ck: Checker, allGeometry: GeometryQuery[], x0: number, y0Start: number, showVertexNeighborhoods: boolean) {
+function exerciseAreaBooleans(
+  dataA: AnyRegion[],
+  dataB: AnyRegion[],
+  ck: Checker,
+  allGeometry: GeometryQuery[],
+  x0: number,
+  y0Start: number,
+  showVertexNeighborhoods: boolean,
+) {
   const areas = [];
   const range = RegionOps.curveArrayRange(dataA.concat(dataB));
   const yStep = Math.max(15.0, 2.0 * range.yLength());
@@ -1479,10 +1486,14 @@ function exerciseAreaBooleans(dataA: AnyRegion[], dataB: AnyRegion[],
   const vertexNeighborhoodFunction = (edgeData: VertexNeighborhoodSortData[]) => {
     GeometryCoreTestIO.consoleLog({ nodeCount: edgeData.length });
     for (const data of edgeData) {
-      GeometryCoreTestIO.consoleLog(` id: ${data.node.id}  x: ${data.node.x}, y: ${data.node.y}, theta: ${data.radians}, curvature: ${data.radiusOfCurvature} `);
+      GeometryCoreTestIO.consoleLog(
+        `id: ${data.node.id}  x: ${data.node.x}, y: ${data.node.y}, theta: ${data.radians}, curvature: ${data.radiusOfCurvature}`,
+      );
     }
   };
-  for (const opType of [RegionBinaryOpType.Union, RegionBinaryOpType.Intersection, RegionBinaryOpType.AMinusB, RegionBinaryOpType.BMinusA]) {
+  for (const opType of [
+    RegionBinaryOpType.Union, RegionBinaryOpType.Intersection, RegionBinaryOpType.AMinusB, RegionBinaryOpType.BMinusA,
+  ]) {
     y0 += yStep;
     if (showVertexNeighborhoods && opType === RegionBinaryOpType.Union)
       HalfEdgeGraphMerge.announceVertexNeighborhoodFunction = vertexNeighborhoodFunction;
@@ -1494,7 +1505,7 @@ function exerciseAreaBooleans(dataA: AnyRegion[], dataB: AnyRegion[],
   }
   const area0 = areas[0]; // union
   const area123 = areas[1] + areas[2] + areas[3];
-  ck.testCoordinate(area0, area123, " UnionArea = sum of parts");
+  ck.testCoordinate(area0, area123, "UnionArea = sum of parts");
 }
 /**
  * Return an ellipse the loops around a segment.

--- a/core/geometry/src/test/topology/RegionOps.test.ts
+++ b/core/geometry/src/test/topology/RegionOps.test.ts
@@ -957,7 +957,7 @@ describe("RegionOps", () => {
     expect(ck.getNumErrors()).toBe(0);
   });
 
-  function testRegionXYArea(
+  function testSignedLoops(
     region: AnyRegion,
     numPositiveLoops: number,
     numNegativeLoops: number,
@@ -994,19 +994,19 @@ describe("RegionOps", () => {
     const loop0 = Loop.create(arc0);
     const loop1 = Loop.create(arc1);
     const unionRegion = UnionRegion.create(loop0, loop1);
-    testRegionXYArea(unionRegion, 3, 1, allGeometry, ck, dx);
+    testSignedLoops(unionRegion, 3, 1, allGeometry, ck, dx);
 
     // parity region
     dx += 5;
     const parityRegion = ParityRegion.create(loop0, loop1);
-    testRegionXYArea(parityRegion, 3, 1, allGeometry, ck, dx);
+    testSignedLoops(parityRegion, 3, 1, allGeometry, ck, dx);
 
     // region with circle holes
     dx += 5;
     const rectangle = Loop.create(LineString3d.create(Sample.createRectangle(0, 0, 3, 2, 0, true)));
     const hole = Loop.create(Arc3d.createXY(Point3d.create(1.5, 1), 0.5));
     const region = RegionOps.regionBooleanXY(rectangle, hole, RegionBinaryOpType.AMinusB)!;
-    testRegionXYArea(region, 2, 1, allGeometry, ck, dx);
+    testSignedLoops(region, 2, 1, allGeometry, ck, dx);
 
     GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps", "constructAllXYRegionLoops");
     expect(ck.getNumErrors()).toBe(0);

--- a/core/geometry/src/test/topology/RegionOps.test.ts
+++ b/core/geometry/src/test/topology/RegionOps.test.ts
@@ -24,7 +24,7 @@ import { Loop } from "../../curve/Loop";
 import { JointOptions, OffsetOptions } from "../../curve/OffsetOptions";
 import { ParityRegion } from "../../curve/ParityRegion";
 import { Path } from "../../curve/Path";
-import { RegionOps } from "../../curve/RegionOps";
+import { RegionBinaryOpType, RegionOps } from "../../curve/RegionOps";
 import { StrokeOptions } from "../../curve/StrokeOptions";
 import { UnionRegion } from "../../curve/UnionRegion";
 import { Geometry } from "../../Geometry";
@@ -329,6 +329,7 @@ describe("RegionOps", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
     let dx = 0;
+    let dy = 0;
     let loop: Loop | undefined;
     const rotationMatrix = Matrix3d.createRotationAroundVector(Vector3d.create(0, 1, 0), Angle.createDegrees(45))!;
     const rotationTransform = Transform.createFixedPointAndMatrix(Point3d.create(), rotationMatrix);
@@ -339,12 +340,12 @@ describe("RegionOps", () => {
     let expectedArea = 1;
     let lineString = LineString3d.create([1, 1], [2, 1], [2, 2], [1, 2], [1, 1]);
     loop = Loop.create(lineString);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     const ray = RegionOps.centroidAreaNormal(loop);
     let centroid: Point3d;
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for square");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for square");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for square");
@@ -356,7 +357,7 @@ describe("RegionOps", () => {
     expectedArea = 1;
     lineString = LineString3d.create([1, 1], [2, 1], [2, 2], [1, 2], [1, 1]);
     loop = Loop.create(lineString).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -372,11 +373,11 @@ describe("RegionOps", () => {
     expectedArea = 2;
     lineString = LineString3d.create([1, 1], [3, 1], [3, 2], [1, 2], [1, 1]);
     loop = Loop.create(lineString);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for rectangle");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for rectangle");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for rectangle");
@@ -388,7 +389,7 @@ describe("RegionOps", () => {
     expectedArea = 2;
     lineString = LineString3d.create([1, 1], [3, 1], [3, 2], [1, 2], [1, 1]);
     loop = Loop.create(lineString).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -405,11 +406,11 @@ describe("RegionOps", () => {
     expectedArea = 0.5;
     lineString = LineString3d.create([0, 0], [2, 1], [0.5, 0.5], [1, 2], [0, 0]);
     loop = Loop.create(lineString);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for dart");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for dart");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for dart");
@@ -421,7 +422,7 @@ describe("RegionOps", () => {
     expectedArea = 0.5;
     lineString = LineString3d.create([0, 0], [2, 1], [0.5, 0.5], [1, 2], [0, 0]);
     loop = Loop.create(lineString).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -437,11 +438,11 @@ describe("RegionOps", () => {
     expectedArea = Math.PI;
     let arc = Arc3d.createXY(expectedCentroid, 1.0);
     loop = Loop.create(arc);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for circle");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for circle");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for circle");
@@ -454,7 +455,7 @@ describe("RegionOps", () => {
     expectedArea = Math.PI;
     arc = Arc3d.createXY(center, 1.0);
     loop = Loop.create(arc).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -472,11 +473,11 @@ describe("RegionOps", () => {
       expectedCentroid, Vector3d.create(2, 2), Vector3d.create(-1, 1), AngleSweep.createStartEndDegrees(360, 0),
     );
     loop = Loop.create(arc);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for arc");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for arc");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for arc");
@@ -489,7 +490,7 @@ describe("RegionOps", () => {
     expectedArea = 4 * Math.PI;
     arc = Arc3d.create(center, Vector3d.create(2, 2), Vector3d.create(-1, 1), AngleSweep.createStartEndDegrees(360, 0));
     loop = Loop.create(arc).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop, dx, dy);
     RegionOps.centroidAreaNormal(loop, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -515,11 +516,11 @@ describe("RegionOps", () => {
     const knotArray0 = [0, 0, 0, 0.33, 0.66, 1, 1, 1];
     const bspline0 = BSplineCurve3d.create(closedPoleArray0, knotArray0, degree + 1)!;
     let loop0 = Loop.create(bspline0);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx, dy);
     RegionOps.centroidAreaNormal(loop0, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for bspline0");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for bspline0");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for bspline0");
@@ -530,7 +531,7 @@ describe("RegionOps", () => {
     expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, -1)));
     expectedArea = 4.817806468040612;
     loop0 = Loop.create(bspline0).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx, dy);
     RegionOps.centroidAreaNormal(loop0, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -554,11 +555,11 @@ describe("RegionOps", () => {
     const knotArray1 = [0, 0, 0, 0.5, 1, 1, 1];
     const bspline1 = BSplineCurve3d.create(closedPoleArray1, knotArray1, degree + 1)!;
     let loop1 = Loop.create(bspline1);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx, dy);
     RegionOps.centroidAreaNormal(loop1, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for bspline1");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for bspline1");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for bspline1");
@@ -569,7 +570,7 @@ describe("RegionOps", () => {
     expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, -1)));
     expectedArea = 2.9971577457816796;
     loop1 = Loop.create(bspline1).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx, dy);
     RegionOps.centroidAreaNormal(loop1, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -579,7 +580,8 @@ describe("RegionOps", () => {
       ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for bspline1 in 3d");
     }
     // loop0 with multiple children
-    dx += 3;
+    dx = 0;
+    dy += 5;
     expectedCentroid = Point3d.create(1, 1);
     expectedNormal = Vector3d.create(0, 0, 1);
     expectedArea = 2 + Math.PI / 2;
@@ -592,23 +594,22 @@ describe("RegionOps", () => {
     );
     const linestring1 = LineString3d.create([1, 0], [2, 0], [2, 1]);
     loop0 = Loop.create(arc0, linestring0, arc1, linestring1);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx, dy);
     RegionOps.centroidAreaNormal(loop0, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for loop0");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for loop0");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for loop0");
       ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for loop0");
     }
     // loop0 with multiple children in 3d
-    center = Point3d.create(1, 1);
-    expectedCentroid = rotationTransform.multiplyPoint3d(center);
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(1, 1));
     expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
     expectedArea = 2 + Math.PI / 2;
     loop0 = Loop.create(arc0, linestring0, arc1, linestring1).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop0, dx, dy);
     RegionOps.centroidAreaNormal(loop0, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -628,30 +629,29 @@ describe("RegionOps", () => {
     arc1 = Arc3d.create(
       Point3d.create(2, 1), Vector3d.create(1, 0), Vector3d.create(0, 1), AngleSweep.createStartEndDegrees(-90, 90),
     );
-    let arc2 = Arc3d.create(
+    const arc2 = Arc3d.create(
       Point3d.create(1, 2), Vector3d.create(1, 0), Vector3d.create(0, 1), AngleSweep.createStartEndDegrees(0, 180),
     );
     const arc3 = Arc3d.create(
       Point3d.create(0, 1), Vector3d.create(1, 0), Vector3d.create(0, 1), AngleSweep.createStartEndDegrees(90, 270),
     );
     loop1 = Loop.create(arc0, arc1, arc2, arc3);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx, dy);
     RegionOps.centroidAreaNormal(loop1, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for loop1");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for loop1");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for loop1");
       ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for loop1");
     }
     // loop1 with multiple children in 3d
-    center = Point3d.create(1, 1);
-    expectedCentroid = rotationTransform.multiplyPoint3d(center);
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(1, 1));
     expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
     expectedArea = 4 + 2 * Math.PI;
     loop1 = Loop.create(arc0, arc1, arc2, arc3).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop1, dx, dy);
     RegionOps.centroidAreaNormal(loop1, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -670,23 +670,22 @@ describe("RegionOps", () => {
     );
     linestring0 = LineString3d.create([2, 1], [-1, 1], [-1, -1], [3, -1], [3, 0]);
     let loop2 = Loop.create(arc0, linestring0);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop2, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop2, dx, dy);
     RegionOps.centroidAreaNormal(loop2, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
       ck.testDefined(ray, "ray defined for loop2");
       ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for loop2");
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for loop2");
       ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for loop2");
     }
     // loop2 with multiple children in 3d
-    center = Point3d.create(0.9510277451111325, -0.02140759703854831);
-    expectedCentroid = rotationTransform.multiplyPoint3d(center);
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(0.9510277451111325, -0.02140759703854831));
     expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
     expectedArea = 7 + Math.PI / 4;
     loop2 = Loop.create(arc0, linestring0).cloneTransformed(rotationTransform) as Loop;
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop2, dx);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, loop2, dx, dy);
     RegionOps.centroidAreaNormal(loop2, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
@@ -695,51 +694,266 @@ describe("RegionOps", () => {
       ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for loop2 in 3d");
       ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for loop2 in 3d");
     }
-    // union region
-    dx += 5;
+    // union region 1
+    dx = 0;
+    dy += 5;
     expectedCentroid = Point3d.create(0.5, 1);
     expectedNormal = Vector3d.create(0, 0, 1);
-    const overlapArea = (2 * Math.PI / 3 - Math.sqrt(3) / 2);
+    let overlapArea = 2 * Math.PI / 3 - Math.sqrt(3) / 2;
     expectedArea = 2 * Math.PI - overlapArea;
-    arc0 = Arc3d.createXY(Point3d.create(0, 1), 1.0);
-    arc1 = Arc3d.createXY(Point3d.create(1, 1), 1.0);
-    arc2 = Arc3d.createXY(Point3d.create(1, 1), 1.0);
-    loop0 = Loop.create(arc0);
-    loop1 = Loop.create(arc1);
-    loop2 = Loop.create(arc2);
-    const unionRegion = UnionRegion.create(loop0, loop1, loop2);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, unionRegion, dx);
+    loop0 = Loop.create(Arc3d.createXY(Point3d.create(0, 1), 1));
+    loop1 = Loop.create(Arc3d.createXY(Point3d.create(1, 1), 1));
+    loop2 = Loop.create(Arc3d.createXY(Point3d.create(1, 1), 1));
+    let unionRegion = UnionRegion.create(loop0, loop1, loop2);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, unionRegion, dx, dy);
     RegionOps.centroidAreaNormal(unionRegion, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
-      ck.testDefined(ray, "ray defined for union region");
-      // TODO: fix via https://github.com/iTwin/itwinjs-backlog/issues/1459
-      // ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for union region");
-      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for union region");
-      // ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for union region");
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
+      ck.testDefined(ray, "ray defined for union region 1");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for union region 1");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for union region 1");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for union region 1");
     }
-    // parity region
+    // union region 1 in 3d
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(0.5, 1));
+    expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
+    expectedArea = 2 * Math.PI - overlapArea;
+    let rotatedUnionRegion = unionRegion.cloneTransformed(rotationTransform) as Loop;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, rotatedUnionRegion, dx, dy);
+    RegionOps.centroidAreaNormal(rotatedUnionRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      ck.testDefined(ray, "ray defined for union region 1 in 3d");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for union region 1 in 3d");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for union region 1 in 3d");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for union region 1 in 3d");
+    }
+    // union region 2
     dx += 4;
+    expectedCentroid = Point3d.create(1, 2);
+    expectedNormal = Vector3d.create(0, 0, 1);
+    expectedArea = 2 * Math.PI;
+    loop0 = Loop.create(Arc3d.createXY(Point3d.create(0, 1), 1));
+    loop1 = Loop.create(Arc3d.createXY(Point3d.create(2, 3), 1));
+    unionRegion = UnionRegion.create(loop0, loop1);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, unionRegion, dx, dy);
+    RegionOps.centroidAreaNormal(unionRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
+      ck.testDefined(ray, "ray defined for union region 2");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for union region 2");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for union region 2");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for union region 2");
+    }
+    // union region 2 in 3d
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(1, 2));
+    expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
+    expectedArea = 2 * Math.PI;
+    rotatedUnionRegion = unionRegion.cloneTransformed(rotationTransform) as Loop;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, rotatedUnionRegion, dx, dy);
+    RegionOps.centroidAreaNormal(rotatedUnionRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      ck.testDefined(ray, "ray defined for union region 2 in 3d");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for union region 2 in 3d");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for union region 2 in 3d");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for union region 2 in 3d");
+    }
+    // union region 3
+    dx += 5;
+    expectedCentroid = Point3d.create(2.4399541531178177, 1);
+    expectedNormal = Vector3d.create(0, 0, 1);
+    expectedArea = 19.251373275327744;
+    loop0 = Loop.create(Arc3d.createXY(Point3d.create(1, 1), 2));
+    loop1 = Loop.create(Arc3d.createXY(Point3d.create(1, 1), 1));
+    let parityRegion = ParityRegion.create(loop0, loop1);
+    loop = Loop.create(Arc3d.createXY(Point3d.create(3.5, 1), 2));
+    unionRegion = UnionRegion.create(parityRegion, loop);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, unionRegion, dx, dy);
+    RegionOps.centroidAreaNormal(unionRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
+      ck.testDefined(ray, "ray defined for union region 3");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for union region 3");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for union region 3");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for union region 3");
+    }
+    // union region 3 in 3d
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(2.4399541531178177, 1));
+    expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
+    expectedArea = 19.251373275327744;
+    rotatedUnionRegion = unionRegion.cloneTransformed(rotationTransform) as Loop;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, rotatedUnionRegion, dx, dy);
+    RegionOps.centroidAreaNormal(rotatedUnionRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      ck.testDefined(ray, "ray defined for union region 3 in 3d");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for union region 3 in 3d");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for union region 3 in 3d");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for union region 3 in 3d");
+    }
+    // parity region 1
+    dx = 0;
+    dy += 5;
     expectedCentroid = Point3d.create(0.5, 1);
     expectedNormal = Vector3d.create(0, 0, 1);
+    overlapArea = 2 * Math.PI / 3 - Math.sqrt(3) / 2;
     expectedArea = 2 * Math.PI - 2 * overlapArea;
-    const parityRegion = ParityRegion.create(loop0, loop1);
-    GeometryCoreTestIO.captureCloneGeometry(allGeometry, parityRegion, dx);
+    loop0 = Loop.create(Arc3d.createXY(Point3d.create(0, 1), 1));
+    loop1 = Loop.create(Arc3d.createXY(Point3d.create(1, 1), 1));
+    parityRegion = ParityRegion.create(loop0, loop1);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, parityRegion, dx, dy);
     RegionOps.centroidAreaNormal(parityRegion, ray);
     if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
       centroid = ray.origin;
-      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx);
-      ck.testDefined(ray, "ray defined for parity region");
-      // TODO: fix via https://github.com/iTwin/itwinjs-backlog/issues/1459
-      // ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region");
-      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region");
-      // ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region");
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
+      ck.testDefined(ray, "ray defined for parity region 1");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 1");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 1");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 1");
     }
+    // parity region 1 in 3d
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(0.5, 1));
+    expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
+    expectedArea = 2 * Math.PI - 2 * overlapArea;
+    let rotatedParityRegion = parityRegion.cloneTransformed(rotationTransform) as Loop;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, rotatedParityRegion, dx, dy);
+    RegionOps.centroidAreaNormal(rotatedParityRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      ck.testDefined(ray, "ray defined for parity region 1 in 3d");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 1 in 3d");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 1 in 3d");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 1 in 3d");
+    }
+    // parity region 2
+    dx += 4;
+    expectedCentroid = Point3d.create(1, 2);
+    expectedNormal = Vector3d.create(0, 0, 1);
+    expectedArea = 2 * Math.PI;
+    loop0 = Loop.create(Arc3d.createXY(Point3d.create(0, 1), 1));
+    loop1 = Loop.create(Arc3d.createXY(Point3d.create(2, 3), 1));
+    parityRegion = ParityRegion.create(loop0, loop1);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, parityRegion, dx, dy);
+    RegionOps.centroidAreaNormal(parityRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
+      ck.testDefined(ray, "ray defined for parity region 2");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 2");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 2");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 2");
+    }
+    // parity region 2 in 3d
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(1, 2));
+    expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
+    expectedArea = 2 * Math.PI;
+    rotatedParityRegion = parityRegion.cloneTransformed(rotationTransform) as Loop;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, rotatedParityRegion, dx, dy);
+    RegionOps.centroidAreaNormal(rotatedParityRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      ck.testDefined(ray, "ray defined for parity region 2 in 3d");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 2 in 3d");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 2 in 3d");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 2 in 3d");
+    }
+    // parity region 3
+    dx += 5;
+    expectedCentroid = Point3d.create(1, 1);
+    expectedNormal = Vector3d.create(0, 0, 1);
+    expectedArea = 3 * Math.PI - 4 * overlapArea;
+    loop0 = Loop.create(Arc3d.createXY(Point3d.create(0, 1), 1));
+    loop1 = Loop.create(Arc3d.createXY(Point3d.create(1, 1), 1));
+    loop2 = Loop.create(Arc3d.createXY(Point3d.create(2, 1), 1));
+    parityRegion = ParityRegion.create(loop0, loop1, loop2);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, parityRegion, dx, dy);
+    RegionOps.centroidAreaNormal(parityRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
+      ck.testDefined(ray, "ray defined for parity region 3");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 3");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 3");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 3");
+    }
+    // parity region 3 in 3d
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(1, 1));
+    expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
+    expectedArea = 3 * Math.PI - 4 * overlapArea;
+    rotatedParityRegion = parityRegion.cloneTransformed(rotationTransform) as Loop;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, rotatedParityRegion, dx, dy);
+    RegionOps.centroidAreaNormal(rotatedParityRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      ck.testDefined(ray, "ray defined for parity region 3 in 3d");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 3 in 3d");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 3 in 3d");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 3 in 3d");
+    }
+    // parity region 4
+    dx += 4;
+    expectedCentroid = Point3d.create(5, 3.8136483127358547);
+    expectedNormal = Vector3d.create(0, 0, 1);
+    expectedArea = 80 - 4 * Math.PI;
+    const rectangle = Loop.create(LineString3d.create(Sample.createRectangle(0, 0, 10, 8, 0, true)));
+    const circle = Loop.create(Arc3d.createXY(Point3d.create(5, 5), 2));
+    const region = RegionOps.regionBooleanXY(rectangle, circle, RegionBinaryOpType.AMinusB)!;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, region, dx, dy);
+    RegionOps.centroidAreaNormal(region, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, centroid, 0.1, dx, dy);
+      ck.testDefined(ray, "ray defined for parity region 4");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 4");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 4");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 4");
+    }
+    // parity region 4 in 3d
+    expectedCentroid = rotationTransform.multiplyPoint3d(Point3d.create(5, 3.8136483127358547));
+    expectedNormal = Vector3d.createFrom(rotationTransform.multiplyPoint3d(Point3d.create(0, 0, 1)));
+    expectedArea = 80 - 4 * Math.PI;
+    const rotatedRegion = region.cloneTransformed(rotationTransform) as Loop;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, rotatedRegion, dx, dy);
+    RegionOps.centroidAreaNormal(rotatedRegion, ray);
+    if (ck.testDefined(ray, "computed centroid and normal") && ck.testDefined(ray.a, "computed area")) {
+      centroid = ray.origin;
+      ck.testDefined(ray, "ray defined for parity region 4 in 3d");
+      ck.testPoint3d(centroid, expectedCentroid, "ray origin matches centroid for parity region 4 in 3d");
+      ck.testVector3d(ray.direction, expectedNormal, "ray direction matches Z axis for parity region 4 in 3d");
+      ck.testCoordinate(ray.a, expectedArea, "ray.a matches area for parity region 4 in 3d");
+    }
+
     GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps", "centroidAreaNormal");
     expect(ck.getNumErrors()).toBe(0);
   });
 
+  it("MergeRegionArea", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+    const rectangle = Loop.create(LineString3d.create(Sample.createRectangle(0, 0, 10, 8, 0, true)));
+    const circle = Loop.create(Arc3d.createXY(Point3d.create(5, 5), 2));
+    const region = RegionOps.regionBooleanXY(rectangle, circle, RegionBinaryOpType.AMinusB)!;
+    const regionArea = RegionOps.computeXYArea(region)!;
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, region);
+
+    const merged = RegionOps.regionBooleanXY(region, undefined, RegionBinaryOpType.Union)!;
+    for (const child of merged.children)
+      GeometryCoreTestIO.captureCloneGeometry(allGeometry, child, 0, 10);
+    const mergedArea = RegionOps.computeXYArea(merged)!;
+
+    const rectangleArea = 80;
+    const circleArea = Math.PI * 4;
+    const expectedArea = rectangleArea - circleArea;
+    ck.testCoordinate(regionArea, expectedArea, "area before merge");
+    ck.testCoordinate(mergedArea, expectedArea, "area after merge");
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps", "MergeRegionArea");
+    expect(ck.getNumErrors()).toBe(0);
+  });
 });
 /**
  * Exercise PolygonWireOffset and output to a file.


### PR DESCRIPTION
Also resolved another related issue where a region with a hole was missing its hole after merge via below call:
RegionOps.regionBooleanXY(region, undefined, RegionBinaryOpType.Union)