### PR TITLE
Allow Contour Lines on Section Drawings

### DIFF
--- a/core/frontend/src/internal/render/RenderPlan.ts
+++ b/core/frontend/src/internal/render/RenderPlan.ts
@@ -123,7 +123,7 @@ export function createRenderPlanFromViewport(vp: Viewport): RenderPlan {
   const ao = style.is3d() ? style.settings.ambientOcclusionSettings : undefined;
   const analysisStyle = style.settings.analysisStyle;
   const thematic = (style.is3d() && view.displayStyle.viewFlags.thematicDisplay) ? style.settings.thematic : undefined;
-  const contours = (style.is3d() && style.settings.contours.groups.length > 0) ? style.settings.contours : undefined;
+  const contours = (style.settings.contours.groups.length > 0) ? style.settings.contours : undefined;
   const shouldDisplayAtmosphere = (style.is3d() && GlobeMode.Ellipsoid === view.globeMode && vp.iModel.isGeoLocated && style.viewFlags.backgroundMap) ? (vp.view as ViewState3d).getDisplayStyle3d().environment.displayAtmosphere : false;
   const atmosphere = shouldDisplayAtmosphere ? (vp.view as ViewState3d).getDisplayStyle3d().environment.atmosphere : undefined;
 


### PR DESCRIPTION
This PR is to address this issue: https://github.com/iTwin/itwinjs-core/issues/8141

Currently, a SectionDrawing created from a Spatial View does not show the contour lines associated with the spatial view. This seems to be a two part problem.

1 - Currently contour lines are not able to be drawn at all on SectionDrawings as they are limited to 3D display styles only. This is fixed by removing the `is3d()` check in `createRenderPlanFromViewport`, and moving all contour logic from `DisplayStyle3dSettings` into `DisplayStyleSettings`. 


2 - While with the above changes a new group of contour lines can be added to an existing section drawing (see image below), when the SectionDrawing is created from a spatial view, the existing contour data is not passed along into the new SectionDrawing. 

For clarity, if a contour line group is defined with specific colors, line style, etc. on a spatial view, and then a SectionDrawing is created from that view, the resulting SectionDrawing has no defined contour groups. A new group can be defined to match the group defined in the spatial view, but it is not created with the SectionDrawing. It seems to me that the expected behavior would be that the contour data defined within the spatial view would be passed along into the SectionDrawing as it's created. 

This problem is still under investigation as to the best way to solve it, which is why this PR is still in draft.



Below is a previously impossible section drawing with a contour lines group defined.

![sectionWithContours](https://github.com/user-attachments/assets/928e1101-84d5-464b-afe8-b069496e1a5d)
 