### PR TITLE
Handling schemaversion validation of dynamic referenced schemas

### DIFF
--- a/common/changes/@itwin/ecschema-editing/schemamerging-dynamic-schemareference-handling_2025-09-10-10-38.json
+++ b/common/changes/@itwin/ecschema-editing/schemamerging-dynamic-schemareference-handling_2025-09-10-10-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-editing",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-editing"
+}

--- a/core/ecschema-editing/src/Differencing/SchemaConflicts.ts
+++ b/core/ecschema-editing/src/Differencing/SchemaConflicts.ts
@@ -44,6 +44,7 @@ export enum ConflictCode {
   ConflictingItemName = "C-001",
   ConflictingReferenceAlias = "C-002",
   ConflictingReferenceVersion = "C-003",
+  ConflictingReferenceDynamic = "C-004",
 
   ConflictingBaseClass = "C-100",
   RemovingBaseClass = "C-101",
@@ -101,6 +102,7 @@ export type AnySchemaDifferenceConflict =
   SchemaDifferenceConflict<ConflictCode.ConflictingItemName, SchemaItemType> |
   SchemaDifferenceConflict<ConflictCode.ConflictingReferenceAlias, SchemaOtherTypes.SchemaReference> |
   SchemaDifferenceConflict<ConflictCode.ConflictingReferenceVersion, SchemaOtherTypes.SchemaReference> |
+  SchemaDifferenceConflict<ConflictCode.ConflictingReferenceDynamic, SchemaOtherTypes.SchemaReference> |
   SchemaDifferenceConflict<ConflictCode.ConflictingBaseClass, EcClassTypes> |
   SchemaDifferenceConflict<ConflictCode.RemovingBaseClass, EcClassTypes> |
   SchemaDifferenceConflict<ConflictCode.SealedBaseClass, EcClassTypes> |

--- a/core/ecschema-editing/src/test/Differencing/Difference.test.ts
+++ b/core/ecschema-editing/src/test/Differencing/Difference.test.ts
@@ -3,7 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Schema, SchemaContext } from "@itwin/ecschema-metadata";
-import { DifferenceType, getSchemaDifferences, SchemaDifferenceResult, SchemaOtherTypes } from "../../Differencing/SchemaDifference";
+import { AnySchemaDifference, DifferenceType, getSchemaDifferences, SchemaDifferenceResult, SchemaOtherTypes } from "../../Differencing/SchemaDifference";
+import { BisTestHelper } from "../TestUtils/BisTestHelper";
 import { expect } from "chai";
 
 import sourceJson from "./sourceSchema.json";
@@ -120,6 +121,66 @@ describe("Schema Differences", () => {
     const differences = await getSchemaDifferences(targetSchema, sourceSchema);
     expect(differences.differences).has.lengthOf(0, "This test should not have differences.");
     expect(differences.conflicts).equals(undefined, "This test should not have conflicts.");
+  });
+
+  it("should return dynamic schema reference difference regardless of their version", async () => {
+    const sourceContext = await BisTestHelper.getNewContext();
+    await Schema.fromJson({
+      $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+      name: "ReferenceA",
+      version: "3.0.0",
+      alias: "ref",
+      references: [
+        { name: "CoreCustomAttributes", version: "01.00.01" },
+      ],
+      customAttributes: [
+        { className: "CoreCustomAttributes.DynamicSchema" },
+      ],
+    }, sourceContext);
+
+    const sourceSchema = await Schema.fromJson({
+      $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+      name: "SourceSchema",
+      version: "1.0.0",
+      alias: "source",
+      references: [
+        { name: "ReferenceA", version: "3.0.0" },
+      ]
+    }, sourceContext);
+
+    const targetContext = await BisTestHelper.getNewContext();
+    await Schema.fromJson({
+      $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+      name: "ReferenceA",
+      version: "1.0.0",
+      alias: "ref",
+      references: [
+        { name: "CoreCustomAttributes", version: "01.00.01" },
+      ],
+      customAttributes: [
+        { className: "CoreCustomAttributes.DynamicSchema" },
+      ],
+    }, targetContext);
+
+    const targetSchema = await Schema.fromJson({
+      $schema: "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+      name: "TargetSchema",
+      version: "1.0.0",
+      alias: "target",
+      references: [
+        { name: "ReferenceA", version: "1.0.0" },
+      ]
+    }, targetContext);
+
+    const differences = await getSchemaDifferences(targetSchema, sourceSchema);
+    expect(differences.conflicts).equals(undefined, "This test should not have conflicts.");
+    expect(differences.differences).has.lengthOf(1).and.satisfies(([result]: AnySchemaDifference[]) => {
+      expect(result).to.have.a.property("changeType", "modify");
+      expect(result).to.have.a.property("schemaType", "SchemaReference");
+      expect(result).to.have.a.nested.property("difference.name", "ReferenceA");
+      expect(result).to.have.a.nested.property("difference.version", "03.00.00");
+      return true;
+    });
   });
 
   it("should return changed or missing references", () => {
@@ -309,7 +370,7 @@ describe("Schema Differences", () => {
               {
                 name: "SourceSchema.MissingUnit",
                 label: "four",
-              }, 
+              },
               {
                 name: "SourceSchema.MissingInvertedUnit",
               },


### PR DESCRIPTION
#### Description

- If a schema references a dynamic schema, we should not validate the version, as this is not reliable
- If a dynamic schema reference is modified, both source and target must be dynamic schemas
- Compatible version check in either direction