### PR TITLE
Add optional description property to FormatSet

### DIFF
--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -797,6 +797,7 @@ export class Format extends SchemaItem {
 
 // @beta
 export interface FormatSet {
+    description?: string;
     formats: {
         [kindOfQuantityId: string]: FormatDefinition;
     };

--- a/common/changes/@itwin/ecschema-metadata/nam-add-description_2025-09-10-17-37.json
+++ b/common/changes/@itwin/ecschema-metadata/nam-add-description_2025-09-10-17-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "Add optional 'description' property to FormatSet",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/ecschema-metadata/src/Deserialization/JsonProps.ts
+++ b/core/ecschema-metadata/src/Deserialization/JsonProps.ts
@@ -297,6 +297,8 @@ export interface FormatSet {
   name: string;
   /** The display label for this format set. */
   label: string;
+  /** The description for this format set. */
+  description?: string;
   /** A [UnitSystemKey]($quantity) that determines the unit system for this format set. */
   unitSystem: UnitSystemKey;
   /** A mapping of kind of quantity identifiers to their corresponding format properties. */

--- a/core/ecschema-metadata/src/test/Formatting/FormatSetFormatsProvider.test.ts
+++ b/core/ecschema-metadata/src/test/Formatting/FormatSetFormatsProvider.test.ts
@@ -137,6 +137,31 @@ describe("FormatSetFormatsProvider", () => {
       await provider.removeFormat("TestFormat");
       expect(formatSet.unitSystem).to.equal(originalUnitSystem);
     });
+
+    it("should support optional description property", () => {
+      // Test FormatSet without description
+      const formatSetWithoutDescription: FormatSet = {
+        name: "TestWithoutDescription",
+        label: "Test Format Set",
+        unitSystem: "metric",
+        formats: {},
+      };
+
+      expect(formatSetWithoutDescription).to.not.have.property("description");
+
+      // Test FormatSet with description
+      const formatSetWithDescription: FormatSet = {
+        name: "TestWithDescription",
+        label: "Test Format Set",
+        description: "A test format set for demonstration purposes",
+        unitSystem: "metric",
+        formats: {},
+      };
+
+      expect(formatSetWithDescription).to.have.property("description");
+      expect(formatSetWithDescription.description).to.be.a("string");
+      expect(formatSetWithDescription.description).to.equal("A test format set for demonstration purposes");
+    });
   });
 
   describe("getFormat", () => {

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -14,6 +14,8 @@ publish: false
     - [@itwin/presentation-common](#itwinpresentation-common)
     - [@itwin/presentation-backend](#itwinpresentation-backend)
     - [@itwin/presentation-frontend](#itwinpresentation-frontend)
+  - [Display](#display)
+    - [Draco decoding](#draco-decoding)
 
 ## @itwin/core-ecschema-metadata
 
@@ -24,7 +26,9 @@ publish: false
 ### Changes
 
 - Added  `unitSystem` property to [FormatSet]($ecschema-metadata) interface, using [UnitSystemKey]($quantity) type. This will help move APIs away from relying on `activeUnitSystem` in `quantityFormatter`, as they move to the new formatting APIs using `IModelApp.formatsProvider`. Looking ahead, tools and components that use formatting APIs can then listen to just the `onFormatsChanged` event from `IModelApp.formatsProvider` instead of `IModelApp.quantityFormatter.onActiveUnitSystemChanged`.
+- Added optional `description` property to [FormatSet]($ecschema-metadata) interface. This property allows for additional descriptive text to be associated with a format set, providing better documentation and user context for format set purposes.
 - Changed interface for formats in `FormatSet` from [SchemaItemFormatProps]($ecschema-metadata) to [FormatDefinition]($quantity). FormatSet just uses the `name`, `label`, `description` field from `SchemaItemFormatProps`, which `FormatDefinition` already has.
+
 ## Presentation
 
 ### Deprecation of hierarchy-related APIs


### PR DESCRIPTION
Add optional `description` property to `FormatSet`.

(Also regenerated table of content for NextVer.md)