### PR TITLE
WIP Sync Quantity Formatting

### DIFF
--- a/core/ecschema-metadata/src/Metadata/InvertedUnit.ts
+++ b/core/ecschema-metadata/src/Metadata/InvertedUnit.ts
@@ -25,10 +25,10 @@ export class InvertedUnit extends SchemaItem {
   public override readonly schemaItemType = InvertedUnit.schemaItemType;
   /** @internal */
   public static override get schemaItemType() { return SchemaItemType.InvertedUnit; }
-  private _invertsUnit?: LazyLoadedUnit; // required
+  private _invertsUnit?: LazyLoadedUnit | Unit; // required
   private _unitSystem?: LazyLoadedUnitSystem; // required
 
-  public get invertsUnit(): LazyLoadedUnit | undefined { return this._invertsUnit; }
+  public get invertsUnit(): LazyLoadedUnit | Unit | undefined { return this._invertsUnit; }
   public get unitSystem(): LazyLoadedUnitSystem | undefined { return this._unitSystem; }
 
   /**

--- a/core/ecschema-metadata/src/Metadata/Unit.ts
+++ b/core/ecschema-metadata/src/Metadata/Unit.ts
@@ -63,19 +63,18 @@ export class Unit extends SchemaItem {
     return true;
   }
 
-  // /**
-  //  * Returns true if a conversion can be calculated between the input units
-  //  * @alpha
-  //  */
-  // public static areCompatible(unitA: Unit, unitB: Unit): boolean {
-  //   const unitAPhenomenon = unitA.phenomenon;
-  //   const unitBPhenomenon = unitB.phenomenon;
+  /**
+   * Returns true if a conversion can be calculated between the input units
+   * @alpha
+   */
+  public static areCompatibleSync(unitA: Unit, unitB: Unit): boolean {
+    const unitAPhenomenon = unitA.phenomenon;
+    const unitBPhenomenon = unitB.phenomenon;
 
-  //   if(SchemaItem.isSchemaItem(unitAPhenomenon) && SchemaItem.isSchemaItem(unitBPhenomenon))
-  //     if (!unitAPhenomenon || !unitBPhenomenon || !unitAPhenomenon.key.matches(unitBPhenomenon.key))
-  //       return false;
-  //   return true;
-  // }
+    if (!unitAPhenomenon || !unitBPhenomenon || !unitAPhenomenon.matches(unitBPhenomenon))
+      return false;
+    return true;
+  }
 
   /**
    * Type guard to check if the SchemaItem is of type Unit.

--- a/core/ecschema-metadata/src/Metadata/Unit.ts
+++ b/core/ecschema-metadata/src/Metadata/Unit.ts
@@ -63,6 +63,20 @@ export class Unit extends SchemaItem {
     return true;
   }
 
+  // /**
+  //  * Returns true if a conversion can be calculated between the input units
+  //  * @alpha
+  //  */
+  // public static areCompatible(unitA: Unit, unitB: Unit): boolean {
+  //   const unitAPhenomenon = unitA.phenomenon;
+  //   const unitBPhenomenon = unitB.phenomenon;
+
+  //   if(SchemaItem.isSchemaItem(unitAPhenomenon) && SchemaItem.isSchemaItem(unitBPhenomenon))
+  //     if (!unitAPhenomenon || !unitBPhenomenon || !unitAPhenomenon.key.matches(unitBPhenomenon.key))
+  //       return false;
+  //   return true;
+  // }
+
   /**
    * Type guard to check if the SchemaItem is of type Unit.
    * @param item The SchemaItem to check.

--- a/core/ecschema-metadata/src/SchemaFormatsProvider.ts
+++ b/core/ecschema-metadata/src/SchemaFormatsProvider.ts
@@ -126,6 +126,43 @@ export class SchemaFormatsProvider implements FormatsProvider {
     return this.convertToFormatDefinition(defaultProps, kindOfQuantity);
   }
 
+  // /**
+  //  * Retrieves a Format from a SchemaContext. If the format is part of a KindOfQuantity, the first presentation format in the KindOfQuantity that matches the current unit system will be retrieved.
+  //  * If no presentation format matches the current unit system, the persistence unit format will be retrieved if it matches the current unit system.
+  //  * Else, the default presentation format will be retrieved.
+  //  * @param name The full name of the Format or KindOfQuantity.
+  //  * @returns
+  //  */
+  // public getFormatSync(name: string): FormatDefinition | undefined {
+  //   const [schemaName, schemaItemName] = SchemaItem.parseFullName(name);
+  //   const schemaKey = new SchemaKey(schemaName);
+  //   let schema: Schema | undefined;
+  //   try {
+  //     schema = this._context.getSchemaSync(schemaKey);
+  //   } catch {
+  //     Logger.logError(loggerCategory, `Failed to find schema ${schemaName}`);
+  //     return undefined;
+  //   }
+  //   if (!schema) {
+  //     return undefined;
+  //   }
+  //   const itemKey = new SchemaItemKey(schemaItemName, schema.schemaKey);
+
+  //   if (schema.name === "Formats") {
+  //     let format: Format | undefined;
+  //     try {
+  //       format = this._context.getSchemaItemSync(itemKey, Format);
+  //     } catch {
+  //       Logger.logError(loggerCategory, `Failed to find Format ${itemKey.fullName}`);
+  //       return undefined;
+  //     }
+  //     if (!format) {
+  //       return undefined;
+  //     }
+  //     return format.toJSON(true);
+  //   }
+  //   return this.getKindOfQuantityFormatFromSchema(itemKey);
+  // }
 
   /**
    * Retrieves a Format from a SchemaContext. If the format is part of a KindOfQuantity, the first presentation format in the KindOfQuantity that matches the current unit system will be retrieved.

--- a/core/ecschema-metadata/src/UnitProvider/SchemaUnitProvider.ts
+++ b/core/ecschema-metadata/src/UnitProvider/SchemaUnitProvider.ts
@@ -36,6 +36,12 @@ export class SchemaUnitProvider implements UnitsProvider {
     }
     this._unitConverter = new UnitConverter(this._context);
   }
+  findUnitByNameSync(): UnitProps {
+    throw new Error("Method not implemented.");
+  }
+  getConversionSync(): UnitConversionProps {
+    throw new Error("Method not implemented.");
+  }
 
   /**
    * Find unit in a schema that has unitName.

--- a/core/frontend/src/quantity-formatting/BasicUnitsProvider.ts
+++ b/core/frontend/src/quantity-formatting/BasicUnitsProvider.ts
@@ -80,8 +80,36 @@ export class BasicUnitsProvider implements UnitsProvider {
     return new BadUnit();
   }
 
+  /** Find a unit given the unit's unique name. */
+  public findUnitByNameSync(unitName: string): UnitProps {
+    const unitDataEntry = this.findUnitDefinition(unitName);
+    if (unitDataEntry) {
+      return new BasicUnit(unitDataEntry.name, unitDataEntry.displayLabel, unitDataEntry.phenomenon, unitDataEntry.system);
+    }
+    return new BadUnit();
+  }
+
   /** Return the information needed to convert a value between two different units.  The units should be from the same phenomenon. */
   public async getConversion(fromUnit: UnitProps, toUnit: UnitProps): Promise<UnitConversionProps> {
+    const fromUnitData = this.findUnitDefinition(fromUnit.name);
+    const toUnitData = this.findUnitDefinition(toUnit.name);
+
+    if (fromUnitData && toUnitData) {
+      const deltaOffset = toUnitData.conversion.offset - fromUnitData.conversion.offset;
+      const deltaNumerator = toUnitData.conversion.numerator * fromUnitData.conversion.denominator;
+      const deltaDenominator = toUnitData.conversion.denominator * fromUnitData.conversion.numerator;
+
+      const conversionData = new ConversionData();
+      conversionData.factor = deltaNumerator / deltaDenominator;
+      conversionData.offset = deltaOffset;
+      return conversionData;
+    }
+
+    return new ConversionData();
+  }
+
+  /** Return the information needed to convert a value between two different units.  The units should be from the same phenomenon. */
+  public getConversionSync(fromUnit: UnitProps, toUnit: UnitProps): UnitConversionProps {
     const fromUnitData = this.findUnitDefinition(fromUnit.name);
     const toUnitData = this.findUnitDefinition(toUnit.name);
 

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -929,7 +929,7 @@ export class QuantityFormatter implements UnitsProvider {
    * @return a formatted string.
    */
   public formatQuantity(magnitude: number, formatSpec?: FormatterSpec): string;
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
+
   public formatQuantity(args: number | object, spec?: FormatterSpec): string | Promise<string> {
     if (typeof args === "number") {
       /** Format a quantity value. Default FormatterSpec implementation uses Formatter.formatQuantity. */
@@ -977,7 +977,7 @@ export class QuantityFormatter implements UnitsProvider {
    * @return QuantityParseResult object containing either the parsed value or an error value if unsuccessful.
    */
   public parseToQuantityValue(inString: string, parserSpec?: ParserSpec): QuantityParseResult;
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
+
   public parseToQuantityValue(args: string | object, parserSpec?: ParserSpec): QuantityParseResult | Promise<QuantityParseResult> {
     if (typeof args === "string") {
       /** Parse a quantity value. Default ParserSpec implementation uses ParserSpec.parseToQuantityValue. */
@@ -1081,9 +1081,19 @@ export class QuantityFormatter implements UnitsProvider {
     return this._unitsProvider.findUnitByName(unitName);
   }
 
+  /** Find [UnitProp] for a specific unit name. */
+  public findUnitByNameSync(unitName: string): UnitProps {
+    return this._unitsProvider.findUnitByNameSync(unitName);
+  }
+
   /** Returns data needed to convert from one Unit to another in the same Unit Family/Phenomenon. */
   public async getConversion(fromUnit: UnitProps, toUnit: UnitProps): Promise<UnitConversionProps> {
     return this._unitsProvider.getConversion(fromUnit, toUnit);
+  }
+
+  /** Returns data needed to convert from one Unit to another in the same Unit Family/Phenomenon. */
+  public getConversionSync(fromUnit: UnitProps, toUnit: UnitProps): UnitConversionProps {
+    return this._unitsProvider.getConversionSync(fromUnit, toUnit);
   }
 
   /**

--- a/core/quantity/src/Interfaces.ts
+++ b/core/quantity/src/Interfaces.ts
@@ -103,7 +103,9 @@ export interface UnitsProvider {
   findUnit(unitLabel: string, schemaName?: string, phenomenon?: string, unitSystem?: string): Promise<UnitProps>;
   getUnitsByFamily(phenomenon: string): Promise<UnitProps[]>;
   findUnitByName(unitName: string): Promise<UnitProps>;
+  findUnitByNameSync(unitName: string): UnitProps;
   getConversion(fromUnit: UnitProps, toUnit: UnitProps): Promise<UnitConversionProps>;
+  getConversionSync(fromUnit: UnitProps, toUnit: UnitProps): UnitConversionProps;
 }
 
 /**

--- a/core/quantity/src/test/TestUtils/TestHelper.ts
+++ b/core/quantity/src/test/TestUtils/TestHelper.ts
@@ -145,8 +145,44 @@ export class TestUnitsProvider implements UnitsProvider, AlternateUnitLabelsProv
     return new BadUnit();
   }
 
+  /** Find a unit given the unit's unique name. */
+  public findUnitByNameSync(unitName: string): UnitProps {
+    const unitDataEntry = this.findUnitDefinition(unitName);
+    if (unitDataEntry) {
+      return new BasicUnit(unitDataEntry.name, unitDataEntry.displayLabel, unitDataEntry.phenomenon, unitDataEntry.system);
+    }
+    return new BadUnit();
+  }
+
   /** Return the information needed to convert a value between two different units.  The units should be from the same phenomenon. */
   public async getConversion(fromUnit: UnitProps, toUnit: UnitProps): Promise<UnitConversionProps> {
+    const fromUnitData = this.findUnitDefinition(fromUnit.name);
+    const toUnitData = this.findUnitDefinition(toUnit.name);
+
+    if (fromUnitData && toUnitData) {
+      const deltaOffset = toUnitData.conversion.offset - fromUnitData.conversion.offset;
+      const deltaNumerator = toUnitData.conversion.numerator * fromUnitData.conversion.denominator;
+      const deltaDenominator = toUnitData.conversion.denominator * fromUnitData.conversion.numerator;
+
+      const conversionData = new ConversionData();
+      conversionData.factor = deltaNumerator / deltaDenominator;
+      conversionData.offset = deltaOffset;
+      if (fromUnitData.isInverted && !toUnitData.isInverted) {
+        conversionData.inversion = UnitConversionInvert.InvertPreConversion;
+      } else if (!fromUnitData.isInverted && toUnitData.isInverted) {
+        conversionData.inversion = UnitConversionInvert.InvertPostConversion;
+      }
+
+      return conversionData;
+    }
+
+    const conversion = new ConversionData();
+    conversion.error = true;
+    return conversion;
+  }
+
+  /** Return the information needed to convert a value between two different units.  The units should be from the same phenomenon. */
+  public getConversionSync(fromUnit: UnitProps, toUnit: UnitProps): UnitConversionProps {
     const fromUnitData = this.findUnitDefinition(fromUnit.name);
     const toUnitData = this.findUnitDefinition(toUnit.name);
 


### PR DESCRIPTION
This provides the needed sync version of create and createFromJSON. This also required sync version of getUnitsByName and UnitsConversion.

Due to modifying the interface there was need to add some sync version in the frontend api's however, they were only async by name i believe and did not use any async features. That being said, since they were frontend related there might be an easy way to avoid creating these async funcs but that would require some change to the Formatter Spec's implementation of create, so this was just simpler for now.