### PR TITLE
export JSON from .bim file

### DIFF
--- a/example-code/snippets/src/backend/ExampleCode.test.ts
+++ b/example-code/snippets/src/backend/ExampleCode.test.ts
@@ -6,7 +6,7 @@
 import { BisCoreSchema, BriefcaseDb, ClassRegistry, CodeService, Element, ExportGraphics, ExportGraphicsInfo, IModelJsFs, PhysicalModel, SnapshotDb, StandaloneDb, Subject } from "@itwin/core-backend";
 import { AccessToken, Guid, Id64, Id64Array, Id64String } from "@itwin/core-bentley";
 import { Code, CodeScopeSpec, CodeSpec, CodeSpecProperties, ConflictingLocksError, ElementGeometryInfo, IModel } from "@itwin/core-common";
-import { BentleyGeometryFlatBuffer, Geometry, IndexedPolyface, PolyfaceQuery, Range3d, Sphere } from "@itwin/core-geometry";
+import { BentleyGeometryFlatBuffer, Geometry, IModelJson, IndexedPolyface, PolyfaceQuery, Range3d, Sphere } from "@itwin/core-geometry";
 import { assert } from "chai";
 import { IModelTestUtils, KnownTestLocations } from "./IModelTestUtils";
 
@@ -128,14 +128,20 @@ describe("Example Code", () => {
     // __PUBLISH_EXTRACT_START__ IModelDb.exportGeometry
     // export each element as a mesh
     const singleMesh: IndexedPolyface[] = [];
-    await Snippets.extractGeometryFromBimFile(inFile, elementIds, singleMesh);
+    await Snippets.extractGeometryFromBimFile(inFile, elementIds, singleMesh, {noPartMesh: true});
     assert.strictEqual(1, singleMesh.length, "extracted the mesh");
 
     // write each element's flatbuffer serialization to a file
-    const outFileBase = `${KnownTestLocations.outputDir}\\geom`;
-    await Snippets.extractGeometryFromBimFile(inFile, elementIds, outFileBase, true);
-    const outFile = `${outFileBase}-${elementIds[0].toString()}.fb`;
-    assert.isTrue(IModelJsFs.existsSync(outFile), "wrote flatbuffer file");
+    const fbFileBase = `${KnownTestLocations.outputDir}\\geom`;
+    await Snippets.extractGeometryFromBimFile(inFile, elementIds, fbFileBase);
+    const fbFileName = `${fbFileBase}-${elementIds[0].toString()}.fb`;
+    assert.isTrue(IModelJsFs.existsSync(fbFileName), "wrote first element to flatbuffer file");
+
+    // write each element's JSON serialization to a file
+    const jsonFileBase = `${KnownTestLocations.outputDir}\\geom`;
+    await Snippets.extractGeometryFromBimFile(inFile, elementIds, jsonFileBase, {exportJSON: true});
+    const jsonFileName = `${jsonFileBase}-${elementIds[0].toString()}.json`;
+    assert.isTrue(IModelJsFs.existsSync(jsonFileName), "wrote first element to JSON file");
 
     // apply ecsql query to generate the ids of elements to export
     const query = "SELECT ECInstanceId FROM bis.Element WHERE ECClassId=0xe7";
@@ -144,14 +150,24 @@ describe("Example Code", () => {
     assert.strictEqual(3, threeMeshes.length, "extracted all three meshes from the model");
     // __PUBLISH_EXTRACT_END__
 
-    // verify outputs
-    const buf = IModelJsFs.readFileSync(outFile);
+    // verify fb output
+    let buf = IModelJsFs.readFileSync(fbFileName);
     assert.isTrue(buf.length > 0, "read flatbuffer file");
     const bytes = new Uint8Array(Buffer.isBuffer(buf) ? buf : Buffer.from(buf));
-    const geometry1 = BentleyGeometryFlatBuffer.bytesToGeometry(bytes, true);
-    assert.isTrue(geometry1 !== undefined, "deserialized the geometry");
-    assert.isTrue(geometry1 instanceof Sphere, "geometry is an ellipsoid");
-    const radius = (geometry1 as Sphere).trueSphereRadius();
+    const geometryFromFB = BentleyGeometryFlatBuffer.bytesToGeometry(bytes, true);
+    assert.isTrue(geometryFromFB !== undefined, "deserialized fb geometry");
+
+    // verify json output
+    buf = IModelJsFs.readFileSync(jsonFileName);
+    assert.isTrue(buf.length > 0, "read json file");
+    const geometryFromJSON = IModelJson.Reader.parse(JSON.parse(buf.toString()));
+    assert.isTrue(geometryFromJSON !== undefined, "deserialized fb geometry");
+
+    // verify geometry
+    assert.instanceOf(geometryFromFB, Sphere, "FB geometry is an ellipsoid");
+    assert.instanceOf(geometryFromJSON, Sphere, "JSON geometry is an ellipsoid");
+    assert.isTrue((geometryFromFB as Sphere).isAlmostEqual(geometryFromJSON as Sphere), "FB and JSON geometry match");
+    const radius = (geometryFromFB as Sphere).trueSphereRadius();
     assert.isTrue(radius !== undefined, "ellipsoid is a sphere");
     const meshVolume = PolyfaceQuery.sumTetrahedralVolumes(singleMesh[0]);
     const sphereVolume = 4 / 3 * Math.PI * radius! * radius! * radius!;
@@ -250,16 +266,23 @@ namespace Snippets {
     // __PUBLISH_EXTRACT_END__
   }
 
+  export interface ExtractGeometryOptions {
+    /** Optional flag to ignore parts when exporting meshes. */
+    noPartMesh?: boolean;
+    /** Optional flag to export JSON instead of the default FlatBuffers format. */
+    exportJSON?: boolean;
+  }
+
   /**
    * Given a .bim file and an array of element ids, extract the element geometry into flatbuffer files and/or export them as meshes.
    * @param bimFilePathName full pathname of input .bim file, e.g., "c:\\tmp\\foo.bim".
    * @param elementIds array of element ids in the bim file (e.g., ["0x1d", "0x2000000000a"]), or an ECSQL query that collects element ids in the first entry of each row.
    * @param geometry array to populate with meshes exported via [IModelDb.exportGraphics]($core-backend), or base pathname (e.g., "c:\\tmp\\bar") to extract element
-   * geometry as flatbuffer files with names of the form `${basePathName}-${elementId.toString()}.fb`.
-   * @param noPartMesh optional flag to ignore parts when exporting meshes.
+   * geometry as flatbuffer/JSON files with names of the form `${basePathName}-${elementId.toString()}.fb/json`.
+   * @param options optional settings for output content/type.
    * @returns number of elements exported
    */
-  export async function extractGeometryFromBimFile(bimFilePathName: string, elementIds: Id64Array | string, geometry: IndexedPolyface[] | string, noPartMesh?: boolean) {
+  export async function extractGeometryFromBimFile(bimFilePathName: string, elementIds: Id64Array | string, geometry: IndexedPolyface[] | string, options?: ExtractGeometryOptions) {
     // __PUBLISH_EXTRACT_START__ IModelDb.extractGeometry
     const myIModel = SnapshotDb.openFile(bimFilePathName);
     const elementIdArray = Array.isArray(elementIds) ? elementIds : [];
@@ -271,14 +294,20 @@ namespace Snippets {
     }
     if (elementIdArray.length === 0)
       return;
-    const fbFilePathNameBase = Array.isArray(geometry) ? undefined : geometry;
-    if (fbFilePathNameBase) {
+    const filePathNameBase = Array.isArray(geometry) ? undefined : geometry;
+    if (filePathNameBase) {
       for (const elementId of elementIdArray) {
         myIModel.elementGeometryRequest({
           elementId,
           onGeometry: (info: ElementGeometryInfo) => {
-            for (const entry of info.entryArray)
-              IModelJsFs.writeFileSync(`${fbFilePathNameBase}-${elementId.toString()}.fb`, entry.data);
+            for (const entry of info.entryArray) {
+              if (options && options.exportJSON) {
+                const geom = BentleyGeometryFlatBuffer.bytesToGeometry(entry.data, true);
+                const json = IModelJson.Writer.toIModelJson(geom);
+                IModelJsFs.writeFileSync(`${filePathNameBase}-${elementId.toString()}.json`, JSON.stringify(json));
+              } else
+                IModelJsFs.writeFileSync(`${filePathNameBase}-${elementId.toString()}.fb`, entry.data);
+            }
           }});
       }
     }
@@ -287,7 +316,7 @@ namespace Snippets {
       myIModel.exportGraphics({
         elementIdArray,
         onGraphics: (info: ExportGraphicsInfo) => meshes.push(ExportGraphics.convertToIndexedPolyface(info.mesh)),
-        partInstanceArray: noPartMesh ? [] : undefined,
+        partInstanceArray: (options && options.noPartMesh) ? [] : undefined,
       });
     myIModel.close();
     // __PUBLISH_EXTRACT_END__


### PR DESCRIPTION
Update `Snippets.extractGeometryFromBimFile` example function and "export elements from local bim file" test with a new option to export the geometry as JSON instead of in FlatBuffers format.