### PR TITLE
Fix blanking fill

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-blanking-fill_2025-05-15-20-53.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-blanking-fill_2025-05-15-20-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix blanking regions inappropriately drawing behind unrelated geometry.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/internal/render/webgl/RenderCommands.ts
+++ b/core/frontend/src/internal/render/webgl/RenderCommands.ts
@@ -230,9 +230,9 @@ export class RenderCommands implements Iterable<DrawCommands> {
       switch (command.renderOrder) {
         case RenderOrder.PlanarLitSurface:
         case RenderOrder.PlanarUnlitSurface:
-        case RenderOrder.BlankingRegion:
           pass = "opaque-planar";
           break;
+        case RenderOrder.BlankingRegion: // draw behind other planar stuff
         case RenderOrder.LitSurface:
         case RenderOrder.UnlitSurface:
           pass = "opaque";
@@ -253,9 +253,9 @@ export class RenderCommands implements Iterable<DrawCommands> {
         switch (command.renderOrder) {
           case RenderOrder.PlanarLitSurface:
           case RenderOrder.PlanarUnlitSurface:
-          case RenderOrder.BlankingRegion:
             opaquePass = RenderPass.OpaquePlanar;
             break;
+          case RenderOrder.BlankingRegion: // draw behind other planar stuff
           case RenderOrder.LitSurface:
           case RenderOrder.UnlitSurface:
             opaquePass = RenderPass.OpaqueGeneral;

--- a/core/frontend/src/internal/render/webgl/glsl/Surface.ts
+++ b/core/frontend/src/internal/render/webgl/glsl/Surface.ts
@@ -241,16 +241,8 @@ const computePositionPrelude = `
   vec4 pos = MAT_MV * rawPos;
 `;
 
-// We used to use gl.polygonOffset() for blanking regions, but that doesn't work with logarithmic depth buffer which overwrites the
-// computed Z. Instead we must manually offset in vertex shader. We do this even if log depth is not enabled/supported.
-// NOTE: If log depth is *not* supported, then the hilite surface vertex shaders previously would still include this logic, but the
-// fragment shaders would not use v_eyeSpace. Some Ubuntu 20.04 graphics drivers cleverly and correctly optimized out the varying and the uniform,
-// causing an exception when gl.getProgramLocation() failed. So, omit this bit in that case.
 const adjustEyeSpace = `
   v_eyeSpace = pos.xyz;
-  const float blankingRegionOffset = 2.0 / 65536.0;
-  if (kRenderOrder_BlankingRegion == u_renderOrder)
-    v_eyeSpace.z -= blankingRegionOffset * (u_frustum.y - u_frustum.x);
 `;
 
 const computeConstantLodUvCustom = `

--- a/core/frontend/src/properties/FormattedQuantityDescription.ts
+++ b/core/frontend/src/properties/FormattedQuantityDescription.ts
@@ -33,7 +33,7 @@ export abstract class FormattedQuantityDescription extends BaseQuantityDescripti
   constructor(name: string, displayLabel: string, iconSpec?: string, kindOfQuantityName?: string);
   constructor(argsOrName: FormattedQuantityDescriptionArgs | string, displayLabel?: string, iconSpec?: string, kindOfQuantityName?: string) {
     if (typeof argsOrName === "string") {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+       
       super(argsOrName, displayLabel!, iconSpec, kindOfQuantityName);
     } else {
       super(argsOrName.name, argsOrName.displayLabel, argsOrName.iconSpec, argsOrName.kindOfQuantityName);


### PR DESCRIPTION
Fixes #8101.
Dunno why we ever tried to do this using the old-fashioned polygon offset thing when we have fragment shader logic for controlling display priority.
Unit tests proved infeasible.

- [ ] Run ImageTests