### PR TITLE
Remove spurious assertions

### DIFF
--- a/common/changes/@itwin/core-common/pmc-fix-feature-appearance-assertions_2025-09-09-16-04.json
+++ b/common/changes/@itwin/core-common/pmc-fix-feature-appearance-assertions_2025-09-09-16-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Fix spurious assertions in FeatureAppearance.equals.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/FeatureSymbology.ts
+++ b/core/common/src/FeatureSymbology.ts
@@ -76,8 +76,6 @@ function equalLineRgb(a: RgbColor | false | undefined, b: RgbColor | false | und
   } else if (a instanceof RgbColor && b instanceof RgbColor) {
     return equalRgb(a, b);
   } else {
-    assert(a === undefined || a === false);
-    assert(b === undefined || b === false);
     return false;
   }
 }

--- a/core/common/src/test/FeatureSymbology.test.ts
+++ b/core/common/src/test/FeatureSymbology.test.ts
@@ -118,6 +118,15 @@ describe("FeatureAppearance", () => {
     test({ }, false);
     test({ color: ColorDef.blue.toJSON() }, false);
   });
+
+  it("compares for equality", () => {
+    const apprA = FeatureAppearance.defaults;
+    const apprB = FeatureAppearance.fromJSON({ lineRgb: RgbColor.fromColorDef(ColorDef.white) });
+    expect(apprA.equals(apprB)).to.be.false;
+    expect(apprA.equals(apprA)).to.be.true;
+    expect(apprB.equals(apprB)).to.be.true;
+    expect(apprB.equals(apprA)).to.be.false;
+  });
 });
 
 describe("FeatureOverrides", () => {


### PR DESCRIPTION
Fixes #8503. The assertions were never correct, but would only produce exceptions if assertions were enabled.