### PR TITLE
Bug fix: Google Maps would only use the supplied session manager if an API key was also configured.

### DIFF
--- a/common/changes/@itwin/map-layers-formats/MichelD-GoogleMapsApiKeyFix_2025-05-15-19-07.json
+++ b/common/changes/@itwin/map-layers-formats/MichelD-GoogleMapsApiKeyFix_2025-05-15-19-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-formats",
+      "comment": "Bug fix: Google Maps would only use the supplied session manager if an API key was also configured.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-formats"
+}

--- a/extensions/map-layers-formats/src/GoogleMaps/GoogleMapsImageryProvider.ts
+++ b/extensions/map-layers-formats/src/GoogleMaps/GoogleMapsImageryProvider.ts
@@ -50,8 +50,11 @@ export class GoogleMapsImageryProvider extends MapLayerImageryProvider {
   }
 
   protected async getSessionManager (): Promise<GoogleMapsSessionManager> {
+    if (this._sessionManager)
+      return this._sessionManager;
+
     if (this._settings.accessKey?.value) {
-      return this._sessionManager ?? new NativeGoogleMapsSessionManager(this._settings.accessKey.value);
+      return new NativeGoogleMapsSessionManager(this._settings.accessKey.value);
     } else {
       const msg = `Missing GoogleMaps api key`;
       Logger.logError(loggerCategory, msg);


### PR DESCRIPTION
The session manager should be used, no matter if an API key is set or not in the map layer format registry.