### PR TITLE
Take RealityTile.transformToRoot into account in loadGeometryFromStream

### DIFF
--- a/common/changes/@itwin/frontend-devtools/nelrod-viewdefdec_2025-11-24-15-00.json
+++ b/common/changes/@itwin/frontend-devtools/nelrod-viewdefdec_2025-11-24-15-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-devtools",
+      "comment": "Added Decorator to show bounds of the view's original Frustum",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-devtools"
+}

--- a/core/frontend-devtools/README.md
+++ b/core/frontend-devtools/README.md
@@ -78,6 +78,7 @@ The key-ins below enable, disable, or toggle a specific feature. They take at mo
 * `fdt toggle reality preload` - Toggles the display of preloaded reality tile bounding boxes.
 * `fdt toggle reality freeze`  - Toggles the freezing of reality tile loading, when the reality tiles are frozen new reality tiles are not downloaded or purged.
 * `fdt toggle reality logging` - Toggle the logging of reality tile loading and selection diagnostics to the console.
+* `fdt toggle viewdef bounds` - Toggles the display of frustum decorations that represent the extents of the current ViewDefinition. For SectionDrawing, this also displays decorations for the associated SpatialView.
 * `fdt reality bounds` - Toggle the display of bounding boxes for reality tiles.
 * `fdt set building display` Toggle the display of the worldwide OpenStreetMap worldwide buildingslayer by attaching or displaying as a reality model in the current viewport.  The OSM buildings are aggregated and supplied from Cesium Ion <https://cesium.com/content/cesium-osm-buildings/>. The first argument is required on|off - the second optional argument is a value for transparency between 0 and 1.
 * `fdt wow ignore background` Toggle whether the background color needs to be white for white-on-white reversal to apply.

--- a/core/frontend-devtools/public/locales/en/FrontendDevTools.json
+++ b/core/frontend-devtools/public/locales/en/FrontendDevTools.json
@@ -93,6 +93,9 @@
     "ToggleRealityTileLogging": {
       "keyin": "fdt toggle reality logging"
     },
+    "ViewDefinitionDecorationTool": {
+      "keyin": "fdt toggle viewdef bounds"
+    },
     "ToggleSectionCut": {
       "keyin": "fdt section cut"
     },

--- a/core/frontend-devtools/src/FrontEndDevTools.ts
+++ b/core/frontend-devtools/src/FrontEndDevTools.ts
@@ -69,6 +69,7 @@ import { ElementIdFromSourceAspectIdTool, SourceAspectIdFromElementIdTool } from
 import { ToggleTileRequestDecorationTool } from "./tools/TileRequestDecoration";
 import { ToggleTileTreeBoundsDecorationTool } from "./tools/TileTreeBoundsDecoration";
 import { ToggleToolTipsTool } from "./tools/ToolTipProvider";
