### PR TITLE
Fix map tile availability

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-map-tile-availability_2025-08-20-16-50.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-map-tile-availability_2025-08-20-16-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix an exception when terrain is enabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/internal/tile/map/MapTileAvailability.ts
+++ b/core/frontend/src/internal/tile/map/MapTileAvailability.ts
@@ -218,7 +218,7 @@ export class TileAvailability {
         if (rectangle.containsCartographic(position))
           maxLevel = rectangle.level;
       }
-      node = expectDefined(node?.parent);
+      node = node?.parent;
     }
     return maxLevel;
   }


### PR DESCRIPTION
Whenever I opened a view with terrain enabled and sufficiently zoomed in, I'd get this:
<img width="1155" height="305" alt="Screenshot from 2025-08-20 12-43-43" src="https://github.com/user-attachments/assets/ef1daaa8-a4b8-49f3-8c13-e167b544badc" />
Regression introduced in #8391.
The non-null assertions were erroneous. It is fine and expected for `node.parent` to be `undefined`. 