### PR TITLE
TxnManager.deleteAllTxns not deleting briefcase changes

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -6555,6 +6555,7 @@ export class TxnManager {
     cancelTo(txnId: TxnIdString): IModelStatus;
     // @internal (undocumented)
     readonly changeMergeManager: ChangeMergeManager;
+    clearAllTxns(): void;
     deleteAllTxns(): void;
     endMultiTxnOperation(): DbResult;
     getChangeTrackingMemoryUsed(): number;

--- a/common/changes/@itwin/core-backend/rohitptnkr-deleteAllTxns-should-revert-local-changes_2025-07-30-10-09.json
+++ b/common/changes/@itwin/core-backend/rohitptnkr-deleteAllTxns-should-revert-local-changes_2025-07-30-10-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "TxnManager.deleteAllTxns now reverts local changes when clearing the txns. Added TxnManager.clearAllTxns which clears the local txns without reverting them.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CatalogDb.ts
+++ b/core/backend/src/CatalogDb.ts
@@ -149,7 +149,7 @@ class EditableCatalogDbImpl extends CatalogDbImpl implements EditableCatalogDb {
       }
 
       // when saved, CatalogIModels should never have any Txns. If we wanted to create a changeset, we'd have to do it here.
-      this[_nativeDb].deleteAllTxns();
+      this[_nativeDb].clearAllTxns();
     } catch { } // ignore errors attempting to update
 
     // might also want to vacuum here?
