### PR TITLE
Presentation: Fix `global-jsdom` and `jsdom` version mismatch

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2814,8 +2814,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       global-jsdom:
-        specifier: ^25.0.0
-        version: 25.0.0(jsdom@26.0.0)
+        specifier: ^26.0.0
+        version: 26.0.0(jsdom@26.0.0)
       i18next-http-backend:
         specifier: ^3.0.2
         version: 3.0.2
@@ -7741,11 +7741,11 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
-  global-jsdom@25.0.0:
-    resolution: {integrity: sha512-Y8dUX6R5Aw5/cutvBY8ofSs2TJyHC3WVGAQGIhCeWlIpKjYcydh3APbxQaeKSfrawVO/YUQ0MAFJfjQDOPVY8Q==}
+  global-jsdom@26.0.0:
+    resolution: {integrity: sha512-BqXpTNZFjP40N+s4k8Bk9HS8GFVPJB/+TKtwcShM84wLv6C5dH9o1dydI3pL6potanhfDiIAVDbaaGj/uSdRSA==}
     engines: {node: '>=18'}
     peerDependencies:
-      jsdom: '>=25 <26'
+      jsdom: '>=26 <27'
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -14492,7 +14492,7 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  global-jsdom@25.0.0(jsdom@26.0.0):
+  global-jsdom@26.0.0(jsdom@26.0.0):
     dependencies:
       jsdom: 26.0.0
 

--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -65,7 +65,7 @@
     "eslint": "^9.31.0",
     "fast-sort": "^3.0.2",
     "fast-xml-parser": "^4.4.1",
-    "global-jsdom": "^25.0.0",
+    "global-jsdom": "^26.0.0",
     "i18next-http-backend": "^3.0.2",
     "internal-tools": "workspace:*",
     "jsdom": "^26.0.0",


### PR DESCRIPTION
Fixes this during `rush install`:
```
../../full-stack-tests/presentation
└─┬ global-jsdom 25.0.0
  └── ✕ unmet peer jsdom@">=25 <26": found 26.0.0
```