### PR TITLE
Address vitest hanging assertions in core-bentley

### DIFF
--- a/common/changes/@itwin/core-bentley/nam-test_2025-07-29-20-28.json
+++ b/common/changes/@itwin/core-bentley/nam-test_2025-07-29-20-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/core/bentley/src/test/OneAtATime.test.ts
+++ b/core/bentley/src/test/OneAtATime.test.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import { describe, expect, it, onTestFinished } from "vitest";
 import { AbandonedError, OneAtATimeAction } from "../OneAtATimeAction";
 import { BeDuration } from "../Time";
@@ -9,15 +9,14 @@ import { BeDuration } from "../Time";
 describe("OneAtATime test", () => {
 
   it("OneAtATime", async () => {
-    expect.assertions(17); // 9 expects from outside the operation, 6 from successful operations, and 2 cancelled unhandledRejection assertions
-
+    const unhandledRejections: Error[] = [];
     const unhandledRejectionHandler = (reason: Error) => {
-      expect(reason.toString()).toContain("cancelled");
+      unhandledRejections.push(reason);
     };
 
     process.on("unhandledRejection", unhandledRejectionHandler);
     onTestFinished(() => {
-      process.removeListener("unhandledRejection", unhandledRejectionHandler)
+      process.removeListener("unhandledRejection", unhandledRejectionHandler);
     });
 
     let calls = 0;
@@ -31,20 +30,49 @@ describe("OneAtATime test", () => {
       return ++calls;
     }, "testAbandon");
 
-    const abandonedError = new AbandonedError("testAbandon");
-    const cancelled = new AbandonedError("cancelled");
+    // First batch of operations
+    const promise1 = operation.request(200, "hello"); // is started immediately, and will complete
+    const promise2 = operation.request(200, "hello"); // becomes pending, doesn't abort previous because its already started
+    const promise3 = operation.request(200, "hello"); // aborts previous, becomes pending
+    const promise4 = operation.request(200, "hello"); // aborts previous, becomes pending, eventually is run
 
-    void expect(operation.request(200, "hello")).resolves; // is started immediately, and will complete
-    void expect(operation.request(200, "hello")).rejects.with.toBeInstanceOf(AbandonedError); // becomes pending, doesn't abort previous because its already started
-    void expect(operation.request(200, "hello")).rejects.with.toBeInstanceOf(AbandonedError); // aborts previous, becomes pending
-    let count = await operation.request(200, "hello"); // aborts previous, becomes pending, eventually is run
-    expect(count).toBe(2); // only the first and last complete
-    // then, just try the whole thing again
-    void expect(operation.request(10, "hello")).rejects; // try calling a function that throws
-    void expect(operation.request(10, "hello")).rejects.with.toEqual(cancelled); // try calling a function that throws
-    void expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // becomes pending, doesn't abort previous because its already started
-    void expect(operation.request(200, "hello")).rejects.with.toEqual(abandonedError); // aborts previous, becomes pending
-    count = await operation.request(200, "hello");
-    expect(count).toBe(3);
+    // Wait for the first promise to resolve
+    const count1 = await promise1;
+    expect(count1).toBe(1);
+
+    // The intermediate promises should be abandoned
+    await expect(promise2).rejects.toBeInstanceOf(AbandonedError);
+    await expect(promise3).rejects.toBeInstanceOf(AbandonedError);
+
+    // The last promise should resolve
+    const count2 = await promise4;
+    expect(count2).toBe(2); // only the first and last complete
+
+    // Second batch with error throwing
+    const errorPromise1 = operation.request(10, "hello"); // try calling a function that throws
+    const errorPromise2 = operation.request(10, "hello"); // try calling a function that throws
+    const promise5 = operation.request(200, "hello"); // becomes pending, doesn't abort previous because its already started
+    const promise6 = operation.request(200, "hello"); // aborts previous, becomes pending
+    const promise7 = operation.request(200, "hello"); // aborts previous, becomes pending, eventually is run
+
+    // Wait for error promises to reject with AbandonedError containing "cancelled" message
+    await expect(errorPromise1).rejects.toThrow("cancelled");
+    await expect(errorPromise2).rejects.toBeInstanceOf(AbandonedError);
+
+    // Wait for the intermediate promise to be abandoned
+    await expect(promise5).rejects.toBeInstanceOf(AbandonedError);
+    await expect(promise6).rejects.toBeInstanceOf(AbandonedError);
+
+    // The last promise should resolve
+    const count3 = await promise7;
+    expect(count3).toBe(3);
+
+    // Check that we had the expected unhandled rejections from the floating promises in start()
+    await BeDuration.wait(10); // Give a moment for unhandled rejections to be captured
+    expect(unhandledRejections.length).toBe(2);
+    // The unhandled rejections are AbandonedError instances with the default message "testAbandon"
+    for (const rejection of unhandledRejections) {
+      expect(rejection.toString()).toContain("testAbandon");
+    }
   });
 });


### PR DESCRIPTION
From a recent CI [build](https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=4166644&view=logs&j=8673a5cb-f235-5320-c755-005ead49efbb&t=ae0ee70f-cf19-52a3-7a8c-c857212779af&l=2802),
Vitest doesn't like hanging assertions, so rewrote OneAtATime.test.ts to avoid using 'void' during promise rejection assertions.

Proven CI [build](https://dev.azure.com/bentleycs/iModelTechnologies/_build/results?buildId=4169765&view=logs&j=607f17b7-2b33-5225-6b64-00ff0e2e25e4&t=89ec18ca-7724-51ff-9cd4-fafaa006e1ca&l=7553) that no longer displays warning