@@ -181,7 +181,7 @@ export namespace CatalogDb {
       nativeDb.setITwinId(Guid.empty); // catalogs must be a StandaloneDb
       nativeDb.setIModelId(Guid.createValue()); // make sure its iModelId is unique
       updateManifest(nativeDb, args.manifest); // store the manifest inside the Catalog
-      nativeDb.deleteAllTxns(); // Catalogs should never have Txns (and, this must be empty before resetting BriefcaseId)
+      nativeDb.clearAllTxns(); // Catalogs should never have Txns (and, this must be empty before resetting BriefcaseId)
       nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned); // catalogs should always be unassigned
       nativeDb.saveChanges(); // save change to briefcaseId
       nativeDb.vacuum();

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -307,7 +307,7 @@ export class CheckpointManager {
 
         if (nativeDb.hasPendingTxns()) {
           Logger.logWarning(loggerCategory, "Checkpoint with Txns found - deleting them", () => traceInfo);
-          nativeDb.deleteAllTxns();
+          nativeDb.clearAllTxns();
         }
 
         if (nativeDb.getBriefcaseId() !== BriefcaseIdValue.Unassigned)

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -2560,7 +2560,7 @@ export namespace IModelDb {
       try {
         return this._iModel[_nativeDb].insertElementAspect(aspectProps);
       } catch (err: any) {
-        const error =  new IModelError(err.errorNumber, `Error inserting ElementAspect [${err.message}], class: ${aspectProps.classFullName}`, aspectProps);
+        const error = new IModelError(err.errorNumber, `Error inserting ElementAspect [${err.message}], class: ${aspectProps.classFullName}`, aspectProps);
         error.cause = err;
         throw error;
       }
@@ -2574,7 +2574,7 @@ export namespace IModelDb {
       try {
         this._iModel[_nativeDb].updateElementAspect(aspectProps);
       } catch (err: any) {
-        const error =  new IModelError(err.errorNumber, `Error updating ElementAspect [${err.message}], id: ${aspectProps.id}`, aspectProps);
+        const error = new IModelError(err.errorNumber, `Error updating ElementAspect [${err.message}], id: ${aspectProps.id}`, aspectProps);
         error.cause = err;
         throw error;
       }
@@ -2590,7 +2590,7 @@ export namespace IModelDb {
         try {
           iModel[_nativeDb].deleteElementAspect(aspectInstanceId);
         } catch (err: any) {
-          const error =  new IModelError(err.errorNumber, `Error deleting ElementAspect [${err.message}], id: ${aspectInstanceId}`);
+          const error = new IModelError(err.errorNumber, `Error deleting ElementAspect [${err.message}], id: ${aspectInstanceId}`);
           error.cause = err;
           throw error;
         }
@@ -3600,7 +3600,7 @@ export class SnapshotDb extends IModelDb {
 
     nativeDb.deleteLocalValue(BriefcaseLocalValue.StandaloneEdit);
     nativeDb.saveChanges();
-    nativeDb.deleteAllTxns();
+    nativeDb.clearAllTxns();
     nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
 
     const snapshotDb = new SnapshotDb(nativeDb, Guid.createValue());
@@ -3816,7 +3816,7 @@ export class StandaloneDb extends BriefcaseDb {
     nativeDb.openIModel(iModelFileName, OpenMode.ReadWrite);
     nativeDb.setITwinId(Guid.empty); // empty iTwinId means "standalone"
     nativeDb.saveChanges(); // save change to iTwinId
-    nativeDb.deleteAllTxns(); // necessary before resetting briefcaseId
+    nativeDb.clearAllTxns(); // necessary before resetting briefcaseId
     nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned); // standalone iModels should always have BriefcaseId unassigned
     nativeDb.saveLocalValue("StandaloneEdit", JSON.stringify({ txns: true }));
     nativeDb.saveChanges(); // save change to briefcaseId

--- a/core/backend/src/LocalHub.ts
+++ b/core/backend/src/LocalHub.ts
@@ -125,7 +125,7 @@ export class LocalHub {
       nativeDb.setITwinId(this.iTwinId);
       nativeDb.setIModelId(this.iModelId);
       nativeDb.saveChanges();
-      nativeDb.deleteAllTxns(); // necessary before resetting briefcaseId
+      nativeDb.clearAllTxns(); // necessary before resetting briefcaseId
       nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
       nativeDb.saveLocalValue(BriefcaseLocalValue.NoLocking, arg.noLocks ? "true" : undefined);
       nativeDb.saveChanges();

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -755,13 +755,22 @@ export class TxnManager {
    */
   public get hasLocalChanges(): boolean { return this.hasUnsavedChanges || this.hasPendingTxns; }
 
-  /** Destroy the record of all local changes that have yet to be saved and/or pushed.
+  /** Revert all local changes that have yet to be saved and/or pushed and destroy any record of them.
    * This permanently eradicates your changes - use with caution!
    * Typically, callers will want to subsequently use [[LockControl.releaseAllLocks]].
    * After calling this function, [[hasLocalChanges]], [[hasPendingTxns]], and [[hasUnsavedChanges]] will all be `false`.
    */
   public deleteAllTxns(): void {
     this._nativeDb.deleteAllTxns();
+  }
+
+  /** Destroy the record of all local changes that have yet to be saved and/or pushed.
+   * This permanently eradicates your changes - use with caution!
+   * Typically, callers will want to subsequently use [[LockControl.releaseAllLocks]].
+   * After calling this function, [[hasLocalChanges]], [[hasPendingTxns]], and [[hasUnsavedChanges]] will all be `false`.
+   */
+  public clearAllTxns(): void {
+    this._nativeDb.clearAllTxns();
   }
 
   /** Obtain a list of the EC instances that have been changed locally by the [[BriefcaseDb]] associated with this `TxnManager` and have not yet been pushed to the iModel.

--- a/core/backend/src/test/element/ElementDependencyGraph.test.ts
+++ b/core/backend/src/test/element/ElementDependencyGraph.test.ts
@@ -148,7 +148,7 @@ describe("ElementDependencyGraph", () => {
       schemaLockHeld: true,
     };
     nativeDb.openIModel(pathname, OpenMode.ReadWrite, upgradeOptions);
-    nativeDb.deleteAllTxns();
+    nativeDb.clearAllTxns();
     nativeDb.closeFile();
   };
 
@@ -168,7 +168,7 @@ describe("ElementDependencyGraph", () => {
     const spatialCategoryId = SpatialCategory.insert(imodel, IModel.dictionaryId, "EDGTestSpatialCategory", new SubCategoryAppearance({ color: ColorByName.darkRed }));
     dbInfo = { physicalModelId, codeSpecId, spatialCategoryId, seedFileName: testFileName };
     imodel.saveChanges("");
-    imodel[_nativeDb].deleteAllTxns();
+    imodel[_nativeDb].clearAllTxns();
     imodel.close();
   });
 

--- a/core/backend/src/test/standalone/GeometryChangeEvents.test.ts
+++ b/core/backend/src/test/standalone/GeometryChangeEvents.test.ts
@@ -32,7 +32,7 @@ describe("Model geometry changes", () => {
     modelId = PhysicalModel.insert(imodel, IModel.rootSubjectId, "TestModel");
     categoryId = SpatialCategory.insert(imodel, IModel.dictionaryId, "TestCategory", new SubCategoryAppearance({ color: ColorByName.darkRed }));
     imodel.saveChanges("set up");
-    imodel[_nativeDb].deleteAllTxns();
+    imodel[_nativeDb].clearAllTxns();
     imodel.txns.onGeometryChanged.addListener((props) => lastChanges = props);
   });
 

--- a/full-stack-tests/backend/src/HubUtility.ts
+++ b/full-stack-tests/backend/src/HubUtility.ts
@@ -278,7 +278,7 @@ export class HubUtility {
 
     const nativeDb = new IModelNative.platform.DgnDb();
     nativeDb.openIModel(iModelPathname, OpenMode.ReadWrite);
-    nativeDb.deleteAllTxns();
+    nativeDb.clearAllTxns();
     nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned);
     if (nativeDb.queryLocalValue("StandaloneEdit"))
       nativeDb.deleteLocalValue("StandaloneEdit");

--- a/full-stack-tests/backend/src/integration/TxnManager.test.ts
+++ b/full-stack-tests/backend/src/integration/TxnManager.test.ts
@@ -1,0 +1,366 @@
+import { assert, expect } from "chai";
+import { _nativeDb, BriefcaseDb, ChannelControl, DrawingCategory, IModelHost } from "@itwin/core-backend";
+import { HubMock } from "@itwin/core-backend/lib/cjs/internal/HubMock";
+import { KnownTestLocations, HubWrappers, IModelTestUtils } from "@itwin/core-backend/lib/cjs/test";
+import { IModel, Code, SubCategoryAppearance } from "@itwin/core-common";
+import { GuidString, Id64, Id64String } from "@itwin/core-bentley";
+
+describe("deleteAllTxns test", async () => {
+  let briefcases: BriefcaseDb[];
+  const adminToken = "super manager token";
+  let elementPropsTemplate: any;
+  let drawingModelId: GuidString;
+
+  before(async () => {
+    await IModelHost.startup();
+    HubMock.startup("deleteAllTxnsTest", KnownTestLocations.outputDir);
+  });
+
+  after(async () => {
+    HubMock.shutdown();
+    await IModelHost.shutdown();
+  });
+
+  afterEach(() => {
+    briefcases.forEach(briefcase => { briefcase.close(); });
+  });
+
+  // Helper to setup schema/model/category without XML string
+  async function setupTestSchemaAndModel() {
+    const iModelName = "LargeChangesetPullTest";
+    const iTwinId = HubMock.iTwinId;
+    const rwIModelId = await HubMock.createNewIModel({ iTwinId, iModelName, description: "TestSubject", accessToken: adminToken });
+    assert.isNotEmpty(rwIModelId);
+
+    // Open two briefcases for the same iModel
+    briefcases = await Promise.all([
+      HubWrappers.downloadAndOpenBriefcase({ iTwinId, iModelId: rwIModelId, accessToken: adminToken }),
+      HubWrappers.downloadAndOpenBriefcase({ iTwinId, iModelId: rwIModelId, accessToken: adminToken })
+    ]);
+
+    const firstBriefcase = briefcases[0];
+
+    try {
+      await firstBriefcase.importSchemaStrings([`<?xml version="1.0" encoding="UTF-8"?>
+        <ECSchema schemaName="TestSchema" alias="ts" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+          <ECSchemaReference name="BisCore" version="1.0.0" alias="bis"/>
+
+          <ECEntityClass typeName="TestElement">
+            <BaseClass>bis:GraphicalElement2d</BaseClass>
+            <ECProperty propertyName="ElementName" typeName="string" />
+            <ECProperty propertyName="ElementState" typeName="string" />
+          </ECEntityClass>
+
+          <ECRelationshipClass typeName="ElementConnectsToElement" strength="referencing" modifier="Sealed">
+            <BaseClass>bis:ElementRefersToElements</BaseClass>
+            <Source multiplicity="(0..1)" roleLabel="connects to" polymorphic="false">
+              <Class class="TestElement"/>
+            </Source>
+            <Target multiplicity="(0..*)" roleLabel="is connected to" polymorphic="false">
+              <Class class="TestElement"/>
+            </Target>
+          </ECRelationshipClass>
+        </ECSchema>`]);
+    } catch (error: any) {
+      console.log(`Error: ${JSON.stringify(error)}`);
+    }
+    firstBriefcase.channels.addAllowedChannel(ChannelControl.sharedChannelName);
+
+    // Create drawing model and category
+    const codeProps = Code.createEmpty();
+    codeProps.value = "DrawingModel";
+    await firstBriefcase.locks.acquireLocks({ shared: IModel.dictionaryId });
+    const [, createdDrawingModelId] = IModelTestUtils.createAndInsertDrawingPartitionAndModel(firstBriefcase, codeProps, true);
+    drawingModelId = createdDrawingModelId;
+    let drawingCategoryId = DrawingCategory.queryCategoryIdByName(firstBriefcase, IModel.dictionaryId, "MyDrawingCategory");
+    if (!drawingCategoryId)
+      drawingCategoryId = DrawingCategory.insert(firstBriefcase, IModel.dictionaryId, "MyDrawingCategory", new SubCategoryAppearance());
+    firstBriefcase.saveChanges();
+    await firstBriefcase.pushChanges({ description: "Initial Test Data Setup", accessToken: adminToken });
+
+    elementPropsTemplate = {
+      classFullName: "TestSchema:TestElement",
+      model: drawingModelId,
+      category: drawingCategoryId,
+      code: Code.createEmpty(),
+    };
+  }
+
+  async function insertElement(briefcase: BriefcaseDb, name: string) {
+    await briefcase.locks.acquireLocks({ shared: drawingModelId });
+    const elementId = briefcase.elements.insertElement({
+      ...elementPropsTemplate,
+      elementName: name,
+      elementState: "Inserted",
+    } as any);
+    assert.isTrue(Id64.isValidId64(elementId));
+
+    briefcase.saveChanges();
+
+    testElement(briefcase, elementId, "Inserted");
+    return elementId;
+  };
+
+  async function updateElementState(briefcase: BriefcaseDb, id: Id64String, state: string) {
+    await briefcase.locks.acquireLocks({ exclusive: id });
+    const props = briefcase.elements.getElementProps({ id }) as any;
+    props.elementState = state;
+    briefcase.elements.updateElement(props);
+
+    briefcase.saveChanges();
+
+    testElement(briefcase, id, state);
+  }
+
+  async function deleteElement(briefcase: BriefcaseDb, id: Id64String) {
+    await briefcase.locks.acquireLocks({ exclusive: id });
+    briefcase.elements.deleteElement(id);
+
+    briefcase.saveChanges();
+
+    testElement(briefcase, id);
+  }
+
+  function testElement(briefcase: BriefcaseDb, id: Id64String, expectedState?: string) {
+    const el = briefcase.elements.tryGetElement(id);
+    if (expectedState) {
+      assert.isDefined(el);
+      expect((el as any).elementState).to.equal(expectedState);
+    } else {
+      assert.isUndefined(el);
+    }
+  }
+
+  it("deleteAllTxns should revert local changes", async () => {
+    // Basic data setup where both briefcases have a single element inserted
+    await setupTestSchemaAndModel();
+    assert.equal(briefcases.length, 2, "Two briefcases should be opened");
+
+    const [firstBriefcase, secondBriefcase] = briefcases;
+
+    const el1Id = await insertElement(firstBriefcase, "FirstElement");
+
+    // Sync both briefcases
+    await firstBriefcase.pushChanges({ description: "Insert Element", accessToken: adminToken });
+    await secondBriefcase.pullChanges({ accessToken: adminToken });
+    firstBriefcase.locks.releaseAllLocks();
+
+    // Insert 2 more elements
+    const el2Id = await insertElement(firstBriefcase, "SecondElement");
+    const el3Id = await insertElement(firstBriefcase, "ThirdElement");
+
+    // Finally, update the first element
+    await updateElementState(firstBriefcase, el1Id, "Updated");
+
+    testElement(firstBriefcase, el1Id, "Updated");
+    testElement(firstBriefcase, el2Id, "Inserted");
+
+    testElement(secondBriefcase, el1Id, "Inserted");
+    testElement(secondBriefcase, el2Id);
+    testElement(secondBriefcase, el3Id);
+
+    // Delete all transactions and verify rollback
+    firstBriefcase[_nativeDb].deleteAllTxns();
+
+    testElement(firstBriefcase, el1Id, "Inserted");
+    testElement(secondBriefcase, el1Id, "Inserted");
+
+    testElement(firstBriefcase, el2Id);
+    testElement(secondBriefcase, el2Id);
+    testElement(firstBriefcase, el3Id);
+    testElement(secondBriefcase, el3Id);
+
+    // Release locks in firstBriefcase before deleting in secondBriefcase
+    await firstBriefcase.locks.releaseAllLocks();
+
+    // Now delete the element from the second briefcase
+    await deleteElement(secondBriefcase, el1Id);
+
+    // Assert element deletion
+    testElement(firstBriefcase, el1Id, "Inserted");
+    testElement(secondBriefcase, el1Id);
+
+    secondBriefcase[_nativeDb].deleteAllTxns();
+
+    testElement(firstBriefcase, el1Id, "Inserted");
+    testElement(secondBriefcase, el1Id, "Inserted");
+  });
+
+  it("Should only push changes made after txns are deleted", async () => {
+    // Basic data setup where both briefcases have a single element inserted
+    await setupTestSchemaAndModel();
+    assert.equal(briefcases.length, 2, "Two briefcases should be opened");
+
+    const [firstBriefcase, secondBriefcase] = briefcases;
+
+    const el1Id = await insertElement(firstBriefcase, "FirstElement");
+
+    // Sync both briefcases
+    await firstBriefcase.pushChanges({ description: "Insert Element", accessToken: adminToken });
+    await secondBriefcase.pullChanges({ accessToken: adminToken });
+    firstBriefcase.locks.releaseAllLocks();
+
+    await updateElementState(secondBriefcase, el1Id, "First Update");
+
+    secondBriefcase[_nativeDb].deleteAllTxns();
+
+    await updateElementState(secondBriefcase, el1Id, "Another Update");
+
+    await secondBriefcase.pushChanges({ description: "Update Element", accessToken: adminToken });
+    await firstBriefcase.pullChanges({ accessToken: adminToken });
+    secondBriefcase.locks.releaseAllLocks();
+
+    testElement(firstBriefcase, el1Id, "Another Update");
+    testElement(secondBriefcase, el1Id, "Another Update");
+  });
+
+  it("With conflicting changes", async () => {
+    // Basic data setup where both briefcases have a single element inserted
+    await setupTestSchemaAndModel();
+    assert.equal(briefcases.length, 2, "Two briefcases should be opened");
+
+    const [firstBriefcase, secondBriefcase] = briefcases;
+
+    const el1Id = await insertElement(firstBriefcase, "FirstElement");
+
+    // Sync both briefcases
+    await firstBriefcase.pushChanges({ description: "Insert Element", accessToken: adminToken });
+    await secondBriefcase.pullChanges({ accessToken: adminToken });
+    firstBriefcase.locks.releaseAllLocks();
+
+    await deleteElement(secondBriefcase, el1Id);
+
+    secondBriefcase[_nativeDb].deleteAllTxns();
+
+    await updateElementState(secondBriefcase, el1Id, "First Update");
+
+    await secondBriefcase.pushChanges({ description: "Update Element", accessToken: adminToken });
+    await firstBriefcase.pullChanges({ accessToken: adminToken });
+    secondBriefcase.locks.releaseAllLocks();
+
+    testElement(firstBriefcase, el1Id, "First Update");
+    testElement(secondBriefcase, el1Id, "First Update");
+  });
+
+  it("With conflicting changes with a relationships", async () => {
+    // Basic data setup where both briefcases have a single element inserted
+    await setupTestSchemaAndModel();
+    assert.equal(briefcases.length, 2, "Two briefcases should be opened");
+
+    const briefcase = briefcases[0];
+
+    const el1Id = await insertElement(briefcase, "FirstElement");
+    const el2Id = await insertElement(briefcase, "SecondElement");
+
+    [el1Id, el2Id].forEach(id => { assert.isDefined(briefcase.elements.getElement(id)); });
+
+    briefcase[_nativeDb].deleteAllTxns();
+
+    // Insert a relationship between the two elements
+    const relProps = {
+      classFullName: "TestSchema:ElementConnectsToElement",
+      sourceId: el1Id,
+      targetId: el2Id,
+    };
+    const relId = briefcase.relationships.insertInstance(relProps);
+    assert.isTrue(Id64.isValidId64(relId));
+
+    expect(() => briefcase.relationships.getInstance("TestSchema:ElementConnectsToElement", relId)).to.throw();
+  });
+
+  it("Only the changes since the last push should be reversed", async () => {
+    // Basic data setup where both briefcases have a single element inserted
+    await setupTestSchemaAndModel();
+    assert.equal(briefcases.length, 2, "Two briefcases should be opened");
+
+    const [firstBriefcase, secondBriefcase] = briefcases;
+
+    // Insert 2 elements in the first briefcase
+    const el1Id = await insertElement(firstBriefcase, "FirstElement");
+    const el2Id = await insertElement(firstBriefcase, "SecondElement");
+
+    await firstBriefcase.pushChanges({ description: "Insert two Elements", accessToken: adminToken });
+    firstBriefcase.locks.releaseAllLocks();
+
+    // Update the first element
+    await updateElementState(firstBriefcase, el1Id, "Updated");
+
+    testElement(firstBriefcase, el1Id, "Updated");
+    testElement(firstBriefcase, el2Id, "Inserted");
+
+    await firstBriefcase.pushChanges({ description: "Update first Element", accessToken: adminToken });
+    firstBriefcase.locks.releaseAllLocks();
+
+    // Insert a third element
+    const el3Id = await insertElement(firstBriefcase, "ThirdElement");
+    testElement(firstBriefcase, el3Id, "Inserted");
+
+    // Also update the second element
+    await updateElementState(firstBriefcase, el2Id, "Temporary Update");
+
+    // Change of plans !
+    // Delete all txns since the last push
+    firstBriefcase[_nativeDb].deleteAllTxns();
+
+    // Update the second element with it's final value
+    await updateElementState(firstBriefcase, el2Id, "Final Update");
+    testElement(firstBriefcase, el2Id, "Final Update");
+
+    // Sync both briefcases
+    await firstBriefcase.pushChanges({ description: "Update second Element", accessToken: adminToken });
+    await secondBriefcase.pullChanges();
+    firstBriefcase.locks.releaseAllLocks();
+
+    // Check if all the values are as expected in the first briefcase
+    testElement(firstBriefcase, el1Id, "Updated");
+    testElement(firstBriefcase, el2Id, "Final Update");
+    testElement(firstBriefcase, el3Id);
+
+    // Check if the second briefcase has the same values after the pull
+    testElement(secondBriefcase, el1Id, "Updated");
+    testElement(secondBriefcase, el2Id, "Final Update");
+
+    // If TxnManager.ClearAllTxns() is called, the third element would be present in the first briefcase.
+    // But since the txn which inserted was cleared, it would not get pushed to the second briefcase.
+    // And both briefcases would have been out-of-sync.
+    // Since TxnManager.DeleteAllTxns() reverses the changes made, the third element would not exist in both briefcases.
+    testElement(secondBriefcase, el3Id);
+  });
+
+  it("Already reversed txns should be handled correctly", async () => {
+    // Basic data setup where both briefcases have a single element inserted
+    await setupTestSchemaAndModel();
+    assert.equal(briefcases.length, 2, "Two briefcases should be opened");
+
+    const firstBriefcase = briefcases[0];
+
+    const el1Id = await insertElement(firstBriefcase, "FirstElement");
+
+    // Sync both briefcases
+    await firstBriefcase.pushChanges({ description: "Insert Element", accessToken: adminToken });
+    firstBriefcase.locks.releaseAllLocks();
+
+    // Update the first element twice
+    await updateElementState(firstBriefcase, el1Id, "First Update");
+    await updateElementState(firstBriefcase, el1Id, "Second Update");
+
+    // Insert a second element
+    let el2Id = await insertElement(firstBriefcase, "SecondElement");
+
+    // Reverse 2 transactions
+    firstBriefcase.txns.reverseTxns(2);
+
+    testElement(firstBriefcase, el1Id, "First Update");
+    testElement(firstBriefcase, el2Id);
+
+    // Re-Insert the second element
+    el2Id = await insertElement(firstBriefcase, "SecondElement");
+    await updateElementState(firstBriefcase, el1Id, "Another Update");
+
+    // Reverse all the changes made since the last push
+    firstBriefcase[_nativeDb].deleteAllTxns();
+
+    testElement(firstBriefcase, el1Id, "Inserted");
+    testElement(firstBriefcase, el2Id);
+  });
+});

--- a/test-apps/display-test-app/src/backend/SetToStandalone.ts
+++ b/test-apps/display-test-app/src/backend/SetToStandalone.ts
@@ -51,7 +51,7 @@ function setToStandalone(iModelName: string) {
     nativeDb.enableWalMode();
     nativeDb.setITwinId(Guid.empty); // empty iTwinId means "standalone"
     nativeDb.saveChanges(); // save change to iTwinId
-    nativeDb.deleteAllTxns(); // necessary before resetting briefcaseId
+    nativeDb.clearAllTxns(); // necessary before resetting briefcaseId
     nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned); // standalone iModels should always have BriefcaseId unassigned
     nativeDb.saveChanges(); // save change to briefcaseId
     nativeDb.closeFile();


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-core/issues/8197

imodel-native: https://github.com/iTwin/imodel-native/pull/1180

The function DeleteAllTxns was simply clearing the Dgn_Txns table without reverting/reversing any of the local changes.
This logic has been fixed.

A new function ClearAllTxns does what DeleteAllTxns used to do.