### PR TITLE
initial fix

### DIFF
--- a/core/common/src/IModel.ts
+++ b/core/common/src/IModel.ts
@@ -522,8 +522,8 @@ export abstract class IModel implements IModelProps {
       projectExtents: this.projectExtents.toJSON(),
       globalOrigin: this.globalOrigin.toJSON(),
       ecefLocation: this.ecefLocation,
-      geographicCoordinateSystem: this.geographicCoordinateSystem,
-      ... this._getRpcProps(),
+      geographicCoordinateSystem: this.geographicCoordinateSystem?.toJSON(),
+      ...this._getRpcProps(),
     };
   }
 

--- a/full-stack-tests/core/src/frontend/hub/IModelConnection.test.ts
+++ b/full-stack-tests/core/src/frontend/hub/IModelConnection.test.ts
@@ -23,7 +23,7 @@ async function executeQuery(iModel: IModelConnection, ecsql: string, bindings?: 
   return rows;
 }
 
-describe("IModelConnection (#integration)", () => {
+describe.only("IModelConnection (#integration)", () => {
   let iModel: IModelConnection;
 
   before(async () => {
@@ -214,4 +214,11 @@ describe("IModelConnection (#integration)", () => {
     const formattedValue = spec.applyFormatting(5.0);
     assert.equal(formattedValue, "5.0 m");
   });
+
+  it("properly deserializes gcs latitude", async () => {
+      const iTwinId = await TestUtility.getTestITwinId();
+      const iModelId = await TestUtility.queryIModelIdByName(iTwinId, TestUtility.testIModelNames.smallTex);
+      iModel = await CheckpointConnection.openRemote(iTwinId, iModelId);
+      assert.notEqual(iModel.geographicCoordinateSystem?.horizontalCRS?.extent?.northEast.latitude, 0);
+    })
 });


### PR DESCRIPTION
We must convert CRS extents to JSON before sending via electron, using object spread, or any other operations which enumerate properties of the extent object. This is due to how class accessors are set. 

While I would prefer the fix to go on the `Carto2DDegrees` class, I don't see a way to do it in a non-breaking fashion.

Fixes #8404.