### PR TITLE
Update silhouette edge decoding

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -4006,6 +4006,10 @@ export abstract class GltfReader {
     protected get _nodes(): GltfDictionary<GltfNode>;
     abstract read(): Promise<GltfReaderResult>;
     // (undocumented)
+    protected readAndOctEncodeNormals(json: {
+        [k: string]: any;
+    }, accessorName: string): Uint16Array | undefined;
+    // (undocumented)
     protected readBatchTable(_mesh: Mesh, _json: GltfMeshPrimitive): void;
     // (undocumented)
     protected readBufferData(json: {
@@ -4048,11 +4052,11 @@ export abstract class GltfReader {
         [k: string]: any;
     }): boolean;
     // (undocumented)
-    protected readMeshPrimitive(primitive: GltfMeshPrimitive, featureTable?: FeatureTable, pseudoRtcBias?: Vector3d): GltfPrimitiveData | undefined;
-    // (undocumented)
-    protected readNormals(mesh: GltfMeshData, json: {
+    protected readMeshNormals(mesh: GltfMeshData, json: {
         [k: string]: any;
     }, accessorName: string): boolean;
+    // (undocumented)
+    protected readMeshPrimitive(primitive: GltfMeshPrimitive, featureTable?: FeatureTable, pseudoRtcBias?: Vector3d): GltfPrimitiveData | undefined;
     // (undocumented)
     protected readPolylines(polylines: MeshPolylineList, json: {
         [k: string]: any;

--- a/common/changes/@itwin/core-frontend/pmc-silhouette-normal-encoding_2025-08-12-12-42.json
+++ b/common/changes/@itwin/core-frontend/pmc-silhouette-normal-encoding_2025-08-12-12-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -47,7 +47,7 @@ import { compactEdgeIterator } from "../common/imdl/CompactEdges";
 import { MeshPolylineGroup } from "@itwin/core-common/lib/cjs/internal/RenderMesh";
 
 /** @internal */
-export type GltfDataBuffer = Uint8Array | Uint16Array | Uint32Array | Float32Array;
+export type GltfDataBuffer = Uint8Array | Uint16Array | Uint32Array | Float32Array | Int8Array;
 
 /**
  * A chunk of binary data exposed as a typed array.
@@ -75,6 +75,7 @@ export class GltfBufferData {
       switch (expectedType) {
         case GltfDataType.Float:
         case GltfDataType.UnsignedByte:
+        case GltfDataType.SignedByte:
           return undefined;
         case GltfDataType.UnsignedShort:
           if (GltfDataType.UnsignedByte !== actualType)
@@ -97,6 +98,8 @@ export class GltfBufferData {
     switch (actualType) {
       case GltfDataType.UnsignedByte:
         return bytes;
+      case GltfDataType.SignedByte:
+        return new Int8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
       case GltfDataType.UnsignedShort:
         return new Uint16Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 2);
       case GltfDataType.UInt32:
@@ -1013,6 +1016,7 @@ export abstract class GltfReader {
       let dataSize = 0;
       switch (type) {
         case GltfDataType.UnsignedByte:
+        case GltfDataType.SignedByte:
           dataSize = 1;
           break;
         case GltfDataType.UnsignedShort:
@@ -1873,6 +1877,28 @@ export abstract class GltfReader {
         return true;
       }
 
+      case GltfDataType.SignedByte: {
+        const data = view.toBufferData(GltfDataType.SignedByte);
+        if (!data) {
+          return false;
+        }
+
+        const normalize = (val: number) => 2 * ((val + 128) / 255) - 1;
+        mesh.normals = new Uint16Array(data.count);
+        const scratchNormal = new Vector3d();
+        const strideSkip = view.stride - 3;
+        for (let i = 0, j = 0; i < data.count; i++, j += strideSkip) {
+          const x = normalize(data.buffer[j++]);
+          const y = normalize(data.buffer[j++]);
+          const z = normalize(data.buffer[j++]);
+          scratchNormal.set(x, y, z);
+          mesh.normals[i] = OctEncodedNormal.encode(scratchNormal);
+        }
+
+        return true;
+      }
+
+      // This is weird, why does it assume 8-bit normal vectors are actually 16-bit oct-encoded normals?
       case GltfDataType.UnsignedByte: {
         const data = view.toBufferData(GltfDataType.UnsignedByte);
         if (undefined === data)

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -1390,8 +1390,8 @@ export abstract class GltfReader {
         assert(indices !== undefined);
         assert(visibility.buffer instanceof Uint8Array);
 
-        const silhouetteNormals = this.readBufferData16(ext, "silhouetteNormals");
-        const normalPairs = silhouetteNormals ? new Uint32Array(silhouetteNormals.buffer.buffer, silhouetteNormals.buffer.byteOffset, silhouetteNormals.buffer.byteLength / 4) : undefined;
+        const silhouetteNormals = this.readAndOctEncodeNormals(ext, "silhouetteNormals");
+        const normalPairs = silhouetteNormals ? new Uint32Array(silhouetteNormals.buffer, silhouetteNormals.byteOffset, silhouetteNormals.byteLength / 4) : undefined;
         mesh.primitive.edges = new MeshEdges();
 
         for (const edge of compactEdgeIterator(visibility.buffer, normalPairs, indices.length, (idx) => indices[idx])) {
@@ -1857,7 +1857,7 @@ export abstract class GltfReader {
   }
 
   protected readMeshNormals(mesh: GltfMeshData, json: { [k: string]: any }, accessorName: string): boolean {
-    const normals = this.readNormals(json, accessorName);
+    const normals = this.readAndOctEncodeNormals(json, accessorName);
     if (normals) {
       mesh.normals = normals;
       return true;
@@ -1866,7 +1866,7 @@ export abstract class GltfReader {
     return false;
   }
 
-  protected readNormals(json: { [k: string]: any }, accessorName: string): Uint16Array | undefined {
+  protected readAndOctEncodeNormals(json: { [k: string]: any }, accessorName: string): Uint16Array | undefined {
     const view = this.getBufferView(json, accessorName);
     if (undefined === view)
       return undefined;


### PR DESCRIPTION
Based on [feedback](https://github.com/KhronosGroup/glTF/pull/2479#discussion_r2254518315) the specification no longer calls for oct-encoded normals; instead it expects float or signed byte components.

This incidentally fixes failure to read vertex normals compressed by meshopt (we previously didn't support signed byte normal components).