### PR TITLE
Add CRS almostEqual

### DIFF
--- a/core/common/src/geometry/CoordinateReferenceSystem.ts
+++ b/core/common/src/geometry/CoordinateReferenceSystem.ts
@@ -281,6 +281,46 @@ export class HorizontalCRS implements HorizontalCRSProps {
 
     return true;
   }
+
+  /** Compares two horizontal CRS, but does not compare descriptions.
+   *  Number compares are applied a minuscule tolerance.
+   *  @public */
+  public almostEquals(other: HorizontalCRS): boolean {
+    if (this.id !== other.id ||
+      this.source !== other.source ||
+      this.deprecated !== other.deprecated ||
+      this.epsg !== other.epsg ||
+      this.datumId !== other.datumId ||
+      this.ellipsoidId !== other.ellipsoidId ||
+      this.unit !== other.unit)
+      return false;
+
+    if ((this.datum === undefined) !== (other.datum === undefined))
+      return false;
+
+    if (this.datum && !this.datum.equals(other.datum!))
+      return false;
+
+    if ((this.ellipsoid === undefined) !== (other.ellipsoid === undefined))
+      return false;
+
+    if (this.ellipsoid && !this.ellipsoid.equals(other.ellipsoid!))
+      return false;
+
+    if ((this.projection === undefined) !== (other.projection === undefined))
+      return false;
+
+    if (this.projection && !this.projection.equals(other.projection!))
+      return false;
+
+    if ((this.extent === undefined) !== (other.extent === undefined))
+      return false;
+
+    if (this.extent && !this.extent.equals(other.extent!))
+      return false;
+
+    return true;
+  }
 }
 
 /** Vertical Geographic Coordinate reference System definition


### PR DESCRIPTION
Add ability to compare horizontal CRS without comparing the description. This is useful for merging imodels with CRS data that is functionally equivalent, but would return as false with the current equals functions.
All other data seems necessary, however not sure if these values can also differ but be functionally the same:
- source
- id

I assume datum and ellipsoid id's are also constant and shouldn't differ between imodels, but not 100% sure.