### PR TITLE
Rename "toggle reality bounds" key-in

### DIFF
--- a/core/frontend-devtools/public/locales/en/FrontendDevTools.json
+++ b/core/frontend-devtools/public/locales/en/FrontendDevTools.json
@@ -82,7 +82,7 @@
       "keyin": "fdt visibility"
     },
     "ToggleRealityTileBounds": {
-      "keyin": "fdt reality bounds"
+      "keyin": "fdt toggle reality bounds"
     },
     "ToggleRealityTilePreload": {
       "keyin": "fdt toggle reality preload"


### PR DESCRIPTION
I noticed the [frontend-devtools readme](https://github.com/iTwin/itwinjs-core/blob/master/core/frontend-devtools/README.md) documents the key-in `fdt toggle reality bounds`, when really the command was `fdt reality bounds`. This PR simply updates the command to match the documentation.  