### PR TITLE
Resolve https://github.com/advisories/GHSA-4hjh-wcwx-xvwj

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -13,6 +13,7 @@
     "rollup-plugin-copy>globby": "^11.0.0", // https://github.com/vladshcherbin/rollup-plugin-copy/issues/77
     "elliptic": "^6.6.1", // https://github.com/advisories/GHSA-vjh7-7g9h-fjfh crypto-browserify>browserify-sign>elliptic
     "form-data": "^4.0.4", // https://github.com/advisories/GHSA-fjxv-7rqg-78g4 azurite>@azure/ms-rest-js>form-data
+    "axios": "^1.12.0" // https://github.com/advisories/GHSA-4hjh-wcwx-xvwj @itwin/object-storage-core>axios
   },
   // A list of temporary advisories excluded from the High and Critical list.
   // Warning this should only be used as a temporary measure to avoid build failures

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   rollup-plugin-copy>globby: ^11.0.0
   elliptic: ^6.6.1
   form-data: ^4.0.4
+  axios: ^1.12.0
 
 pnpmfileChecksum: avk5jcsa6uxo2n5cahoirjiuw4
 
@@ -6471,14 +6472,8 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
-
-  axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-
-  axios@1.8.2:
-    resolution: {integrity: sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==}
+  axios@1.12.2:
+    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -10865,7 +10860,7 @@ snapshots:
   '@azure/ms-rest-js@1.11.2':
     dependencies:
       '@azure/core-auth': 1.9.0
-      axios: 0.21.4
+      axios: 1.12.2
       form-data: 4.0.4
       tough-cookie: 2.5.0
       tslib: 1.14.1
@@ -11500,7 +11495,7 @@ snapshots:
       '@itwin/core-common': link:../../core/common
       '@itwin/imodels-access-common': 5.2.1(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)
       '@itwin/imodels-client-authoring': 5.8.1(inversify@6.0.1)(reflect-metadata@0.1.13)
-      axios: 1.8.2
+      axios: 1.12.2
     transitivePeerDependencies:
       - debug
       - inversify
@@ -11539,13 +11534,13 @@ snapshots:
 
   '@itwin/imodels-client-management@5.8.1':
     dependencies:
-      axios: 1.8.2
+      axios: 1.12.2
     transitivePeerDependencies:
       - debug
 
   '@itwin/itwins-client@1.6.1':
     dependencies:
-      axios: 1.8.2
+      axios: 1.12.2
     transitivePeerDependencies:
       - debug
 
@@ -11565,7 +11560,7 @@ snapshots:
   '@itwin/object-storage-core@2.3.0(inversify@6.0.1)(reflect-metadata@0.1.13)':
     dependencies:
       '@itwin/cloud-agnostic-core': 2.3.0(inversify@6.0.1)(reflect-metadata@0.1.13)
-      axios: 1.8.2
+      axios: 1.12.2
     optionalDependencies:
       inversify: 6.0.1
       reflect-metadata: 0.1.13
@@ -11594,7 +11589,7 @@ snapshots:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
       '@itwin/core-geometry': link:../../core/geometry
-      axios: 1.8.2
+      axios: 1.12.2
     transitivePeerDependencies:
       - debug
 
@@ -12960,20 +12955,7 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios@0.21.4:
-    dependencies:
-      follow-redirects: 1.15.9
-    transitivePeerDependencies:
-      - debug
-
-  axios@0.27.2:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.8.2:
+  axios@1.12.2:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.4
@@ -12988,7 +12970,7 @@ snapshots:
       '@azure/ms-rest-js': 1.11.2
       applicationinsights: 2.9.6
       args: 5.0.3
-      axios: 0.27.2
+      axios: 1.12.2
       etag: 1.8.1
       express: 4.21.2
       fs-extra: 11.3.0


### PR DESCRIPTION
Adds a temporary override to update axios to 1.12.0 until iTwin/object-storage-core can be updated
Resolves CVE https://github.com/advisories/GHSA-4hjh-wcwx-xvwj