### PR TITLE
EXT_mesh_primitive_restart

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -4030,7 +4030,7 @@ export abstract class GltfReader {
     // (undocumented)
     protected readPolylines(polylines: MeshPolylineList, json: {
         [k: string]: any;
-    }, accessorName: string, disjoint: boolean): boolean;
+    }, accessorName: string, mode: GltfMeshMode.Points | GltfMeshMode.Lines | GltfMeshMode.LineStrip): boolean;
     // (undocumented)
     protected readPrimitiveFeatures(primitive: GltfMeshPrimitive): Feature | number[] | undefined;
     // (undocumented)

--- a/common/changes/@itwin/core-frontend/pmc-EXT_mesh_primitive_restart_2025-07-10-14-31.json
+++ b/common/changes/@itwin/core-frontend/pmc-EXT_mesh_primitive_restart_2025-07-10-14-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add support for glTF EXT_mesh_primitive_restart extension.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"./src/**/*.ts\" 1>&2",
     "lint-fix": "eslint --fix -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./src/public/locales/en --out ./public/locales/en-PSEUDO",
-    "test": "npm run webpackTestWorker && vitest --run",
+    "test": "npm run webpackTestWorker && vitest --run GltfReader",
     "cover": "npm run webpackTestWorker && vitest --run",
     "webpackTests": "webpack --config ./src/test/utils/webpack.config.js 1>&2 && npm run -s webpackTestWorker",
     "webpackTestWorker": "webpack --config ./src/test/worker/webpack.config.js 1>&2 && cpx \"./lib/test/test-worker.js\" ./lib/test",

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"./src/**/*.ts\" 1>&2",
     "lint-fix": "eslint --fix -f visualstudio \"./src/**/*.ts\" 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./src/public/locales/en --out ./public/locales/en-PSEUDO",
-    "test": "npm run webpackTestWorker && vitest --run GltfReader",
+    "test": "npm run webpackTestWorker && vitest --run",
     "cover": "npm run webpackTestWorker && vitest --run",
     "webpackTests": "webpack --config ./src/test/utils/webpack.config.js 1>&2 && npm run -s webpackTestWorker",
     "webpackTestWorker": "webpack --config ./src/test/worker/webpack.config.js 1>&2 && cpx \"./lib/test/test-worker.js\" ./lib/test",

--- a/core/frontend/src/common/gltf/GltfSchema.ts
+++ b/core/frontend/src/common/gltf/GltfSchema.ts
@@ -198,6 +198,14 @@ export interface GltfMesh extends GltfChildOfRootProperty {
   primitives?: GltfMeshPrimitive[];
   /** For morph targets - currently unsupported. */
   weights?: number[];
+  extensions?: GltfExtensions & {
+    EXT_mesh_primitive_restart?: {
+      primitiveGroups: Array<{
+        primitives: number[];
+        indices: number;
+      }>;
+    }
+  };
 }
 
 /** Properties common to [[Gltf1Node]] and [[Gltf2Node]]. @internal */

