### PR TITLE
Presentation: Make `KoqPropertyValueFormatter` use `FormatsProvider` for finding format props

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -24,6 +24,7 @@ import { Entity } from '@itwin/core-backend';
 import { FilterByInstancePathsHierarchyRequestOptions } from '@itwin/presentation-common';
 import { FilterByTextHierarchyRequestOptions } from '@itwin/presentation-common';
 import { FormatsMap } from '@itwin/presentation-common';
+import { FormatsProvider } from '@itwin/core-quantity';
 import { HierarchyCompareInfo } from '@itwin/presentation-common';
 import { HierarchyCompareOptions } from '@itwin/presentation-common';
 import { HierarchyLevelDescriptorRequestOptions } from '@itwin/presentation-common';
@@ -243,9 +244,11 @@ export interface PresentationManagerCachingConfig {
 // @public
 export interface PresentationManagerProps {
     caching?: PresentationManagerCachingConfig;
+    // @deprecated
     defaultFormats?: FormatsMap;
     defaultUnitSystem?: UnitSystemKey;
     diagnostics?: BackendDiagnosticsOptions;
+    formatsProvider?: FormatsProvider;
     getLocalizedString?: (key: string) => string;
     // @deprecated
     presentationAssetsRoot?: string | PresentationAssetsRootConfig;

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -9,6 +9,7 @@ import { BentleyError } from '@itwin/core-bentley';
 import { CompressedId64Set } from '@itwin/core-bentley';
 import { EntityProps } from '@itwin/core-common';
 import { FormatProps } from '@itwin/core-quantity';
+import { FormatsProvider } from '@itwin/core-quantity';
 import { FormatterSpec } from '@itwin/core-quantity';
 import { GetMetaDataFunction } from '@itwin/core-bentley';
 import { GuidString } from '@itwin/core-bentley';
@@ -860,7 +861,7 @@ export interface FormatOptions {
     unitSystem?: UnitSystemKey;
 }
 
-// @public
+// @public @deprecated
 export interface FormatsMap {
     // (undocumented)
     [phenomenon: string]: UnitSystemFormat | UnitSystemFormat[];
@@ -1275,7 +1276,12 @@ export interface KindOfQuantityInfo {
 
 // @public
 export class KoqPropertyValueFormatter {
-    constructor(_schemaContext: SchemaContext, defaultFormats?: FormatsMap);
+    // @deprecated
+    constructor(schemaContext: SchemaContext, defaultFormats?: FormatsMap, formatsProvider?: FormatsProvider);
+    constructor(props: KoqPropertyValueFormatterProps);
+    // @internal (undocumented)
+    get defaultFormats(): FormatsMap | undefined;
+    set defaultFormats(value: FormatsMap | undefined);
     // (undocumented)
     format(value: number, options: FormatOptions): Promise<string | undefined>;
     // (undocumented)
@@ -2514,7 +2520,7 @@ export function traverseFieldHierarchy(hierarchy: FieldHierarchy, cb: (h: FieldH
 // @public
 export type TypeDescription = PrimitiveTypeDescription | ArrayTypeDescription | StructTypeDescription;
 
-// @public
+// @public @deprecated
 export interface UnitSystemFormat {
     // (undocumented)
     format: FormatProps;

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -290,6 +290,7 @@ export interface PresentationManagerProps {
     // @deprecated
     activeUnitSystem?: UnitSystemKey;
     clientId?: string;
+    // @deprecated
     defaultFormats?: FormatsMap;
     requestTimeout?: number;
     // @deprecated

--- a/common/api/summary/presentation-common.exports.csv
+++ b/common/api/summary/presentation-common.exports.csv
@@ -119,6 +119,7 @@ public;interface;FilterByTextHierarchyRequestOptions
 public;type;FilterByTextHierarchyRpcRequestOptions
 public;interface;FormatOptions
 public;interface;FormatsMap
+deprecated;interface;FormatsMap
 public;const;getInstancesCount
 public;interface;GroupingNodeKey
 public;interface;GroupingRule
@@ -339,6 +340,7 @@ public;function;traverseContentItem
 public;function;traverseFieldHierarchy
 public;type;TypeDescription
 public;interface;UnitSystemFormat
+deprecated;interface;UnitSystemFormat
 public;const;UPDATE_FULL
 public;interface;UpdateInfo
 public;type;Value

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -8,6 +8,7 @@ Table of contents:
 
 - [Electron 36 support](#electron-36-support)
 - [API deprecations](#api-deprecations)
+  - [@itwin/presentation-common](#itwinpresentation-common)
   - [@itwin/presentation-backend](#itwinpresentation-backend)
   - [@itwin/presentation-frontend](#itwinpresentation-frontend)
 
@@ -17,10 +18,16 @@ In addition to [already supported Electron versions](../learning/SupportedPlatfo
 
 ## API deprecations
 
+### @itwin/presentation-common
+
+- `UnitSystemFormat`, `FormatsMap` and `KoqPropertyValueFormatter` constructor using the latter type have been deprecated. Instead, the constructor overload with "props" object should be used. The props object allows passing an optional `FormatsProvider` to use for finding formatting props for different types of values. When not specified, the `SchemaFormatsProvider` is used by default, so the behavior stays the same as before. Ideally, it's expected that frontend apps will pass `IModelApp.formatsProvider` for this prop.
+
 ### @itwin/presentation-backend
 
 - The `PresentationManagerProps.schemaContextProvider` property has been deprecated. Starting with `5.0` release, `SchemaContext` is always available on [IModelDb]($core-backend), so this prop is no longer needed. If supplied, it will still be preferred over the iModel's schema context, until the property is removed completely in a future release.
+- The `PresentationManagerProps.defaultFormats` property has been deprecated in favor of the new `formatsProvider` property.
 
 ### @itwin/presentation-frontend
 
 - The `PresentationManagerProps.schemaContextProvider` property has been deprecated. Starting with `5.0` release, `SchemaContext` is always available on [IModelConnection]($core-frontend), so this prop is no longer needed. If supplied, it will still be preferred over the iModel's schema context, until the property is removed completely in a future release.
+- The `PresentationManagerProps.defaultFormats` property has been deprecated in favor of the `FormatsProvider` now being available on [IModelApp.formatsProvider]($core-frontend).

--- a/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
+++ b/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
@@ -147,6 +147,7 @@ describe("PresentationManager", () => {
           expect(await getAreaDisplayValue("usSurvey", defaultFormats)).to.eq("0.018 yrd² (US Survey)");
         });
 
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         async function getAreaDisplayValue(unitSystem: UnitSystemKey, defaultFormats?: FormatsMap): Promise<DisplayValue> {
           using manager = new PresentationManager({ defaultFormats, ...config });
           const descriptor = await manager.getContentDescriptor({

--- a/presentation/backend/src/presentation-backend/PresentationManager.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManager.ts
@@ -10,8 +10,8 @@ import { firstValueFrom } from "rxjs";
 import { eachValueFrom } from "rxjs-for-await";
 import { IModelDb } from "@itwin/core-backend";
 import { BeEvent, Id64Array } from "@itwin/core-bentley";
-import { UnitSystemKey } from "@itwin/core-quantity";
-import { SchemaContext } from "@itwin/ecschema-metadata";
+import { FormatsProvider, UnitSystemKey } from "@itwin/core-quantity";
+import { SchemaContext, SchemaFormatsProvider } from "@itwin/ecschema-metadata";
 import {
   UnitSystemFormat as CommonUnitSystemFormat,
   ComputeSelectionRequestOptions,
@@ -288,8 +288,17 @@ export interface PresentationManagerProps {
   /**
    * A map of default unit formats to use for formatting properties that don't have a presentation format
    * in requested unit system.
+   *
+   * @deprecated in 5.1. Use `formatsProvider` instead. Still used as a fallback if `formatsProvider` is not supplied.
    */
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   defaultFormats?: FormatsMap;
+
+  /**
+   * A custom formats provider to use for formatting property values with units. Defaults to [SchemaFormatsProvider]($core-quantity) if
+   * not supplied.
+   */
+  formatsProvider?: FormatsProvider;
 
   /**
    * A number of worker threads to use for handling presentation requests. Defaults to `2`.
@@ -511,8 +520,17 @@ export class PresentationManager {
   }
 
   private createContentFormatter({ imodel, unitSystem }: { imodel: IModelDb; unitSystem?: UnitSystemKey }): ContentFormatter {
-    const koqPropertyFormatter = new KoqPropertyValueFormatter(this._schemaContextProvider(imodel), this.props.defaultFormats);
-    return new ContentFormatter(new ContentPropertyValueFormatter(koqPropertyFormatter), unitSystem ?? this.props.defaultUnitSystem);
+    if (!unitSystem) {
+      unitSystem = this.props.defaultUnitSystem ?? "metric";
+    }
+    const schemaContext = this._schemaContextProvider(imodel);
+    const koqPropertyFormatter = new KoqPropertyValueFormatter({
+      schemaContext,
+      formatsProvider: this.props.formatsProvider ?? new SchemaFormatsProvider(schemaContext, unitSystem),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    koqPropertyFormatter.defaultFormats = this.props.defaultFormats;
+    return new ContentFormatter(new ContentPropertyValueFormatter(koqPropertyFormatter), unitSystem);
   }
 
   /**

--- a/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
+++ b/presentation/backend/src/presentation-backend/PresentationManagerDetail.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+
 import * as hash from "object-hash";
 import * as path from "path";
 import { IModelDb, IModelJsNative, IpcHost } from "@itwin/core-backend";
@@ -102,6 +103,7 @@ export class PresentationManagerDetail implements Disposable {
         params.workerThreadsCount ?? 2,
         IpcHost.isValid ? ipcUpdatesHandler : noopUpdatesHandler,
         params.caching,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         params.defaultFormats,
         params.useMmap,
       );
@@ -507,6 +509,7 @@ function createNativePlatform(
   workerThreadsCount: number,
   updateCallback: (updateInfo: UpdateInfo | undefined) => void,
   caching: PresentationManagerProps["caching"],
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   defaultFormats: FormatsMap | undefined,
   useMmap: boolean | number | undefined,
 ): NativePlatformDefinition {
@@ -544,6 +547,7 @@ function createNativePlatform(
     return directory ? path.resolve(directory) : "";
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   function toNativeUnitFormatsMap(map: FormatsMap | undefined): NativePresentationDefaultUnitFormats | undefined {
     if (!map) {
       return undefined;

--- a/presentation/common/src/presentation-common/AsyncTasks.ts
+++ b/presentation/common/src/presentation-common/AsyncTasks.ts
@@ -11,7 +11,7 @@ import { Guid, GuidString } from "@itwin/core-bentley";
 /**
  * A helper to track ongoing async tasks. Usage:
  * ```
- * { 
+ * {
  *   using _r = tracker.trackAsyncTask();
  *   await doSomethingAsync();
  * }

--- a/presentation/common/src/presentation-common/KoqPropertyValueFormatter.ts
+++ b/presentation/common/src/presentation-common/KoqPropertyValueFormatter.ts
@@ -6,24 +6,17 @@
  * @module Core
  */
 
-import { Format, FormatProps, FormatterSpec, ParserSpec, UnitsProvider, UnitSystemKey } from "@itwin/core-quantity";
-import {
-  getFormatProps,
-  InvertedUnit,
-  KindOfQuantity,
-  SchemaContext,
-  SchemaKey,
-  SchemaMatchType,
-  SchemaUnitProvider,
-  Unit,
-  UnitSystem,
-} from "@itwin/ecschema-metadata";
+import { assert, BeEvent } from "@itwin/core-bentley";
+import { Format, FormatProps, FormatsChangedArgs, FormatsProvider, FormatterSpec, ParserSpec, UnitsProvider, UnitSystemKey } from "@itwin/core-quantity";
+import { InvertedUnit, KindOfQuantity, SchemaContext, SchemaFormatsProvider, SchemaKey, SchemaMatchType, SchemaUnitProvider } from "@itwin/ecschema-metadata";
 
 /**
  * A data structure that associates unit systems with property value formatting props. The associations are used for
  * assigning formatting props for specific phenomenon and unit system combinations (see [[FormatsMap]]).
  *
  * @public
+ *
+ * @deprecated in 5.1. `FormatsMap` and related APIs have been deprecated in favor of [FormatsProvider]($core-quantity).
  */
 export interface UnitSystemFormat {
   unitSystems: UnitSystemKey[];
@@ -50,8 +43,11 @@ export interface UnitSystemFormat {
  * ```
  *
  * @public
+ *
+ * @deprecated in 5.1. `FormatsMap` and related APIs have been deprecated in favor of [FormatsProvider]($core-quantity).
  */
 export interface FormatsMap {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   [phenomenon: string]: UnitSystemFormat | UnitSystemFormat[];
 }
 
@@ -67,22 +63,57 @@ export interface FormatOptions {
 }
 
 /**
+ * Props for creating [[KoqPropertyValueFormatter]].
+ * @public
+ */
+interface KoqPropertyValueFormatterProps {
+  /** Schema context to use for locating units, formats, etc. Generally retrieved through the `schemaContext` getter on an iModel. */
+  schemaContext: SchemaContext;
+  /** Formats provider to use for finding formatting props. Defaults to [SchemaFormatsProvider]($ecschema-metadata) when not supplied. */
+  formatsProvider?: FormatsProvider;
+}
+
+/**
  * An utility for formatting property values based on `KindOfQuantity` and unit system.
  * @public
  */
 export class KoqPropertyValueFormatter {
+  private _schemaContext: SchemaContext;
   private _unitsProvider: UnitsProvider;
+  private _formatsProvider?: FormatsProvider;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   private _defaultFormats?: FormatsMap;
 
-  constructor(
-    private _schemaContext: SchemaContext,
-    defaultFormats?: FormatsMap,
-  ) {
-    this._unitsProvider = new SchemaUnitProvider(_schemaContext);
-    this._defaultFormats = defaultFormats
-      ? Object.entries(defaultFormats).reduce((acc, [phenomenon, unitSystemFormats]) => ({ ...acc, [phenomenon.toUpperCase()]: unitSystemFormats }), {})
-      : /* c8 ignore next */ undefined;
+  /** @deprecated in 5.1. Use the overload that takes a props object. */
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  constructor(schemaContext: SchemaContext, defaultFormats?: FormatsMap, formatsProvider?: FormatsProvider);
+  constructor(props: KoqPropertyValueFormatterProps);
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  constructor(schemaContextOrProps: SchemaContext | KoqPropertyValueFormatterProps, defaultFormats?: FormatsMap, formatsProvider?: FormatsProvider) {
+    if (schemaContextOrProps instanceof SchemaContext) {
+      this._schemaContext = schemaContextOrProps;
+      this._formatsProvider = formatsProvider;
+      this.defaultFormats = defaultFormats;
+    } else {
+      this._schemaContext = schemaContextOrProps.schemaContext;
+      this._formatsProvider = schemaContextOrProps.formatsProvider;
+    }
+    this._unitsProvider = new SchemaUnitProvider(this._schemaContext);
   }
+
+  /* c8 ignore start */
+  /** @internal */
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  public get defaultFormats(): FormatsMap | undefined {
+    return this._defaultFormats;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  public set defaultFormats(value: FormatsMap | undefined) {
+    this._defaultFormats = value
+      ? Object.entries(value).reduce((acc, [phenomenon, unitSystemFormats]) => ({ ...acc, [phenomenon.toUpperCase()]: unitSystemFormats }), {})
+      : undefined;
+  }
+  /* c8 ignore end */
 
   public async format(value: number, options: FormatOptions) {
     const formatterSpec = await this.getFormatterSpec(options);
@@ -93,7 +124,7 @@ export class KoqPropertyValueFormatter {
   }
 
   public async getFormatterSpec(options: FormatOptions) {
-    const formattingProps = await getFormattingProps(this._schemaContext, this._defaultFormats, options);
+    const formattingProps = await this.#getFormattingProps(options);
     if (!formattingProps) {
       return undefined;
     }
@@ -104,7 +135,7 @@ export class KoqPropertyValueFormatter {
   }
 
   public async getParserSpec(options: FormatOptions) {
-    const formattingProps = await getFormattingProps(this._schemaContext, this._defaultFormats, options);
+    const formattingProps = await this.#getFormattingProps(options);
     if (!formattingProps) {
       return undefined;
     }
@@ -113,37 +144,44 @@ export class KoqPropertyValueFormatter {
     const format = await Format.createFromJSON("", this._unitsProvider, formatProps);
     return ParserSpec.create(format, this._unitsProvider, persistenceUnit);
   }
+
+  async #getFormattingProps(options: FormatOptions): Promise<FormattingProps | undefined> {
+    const { koqName } = options;
+    const koq = await getKoq(this._schemaContext, koqName);
+    if (!koq) {
+      return undefined;
+    }
+    const persistenceUnit = await koq.persistenceUnit;
+    assert(!!persistenceUnit);
+
+    // default to metric as it's the persistence unit system
+    const unitSystem = options.unitSystem ?? "metric";
+
+    const formatsProvider = this._formatsProvider ?? new SchemaFormatsProvider(this._schemaContext, unitSystem);
+    const formatProps = await formatsProvider.getFormat(koqName);
+
+    // `SchemaFormatsProvider` will fall back to default presentation format, but we want to fall back
+    // to default formats' map first, and only then to the default presentation format. All of this can
+    // be removed with the removal of default formats map.
+    if (this._defaultFormats && (!formatProps || (await getUnitSystemKey(this._unitsProvider, formatProps)) !== unitSystem)) {
+      const defaultFormatsProvider = createFormatsProviderFromDefaultFormats(this._schemaContext, this._defaultFormats, unitSystem);
+      const defaultFormatProps = await defaultFormatsProvider.getFormat(koqName);
+      if (defaultFormatProps) {
+        return { formatProps: defaultFormatProps, persistenceUnitName: persistenceUnit.fullName };
+      }
+    }
+
+    if (formatProps) {
+      return { formatProps, persistenceUnitName: persistenceUnit.fullName };
+    }
+
+    return undefined;
+  }
 }
 
 interface FormattingProps {
   formatProps: FormatProps;
   persistenceUnitName: string;
-}
-
-async function getFormattingProps(
-  schemaLocater: SchemaContext,
-  defaultFormats: FormatsMap | undefined,
-  options: FormatOptions,
-): Promise<FormattingProps | undefined> {
-  const { koqName, unitSystem } = options;
-
-  const koq = await getKoq(schemaLocater, koqName);
-  if (!koq) {
-    return undefined;
-  }
-
-  const persistenceUnit = await koq.persistenceUnit;
-  /* c8 ignore next 3 */
-  if (!persistenceUnit) {
-    return undefined;
-  }
-
-  const formatProps = await getKoqFormatProps(koq, persistenceUnit, defaultFormats, unitSystem);
-  if (!formatProps) {
-    return undefined;
-  }
-
-  return { formatProps, persistenceUnitName: persistenceUnit.fullName };
 }
 
 async function getKoq(schemaLocater: SchemaContext, fullName: string) {
@@ -155,103 +193,56 @@ async function getKoq(schemaLocater: SchemaContext, fullName: string) {
   return schema.getItem(propKoqName, KindOfQuantity);
 }
 
-async function getKoqFormatProps(
-  koq: KindOfQuantity,
-  persistenceUnit: Unit | InvertedUnit,
-  defaultFormats: FormatsMap | undefined,
-  unitSystem?: UnitSystemKey,
-) {
-  const unitSystemMatchers = getUnitSystemGroupMatchers(unitSystem);
-  // use one of KOQ presentation format that matches requested unit system
-  const presentationFormat = await getKoqPresentationFormat(koq, unitSystemMatchers);
-  if (presentationFormat) {
-    return getFormatProps(presentationFormat);
+async function getUnitSystemKey(unitsProvider: UnitsProvider, formatProps: FormatProps): Promise<UnitSystemKey | undefined> {
+  const unitName = formatProps.composite?.units[0].name;
+  assert(!!unitName);
+  const unit = await unitsProvider.findUnitByName(unitName);
+  assert(!!unit);
+  const [_, unitSystemName] = unit.system.split(/[\.:]/);
+  switch (unitSystemName.toUpperCase()) {
+    case "METRIC":
+      return "metric";
+    case "IMPERIAL":
+      return "imperial";
+    case "USCUSTOM":
+      return "usCustomary";
+    case "USSURVEY":
+      return "usSurvey";
+    /* c8 ignore next 2 */
+    default:
+      return undefined;
   }
+}
 
-  // use one of the formats in default formats map if there is one for matching phenomena and requested unit
-  // system combination
-  if (defaultFormats && unitSystem) {
-    const actualPersistenceUnit = persistenceUnit instanceof InvertedUnit ? /* c8 ignore next */ await persistenceUnit.invertsUnit : persistenceUnit;
-    const phenomenon = await actualPersistenceUnit?.phenomenon;
-    if (phenomenon && defaultFormats[phenomenon.name.toUpperCase()]) {
-      const defaultPhenomenonFormats = defaultFormats[phenomenon.name.toUpperCase()];
-      for (const defaultUnitSystemFormat of Array.isArray(defaultPhenomenonFormats)
-        ? /* c8 ignore next */ defaultPhenomenonFormats
-        : [defaultPhenomenonFormats]) {
-        if (defaultUnitSystemFormat.unitSystems.includes(unitSystem)) {
-          return defaultUnitSystemFormat.format;
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+function createFormatsProviderFromDefaultFormats(schemaContext: SchemaContext, formatsMap: FormatsMap, unitSystem: UnitSystemKey): FormatsProvider {
+  return {
+    onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
+    getFormat: async (name: string) => {
+      const koq = await getKoq(schemaContext, name);
+      /* c8 ignore next 3 */
+      if (!koq) {
+        return undefined;
+      }
+
+      const persistenceUnit = await koq.persistenceUnit;
+      /* c8 ignore next 3 */
+      if (!persistenceUnit) {
+        return undefined;
+      }
+      const actualPersistenceUnit = persistenceUnit instanceof InvertedUnit ? /* c8 ignore next */ await persistenceUnit.invertsUnit : persistenceUnit;
+      const phenomenon = await actualPersistenceUnit?.phenomenon;
+      if (phenomenon && formatsMap[phenomenon.name.toUpperCase()]) {
+        const defaultPhenomenonFormats = formatsMap[phenomenon.name.toUpperCase()];
+        for (const defaultUnitSystemFormat of Array.isArray(defaultPhenomenonFormats)
+          ? /* c8 ignore next */ defaultPhenomenonFormats
+          : [defaultPhenomenonFormats]) {
+          if (defaultUnitSystemFormat.unitSystems.includes(unitSystem)) {
+            return defaultUnitSystemFormat.format;
+          }
         }
       }
-    }
-  }
-
-  // use persistence unit format if it matches requested unit system and matching presentation format was not found
-  const persistenceUnitSystem = await persistenceUnit.unitSystem;
-  if (persistenceUnitSystem && unitSystemMatchers.some((matcher) => matcher(persistenceUnitSystem))) {
-    return getPersistenceUnitFormatProps(persistenceUnit);
-  }
-
-  // use default presentation format if persistence unit does not match requested unit system
-  if (koq.defaultPresentationFormat) {
-    return getFormatProps(await koq.defaultPresentationFormat);
-  }
-
-  return undefined;
-}
-
-async function getKoqPresentationFormat(koq: KindOfQuantity, unitSystemMatchers: Array<(unitSystem: UnitSystem) => boolean>) {
-  const presentationFormats = koq.presentationFormats;
-  for (const matcher of unitSystemMatchers) {
-    for (const lazyFormat of presentationFormats) {
-      const format = await lazyFormat;
-      const lazyUnit = format.units && format.units[0][0];
-      /* c8 ignore next 3 */
-      if (!lazyUnit) {
-        continue;
-      }
-      const unit = await lazyUnit;
-      const currentUnitSystem = await unit.unitSystem;
-      if (currentUnitSystem && matcher(currentUnitSystem)) {
-        return format;
-      }
-    }
-  }
-  return undefined;
-}
-
-function getPersistenceUnitFormatProps(persistenceUnit: Unit | InvertedUnit): FormatProps {
-  // Same as Format "DefaultRealU" in Formats ecschema
-  return {
-    formatTraits: ["keepSingleZero", "keepDecimalPoint", "showUnitLabel"],
-    precision: 6,
-    type: "Decimal",
-    uomSeparator: " ",
-    decimalSeparator: ".",
-    composite: {
-      units: [
-        {
-          name: persistenceUnit.fullName,
-          label: persistenceUnit.label,
-        },
-      ],
+      return undefined;
     },
   };
-}
-
-function getUnitSystemGroupMatchers(groupKey?: UnitSystemKey) {
-  function createMatcher(name: string | string[]) {
-    const names = Array.isArray(name) ? name : [name];
-    return (unitSystem: UnitSystem) => names.some((n) => n === unitSystem.name.toUpperCase());
-  }
-  switch (groupKey) {
-    case "imperial":
-      return ["IMPERIAL", "USCUSTOM", "INTERNATIONAL", "FINANCE"].map(createMatcher);
-    case "metric":
-      return [["SI", "METRIC"], "INTERNATIONAL", "FINANCE"].map(createMatcher);
-    case "usCustomary":
-      return ["USCUSTOM", "INTERNATIONAL", "FINANCE"].map(createMatcher);
-    case "usSurvey":
-      return ["USSURVEY", "USCUSTOM", "INTERNATIONAL", "FINANCE"].map(createMatcher);
-  }
-  return [];
 }

--- a/presentation/common/src/test/KoqPropertyValueFormatter.test.ts
+++ b/presentation/common/src/test/KoqPropertyValueFormatter.test.ts
@@ -20,163 +20,224 @@ import { KoqPropertyValueFormatter } from "../presentation-common/KoqPropertyVal
 describe("KoqPropertyValueFormatter", () => {
   let formatter: KoqPropertyValueFormatter;
 
-  beforeEach(async () => {
-    const schemaContext = new SchemaContext();
-    await Schema.fromJson(schemaProps, schemaContext);
-    formatter = new KoqPropertyValueFormatter(schemaContext, {
-      [phenomenon.name!]: {
-        unitSystems: ["usSurvey"],
-        format: usSurveyFormat,
-      },
+  describe("with default props", () => {
+    beforeEach(async () => {
+      const schemaContext = new SchemaContext();
+      await Schema.fromJson(schemaProps, schemaContext);
+      formatter = new KoqPropertyValueFormatter({
+        schemaContext,
+      });
+    });
+
+    describe("getFormatterSpec", () => {
+      it("creates FormatterSpec", async () => {
+        const formatterSpec = await formatter.getFormatterSpec({
+          koqName: "TestSchema:TestKOQ",
+          unitSystem: "metric",
+        });
+        expect(formatterSpec).to.not.be.undefined;
+      });
+
+      it("returns undefined if schema is not found", async () => {
+        const formatterSpec = await formatter.getFormatterSpec({
+          koqName: "InvalidSchema:TestKOQ",
+          unitSystem: "metric",
+        });
+        expect(formatterSpec).to.be.undefined;
+      });
+
+      it("returns undefined if KOQ is not found", async () => {
+        const formatterSpec = await formatter.getFormatterSpec({
+          koqName: "TestSchema:InvalidKOQ",
+          unitSystem: "metric",
+        });
+        expect(formatterSpec).to.be.undefined;
+      });
+
+      it("returns undefined if KOQ does not have matching formats", async () => {
+        const formatterSpec = await formatter.getFormatterSpec({
+          koqName: "TestSchema:TestKOQNoPresentationUnit",
+          unitSystem: "imperial",
+        });
+        expect(formatterSpec).to.be.undefined;
+      });
+    });
+
+    describe("getParserSpec", () => {
+      it("creates ParserSpec", async () => {
+        const parserSpec = await formatter.getParserSpec({
+          koqName: "TestSchema:TestKOQ",
+          unitSystem: "metric",
+        });
+        expect(parserSpec).to.not.be.undefined;
+      });
+
+      it("returns undefined if schema is not found", async () => {
+        const parserSpec = await formatter.getParserSpec({
+          koqName: "InvalidSchema:TestKOQ",
+          unitSystem: "metric",
+        });
+        expect(parserSpec).to.be.undefined;
+      });
+
+      it("returns undefined if KOQ is not found", async () => {
+        const parserSpec = await formatter.getParserSpec({
+          koqName: "TestSchema:InvalidKOQ",
+          unitSystem: "metric",
+        });
+        expect(parserSpec).to.be.undefined;
+      });
+
+      it("returns undefined if KOQ does not have matching formats", async () => {
+        const parserSpec = await formatter.getParserSpec({
+          koqName: "TestSchema:TestKOQNoPresentationUnit",
+          unitSystem: "imperial",
+        });
+        expect(parserSpec).to.be.undefined;
+      });
+    });
+
+    describe("format", () => {
+      it("formats value using 'Metric' system", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKOQ",
+          unitSystem: "metric",
+        });
+        expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
+      });
+
+      it("formats value using 'Imperial' system", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKOQ",
+          unitSystem: "imperial",
+        });
+        expect(formatted).to.be.eq(`1,5 ${imperialUnit.label}`);
+      });
+
+      it("formats value using 'UsCustomary' system", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKOQ",
+          unitSystem: "usCustomary",
+        });
+        expect(formatted).to.be.eq(`1,5 ${usCustomUnit.label}`);
+      });
+
+      it("formats value using 'UsSurvey' system", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKOQ",
+          unitSystem: "usSurvey",
+        });
+        expect(formatted).to.be.eq(`1,5 ${usSurveyUnit.label}`);
+      });
+
+      // FIXME: Fails because `SchemaFormatsProvider` doesn't have these changes: https://github.com/iTwin/itwinjs-core/pull/6262
+      it.skip("formats value using 'Metric' system when KoQ supports metric and SI", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKoqMetricAndSi",
+          unitSystem: "metric",
+        });
+        expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
+      });
+
+      it("formats value using default format", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKOQOnlyMetric",
+          unitSystem: "imperial",
+        });
+        expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
+      });
+
+      it("formats value using persistence unit format if it matches unit system", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKOQNoPresentationUnit",
+          unitSystem: "metric",
+        });
+        expect(formatted).to.be.eq(`1.5 ${metricUnit.label}`);
+      });
+
+      it("formats value using default format if unit system is not provided", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:TestKOQ",
+        });
+        expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
+      });
+
+      it("returns `undefined` if format is not found", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: "TestSchema:InvalidKoq",
+          unitSystem: "imperial",
+        });
+        expect(formatted).to.be.undefined;
+      });
     });
   });
 
-  describe("getFormatterSpec", () => {
-    it("creates FormatterSpec", async () => {
-      const formatterSpec = await formatter.getFormatterSpec({
-        koqName: "TestSchema:TestKOQ",
-        unitSystem: "metric",
+  describe("with deprecated default formats map", () => {
+    beforeEach(async () => {
+      const defaultFormat: SchemaItemFormatProps = {
+        schemaItemType: SchemaItemType.Format,
+        name: "DefaultLengthFormat",
+        schema: "TestSchema",
+        type: "decimal",
+        decimalSeparator: ",",
+        formatTraits: ["ShowUnitLabel"],
+        composite: {
+          units: [{ name: `${siUnit.schema}.${siUnit.name}` }],
+          includeZero: true,
+          spacer: " ",
+        },
+      };
+      const schemaContext = new SchemaContext();
+      await Schema.fromJson(schemaProps, schemaContext);
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      formatter = new KoqPropertyValueFormatter(schemaContext, {
+        [phenomenon.name!]: {
+          unitSystems: ["usSurvey", "metric"],
+          format: defaultFormat,
+        },
       });
-      expect(formatterSpec).to.not.be.undefined;
     });
 
-    it("returns undefined if schema is not found", async () => {
-      const formatterSpec = await formatter.getFormatterSpec({
-        koqName: "InvalidSchema:TestKOQ",
-        unitSystem: "metric",
+    describe("format", () => {
+      it("formats `metric` koq value using format in default formats map", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: `${koqOnlyMetric.schema}:${koqOnlyMetric.name}`,
+          unitSystem: "usSurvey",
+        });
+        expect(formatted).to.be.eq(`1,5 ${siUnit.label}`);
       });
-      expect(formatterSpec).to.be.undefined;
-    });
 
-    it("returns undefined if KOQ is not found", async () => {
-      const formatterSpec = await formatter.getFormatterSpec({
-        koqName: "TestSchema:InvalidKOQ",
-        unitSystem: "metric",
+      it("formats `imperial` koq value using format in default formats map", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: `${koqOnlyImperial.schema}:${koqOnlyImperial.name}`,
+          unitSystem: "usSurvey",
+        });
+        expect(formatted).to.be.eq(`1,5 ${siUnit.label}`);
       });
-      expect(formatterSpec).to.be.undefined;
-    });
 
-    it("returns undefined if KOQ does not have matching formats", async () => {
-      const formatterSpec = await formatter.getFormatterSpec({
-        koqName: "TestSchema:TestKOQNoPresentationUnit",
-        unitSystem: "imperial",
+      it("formats `usCustomary` koq value using format in default formats map", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: `${koqOnlyUsCustomary.schema}:${koqOnlyUsCustomary.name}`,
+          unitSystem: "usSurvey",
+        });
+        expect(formatted).to.be.eq(`1,5 ${siUnit.label}`);
       });
-      expect(formatterSpec).to.be.undefined;
-    });
-  });
 
-  describe("getParserSpec", () => {
-    it("creates ParserSpec", async () => {
-      const parserSpec = await formatter.getParserSpec({
-        koqName: "TestSchema:TestKOQ",
-        unitSystem: "metric",
+      it("formats `usSurvey` koq value using format in default formats map", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: `${koqOnlyUsSurvey.schema}:${koqOnlyUsSurvey.name}`,
+          unitSystem: "metric",
+        });
+        expect(formatted).to.be.eq(`1,5 ${siUnit.label}`);
       });
-      expect(parserSpec).to.not.be.undefined;
-    });
 
-    it("returns undefined if schema is not found", async () => {
-      const parserSpec = await formatter.getParserSpec({
-        koqName: "InvalidSchema:TestKOQ",
-        unitSystem: "metric",
+      it("formats using default presentation format when format in default formats map is not found", async () => {
+        const formatted = await formatter.format(1.5, {
+          koqName: `${koqOnlyUsSurvey.schema}:${koqOnlyUsSurvey.name}`,
+          unitSystem: "imperial",
+        });
+        expect(formatted).to.be.eq(`1,5 ${usSurveyUnit.label}`);
       });
-      expect(parserSpec).to.be.undefined;
-    });
-
-    it("returns undefined if KOQ is not found", async () => {
-      const parserSpec = await formatter.getParserSpec({
-        koqName: "TestSchema:InvalidKOQ",
-        unitSystem: "metric",
-      });
-      expect(parserSpec).to.be.undefined;
-    });
-
-    it("returns undefined if KOQ does not have matching formats", async () => {
-      const parserSpec = await formatter.getParserSpec({
-        koqName: "TestSchema:TestKOQNoPresentationUnit",
-        unitSystem: "imperial",
-      });
-      expect(parserSpec).to.be.undefined;
-    });
-  });
-
-  describe("format", () => {
-    it("formats value using 'Metric' system", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQ",
-        unitSystem: "metric",
-      });
-      expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
-    });
-
-    it("formats value using 'Imperial' system", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQ",
-        unitSystem: "imperial",
-      });
-      expect(formatted).to.be.eq(`1,5 ${imperialUnit.label}`);
-    });
-
-    it("formats value using 'UsCustomary' system", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQ",
-        unitSystem: "usCustomary",
-      });
-      expect(formatted).to.be.eq(`1,5 ${usCustomUnit.label}`);
-    });
-
-    it("formats value using 'UsSurvey' system", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQ",
-        unitSystem: "usSurvey",
-      });
-      expect(formatted).to.be.eq(`1,5 ${usSurveyUnit.label}`);
-    });
-
-    it("formats value using 'Metric' system when KoQ supports metric and SI", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKoqMetricAndSi",
-        unitSystem: "metric",
-      });
-      expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
-    });
-
-    it("formats value format in default formats map", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQOnlyMetric",
-        unitSystem: "usSurvey",
-      });
-      expect(formatted).to.be.eq(`1,5 ${usSurveyUnit.label}`);
-    });
-
-    it("formats value using default format", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQOnlyMetric",
-        unitSystem: "imperial",
-      });
-      expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
-    });
-
-    it("formats value using persistence unit format if it matches unit system", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQNoPresentationUnit",
-        unitSystem: "metric",
-      });
-      expect(formatted).to.be.eq(`1.5 ${metricUnit.label}`);
-    });
-
-    it("formats value using default format if unit system is not provided", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:TestKOQ",
-      });
-      expect(formatted).to.be.eq(`1,5 ${metricUnit.label}`);
-    });
-
-    it("returns `undefined` if format is not found", async () => {
-      const formatted = await formatter.format(1.5, {
-        koqName: "TestSchema:InvalidKoq",
-        unitSystem: "imperial",
-      });
-      expect(formatted).to.be.undefined;
     });
   });
 });
@@ -354,6 +415,33 @@ const koq: KindOfQuantityProps = {
   presentationUnits: ["TestSchema.MetricFormat", "TestSchema.ImperialFormat", "TestSchema.UsSurveyFormat", "TestSchema.UsCustomFormat"],
 };
 
+const koqOnlyImperial: KindOfQuantityProps = {
+  schemaItemType: SchemaItemType.KindOfQuantity,
+  name: "TestKOQOnlyImperial",
+  schema: "TestSchema",
+  relativeError: 6,
+  persistenceUnit: `TestSchema.${imperialUnit.name}`,
+  presentationUnits: [`TestSchema.${imperialFormat.name}`],
+};
+
+const koqOnlyUsSurvey: KindOfQuantityProps = {
+  schemaItemType: SchemaItemType.KindOfQuantity,
+  name: "TestKOQOnlyUsSurvey",
+  schema: "TestSchema",
+  relativeError: 6,
+  persistenceUnit: `TestSchema.${usSurveyUnit.name}`,
+  presentationUnits: [`TestSchema.${usSurveyFormat.name}`],
+};
+
+const koqOnlyUsCustomary: KindOfQuantityProps = {
+  schemaItemType: SchemaItemType.KindOfQuantity,
+  name: "TestKOQOnlyUsCustomary",
+  schema: "TestSchema",
+  relativeError: 6,
+  persistenceUnit: `TestSchema.${usCustomUnit.name}`,
+  presentationUnits: [`TestSchema.${usCustomFormat.name}`],
+};
+
 const koqOnlyMetric: KindOfQuantityProps = {
   schemaItemType: SchemaItemType.KindOfQuantity,
   name: "TestKOQOnlyMetric",
@@ -403,6 +491,9 @@ const schemaProps: SchemaProps = {
     [usCustomFormat.name!]: usCustomFormat,
     [phenomenon.name!]: phenomenon,
     [koq.name!]: koq,
+    [koqOnlyImperial.name!]: koqOnlyImperial,
+    [koqOnlyUsCustomary.name!]: koqOnlyUsCustomary,
+    [koqOnlyUsSurvey.name!]: koqOnlyUsSurvey,
     [koqOnlyMetric.name!]: koqOnlyMetric,
     [koqMetricAndSi.name!]: koqMetricAndSi,
     [koqNoPresentationUnits.name!]: koqNoPresentationUnits,


### PR DESCRIPTION
Part of: https://github.com/iTwin/viewer-components-react/issues/1340

@aruniverse, this is based on your request to use the new formatting APIs in the properties widget. I'm targeting `master` branch here, do you think we need to backport these changes to 5.0?