### PR TITLE
DRAFT: Clean up lint warnings in core/ec*

### DIFF
--- a/core/ecschema-editing/src/Editing/Constants.ts
+++ b/core/ecschema-editing/src/Editing/Constants.ts
@@ -59,7 +59,7 @@ export class Constants extends SchemaItems {
       const newConstant = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createConstant.bind(schema), constantProps);
       return newConstant.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, constantProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, constantProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 }

--- a/core/ecschema-editing/src/Editing/CustomAttributes.ts
+++ b/core/ecschema-editing/src/Editing/CustomAttributes.ts
@@ -53,7 +53,7 @@ export class CustomAttributes extends ECClasses {
       const newClass = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createCustomAttributeClass.bind(schema), caProps);
       return newClass.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, caProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, caProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 }

--- a/core/ecschema-editing/src/Editing/Entities.ts
+++ b/core/ecschema-editing/src/Editing/Entities.ts
@@ -99,7 +99,7 @@ export class Entities extends ECClasses {
       const newClass = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createEntityClass.bind(schema), entityProps);
       return newClass.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, entityProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, entityProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 

--- a/core/ecschema-editing/src/Editing/Enumerations.ts
+++ b/core/ecschema-editing/src/Editing/Enumerations.ts
@@ -59,7 +59,7 @@ export class Enumerations extends SchemaItems {
       const newEnum = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createEnumeration.bind(schema), enumProps);
       return newEnum.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, enumProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, enumProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 

--- a/core/ecschema-editing/src/Editing/Exception.ts
+++ b/core/ecschema-editing/src/Editing/Exception.ts
@@ -253,7 +253,7 @@ export class SchemaItemId implements ISchemaItemIdentifier {
       if (!schemaKey)
         throw new Error("schemaKey if required if the specified schemaItem the name of the schema item.");
 
-      this.schemaKey = schemaKey!;
+      this.schemaKey = schemaKey;
       this.schemaItemKey = new SchemaItemKey(schemaItemKeyOrName, schemaKey);
     } else {
       this.schemaKey = schemaItemKeyOrName.schemaKey;

--- a/core/ecschema-editing/src/Editing/Formats.ts
+++ b/core/ecschema-editing/src/Editing/Formats.ts
@@ -68,7 +68,7 @@ export class Formats extends SchemaItems {
       const newFormat = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createFormat.bind(schema), formatProps);
       return newFormat.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, formatProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, formatProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 }

--- a/core/ecschema-editing/src/Editing/InvertedUnits.ts
+++ b/core/ecschema-editing/src/Editing/InvertedUnits.ts
@@ -51,7 +51,7 @@ export class InvertedUnits extends SchemaItems {
       const newUnit = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createInvertedUnit.bind(schema), invertedUnitProps);
       return newUnit.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, invertedUnitProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, invertedUnitProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 

--- a/core/ecschema-editing/src/Editing/KindOfQuantities.ts
+++ b/core/ecschema-editing/src/Editing/KindOfQuantities.ts
@@ -58,7 +58,7 @@ export class KindOfQuantities extends SchemaItems {
       const koqItem = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createKindOfQuantity.bind(schema), koqProps);
       return koqItem.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, koqProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, koqProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 

--- a/core/ecschema-editing/src/Editing/Mixins.ts
+++ b/core/ecschema-editing/src/Editing/Mixins.ts
@@ -60,7 +60,7 @@ export class Mixins extends ECClasses {
       const newClass = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createMixinClass.bind(schema), mixinProps);
       return newClass.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, mixinProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, mixinProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 

--- a/core/ecschema-editing/src/Editing/Phenomena.ts
+++ b/core/ecschema-editing/src/Editing/Phenomena.ts
@@ -45,7 +45,7 @@ export class Phenomena extends SchemaItems {
       const newPhenomenon = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createPhenomenon.bind(schema), phenomenonProps);
       return newPhenomenon.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, phenomenonProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, phenomenonProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 }

--- a/core/ecschema-editing/src/Editing/PropertyCategories.ts
+++ b/core/ecschema-editing/src/Editing/PropertyCategories.ts
@@ -43,7 +43,7 @@ export class PropertyCategories extends SchemaItems {
       const newPropCategory = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createPropertyCategory.bind(schema), propertyCategoryProps);
       return newPropCategory.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, propertyCategoryProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, propertyCategoryProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 

--- a/core/ecschema-editing/src/Editing/RelationshipClasses.ts
+++ b/core/ecschema-editing/src/Editing/RelationshipClasses.ts
@@ -6,6 +6,7 @@
  * @module Editing
  */
 