--- a/core/frontend/src/common/gltf/GltfSchema.ts
+++ b/core/frontend/src/common/gltf/GltfSchema.ts
@@ -12,6 +12,7 @@
 export enum GltfMeshMode {
   Points = 0,
   Lines = 1,
+  LineLoop = 2,
   LineStrip = 3,
   Triangles = 4,
   /** Not currently supported. */

--- a/core/frontend/src/common/gltf/GltfSchema.ts
+++ b/core/frontend/src/common/gltf/GltfSchema.ts
@@ -200,6 +200,7 @@ export interface GltfMesh extends GltfChildOfRootProperty {
   /** For morph targets - currently unsupported. */
   weights?: number[];
   extensions?: GltfExtensions & {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     EXT_mesh_primitive_restart?: {
       primitiveGroups: Array<{
         primitives: number[];

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -1399,11 +1399,60 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
     function expectPrimitives(mesh: GltfMesh, expected: GltfMeshPrimitive[] | "fallback"): void {
       const expectedPrimitives = "fallback" === expected ? mesh.primitives : expected;
       const actualPrimitives = getMeshPrimitives(mesh);
-      expect(actualPrimitives).to.equal(expectedPrimitives);
+      expect(actualPrimitives).toEqual(expectedPrimitives);
     }
 
     it("combines primitives", () => {
-      
+      expectPrimitives({
+        primitives: [{
+          attributes: {},
+          indices: 0,
+          mode: GltfMeshMode.LineStrip,
+        }, {
+          attributes: {},
+          indices: 1,
+          mode: GltfMeshMode.TriangleFan,
+        }, {
+          attributes: {},
+          indices: 2,
+          mode: GltfMeshMode.TriangleFan,
+        }, {
+          attributes: {},
+          indices: 3,
+          mode: GltfMeshMode.Triangles,
+        }, {
+          attributes: {},
+          indices: 4,
+          mode: GltfMeshMode.LineStrip,
+        }, {
+          attributes: {},
+          indices: 5,
+          mode: GltfMeshMode.LineStrip,
+        }],
+        extensions: {
+          EXT_mesh_primitive_restart: {
+            primitiveGroups: [{
+              primitives: [5, 0, 4],
+              indices: 111,
+            }, {
+                primitives: [1, 2],
+                indices: 222,
+            }],
+          },
+        },
+      }, [{
+        attributes: {},
+        indices: 222,
+        mode: GltfMeshMode.TriangleFan,
+      }, {
+        attributes: {},
+        indices: 3,
+        mode: GltfMeshMode.Triangles,
+      }, {
+        attributes: {},
+        indices: 111,
+        mode: GltfMeshMode.LineStrip,
+      }]);
     });
 
     describe("falls back to mesh.primitives", () => {
@@ -1420,9 +1469,41 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
             },
           },
         }, "fallback");
+
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 123,
+            mode: GltfMeshMode.LineStrip,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: undefined as any,
+            },
+          },
+        }, "fallback");
       });
 
       it("if a group refers to a non-existent primitive", () => {
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 0,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: 1,
+            mode: GltfMeshMode.LineStrip,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: [{
+                primitives: [0, 1, 2],
+                indices: 999,
+              }],
+            },
+          },
+        }, "fallback");
         
       });
 

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -1508,23 +1508,136 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
       });
 
       it("if a given primitive appears more than once in the same group", () => {
-        
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 0,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: 1,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: 2,
+            mode: GltfMeshMode.LineStrip,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: [{
+                primitives: [0, 2, 0],
+                indices: 111,
+              }],
+            },
+          },
+        }, "fallback");
       });
 
       it("if a given primitive appears in more than one group", () => {
-        
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 0,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: 1,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: 2,
+            mode: GltfMeshMode.LineStrip,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: [{
+                primitives: [0, 1],
+                indices: 111,
+              }, {
+                primitives: [1, 2],
+                indices: 222,
+              }],
+            },
+          },
+        }, "fallback");
       });
 
       it("if any primitive does not use indexed geometry", () => {
-        
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 0,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: 1,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: undefined,
+            mode: GltfMeshMode.LineStrip,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: [{
+                primitives: [0, 1, 2],
+                indices: 111,
+              }],
+            },
+          },
+        }, "fallback");
       });
 
       it("if any primitive has a topology other than line loop, line strip, triangle strip, or triangle fan", () => {
-        
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 0,
+            mode: GltfMeshMode.Triangles,
+          }, {
+            attributes: {},
+            indices: 1,
+            mode: GltfMeshMode.Triangles,
+          }, {
+            attributes: {},
+            indices: 2,
+            mode: GltfMeshMode.Triangles,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: [{
+                primitives: [0, 1, 2],
+                indices: 111,
+              }],
+            },
+          },
+        }, "fallback");
       });
 
       it("if primitives within a group have different topologies", () => {
-        
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 0,
+            mode: GltfMeshMode.LineStrip,
+          }, {
+            attributes: {},
+            indices: 1,
+            mode: GltfMeshMode.TriangleFan,
+          }, {
+            attributes: {},
+            indices: 2,
+            mode: GltfMeshMode.LineStrip,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: [{
+                primitives: [0, 1, 2],
+                indices: 111,
+              }],
+            },
+          },
+        }, "fallback");
       });
     });
   });

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -13,6 +13,8 @@ import { createBlankConnection } from "../createBlankConnection";
 import { BatchedTileIdMap } from "../../tile/internal";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+// eslint-disable @typescript-eslint/naming-convention
