### PR TITLE
fix iModelDb documentation include examples

### DIFF
--- a/common/changes/@itwin/core-backend/master_2026-01-09-17-02.json
+++ b/common/changes/@itwin/core-backend/master_2026-01-09-17-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -416,11 +416,8 @@ export abstract class IModelDb extends IModel {
    * @note There are some reserve tablespace names that cannot be used. They are 'main', 'schema_sync_db', 'ecchange' & 'temp'
    * @param fileName IModel file name
    * @param alias identifier for the attached file. This identifier is used to access schema from the attached file. e.g. if alias is 'abc' then schema can be accessed using 'abc.MySchema.MyClass'
-   *
-   * *Example:*
-   * ``` ts
-   *  [[include:IModelDb_attachDb.code]]
-   * ```
+   * @example
+   * [[include:IModelDb_attachDb.code]]
    */
   public attachDb(fileName: string, alias: string): void {
     if (alias.toLowerCase() === "main" || alias.toLowerCase() === "schema_sync_db" || alias.toLowerCase() === "ecchange" || alias.toLowerCase() === "temp") {
@@ -433,10 +430,8 @@ export abstract class IModelDb extends IModel {
    * @note There are some reserve tablespace names that cannot be used. They are 'main', 'schema_sync_db', 'ecchange' & 'temp'
    * @param alias identifer that was used in the call to [[attachDb]]
    *
-   * *Example:*
-   * ``` ts
-   *  [[include:IModelDb_attachDb.code]]
-   * ```
+   * @example [[include:IModelDb_attachDb.code]]
+   * 
    */
   public detachDb(alias: string): void {
     if (alias.toLowerCase() === "main" || alias.toLowerCase() === "schema_sync_db" || alias.toLowerCase() === "ecchange" || alias.toLowerCase() === "temp") {

--- a/docs/learning/guidelines/documentation-link-syntax.md
+++ b/docs/learning/guidelines/documentation-link-syntax.md
@@ -90,8 +90,7 @@ For example:
 /**
  * Does the thing
  *
- * ** Example:**
- * ``` ts
+ * @example
  * [[IModelDb.somethingUsingIModelDb]]
  * ```
  * @public


### PR DESCRIPTION
When using `[[include]]` syntax to embed snippets of example code in code comments, we should prefer the `@example` tag. 

In at least one case (`@param`), the final tsdoc tag before an `[[include]]` slurps up the example code. This can result in [poorly rendered examples](https://www.itwinjs.org/reference/core-backend/imodels/imodeldb/attachdb/).

I've fixed two examples found thanks to https://github.com/iTwin/itwinjs-core/issues/8893 h/t @khanaffan, and updated our guidance to always use `@example` tags.