### PR TITLE
ECSqlReader/ConcurrentQuery unable to see modification to file

### DIFF
--- a/common/changes/@itwin/core-backend/affank-query-reader-bugfix_2025-10-08-02-26.json
+++ b/common/changes/@itwin/core-backend/affank-query-reader-bugfix_2025-10-08-02-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "ECSqlReader/ConcurrentQuery unable to see modification to file",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}


### PR DESCRIPTION
fixes: https://github.com/iTwin/itwinjs-backlog/issues/1657

`ConcurrentQuery` relies on `PRAGMA data_version` to detect if the database file has been modified by another connection. However, this mechanism doesn't work reliably when there are active statements, as these likely lock the database and prevent `PRAGMA data_version` from reflecting any changes until those statements are closed.

In ECDb, `InstanceReader` maintains active statements for performance reasons. For example, executing a query like `SELECT $ FROM Bis.Element` creates an active statement, which in turn blocks `PRAGMA data_version` from updating.

As a workaround, we now check the primary connection to determine if it has changed since the last time a query was executed via `ConcurrentQuery`. If a change is detected, we clear the cache to ensure consistency.