### PR TITLE
Handle leak fixes

### DIFF
--- a/common/changes/@itwin/core-backend/tcobbs-handle-leak-fixes_2025-05-12-18-00.json
+++ b/common/changes/@itwin/core-backend/tcobbs-handle-leak-fixes_2025-05-12-18-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-frontend/tcobbs-handle-leak-fixes_2025-05-12-18-00.json
+++ b/common/changes/@itwin/core-frontend/tcobbs-handle-leak-fixes_2025-05-12-18-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -121,7 +121,7 @@ export namespace CloudSqlite {
           await container.refreshPromise;
           container.refreshPromise = undefined;
           tokenRefreshFn(); // schedule next refresh
-        }, refreshSeconds * 1000);
+        }, refreshSeconds * 1000).unref(); // unref so it doesn't keep the process alive
       };
       addHiddenProperty(container, "onConnected", tokenRefreshFn); // schedule the first refresh when the container is connected
       addHiddenProperty(container, "onDisconnect", () => { // clear the refresh timer when the container is disconnected

--- a/core/frontend/src/IpcApp.ts
+++ b/core/frontend/src/IpcApp.ts
@@ -28,6 +28,7 @@ export interface IpcAppOptions {
  */
 export class IpcApp {
   private static _ipc: IpcSocketFrontend | undefined;
+  private static _removeAppNotify: RemoveFunction | undefined;
   /** Get the implementation of the [[IpcSocketFrontend]] interface. */
 
   private static get ipc(): IpcSocketFrontend { return this._ipc!; }
@@ -152,12 +153,13 @@ export class IpcApp {
    * @note this should not be called directly. It is called by NativeApp.startup */
   public static async startup(ipc: IpcSocketFrontend, opts?: IpcAppOptions) {
     this._ipc = ipc;
-    IpcAppNotifyHandler.register(); // receives notifications from backend
+    this._removeAppNotify = IpcAppNotifyHandler.register(); // receives notifications from backend
     await IModelApp.startup(opts?.iModelApp);
   }
 
   /** @internal */
   public static async shutdown() {
+    this._removeAppNotify?.();
     this._ipc = undefined;
     await IModelApp.shutdown();
   }


### PR DESCRIPTION
* Call `unref` on long-running CloudSqlite token refresh timeout.
* Remove registered IpcAppNotifyHandler in `IpcApp.shutdown`.
Hopefully this will fix the handle leaks that are occurring on the Mac CI pipeline.