+
 const minimalBin = new Uint8Array([12, 34, 0xfe, 0xdc]);
 const minimalJson = { asset: { version: "02.00" }, meshes: [] };
 

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -8,7 +8,7 @@ import { EmptyLocalization, GltfV2ChunkTypes, GltfVersions, RenderTexture, TileF
 import { IModelConnection } from "../../IModelConnection";
 import { IModelApp } from "../../IModelApp";
 import { GltfDataType, GltfDocument, GltfId, GltfNode, GltfSampler, GltfWrapMode } from "../../common/gltf/GltfSchema";
-import { GltfDataBuffer, GltfGraphicsReader, GltfReader, GltfReaderArgs, GltfReaderProps, GltfReaderResult } from "../../tile/GltfReader";
+import { getMeshPrimitives, GltfDataBuffer, GltfGraphicsReader, GltfReader, GltfReaderArgs, GltfReaderProps, GltfReaderResult } from "../../tile/GltfReader";
 import { createBlankConnection } from "../createBlankConnection";
 import { BatchedTileIdMap } from "../../tile/internal";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -1391,6 +1391,34 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
           expect(properties?.class1?.color1).toEqual(colorHex); // multiple feature property tables should be supported
         });
         expect(featureIndexToColorMap.size).toEqual(uniqueEntriesSize);
+      });
+    });
+  });
+
+  describe("EXT_mesh_primitive_restart", () => {
+    it("combines primitives", () => {
+      
+    });
+
+    describe("falls back to mesh.primitives", () => {
+      it("if no groups are defined", () => {
+
+      });
+
+      it("if a given primitive appears more than once in the same group", () => {
+        
+      });
+
+      it("if a given primitive appears in more than one group", () => {
+        
+      });
+
+      it("if any primitive does not use indexed geometry", () => {
+        
+      });
+
+      it("if any primitive has a topology other than line loop, line strip, triangle strip, or triangle fan", () => {
+        
       });
     });
   });

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -7,7 +7,7 @@ import { Range3d } from "@itwin/core-geometry";
 import { EmptyLocalization, GltfV2ChunkTypes, GltfVersions, RenderTexture, TileFormat } from "@itwin/core-common";
 import { IModelConnection } from "../../IModelConnection";
 import { IModelApp } from "../../IModelApp";
-import { GltfDataType, GltfDocument, GltfId, GltfNode, GltfSampler, GltfWrapMode } from "../../common/gltf/GltfSchema";
+import { GltfDataType, GltfDocument, GltfId, GltfMesh, GltfMeshMode, GltfMeshPrimitive, GltfNode, GltfSampler, GltfWrapMode } from "../../common/gltf/GltfSchema";
 import { getMeshPrimitives, GltfDataBuffer, GltfGraphicsReader, GltfReader, GltfReaderArgs, GltfReaderProps, GltfReaderResult } from "../../tile/GltfReader";
 import { createBlankConnection } from "../createBlankConnection";
 import { BatchedTileIdMap } from "../../tile/internal";
