### PR TITLE
Increase Chrome handle leak timeout back to 30 seconds

### DIFF
--- a/common/changes/@itwin/build-tools/tcobbs-handle-leak-30-seconds_2025-05-08-21-00.json
+++ b/common/changes/@itwin/build-tools/tcobbs-handle-leak-30-seconds_2025-05-08-21-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/build-tools",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/build-tools"
+}

--- a/tools/build/src/mocha-reporter/index.ts
+++ b/tools/build/src/mocha-reporter/index.ts
@@ -91,7 +91,7 @@ class BentleyMochaReporter extends Spec {
     }
   }
 
-  private confirmExit(seconds: number = 10) {
+  private confirmExit(seconds: number = 30) {
     // NB: By calling unref() on this timer, we stop it from keeping the process alive, so it will only fire if _something else_ is still keeping
     // the process alive after n seconds.  This also has the benefit of preventing the timer from showing up in wtfnode's dump of open handles.
     setTimeout(() => {


### PR DESCRIPTION
I decreased it to 10 after moving where it executed from. While that worked on my local machine and solved the test failures, it isn't working on the CI Macs.