### PR TITLE
Backport planar clip mask test

### DIFF
--- a/full-stack-tests/core/src/frontend/map/PlanarClipMask.test.ts
+++ b/full-stack-tests/core/src/frontend/map/PlanarClipMask.test.ts
@@ -116,7 +116,9 @@ describe("Planar clip mask (#integration)", () => {
     await expectPixels(undefined, "map");
   });
 
-  it("is masked by specific model", async () => {
+  it("is masked by specific model", async function () {
+    // These tests can exceed the default timeout due to shader compilation for draping.
+    this.timeout(480000);
     const mask: PlanarClipMaskProps = { mode: PlanarClipMaskMode.Models, modelIds: CompressedId64Set.compressArray(["0x1c"]) };
 
     // If the model is visible, it fills the masked region of the mask.
@@ -126,7 +128,9 @@ describe("Planar clip mask (#integration)", () => {
     await expectPixels(mask, "bg", (vp) => vp.changeViewedModels([]));
   });
 
-  it("is masked by DesignModel priority", async () => {
+  it("is masked by DesignModel priority",  async function () {
+    // These tests can exceed the default timeout due to shader compilation for draping.
+    this.timeout(480000);
     const mask: PlanarClipMaskProps = { mode: PlanarClipMaskMode.Priority, priority: PlanarClipMaskPriority.BackgroundMap };
 
     // Models only contribute to the mask in priority mode if they are visible.
@@ -178,7 +182,9 @@ describe("Planar clip mask (#integration)", () => {
     await expectPixels(undefined, "map", addDynamicGeometry);
   });
 
-  it("is masked by dynamic element geometry", async () => {
+  it("is masked by dynamic element geometry",  async function () {
+    // These tests can exceed the default timeout due to shader compilation for draping.
+    this.timeout(480000);
     const bytes = (await IModelApp.tileAdmin.requestElementGraphics(imodel, {
       elementId: "0x29",
       id: Guid.createValue(),
@@ -204,7 +210,9 @@ describe("Planar clip mask (#integration)", () => {
     });
   });
 
-  it("is masked by priority by dynamic geometry", async () => {
+  it("is masked by priority by dynamic geometry", async function () {
+    // These tests can exceed the default timeout due to shader compilation for draping.
+    this.timeout(480000);
     await expectPixels({
       mode: PlanarClipMaskMode.Priority,
       priority: PlanarClipMaskPriority.BackgroundMap,


### PR DESCRIPTION
Backport PlanarClipMaskTest.ts to avoid flaky test in release/5.0x

https://github.com/iTwin/itwinjs-backlog/issues/1551