@@ -1396,13 +1396,34 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
   });
 
   describe("EXT_mesh_primitive_restart", () => {
+    function expectPrimitives(mesh: GltfMesh, expected: GltfMeshPrimitive[] | "fallback"): void {
+      const expectedPrimitives = "fallback" === expected ? mesh.primitives : expected;
+      const actualPrimitives = getMeshPrimitives(mesh);
+      expect(actualPrimitives).to.equal(expectedPrimitives);
+    }
+
     it("combines primitives", () => {
       
     });
 
     describe("falls back to mesh.primitives", () => {
       it("if no groups are defined", () => {
+        expectPrimitives({
+          primitives: [{
+            attributes: {},
+            indices: 123,
+            mode: GltfMeshMode.LineStrip,
+          }],
+          extensions: {
+            EXT_mesh_primitive_restart: {
+              primitiveGroups: [],
+            },
+          },
+        }, "fallback");
+      });
 
+      it("if a group refers to a non-existent primitive", () => {
+        
       });
 
       it("if a given primitive appears more than once in the same group", () => {
@@ -1418,6 +1439,10 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
       });
 
       it("if any primitive has a topology other than line loop, line strip, triangle strip, or triangle fan", () => {
+        
+      });
+
+      it("if primitives within a group have different topologies", () => {
         
       });
     });

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -13,7 +13,7 @@ import { createBlankConnection } from "../createBlankConnection";
 import { BatchedTileIdMap } from "../../tile/internal";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// eslint-disable @typescript-eslint/naming-convention
+/* eslint-disable @typescript-eslint/naming-convention */
 
 const minimalBin = new Uint8Array([12, 34, 0xfe, 0xdc]);
 const minimalJson = { asset: { version: "02.00" }, meshes: [] };

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1200,6 +1200,7 @@ export abstract class GltfReader {
     let primitiveType: number = -1;
     switch (meshMode) {
       case GltfMeshMode.Lines:
+      case GltfMeshMode.LineStrip:
         primitiveType = MeshPrimitiveType.Polyline;
         break;
 
@@ -1299,7 +1300,8 @@ export abstract class GltfReader {
 
       case MeshPrimitiveType.Polyline:
       case MeshPrimitiveType.Point: {
-        if (undefined !== mesh.primitive.polylines && !this.readPolylines(mesh.primitive.polylines, primitive, "indices", MeshPrimitiveType.Point === primitiveType))
+        assert(meshMode === GltfMeshMode.Points || meshMode === GltfMeshMode.Lines || meshMode === GltfMeshMode.LineStrip);
+        if (undefined !== mesh.primitive.polylines && !this.readPolylines(mesh.primitive.polylines, primitive, "indices", meshMode))
           return undefined;
         break;
       }
@@ -1847,13 +1849,13 @@ export abstract class GltfReader {
     return true;
   }
 
-  protected readPolylines(polylines: MeshPolylineList, json: { [k: string]: any }, accessorName: string, disjoint: boolean): boolean {
+  protected readPolylines(polylines: MeshPolylineList, json: { [k: string]: any }, accessorName: string, mode: GltfMeshMode.Points | GltfMeshMode.Lines | GltfMeshMode.LineStrip): boolean {
     const data = this.readBufferData32(json, accessorName);
     if (undefined === data)
       return false;
 
     const indices = new Array<number>();
-    if (disjoint) {
+    if (GltfMeshMode.Lines !== mode) {
       for (let i = 0; i < data.count;)
         indices.push(data.buffer[i++]);
     } else {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -452,12 +452,28 @@ export function getMeshPrimitives(mesh: GltfMesh | undefined): GltfMeshPrimitive
     }
 
     const primitive = { ...meshPrimitives[firstPrimitiveIndex], indices: group.indices };
+
+    // Spec: primitive restart only supported for these topologies.
+    switch (primitive.mode) {
+      case GltfMeshMode.TriangleFan:
+      case GltfMeshMode.TriangleStrip:
+      case GltfMeshMode.LineStrip:
+      case GltfMeshMode.LineLoop:
+        break;
+      default:
+        return meshPrimitives;
+    }
+
+
     for (const primitiveIndex of group.primitives) {
+      const thisPrimitive = primitives[primitiveIndex];
+      
       // Spec: all primitives must use indexed geometry and a given primitive may appear in at most one group.
-      if (undefined === primitives[primitiveIndex]?.indices) {
+      // Spec: all primitives must have same topology.
+      if (undefined === thisPrimitive?.indices || thisPrimitive.mode !== primitive.mode) {
         return meshPrimitives;
       }
-
+      
       primitives[primitiveIndex] = undefined;
     }
 

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -431,8 +431,7 @@ interface StructuralMetadata{
 }
 
 /** @internal exported strictly for testing */
-
-function getMeshPrimitives(mesh: GltfMesh | undefined): GltfMeshPrimitive[] | undefined {
+export function getMeshPrimitives(mesh: GltfMesh | undefined): GltfMeshPrimitive[] | undefined {
   const ext = mesh?.extensions?.EXT_mesh_primitive_restart;
   const meshPrimitives = mesh?.primitives;
   if (!meshPrimitives || meshPrimitives.length === 0 || !ext?.primitiveGroups || ext.primitiveGroups.length === 0) {

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -438,7 +438,7 @@ export function getMeshPrimitives(mesh: GltfMesh | undefined): GltfMeshPrimitive
     return meshPrimitives;
   }
 
-  // Note: per the spec, any violation of the extension's specification must cause us to fall back to mesh.primitives.
+  // Note: per the spec, any violation of the extension's specification should cause us to fall back to mesh.primitives, if detecting the violation is feasible.
 
   // Start with a copy of mesh.primitives. For each group, replace the first primitive in the group with a primitive representing the entire group,
   // and set the rest of the primitives in the group to `undefined`.


### PR DESCRIPTION
Implement the EXT_mesh_primitive_restart extension described by the specification in https://github.com/KhronosGroup/glTF/pull/2478.
iTwin.js did not previously support line strips. Now it does, with or without the extension.
It still lacks support for line loops, triangle fans, and triangle strips, so no changes were made to support the extension for those.

[Example glb model](https://github.com/user-attachments/files/21167811/primitive-restart.zip) encoding line strings using primitive restart.

