### PR TITLE
Add downloadChangeset and downloadChangesets wrappers to BriefcaseManager

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -561,6 +561,10 @@ export class BriefcaseManager {
     // @internal
     static deleteChangeSetsFromLocalDisk(iModelId: string): void;
     static downloadBriefcase(arg: RequestNewBriefcaseArg): Promise<LocalBriefcaseProps>;
+    // @beta
+    static downloadChangeset(arg: DownloadChangesetArg): Promise<ChangesetFileProps>;
+    // @beta
+    static downloadChangesets(arg: DownloadChangesetRangeArg): Promise<ChangesetFileProps[]>;
     static getBriefcaseBasePath(iModelId: GuidString): LocalDirName;
     static getCachedBriefcases(iModelId?: GuidString): LocalBriefcaseProps[];
     // @internal (undocumented)

--- a/common/changes/@itwin/core-backend/tcobbs-download-changesets_2025-05-21-18-39.json
+++ b/common/changes/@itwin/core-backend/tcobbs-download-changesets_2025-05-21-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add Beta downloadChangeset and downloadChangesets to BriefcaseManager.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -16,7 +16,7 @@ import {
   BriefcaseId, BriefcaseIdValue, BriefcaseProps, ChangesetFileProps, ChangesetIndex, ChangesetIndexOrId, ChangesetProps, ChangesetRange, ChangesetType, IModelError, IModelVersion, LocalBriefcaseProps,
   LocalDirName, LocalFileName, RequestNewBriefcaseProps,
 } from "@itwin/core-common";
-import { AcquireNewBriefcaseIdArg, IModelNameArg } from "./BackendHubAccess";
+import { AcquireNewBriefcaseIdArg, DownloadChangesetArg, DownloadChangesetRangeArg, IModelNameArg } from "./BackendHubAccess";
 import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { CheckpointManager, CheckpointProps, ProgressFunction } from "./CheckpointManager";
 import { BriefcaseDb, IModelDb, TokenArg } from "./IModelDb";
@@ -400,6 +400,20 @@ export class BriefcaseManager {
         status = false;
     }
     return status;
+  }
+
+  /** Download all the changesets in the specified range.
+   * @beta
+   */
+  public static async downloadChangesets(arg: DownloadChangesetRangeArg): Promise<ChangesetFileProps[]> {
+    return IModelHost[_hubAccess].downloadChangesets(arg);
+  }
+
+  /** Download a single changeset.
+   * @beta
+   */
+  public static async downloadChangeset(arg: DownloadChangesetArg): Promise<ChangesetFileProps> {
+    return IModelHost[_hubAccess].downloadChangeset(arg);
   }
 
   /** Query the hub for the properties for a ChangesetIndex or ChangesetId  */


### PR DESCRIPTION
Both new functions are tagged as `@beta`. I'm not sure if this is needed or not.