### PR TITLE
NavigationProperty override fix

### DIFF
--- a/common/changes/@itwin/ecschema-metadata/navigationproperty-override-fix_2025-08-28-10-50.json
+++ b/common/changes/@itwin/ecschema-metadata/navigationproperty-override-fix_2025-08-28-10-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-metadata/src/Metadata/EntityClass.ts
+++ b/core/ecschema-metadata/src/Metadata/EntityClass.ts
@@ -309,7 +309,7 @@ export async function createNavigationProperty(ecClass: ECClass, name: string, r
 
 /** @internal */
 export function createNavigationPropertySync(ecClass: ECClass, name: string, relationship: string | RelationshipClass, direction: string | StrengthDirection): NavigationProperty {
-  if (ecClass.getPropertySync(name))
+  if (ecClass.getPropertySync(name, true))
     throw new ECSchemaError(ECSchemaStatus.DuplicateProperty, `An ECProperty with the name ${name} already exists in the class ${ecClass.name}.`);
 
   let resolvedRelationship: RelationshipClass | undefined;


### PR DESCRIPTION
**Description**
When a class overrides a property with a navigation property an error like this was thrown.
```
An ECProperty with the name <PROPERTYNAME> already exists in the class <CLASSNAME>.
```
This issue only occurred during sync deserialization. The reason for this, is that the check is supposed to check the local properties only, when creating a NavigationProperty synchronously, it's check is not restricted to local properties and so overriding a property fails.

Code has been changed to work as it's async method.
