### PR TITLE
Non-degenerate vertex discard

### DIFF
--- a/core/frontend/src/internal/render/webgl/glsl/Vertex.ts
+++ b/core/frontend/src/internal/render/webgl/glsl/Vertex.ts
@@ -339,7 +339,8 @@ export function replaceLineCode(vert: VertexShaderBuilder, func: string): void {
 // This vertex belongs to a triangle which should not be rendered. Produce a degenerate triangle.
 // Also place it outside NDC range (for GL_POINTS)
 const discardVertex = ` {
-    gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    int vertId = gl_VertexID % 3;
+    gl_Position = vec4(2.0 + float(vertId == 1), 2.0 + float(vertId == 2), 2.0, 1.0);
     return;
   }
 `;


### PR DESCRIPTION
Don't review - investigating.
Potential alternate solution for #8730.
We observe that the Intel driver bug is triggered by vertex discard, which we implement by having the vertex shader produce a degenerate triangle outside of NDC space.
See if producing a non-degenerate triangle (still outside of NDC space) behaves differently on that hardware.