### PR TITLE
Move exception handling from ECSchemaRpcLocater to backend implementation. 

### DIFF
--- a/common/api/ecschema-rpc-impl.api.md
+++ b/common/api/ecschema-rpc-impl.api.md
@@ -12,7 +12,7 @@ import { SchemaProps } from '@itwin/ecschema-metadata';
 
 // @internal
 export class ECSchemaRpcImpl extends RpcInterface implements ECSchemaRpcInterface {
-    getSchemaJSON(tokenProps: IModelRpcProps, schemaName: string): Promise<SchemaProps>;
+    getSchemaJSON(tokenProps: IModelRpcProps, schemaName: string): Promise<SchemaProps | undefined>;
     getSchemaKeys(tokenProps: IModelRpcProps): Promise<SchemaKeyProps[]>;
     static register(): void;
 }

--- a/common/api/ecschema-rpc-interface.api.md
+++ b/common/api/ecschema-rpc-interface.api.md
@@ -21,7 +21,7 @@ import { SchemaProps } from '@itwin/ecschema-metadata';
 // @internal
 export abstract class ECSchemaRpcInterface extends RpcInterface {
     static getClient(): ECSchemaRpcInterface;
-    getSchemaJSON(_tokenProps: IModelRpcProps, _schemaName: string): Promise<SchemaProps>;
+    getSchemaJSON(_tokenProps: IModelRpcProps, _schemaName: string): Promise<SchemaProps | undefined>;
     getSchemaKeys(_tokenProps: IModelRpcProps): Promise<SchemaKeyProps[]>;
     // (undocumented)
     static readonly interfaceName = "ECSchemaRpcInterface";

--- a/common/changes/@itwin/ecschema-rpcinterface-common/catch-getschemajson-notfound_2025-08-14-15-36.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-common/catch-getschemajson-notfound_2025-08-14-15-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-common",
+      "comment": "Moved exception handling of 'schema not found' to backend implementation to avoid RPC error logging.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-common"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-impl/catch-getschemajson-notfound_2025-08-14-15-36.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-impl/catch-getschemajson-notfound_2025-08-14-15-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-impl",
+      "comment": "Moved exception handling of 'schema not found' to backend implementation to avoid RPC error logging.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-impl"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-tests/catch-getschemajson-notfound_2025-08-14-15-36.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-tests/catch-getschemajson-notfound_2025-08-14-15-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-tests"
+}

