### PR TITLE
Update webgl compatibility docs to mention compatibility checker site

### DIFF
--- a/common/changes/@itwin/webgl-compatibility/nam-compat-docs_2025-10-20-18-13.json
+++ b/common/changes/@itwin/webgl-compatibility/nam-compat-docs_2025-10-20-18-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}

--- a/core/webgl-compatibility/README.md
+++ b/core/webgl-compatibility/README.md
@@ -6,6 +6,8 @@ Copyright © Bentley Systems, Incorporated. All rights reserved. See LICENSE.md 
 
 The __@itwin/webgl-compatibility__ package provides APIs for determining the level of compatibility of a browser+device with the iTwin.js rendering system.
 
+This package is used by the [iTwin.js Compatibility Checker website](https://itwinjscompatibility.bentley.com/) to evaluate whether
+a user's browser and hardware meet the requirements for running iTwin.js applications.
 ## Documentation
 
 See the [iTwin.js](https://www.itwinjs.org) documentation for more information.

--- a/core/webgl-compatibility/src/webgl-compatibility.ts
+++ b/core/webgl-compatibility/src/webgl-compatibility.ts
@@ -6,7 +6,10 @@ export * from "./Capabilities";
 export * from "./RenderCompatibility";
 
 /** @docs-package-description
- * The webgl-compatibility package provides APIs for determining the level of compatibility of a browser+device with the iTwin.js rendering system.
+ * The webgl-compatibility package provides APIs for determining the level of compatibility of a browser and device with the iTwin.js rendering system.
+ *
+ * This package is used by the [iTwin.js Compatibility Checker website](https://itwinjscompatibility.bentley.com/) to evaluate whether
+ * a user's browser and hardware meet the requirements for running iTwin.js applications.
  */
 
 /**


### PR DESCRIPTION
This pull request updates the documentation for the `@itwin/webgl-compatibility` package to clarify its purpose and usage. 

Includes mentioning of the iTwin.js compatibility checker [website](https://itwinjscompatibility.bentley.com/) both in the README of the package and the package documentation that will be featured on iTwinjs.org.