### PR TITLE
disable flaky test

### DIFF
--- a/common/changes/@itwin/core-geometry/da4-flaky-test-announce-boundary-edges_2025-06-11-00-41.json
+++ b/common/changes/@itwin/core-geometry/da4-flaky-test-announce-boundary-edges_2025-06-11-00-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/test/polyface/PolyfaceQuery.test.ts
+++ b/core/geometry/src/test/polyface/PolyfaceQuery.test.ts
@@ -1535,7 +1535,8 @@ describe("PolyfaceSpeedup", () => {
       PolyfaceQuery.announceBoundaryEdges(mesh2, (_p0: any, _p1: any, i0: number, i1: number, a: number) => announce(i0, i1, a, edges1));
       const elapsedAnnounceWithTopo = timer.stop().milliseconds;
 
-      ck.testLE(elapsedAnnounceWithTopo, elapsedAnnounce, "topo cache speeds up announceBoundaryEdges");
+      if (GeometryCoreTestIO.enableLongTests) // on CI machine, topo cache can be 5-13x SLOWER oddly enough
+        ck.testLE(elapsedAnnounceWithTopo, elapsedAnnounce, "topo cache speeds up announceBoundaryEdges");
 
       ck.testExactNumber(edges0.size, edges1.size, "same number of announced edges");
       for (const edge of edges0)


### PR DESCRIPTION
Timing for this test can be off by as much as 5-13x in a CI build.  Never happens on a dev box.

Just disable the check for CI builds.
