### PR TITLE
[presentation]: Fix content formatting

### DIFF
--- a/common/changes/@itwin/presentation-common/fix-content-formatting_2025-09-03-08-41.json
+++ b/common/changes/@itwin/presentation-common/fix-content-formatting_2025-09-03-08-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Fixed content formatting failure when struct property value has members with `undefined` value.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
+++ b/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
@@ -96,7 +96,11 @@ export class ContentFormatter {
     const displayValues: DisplayValuesMap = {};
     await Promise.all(
       field.memberFields.map(async (memberField) => {
-        displayValues[memberField.name] = await this.formatPropertyValue(memberValues[memberField.name], memberField);
+        const memberValue = memberValues[memberField.name];
+        if (memberValue === undefined) {
+          return;
+        }
+        displayValues[memberField.name] = await this.formatPropertyValue(memberValue, memberField);
       }),
     );
     return displayValues;

--- a/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
+++ b/presentation/common/src/presentation-common/content/PropertyValueFormatter.ts
@@ -97,6 +97,7 @@ export class ContentFormatter {
     await Promise.all(
       field.memberFields.map(async (memberField) => {
         const memberValue = memberValues[memberField.name];
+        // do not add undefined value to display values
         if (memberValue === undefined) {
           return;
         }

--- a/presentation/common/src/test/content/PropertyFormatter.test.ts
+++ b/presentation/common/src/test/content/PropertyFormatter.test.ts
@@ -156,6 +156,74 @@ describe("ContentFormatter", () => {
     expect(formattedContent.contentSet[0].displayValues[structPropField.name]).to.deep.eq({ prop1: "FormattedValue", prop2: "FormattedValue" });
   });
 
+  it("formats structs values with undefined member", async () => {
+    const structPropField = createTestStructPropertiesContentField({
+      name: "structPropFieldName",
+      properties: [
+        {
+          property: createTestPropertyInfo({ name: "structProperty" }),
+        },
+      ],
+      memberFields: [
+        createTestPropertiesContentField({ name: "prop1", properties: [{ property: createTestPropertyInfo() }] }),
+        createTestPropertiesContentField({ name: "prop2", properties: [{ property: createTestPropertyInfo() }] }),
+      ],
+    });
+    const descriptor = createTestContentDescriptor({ fields: [structPropField] });
+    const contentItem = createTestContentItem({
+      displayValues: {},
+      values: {
+        [structPropField.name]: {
+          prop1: "123",
+        },
+      },
+    });
+    const content = new Content(descriptor, [contentItem]);
+    const formattedContent = await formatter.formatContent(content);
+    expect(formattedContent.contentSet[0].displayValues[structPropField.name]).to.deep.eq({ prop1: "FormattedValue" });
+  });
+
+  it("formats structs values with undefined array member", async () => {
+    const structPropField = createTestStructPropertiesContentField({
+      name: "structPropFieldName",
+      properties: [
+        {
+          property: createTestPropertyInfo({ name: "structProperty" }),
+        },
+      ],
+      memberFields: [
+        createTestArrayPropertiesContentField({
+          name: "prop1",
+          properties: [
+            {
+              property: createTestPropertyInfo({ name: "arrayProperty" }),
+            },
+          ],
+        }),
+        createTestArrayPropertiesContentField({
+          name: "prop2",
+          properties: [
+            {
+              property: createTestPropertyInfo({ name: "arrayProperty" }),
+            },
+          ],
+        }),
+      ],
+    });
+    const descriptor = createTestContentDescriptor({ fields: [structPropField] });
+    const contentItem = createTestContentItem({
+      displayValues: {},
+      values: {
+        [structPropField.name]: {
+          prop1: ["123", "456"],
+        },
+      },
+    });
+    const content = new Content(descriptor, [contentItem]);
+    const formattedContent = await formatter.formatContent(content);
+    expect(formattedContent.contentSet[0].displayValues[structPropField.name]).to.deep.eq({ prop1: ["FormattedValue", "FormattedValue"] });
+  });
+
   it("formats nested content item value", async () => {
     const nestedField = createTestSimpleContentField({
       name: "calculatedFieldName",


### PR DESCRIPTION
Content formatter was assuming that all struct members have values. If one of them does not have value it was crashing. Added additional check and tests.