### PR TITLE
`RegionOps.constructCurveXYOffset` failed to offset at seam of Loop

### DIFF
--- a/common/changes/@itwin/core-geometry/da4-offset-curve-chain-anomaly_2025-09-15-21-44.json
+++ b/common/changes/@itwin/core-geometry/da4-offset-curve-chain-anomaly_2025-09-15-21-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/curve/internalContexts/PolygonOffsetContext.ts
+++ b/core/geometry/src/curve/internalContexts/PolygonOffsetContext.ts
@@ -311,7 +311,7 @@ class Joint {
       this.flexure = JointMode.Cap;
       this.fraction0 = 1.0;
     } else if (this.curve0 && this.curve1) { // joints at the middle of the chain
-      if (this.curve0.endPoint().isAlmostEqualXY(this.curve1.startPoint())) { // joint between colinear xy-segments
+      if (this.curve0.endPoint().isAlmostEqualXY(this.curve1.startPoint())) { // joint at shared endpoint
         this.fraction0 = 1.0;
         this.fraction1 = 0.0;
         this.flexure = JointMode.Trim;
@@ -356,16 +356,12 @@ class Joint {
   public static removeDegeneratePrimitives(
     start: Joint, options: JointOptions, maxTest: number,
   ): { newStart: Joint, numJointRemoved: number } {
-    /*
-    if (Checker.noisy.PolygonOffset)
-      GeometryCoreTestIO.consoleLog("\nENTER removeDegenerates");
-    */
     let jointA: Joint | undefined = start;
     let numRemoved = 0;
-    const maxRemove = 1;
     let numTest = 0;
     if (jointA) {
       while (jointA !== undefined && numTest++ < maxTest) {
+        // each iteration looks at the two curves f, g on either side of jointB
         const jointB = jointA.nextJoint;
         if (jointA
           && jointB
@@ -374,60 +370,41 @@ class Joint {
           && jointA.fraction1 !== undefined
           && jointB.fraction0 !== undefined
         ) {
+          // f0 and f1 are fractions on primitive f, between jointA and jointB.
           const f0 = jointA.fraction1;
           const f1 = jointB.fraction0;
+          // g0 and g1 are fractions on primitive g, between jointB and jointC.
           const g0 = jointB.fraction1;
           const g1 = jointB.nextJoint.fraction0;
-          // f0 and f1 are fractions on the single primitive between these joints.
-          /*
-            if (Checker.noisy.PolygonOffset) {
-              GeometryCoreTestIO.consoleLog("joint candidate");
-              GeometryCoreTestIO.consoleLog(prettyPrint(jointA.shallowExtract()));
-              GeometryCoreTestIO.consoleLog(prettyPrint(jointB.shallowExtract()));
-              GeometryCoreTestIO.consoleLog("FRACTIONS ", { fA1: f0, fB0: f1 });
-            }
-          */
           const eliminateF = f0 >= f1 || f0 > 1.0;
           const eliminateG = (g0 !== undefined && g0 > 1.0) || (g0 !== undefined && g1 !== undefined && g0 >= g1);
-          if (eliminateF && eliminateG) {
+          if (eliminateF && eliminateG) { // collapse jointA, jointB, and jointC into a new joint
             const jointC = jointB.nextJoint;
             const newJoint: Joint = new Joint(jointA.curve0, jointC.curve1, undefined);
             Joint.link(jointA.previousJoint, newJoint);
             Joint.link(newJoint, jointC.nextJoint);
             newJoint.annotateJointMode(options);
-            newJoint.previousJoint!.annotateJointMode(options);
+            if (newJoint.previousJoint)
+              newJoint.previousJoint.annotateJointMode(options);
             if (newJoint.nextJoint)
               newJoint.nextJoint.annotateJointMode(options);
-            /*
-            if (Checker.noisy.PolygonOffset) {
-              GeometryCoreTestIO.consoleLog(" NEW DOUBLE CUT");
-              GeometryCoreTestIO.consoleLog(prettyPrint(newJoint.shallowExtract()));
-            }
-            */
-          } else if (eliminateF) {
+            numRemoved += 2;
+            if (jointA === start || jointB === start || jointC === start)
+              start = newJoint;
+            jointA = newJoint;
+          } else if (eliminateF) { // collapse jointA and jointB into a new joint
             const newJoint: Joint = new Joint(jointA.curve0, jointB.curve1, undefined);
             Joint.link(jointA.previousJoint, newJoint);
             Joint.link(newJoint, jointB.nextJoint);
             newJoint.annotateJointMode(options);
-            newJoint.previousJoint!.annotateJointMode(options);
-            newJoint.nextJoint!.annotateJointMode(options);
-            /*
-            if (Checker.noisy.PolygonOffset) {
-              GeometryCoreTestIO.consoleLog(" NEW JOINT");
-              GeometryCoreTestIO.consoleLog(prettyPrint(newJoint.shallowExtract()));
-            }
-          */
+            if (newJoint.previousJoint)
+              newJoint.previousJoint.annotateJointMode(options);
+            if (newJoint.nextJoint)
+              newJoint.nextJoint.annotateJointMode(options);
             numRemoved++;
-            if (jointA === start)
+            if (jointA === start || jointB === start)
               start = newJoint;
             jointA = newJoint;
-            if (numRemoved >= maxRemove) {
-              /*
-              if (Checker.noisy.PolygonOffset)
-                GeometryCoreTestIO.consoleLog(" EXIT removeDegenerates at maxRemove\n");
-              */
-              return { newStart: start, numJointRemoved: numRemoved };
-            }
           }
         }
         jointA = jointA.nextJoint;
@@ -513,12 +490,6 @@ export class PolygonWireOffsetContext {
       joint0 = state.newStart;
       if (state.numJointRemoved === 0)
         break;
-      /*
-      if (Checker.noisy.PolygonOffset) {
-        GeometryCoreTestIO.consoleLog("  POST REMOVE DEGENERATES  " + state.numJointRemoved);
-        Joint.visitJointsOnChain(joint0, (joint: Joint) => { GeometryCoreTestIO.consoleLog(prettyPrint(joint.shallowExtract())); return true; });
-      }
-      */
     }
     const chain = LineString3d.create();
     Joint.collectStrokesFromChain(joint0, chain, numPoints);  // compute offset corners (by extension/trim)
@@ -597,7 +568,7 @@ export class CurveChainWireOffsetContext {
     const wrap: boolean = curves instanceof Loop;
     const offsetOptions = OffsetOptions.create(offsetDistanceOrOptions);
     const simpleOffsets: CurvePrimitive[] = [];
-    /** traverse primitives (children of curves) and create simple offsets of each primitive as an array */
+    // traverse primitives (children of curves) and create simple offsets of each primitive as an array
     for (const c of curves.children) {
       const c1 = CurveChainWireOffsetContext.createSingleOffsetPrimitiveXY(c, offsetOptions);
       if (c1 === undefined) {
@@ -611,7 +582,7 @@ export class CurveChainWireOffsetContext {
         }
       }
     }
-    /** create joints between array elements to make offsets as a linked list (joint0) */
+    // create joints between array elements to make offsets as a linked list (joint0)
     let fragment0;
     let newJoint;
     let previousJoint;
@@ -630,10 +601,19 @@ export class CurveChainWireOffsetContext {
     }
     if (joint0 && previousJoint && curves instanceof Loop)
       Joint.link(previousJoint, joint0);
-    /** annotateChain sets some of the joints attributes (including how to extend curves or fill the gap between curves) */
+    // annotateChain sets some of the joint attributes (including how to extend curves or fill the gap between curves)
     const numOffset = simpleOffsets.length;
     Joint.annotateChain(joint0, offsetOptions.jointOptions, numOffset);
-    /** turn the Joint linked list into a CurveCollection. trimming is done in collectCurvesFromChain */
+    if (joint0) {
+      // make limited passes through the Joint chain until no self-intersections are removed
+      for (let pass = 0; pass++ < 5;) {
+        const state = Joint.removeDegeneratePrimitives(joint0, offsetOptions.jointOptions, numOffset);
+        joint0 = state.newStart;
+        if (state.numJointRemoved === 0)
+          break;
+      }
+    }
+    // turn the Joint linked list into a CurveCollection. trimming is done in collectCurvesFromChain
     const outputCurves: CurvePrimitive[] = [];
     Joint.collectCurvesFromChain(joint0, outputCurves, numOffset);
     return RegionOps.createLoopPathOrBagOfCurves(outputCurves, wrap, true);

--- a/core/geometry/src/test/topology/RegionOps.test.ts
+++ b/core/geometry/src/test/topology/RegionOps.test.ts
@@ -2401,7 +2401,7 @@ describe("RegionOps.constructPolygonWireXYOffset", () => {
 });
 
 describe("RegionOps.constructCurveXYOffset", () => {
-  it("constructCurveXYOffsetDefaultOption", () => {
+  it("defaultOptions", () => {
     const allGeometry: GeometryQuery[] = [];
     const lineStrings: CurveChain[] = [
       Path.create([Point3d.create(-2, -1), Point3d.create(-2, 0), Point3d.create(-3, -1)]),
@@ -2430,10 +2430,10 @@ describe("RegionOps.constructCurveXYOffset", () => {
         GeometryCoreTestIO.captureCloneGeometry(allGeometry, curveCollection);
       }
     }
-    GeometryCoreTestIO.saveGeometry(allGeometry, "PolygonOffset", "CurveXYOffsetDefaultOption");
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.constructCurveXYOffset", "defaultOptions");
   });
 
-  it("constructCurveXYOffsetCustomOption", () => {
+  it("customOptions", () => {
     const allGeometry: GeometryQuery[] = [];
     const lineStrings: CurveChain[] = [
       Path.create([Point3d.create(-2, -1), Point3d.create(-2, 0), Point3d.create(-3, -1)]),
@@ -2468,10 +2468,10 @@ describe("RegionOps.constructCurveXYOffset", () => {
         GeometryCoreTestIO.captureCloneGeometry(allGeometry, curveCollection);
       }
     }
-    GeometryCoreTestIO.saveGeometry(allGeometry, "PolygonOffset", "CurveXYOffsetCustomOption");
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.constructCurveXYOffset", "customOptions");
   });
 
-  it("EllipsePreserveEllipticalArcsTrue", () => {
+  it("preserveEllipticalArcsTrue", () => {
     const allGeometry: GeometryQuery[] = [];
     const origin = Point3d.create(0, 0, 0);
     const vector0 = Vector3d.create(5, 0, 0);
@@ -2492,10 +2492,10 @@ describe("RegionOps.constructCurveXYOffset", () => {
       const curveCollection = RegionOps.constructCurveXYOffset(loop, jointOption);
       GeometryCoreTestIO.captureCloneGeometry(allGeometry, curveCollection);
     }
-    GeometryCoreTestIO.saveGeometry(allGeometry, "PolygonOffset", "EllipsePreserveEllipticalArcsTrue");
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.constructCurveXYOffset", "preserveEllipticalArcsTrue");
   });
 
-  it("EllipsePreserveEllipticalArcsFalse", () => {
+  it("preserveEllipticalArcsFalse", () => {
     const allGeometry: GeometryQuery[] = [];
     const origin = Point3d.create(0, 0, 0);
     const vector0 = Vector3d.create(5, 0, 0);
@@ -2516,9 +2516,10 @@ describe("RegionOps.constructCurveXYOffset", () => {
       const curveCollection = RegionOps.constructCurveXYOffset(loop, jointOption);
       GeometryCoreTestIO.captureCloneGeometry(allGeometry, curveCollection);
     }
-    GeometryCoreTestIO.saveGeometry(allGeometry, "PolygonOffset", "EllipsePreserveEllipticalArcsFalse");
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.constructCurveXYOffset", "preserveEllipticalArcsFalse");
   });
-  it("constructCurveXYOffsetMaxChamferDegree", () => {
+
+  it("maxChamferDegree", () => {
     const ck = new Checker();
     const allGeometry: GeometryQuery[] = [];
     const origin = Point3d.create(0, 0, 0);
@@ -2546,7 +2547,59 @@ describe("RegionOps.constructCurveXYOffset", () => {
       dx += 15;
     }
 
-    GeometryCoreTestIO.saveGeometry(allGeometry, "PolygonOffset", "constructCurveXYOffsetMaxChamferDegree");
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.constructCurveXYOffset", "maxChamferDegree");
+    expect(ck.getNumErrors()).toBe(0);
+  });
+
+  it("swallowsSegmentAtSeam", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+    const jointOptions = new JointOptions(-0.3109, 180, 360, true, true);
+    const loop = Loop.create(
+      LineString3d.create([[93089.5657959348, 272528.15824223746, 0], [93100.03808225933, 272531.43445330666, 0], [93101.22876909783, 272527.6284672965, 0]]),
+      Arc3d.create(Point3d.create(93099.77428488612, 272527.17343798134, 0), Vector3d.create(1.488251776014865, 0.32815034802058346, 0), Vector3d.create(0.3281503480205824, -1.4882517760148655, 0), AngleSweep.fromJSON([-4.937670015113557, 4.937670015113557])),
+      LineString3d.create([93101.28525819005, 272527.3722737793, 0]), // singleton line strings may be problematic elsewhere, but not for offset
+      Arc3d.create(Point3d.create(93099.77428488623, 272527.17343798134, 0), Vector3d.create(1.5226584933015492, 0.06393052644921698, 0), Vector3d.create(0.06393052644921829, -1.522658493301549, 0), AngleSweep.fromJSON([-5.092518821342509, 5.092518821342509])),
+      LineString3d.create([93101.29660767947, 272527.1019585258, 0]),
+      Arc3d.create(Point3d.create(93099.77428488602, 272527.1734379813, 0), Vector3d.create(1.510520957673389, -0.20224350780197875, 0), Vector3d.create(-0.20224350780197886, -1.5105209576733885, 0), AngleSweep.fromJSON([-4.937670013019398, 4.937670013019398])),
+      LineString3d.create([93101.2617926862, 272526.841931504, 0]),
+      Arc3d.create(Point3d.create(93099.77428488611, 272527.1734379812, 0), Vector3d.create(1.4168797543015519, -0.561273339465388, 0), Vector3d.create(-0.5612733394653889, -1.4168797543015517, 0), AngleSweep.fromJSON([-9.04652736096125, 9.04652736096125])),
+      LineString3d.create([93101.08528740756, 272526.39636115846, 0]),
+      Arc3d.create(Point3d.create(93099.77428488612, 272527.1734379812, 0), Vector3d.create(1.1534997964345772, -0.9959991060709421, 0), Vector3d.create(-0.9959991060709413, -1.1534997964345777, 0), AngleSweep.fromJSON([-10.152545440293755, 10.152545440293755])),
+      LineString3d.create([93100.73415881662, 272525.9897074218, 0]),
+      Arc3d.create(Point3d.create(93099.77428488611, 272527.1734379812, 0), Vector3d.create(0.7618084247839977, -1.319933302722175, 0), Vector3d.create(-1.3199333027221751, -0.7618084247839976, 0), AngleSweep.fromJSON([-9.046527362119292, 9.046527362119292])),
+      LineString3d.create([93100.31907550692, 272525.7501392848, 0]),
+      Arc3d.create(Point3d.create(93099.77428488618, 272527.1734379807, 0), Vector3d.create(0.4202627410270718, -1.4649079242989695, 0), Vector3d.create(-1.4649079242989695, -0.420262741027071, 0), AngleSweep.fromJSON([-4.937670014773152, 4.937670014773152])),
+      LineString3d.create([93100.06690049211, 272525.67779360275, 0]),
+      Arc3d.create(Point3d.create(93099.7742848862, 272527.1734379802, 0), Vector3d.create(0.15870081460091126, -1.5157143688814274, 0), Vector3d.create(-1.5157143688814272, -0.15870081460091198, 0), AngleSweep.fromJSON([-5.092518816611678, 5.092518816611678])),
+      LineString3d.create([93099.79781801868, 272525.64961968776, 0]),
+      Arc3d.create(Point3d.create(93099.77428488608, 272527.1734379793, 0), Vector3d.create(-0.10771223944506644, -1.5201888262126835, 0), Vector3d.create(-1.5201888262126835, 0.1077122394450671, 0), AngleSweep.fromJSON([-4.937670017137359, 4.937670017137359])),
+      LineString3d.create([[93099.53612673173, 272525.6681616965, 0], [93090.80016320662, 272527.050327199, 0]]),
+      Arc3d.create(Point3d.create(93091.03832136128, 272528.55560348375, 0), Vector3d.create(-0.4976031275002508, -1.4404746188394117, 0), Vector3d.create(-1.440474618839412, 0.49760312750025065, 0), AngleSweep.fromJSON([-10.066596761922968, 10.066596761922968])),
+      LineString3d.create([93090.29659421161, 272527.22428202163, 0]),
+      Arc3d.create(Point3d.create(93091.03832136106, 272528.5556034833, 0), Vector3d.create(-0.8299089173113726, -1.278212497007433, 0), Vector3d.create(-1.2782124970074327, 0.8299089173113732, 0), AngleSweep.fromJSON([-3.870822439014021, 3.870822439014021])),
+      LineString3d.create([93090.12401707575, 272527.33633170376, 0]),
+      Arc3d.create(Point3d.create(93091.03832136084, 272528.55560348294, 0), Vector3d.create(-0.9959991057076077, -1.1534997957220827, 0), Vector3d.create(-1.153499795722083, 0.9959991057076072, 0), AngleSweep.fromJSON([-3.9438437437170264, 3.9438437437170264])),
+      LineString3d.create([93089.9653446053, 272527.47333878366, 0]),
+      Arc3d.create(Point3d.create(93091.03832136112, 272528.55560348375, 0), Vector3d.create(-1.1435897437288622, -1.00736214820259, 0), Vector3d.create(-1.00736214820259, 1.1435897437288622, 0), AngleSweep.fromJSON([-3.87082243002207, 3.87082243002207])),
+      LineString3d.create([93089.82933617584, 272527.6277399047, 0]),
+      Arc3d.create(Point3d.create(93091.03832136087, 272528.55560348363, 0), Vector3d.create(-1.3525569735883416, -0.702257525417748, 0), Vector3d.create(-0.7022575254177474, 1.3525569735883416, 0), AngleSweep.fromJSON([-10.066596764821469, 10.066596764821469])),
+      LineString3d.create([[93089.58383714946, 272528.1005741686, 0], [93089.5657959348, 272528.15824223746, 0]]), // this last segment should be absent in the offset
+    );
+    const loopForDisplay = Loop.create(...loop.children.filter((c) => c.quickLength() > Geometry.smallFloatingPoint));  // can't import singleton linestrings in DGN!
+    GeometryCoreTestIO.captureGeometry(allGeometry, loopForDisplay);
+    const offset = RegionOps.constructCurveXYOffset(loop, jointOptions);
+    GeometryCoreTestIO.captureGeometry(allGeometry, offset);
+    if (ck.testDefined(offset, "RegionOps.constructCurveXYOffset succeeded")) {
+      if (ck.testType(offset, Loop, "RegionOps.constructCurveXYOffset returned a Loop")) {
+        ck.testExactNumber(offset.children.length, 4, "RegionOps.constructCurveXYOffset returned a Loop with 4 children");
+        const area = RegionOps.computeXYArea(offset);
+        if (ck.testDefined(area, "RegionOps.computeXYArea succeeded")) {
+          ck.testCoordinate(-30.77708229, area, "RegionOps.constructCurveXYOffset returned a Loop with expected area");
+        }
+      }
+    }
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.constructCurveXYOffset", "swallowsSegmentAtSeam");
     expect(ck.getNumErrors()).toBe(0);
   });
 });


### PR DESCRIPTION
A `Loop` with a last line segment much smaller than the interior offset distance now correctly vanishes in the offset curve.

We were not handling the seam correctly, nor were we trying to excise swallowed primitives.

Existing polygon offset code came in handy here, and this too was cleaned up.