### PR TITLE
Presentation: Fix flaky full stack test

### DIFF
--- a/full-stack-tests/presentation/src/backend/ReadWrite.test.ts
+++ b/full-stack-tests/presentation/src/backend/ReadWrite.test.ts
@@ -10,14 +10,14 @@ import { PresentationManager } from "@itwin/presentation-backend";
 import { ChildNodeSpecificationTypes, Ruleset, RuleTypes } from "@itwin/presentation-common";
 import { initialize, terminate } from "../IntegrationTests.js";
 import { collect, prepareOutputFilePath } from "../Utils.js";
+import { createValidIModelFileName } from "../IModelSetupUtils.js";
 
-// Skipped until https://github.com/iTwin/itwinjs-core/issues/8751 is fixed
-describe.skip("ReadWrite", () => {
+describe("ReadWrite", () => {
   let manager: PresentationManager;
   let imodel: IModelDb;
 
-  function createIModelFromSeed() {
-    const imodelPath = prepareOutputFilePath("ReadWrite.bim");
+  function createIModelFromSeed(testName: string) {
+    const imodelPath = prepareOutputFilePath(`${createValidIModelFileName(testName)}.bim`);
     fs.copyFileSync("assets/datasets/Properties_60InstancesWithUrl2.ibim", imodelPath);
     return StandaloneDb.openFile(imodelPath);
   }
@@ -31,9 +31,9 @@ describe.skip("ReadWrite", () => {
     await terminate();
   });
 
-  beforeEach(async () => {
+  beforeEach(function () {
     manager = new PresentationManager();
-    imodel = createIModelFromSeed();
+    imodel = createIModelFromSeed(this.test!.fullTitle());
   });
 
   afterEach(async () => {


### PR DESCRIPTION
~Fixes https://github.com/iTwin/itwinjs-core/issues/8751.~

Couldn't reproduce locally, but my assumption is that when the first of two tests finishes and "deletes" the test imodel, the second test immediately tries to create a new imodel at the same file path, and FS has that file path locked, causing a hang. The change ensures that we use unique file names for each of the tests.

Update: The above assumption was wrong.