### PR TITLE
remove extract api from native builds

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -134,8 +134,3 @@ steps:
   - script: node common/scripts/install-run-rush.js docs
     displayName: rush docs
     workingDirectory: ${{ parameters.workingDir }}
-
-  - script: node common/scripts/install-run-rush.js extract-api
-    displayName: rush extract-api
-    workingDirectory: ${{ parameters.workingDir }}
-    condition: ${{ parameters.nativePrVal }}


### PR DESCRIPTION
remove extract api check in native builds because it does not break addon, and extract api is checked during the core PR validation as a GH workflow