--- a/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcInterface.ts
@@ -45,8 +45,8 @@ export abstract class ECSchemaRpcInterface extends RpcInterface {
    * @returns                 The SchemaProps.
    */
   @RpcOperation.allowResponseCaching(RpcResponseCacheControl.Immutable)
-  public async getSchemaJSON(_tokenProps: IModelRpcProps, _schemaName: string): Promise<SchemaProps> {
-    return this.forward.apply(this, [arguments]) as Promise<SchemaProps>;
+  public async getSchemaJSON(_tokenProps: IModelRpcProps, _schemaName: string): Promise<SchemaProps | undefined> {
+    return this.forward.apply(this, [arguments]) as Promise<SchemaProps | undefined>;
   }
 
 }

--- a/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { ISchemaLocater, Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType, SchemaProps } from "@itwin/ecschema-metadata";
+import { ISchemaLocater, Schema, SchemaContext, SchemaInfo, SchemaKey, SchemaMatchType } from "@itwin/ecschema-metadata";
 import { IModelRpcProps } from "@itwin/core-common";
 import { ECSchemaRpcInterface } from "./ECSchemaRpcInterface";
 
@@ -39,7 +39,7 @@ export class ECSchemaRpcLocater implements ISchemaLocater {
     const schemaJson = await ECSchemaRpcInterface.getClient().getSchemaJSON(this.token, schemaKey.name);
     if (!schemaJson)
       return undefined;
-    
+
     const schemaInfo = await Schema.startLoadingFromJson(schemaJson, context || new SchemaContext());
     if (schemaInfo !== undefined && schemaInfo.schemaKey.matches(schemaKey, matchType)) {
       return schemaInfo;

--- a/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
+++ b/core/ecschema-rpc/common/src/ECSchemaRpcLocater.ts
@@ -36,15 +36,10 @@ export class ECSchemaRpcLocater implements ISchemaLocater {
     * @param matchType The match type to use when locating the schema
     */
   public async getSchemaInfo(schemaKey: SchemaKey, matchType: SchemaMatchType, context: SchemaContext): Promise<SchemaInfo | undefined> {
-    let schemaJson: SchemaProps;
-    try {
-      schemaJson = await ECSchemaRpcInterface.getClient().getSchemaJSON(this.token, schemaKey.name);
-    } catch(e: any) {
-      if (e.message && e.message === "schema not found")
-        return undefined;
-
-      throw(e);
-    }
+    const schemaJson = await ECSchemaRpcInterface.getClient().getSchemaJSON(this.token, schemaKey.name);
+    if (!schemaJson)
+      return undefined;
+    
     const schemaInfo = await Schema.startLoadingFromJson(schemaJson, context || new SchemaContext());
     if (schemaInfo !== undefined && schemaInfo.schemaKey.matches(schemaKey, matchType)) {
       return schemaInfo;

--- a/core/ecschema-rpc/impl/src/ECSchemaRpcImpl.ts
+++ b/core/ecschema-rpc/impl/src/ECSchemaRpcImpl.ts
@@ -73,12 +73,20 @@ export class ECSchemaRpcImpl extends RpcInterface implements ECSchemaRpcInterfac
    * @param schemaName        The name of the schema that shall be returned.
    * @returns                 The SchemaProps.
    */
-  public async getSchemaJSON(tokenProps: IModelRpcProps, schemaName: string): Promise<SchemaProps> {
+  public async getSchemaJSON(tokenProps: IModelRpcProps, schemaName: string): Promise<SchemaProps | undefined> {
     if (schemaName === undefined || schemaName.length < 1) {
       throw new Error(`Schema name must not be undefined or empty.`);
     }
 
     const iModelDb = await this.getIModelDatabase(tokenProps);
-    return iModelDb[backend._nativeDb].getSchemaProps(schemaName);
+
+    try {
+      return iModelDb[backend._nativeDb].getSchemaProps(schemaName);
+    } catch(e: any) {
+      if (e.message && e.message === "schema not found")
+        return undefined;
+
+      throw(e);
+    }
   }
 }

--- a/full-stack-tests/ecschema-rpc-interface/src/frontend/SchemaRpcInterface.test.ts
+++ b/full-stack-tests/ecschema-rpc-interface/src/frontend/SchemaRpcInterface.test.ts
@@ -31,7 +31,12 @@ describe("Schema RPC Interface", () => {
     const schemaKeys: SchemaKey[] = [];
     const props: SchemaKeyProps[] = await ECSchemaRpcInterface.getClient().getSchemaKeys(iModel.getRpcProps());
     props.forEach((prop: SchemaKeyProps) => schemaKeys.push(SchemaKey.fromJSON(prop)));
-    const schemaJSON: SchemaProps = await ECSchemaRpcInterface.getClient().getSchemaJSON(iModel.getRpcProps(), schemaKeys[0].name);
+    const schemaJSON: SchemaProps | undefined = await ECSchemaRpcInterface.getClient().getSchemaJSON(iModel.getRpcProps(), schemaKeys[0].name);
     expect(schemaJSON).to.not.be.undefined;
+  });
+
+  it("should return undefined for non-existent schema", async () => {
+    const schemaJSON: SchemaProps | undefined = await ECSchemaRpcInterface.getClient().getSchemaJSON(iModel.getRpcProps(), "DoesNotExist");
+    expect(schemaJSON).to.be.undefined;
   });
 });


### PR DESCRIPTION
Moved exception handling of 'schema not found' from ECSchemaRpcLocater to backend implementation ECSchemaRpcImpl.getSchemaJson to avoid RPC error logging when bentley Logger is initialized. 