### PR TITLE
docs ci: prevent gathering docs artifacts from failed builds

### DIFF
--- a/common/config/azure-pipelines/templates/copy-docs-artifact.yaml
+++ b/common/config/azure-pipelines/templates/copy-docs-artifact.yaml
@@ -53,7 +53,7 @@ steps:
           project: ${{ parameters.projectId }}
           pipeline: ${{ parameters.pipelineId }}
           allowPartiallySucceededBuilds: true
-          allowFailedBuilds: true
+          allowFailedBuilds: false
           artifactName: ${{ parameters.artifactName }}
           targetPath: $(Pipeline.Workspace)/${{ parameters.artifactName }}
           ${{ if parameters.buildTag }}:


### PR DESCRIPTION
Perhaps there was an instance in the past when we wanted to gather an artifact from a failed build, but now this behavior is failing docs builds and preventing PRs from completing. 

I don't believe we're relying on this behavior, so toggling it to false. 

Fixes #8706 