### PR TITLE
Improve frame rate during interactive editing

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-element-graphics_2025-08-11-18-17.json
+++ b/common/changes/@itwin/core-frontend/pmc-element-graphics_2025-08-11-18-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Improve frame rate during interactive editing.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/internal/tile/DynamicIModelTile.ts
+++ b/core/frontend/src/internal/tile/DynamicIModelTile.ts
@@ -366,6 +366,7 @@ class GraphicsTile extends Tile {
       smoothPolyfaceEdges: this.tree.edgeOptions && this.tree.edgeOptions.smooth,
       clipToProjectExtents: this.tree.is3d,
       sectionCut: this.tree.stringifiedSectionClip,
+      useAbsolutePositions: true,
     };
 
     return IModelApp.tileAdmin.requestElementGraphics(this.tree.iModel, props);

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -344,7 +344,7 @@ display-test-app has access to all key-ins defined in the `@itwin/editor-fronten
 
 * `dta edit` - begin a new editing scope, or end the current editing scope. The title of the window or browser tab will update to reflect the current state: "[R/W]" indicating no current editing scope, or "[EDIT]" indicating an active editing scope.
 * `dta place line string` - start placing a line string. Each data point defines another point in the string; a reset (right mouse button) finishes. The element is placed into the first spatial model and spatial category in the viewport's model and category selectors.
-* `dta move element *elementId* *x* *y* *z*` - Move an element, given an element Id and an x y z offset (in world space, relative to its current). If Y and/or Z are not specified they will default to 0.
+* `dta move element e=*elementId* x=*x* y=*y* z=*z*` - Move an element, given an element Id and an x y z offset (in world space, relative to its current). If X, Y and/or Z are not specified they will default to 0. If element Id is not specified, all currently-selected elements will be moved. You must specify at least one argument.
 * `dta push` - push local changes to iModelHub. A description of the changes must be supplied. It should be enclosed in double quotes if it contains whitespace characters.
 * `dta pull` - pull and merge changes from iModelHub into the local briefcase. You must be signed in.
 * `dta create section drawing *drawingName*` - insert a spatial view matching the active viewport's current view and a section drawing referencing that view, then switch to a non-persistent drawing view to visualize the spatial view in a 2d context. Requires the camera to be turned off.

--- a/test-apps/display-test-app/src/frontend/EditingTools.ts
+++ b/test-apps/display-test-app/src/frontend/EditingTools.ts
@@ -277,19 +277,19 @@ export class MoveElementTool extends Tool {
   /** Executes this tool's run method passing in the elementId and the offset.
    * @see [[run]]
    */
-  public override async parseAndRun(...args: string[]): Promise<boolean> {
-    let x = 0;
-    let y = 0;
-    let z = 0;
+  public override async parseAndRun(...inputs: string[]): Promise<boolean> {
+    const args = parseArgs(inputs);
 
-    if (args.length > 1)
-      x = parseFloat(args[1]);
-    if (args.length > 2)
-      y = parseFloat(args[2]);
-    if (args.length > 3)
-      z = parseFloat(args[3]);
+    const elementId = args.get("e");
+    if (!elementId) {
+      return false;
+    }
 
-    return this.run(args[0], x, y, z);
+    const x = args.getFloat("x") ?? 0;
+    const y = args.getFloat("y") ?? 0;
+    const z = args.getFloat("z") ?? 0;
+
+    return this.run(elementId, x, y, z);
   }
 }
 

--- a/test-apps/display-test-app/src/frontend/EditingTools.ts
+++ b/test-apps/display-test-app/src/frontend/EditingTools.ts
@@ -256,18 +256,19 @@ export async function transformElements(imodel: BriefcaseConnection, ids: string
 /** This tool moves an element relative to its current position. */
 export class MoveElementTool extends Tool {
   public static override toolId = "MoveElement";
-  public static override get minArgs() { return 2; }
+  public static override get minArgs() { return 1; }
   public static override get maxArgs() { return 4; }
 
-  public override async run(elementId: string, x: number, y: number, z: number): Promise<boolean> {
+  public override async run(elementId: string | undefined, x: number, y: number, z: number): Promise<boolean> {
 
     if (!IModelApp.viewManager.selectedView) {
       return false;
     }
     const imodel = IModelApp.viewManager.selectedView.iModel;
 
+    const elementIds = elementId ? [elementId] : Array.from(imodel.selectionSet.elements);
     if (imodel.isBriefcaseConnection()) {
-      await transformElements(imodel, [elementId], Transform.createTranslationXYZ(x, y, z));
+      await transformElements(imodel, elementIds, Transform.createTranslationXYZ(x, y, z));
       await imodel.saveChanges();
     }
 
@@ -281,10 +282,6 @@ export class MoveElementTool extends Tool {
     const args = parseArgs(inputs);
 
     const elementId = args.get("e");
-    if (!elementId) {
-      return false;
-    }
-
     const x = args.getFloat("x") ?? 0;
     const y = args.getFloat("y") ?? 0;
     const z = args.getFloat("z") ?? 0;


### PR DESCRIPTION
#4485 made `requestElementGraphics` translate the graphics relative to the center of the element's bounding box. This fixed #4404 wherein decoration graphics were being displayed with absolute coordinates thousands of kilometers from the origin, resulting in floating point precision artifacts.

However, this negatively affects the temporary element graphics drawn by `DynamicIModelTile` to represent elements inserted or modified during a `GraphicalEditingScope`. Because of the translation, each element's graphics had to be placed into its own `GraphicBranch` to be pushed and popped during rendering. Pushing a branch invalidates a ton of uniform state on the GPU that must then be recomputed and re-uploaded.

These element graphics are already translated relative to the center of the model's bounding box, so floating point precision issues are not a concern. So the fix is to specify `useAbsolutePosition: true` when requesting the graphics. Then the element graphics get an identity transform, and don't need to be placed inside their own branches. (They all still end up together inside a single branch that applies the model's transform to them).

Prior to this change, moving 248 elements by half a meter in Z would cause FPS to drop from 43.5 to 30.0. After this change, it drops to 42.5. This should enable applications to keep an editing scope active for much longer without worrying about significant performance impact.