### PR TITLE
Permit a material to not override element transparency.

### DIFF
--- a/common/changes/@itwin/core-backend/pmc-material-transparency-override_2025-07-31-11-32.json
+++ b/common/changes/@itwin/core-backend/pmc-material-transparency-override_2025-07-31-11-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/pmc-material-transparency-override_2025-07-31-11-32.json
+++ b/common/changes/@itwin/core-common/pmc-material-transparency-override_2025-07-31-11-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -167,7 +167,6 @@ export class RenderMaterialElement extends DefinitionElement {
       }
     }
 
-    // const map = undefined !== params.patternMap ? { Pattern: params.patternMap } : undefined;
     const renderMaterialProps: RenderMaterialProps = {
       classFullName: this.classFullName,
       code: this.createCode(iModelDb, definitionModelId, materialName),
@@ -182,7 +181,7 @@ export class RenderMaterialElement extends DefinitionElement {
             specular_color: params.specularColor,
             HasFinish: params.finish !== undefined,
             finish: params.finish,
-            HasTransmit: params.transmit !== undefined,
+            HasTransmit: params.transmit !== undefined ? true : undefined,
             transmit: params.transmit,
             HasDiffuse: params.diffuse !== undefined,
             diffuse: params.diffuse,
@@ -258,8 +257,9 @@ export namespace RenderMaterialElement {
      */
     public finish?: number;
     /** A transparency to be applied to the surface, ranging from 0 (fully opaque) to 1 (fully transparent).
-     * The surface's own transparency will be multiplied by `(1 - transmit)`. permitting the material to increase but not decrease the surface transparency.
-     * Default: 13.5.
+     * If defined, then the material transparency overrides the transparency of whatever surface the material is applied to.
+     * If undefined, the material has no effect on surface transparency.
+     * Default: undefined.
      */
     public transmit?: number;
     /** The surface's diffuse reflectivity from 0.0 to 1.0. Default: 0.6. */

--- a/core/backend/src/test/standalone/RenderMaterialElement.test.ts
+++ b/core/backend/src/test/standalone/RenderMaterialElement.test.ts
@@ -29,7 +29,7 @@ function removeUndefined(assetProps: RenderMaterialAssetProps): RenderMaterialAs
 }
 
 function defaultBooleans(assetProps: RenderMaterialAssetProps): RenderMaterialAssetProps {
-  const boolKeys = ["HasBaseColor", "HasDiffuse", "HasFinish", "HasReflect", "HasReflectColor", "HasSpecular", "HasSpecularColor", "HasTransmit"] as const;
+  const boolKeys = ["HasBaseColor", "HasDiffuse", "HasFinish", "HasReflect", "HasReflectColor", "HasSpecular", "HasSpecularColor"] as const;
   for (const boolKey of boolKeys)
     if (undefined === assetProps[boolKey])
       assetProps[boolKey] = false;

--- a/core/backend/src/test/standalone/RenderMaterialElement.test.ts
+++ b/core/backend/src/test/standalone/RenderMaterialElement.test.ts
@@ -189,6 +189,31 @@ describe("RenderMaterialElement", () => {
         HasReflect: true, reflect: params.reflect,
         HasReflectColor: true, reflect_color: params.reflectColor,
       });
+
+      params.transmit = undefined;
+      /* eslint-disable @typescript-eslint/naming-convention */
+      test(params, {
+        HasBaseColor: true, color: params.color,
+        HasSpecularColor: true, specular_color: params.specularColor,
+        HasFinish: true, finish: params.finish,
+        HasDiffuse: true, diffuse: params.diffuse,
+        HasSpecular: true, specular: params.specular,
+        HasReflect: true, reflect: params.reflect,
+        HasReflectColor: true, reflect_color: params.reflectColor,
+      });
+
+      params.transmit = 0.0;
+      /* eslint-disable @typescript-eslint/naming-convention */
+      test(params, {
+        HasBaseColor: true, color: params.color,
+        HasSpecularColor: true, specular_color: params.specularColor,
+        HasFinish: true, finish: params.finish,
+        HasTransmit: true, transmit: params.transmit,
+        HasDiffuse: true, diffuse: params.diffuse,
+        HasSpecular: true, specular: params.specular,
+        HasReflect: true, reflect: params.reflect,
+        HasReflectColor: true, reflect_color: params.reflectColor,
+      });
     });
 
     it("pattern map with default values", () => {

--- a/core/common/src/MaterialProps.ts
+++ b/core/common/src/MaterialProps.ts
@@ -155,9 +155,12 @@ export interface RenderMaterialAssetProps {
   HasFinish?: boolean;
   /** Specular exponent (surface shininess); range is 0 to 128; if undefined, defaults to 13.5 */
   finish?: number;
-  /** If true, this material has surface transparency; if undefined, defaults to false */
+  /** If true, then this material overrides the surface transparency to be the value of [[transmit]].
+   * If false, then this material overrides the surface to be fully opaque.
+   * If undefined, then this material does not override the surface transparency at all.
+   */
   HasTransmit?: boolean;
-  /** Surface transparency; if undefined, defaults to 0.0 */
+  /** Surface transparency; if undefined, defaults to 0.0. Has no effect unless [[HasTransmit]] is true. */
   transmit?: number;
   /** If true, this material has a value for diffuse reflectivity; if undefined, defaults to false */
   HasDiffuse?: boolean;


### PR DESCRIPTION
Updates docs for how material transparency behaves to be consistent with https://github.com/iTwin/imodel-native/pull/1182.