### PR TITLE
Meshing a mirrored `SolidPrimitive` should result in outward-facing facet normals

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -2217,9 +2217,9 @@ export class Geometry {
     static isSmallRelative(value: number): boolean;
     static readonly largeCoordinateResult = 10000000000000;
     static readonly largeFractionResult = 10000000000;
-    static lexicalXYLessThan(a: XY | XYZ, b: XY | XYZ): -1 | 0 | 1;
-    static lexicalXYZLessThan(a: XYZ, b: XYZ): -1 | 0 | 1;
-    static lexicalYXLessThan(a: XY | XYZ, b: XY | XYZ): -1 | 0 | 1;
+    static lexicalXYLessThan(a: XAndY, b: XAndY): -1 | 0 | 1;
+    static lexicalXYZLessThan(a: XYAndZ, b: XYAndZ): -1 | 0 | 1;
+    static lexicalYXLessThan(a: XAndY, b: XAndY): -1 | 0 | 1;
     static maxAbsDiff(a: number, b0: number, b1: number): number;
     static maxAbsXY(x: number, y: number): number;
     static maxAbsXYZ(x: number, y: number, z: number): number;

--- a/common/changes/@itwin/core-geometry/da4-mirrored-solids-redux_2025-07-10-20-13.json
+++ b/common/changes/@itwin/core-geometry/da4-mirrored-solids-redux_2025-07-10-20-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/Geometry.ts
+++ b/core/geometry/src/Geometry.ts
@@ -8,9 +8,9 @@
  */
 
 import { AngleSweep } from "./geometry3d/AngleSweep";
-import { Point2d, Vector2d, XY } from "./geometry3d/Point2dVector2d";
+import { Point2d, Vector2d } from "./geometry3d/Point2dVector2d";
 import { Point3d, Vector3d, XYZ } from "./geometry3d/Point3dVector3d";
-import { XAndY } from "./geometry3d/XYZProps";
+import { XAndY, XYAndZ } from "./geometry3d/XYZProps";
 import { Point4d } from "./geometry4d/Point4d";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -446,7 +446,7 @@ export class Geometry {
    * Lexical comparison of (a.x, a.y) and (b.x, b.y) with x as first test and y as second (z is ignored).
    * * This is appropriate for a horizontal sweep in the plane.
    */
-  public static lexicalXYLessThan(a: XY | XYZ, b: XY | XYZ): -1 | 0 | 1 {
+  public static lexicalXYLessThan(a: XAndY, b: XAndY): -1 | 0 | 1 {
     if (a.x < b.x)
       return -1;
     else if (a.x > b.x)
@@ -461,7 +461,7 @@ export class Geometry {
    * Lexical comparison of (a.x, a.y) and (b.x, b.y) with y as first test and x as second (z is ignored).
    * * This is appropriate for a vertical sweep in the plane.
    */
-  public static lexicalYXLessThan(a: XY | XYZ, b: XY | XYZ): -1 | 0 | 1 {
+  public static lexicalYXLessThan(a: XAndY, b: XAndY): -1 | 0 | 1 {
     if (a.y < b.y)
       return -1;
     else if (a.y > b.y)
@@ -473,7 +473,7 @@ export class Geometry {
     return 0;
   }
   /** Lexical comparison of (a.x, a.y, a.z) and (b.x, b.y, b.z) with x as first test, y as second, and z as third. */
-  public static lexicalXYZLessThan(a: XYZ, b: XYZ): -1 | 0 | 1 {
+  public static lexicalXYZLessThan(a: XYAndZ, b: XYAndZ): -1 | 0 | 1 {
     if (a.x < b.x)
       return -1;
     else if (a.x > b.x)

--- a/core/geometry/src/solid/Box.ts
+++ b/core/geometry/src/solid/Box.ts
@@ -71,6 +71,13 @@ export class Box extends SolidPrimitive {
     if (transform.matrix.isSingular())
       return false;
     transform.multiplyTransformTransform(this._localToWorld, this._localToWorld);
+    if (transform.matrix.determinant() < 0.0) {
+      // if mirror, reverse z-axis (origin and direction) to preserve outward normals
+      this._localToWorld.origin.addInPlace(this._localToWorld.matrix.columnZ());
+      this._localToWorld.matrix.scaleColumnsInPlace(1, 1, -1);
+      [this._baseX, this._topX] = [this._topX, this._baseX];
+      [this._baseY, this._topY] = [this._topY, this._baseY];
+    }
     return true;
   }
   /**

--- a/core/geometry/src/solid/Cone.ts
+++ b/core/geometry/src/solid/Cone.ts
@@ -78,6 +78,12 @@ export class Cone extends SolidPrimitive implements UVSurface, UVSurfaceIsoParam
     if (transform.matrix.isSingular())
       return false;
     transform.multiplyTransformTransform(this._localToWorld, this._localToWorld);
+    if (transform.matrix.determinant() < 0.0) {
+      // if mirror, reverse z-axis (origin and direction) to preserve outward normals
+      this._localToWorld.origin.addInPlace(this._localToWorld.matrix.columnZ());
+      this._localToWorld.matrix.scaleColumnsInPlace(1, 1, -1);
+      [this._radiusA, this._radiusB] = [this._radiusB, this._radiusA];
+    }
     return true;
   }
   /**

--- a/core/geometry/src/solid/LinearSweep.ts
+++ b/core/geometry/src/solid/LinearSweep.ts
@@ -93,11 +93,16 @@ export class LinearSweep extends SolidPrimitive {
   public tryTransformInPlace(transform: Transform): boolean {
     if (transform.matrix.isSingular())
       return false;
-    if (this._contour.tryTransformInPlace(transform)) {
-      transform.multiplyVector(this._direction, this._direction);
-      return true;
+    if (!this._contour.tryTransformInPlace(transform))
+      return false;
+    transform.multiplyVector(this._direction, this._direction);
+    if (transform.matrix.determinant() < 0.0) {
+      // if mirror, reverse the sweep (origin and direction) to preserve outward normals
+      if (!this._contour.tryTransformInPlace(Transform.createTranslation(this._direction)))
+        return false;
+      this._direction.scaleInPlace(-1.0);
     }
-    return false;
+    return true;
   }
 
   /** Return a coordinate frame (right handed unit vectors)

--- a/core/geometry/src/solid/RuledSweep.ts
+++ b/core/geometry/src/solid/RuledSweep.ts
@@ -27,7 +27,7 @@ import { SweepContour } from "./SweepContour";
 export type CurvePrimitiveMutator = (primitiveA: CurvePrimitive, primitiveB: CurvePrimitive) => CurvePrimitive | undefined;
 /**
  * A ruled sweep (surface) is a collection of 2 or more contours.
- * * All contours must have identical number and type of geometry. (paths, loops, parity regions, lines, arcs, other curves).
+ * * All contours must have identical number and type of geometry: (paths, loops, parity regions, lines, arcs, other curves).
  * @public
  */
 export class RuledSweep extends SolidPrimitive {
@@ -93,6 +93,10 @@ export class RuledSweep extends SolidPrimitive {
     for (const contour of this._contours) {
       if (!contour.tryTransformInPlace(transform))
         return false;
+    }
+    if (transform.matrix.determinant() < 0.0) {
+      // if mirror, reverse the sweep order to preserve outward normals
+      this._contours.reverse();
     }
     return true;
   }

--- a/core/geometry/src/solid/Sphere.ts
+++ b/core/geometry/src/solid/Sphere.ts
@@ -68,8 +68,11 @@ export class Sphere extends SolidPrimitive implements UVSurface {
     if (transform.matrix.isSingular())
       return false;
     transform.multiplyTransformTransform(this._localToWorld, this._localToWorld);
-    if (transform.matrix.determinant() < 0.0)
-      this._latitudeSweep.reverseInPlace();
+    if (transform.matrix.determinant() < 0.0) {
+      // if mirror, reverse z-axis to preserve outward normals
+      this._localToWorld.matrix.scaleColumnsInPlace(1, 1, -1);
+      this._latitudeSweep.setStartEndRadians(-this._latitudeSweep.endRadians, -this._latitudeSweep.startRadians);
+    }
     return true;
   }
   /**

--- a/core/geometry/src/solid/TorusPipe.ts
+++ b/core/geometry/src/solid/TorusPipe.ts
@@ -80,6 +80,10 @@ export class TorusPipe extends SolidPrimitive implements UVSurface, UVSurfaceIso
     if (transform.matrix.isSingular())
       return false;
     transform.multiplyTransformTransform(this._localToWorld, this._localToWorld);
+    if (transform.matrix.determinant() < 0.0) {
+      // if mirror, reverse z-axis to preserve outward normals
+      this._localToWorld.matrix.scaleColumnsInPlace(1, 1, -1);
+    }
     return true;
   }
   /**

--- a/core/geometry/src/test/polyface/Polyface.test.ts
+++ b/core/geometry/src/test/polyface/Polyface.test.ts
@@ -1959,62 +1959,56 @@ describe("SphericalMeshData", () => {
             outward = false;
           else if (!visitor.getPoint(i, storedNormal.origin))
             outward = false;
-          else if (!normalPointsOutward(closedMesh, storedNormal)) { // stored normal points outward
-            GeometryCoreTestIO.captureCloneGeometry(
-              allGeometry, [storedNormal.origin, storedNormal.fractionToPoint(2.5)], x0, y0,
-            );
+          else if (!normalPointsOutward(closedMesh, storedNormal)) // check stored normal
             outward = false;
-          }
         }
         const computedNormal = PolygonOps.centroidAreaNormal(visitor.point);
         if (!computedNormal)
           outward = false;
-        else if (!normalPointsOutward(closedMesh, computedNormal)) { // facet orientation points outward
-          GeometryCoreTestIO.captureCloneGeometry(
-            allGeometry, [computedNormal.origin, computedNormal.fractionToPoint(4)], x0, y0,
-          );
+        else if (!normalPointsOutward(closedMesh, computedNormal)) // check facet orientation
           outward = false;
-        }
       }
       return outward;
     };
-    const testMirror = (g: IndexedPolyface | SolidPrimitive | undefined, t: Transform): void => {
-      if (!ck.testDefined(g, "geometry is defined"))
+    const testMirror = (geom: IndexedPolyface | SolidPrimitive | undefined, mirror: Transform): void => {
+      if (!ck.testDefined(geom, "geometry is defined"))
         return;
-      ck.testTrue(t.matrix.determinant() < 0, "transform is a mirror");
-      let closedMesh = g;
-      let type = g.geometryCategory;
-      if (closedMesh instanceof SolidPrimitive) {
-        type = closedMesh.solidPrimitiveType;
-        const options = StrokeOptions.createForFacets();
-        options.needNormals = true;
-        const builder = PolyfaceBuilder.create(options);
-        builder.addGeometryQuery(closedMesh);
-        closedMesh = builder.claimPolyface();
-      }
+      ck.testTrue(mirror.matrix.determinant() < 0, "transform is a mirror");
+      const type = geom instanceof SolidPrimitive ? geom.solidPrimitiveType : geom.geometryCategory;
+      const testOutwardNormals = (meshOrSolid: IndexedPolyface | SolidPrimitive): void => {
+        GeometryCoreTestIO.captureCloneGeometry(allGeometry, meshOrSolid, x0, y0);
+        let mesh: IndexedPolyface;
+        if (meshOrSolid instanceof SolidPrimitive) {
+          const options = StrokeOptions.createForFacets();
+          options.needNormals = true;
+          const builder = PolyfaceBuilder.create(options);
+          builder.addGeometryQuery(meshOrSolid);
+          mesh = builder.claimPolyface();
+          ck.testFalse(mesh.isEmpty, "generated mesh is not empty");
+        } else {
+          mesh = meshOrSolid;
+        }
+        GeometryCoreTestIO.captureCloneGeometry(allGeometry, mesh, x0, y0 += delta);
+        const outward = hasOutwardOrientationAndFacetNormals(mesh);
+        ck.testTrue(outward, `${type} computed and stored facet normals point outward`);
+        y0 += delta;
+      };
       y0 = 0;
-      GeometryCoreTestIO.captureCloneGeometry(allGeometry, closedMesh, x0, y0);
-      const outward = hasOutwardOrientationAndFacetNormals(closedMesh);
-      ck.testTrue(outward, `${type} facets and normals point outward`);
-      y0 = delta;
-      const mirrorMesh = closedMesh.cloneTransformed(t);
-      GeometryCoreTestIO.captureCloneGeometry(allGeometry, mirrorMesh, x0, y0);
-      const mirrorOutward = hasOutwardOrientationAndFacetNormals(mirrorMesh);
-      ck.testTrue(mirrorOutward, `${type} mirrored facets and normals point outward`);
+      testOutwardNormals(geom);
+      const geomMirrored = geom.cloneTransformed(mirror) as IndexedPolyface | SolidPrimitive;
+      if (ck.testDefined(geomMirrored, "mirrored geometry is defined"))
+        testOutwardNormals(geomMirrored);
+      // TOOD: check mirrored centroid === mirrored solid's centroid
     };
     // mirror across plane at origin with normal (1,1,0)
     const mirrorMatrix = Matrix3d.createDirectionalScale(Vector3d.createNormalized(1, 1)!, -1.0);
     const mirrorTrans = Transform.createFixedPointAndMatrix(Point3d.createZero(), mirrorMatrix);
 
-    // all solids are centered at zero
+    // solid primitives: all solids are centered at zero
     const geometry: (IndexedPolyface | SolidPrimitive | undefined)[] = [];
-
-    geometry.push(ImportedSample.createPolyhedron62());
-
     geometry.push(Box.createRange(Range3d.create(Point3d.create(-1.5, -1, -0.5), Point3d.create(1.5, 1, 0.5)), true));
-
+    geometry.push(Box.createDgnBoxWithAxes(Point3d.create(-3/8, -1/2, -5/8), Matrix3d.createColumns(Vector3d.unitZ(), Vector3d.unitX(), Vector3d.unitY()), Point3d.create(-3/8, 1/2, -5/8), 2, 1, 0.5, 0.5, true));
     geometry.push(Cone.createAxisPoints(Point3d.create(-1), Point3d.create(1), 2, 1, true));
-
     const sweepLength = 3;
     const washer = RegionOps.sortOuterAndHoleLoopsXY([
       Loop.create(Arc3d.createXY(Point3d.create(0, 0, -sweepLength / 2), 2)),
@@ -2024,27 +2018,23 @@ describe("SphericalMeshData", () => {
     const rotation = Matrix3d.createRotationVectorToVector(Vector3d.unitZ(), arcNormal);
     washer.tryTransformInPlace(Transform.createOriginAndMatrix(undefined, rotation));
     geometry.push(LinearSweep.create(washer, arcNormal.scale(sweepLength), true));
-
     const polygonCCW = [Point3d.create(-1, -1), Point3d.create(-1, -2), Point3d.create(1, -2), Point3d.create(1, -1)];
     const polygonCW = polygonCCW.slice().reverse();
     const sweepRay = Ray3d.create(Point3d.createZero(), Vector3d.unitX());
-    const sweepAngle = Angle.createDegrees(20);
+    const sweepAngle = Angle.createDegrees(55);
     geometry.push(RotationalSweep.create(Loop.createPolygon(polygonCCW), sweepRay, sweepAngle, true));
     geometry.push(RotationalSweep.create(Loop.createPolygon(polygonCCW), sweepRay, sweepAngle.cloneScaled(-1), true));
     geometry.push(RotationalSweep.create(Loop.createPolygon(polygonCW), sweepRay, sweepAngle, true));
     geometry.push(RotationalSweep.create(Loop.createPolygon(polygonCW), sweepRay, sweepAngle.cloneScaled(-1), true));
-
-    const sections = [
-      Loop.create(Arc3d.createXY(Point3d.create(0, -1, -1), 1)),
-      Loop.create(Arc3d.createXY(Point3d.create(0, 1, 1), 1.5)),
-    ];
+    const sections = [Loop.create(Arc3d.createXY(Point3d.create(0, -1, -1), 1)), Loop.create(Arc3d.createXY(Point3d.create(0, 1, 1), 1.5))];
     geometry.push(RuledSweep.create(sections, true));
-
     const eAxes = Transform.createOriginAndMatrix(undefined, Matrix3d.createScale(2, 3, 1))
     geometry.push(Sphere.createEllipsoid(eAxes, AngleSweep.createStartEndDegrees(-45, 0), true));
-
     geometry.push(TorusPipe.createAlongArc(Arc3d.createCenterNormalRadius(undefined, Vector3d.unitY(-1), 2), 0.25, true));
+    geometry.push(TorusPipe.createAlongArc(Arc3d.createRefs(Point3d.createZero(), Matrix3d.createRigidHeadsUp(Vector3d.unitY(-1)).scaleColumns(2, 2, 2), AngleSweep.createStartEndDegrees(30, 120)), 0.25, true));
 
+    // various closed mesh constructions
+    geometry.push(ImportedSample.createPolyhedron62());
     const centerlineSweeps: AngleSweep[] = [AngleSweep.createStartEndDegrees(0, 90), AngleSweep.createStartEndDegrees(0, -90)];
     const sectionDataSweeps: AngleSweep[] = [AngleSweep.create360(), AngleSweep.createStartEndDegrees(360, 0)];
     const strokeOptions = StrokeOptions.createForFacets();


### PR DESCRIPTION
After the [last PR](https://github.com/iTwin/itwinjs-core/pull/7337) only `RotationalSweep` was correctly mirroring with outward normals. This follow-up PR ensures outward normals after mirroring the remaining `SolidPrimitive` types.

 The fix involves the transformation itself, not the mesher. Basically, when a mirror transform is passed into `tryTransformInPlace` we now reverse the local z-axis of the SolidPrimitive, along with ancillary changes unique to each type.