### PR TITLE
Presentation: More elaborate full class name comparisons

### DIFF
--- a/common/changes/@itwin/presentation-backend/master_2025-06-06-07-55.json
+++ b/common/changes/@itwin/presentation-backend/master_2025-06-06-07-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fix `getDisplayLabelDefinitions` implementation not taking into account different formats and casings of full class name.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/master_2025-06-06-07-55.json
+++ b/common/changes/@itwin/presentation-common/master_2025-06-06-07-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Fix `InstanceKey.compare` implementation not taking into account different formats and casings of full class name.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -331,6 +331,10 @@
       "allowedCategories": [ "integration-testing", "internal" ]
     },
     {
+      "name": "@itwin/presentation-shared",
+      "allowedCategories": [ "backend", "common" ]
+    },
+    {
       "name": "@itwin/reality-data-client",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3060,6 +3060,9 @@ importers:
 
   ../../presentation/backend:
     dependencies:
+      '@itwin/presentation-shared':
+        specifier: ^1.2.1
+        version: 1.2.1
       object-hash:
         specifier: ^1.3.1
         version: 1.3.1
@@ -3195,6 +3198,10 @@ importers:
         version: 5.6.2
 
   ../../presentation/common:
+    dependencies:
+      '@itwin/presentation-shared':
+        specifier: ^1.2.1
+        version: 1.2.1
     devDependencies:
       '@itwin/build-tools':
         specifier: workspace:*
@@ -5249,8 +5256,8 @@ packages:
       '@itwin/core-bentley': workspace:*
       '@itwin/core-common': workspace:*
 
-  '@itwin/presentation-shared@1.2.0':
-    resolution: {integrity: sha512-+esa0GJhWxO1MaF5cGH439mOXPXWNX/SZGgaVfPyRE/1DdH33ECaXaeJVSpFqNrrBHn5XxYN5/7Rayb78k2LOg==}
+  '@itwin/presentation-shared@1.2.1':
+    resolution: {integrity: sha512-b8In5BV+6q1FjMC+zUmkcSAVgbvp+F0M6WlOOiToSWVx+UpcolctlQZSMCKyBuvYvXVDh7DRfAFOm8k2nfgQfw==}
 
   '@itwin/reality-data-client@1.2.1':
     resolution: {integrity: sha512-pNpnO1tbsM1HwyZcr6UkZLyMczNcYFHqsnREmjYJ4GIeCMdrWKGbH5ar4hyajqc/ZkV9zO4FXFMYgQx3yKK1zQ==}
@@ -11555,7 +11562,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@itwin/presentation-shared@1.2.0':
+  '@itwin/presentation-shared@1.2.1':
     dependencies:
       '@itwin/core-bentley': 4.10.10
 
@@ -11591,7 +11598,7 @@ snapshots:
   '@itwin/unified-selection@1.2.0':
     dependencies:
       '@itwin/core-bentley': 4.10.10
-      '@itwin/presentation-shared': 1.2.0
+      '@itwin/presentation-shared': 1.2.1
       rxjs: 7.8.2
       rxjs-for-await: 1.0.0(rxjs@7.8.2)
 

--- a/full-stack-tests/presentation/src/frontend/content/DisplayLabels.test.ts
+++ b/full-stack-tests/presentation/src/frontend/content/DisplayLabels.test.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { Presentation } from "@itwin/presentation-frontend";
+import { collect } from "../../Utils.js";
+import { describeContentTestSuite } from "./Utils.js";
+
+describeContentTestSuite("Display labels", ({ getDefaultSuiteIModel }) => {
+  it("returns display labels for given instances", async () => {
+    const iter = await Presentation.presentation.getDisplayLabelDefinitionsIterator({
+      imodel: await getDefaultSuiteIModel(),
+      keys: [
+        // we should be able to handle both `:` and `.` as schema/class name separator
+        { className: "PCJ_TestSchema:TestClass", id: "0x70" },
+        { className: "PCJ_TestSchema.TestClass", id: "0x71" },
+      ],
+    });
+    expect(iter.total).to.eq(2);
+    const labels = await collect(iter.items);
+    expect(labels).to.deep.eq([
+      {
+        displayValue: "TestClass [0-34]",
+        rawValue: "TestClass [0-34]",
+        typeName: "string",
+      },
+      {
+        displayValue: "TestClass [0-35]",
+        rawValue: "TestClass [0-35]",
+        typeName: "string",
+      },
+    ]);
+  });
+});

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -101,6 +101,7 @@
     "typescript": "~5.6.2"
   },
   "dependencies": {
+    "@itwin/presentation-shared": "^1.2.1",
     "object-hash": "^1.3.1",
     "rxjs": "^7.8.1",
     "rxjs-for-await": "^1.0.0",

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -48,6 +48,7 @@ import {
   WithCancelEvent,
 } from "@itwin/presentation-common";
 import { deepReplaceNullsToUndefined, PresentationIpcEvents } from "@itwin/presentation-common/internal";
+import { normalizeFullClassName } from "@itwin/presentation-shared";
 import { PresentationBackendLoggerCategory } from "./BackendLoggerCategory.js";
 import {
   createDefaultNativePlatform,
@@ -305,7 +306,7 @@ export class PresentationManagerDetail implements Disposable {
   ): Promise<LabelDefinition[]> {
     const concreteKeys = requestOptions.keys
       .map((k) => {
-        if (k.className === "BisCore:Element") {
+        if (normalizeFullClassName(k.className).toLowerCase() === "BisCore.Element".toLowerCase()) {
           return getElementKey(requestOptions.imodel, k.id);
         }
         return k;

--- a/presentation/common/package.json
+++ b/presentation/common/package.json
@@ -64,6 +64,9 @@
     "test": "mocha --enable-source-maps --config ./.mocharc.json",
     "prettier:fix": "prettier --write ."
   },
+  "dependencies": {
+    "@itwin/presentation-shared": "^1.2.1"
+  },
   "peerDependencies": {
     "@itwin/core-bentley": "workspace:*",
     "@itwin/core-common": "workspace:*",

--- a/presentation/common/src/presentation-common/EC.ts
+++ b/presentation/common/src/presentation-common/EC.ts
@@ -8,6 +8,7 @@
 
 import { assert, Id64String } from "@itwin/core-bentley";
 import { FormatProps } from "@itwin/core-quantity";
+import { parseFullClassName } from "@itwin/presentation-shared";
 import { PartialBy } from "./Utils.js";
 
 /**
@@ -37,11 +38,17 @@ export interface InstanceKey {
 export namespace InstanceKey {
   /** Compare 2 instance keys */
   export function compare(lhs: InstanceKey, rhs: InstanceKey): number {
-    const classNameCompare = lhs.className.localeCompare(rhs.className);
+    const lhsClass = parseFullClassName(lhs.className);
+    const rhsClass = parseFullClassName(rhs.className);
+    const schemaNameCompare = lhsClass.schemaName.toLowerCase().localeCompare(rhsClass.schemaName.toLowerCase());
+    if (schemaNameCompare !== 0) {
+      return schemaNameCompare;
+    }
+    const classNameCompare = lhsClass.className.toLowerCase().localeCompare(rhsClass.className.toLowerCase());
     if (classNameCompare !== 0) {
       return classNameCompare;
     }
-    return lhs.id.localeCompare(rhs.id);
+    return lhs.id.toLowerCase().localeCompare(rhs.id.toLowerCase());
   }
 }
 

--- a/presentation/common/src/test/EC.test.ts
+++ b/presentation/common/src/test/EC.test.ts
@@ -15,34 +15,52 @@ import { createTestECClassInfo, createTestRelatedClassInfo, createTestRelatedCla
 
 describe("InstanceKey", () => {
   describe("compare", () => {
-    it("returns less than 0 when `lhs.className` < `rhs.className`", () => {
-      const lhs = { className: "a", id: Id64.invalid };
-      const rhs = { className: "b", id: Id64.invalid };
+    it("returns less than 0 when lhs schema name < rhs schema name", () => {
+      const lhs = { className: "a.x", id: Id64.invalid };
+      const rhs = { className: "b.x", id: Id64.invalid };
       expect(InstanceKey.compare(lhs, rhs)).to.be.lt(0);
     });
 
-    it("returns less than 0 when `lhs.className` = `rhs.className` and `lhs.id` < `rhs.id`", () => {
-      const lhs = { className: "a", id: "0x1" };
-      const rhs = { className: "a", id: "0x2" };
+    it("returns less than 0 when lhs class name < rhs class name", () => {
+      const lhs = { className: "x.a", id: Id64.invalid };
+      const rhs = { className: "x.b", id: Id64.invalid };
       expect(InstanceKey.compare(lhs, rhs)).to.be.lt(0);
     });
 
-    it("returns 0 when `lhs.className` = `rhs.className` and `lhs.id` = `rhs.id`", () => {
-      const lhs = { className: "a", id: "0x1" };
-      const rhs = { className: "a", id: "0x1" };
+    it("returns less than 0 when lhs id < rhs id", () => {
+      const lhs = { className: "x.y", id: "0x1" };
+      const rhs = { className: "x.y", id: "0x2" };
+      expect(InstanceKey.compare(lhs, rhs)).to.be.lt(0);
+    });
+
+    it("returns more than 0 when lhs schema name < rhs schema name", () => {
+      const lhs = { className: "b.x", id: Id64.invalid };
+      const rhs = { className: "a.x", id: Id64.invalid };
+      expect(InstanceKey.compare(lhs, rhs)).to.be.gt(0);
+    });
+
+    it("returns more than 0 when lhs class name < rhs class name", () => {
+      const lhs = { className: "x.b", id: Id64.invalid };
+      const rhs = { className: "x.a", id: Id64.invalid };
+      expect(InstanceKey.compare(lhs, rhs)).to.be.gt(0);
+    });
+
+    it("returns more than 0 when lhs id < rhs id", () => {
+      const lhs = { className: "x.y", id: "0x2" };
+      const rhs = { className: "x.y", id: "0x1" };
+      expect(InstanceKey.compare(lhs, rhs)).to.be.gt(0);
+    });
+
+    it("returns 0 when everything's equal", () => {
+      const lhs = { className: "a.b", id: "0x1" };
+      const rhs = { className: "a.b", id: "0x1" };
       expect(InstanceKey.compare(lhs, rhs)).to.eq(0);
     });
 
-    it("returns more than 0 when `lhs.className` > `rhs.className`", () => {
-      const lhs = { className: "b", id: Id64.invalid };
-      const rhs = { className: "1", id: Id64.invalid };
-      expect(InstanceKey.compare(lhs, rhs)).to.be.gt(0);
-    });
-
-    it("returns more than 0 when `lhs.className` = `rhs.className` and `lhs.id` > `rhs.id`", () => {
-      const lhs = { className: "a", id: "0x2" };
-      const rhs = { className: "a", id: "0x1" };
-      expect(InstanceKey.compare(lhs, rhs)).to.be.gt(0);
+    it("ignores letter casing", () => {
+      const lhs = { className: "a.B", id: "0xaBC" };
+      const rhs = { className: "A.b", id: "0xAbc" };
+      expect(InstanceKey.compare(lhs, rhs)).to.eq(0);
     });
   });
 });


### PR DESCRIPTION
- Fix `getDisplayLabelDefinitions` implementation not taking into account different formats and casings of full class name.
- Fix `InstanceKey.compare` implementation not taking into account different formats and casings of full class name.