### PR TITLE
Improve `IModelConnection.findClassFor` tests

### DIFF
--- a/common/changes/@itwin/core-frontend/gytis-findclassfor_2025-08-13-13-31.json
+++ b/common/changes/@itwin/core-frontend/gytis-findclassfor_2025-08-13-13-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/rpcinterface-full-stack-tests/gytis-findclassfor_2025-08-13-13-31.json
+++ b/common/changes/@itwin/rpcinterface-full-stack-tests/gytis-findclassfor_2025-08-13-13-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/rpcinterface-full-stack-tests"
+}

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -27,7 +27,7 @@ import { ExtensionAdmin } from "./extension/ExtensionAdmin";
 import * as displayStyleState from "./DisplayStyleState";
 import * as drawingViewState from "./DrawingViewState";
 import { ElementLocateManager } from "./ElementLocateManager";
-import { EntityState } from "./EntityState";
+import { ElementState, EntityState } from "./EntityState";
 import { FrontendHubAccess } from "./FrontendHubAccess";
 import { FrontendLoggerCategory } from "./common/FrontendLoggerCategory";
 import * as modelselector from "./ModelSelectorState";
@@ -394,6 +394,7 @@ export class IModelApp {
     ].forEach((tool) => this.tools.registerModule(tool, toolsNs));
 
     this.registerEntityState(EntityState.classFullName, EntityState);
+    this.registerEntityState(ElementState.classFullName, ElementState);
     [
       modelState,
       sheetState,

--- a/core/frontend/src/IModelConnection.ts
+++ b/core/frontend/src/IModelConnection.ts
@@ -188,7 +188,6 @@ export abstract class IModelConnection extends IModel {
       return ctor;
 
     // it's not registered, we need to query its class hierarchy.
-    ctor = defaultClass; // in case we cant find a registered class that handles this class
 
     // wait until we get the full list of base classes from backend
     if (this.isOpen) {
@@ -210,7 +209,7 @@ export abstract class IModelConnection extends IModel {
         return true; // stop
       });
     }
-    return ctor; // either the baseClass handler or defaultClass if we didn't find a registered baseClass
+    return ctor ?? defaultClass; // either the baseClass handler or defaultClass if we didn't find a registered baseClass
   }
 
   /** @internal */

--- a/full-stack-tests/core/src/frontend/standalone/FIndClassFor.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/FIndClassFor.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { ElementState, IModelConnection, ModelState } from "@itwin/core-frontend";
+import { ElementState, IModelApp, IModelConnection, ModelState } from "@itwin/core-frontend";
 import { IModelError } from "@itwin/core-common";
 import { IModelStatus } from "@itwin/core-bentley";
 import { TestUtility } from "../TestUtility";
@@ -25,8 +25,10 @@ describe("IModelConnection.findClassFor", () => {
   });
 
   it("should return closes base class if given class name does not have class associated", async () => {
-    const stateClass = await iModel.findClassFor("BisCore:GeometricElement", undefined);
+    const fullClassName = "BisCore:GeometricElement3d";
+    const stateClass = await iModel.findClassFor(fullClassName, undefined);
     expect(stateClass?.name).to.be.equal(ElementState.name);
+    expect(IModelApp.lookupEntityClass(fullClassName)?.name).to.be.equal(ElementState.name);
   });
 
   it("should fallback to provided default class if no class is registered for any of the class names", async () => {
@@ -35,7 +37,7 @@ describe("IModelConnection.findClassFor", () => {
   });
 
   it("should throw an error if class does not exist", async () => {
-    await expect(iModel.findClassFor("BisCore:NonExistentClass", ModelState)).to.be.eventually.rejected.then((error: unknown) => {
+    await expect(iModel.findClassFor("BisCore:NonExistentClass", undefined)).to.be.eventually.rejected.then((error: unknown) => {
       expect(error).to.be.instanceOf(IModelError);
       expect((error as IModelError).errorNumber).to.equal(IModelStatus.NotFound);
     });

--- a/full-stack-tests/core/src/frontend/standalone/FIndClassFor.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/FIndClassFor.test.ts
@@ -1,0 +1,43 @@
+import { expect } from "chai";
+import { ElementState, IModelConnection, ModelState } from "@itwin/core-frontend";
+import { IModelError } from "@itwin/core-common";
+import { IModelStatus } from "@itwin/core-bentley";
+import { TestUtility } from "../TestUtility";
+import { TestSnapshotConnection } from "../TestSnapshotConnection";
+
+describe("IModelConnection.findClassFor", () => {
+
+  let iModel: IModelConnection;
+
+  before(async () => {
+    await TestUtility.startFrontend(undefined, true);
+    iModel = await TestSnapshotConnection.openFile("test.bim");
+  });
+
+  after(async () => {
+    await iModel.close();
+    await TestUtility.shutdownFrontend();
+  });
+
+  it("should return class for given class name", async () => {
+    const stateClass = (await iModel.findClassFor("BisCore:Model", undefined));
+    expect(stateClass?.name).to.be.equal(ModelState.name);
+  });
+
+  it("should return closes base class if given class name does not have class associated", async () => {
+    const stateClass = await iModel.findClassFor("BisCore:GeometricElement", undefined);
+    expect(stateClass?.name).to.be.equal(ElementState.name);
+  });
+
+  it("should fallback to provided default class if no class is registered for any of the class names", async () => {
+    const stateClass = await iModel.findClassFor("BisCore:CodeSpec", ModelState);
+    expect(stateClass?.name).to.be.equal(ModelState.name);
+  });
+
+  it("should throw an error if class does not exist", async () => {
+    await expect(iModel.findClassFor("BisCore:NonExistentClass", ModelState)).to.be.eventually.rejected.then((error: unknown) => {
+      expect(error).to.be.instanceOf(IModelError);
+      expect((error as IModelError).errorNumber).to.equal(IModelStatus.NotFound);
+    });
+  });
+});

--- a/full-stack-tests/rpc-interface/src/frontend/IModelConnection.test.ts
+++ b/full-stack-tests/rpc-interface/src/frontend/IModelConnection.test.ts
@@ -167,11 +167,6 @@ describe("IModelReadRpcInterface Methods from an IModelConnection", () => {
     expect(iModel.models.loaded.get(modelId)).to.not.be.undefined;
   });
 
-  it("getClassHierarchy should work as expected", async () => {
-    const result = await iModel.findClassFor("BisCore:LineStyle", undefined);
-    expect(result).undefined;
-  });
-
   it("getIModelCoordinatesFromGeoCoordinates should work as expected", async () => {
     const wgs84Converter = iModel.geoServices.getConverter("WGS84");
     const nad27Converter = iModel.geoServices.getConverter("NAD27");


### PR DESCRIPTION
We would like to move `IModelConnection.findClassFor` from using `IModelReadRpcInterface.getClassHierarchy` to `IModelConnection.schemaContext`, but that could be considered a breaking change as `IModelConnection.findClassFor` will have to start requiring `ECSchemaRpcInterface` to be registered.

For now, just added new tests to decrease chance of introducing regressions later.