### PR TITLE
Add support for coordinate length KindOfQuantity

### DIFF
--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -335,6 +335,7 @@ export class QuantityTypeFormatsProvider implements FormatsProvider {
     ["AecUnits.ANGLE", QuantityType.Angle],
     ["AecUnits.AREA", QuantityType.Area],
     ["AecUnits.VOLUME", QuantityType.Volume],
+    ["AecUnits.LENGTH_COORDINATE", QuantityType.Coordinate],
     ["RoadRailUnits.STATION", QuantityType.Stationing],
     ["RoadRailUnits.LENGTH", QuantityType.LengthSurvey],
   ]);
@@ -607,7 +608,7 @@ export class QuantityFormatter implements UnitsProvider {
   public async onInitialized() {
     await this.initializeQuantityTypesRegistry();
 
-    const initialKoQs = [["AecUnits.LENGTH", "Units.M"], ["AecUnits.ANGLE", "Units.RAD"], ["AecUnits.AREA", "Units.SQ_M"], ["AecUnits.VOLUME", "Units.CUB_M"], ["RoadRailUnits.STATION", "Units.M"], ["RoadRailUnits.LENGTH", "Units.M"]];
+    const initialKoQs = [["AecUnits.LENGTH", "Units.M"], ["AecUnits.ANGLE", "Units.RAD"], ["AecUnits.AREA", "Units.SQ_M"], ["AecUnits.VOLUME", "Units.CUB_M"], ["AecUnits.LENGTH_COORDINATE", "Units.M"], ["RoadRailUnits.STATION", "Units.M"], ["RoadRailUnits.LENGTH", "Units.M"]];
     for (const entry of initialKoQs) {
       try {
         await this.addFormattingSpecsToRegistry(entry[0], entry[1]);
@@ -929,7 +930,7 @@ export class QuantityFormatter implements UnitsProvider {
    * @return a formatted string.
    */
   public formatQuantity(magnitude: number, formatSpec?: FormatterSpec): string;
-   
+
   public formatQuantity(args: number | object, spec?: FormatterSpec): string | Promise<string> {
     if (typeof args === "number") {
       /** Format a quantity value. Default FormatterSpec implementation uses Formatter.formatQuantity. */
@@ -977,7 +978,7 @@ export class QuantityFormatter implements UnitsProvider {
    * @return QuantityParseResult object containing either the parsed value or an error value if unsuccessful.
    */
   public parseToQuantityValue(inString: string, parserSpec?: ParserSpec): QuantityParseResult;
-   
+
   public parseToQuantityValue(args: string | object, parserSpec?: ParserSpec): QuantityParseResult | Promise<QuantityParseResult> {
     if (typeof args === "string") {
       /** Parse a quantity value. Default ParserSpec implementation uses ParserSpec.parseToQuantityValue. */

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -519,6 +519,27 @@ describe("Quantity formatter", async () => {
     if (Parser.isParsedQuantity(parsedQuantity))
       expect(parsedQuantity.value).toBe(0.3048);
   });
+
+  it("should be able to get formatSpec for AecUnits.LENGTH_COORDINATE", async () => {
+    const formatSpec = quantityFormatter.getSpecsByName("AecUnits.LENGTH_COORDINATE");
+    expect(formatSpec).toBeDefined();
+    expect(formatSpec?.formatterSpec).toBeDefined();
+    expect(formatSpec?.parserSpec).toBeDefined();
+    
+    // Verify that the formatSpec can be used for formatting
+    const testValue = 1000.0; // 1000 meters
+    const formattedValue = quantityFormatter.formatQuantity(testValue, formatSpec?.formatterSpec);
+    expect(formattedValue).toBeDefined();
+    expect(typeof formattedValue).toBe("string");
+    
+    // Verify that the parserSpec can be used for parsing
+    const parsedValue = quantityFormatter.parseToQuantityValue(formattedValue, formatSpec?.parserSpec);
+    expect(parsedValue.ok).toBe(true);
+    if (Parser.isParsedQuantity(parsedValue)) {
+      expect(withinTolerance(parsedValue.value, testValue, 0.01)).toBe(true);
+    }
+  });
+
   describe("Test native unit conversions", async () => {
     async function testUnitConversion(magnitude: number, fromUnitName: string, expectedValue: number, toUnitName: string, tolerance?: number) {
       const fromUnit = await quantityFormatter.findUnitByName(fromUnitName);

--- a/docs/learning/frontend/QuantityFormatting.md
+++ b/docs/learning/frontend/QuantityFormatting.md
@@ -36,7 +36,7 @@ Here is a table of replacements for each `QuantityType`:
 | Area  |  AecUnits.AREA |
 | Volume  | AecUnits.VOLUME  |
 | LatLong | AecUnits.ANGLE |
-| Coordinate | AecUnits.LENGTH |
+| Coordinate | AecUnits.LENGTH_COORDINATE |
 | Stationing | RoadRailUnits.STATION |
 | LengthSurvey | RoadRailUnits.LENGTH |
 | LengthEngineering | AecUnits.LENGTH |
@@ -338,6 +338,7 @@ The [AlternateUnitLabelsProvider]($quantity) interface allows users to specify a
 ### Mathematical Operation Parsing
 
 The quantity formatter supports parsing mathematical operations. The operation is solved, formatting every values present, according to the specified format. This makes it possible to process several different units at once.
+
 ```Typescript
 const unitsProvider = new BasicUnitsProvider(); // If @itwin/core-frontend is available, can use IModelApp.quantityFormatter.unitsProvider
 const outUnit = await unitsProvider.findUnitByName("Units.FT");

--- a/docs/learning/quantity/index.md
+++ b/docs/learning/quantity/index.md
@@ -194,19 +194,20 @@ Building off of [FormatSet](#formatset), Tools and components that format quanti
 
 The table below lists common measurements with their typical `KindOfQuantity` and Persistence Unit. This allows tools to request a default `KindOfQuantity` from [IModelApp.formatsProvider]($core-frontend) and a Persistence Unit from [IModelApp.quantityFormatter]($core-frontend) to create a `FormatterSpec` for quantity formatting.
 
-| Measurement  | Actual KindOfQuantity (EC Full Name) | Persistence Unit
-| ------------- | ------------- | -------------
-| Length  |  AecUnits.LENGTH | Units.M
-| Angle  | AecUnits.ANGLE  | Units.RAD
-| Area  |  AecUnits.AREA | Units.SQ_M
-| Volume  | AecUnits.VOLUME  | Units.CUB_M
-| Latitude/Longitude | AecUnits.ANGLE | Units.RAD
-| Coordinate | AecUnits.LENGTH | Units.M
-| Stationing | RoadRailUnits.STATION | Units.M
-| Length (Survey Feet) | RoadRailUnits.LENGTH | Units.M
-| Bearing | RoadRailUnits.BEARING | Units.RAD
-| Weight | AecUnits.WEIGHT | Units.KG
-| Time | AecUnits.TIME | Units.S
+| Measurement  | Actual KindOfQuantity (EC Full Name) | Persistence Unit |
+| ------------- | ------------- | ------------- |
+| Length  |  AecUnits.LENGTH | Units.M |
+| Angle  | AecUnits.ANGLE  | Units.RAD |
+| Area  |  AecUnits.AREA | Units.SQ_M |
+| Volume  | AecUnits.VOLUME  | Units.CUB_M |
+| Latitude/Longitude | AecUnits.ANGLE | Units.RAD |
+| Coordinate | AecUnits.LENGTH_COORDINATE | Units.M |
+| Stationing | RoadRailUnits.STATION | Units.M |
+| Length (Survey Feet) | RoadRailUnits.LENGTH | Units.M |
+| Bearing | RoadRailUnits.BEARING | Units.RAD |
+| Weight | AecUnits.WEIGHT | Units.KG |
+| Time | AecUnits.TIME | Units.S |
+
 
 ## Examples of Usage
 


### PR DESCRIPTION
Related: https://github.com/iTwin/bis-schemas/pull/562

Adds support for a KindOfQuantity for coordinate length. Updated documentation for migrating away from `QuantityType.Coordinate`.

