### PR TITLE
Fix IModelDb coordinate conversions

### DIFF
--- a/common/changes/@itwin/core-backend/pmc-empty-geocoord-array_2025-07-07-13-21.json
+++ b/common/changes/@itwin/core-backend/pmc-empty-geocoord-array_2025-07-07-13-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fix IModelDb coordinate conversion results to include `fromCache` and also the point array if input point array was empty.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1466,12 +1466,18 @@ export abstract class IModelDb extends IModel {
 
   /** Get the IModel coordinate corresponding to each GeoCoordinate point in the input */
   public async getIModelCoordinatesFromGeoCoordinates(props: IModelCoordinatesRequestProps): Promise<IModelCoordinatesResponseProps> {
-    return this[_nativeDb].getIModelCoordinatesFromGeoCoordinates(props);
+    const response = this[_nativeDb].getIModelCoordinatesFromGeoCoordinates(props);
+    response.fromCache = 0;
+    response.iModelCoords = response.iModelCoords ?? [];
+    return response;
   }
 
   /** Get the GeoCoordinate (longitude, latitude, elevation) corresponding to each IModel Coordinate point in the input */
   public async getGeoCoordinatesFromIModelCoordinates(props: GeoCoordinatesRequestProps): Promise<GeoCoordinatesResponseProps> {
-    return this[_nativeDb].getGeoCoordinatesFromIModelCoordinates(props);
+    const response = this[_nativeDb].getGeoCoordinatesFromIModelCoordinates(props);
+    response.fromCache = 0;
+    response.geoCoords = response.geoCoords ?? [];
+    return response;
   }
 
   /** Export meshes suitable for graphics APIs from arbitrary geometry in elements in this IModelDb.

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1467,7 +1467,10 @@ export abstract class IModelDb extends IModel {
   /** Get the IModel coordinate corresponding to each GeoCoordinate point in the input */
   public async getIModelCoordinatesFromGeoCoordinates(props: IModelCoordinatesRequestProps): Promise<IModelCoordinatesResponseProps> {
     const response = this[_nativeDb].getIModelCoordinatesFromGeoCoordinates(props);
+
+    // fromCache is only meaningful on the front-end; provide it for compatibility with return type.
     response.fromCache = 0;
+    // Native omits the array if the input was empty.
     response.iModelCoords = response.iModelCoords ?? [];
     return response;
   }
@@ -1475,7 +1478,10 @@ export abstract class IModelDb extends IModel {
   /** Get the GeoCoordinate (longitude, latitude, elevation) corresponding to each IModel Coordinate point in the input */
   public async getGeoCoordinatesFromIModelCoordinates(props: GeoCoordinatesRequestProps): Promise<GeoCoordinatesResponseProps> {
     const response = this[_nativeDb].getGeoCoordinatesFromIModelCoordinates(props);
+
+    // fromCache is only meaningful on the front-end; provide it for compatibility with return type.
     response.fromCache = 0;
+    // Native omits the array if the input was empty.
     response.geoCoords = response.geoCoords ?? [];
     return response;
   }

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1789,7 +1789,7 @@ describe("iModel", () => {
   });
 
   describe("async coordinate conversions", () => {
-    it.only("should output same number of points as input", async () => {
+    it("should output same number of points as input", async () => {
       const iModelCoords: Point3d[] = [];
       const geoCoords: Point3d[] = [];
       for (let numPts = 0; numPts < 3; numPts++) {
@@ -1804,7 +1804,7 @@ describe("iModel", () => {
       }
     });
 
-    it.only("should always have fromCache = 0", async () => {
+    it("should always have fromCache = 0", async () => {
       const iModelCoords: Point3d[] = [];
       const geoCoords: Point3d[] = [];
       for (let numPts = 0; numPts < 3; numPts++) {

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1788,6 +1788,39 @@ describe("iModel", () => {
     iModel2.close();
   });
 
+  describe("async coordinate conversions", () => {
+    it.only("should output same number of points as input", async () => {
+      const iModelCoords: Point3d[] = [];
+      const geoCoords: Point3d[] = [];
+      for (let numPts = 0; numPts < 3; numPts++) {
+        const geoResponse = await imodel5.getGeoCoordinatesFromIModelCoordinates({ target: "WGS84", iModelCoords });
+        expect(geoResponse.geoCoords.length).to.equal(numPts);
+        
+        const iModelResponse = await imodel5.getIModelCoordinatesFromGeoCoordinates({ source: "WGS84", geoCoords });
+        expect(iModelResponse.iModelCoords.length).to.equal(numPts);
+        
+        iModelCoords.push(new Point3d());
+        geoCoords.push(new Point3d());
+      }
+    });
+
+    it.only("should always have fromCache = 0", async () => {
+      const iModelCoords: Point3d[] = [];
+      const geoCoords: Point3d[] = [];
+      for (let numPts = 0; numPts < 3; numPts++) {
+        const geoResponse = await imodel5.getGeoCoordinatesFromIModelCoordinates({ target: "WGS84", iModelCoords });
+        expect(geoResponse.fromCache).to.equal(0);
+        
+        const iModelResponse = await imodel5.getIModelCoordinatesFromGeoCoordinates({ source: "WGS84", geoCoords });
+        expect(iModelResponse.iModelCoords.length).to.equal(numPts);
+        expect(iModelResponse.fromCache).to.equal(0);
+        
+        iModelCoords.push(new Point3d());
+        geoCoords.push(new Point3d());
+      }
+    });
+  });
+
   if (!ProcessDetector.isIOSAppBackend) {
     it("should be able to reproject with iModel coordinates to or from any other GeographicCRS", async () => {
       const convertTest = async (fileName: string, fileGCS: GeographicCRSProps, datum: string | GeographicCRSProps, inputCoord: XYZProps, outputCoord: PointWithStatus) => {


### PR DESCRIPTION
Fixes #8301.

These two functions were clearly written to serve the RPC interface, not as standalone APIs. They are async, yet do nothing asynchronous (not addressed by this PR), and the return type includes a `fromCache` field that is only meaningful on the front-end. They should have just returned (synchronously) an array of `PointWithStatus`.

Fixes:
- Ensure `fromCache` always present and zero.
- Ensure the point array is present even if input array was empty.