### PR TITLE
replace sqlite3_interrupt() with sqlite3_progress_handler() to cancel query

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -615,8 +615,6 @@ export interface BaseReaderOptions {
     priority?: number;
     quota?: QueryQuota;
     restartToken?: string;
-    // @internal (undocumented)
-    testingArgs?: TestingArgs;
     usePrimaryConn?: boolean;
 }
 
@@ -2140,9 +2138,7 @@ export interface DbBlobResponse extends DbResponse {
 
 // @internal (undocumented)
 export interface DbQueryConfig {
-    allowTestingArgs?: boolean;
-    autoShutdowWhenIdlelForSeconds?: number;
-    // (undocumented)
+    autoShutdownWhenIdleForSeconds?: number;
     doNotUsePrimaryConnToPrepare?: boolean;
     // (undocumented)
     globalQuota?: QueryQuota;
@@ -2151,6 +2147,7 @@ export interface DbQueryConfig {
     memoryMapFileSize?: number;
     // (undocumented)
     monitorPollInterval?: number;
+    progressOpCount?: number;
     requestQueueSize?: number;
     statementCacheSizePerWorker?: number;
     workerThreads?: number;
@@ -2191,8 +2188,6 @@ export interface DbQueryResponse extends DbResponse {
 export interface DbRequest extends BaseReaderOptions {
     // (undocumented)
     kind?: DbRequestKind;
-    // (undocumented)
-    testingArgs?: TestingArgs;
 }
 
 // @internal (undocumented)
@@ -7544,8 +7539,6 @@ export class QueryOptionsBuilder {
     setRestartToken(val: string): this;
     setRowFormat(val: QueryRowFormat): this;
     setSuppressLogErrors(val: boolean): this;
-    // @internal
-    setTestingArgs(val: TestingArgs): this;
     setUsePrimaryConnection(val: boolean): this;
 }
 
@@ -9807,12 +9800,6 @@ export class TerrainSettings {
     readonly providerName: string;
     // (undocumented)
     toJSON(): TerrainProps;
-}
-
-// @internal (undocumented)
-export interface TestingArgs {
-    // (undocumented)
-    interrupt?: boolean;
 }
 
 // @internal

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -890,7 +890,6 @@ public;enum;SyncMode
 public;enum;TerrainHeightOriginMode
 public;interface;TerrainProps
 public;class;TerrainSettings
-internal;interface;TestingArgs
 internal;class;TestRpcManager
 beta;class;TextAnnotation
 public;interface;TextAnnotation2dProps

--- a/common/changes/@itwin/core-backend/affank-concurrent-query_2025-06-18-14-14.json
+++ b/common/changes/@itwin/core-backend/affank-concurrent-query_2025-06-18-14-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "add unit test for concurrent query",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/affank-concurrent-query_2025-06-18-14-14.json
+++ b/common/changes/@itwin/core-common/affank-concurrent-query_2025-06-18-14-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "remove unused parameters for concurrent query",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   ../../core/backend:
     dependencies:
       '@bentley/imodeljs-native':
-        specifier: 5.1.49
-        version: 5.1.49
+        specifier: 5.1.50
+        version: 5.1.50
       '@itwin/cloud-agnostic-core':
         specifier: ^2.2.4
         version: 2.2.4(inversify@6.0.1)(reflect-metadata@0.1.13)
@@ -4669,8 +4669,8 @@ packages:
   '@bentley/icons-generic@1.0.34':
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  '@bentley/imodeljs-native@5.1.49':
-    resolution: {integrity: sha512-ONwFR4pi9FI9NoGbHMijfRso3H+nNfbkgBziEyGMDhImIW4Z9N3ZH4FFzG4Ty1GTVF0by90dneuQX9U9VstxHw==}
+  '@bentley/imodeljs-native@5.1.50':
+    resolution: {integrity: sha512-oWkYM/NpcIXBZprazUz+dhvrMtGiqLhOs3D/CXgMmwxSoNCGsSyB0TAVjj2RBYF4DxpfPA4nFkKvZXDWMwvgLA==}
 
   '@bentley/linear-referencing-schema@2.0.3':
     resolution: {integrity: sha512-2pFIEN4BS7alIDhGous6N2icKAS8ZhVBfoWB8WvSFaYnneGv5YwbbXl46qATDdPO5jUFezkW6uVxdpp1eOgUHQ==}
@@ -11060,7 +11060,7 @@ snapshots:
 
   '@bentley/icons-generic@1.0.34': {}
 
-  '@bentley/imodeljs-native@5.1.49': {}
+  '@bentley/imodeljs-native@5.1.50': {}
 
   '@bentley/linear-referencing-schema@2.0.3': {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -106,7 +106,7 @@
     "webpack": "^5.97.1"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "5.1.49",
+    "@bentley/imodeljs-native": "5.1.50",
     "@itwin/cloud-agnostic-core": "^2.2.4",
     "@itwin/object-storage-azure": "^2.3.0",
     "@itwin/object-storage-core": "^2.3.0",

--- a/core/backend/src/test/ecdb/ConcurrentQuery.test.ts
+++ b/core/backend/src/test/ecdb/ConcurrentQuery.test.ts
@@ -11,7 +11,7 @@ async function delay(ms: number): Promise<void> {
   });
 }
 
-describe.only("ConcurrentQuery", () => {
+describe("ConcurrentQuery", () => {
   it("default config", () => {
     const testFile = IModelTestUtils.resolveAssetFile("test.bim");
     const db = SnapshotDb.openFile(testFile);

--- a/core/backend/src/test/ecdb/ConcurrentQuery.test.ts
+++ b/core/backend/src/test/ecdb/ConcurrentQuery.test.ts
@@ -69,7 +69,7 @@ describe("ConcurrentQuery", () => {
     expect(resp.status).equals(DbResponseStatus.Partial);
     expect(resp.stats.timeLimit).equals(1000);
     expect(resp.stats.memLimit).equals(100000);
-    expect(resp.stats.cpuTime).to.be.closeTo(1000970, 10000);
+    expect(resp.stats.cpuTime).to.be.closeTo(1000970, 500000);
     expect(resp.stats.totalTime).to.be.closeTo(1001, 100);
     expect(resp.stats.memUsed).to.be.closeTo(2, 3);
     expect(resp.stats.prepareTime).to.be.closeTo(0, 2);

--- a/core/backend/src/test/ecdb/ConcurrentQuery.test.ts
+++ b/core/backend/src/test/ecdb/ConcurrentQuery.test.ts
@@ -1,0 +1,179 @@
+import { DbQueryRequest, DbQueryResponse, DbResponseStatus } from "@itwin/core-common";
+import { expect } from "chai";
+import { ConcurrentQuery } from "../../ConcurrentQuery";
+import { SnapshotDb } from "../../IModelDb";
+import { _nativeDb } from "../../core-backend";
+import { IModelTestUtils } from "../IModelTestUtils";
+
+async function delay(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+describe.only("ConcurrentQuery", () => {
+  it("default config", () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    const defaultConfig = {
+      autoShutdownWhenIdleForSeconds: 1800,
+      doNotUsePrimaryConnToPrepare: false,
+      globalQuota: { time: 60, memory: 8388608 },
+      ignoreDelay: true,
+      ignorePriority: false,
+      memoryMapFileSize: 0,
+      monitorPollInterval: 5000,
+      progressOpCount: 5000,
+      requestQueueSize: 2000,
+      statementCacheSizePerWorker: 40,
+      workerThreads: 4,
+    };
+    const config = ConcurrentQuery.resetConfig(db[_nativeDb], {});
+    expect(config).deep.eq(defaultConfig);
+    db.close();
+  });
+
+  it("modify config", () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    const modifiedConfig = {
+      autoShutdownWhenIdleForSeconds: 100,
+      doNotUsePrimaryConnToPrepare: true,
+      globalQuota: { time: 10, memory: 1000000 },
+      ignoreDelay: false,
+      ignorePriority: true,
+      memoryMapFileSize: 100,
+      monitorPollInterval: 2000,
+      progressOpCount: 6000,
+      requestQueueSize: 1000,
+      statementCacheSizePerWorker: 20,
+      workerThreads: 3,
+    };
+    const config = ConcurrentQuery.resetConfig(db[_nativeDb], modifiedConfig);
+    expect(config).deep.eq(modifiedConfig);
+    db.close();
+  });
+
+  it("time limit check", async () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    ConcurrentQuery.resetConfig(db[_nativeDb], { globalQuota: { time: 1, memory: 100000 }, progressOpCount: 1000 });
+    // await runSingleRequest(db, `SELECT 1`);
+    const req: DbQueryRequest = {
+      query: `WITH sequence(n,k) AS (
+                SELECT  1,1 UNION ALL SELECT n + 1, random() FROM sequence WHERE n < 10000000
+              ) SELECT COUNT(*) FROM sequence s`
+    };
+
+    const resp = await ConcurrentQuery.executeQueryRequest(db[_nativeDb], req);
+    expect(resp.status).equals(DbResponseStatus.Partial);
+    expect(resp.stats.timeLimit).equals(1000);
+    expect(resp.stats.memLimit).equals(100000);
+    expect(resp.stats.cpuTime).to.be.closeTo(1000970, 10000);
+    expect(resp.stats.totalTime).to.be.closeTo(1001, 100);
+    expect(resp.stats.memUsed).to.be.closeTo(2, 3);
+    expect(resp.stats.prepareTime).to.be.closeTo(0, 2);
+    db.close();
+  });
+
+  it("memory limit check", async () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    ConcurrentQuery.resetConfig(db[_nativeDb], { globalQuota: { time: 60, memory: 1000 }, progressOpCount: 1000 });
+    // await runSingleRequest(db, `SELECT 1`);
+    const req: DbQueryRequest = {
+      query: `WITH sequence(n) AS (
+                SELECT  1
+                UNION ALL
+                SELECT n + 1 FROM sequence WHERE n < 10000000
+              )
+              SELECT 'xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx' FROM sequence s`
+    };
+
+    const resp = await ConcurrentQuery.executeQueryRequest(db[_nativeDb], req);
+    expect(resp.status).equals(DbResponseStatus.Partial);
+    expect(resp.stats.timeLimit).equals(60000);
+    expect(resp.stats.memLimit).equals(1000);
+    expect(resp.stats.memUsed).to.be.closeTo(1037, 100);
+    db.close();
+  });
+
+  it("prepare error", async () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    const req: DbQueryRequest = {
+      query: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+    };
+
+    const resp = await ConcurrentQuery.executeQueryRequest(db[_nativeDb], req);
+    expect(resp.status).equals(DbResponseStatus.Error_ECSql_PreparedFailed);
+    db.close();
+  });
+
+  it("restart query", async () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    ConcurrentQuery.resetConfig(db[_nativeDb], { globalQuota: { time: 60, memory: 10000000 }, progressOpCount: 1000 });
+    const req0: DbQueryRequest = {
+      query: `WITH sequence(n) AS (
+                SELECT  1 UNION ALL SELECT n + 1 FROM sequence WHERE n < 10000000
+              ) SELECT n FROM sequence s`,
+      restartToken: "Blah",
+    };
+
+    const req1: DbQueryRequest = {
+      query: `WITH sequence(n) AS (
+                SELECT  1 UNION ALL SELECT n + 1 FROM sequence WHERE n < 1000
+              ) SELECT n FROM sequence s`,
+      restartToken: "Blah",
+    };
+
+    const resp1 = ConcurrentQuery.executeQueryRequest(db[_nativeDb], req0);
+    await delay(1);
+    const resp2 = ConcurrentQuery.executeQueryRequest(db[_nativeDb], req1);
+    const resp = await Promise.all([resp1, resp2]);
+    expect(resp[0].status).equals(DbResponseStatus.Cancel);
+    expect(resp[1].status).equals(DbResponseStatus.Done);
+    db.close();
+  });
+
+  it("queue limit check", async () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    ConcurrentQuery.resetConfig(db[_nativeDb], { requestQueueSize: 40, globalQuota: { time: 5, memory: 100000 } });
+    const req: DbQueryRequest = {
+      query: `WITH sequence(n) AS (
+                SELECT  1 UNION ALL SELECT n + 1 FROM sequence WHERE n < 10000000
+              ) SELECT n FROM sequence s`,
+    };
+
+    const responsePromises: Promise<DbQueryResponse>[] = [];
+    for (let i = 0; i < 60; ++i) {
+      responsePromises.push(ConcurrentQuery.executeQueryRequest(db[_nativeDb], req));
+    }
+    const responses = await Promise.all(responsePromises);
+    const queueResponses = Array.from(responses.filter((x) => x.status === DbResponseStatus.QueueFull));
+    expect(queueResponses.length).to.be.greaterThanOrEqual(10);
+    db.close();
+  });
+
+  it("timeout check", async () => {
+    const testFile = IModelTestUtils.resolveAssetFile("test.bim");
+    const db = SnapshotDb.openFile(testFile);
+    ConcurrentQuery.resetConfig(db[_nativeDb], { monitorPollInterval: 1, globalQuota: { time: 5, memory: 10000000 } });
+    const req: DbQueryRequest = {
+      query: `WITH sequence(n) AS (
+                SELECT  1 UNION ALL SELECT n + 1 FROM sequence WHERE n < 10000000
+              ) SELECT n FROM sequence s`,
+    };
+
+    const responsePromises: Promise<DbQueryResponse>[] = [];
+    for (let i = 0; i < 100; ++i) {
+      responsePromises.push(ConcurrentQuery.executeQueryRequest(db[_nativeDb], req));
+    }
+    const responses = await Promise.all(responsePromises);
+    const queueResponses = Array.from(responses.filter((x) => x.status === DbResponseStatus.Timeout));
+    expect(queueResponses.length).to.be.greaterThanOrEqual(10);
+    db.close();
+  });
+});

--- a/core/backend/src/test/ecdb/ECSqlQuery.test.ts
+++ b/core/backend/src/test/ecdb/ECSqlQuery.test.ts
@@ -389,60 +389,6 @@ describe("ECSql Query", () => {
       assert.isTrue(hasRow, "imodel1.query() must return latest one row");
     }
   });
-  // new new addon build
-  it("ecsql interrupt check", async () => {
-    let cancelled = 0;
-    let successful = 0;
-    let rowCount = 0;
-    try {
-      ConcurrentQuery.shutdown(imodel1[_nativeDb]);
-      ConcurrentQuery.resetConfig(imodel1[_nativeDb], { allowTestingArgs: true });
-      const scheduleQuery = async () => {
-        return new Promise<void>(async (resolve, reject) => {
-          try {
-            const options = new QueryOptionsBuilder();
-            options.setTestingArgs({ interrupt: true });
-            options.setDelay(1000);
-            const reader = imodel1.createQueryReader(`
-              WITH sequence(n) AS (
-                SELECT  1
-                UNION ALL
-                SELECT n + 1 FROM sequence WHERE n < 10000
-              )
-              SELECT  COUNT(*)
-              FROM bis.SpatialIndex i, sequence s`, undefined, options.getOptions());
-            while (await reader.step()) {
-              rowCount++;
-            }
-            successful++;
-            resolve();
-          } catch (err: any) {
-            // we expect query to be cancelled
-            if (err.errorNumber === DbResult.BE_SQLITE_INTERRUPT) {
-              cancelled++;
-              resolve();
-            } else {
-              reject(new Error("rejected"));
-            }
-          }
-        });
-      };
-
-      const queries = [];
-      for (let i = 0; i < 100; i++) {
-        queries.push(scheduleQuery());
-      }
-
-      await Promise.all(queries);
-      // We expect at least one query to be cancelled
-      assert.equal(successful, 100, "success should be 100");
-      assert.equal(rowCount, 100, "expect 100 rows");
-      assert.isAtLeast(cancelled, 0, "should not have any cancelled query");
-    } finally {
-      ConcurrentQuery.shutdown(imodel1[_nativeDb]);
-      ConcurrentQuery.resetConfig(imodel1[_nativeDb]);
-    }
-  });
   it("check prepare logErrors flag", () => {
     const ecdb = imodel1;
     // expect log message when statement fails

--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -27,7 +27,7 @@ export enum QueryRowFormat {
   UseECSqlPropertyIndexes,
   /** Each row is an object in which each non-null column value can be accessed by a [remapped property name]($docs/learning/ECSqlRowFormat.md).
    * This format is backwards-compatible with the format produced by iTwin.js 2.x. Null values are omitted.
-   * @depreacted in 4.11.  Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
+   * @deprecated in 4.11.  Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
    */
   UseJsPropertyNames,
 }
@@ -116,10 +116,6 @@ export interface BaseReaderOptions {
    * concurrent query is configure to honour it.
    */
   delay?: number;
-  /**
-   * @internal
-   */
-  testingArgs?: TestingArgs;
 }
 
 /**
@@ -258,16 +254,6 @@ export class QueryOptionsBuilder {
    */
   public setDelay(val: number) {
     this._options.delay = val;
-    return this;
-  }
-  /**
- * @internal
- * Use for testing internal logic. This parameter is ignored by default unless concurrent query is configure to not ignore it.
- * @param val Testing arguments.
- * @returns @type QueryOptionsBuilder for fluent interface.
- */
-  public setTestingArgs(val: TestingArgs) {
-    this._options.testingArgs = val;
     return this;
   }
 }
@@ -693,11 +679,6 @@ export enum DbResponseStatus {
 }
 
 /** @internal */
-export interface TestingArgs {
-  interrupt?: boolean
-}
-
-/** @internal */
 export enum DbValueFormat {
   ECSqlNames = 0,
   JsNames = 1
@@ -706,7 +687,6 @@ export enum DbValueFormat {
 /** @internal */
 export interface DbRequest extends BaseReaderOptions {
   kind?: DbRequestKind;
-  testingArgs?: TestingArgs
 }
 
 /** @internal */
@@ -775,15 +755,16 @@ export interface DbQueryConfig {
   requestQueueSize?: number;
   /** Number of worker thread, default to 4 */
   workerThreads?: number;
+  /** Use thread connection to prepare the statement */
   doNotUsePrimaryConnToPrepare?: boolean;
-  /** After no activity for given time concurrenty query will automatically shutdown */
-  autoShutdowWhenIdlelForSeconds?: number;
+  /** After no activity for given time concurrent query will automatically shutdown */
+  autoShutdownWhenIdleForSeconds?: number;
   /** Maximum number of statement cache per worker. Default to 40 */
   statementCacheSizePerWorker?: number;
-  /* Monitor poll interval in milliseconds. Its responsable for cancelling queries that pass quota. It can be set between 1000 and Max time quota for query */
+  /* Monitor poll interval in milliseconds. Its responsible for cancelling queries that pass quota. It can be set between 1000 and Max time quota for query */
   monitorPollInterval?: number;
   /** Set memory map io for each worker connection size in bytes. Default to zero mean do not use mmap io */
   memoryMapFileSize?: number;
-  /** Used by test to simulate certain test cases. Its is false by default. */
-  allowTestingArgs?: boolean;
+  /** How often to measure progress of a running ECSql statement which is used to enforced time limit */
+  progressOpCount?: number;
 }

--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -27,7 +27,7 @@ export enum QueryRowFormat {
   UseECSqlPropertyIndexes,
   /** Each row is an object in which each non-null column value can be accessed by a [remapped property name]($docs/learning/ECSqlRowFormat.md).
    * This format is backwards-compatible with the format produced by iTwin.js 2.x. Null values are omitted.
-   * @deprecated in 4.11.  Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
+   * @depreacted in 4.11.  Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
    */
   UseJsPropertyNames,
 }

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:5.1.49'
+    implementation 'com.github.itwin:mobile-native-android:5.1.50'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.1.49;
+				version = 5.1.50;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.1.49;
+				version = 5.1.50;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/1156

his PR addresses a stability issue reported by users involving concurrent queries, where `SQLITE_INTERRUPT` is returned and the backend enters a failure loop, causing all subsequent queries to fail with the same error. This typically occurs with large, long-running queries.

**Why switch API:**

- `sqlite3_interrupt()` must be called from a separate thread. It interrupts the currently executing statement, but the exact timing is unpredictable. This can lead to unintended behavior, such as interrupting a different statement than the one originally targeted.
  
- On the other hand, `sqlite3_progress_handler()` allows cancellation from within the same thread. Its timing can be precisely controlled within the scope of the specific statement we intend to cancel—especially useful when enforcing time limits.

- The monitor thread no longer interrupts active queries. Instead, it now only cancels queries that are still in the queue. As a result, concurrent queries should no longer return `SQLITE_INTERRUPT` errors to the caller. This change also improves performance, as the monitor thread no longer needs to acquire a mutex lock to access the connection that cause request queue to block every time monitor thread wakes.
 
In general, `sqlite3_interrupt()` is riskier. When one thread calls `interrupt()` on a connection used by another thread, there's a chance the original statement has already completed, and a new one is being executed or prepared. This can lead to flaky and inconsistent behavior in the backend.

**Todo** 
- [x] Perform stress test
- [x] Add new test for query limit and errors