### PR TITLE
Improve copilot instructions regarding documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -246,6 +246,25 @@ All public APIs must include TSDoc comments with:
 - `@throws` tag for exceptions
 - `@deprecated` tag with migration guidance for deprecated APIs
 
+### Deprecation Format
+
+When adding `@deprecated` tags, follow these formats - **do NOT manually add dates** (the pipeline automatically adds them):
+
+```typescript
+// Basic deprecation with description only:
+/** @deprecated Use NewClass instead. */
+
+// With version (pipeline will auto-add date):
+/** @deprecated in 4.5.0. Use NewClass instead. */
+```
+
+Valid formats recognized by the ESLint rule:
+- `@deprecated {description}` - Description only (5+ characters required)
+- `@deprecated in {major}.{minor}.{patch}. {description}` - With version number
+- Description must start with alphanumeric character, `]`, or backtick
+- Description should be capitalized and separated by `. ` when version/date present
+
+
 ## Pull Request Workflow
 
 1. Branch naming: `<gh_username>/<descriptive-name>` (lowercase, dash-separated)
@@ -313,6 +332,7 @@ Use ECSQL (ECMAScript SQL dialect) via:
 - ❌ Don't call RPC interfaces directly in new code - use wrapper classes like `IModelConnection`
 - ❌ Don't make "chatty" RPC interfaces - batch operations and use pagination
 - ❌ Don't use absolute imports for modules within the same package - always use relative paths (e.g., `import { MyClass } from "./MyClass"` instead of `import { MyClass } from "@itwin/package-name"`)
+- ❌ Don't manually add dates to `@deprecated` tags - the pipeline adds them automatically
 - ✅ **DO write tests for new source code** - aim for comprehensive test coverage of new features and bug fixes
 
 ## Key Files to Reference


### PR DESCRIPTION
Improving on https://github.com/iTwin/itwinjs-core/pull/8792

I tested the copilot instructions with a moderately open ended prompt to add a new feature, intentionally limiting the context to a test file and one source code file, to see if the agent can grab other files across the repo that are relevant. 

<img width="1104" height="163" alt="image" src="https://github.com/user-attachments/assets/49f66721-4ee7-4ef2-a191-c7789cffeabb" />

The result was it was able to grab more, as expected, and it was able to interpret my added instructions on code examples, inserting the code example into NextVersion.md. I hoped it was able to grab the index.md found in docs/quantity, but not bad. I compared the output to my current draft [PR](https://github.com/iTwin/itwinjs-core/pull/8787) for ratio, it was closely similar
<img width="1097" height="547" alt="image" src="https://github.com/user-attachments/assets/80be2083-263a-4ee2-8e7d-cbae35801715" />
<img width="1110" height="243" alt="image" src="https://github.com/user-attachments/assets/1c0008c6-78c1-40ef-82a7-fbf8662dd456" />

The agent asked for permission to execute rushx build and then rushx test, which was a key difference from when we didn't have copilot instructions (it would use npm build and npm test). We still need more changes to the instructions, haven't figured out how to restructure it yet, but the agent should be able to prompt (or remind) the user to run rush change **after** staging changes to the git branch.

I also tweaked the instructions for vitest - vitest doesn't need to run rushx build, as long as you have the vitest extension installed - copilot will be very effective, selectively running tests, and able to read test results, and fix source code (near instantaneous too) without needing to look at the terminal.

I find GHCP sometimes hangs when trying to read test results from mocha based tests. Another incentive to move to vitest.