+import { expectDefined } from "@itwin/core-bentley";
 import {
   CustomAttribute, DelayedPromiseWithProps, ECClass, ECClassModifier, EntityClass, LazyLoadedRelationshipConstraintClass, Mixin, NavigationPropertyProps,
   RelationshipClass, RelationshipClassProps, RelationshipConstraint, RelationshipEnd, RelationshipMultiplicity, SchemaItemKey, SchemaItemType,
@@ -102,7 +103,7 @@ export class RelationshipClasses extends ECClasses {
 
       return newClass.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, relationshipProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, relationshipProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 
@@ -121,9 +122,9 @@ export class RelationshipClasses extends ECClasses {
     await super.setBaseClass(itemKey, baseClassKey);
 
     try {
-      await this.validate(relClass!);
+      await this.validate(expectDefined(relClass));
     } catch(e: any) {
-      await (relClass! as ECClass as MutableClass).setBaseClass(baseClass);
+      await (expectDefined(relClass) as ECClass as MutableClass).setBaseClass(baseClass);
       throw new SchemaEditingError(ECEditingStatus.SetBaseClass, new ClassId(SchemaItemType.RelationshipClass, itemKey), e);
     }
   }

--- a/core/ecschema-editing/src/Editing/Structs.ts
+++ b/core/ecschema-editing/src/Editing/Structs.ts
@@ -47,7 +47,7 @@ export class Structs extends ECClasses {
       const newClass = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createStructClass.bind(schema), structProps);
       return newClass.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, structProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new ClassId(this.schemaItemType, structProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 }

--- a/core/ecschema-editing/src/Editing/UnitSystems.ts
+++ b/core/ecschema-editing/src/Editing/UnitSystems.ts
@@ -44,7 +44,7 @@ export class UnitSystems extends SchemaItems {
       const newUnitSystem = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createUnitSystem.bind(schema), unitSystemProps);
       return newUnitSystem.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, unitSystemProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, unitSystemProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 }

--- a/core/ecschema-editing/src/Editing/Units.ts
+++ b/core/ecschema-editing/src/Editing/Units.ts
@@ -52,7 +52,7 @@ export class Units extends SchemaItems {
       const newUnit = await this.createSchemaItemFromProps(schemaKey, this.schemaItemType, (schema) => schema.createUnit.bind(schema), unitProps);
       return newUnit.key;
     } catch (e: any) {
-      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, unitProps.name!, schemaKey), e);
+      throw new SchemaEditingError(ECEditingStatus.CreateSchemaItemFromProps, new SchemaItemId(this.schemaItemType, unitProps.name ?? "<unknown>", schemaKey), e);
     }
   }
 }

