### PR TITLE
Fix model masking when contour lines are enabled

### DIFF
--- a/common/changes/@itwin/core-frontend/pmc-fix-contour-mask_2025-08-20-17-12.json
+++ b/common/changes/@itwin/core-frontend/pmc-fix-contour-mask_2025-08-20-17-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "A model drawn as only contour lines will only mask the background map where the contour lines draw.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/internal/render/webgl/BackgroundMapDrape.ts
+++ b/core/frontend/src/internal/render/webgl/BackgroundMapDrape.ts
@@ -152,7 +152,7 @@ export class BackgroundMapDrape extends TextureDrape {
     const prevPlan = target.plan;
     const drawingParams = PlanarTextureProjection.getTextureDrawingParams(target);
     const stack = new BranchStack();
-    stack.changeRenderPlan(drawingParams.viewFlags, prevPlan.is3d, prevPlan.hline);
+    stack.changeRenderPlan(drawingParams.viewFlags, prevPlan.is3d, prevPlan.hline, prevPlan.contours);
     stack.setSymbologyOverrides(this._symbologyOverrides);
 
     const batchState = new BatchState(stack);

--- a/core/frontend/src/internal/render/webgl/PlanarClassifier.ts
+++ b/core/frontend/src/internal/render/webgl/PlanarClassifier.ts
@@ -556,7 +556,7 @@ export class PlanarClassifier extends RenderPlanarClassifier implements RenderMe
 
     const prevProjMatrix = target.uniforms.frustum.projectionMatrix;
     target.uniforms.frustum.changeProjectionMatrix(PlanarClassifier._postProjectionMatrix.multiplyMatrixMatrix(prevProjMatrix));
-    target.uniforms.branch.changeRenderPlan(vf, target.plan.is3d, target.plan.hline);
+    target.uniforms.branch.changeRenderPlan(vf, target.plan.is3d, target.plan.hline, target.plan.contours);
 
     const addCmds = (oldCmds: DrawCommands, newCmds: DrawCommands) => {
       if (undefined === newCmds)


### PR DESCRIPTION
Set up a view with background map enabled, and one or more design models masking out the background map.
Now turn on contour lines with "show element" set to false, so the model only draws as contour lines - no surfaces.
The map will continue to be masked by the full model geometry.
Instead we want to only mask the map where the model's contour lines draw.