### PR TITLE
[presentatio-backend]: Fixed RulesetEmbedder failing to insert ruleset when Rulesets CodeSpec does not exist

### DIFF
--- a/common/changes/@itwin/presentation-backend/ruleset-embed-fix_2025-07-11-14-20.json
+++ b/common/changes/@itwin/presentation-backend/ruleset-embed-fix_2025-07-11-14-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fixed `RulesetEmbedder` failling to insert ruleset into iModel if Ruleset schema is present bus CodeSpec for rulesets does not exist.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/presentation/backend/src/test/RulesetEmbedder.test.ts
+++ b/presentation/backend/src/test/RulesetEmbedder.test.ts
@@ -257,6 +257,28 @@ describe("RulesetEmbedder", () => {
       imodelMock.verify((x) => x.saveChanges(), moq.Times.exactly(2));
     });
 
+    it("sets up prerequisites when inserting element and prerequisites are partially available", async () => {
+      const ruleset: Ruleset = { id: "test", rules: [] };
+      const rulesetElementId = "0x111";
+
+      // mock that ruleset schema is present
+      imodelMock.setup((x) => x.containsClass(RulesetElements.Ruleset.classFullName)).returns(() => true);
+      // mock that ruleset CodeSpec is not present
+      codeSpecsMock.setup((x) => x.hasName(PresentationRules.CodeSpec.Ruleset)).returns(() => false);
+      codeSpecsMock.setup((x) => x.insert(rulesetCodeSpec)).returns(() => "0x2025");
+
+      setupMocksForCreatingRulesetModel();
+      setupMocksForQueryingExistingRulesets("test", []);
+      setupMocksForInsertingNewRuleset(ruleset, rulesetElementId);
+
+      await embedder.insertRuleset(ruleset);
+
+      imodelMock.verify(async (x) => x.importSchemas(moq.It.isAny()), moq.Times.never());
+      codeSpecsMock.verify((x) => x.insert(rulesetCodeSpec), moq.Times.once());
+      rulesetModelMock.verify((x) => x.insert(), moq.Times.once());
+      imodelMock.verify((x) => x.saveChanges(), moq.Times.exactly(2));
+    });
+
     it("calls `onElementInsert` and `onModelInsert` callbacks when creating RulesetModel", async () => {
       const ruleset: Ruleset = { id: "test", rules: [] };
       const rulesetElementId = "0x111";


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-core/issues/8317

Looks like changes in iModel can be reverted without removing newly imported schema. This leads us in a state where Rulesets schema is present in iModel but Ruleset CodeSpec is missing. Previous implementation was only looking for Rulesets schema and assumed that if schema exists CodeSpec should exists too.

Added explicit check of Rulesets CodeSpec. This should ensure that RulesetEmbedder does not fail inserting ruleset if only Rulesets schema is present in iModel.