+import { ViewDefinitionDecorationTool } from "./tools/ViewDefinitionDecorator";
 
 /** Entry-point for the package. Before using the package you *must* call [[FrontendDevTools.initialize]].
  * @beta
@@ -198,6 +199,7 @@ export class FrontendDevTools {
       ToggleViewAttachmentBoundariesTool,
       ToggleViewAttachmentClipShapesTool,
       ToggleViewAttachmentsTool,
+      ViewDefinitionDecorationTool,
       ToggleWiremeshTool,
       ToggleRealityTileBounds,
       ToggleRealityTilePreload,

--- a/core/frontend-devtools/src/tools/ViewDefinitionDecorator.ts
+++ b/core/frontend-devtools/src/tools/ViewDefinitionDecorator.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+/** @packageDocumentation
+ * @module Tools
+ */
+
+import { ColorDef, Frustum, LinePixels } from "@itwin/core-common";
+import { DecorateContext, GraphicType, IModelApp, IModelConnection, OffScreenViewport, Tool, Viewport, ViewRect } from "@itwin/core-frontend";
+import { parseToggle } from "./parseToggle";
+import { Id64, Id64String, Logger } from "@itwin/core-bentley";
+import { Transform, Vector2d } from "@itwin/core-geometry";
+
+class ViewDefinitionDecoration {
+  private static _instance?: ViewDefinitionDecoration;
+  private _removeMe?: () => void;
+
+  private constructor() {
+    this._removeMe = IModelApp.viewManager.addDecorator(this);
+  }
+
+  private stop() {
+    if (this._removeMe) {
+      this._removeMe();
+      this._removeMe = undefined;
+    }
+  }
+
+  private _viewId?: Id64String;
+  private _loading: boolean = false;
+  private _preloadedFrustum: Frustum[] = [];
+
+  private async getFrustumForViewId(iModel: IModelConnection, viewId: Id64String, transform: Transform = Transform.createIdentity()): Promise<void> {
+    return iModel.views.load(viewId).then((result) => {
+      // Use the view extents/delta
+      let vector: Vector2d;
+      if (result.is2d()) vector = Vector2d.create(result.delta.x, result.delta.y);
+      else vector = Vector2d.create(result.getExtents().x, result.getExtents().y);
+      // create a viewport to the size of the extents to ensure the aspect is correct.
+      const vp = OffScreenViewport.create({ view: result, viewRect: new ViewRect(0,0,vector.x,vector.y) });
+      const frustum = vp.getFrustum();
+      this._preloadedFrustum.push(frustum.transformBy(transform));
+
+    }).catch((err: unknown) => { Logger.logException("FrontendDevTools", err)});
+  }
+
+  public preload(viewport: Viewport) {
+    this._loading = true;
+    const iModel = viewport.iModel;
+    const view = viewport.view;
+    const viewId = view.id;
+
+    const loadPromises: Promise<void>[] = [];
+    loadPromises.push(this.getFrustumForViewId(iModel, viewId));
+
+    if (view.isDrawingView() && view.sectionDrawingInfo.spatialView)
+      loadPromises.push(this.getFrustumForViewId(iModel, view.sectionDrawingInfo.spatialView, view.sectionDrawingInfo.drawingToSpatialTransform.inverse()));
+
+    void Promise.all(loadPromises).finally(() => {
+      IModelApp.viewManager.invalidateCachedDecorationsAllViews(this);
+      this._viewId = viewId;
+      this._loading = false;
+    });
+  }
+
+  /** This will allow the render system to cache and reuse the decorations created by this decorator's decorate() method. */
+  public readonly useCachedDecorations = true;
+
+  public decorate(context: DecorateContext): void {
+    if (context.viewport.view.id !== this._viewId && !this._loading) {
+      this._preloadedFrustum.length = 0;
+      // just clear the decoration if the view is not from a view definition
+      if (Id64.isValidId64(context.viewport.view.id))
+        this.preload(context.viewport);
+    }
+
+    const builder = context.createGraphicBuilder(GraphicType.WorldDecoration);
+    const purple = ColorDef.fromString("#800080");
+
+    // The current view's frustum is at the end of the array.
+    builder.setSymbology(purple, purple, 5,  LinePixels.Code0);
+    const endIndex = this._preloadedFrustum.length - 1;
+    const currentFrustum = this._preloadedFrustum[endIndex];
+    if (currentFrustum) builder.addFrustum(currentFrustum);
+
+    // Add other frustums.
+    builder.setSymbology(purple, purple, 4,  LinePixels.Code2);
+    const remainingFrustums = this._preloadedFrustum.slice(0, endIndex);
+    remainingFrustums.forEach((frustum) => builder.addFrustum(frustum));
+
+    context.addDecorationFromBuilder(builder);
+  }
+
+  public static toggle(enabled?: boolean): void {
+    const instance = ViewDefinitionDecoration._instance;
+    if (undefined !== enabled && (undefined !== instance) === enabled)
+      return;
+
+    if (undefined === instance) {
+      ViewDefinitionDecoration._instance = new ViewDefinitionDecoration();
+    } else {
+      instance.stop();
+      ViewDefinitionDecoration._instance = undefined;
+    }
+  }
+}
+
+/** Display in every viewport a green range graphic for each displayed tile tree, plus a red range graphic for each tile tree's content range if defined.
+ * @beta
+ */
+export class ViewDefinitionDecorationTool extends Tool {
+  public static override toolId = "ViewDefinitionDecorationTool";
+  public static override get minArgs() { return 0; }
+  public static override get maxArgs() { return 1; }
+
+  public override async run(enable?: boolean): Promise<boolean> {
+    ViewDefinitionDecoration.toggle(enable);
+    return true;
+  }
+
+  public override async parseAndRun(...args: string[]): Promise<boolean> {
+    const enable = parseToggle(args[0]);
+    if (typeof enable !== "string")
+      await this.run(enable);
+
+    return true;
+  }
+}


### PR DESCRIPTION
There is a discrepancy between the collected geometry result of `GltfReader.readGltfAndCreateGeometry()`, and the rendered graphics from `GltfReader.readGltfAndCreateGraphics()`.

The cause was is that both methods take a `transformToRoot` argument, which is a transform that is applied to the result. The transform provided to `readGltfAndCreateGraphics` is a `RealityTile.transformToRoot`. On the other hand, the transform provided to `readGltfAndCreateGeometry` is a `RealityTile.tree.iModelTransform`. This means that if a tile had a `transformToRoot` defined, that was likely not taken into account when `readGltfAndCreateGeometry` was called.

My solution in this PR is to multiply the `RealityTile.tree.iModelTransform` and `RealityTile.transformToRoot` to provide one transform to `readGltfAndCreateGeometry`. With this fix, the TerrainDrapeTool in DTA collects geometry at the same height as the rendered geometry.

TODO
- [x] Manually test in display-test-app
- [x] Those who reported the bug also manually tested this fix
- [x] Run image tests

Unit tests will be added in a follow up-PR: https://github.com/iTwin/itwinjs-core/pull/8809