### PR TITLE
bump eslint-config-prettier versions CVE-2025-54313

### DIFF
--- a/common/changes/@itwin/presentation-backend/master_2025-07-22-13-17.json
+++ b/common/changes/@itwin/presentation-backend/master_2025-07-22-13-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/master_2025-07-22-13-17.json
+++ b/common/changes/@itwin/presentation-common/master_2025-07-22-13-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/master_2025-07-22-13-17.json
+++ b/common/changes/@itwin/presentation-frontend/master_2025-07-22-13-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2817,8 +2817,8 @@ importers:
         specifier: ^9.31.0
         version: 9.31.0
       eslint-config-prettier:
-        specifier: ^9.1.0
-        version: 9.1.0(eslint@9.31.0)
+        specifier: ^9.1.2
+        version: 9.1.2(eslint@9.31.0)
       fast-sort:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3222,8 +3222,8 @@ importers:
         specifier: ^9.31.0
         version: 9.31.0
       eslint-config-prettier:
-        specifier: ^9.1.0
-        version: 9.1.0(eslint@9.31.0)
+        specifier: ^9.1.2
+        version: 9.1.2(eslint@9.31.0)
       internal-tools:
         specifier: workspace:*
         version: link:../../tools/internal
@@ -3328,8 +3328,8 @@ importers:
         specifier: ^9.31.0
         version: 9.31.0
       eslint-config-prettier:
-        specifier: ^9.1.0
-        version: 9.1.0(eslint@9.31.0)
+        specifier: ^9.1.2
+        version: 9.1.2(eslint@9.31.0)
       internal-tools:
         specifier: workspace:*
         version: link:../../tools/internal
@@ -3452,8 +3452,8 @@ importers:
         specifier: ^9.31.0
         version: 9.31.0
       eslint-config-prettier:
-        specifier: ^9.1.0
-        version: 9.1.0(eslint@9.31.0)
+        specifier: ^9.1.2
+        version: 9.1.2(eslint@9.31.0)
       internal-tools:
         specifier: workspace:*
         version: link:../../tools/internal
@@ -7320,8 +7320,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-prettier@9.1.0:
-    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
+  eslint-config-prettier@9.1.2:
+    resolution: {integrity: sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -13950,7 +13950,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@9.1.0(eslint@9.31.0):
+  eslint-config-prettier@9.1.2(eslint@9.31.0):
     dependencies:
       eslint: 9.31.0
 

--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -61,7 +61,7 @@
     "deep-equal": "^1",
     "dotenv-expand": "^5.1.0",
     "dotenv": "^16.4.5",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-prettier": "^9.1.2",
     "eslint": "^9.31.0",
     "fast-sort": "^3.0.2",
     "fast-xml-parser": "^4.4.1",

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -91,7 +91,7 @@
     "cross-env": "^7.0.3",
     "deep-equal": "^1",
     "eslint": "^9.31.0",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-prettier": "^9.1.2",
     "internal-tools": "workspace:*",
     "mocha": "^11.1.0",
     "prettier": "^3.2.5",

--- a/presentation/common/package.json
+++ b/presentation/common/package.json
@@ -99,7 +99,7 @@
     "cross-env": "^7.0.3",
     "deep-equal": "^1",
     "eslint": "^9.31.0",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-prettier": "^9.1.2",
     "internal-tools": "workspace:*",
     "mocha": "^11.1.0",
     "prettier": "^3.2.5",

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -86,7 +86,7 @@
     "cross-env": "^7.0.3",
     "deep-equal": "^1",
     "eslint": "^9.31.0",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-prettier": "^9.1.2",
     "internal-tools": "workspace:*",
     "jsdom": "^26.0.0",
     "mocha": "^11.1.0",


### PR DESCRIPTION
eslint-config-prettier was [hacked](https://www.endorlabs.com/learn/cve-2025-54313-eslint-config-prettier-compromise----high-severity-but-windows-only)

More: https://github.com/prettier/eslint-config-prettier/issues/339

