### PR TITLE
Support for volume selection.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2973,6 +2973,8 @@ export abstract class ElementSetTool extends PrimitiveTool {
     filterHit(hit: HitDetail, out?: LocateResponse): Promise<LocateFilterStatus>;
     protected gatherElements(ev: BeButtonEvent): Promise<EventHandled | undefined>;
     protected gatherInput(ev: BeButtonEvent): Promise<EventHandled | undefined>;
+    // @internal
+    static getAreaOrVolumeSelectionCandidates(vp: Viewport, origin: XAndY, corner: XAndY, method: SelectionMethod, allowOverlaps: boolean, filter?: (id: Id64String) => boolean, includeDecorationsForVolume?: boolean): Promise<Set<Id64String>>;
     protected getDragSelectCandidates(vp: Viewport, origin: Point3d, corner: Point3d, method: SelectionMethod, overlap: boolean): Promise<Id64Arg>;
     protected getGroupIds(id: Id64String): Promise<Id64Arg>;
     protected getLocateCandidates(hit: HitDetail): Promise<Id64Arg>;
@@ -9439,9 +9441,9 @@ export class SelectionTool extends PrimitiveTool {
     // (undocumented)
     requireWriteableTarget(): boolean;
     // (undocumented)
-    protected selectByPointsEnd(ev: BeButtonEvent): boolean;
+    protected selectByPointsEnd(ev: BeButtonEvent): Promise<boolean>;
     // (undocumented)
-    protected selectByPointsProcess(origin: Point3d, corner: Point3d, ev: BeButtonEvent, method: SelectionMethod, overlap: boolean): void;
+    protected selectByPointsProcess(origin: Point3d, corner: Point3d, ev: BeButtonEvent, method: SelectionMethod, overlap: boolean): Promise<boolean>;
     // (undocumented)
     protected selectByPointsStart(ev: BeButtonEvent): boolean;
     // (undocumented)
@@ -11725,6 +11727,8 @@ export class ToolSettings {
     static doubleTapTimeout: BeDuration;
     // @beta
     static enableVirtualCursorForLocate: boolean;
+    // @beta
+    static enableVolumeSelection: boolean;
     static maxOnMotionSnapCallPerSecond: number;
     static preserveWorldUp: boolean;
     static scrollSpeed: number;

--- a/common/changes/@itwin/core-frontend/select-by-volume_2025-05-25-07-15.json
+++ b/common/changes/@itwin/core-frontend/select-by-volume_2025-05-25-07-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/ElementSetTool.ts
+++ b/core/frontend/src/tools/ElementSetTool.ts
@@ -6,9 +6,9 @@
  * @module Tools
  */
 
-import { CompressedId64Set, Id64, Id64Arg, Id64Array, Id64String, OrderedId64Array } from "@itwin/core-bentley";
-import { ColorDef, QueryRowFormat } from "@itwin/core-common";
-import { Point2d, Point3d, Range2d } from "@itwin/core-geometry";
+import { BentleyStatus, CompressedId64Set, Id64, Id64Arg, Id64Array, Id64String, OrderedId64Array } from "@itwin/core-bentley";
+import { ColorDef, GeometryContainmentRequestProps, QueryRowFormat } from "@itwin/core-common";
+import { ClipPlane, ClipPlaneContainment, ClipPrimitive, ClipUtilities, ClipVector, ConvexClipPlaneSet, Point2d, Point3d, Range2d, Vector3d, XAndY } from "@itwin/core-geometry";
 import { AccuDrawHintBuilder } from "../AccuDraw";
 import { LocateFilterStatus, LocateResponse } from "../ElementLocateManager";
 import { HitDetail } from "../HitDetail";
@@ -24,6 +24,7 @@ import { PrimitiveTool } from "./PrimitiveTool";
 import { SelectionMethod } from "./SelectTool";
 import { BeButton, BeButtonEvent, BeModifierKeys, CoreTools, EventHandled } from "./Tool";
 import { ToolAssistance, ToolAssistanceImage, ToolAssistanceInputMethod, ToolAssistanceInstruction, ToolAssistanceSection } from "./ToolAssistance";
+import { ToolSettings } from "./ToolSettings";
 
 /** Identifies the source of the elements in the agenda.
  * @public
@@ -509,13 +510,130 @@ export abstract class ElementSetTool extends PrimitiveTool {
     return true;
   }
 
-  /** Get element ids to process from drag box or crossing line selection.
-   * Sub-classes may override to support selection scopes or apply tool specific filtering.
-   */
-  protected async getDragSelectCandidates(vp: Viewport, origin: Point3d, corner: Point3d, method: SelectionMethod, overlap: boolean): Promise<Id64Arg> {
+  /** Get ids of spatial elements to process from a clip volume created by drag box selection. */
+  private static async getVolumeSelectionCandidates(vp: Viewport, origin: XAndY, corner: XAndY, allowOverlaps: boolean, filter?: (id: Id64String) => boolean): Promise<Set<Id64String>> {
+    const contents = new Set<Id64String>();
+    if (!vp.view.isSpatialView())
+      return contents;
+
+    const boxRange = Range2d.createXYXY(origin.x, origin.y, corner.x, corner.y);
+    if (boxRange.isNull || boxRange.isAlmostZeroX || boxRange.isAlmostZeroY)
+      return contents;
+
+    const getClipPlane = (viewPt: Point2d, viewDir: Vector3d, negate: boolean): ClipPlane | undefined => {
+      const point = vp.viewToWorld(Point3d.createFrom(viewPt));
+      const boresite = AccuDrawHintBuilder.getBoresite(point, vp);
+      const normal = viewDir.crossProduct(boresite.direction);
+
+      if (negate)
+        normal.negate(normal);
+
+      return ClipPlane.createNormalAndPoint(normal, point)
+    };
+
+    const planeSet = ConvexClipPlaneSet.createEmpty();
+
+    planeSet.addPlaneToConvexSet(getClipPlane(boxRange.low, vp.rotation.rowX(), true));
+    planeSet.addPlaneToConvexSet(getClipPlane(boxRange.low, vp.rotation.rowY(), true));
+    planeSet.addPlaneToConvexSet(getClipPlane(boxRange.high, vp.rotation.rowX(), false));
+    planeSet.addPlaneToConvexSet(getClipPlane(boxRange.high, vp.rotation.rowY(), false));
+
+    if (0 === planeSet.planes.length)
+      return contents;
+
+    const clip = ClipVector.createCapture([ClipPrimitive.createCapture(planeSet)]);
+    const viewRange = vp.computeViewRange();
+    const range = ClipUtilities.rangeOfClipperIntersectionWithRange(clip, viewRange);
+
+    if (range.isNull)
+      return contents;
+
+    // TODO: Possible to make UnionOfComplexClipPlaneSets from view clip and planes work and remove 2nd containment check?
+    const viewClip = (vp.viewFlags.clipVolume ? vp.view.getViewClip()?.clone() : undefined);
+    if (viewClip) {
+      const viewClipRange = ClipUtilities.rangeOfClipperIntersectionWithRange(viewClip, viewRange);
+      if (viewClipRange.isNull || !viewClipRange.intersectsRange(range))
+        return contents;
+    }
+
+    const candidates: Id64Array = [];
+    const categories = new Set<Id64String>();
+
+    try {
+      const viewedModels = [...vp.view.modelSelector.models].join(",");
+      const viewedCategories = [...vp.view.categorySelector.categories].join(",");
+      const ecsql = `SELECT e.ECInstanceId, Category.Id as category, ec_classname(e.ECClassId, 's:c') FROM bis.SpatialElement e JOIN bis.SpatialIndex i ON e.ECInstanceId=i.ECInstanceId WHERE Model.Id IN (${viewedModels}) AND Category.Id IN (${viewedCategories}) AND i.MinX <= ${range.xHigh} AND i.MinY <= ${range.yHigh} AND i.MinZ <= ${range.zHigh} AND i.MaxX >= ${range.xLow} AND i.MaxY >= ${range.yLow} AND i.MaxZ >= ${range.zLow}`;
+      const reader = vp.iModel.createQueryReader(ecsql, undefined, { rowFormat: QueryRowFormat.UseECSqlPropertyNames });
+
+      for await (const row of reader) {
+        candidates.push(row.ECInstanceId);
+        categories.add(row.category);
+      }
+    } catch { }
+
+    if (0 === candidates.length)
+      return contents;
+
+    let offSubCategories: Id64Array | undefined;
+    if (0 !== categories.size) {
+      for (const categoryId of categories) {
+        const subcategories = vp.iModel.subcategories.getSubCategories(categoryId);
+        if (undefined === subcategories)
+          continue;
+
+        for (const subCategoryId of subcategories) {
+          const appearance = vp.iModel.subcategories.getSubCategoryAppearance(subCategoryId);
+          if (undefined === appearance || (!appearance.invisible && !appearance.dontLocate))
+            continue;
+
+          if (undefined === offSubCategories)
+            offSubCategories = new Array<Id64String>;
+          offSubCategories.push(subCategoryId);
+        }
+      }
+    }
+
+    const requestProps: GeometryContainmentRequestProps = {
+      candidates,
+      clip: clip.toJSON(),
+      allowOverlaps,
+      viewFlags: vp.viewFlags.toJSON(),
+      offSubCategories,
+    };
+
+    const result = await vp.iModel.getGeometryContainment(requestProps);
+    if (BentleyStatus.SUCCESS !== result.status || undefined === result.candidatesContainment)
+      return contents;
+
+    result.candidatesContainment.forEach((status: ClipPlaneContainment, index: number) => {
+      if (ClipPlaneContainment.StronglyOutside !== status && (undefined === filter || filter(candidates[index])))
+        contents.add(candidates[index]);
+    });
+
+    if (0 !== contents.size && viewClip) {
+      requestProps.clip = viewClip.toJSON();
+      requestProps.candidates.length = 0;
+      for (const id of contents)
+        requestProps.candidates.push(id);
+      contents.clear();
+
+      const resultViewClip = await vp.iModel.getGeometryContainment(requestProps);
+      if (BentleyStatus.SUCCESS !== resultViewClip.status || undefined === resultViewClip.candidatesContainment)
+        return contents;
+
+      resultViewClip.candidatesContainment.forEach((status: ClipPlaneContainment, index: number) => {
+        if (ClipPlaneContainment.StronglyOutside !== status)
+          contents.add(candidates[index]);
+      });
+    }
+
+    return contents;
+  }
+
+  /** Get ids of visible elements to process from drag box or crossing line selection. */
+  private static getAreaSelectionCandidates(vp: Viewport, origin: XAndY, corner: XAndY, method: SelectionMethod, allowOverlaps: boolean, filter?: (id: Id64String) => boolean): Set<Id64String> {
     let contents = new Set<Id64String>();
 
-    // TODO: Include option to use IModelConnection.getGeometryContainment instead of readPixels. No/Yes/2dOnly...
     const pts: Point2d[] = [];
     pts[0] = new Point2d(Math.floor(origin.x + 0.5), Math.floor(origin.y + 0.5));
     pts[1] = new Point2d(Math.floor(corner.x + 0.5), Math.floor(corner.y + 0.5));
@@ -546,14 +664,14 @@ export abstract class ElementSetTool extends PrimitiveTool {
         if (!vp.isPixelSelectable(pixel))
           return undefined; // reality model, terrain, etc - not selectable
 
-        if (!this.isElementIdValid(pixel.elementId, ModifyElementSource.DragSelect))
+        if (undefined !== filter && !filter(pixel.elementId))
           return undefined;
 
         return pixel.elementId;
       };
 
       if (SelectionMethod.Box === method) {
-        const outline = overlap ? undefined : new Set<string>();
+        const outline = allowOverlaps ? undefined : new Set<string>();
         const offset = sRange.clone();
         offset.expandInPlace(-2);
         for (testPoint.x = sRange.low.x; testPoint.x <= sRange.high.x; ++testPoint.x) {
@@ -597,6 +715,37 @@ export abstract class ElementSetTool extends PrimitiveTool {
     }, true);
 
     return contents;
+  }
+
+  /** Get ids of elements to process from drag box or crossing line selection using either the depth buffer or clip vector...
+   * @internal
+   */
+  public static async getAreaOrVolumeSelectionCandidates(vp: Viewport, origin: XAndY, corner: XAndY, method: SelectionMethod, allowOverlaps: boolean, filter?: (id: Id64String) => boolean, includeDecorationsForVolume?: boolean): Promise<Set<Id64String>> {
+    let contents;
+
+    if (ToolSettings.enableVolumeSelection && SelectionMethod.Box === method && vp.view.isSpatialView()) {
+      contents = await ElementSetTool.getVolumeSelectionCandidates(vp, origin, corner, allowOverlaps, filter);
+
+      // Use area select to identify pickable transients...
+      if (includeDecorationsForVolume) {
+        const acceptTransientsFilter = (id: Id64String) => { return Id64.isTransient(id) && (undefined === filter || filter(id)); };
+        const transients = ElementSetTool.getAreaSelectionCandidates(vp, origin, corner, method, allowOverlaps, acceptTransientsFilter);
+        for (const id of transients)
+          contents.add(id);
+      }
+    } else {
+      contents = ElementSetTool.getAreaSelectionCandidates(vp, origin, corner, method, allowOverlaps, filter);
+    }
+
+    return contents;
+  }
+
+  /** Get element ids to process from drag box or crossing line selection.
+   * Sub-classes may override to support selection scopes or apply tool specific filtering.
+   */
+  protected async getDragSelectCandidates(vp: Viewport, origin: Point3d, corner: Point3d, method: SelectionMethod, overlap: boolean): Promise<Id64Arg> {
+    const filter = (id: Id64String) => { return this.isElementIdValid(id, ModifyElementSource.DragSelect); };
+    return ElementSetTool.getAreaOrVolumeSelectionCandidates(vp, origin, corner, method, overlap, filter, IModelApp.locateManager.options.allowDecorations);
   }
 
   /** Populate [[ElementSetTool.agenda]] by drag box or crossing line information.

--- a/core/frontend/src/tools/SelectTool.ts
+++ b/core/frontend/src/tools/SelectTool.ts
@@ -6,8 +6,8 @@
  * @module SelectionSet
  */
 
-import { Id64, Id64Arg } from "@itwin/core-bentley";
-import { Point2d, Point3d, Range2d } from "@itwin/core-geometry";
+import { Id64, Id64Arg, Id64String } from "@itwin/core-bentley";
+import { Point3d } from "@itwin/core-geometry";
 import { ColorDef } from "@itwin/core-common";
 import {
   ButtonGroupEditorParams, DialogItem, DialogItemValue, DialogPropertySyncItem, PropertyDescription, PropertyEditorParamTypes,
@@ -16,13 +16,12 @@ import {
 import { LocateFilterStatus, LocateResponse } from "../ElementLocateManager";
 import { HitDetail } from "../HitDetail";
 import { IModelApp } from "../IModelApp";
-import { Pixel } from "../render/Pixel";
 import { DecorateContext } from "../ViewContext";
-import { ViewRect } from "../common/ViewRect";
 import { PrimitiveTool } from "./PrimitiveTool";
 import { BeButton, BeButtonEvent, BeModifierKeys, BeTouchEvent, CoordinateLockOverrides, CoreTools, EventHandled, InputSource } from "./Tool";
 import { ManipulatorToolEvent } from "./ToolAdmin";
 import { ToolAssistance, ToolAssistanceImage, ToolAssistanceInputMethod, ToolAssistanceInstruction, ToolAssistanceSection } from "./ToolAssistance";
+import { ElementSetTool } from "./ElementSetTool";
 
 // cSpell:ignore buttongroup
 
@@ -327,114 +326,34 @@ export class SelectionTool extends PrimitiveTool {
     context.addCanvasDecoration({ position, drawDecoration });
   }
 
-  protected selectByPointsProcess(origin: Point3d, corner: Point3d, ev: BeButtonEvent, method: SelectionMethod, overlap: boolean) {
+  protected async selectByPointsProcess(origin: Point3d, corner: Point3d, ev: BeButtonEvent, method: SelectionMethod, overlap: boolean): Promise<boolean> {
     const vp = ev.viewport;
     if (!vp)
-      return;
+      return false;
 
-    const pts: Point2d[] = [];
-    pts[0] = new Point2d(Math.floor(origin.x + 0.5), Math.floor(origin.y + 0.5));
-    pts[1] = new Point2d(Math.floor(corner.x + 0.5), Math.floor(corner.y + 0.5));
-    const range = Range2d.createArray(pts);
+    const filter = (id: Id64String) => { return !Id64.isTransient(id); };
+    const contents = await ElementSetTool.getAreaOrVolumeSelectionCandidates(vp, origin, corner, method, overlap, this.wantPickableDecorations() ? undefined : filter, this.wantPickableDecorations());
 
-    const rect = new ViewRect();
-    rect.initFromRange(range);
-    const allowTransients = this.wantPickableDecorations();
-
-    vp.readPixels(rect, Pixel.Selector.Feature, (pixels) => {
-      if (undefined === pixels)
-        return;
-
-      const sRange = Range2d.createNull();
-      sRange.extendPoint(Point2d.create(vp.cssPixelsToDevicePixels(range.low.x), vp.cssPixelsToDevicePixels(range.low.y)));
-      sRange.extendPoint(Point2d.create(vp.cssPixelsToDevicePixels(range.high.x), vp.cssPixelsToDevicePixels(range.high.y)));
-
-      pts[0].x = vp.cssPixelsToDevicePixels(pts[0].x);
-      pts[0].y = vp.cssPixelsToDevicePixels(pts[0].y);
-
-      pts[1].x = vp.cssPixelsToDevicePixels(pts[1].x);
-      pts[1].y = vp.cssPixelsToDevicePixels(pts[1].y);
-
-      let contents = new Set<string>();
-      const testPoint = Point2d.createZero();
-
-      const getPixelElementId = (pixel: Pixel.Data) => {
-        if (undefined === pixel.elementId || Id64.isInvalid(pixel.elementId))
-          return undefined; // no geometry at this location...
-
-        if (!allowTransients && Id64.isTransient(pixel.elementId))
-          return undefined; // tool didn't request pickable decorations...
-
-        if (!vp.isPixelSelectable(pixel))
-          return undefined; // reality model, terrain, etc - not selectable
-
-        return pixel.elementId;
-      };
-
-      if (SelectionMethod.Box === method) {
-        const outline = overlap ? undefined : new Set<string>();
-        const offset = sRange.clone();
-        offset.expandInPlace(-2);
-        for (testPoint.x = sRange.low.x; testPoint.x <= sRange.high.x; ++testPoint.x) {
-          for (testPoint.y = sRange.low.y; testPoint.y <= sRange.high.y; ++testPoint.y) {
-            const pixel = pixels.getPixel(testPoint.x, testPoint.y);
-            const elementId = getPixelElementId(pixel);
-            if (undefined === elementId)
-              continue;
-
-            if (undefined !== outline && !offset.containsPoint(testPoint))
-              outline.add(elementId.toString());
-            else
-              contents.add(elementId.toString());
-          }
-        }
-        if (undefined !== outline && 0 !== outline.size) {
-          const inside = new Set<string>();
-          contents.forEach((id) => {
-            if (!outline.has(id))
-              inside.add(id);
-          });
-
-          contents = inside;
-        }
-      } else {
-        const closePoint = Point2d.createZero();
-        for (testPoint.x = sRange.low.x; testPoint.x <= sRange.high.x; ++testPoint.x) {
-          for (testPoint.y = sRange.low.y; testPoint.y <= sRange.high.y; ++testPoint.y) {
-            const pixel = pixels.getPixel(testPoint.x, testPoint.y);
-            const elementId = getPixelElementId(pixel);
-            if (undefined === elementId)
-              continue;
-
-            const fraction = testPoint.fractionOfProjectionToLine(pts[0], pts[1], 0.0);
-            pts[0].interpolate(fraction, pts[1], closePoint);
-            if (closePoint.distance(testPoint) < 1.5)
-              contents.add(elementId.toString());
-          }
-        }
+    if (0 === contents.size) {
+      if (!ev.isControlKey && this.wantSelectionClearOnMiss(ev) && this.processMiss(ev)) {
+        this.syncSelectionMode();
+        return true;
       }
+      return false;
+    }
 
-      if (0 === contents.size) {
-        if (!ev.isControlKey && this.wantSelectionClearOnMiss(ev) && this.processMiss(ev))
-          this.syncSelectionMode();
-        return;
-      }
+    switch (this.selectionMode) {
+      case SelectionMode.Replace:
+        if (!ev.isControlKey)
+          return this.processSelection(contents, SelectionProcessing.ReplaceSelectionWithElement);
+        return this.processSelection(contents, SelectionProcessing.InvertElementInSelection);
 
-      switch (this.selectionMode) {
-        case SelectionMode.Replace:
-          if (!ev.isControlKey)
-            this.processSelection(contents, SelectionProcessing.ReplaceSelectionWithElement); // eslint-disable-line @typescript-eslint/no-floating-promises
-          else
-            this.processSelection(contents, SelectionProcessing.InvertElementInSelection); // eslint-disable-line @typescript-eslint/no-floating-promises
-          break;
-        case SelectionMode.Add:
-          this.processSelection(contents, SelectionProcessing.AddElementToSelection); // eslint-disable-line @typescript-eslint/no-floating-promises
-          break;
-        case SelectionMode.Remove:
-          this.processSelection(contents, SelectionProcessing.RemoveElementFromSelection); // eslint-disable-line @typescript-eslint/no-floating-promises
-          break;
-      }
-    }, true);
+      case SelectionMode.Add:
+        return this.processSelection(contents, SelectionProcessing.AddElementToSelection);
+
+      case SelectionMode.Remove:
+        return this.processSelection(contents, SelectionProcessing.RemoveElementFromSelection);
+    }
   }
 
   protected selectByPointsStart(ev: BeButtonEvent): boolean {
@@ -449,7 +368,7 @@ export class SelectionTool extends PrimitiveTool {
     return true;
   }
 
-  protected selectByPointsEnd(ev: BeButtonEvent): boolean {
+  protected async selectByPointsEnd(ev: BeButtonEvent): Promise<boolean> {
     if (!this._isSelectByPoints)
       return false;
 
@@ -462,9 +381,9 @@ export class SelectionTool extends PrimitiveTool {
     const origin = vp.worldToView(this._points[0]);
     const corner = vp.worldToView(ev.point);
     if (SelectionMethod.Line === this.selectionMethod || (SelectionMethod.Pick === this.selectionMethod && BeButton.Reset === ev.button))
-      this.selectByPointsProcess(origin, corner, ev, SelectionMethod.Line, true);
+      await this.selectByPointsProcess(origin, corner, ev, SelectionMethod.Line, true);
     else
-      this.selectByPointsProcess(origin, corner, ev, SelectionMethod.Box, this.useOverlapSelection(ev));
+      await this.selectByPointsProcess(origin, corner, ev, SelectionMethod.Box, this.useOverlapSelection(ev));
 
     this.initSelectTool();
     vp.invalidateDecorations();
@@ -516,14 +435,14 @@ export class SelectionTool extends PrimitiveTool {
   }
 
   public override async onMouseEndDrag(ev: BeButtonEvent): Promise<EventHandled> {
-    return this.selectByPointsEnd(ev) ? EventHandled.Yes : EventHandled.No;
+    return await this.selectByPointsEnd(ev) ? EventHandled.Yes : EventHandled.No;
   }
 
   public override async onDataButtonUp(ev: BeButtonEvent): Promise<EventHandled> {
     if (undefined === ev.viewport)
       return EventHandled.No;
 
-    if (this.selectByPointsEnd(ev))
+    if (await this.selectByPointsEnd(ev))
       return EventHandled.Yes;
 
     if (SelectionMethod.Pick !== this.selectionMethod) {

--- a/core/frontend/src/tools/ToolSettings.ts
+++ b/core/frontend/src/tools/ToolSettings.ts
@@ -77,4 +77,9 @@ export class ToolSettings {
   };
   /** Maximum number of times in a second the accuSnap tool's onMotion function is called. */
   public static maxOnMotionSnapCallPerSecond = 15;
+  /** If true, drag box selection will accept spatial elements that are inside or overlap a clip volume instead of only what is visible in the view.
+   * @note Enabling is not recommended for web applications.
+   * @beta
+   */
+  public static enableVolumeSelection = false;
 }


### PR DESCRIPTION
Addresses this issue #8120 which has been brought up several times now.

Share crossing line and drag box selection code between SelectTool and ElementSetTool.
Breaking api change to SelectTool to make protected selectByPointsProcess and selectByPointsEnd methods async.
Promise calling public processSelection method was already being ignored which didn't allow it to be overridden properly.
Doubt many (if any) apps have overridden these SelectTool methods, best to break now before 5.0 is released.
