### PR TITLE
Add SqliteChangesetReader.openInMemory() to allow read unsaved changes

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -6038,6 +6038,9 @@ export class SqliteChangesetReader implements Disposable {
     static openGroup(args: {
         readonly changesetFiles: string[];
     } & SqliteChangesetReaderArgs): SqliteChangesetReader;
+    static openInMemory(args: SqliteChangesetReaderArgs & {
+        db: IModelDb;
+    }): SqliteChangesetReader;
     static openLocalChanges(args: Omit<SqliteChangesetReaderArgs, "db"> & {
         db: IModelDb;
         includeInMemoryChanges?: true;

--- a/common/changes/@itwin/core-backend/affank-allow-reading-in-mem-changes_2025-09-23-18-18.json
+++ b/common/changes/@itwin/core-backend/affank-allow-reading-in-mem-changes_2025-09-23-18-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add SqliteChangesetReader.openInMemory() to allow read unsaved changes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
   ../../core/backend:
     dependencies:
       '@bentley/imodeljs-native':
-        specifier: 5.2.16
-        version: 5.2.16
+        specifier: 5.3.1
+        version: 5.3.1
       '@itwin/cloud-agnostic-core':
         specifier: ^2.2.4
         version: 2.2.4(inversify@6.0.1)(reflect-metadata@0.1.13)
@@ -4734,8 +4734,8 @@ packages:
   '@bentley/icons-generic@1.0.34':
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  '@bentley/imodeljs-native@5.2.16':
-    resolution: {integrity: sha512-Nt5rrvZQXYZE2pdohbv0/ZLEH8jcZ+vu2JvzBO9t3cXE5fDtBraJ4/O6s7IKItlKQdIVvNb9GmA38livOM2aMw==}
+  '@bentley/imodeljs-native@5.3.1':
+    resolution: {integrity: sha512-CslUF5b+XHg+jYoh4FKWkZfc2kx9sqh3HCs5d2x4ZBL+B658Cs5aSUbm96NHR6pKH32aCtRQrqt4iUQRzA1g8w==}
 
   '@bentley/linear-referencing-schema@2.0.3':
     resolution: {integrity: sha512-2pFIEN4BS7alIDhGous6N2icKAS8ZhVBfoWB8WvSFaYnneGv5YwbbXl46qATDdPO5jUFezkW6uVxdpp1eOgUHQ==}
@@ -11088,7 +11088,7 @@ snapshots:
 
   '@bentley/icons-generic@1.0.34': {}
 
-  '@bentley/imodeljs-native@5.2.16': {}
+  '@bentley/imodeljs-native@5.3.1': {}
 
   '@bentley/linear-referencing-schema@2.0.3': {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -112,7 +112,7 @@
     "webpack": "^5.97.1"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "5.2.16",
+    "@bentley/imodeljs-native": "5.3.1",
     "@itwin/cloud-agnostic-core": "^2.2.4",
     "@itwin/object-storage-azure": "^2.3.0",
     "@itwin/object-storage-core": "^2.3.0",

--- a/core/backend/src/SqliteChangesetReader.ts
+++ b/core/backend/src/SqliteChangesetReader.ts
@@ -133,6 +133,17 @@ export class SqliteChangesetReader implements Disposable {
     return reader;
   }
   /**
+   * Open in-memory changes for the given iModel.
+   * @param args - The arguments for opening in-memory changes.
+   * @returns SqliteChangesetReader instance
+   */
+  public static openInMemory(args: SqliteChangesetReaderArgs & { db: IModelDb }): SqliteChangesetReader {
+    const reader = new SqliteChangesetReader(args.db);
+    reader._disableSchemaCheck = args.disableSchemaCheck ?? false;
+    reader._nativeReader.openInMemoryChanges(args.db[_nativeDb], args.invert ?? false);
+    return reader;
+  }
+  /**
    * Writes the changeset to a file.
    * @note can be use with openGroup() or openLocalChanges() to persist changeset.
    * @param args - The arguments for writing to the file.

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:5.2.16'
+    implementation 'com.github.itwin:mobile-native-android:5.3.1'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.2.16;
+				version = 5.3.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.2.16;
+				version = 5.3.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/1217

This has been added to help developer debug problem by looking into changes before calling `saveChanges()`.