### PR TITLE
Fix OrbitGT point cloud rendering

### DIFF
--- a/common/changes/@itwin/core-frontend/markschlosser-fix-orbitgt-layerhandler_2025-06-24-17-27.json
+++ b/common/changes/@itwin/core-frontend/markschlosser-fix-orbitgt-layerhandler_2025-06-24-17-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/internal/tile/OrbitGtTileTree.ts
+++ b/core/frontend/src/internal/tile/OrbitGtTileTree.ts
@@ -30,6 +30,8 @@ import { RenderSystem } from "../../render/RenderSystem";
 import { ViewingSpace } from "../../ViewingSpace";
 import { Viewport } from "../../Viewport";
 import {
+  LayerTileTreeHandler,
+  MapLayerTreeSetting,
   RealityModelTileTree, Tile, TileContent, TileDrawArgs, TileLoadPriority, TileParams, TileRequest, TileTree, TileTreeOwner,
   TileTreeParams, TileTreeSupplier, TileUsageMarker,
 } from "../../tile/internal";
@@ -226,9 +228,15 @@ export class OrbitGtTileTree extends TileTree {
   public rootTile: OrbitGtRootTile;
   public viewFlagOverrides: ViewFlagOverrides = {};
   private _tileGraphics = new Map<string, OrbitGtTileGraphic>();
+  private readonly _layerHandler: LayerTileTreeHandler;
+  public layerImageryTrees: MapLayerTreeSetting[] = [];
+
+  public override get layerHandler() { return this._layerHandler; }
 
   public constructor(treeParams: TileTreeParams, private _dataManager: OrbitGtDataManager, cloudRange: Range3d, private _centerOffset: Vector3d, private _ecefTransform: Transform) {
     super(treeParams);
+
+    this._layerHandler = new LayerTileTreeHandler(this);
 
     this._tileParams = { contentId: "0", range: cloudRange, maximumSize: 256 };
     this.rootTile = new OrbitGtRootTile(this._tileParams, this);


### PR DESCRIPTION
https://github.com/iTwin/itwinjs-core/pull/7637 inadvertently broke OrbitGT point cloud rendering.

It did this by not including the new `layerHandler` getter on the `OrbitGTTileTree` implementation of `TileTree`. Because an `OrbitGTTileTree` will get loaded from places like `RealityModelTileTree.ts`, the adding of its geometry to the scene would get skipped in [the code here](https://github.com/iTwin/itwinjs-core/blob/e8e1889a9991c921c5d16db685ab35c8df07efc0/core/frontend/src/internal/tile/RealityModelTileTree.ts#L671).

To resolve this, this PR makes `OrbitGtTileTree` implement the `layerHandler` getter so it will pass the above check and get successfully loaded in the draping re-architecture of reality model tile trees.

`OrbitGtTileTree` will still not support actual draping.