### PR TITLE
Add Viewport.backgroundMapTileTreeReference

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -12909,6 +12909,7 @@ export abstract class Viewport implements Disposable, TileUser {
     get backgroundMapGeometry(): BackgroundMapGeometry | undefined;
     get backgroundMapSettings(): BackgroundMapSettings;
     set backgroundMapSettings(settings: BackgroundMapSettings);
+    get backgroundMapTileTreeReference(): TileTreeReference | undefined;
     changeBackgroundMapProps(props: BackgroundMapProps): void;
     changeBackgroundMapProvider(props: BackgroundMapProviderProps): void;
     changeCategoryDisplay(categories: Id64Arg, display: boolean, enableAllSubCategories?: boolean): void;

--- a/common/changes/@itwin/core-frontend/pmc-background-map-tile-tree-reference_2025-05-14-15-33.json
+++ b/common/changes/@itwin/core-frontend/pmc-background-map-tile-tree-reference_2025-05-14-15-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add Viewport.backgroundMapTileTreeReference",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -836,6 +836,11 @@ export abstract class Viewport implements Disposable, TileUser {
     this.displayStyle.changeBackgroundMapProvider(props);
   }
 
+  /** A reference to the [[TileTree]] used to display the background map in this viewport, if the background map is being displayed. */
+  public get backgroundMapTileTreeReference(): TileTreeReference | undefined {
+    return this.backgroundMap;
+  }
+
   /** @internal */
   public get backgroundMap(): MapTileTreeReference | undefined { return this._mapTiledGraphicsProvider?.backgroundMap; }
 


### PR DESCRIPTION
`backgroundMap` is @internal and returns `MapTileTreeReference` which is @internal.