--- a/core/ecschema-editing/src/Merging/EnumerationMerger.ts
+++ b/core/ecschema-editing/src/Merging/EnumerationMerger.ts
@@ -39,7 +39,7 @@ export async function addEnumeration(context: SchemaMergeContext, change: Enumer
 export async function modifyEnumeration(context: SchemaMergeContext, change: EnumerationDifference, itemKey: SchemaItemKey) {
   const enumeration = await context.targetSchema.lookupItem(itemKey) as MutableEnumeration;
   if(change.difference.type !== undefined) {
-    throw new Error(`The Enumeration ${itemKey.name} has an incompatible type. It must be "${primitiveTypeToString(enumeration.type!)}", not "${change.difference.type}".`);
+    throw new Error(`The Enumeration ${itemKey.name} has an incompatible type. It must be "${enumeration.type ? primitiveTypeToString(enumeration.type) : "<unknown>"}", not "${change.difference.type}".`);
   }
   if(change.difference.label !== undefined) {
     await context.editor.enumerations.setDisplayLabel(itemKey, change.difference.label);

--- a/core/ecschema-editing/src/Merging/RelationshipClassMerger.ts
+++ b/core/ecschema-editing/src/Merging/RelationshipClassMerger.ts
@@ -114,7 +114,7 @@ export async function mergeRelationshipConstraint(context: SchemaMergeContext, c
  */
 export async function mergeRelationshipClassConstraint(context: SchemaMergeContext, change: RelationshipConstraintClassDifference): Promise<void> {
   if(change.changeType !== "add") {
-    throw new Error(`Change type ${change.changeType} is not supported for Relationship constraint classes.`);
+    throw new Error(`Change type ${String(change.changeType)} is not supported for Relationship constraint classes.`);
   }
 
   const item = await locateSchemaItem(context, change.itemName, SchemaItemType.RelationshipClass) as MutableRelationshipClass;

--- a/core/ecschema-editing/src/Merging/SchemaReferenceMerger.ts
+++ b/core/ecschema-editing/src/Merging/SchemaReferenceMerger.ts
@@ -28,7 +28,7 @@ export async function modifySchemaReferences(context: SchemaMergeContext, change
   }
 
   if(!latest.matches(older, SchemaMatchType.LatestWriteCompatible)) {
-    throw new Error(`Schemas references of ${change.difference.name} have incompatible versions: ${older.version} and ${latest.version}`);
+    throw new Error(`Schemas references of ${change.difference.name} have incompatible versions: ${older.version.toString()} and ${latest.version.toString()}`);
   }
 
   const index = context.targetSchema.references.findIndex((reference) => reference === existingSchema);

--- a/core/ecschema-editing/src/Validation/DiagnosticReporter.ts
+++ b/core/ecschema-editing/src/Validation/DiagnosticReporter.ts
@@ -70,6 +70,7 @@ export abstract class SuppressionDiagnosticReporter implements IDiagnosticReport
   public report(diagnostic: AnyDiagnostic) {
     if (this._suppressions && this._suppressions.has(diagnostic.schema.fullName)) {
       const suppressedCodes = this._suppressions.get(diagnostic.schema.fullName);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       if (suppressedCodes!.includes(diagnostic.code))
         return;
     }

--- a/core/ecschema-editing/src/Validation/ECRules.ts
+++ b/core/ecschema-editing/src/Validation/ECRules.ts
@@ -6,6 +6,7 @@
  * @module Validation
  */
 
+import { expectDefined } from "@itwin/core-bentley";
 import {
   AnyClass, AnyProperty, CustomAttribute, CustomAttributeContainerProps, ECClass, ECClassModifier,
   ECStringConstants, EntityClass, Enumeration, Mixin, PrimitiveProperty, PrimitiveType, primitiveTypeToString,
@@ -328,7 +329,7 @@ export async function* incompatibleValueTypePropertyOverride(property: AnyProper
     if (!baseType || primitiveType === baseType)
       return;
 
-    return new Diagnostics.IncompatibleValueTypePropertyOverride(property, [property.class.fullName, property.name, baseClass.fullName, primitiveTypeToString(baseType), primitiveTypeToString(primitiveType!)]);
+    return new Diagnostics.IncompatibleValueTypePropertyOverride(property, [property.class.fullName, property.name, baseClass.fullName, primitiveTypeToString(baseType), primitiveTypeToString(expectDefined(primitiveType))]);
   }
 
   for await (const baseClass of property.class.getAllBaseClasses()) {

--- a/core/ecschema-editing/src/Validation/SchemaChanges.ts
+++ b/core/ecschema-editing/src/Validation/SchemaChanges.ts
@@ -203,9 +203,9 @@ export abstract class BaseSchemaChanges implements ISchemaChanges {
    * @param changeKey The key used to identify the ISchemaChanges in the Map (typically the name of the EC type, ie. SchemaItem.name).
    */
   protected addChangeToMap<V extends ISchemaChanges>(changes: Map<string, V>, changesType: SchemaChangesConstructor, change: ISchemaChange, changeKey: string) {
-    if (changes.has(changeKey)) {
-      const existingChanges = changes.get(changeKey);
-      existingChanges!.addChange(change);
+    const existingChanges = changes.get(changeKey);
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new changesType(this._schema, changeKey);
       newChanges.addChange(change);
@@ -457,9 +457,9 @@ export class SchemaChanges extends BaseSchemaChanges {
   }
 
   private addChangeToSchemaItemMap(change: ISchemaChange, schemaItem: SchemaItem) {
-    if (this.schemaItemChanges.has(schemaItem.name)) {
-      const existingChanges = this.schemaItemChanges.get(schemaItem.name);
-      existingChanges!.addChange(change);
+    const existingChanges = this.schemaItemChanges.get(schemaItem.name)
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new SchemaItemChanges(this.schema, schemaItem.name, schemaItem.schemaItemType);
       newChanges.addChange(change);
@@ -468,9 +468,9 @@ export class SchemaChanges extends BaseSchemaChanges {
   }
 
   private addChangeToClassMap(change: ISchemaChange, ecClass: AnyClass) {
-    if (this.classChanges.has(ecClass.name)) {
-      const existingChanges = this.classChanges.get(ecClass.name);
-      existingChanges!.addChange(change);
+    const existingChanges = this.classChanges.get(ecClass.name);
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new ClassChanges(this.schema, ecClass.name, ecClass.schemaItemType);
       newChanges.addChange(change);
@@ -479,9 +479,9 @@ export class SchemaChanges extends BaseSchemaChanges {
   }
 
   private addChangeToEntityClassMap(change: ISchemaChange, ecClass: EntityClass) {
-    if (this.entityClassChanges.has(ecClass.name)) {
       const existingChanges = this.entityClassChanges.get(ecClass.name);
-      existingChanges!.addChange(change);
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new EntityClassChanges(this.schema, ecClass.name, ecClass.schemaItemType);
       newChanges.addChange(change);
@@ -490,9 +490,9 @@ export class SchemaChanges extends BaseSchemaChanges {
   }
 
   private addChangeToRelationshipClassMap(change: ISchemaChange, ecClass: RelationshipClass) {
-    if (this.relationshipClassChanges.has(ecClass.name)) {
-      const existingChanges = this.relationshipClassChanges.get(ecClass.name);
-      existingChanges!.addChange(change);
+    const existingChanges = this.relationshipClassChanges.get(ecClass.name);
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new RelationshipClassChanges(this.schema, ecClass.name, ecClass.schemaItemType);
       newChanges.addChange(change);
@@ -501,9 +501,9 @@ export class SchemaChanges extends BaseSchemaChanges {
   }
 
   private addChangeToEnumerationMap(change: ISchemaChange, enumeration: Enumeration) {
-    if (this.enumerationChanges.has(enumeration.name)) {
-      const existingChanges = this.enumerationChanges.get(enumeration.name);
-      existingChanges!.addChange(change);
+    const existingChanges = this.enumerationChanges.get(enumeration.name);
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new EnumerationChanges(this.schema, enumeration.name, enumeration.schemaItemType);
       newChanges.addChange(change);
@@ -512,9 +512,9 @@ export class SchemaChanges extends BaseSchemaChanges {
   }
 
   private addChangeToKOQMap(change: ISchemaChange, koq: KindOfQuantity) {
-    if (this.kindOfQuantityChanges.has(koq.name)) {
-      const existingChanges = this.kindOfQuantityChanges.get(koq.name);
-      existingChanges!.addChange(change);
+    const existingChanges = this.kindOfQuantityChanges.get(koq.name);
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new KindOfQuantityChanges(this.schema, koq.name, koq.schemaItemType);
       newChanges.addChange(change);
@@ -523,9 +523,9 @@ export class SchemaChanges extends BaseSchemaChanges {
   }
 
   private addChangeToFormatMap(change: ISchemaChange, format: Format) {
-    if (this.formatChanges.has(format.name)) {
-      const existingChanges = this.formatChanges.get(format.name);
-      existingChanges!.addChange(change);
+    const existingChanges = this.formatChanges.get(format.name);
+    if (undefined !== existingChanges) {
+      existingChanges.addChange(change);
     } else {
       const newChanges = new FormatChanges(this.schema, format.name, format.schemaItemType);
       newChanges.addChange(change);

--- a/core/ecschema-locaters/src/StubSchemaXmlFileLocater.ts
+++ b/core/ecschema-locaters/src/StubSchemaXmlFileLocater.ts
@@ -84,7 +84,8 @@ export class StubSchemaXmlFileLocater extends SchemaFileLocater implements ISche
       return undefined;
 
     const maxCandidate = candidates.sort(this.compareSchemaKeyByVersion)[candidates.length - 1];
-    const alias = this.getSchemaAlias(maxCandidate.schemaText!);
+    // Note: if maxCandidate.schemaText is undefined, getSchemaAlias will throw an ECSchemaError.
+    const alias = this.getSchemaAlias(maxCandidate.schemaText ?? "");
     const schema = new Schema(context, maxCandidate, alias);
     context.addSchemaSync(schema);
 

--- a/core/ecschema-metadata/src/Deserialization/JsonParser.ts
+++ b/core/ecschema-metadata/src/Deserialization/JsonParser.ts
@@ -103,7 +103,7 @@ export class JsonParser extends AbstractParser<UnknownObject> {
   public *getReferences(): Iterable<SchemaReferenceProps> {
     if (undefined !== this._rawSchema.references) {
       if (!Array.isArray(this._rawSchema.references))
-        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The schema ${this._rawSchema.name} has an invalid 'references' attribute. It should be of type 'object[]'.`);
+        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The schema ${String(this._rawSchema.name)} has an invalid 'references' attribute. It should be of type 'object[]'.`);
 
       for (const ref of this._rawSchema.references) {
         yield this.checkSchemaReference(ref);
@@ -704,45 +704,45 @@ export class JsonParser extends AbstractParser<UnknownObject> {
     const propName = jsonObj.name;
 
     if (undefined !== jsonObj.label && typeof (jsonObj.label) !== "string")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'label' attribute. It should be of type 'string'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'label' attribute. It should be of type 'string'.`);
 
     if (undefined !== jsonObj.description && typeof (jsonObj.description) !== "string")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'description' attribute. It should be of type 'string'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'description' attribute. It should be of type 'string'.`);
 
     if (undefined !== jsonObj.priority && typeof (jsonObj.priority) !== "number")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'priority' attribute. It should be of type 'number'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'priority' attribute. It should be of type 'number'.`);
 
     if (undefined !== jsonObj.isReadOnly && typeof (jsonObj.isReadOnly) !== "boolean")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'isReadOnly' attribute. It should be of type 'boolean'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'isReadOnly' attribute. It should be of type 'boolean'.`);
 
     if (undefined !== jsonObj.category && typeof (jsonObj.category) !== "string")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'category' attribute. It should be of type 'string'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'category' attribute. It should be of type 'string'.`);
 
     if (undefined !== jsonObj.kindOfQuantity && typeof (jsonObj.kindOfQuantity) !== "string")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'kindOfQuantity' attribute. It should be of type 'string'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'kindOfQuantity' attribute. It should be of type 'string'.`);
 
     if (undefined !== jsonObj.inherited && typeof (jsonObj.inherited) !== "boolean")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'inherited' attribute. It should be of type 'boolean'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'inherited' attribute. It should be of type 'boolean'.`);
 
     if (undefined !== jsonObj.customAttributes && !Array.isArray(jsonObj.customAttributes))
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'customAttributes' attribute. It should be of type 'array'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'customAttributes' attribute. It should be of type 'array'.`);
     return (jsonObj as unknown) as PropertyProps;
   }
 
   private checkPropertyTypename(jsonObj: UnknownObject): void {
     const propName = jsonObj.name;
     if (undefined === jsonObj.typeName)
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} is missing the required 'typeName' attribute.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} is missing the required 'typeName' attribute.`);
     if (typeof (jsonObj.typeName) !== "string")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'typeName' attribute. It should be of type 'string'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'typeName' attribute. It should be of type 'string'.`);
   }
 
   private checkPropertyMinAndMaxOccurs(jsonObj: UnknownObject): void {
     const propName = jsonObj.name;
     if (undefined !== jsonObj.minOccurs && typeof (jsonObj.minOccurs) !== "number")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'minOccurs' attribute. It should be of type 'number'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'minOccurs' attribute. It should be of type 'number'.`);
     if (undefined !== jsonObj.maxOccurs && typeof (jsonObj.maxOccurs) !== "number")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'maxOccurs' attribute. It should be of type 'number'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'maxOccurs' attribute. It should be of type 'number'.`);
   }
 
   /**
@@ -756,19 +756,19 @@ export class JsonParser extends AbstractParser<UnknownObject> {
     const propName = jsonObj.name;
 
     if (undefined !== jsonObj.minLength && typeof (jsonObj.minLength) !== "number")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'minLength' attribute. It should be of type 'number'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'minLength' attribute. It should be of type 'number'.`);
 
     if (undefined !== jsonObj.maxLength && typeof (jsonObj.maxLength) !== "number")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'maxLength' attribute. It should be of type 'number'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'maxLength' attribute. It should be of type 'number'.`);
 
     if (undefined !== jsonObj.minValue && typeof (jsonObj.minValue) !== "number")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'minValue' attribute. It should be of type 'number'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'minValue' attribute. It should be of type 'number'.`);
 
     if (undefined !== jsonObj.maxValue && typeof (jsonObj.maxValue) !== "number")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'maxValue' attribute. It should be of type 'number'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'maxValue' attribute. It should be of type 'number'.`);
 
     if (undefined !== jsonObj.extendedTypeName && typeof (jsonObj.extendedTypeName) !== "string")
-      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${propName} has an invalid 'extendedTypeName' attribute. It should be of type 'string'.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The ECProperty ${this._currentItemFullName}.${String(propName)} has an invalid 'extendedTypeName' attribute. It should be of type 'string'.`);
     return (jsonObj as unknown) as PrimitiveOrEnumPropertyBaseProps;
   }
 
@@ -823,7 +823,7 @@ export class JsonParser extends AbstractParser<UnknownObject> {
    */
   public parseNavigationProperty(jsonObj: UnknownObject): NavigationPropertyProps {
     this.checkPropertyProps(jsonObj);
-    const fullname = `${this._currentItemFullName}.${jsonObj.name}`;
+    const fullname = `${this._currentItemFullName}.${String(jsonObj.name)}`;
 
     if (undefined === jsonObj.relationshipName)
       throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The Navigation Property ${fullname} is missing the required 'relationshipName' property.`);
@@ -847,7 +847,7 @@ export class JsonParser extends AbstractParser<UnknownObject> {
   }
 
   public getPropertyCustomAttributeProviders(jsonObj: UnknownObject): Iterable<CAProviderTuple> {
-    return this.getCustomAttributeProviders(jsonObj, "ECProperty", `${this._currentItemFullName}.${jsonObj.name}`);
+    return this.getCustomAttributeProviders(jsonObj, "ECProperty", `${this._currentItemFullName}.${String(jsonObj.name)}`);
   }
 
   public getRelationshipConstraintCustomAttributeProviders(jsonObj: UnknownObject): [Iterable<CAProviderTuple> /* source */, Iterable<CAProviderTuple> /* target */] {

--- a/core/ecschema-metadata/src/IncrementalLoading/IncrementalSchemaLocater.ts
+++ b/core/ecschema-metadata/src/IncrementalLoading/IncrementalSchemaLocater.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { expectDefined } from "@itwin/core-bentley";
 import { ECSchemaNamespaceUris } from "../Constants";
 import { ISchemaLocater, SchemaContext } from "../Context";
 import { SchemaProps } from "../Deserialization/JsonProps";
@@ -139,7 +140,7 @@ export abstract class IncrementalSchemaLocater implements ISchemaLocater {
     // to fetch the whole schema json.
     if (!await this.supportPartialSchemaLoading(schemaContext)) {
       const schemaJson = await this.getSchemaJson(schemaInfo.schemaKey, schemaContext);
-      return Schema.fromJson(schemaJson!, schemaContext);
+      return Schema.fromJson(expectDefined(schemaJson), schemaContext);
     }
 
     // Fetches the schema partials for the given schema key. The first item in the array is the
@@ -186,9 +187,9 @@ export abstract class IncrementalSchemaLocater implements ISchemaLocater {
     if (!schemaProps.references)
       throw new Error(`Schema references is undefined for the Schema ${schemaInfo.schemaKey.name}`);
 
-    schemaInfo.references.forEach((ref) => {
-      schemaProps.references!.push({ name: ref.schemaKey.name, version: ref.schemaKey.version.toString() });
-    });
+    for (const ref of schemaInfo.references) {
+      schemaProps.references.push({ name: ref.schemaKey.name, version: ref.schemaKey.version.toString() });
+    }
 
     return schemaProps;
   }

--- a/core/ecschema-metadata/src/IncrementalLoading/IncrementalSchemaReader.ts
+++ b/core/ecschema-metadata/src/IncrementalLoading/IncrementalSchemaReader.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { assert } from "@itwin/core-bentley";
 import { SchemaContext } from "../Context";
 import { SchemaReadHelper } from "../Deserialization/Helper";
 import { JsonParser } from "../Deserialization/JsonParser";
@@ -74,13 +75,14 @@ export class IncrementalSchemaReader extends SchemaReadHelper {
     if (schemaItem.loadingController === undefined) {
       const controller = new SchemaLoadingController();
       schemaItem.setLoadingController(controller);
+      assert(undefined !== schemaItem.loadingController);
     }
 
     if (ECClass.isECClass(schemaItem)
       || schemaItem.schemaItemType === SchemaItemType.KindOfQuantity
       || schemaItem.schemaItemType === SchemaItemType.Format)
-      schemaItem.loadingController!.isComplete = !this._incremental;
+      schemaItem.loadingController.isComplete = !this._incremental;
     else
-      schemaItem.loadingController!.isComplete = true;
+      schemaItem.loadingController.isComplete = true;
   }
 }

--- a/core/ecschema-metadata/src/IncrementalLoading/SchemaParser.ts
+++ b/core/ecschema-metadata/src/IncrementalLoading/SchemaParser.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { expectDefined } from "@itwin/core-bentley";
 import { ECSchemaNamespaceUris } from "../Constants";
 import { SchemaContext } from "../Context";
 import { SchemaItemProps, SchemaProps } from "../Deserialization/JsonProps";
@@ -72,7 +73,7 @@ export class SchemaParser {
     const items: { [name: string]: SchemaItemProps } = {};
     for (const itemProps of schemaItemProps) {
       const props = await this.parseItem(itemProps, schemaName, context);
-      items[props.name!] = props;
+      items[expectDefined(props.name)] = props;
       delete (props as any).name;
     }
 

--- a/core/ecschema-metadata/src/Metadata/Class.ts
+++ b/core/ecschema-metadata/src/Metadata/Class.ts
@@ -373,7 +373,7 @@ export abstract class ECClass extends SchemaItem implements CustomAttributeConta
 
     if (!correctType)
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided Struct type, ${structType}, is not a valid StructClass.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided Struct type, ${String(structType)}, is not a valid StructClass.`);
 
     return correctType;
   }
@@ -395,7 +395,7 @@ export abstract class ECClass extends SchemaItem implements CustomAttributeConta
 
     if (!correctType)
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided Struct type, ${structType}, is not a valid StructClass.`);
+      throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided Struct type, ${String(structType)}, is not a valid StructClass.`);
 
     return correctType;
   }

--- a/core/ecschema-metadata/src/Metadata/EntityClass.ts
+++ b/core/ecschema-metadata/src/Metadata/EntityClass.ts
@@ -294,7 +294,7 @@ export async function createNavigationProperty(ecClass: ECClass, name: string, r
     resolvedRelationship = relationship;
 
   if (!resolvedRelationship)
-    throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided RelationshipClass, ${relationship}, is not a valid RelationshipClassInterface.`);  // eslint-disable-line @typescript-eslint/no-base-to-string
+    throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided RelationshipClass, ${String(relationship)}, is not a valid RelationshipClassInterface.`);  // eslint-disable-line @typescript-eslint/no-base-to-string
 
   if (typeof (direction) === "string") {
     const tmpDirection = parseStrengthDirection(direction);
@@ -319,7 +319,7 @@ export function createNavigationPropertySync(ecClass: ECClass, name: string, rel
     resolvedRelationship = relationship;
 
   if (!resolvedRelationship)
-    throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided RelationshipClass, ${relationship}, is not a valid RelationshipClassInterface.`);  // eslint-disable-line @typescript-eslint/no-base-to-string
+    throw new ECSchemaError(ECSchemaStatus.InvalidType, `The provided RelationshipClass, ${String(relationship)}, is not a valid RelationshipClassInterface.`);  // eslint-disable-line @typescript-eslint/no-base-to-string
 
   if (typeof (direction) === "string") {
     const tmpDirection = parseStrengthDirection(direction);

--- a/core/ecschema-metadata/src/Metadata/InvertedUnit.ts
+++ b/core/ecschema-metadata/src/Metadata/InvertedUnit.ts
@@ -6,6 +6,7 @@
  * @module Metadata
  */
 
+import { expectDefined } from "@itwin/core-bentley";
 import { DelayedPromiseWithProps } from "../DelayedPromise";
 import { InvertedUnitProps } from "../Deserialization/JsonProps";
 import { XmlSerializationUtils } from "../Deserialization/XmlSerializationUtils";
@@ -61,8 +62,8 @@ export class InvertedUnit extends SchemaItem {
    */
   public override toJSON(standalone: boolean = false, includeSchemaVersion: boolean = false): InvertedUnitProps {
     const schemaJson = super.toJSON(standalone, includeSchemaVersion) as any;
-    schemaJson.invertsUnit = this.invertsUnit!.fullName;
-    schemaJson.unitSystem = this.unitSystem!.fullName;
+    schemaJson.invertsUnit = expectDefined(this.invertsUnit).fullName;
+    schemaJson.unitSystem = expectDefined(this.unitSystem).fullName;
     return schemaJson;
   }
 

--- a/core/ecschema-metadata/src/Metadata/KindOfQuantity.ts
+++ b/core/ecschema-metadata/src/Metadata/KindOfQuantity.ts
@@ -6,6 +6,7 @@
  * @module Metadata
  */
 
+import { expectDefined } from "@itwin/core-bentley";
 import { DelayedPromiseWithProps } from "../DelayedPromise";
 import { KindOfQuantityProps } from "../Deserialization/JsonProps";
 import { XmlSerializationUtils } from "../Deserialization/XmlSerializationUtils";
@@ -151,7 +152,7 @@ export class KindOfQuantity extends SchemaItem {
   public override toJSON(standalone: boolean = false, includeSchemaVersion: boolean = false): KindOfQuantityProps {
     const schemaJson = super.toJSON(standalone, includeSchemaVersion) as any;
     schemaJson.relativeError = this.relativeError;
-    schemaJson.persistenceUnit = this.persistenceUnit!.fullName;
+    schemaJson.persistenceUnit = expectDefined(this.persistenceUnit).fullName;
     if (undefined !== this.presentationFormats && 0 < this.presentationFormats.length)
       schemaJson.presentationUnits = this.presentationFormats.map((format) => format.fullName);
     return schemaJson;

--- a/core/ecschema-metadata/src/Metadata/OverrideFormat.ts
+++ b/core/ecschema-metadata/src/Metadata/OverrideFormat.ts
@@ -93,7 +93,7 @@ export class OverrideFormat {
     for (const [unit, unitLabel] of this._units) {
       const unitSchema = koqSchema.context.getSchemaSync(unit.schemaKey);
       if(unitSchema === undefined)
-        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The unit schema ${unit.schemaKey} is not found in the context.`);
+        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The unit schema ${String(unit.schemaKey)} is not found in the context.`);
 
       fullName += "[";
       fullName += XmlSerializationUtils.createXmlTypedName(koqSchema, unitSchema, unit.name);

--- a/core/ecschema-metadata/src/Metadata/Property.ts
+++ b/core/ecschema-metadata/src/Metadata/Property.ts
@@ -6,6 +6,7 @@
  * @module Metadata
  */
 
+import { expectDefined } from "@itwin/core-bentley";
 import { DelayedPromiseWithProps } from "../DelayedPromise";
 import {
   ArrayPropertyProps, EnumerationPropertyProps, NavigationPropertyProps, PrimitiveArrayPropertyProps, PrimitiveOrEnumPropertyBaseProps,
@@ -515,7 +516,7 @@ export class EnumerationProperty extends PrimitiveOrEnumPropertyBase {
    */
   public override toJSON(): EnumerationPropertyProps {
     const schemaJson = super.toJSON() as any;
-    schemaJson.typeName = this.enumeration!.fullName;
+    schemaJson.typeName = expectDefined(this.enumeration).fullName;
     return schemaJson;
   }
 
@@ -529,9 +530,9 @@ export class EnumerationProperty extends PrimitiveOrEnumPropertyBase {
   public override fromJSONSync(enumerationPropertyProps: EnumerationPropertyProps) {
     super.fromJSONSync(enumerationPropertyProps);
     if (undefined !== enumerationPropertyProps.typeName) {
-      if (!(this.enumeration!.fullName).match(enumerationPropertyProps.typeName)) // need to match {schema}.{version}.{itemName} on typeName
+      if (!(expectDefined(this.enumeration).fullName).match(enumerationPropertyProps.typeName)) // need to match {schema}.{version}.{itemName} on typeName
         throw new ECSchemaError(ECSchemaStatus.InvalidECJson, ``);
-      const enumSchemaItemKey = this.class.schema.getSchemaItemKey(this.enumeration!.fullName);
+      const enumSchemaItemKey = this.class.schema.getSchemaItemKey(expectDefined(this.enumeration).fullName);
       if (!enumSchemaItemKey)
         throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `Unable to locate the enumeration ${enumerationPropertyProps.typeName}.`);
       this._enumeration = new DelayedPromiseWithProps<SchemaItemKey, Enumeration>(enumSchemaItemKey,
@@ -547,8 +548,8 @@ export class EnumerationProperty extends PrimitiveOrEnumPropertyBase {
   /** @internal */
   public override async toXml(schemaXml: Document): Promise<Element> {
     const itemElement = await super.toXml(schemaXml);
-    const enumeration = await this.enumeration;
-    const enumerationName = XmlSerializationUtils.createXmlTypedName(this.schema, enumeration!.schema, enumeration!.name);
+    const enumeration = expectDefined(await this.enumeration);
+    const enumerationName = XmlSerializationUtils.createXmlTypedName(this.schema, enumeration.schema, enumeration.name);
     itemElement.setAttribute("typeName", enumerationName);
     return itemElement;
   }

--- a/core/ecschema-metadata/src/Metadata/RelationshipClass.ts
+++ b/core/ecschema-metadata/src/Metadata/RelationshipClass.ts
@@ -6,6 +6,7 @@
  * @module Metadata
  */
 
+import { expectDefined } from "@itwin/core-bentley";
 import { DelayedPromiseWithProps } from "../DelayedPromise";
 import { ECSpecVersion, SchemaReadHelper } from "../Deserialization/Helper";
 import { RelationshipClassProps, RelationshipConstraintProps } from "../Deserialization/JsonProps";
@@ -344,7 +345,7 @@ export class RelationshipConstraint implements CustomAttributeContainerProps {
         throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `Unable to locate the abstractConstraint ${relationshipConstraintProps.abstractConstraint}.`);
       this.setAbstractConstraint(new DelayedPromiseWithProps<SchemaItemKey, AnyConstraintClass>(abstractConstraintSchemaItemKey,
         async () => {
-          const tempAbstractConstraint = await relClassSchema.lookupItem(relationshipConstraintProps.abstractConstraint!);
+          const tempAbstractConstraint = await relClassSchema.lookupItem(expectDefined(relationshipConstraintProps.abstractConstraint));
           if (undefined === tempAbstractConstraint ||
             (!EntityClass.isEntityClass(tempAbstractConstraint) && !Mixin.isMixin(tempAbstractConstraint) && !RelationshipClass.isRelationshipClass(tempAbstractConstraint)))
             throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `Unable to locate the abstractConstraint ${relationshipConstraintProps.abstractConstraint}.`);

--- a/core/ecschema-metadata/src/Metadata/Schema.ts
+++ b/core/ecschema-metadata/src/Metadata/Schema.ts
@@ -820,7 +820,7 @@ export class Schema implements CustomAttributeContainerProps {
       if (schemaProps.name.toLowerCase() !== this.name.toLowerCase())
         throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The Schema ${this.name} does not match the provided name, '${schemaProps.name}'.`);
       if (this.schemaKey.version.compare(ECVersion.fromString(schemaProps.version)))
-        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The Schema ${this.name} has the version '${this.schemaKey.version}' that does not match the provided version '${schemaProps.version}'.`);
+        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `The Schema ${this.name} has the version '${String(this.schemaKey.version)}' that does not match the provided version '${schemaProps.version}'.`);
     }
 
     if (schemaProps.$schema.match(`https://dev\\.bentley\\.com/json_schemas/ec/([0-9]+)/ecschema`) == null && schemaProps.$schema.match(`http://www\\.bentley\\.com/schemas/Bentley\\.ECXML\\.([0-9]+)`) == null)

--- a/core/ecschema-metadata/src/Metadata/SchemaItem.ts
+++ b/core/ecschema-metadata/src/Metadata/SchemaItem.ts
@@ -108,7 +108,7 @@ export abstract class SchemaItem {
 
     if (undefined !== schemaItemProps.schemaVersion) {
       if (this.key.schemaKey.version.compare(ECVersion.fromString(schemaItemProps.schemaVersion)))
-        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `Unable to deserialize the SchemaItem '${this.fullName}' with a different schema version, ${schemaItemProps.schemaVersion}, than the current Schema version of this SchemaItem, ${this.key.schemaKey.version}.`);
+        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `Unable to deserialize the SchemaItem '${this.fullName}' with a different schema version, ${schemaItemProps.schemaVersion}, than the current Schema version of this SchemaItem, ${String(this.key.schemaKey.version)}.`);
     }
   }
 
@@ -125,7 +125,7 @@ export abstract class SchemaItem {
 
     if (undefined !== schemaItemProps.schemaVersion) {
       if (this.key.schemaKey.version.compare(ECVersion.fromString(schemaItemProps.schemaVersion)))
-        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `Unable to deserialize the SchemaItem '${this.fullName}' with a different schema version, ${schemaItemProps.schemaVersion}, than the current Schema version of this SchemaItem, ${this.key.schemaKey.version}.`);
+        throw new ECSchemaError(ECSchemaStatus.InvalidECJson, `Unable to deserialize the SchemaItem '${this.fullName}' with a different schema version, ${schemaItemProps.schemaVersion}, than the current Schema version of this SchemaItem, ${String(this.key.schemaKey.version)}.`);
     }
   }
 

--- a/core/ecschema-metadata/src/Metadata/Unit.ts
+++ b/core/ecschema-metadata/src/Metadata/Unit.ts
@@ -6,6 +6,7 @@
  * @module Metadata
  */
 
+import { expectDefined } from "@itwin/core-bentley";
 import { DelayedPromiseWithProps } from "../DelayedPromise";
 import { SchemaItemUnitProps } from "../Deserialization/JsonProps";
 import { XmlSerializationUtils } from "../Deserialization/XmlSerializationUtils";
@@ -82,8 +83,8 @@ export class Unit extends SchemaItem {
    */
   public override toJSON(standalone: boolean = false, includeSchemaVersion: boolean = false): SchemaItemUnitProps {
     const schemaJson = super.toJSON(standalone, includeSchemaVersion) as any;
-    schemaJson.phenomenon = this.phenomenon!.fullName;
-    schemaJson.unitSystem = this.unitSystem!.fullName;
+    schemaJson.phenomenon = expectDefined(this.phenomenon).fullName;
+    schemaJson.unitSystem = expectDefined(this.unitSystem).fullName;
     schemaJson.definition = this.definition;
     if (this.hasNumerator)
       schemaJson.numerator = this.numerator;

--- a/core/ecschema-metadata/src/SchemaFormatsProvider.ts
+++ b/core/ecschema-metadata/src/SchemaFormatsProvider.ts
@@ -113,6 +113,8 @@ export class SchemaFormatsProvider implements FormatsProvider {
     const persistenceUnitSystem = await persistenceUnit?.unitSystem;
     if (persistenceUnitSystem && unitSystemMatchers.some((matcher) => matcher(persistenceUnitSystem))) {
       this._formatsRetrieved.add(itemKey.fullName);
+      // It is only possible to get here if persistenceUnit is defined.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const props = getPersistenceUnitFormatProps(persistenceUnit!);
       return this.convertToFormatDefinition(props, kindOfQuantity);
     }

--- a/core/ecschema-metadata/src/UnitConversion/Parser.ts
+++ b/core/ecschema-metadata/src/UnitConversion/Parser.ts
@@ -30,8 +30,8 @@ export function parseDefinition(definition: string): Map<string, DefinitionFragm
       const name = tokens[Tokens.Word];
       const exponent = tokens[Tokens.Exponent] ? Number(tokens[Tokens.Exponent]) : 1;
       const constant = tokens[Tokens.Bracket] !== undefined;
-      if (unitMap.has(name)) {
-        const currentDefinition = unitMap.get(name)!;
+      const currentDefinition = unitMap.get(name);
+      if (currentDefinition !== undefined) {
         currentDefinition.exponent += exponent;
         unitMap.set(name, currentDefinition);
       } else {

--- a/core/ecschema-metadata/src/UnitConversion/UnitTree.ts
+++ b/core/ecschema-metadata/src/UnitConversion/UnitTree.ts
@@ -37,8 +37,8 @@ export class GraphUtils {
         t,
       );
     } else {
-      if (baseUnitsMap.has(key)) {
-        const oldExponent = baseUnitsMap.get(key)!;
+      const oldExponent = baseUnitsMap.get(key);
+      if (oldExponent !== undefined) {
         baseUnitsMap.set(key, oldExponent + accumulatedExponent);
       } else {
         baseUnitsMap.set(key, accumulatedExponent);

--- a/core/ecschema-metadata/src/test/UnitProvider/UnitProvider.test.ts
+++ b/core/ecschema-metadata/src/test/UnitProvider/UnitProvider.test.ts
@@ -149,21 +149,21 @@ describe("Unit Provider tests", () => {
     it("should find alternate display labels of Units.US_SURVEY_FT", () => {
       const altDisplayLabels = provider.getAlternateDisplayLabels("Units.US_SURVEY_FT");
       const expectedLabels = ["ft", "SF", "USF", "ft (US Survey)"];
-      expect(altDisplayLabels, `Alternate display labels should be ${expectedLabels}`).to.include.members(expectedLabels);
+      expect(altDisplayLabels, `Alternate display labels should be ${JSON.stringify(expectedLabels)}`).to.include.members(expectedLabels);
       expect(altDisplayLabels).to.have.lengthOf(4);
     });
 
     it("should find alternate display labels of Units.CUB_US_SURVEY_FT", () => {
       const altDisplayLabels = provider.getAlternateDisplayLabels("Units.CUB_US_SURVEY_FT");
       const expectedLabels = ["cf"];
-      expect(altDisplayLabels, `Alternate display labels should be ${expectedLabels}`).to.include.members(expectedLabels);
+      expect(altDisplayLabels, `Alternate display labels should be ${JSON.stringify(expectedLabels)}`).to.include.members(expectedLabels);
       expect(altDisplayLabels).to.have.lengthOf(1);
     });
 
     it("should not find any alternate display labels of Unit", () => {
       const altDisplayLabels = provider.getAlternateDisplayLabels("Units.CELSIUS");
       const expectedLabels: string[] = [];
-      expect(altDisplayLabels, `Alternate display labels should be ${expectedLabels}`).to.include.members(expectedLabels);
+      expect(altDisplayLabels, `Alternate display labels should be ${JSON.stringify(expectedLabels)}`).to.include.members(expectedLabels);
       expect(altDisplayLabels).to.have.lengthOf(0);
     });
 

--- a/core/ecsql/common/src/ECSqlAst.ts
+++ b/core/ecsql/common/src/ECSqlAst.ts
@@ -825,7 +825,7 @@ export class QualifiedJoinExpr extends ClassRefExpr {
       writer.appendKeyword("INNER").appendSpace();
       writer.appendKeyword("JOIN").appendSpace();
     } else {
-      throw new Error(`not supported join type ${this.joinType}`);
+      throw new Error(`not supported join type ${String(this.joinType)}`);
     }
     writer.appendExp(this.to);
     if (this.spec) {


### PR DESCRIPTION
__NOTE:__ This was created after a `git stash pop` on master, with a local build that included changes from another PR (notably the creation of `expectDefined` and `expectNotNull`). Until that PR is merged, and then origin/master is merged into this PR, it won't work at all. Once that happens, I will remove this message and promote this PR out of draft.

Clean up the lint warnings in all the core/ec* directories.

1. Where possible, clean up code to not require non-null assertions (`!`).
2. Use the new `expectDefined` and `expectNotNull` functions when there isn't an obviously correct way to get rid of the `!`. As time passes, code using `expectDefined` and `expectNotNull` will be updated to stop using it.
3. Fix code that triggers the `@typescript-eslint/restrict-template-expressions` warning.