### PR TITLE
Add changeset ID verification before pushing

### DIFF
--- a/common/changes/@itwin/core-backend/affank-check-changeset-id_2025-06-25-13-18.json
+++ b/common/changes/@itwin/core-backend/affank-check-changeset-id_2025-06-25-13-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "verify changeset id before pushing",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -10,7 +10,7 @@
 
 import * as path from "path";
 import {
-  AccessToken, BeDuration, ChangeSetStatus, GuidString, IModelHubStatus, IModelStatus, Logger, OpenMode, Optional, StopWatch,
+  AccessToken, BeDuration, ChangeSetStatus, DbResult, GuidString, IModelHubStatus, IModelStatus, Logger, OpenMode, Optional, StopWatch
 } from "@itwin/core-bentley";
 import {
   BriefcaseId, BriefcaseIdValue, BriefcaseProps, ChangesetFileProps, ChangesetIndex, ChangesetIndexOrId, ChangesetProps, ChangesetRange, ChangesetType, IModelError, IModelVersion, LocalBriefcaseProps,
@@ -611,8 +611,7 @@ export class BriefcaseManager {
     changesetProps.size = fileSize;
     const id = IModelNative.platform.DgnDb.computeChangesetId(changesetProps);
     if (id !== changesetProps.id) {
-      Logger.logWarning(loggerCategory, `Changeset id ${changesetProps.id} does not match computed id ${id}.`);
-      changesetProps.id = id;
+      throw new IModelError(DbResult.BE_SQLITE_ERROR_InvalidChangeSetVersion, `Changeset id ${changesetProps.id} does not match computed id ${id}.`);
     }
 
     let retryCount = arg.pushRetryCount ?? 3;

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -611,7 +611,7 @@ export class BriefcaseManager {
     changesetProps.size = fileSize;
     const id = IModelNative.platform.DgnDb.computeChangesetId(changesetProps);
     if (id !== changesetProps.id) {
-      Logger.logWarning(loggerCategory, `Changeset id ${changesetProps.id} does not match computed id ${id}. Using computed id.`);
+      Logger.logWarning(loggerCategory, `Changeset id ${changesetProps.id} does not match computed id ${id}.`);
       changesetProps.id = id;
     }
 

--- a/core/backend/src/BriefcaseManager.ts
+++ b/core/backend/src/BriefcaseManager.ts
@@ -609,6 +609,11 @@ export class BriefcaseManager {
       throw new IModelError(IModelStatus.NoContent, "error creating changeset");
 
     changesetProps.size = fileSize;
+    const id = IModelNative.platform.DgnDb.computeChangesetId(changesetProps);
+    if (id !== changesetProps.id) {
+      Logger.logWarning(loggerCategory, `Changeset id ${changesetProps.id} does not match computed id ${id}. Using computed id.`);
+      changesetProps.id = id;
+    }
 
     let retryCount = arg.pushRetryCount ?? 3;
     while (true) {


### PR DESCRIPTION
Introduce a validation step to verify the changeset ID before pushing, ensuring the consistency and accuracy of the changeset data.

This update addresses a customer-reported issue where the changeset ID sent to the hub was not the actual SHA1 hash of the changeset file. Although the issue could not be reproduced, this safeguard helps prevent similar inconsistencies in the future.
