### PR TITLE
Increase logo card width in attribution popup to fix Google Maps image clipping

### DIFF
--- a/common/changes/@itwin/core-frontend/wilmaier-logo-card-width-5.2.x_2025-10-02-15-38.json
+++ b/common/changes/@itwin/core-frontend/wilmaier-logo-card-width-5.2.x_2025-10-02-15-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Increase logo card width in attribution popup to fix Google Maps image clipping",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/IModeljs-css.ts
+++ b/core/frontend/src/IModeljs-css.ts
@@ -32,7 +32,7 @@ let iModelJsCss: string | undefined = `
 }
 
 .logo-card-logo {
-  width:124px;
+  width:144px;
   overflow:hidden;
   vertical-align:text-top;
   text-align:center


### PR DESCRIPTION
Backported from master PR:
https://github.com/iTwin/itwinjs-core/pull/8597

Before:

<img width="425" height="160" alt="image" src="https://github.com/user-attachments/assets/2cf4112c-f78e-4c94-a6ee-60bc6c52ef56" />

After:

<img width="433" height="180" alt="image" src="https://github.com/user-attachments/assets/30da3aec-88b0-4fd9-ba39-8d3d60eef83b" />
