### PR TITLE
Add applicationLogoCardFooter method to IModelApp for custom logo footer support

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -969,6 +969,7 @@ export interface ChannelControl {
     }): void;
     queryChannelRoot(channelKey: ChannelKey): Id64String | undefined;
     removeAllowedChannel(channelKey: ChannelKey): void;
+    upgradeChannel(options: ChannelUpgradeOptions, iModel: IModelDb, data?: any): Promise<void>;
 }
 
 // @beta (undocumented)
@@ -985,6 +986,31 @@ export class ChannelRootAspect extends ElementUniqueAspect {
     static get className(): string;
     // @deprecated
     static insert(iModel: IModelDb, ownerId: Id64String, channelName: string): void;
+}
+
+// @beta
+export interface ChannelUpgradeContext<T = any> {
+    // (undocumented)
+    channelKey: string;
+    data?: T;
+    // (undocumented)
+    fromVersion: string;
+    // (undocumented)
+    iModel: IModelDb;
+    // (undocumented)
+    toVersion: string;
+}
+
+// @beta
+export interface ChannelUpgradeOptions<T = any> {
+    // (undocumented)
+    callback: (context: ChannelUpgradeContext<T>) => Promise<void>;
+    // (undocumented)
+    channelKey: string;
+    // (undocumented)
+    fromVersion: string;
+    // (undocumented)
+    toVersion: string;
 }
 
 // @internal (undocumented)
@@ -1746,6 +1772,18 @@ export function createTerminatorGeometry(builder: ElementGeometry.Builder, point
 export interface CustomHandledProperty {
     readonly propertyName: string;
     readonly source: "Class" | "Computed";
+}
+
+// @beta
+export interface DataTransformationResources extends PreImportCallbackResult {
+    snapshot?: SnapshotDb;
+}
+
+// @beta
+export enum DataTransformationStrategy {
+    InMemory = "InMemory",
+    None = "None",
+    Snapshot = "Snapshot"
 }
 
 // @public @preview
@@ -3668,7 +3706,7 @@ export abstract class IModelDb extends IModel {
     get iModelId(): GuidString;
     importSchemas(schemaFileNames: LocalFileName[], options?: SchemaImportOptions): Promise<void>;
     // @alpha
-    importSchemaStrings(serializedXmlSchemas: string[]): Promise<void>;
+    importSchemaStrings(serializedXmlSchemas: string[], options?: SchemaImportOptions): Promise<void>;
     // @internal (undocumented)
     protected initializeIModelDb(when?: "pullMerge"): void;
     // @beta
@@ -5101,6 +5139,27 @@ export class Platform {
     static get platformName(): "win32" | "linux" | "darwin" | "ios" | "android" | "uwp";
 }
 
+// @beta
+export interface PostImportContext<T = any> {
+    data?: T;
+    iModel: IModelDb;
+    resources: DataTransformationResources;
+}
+
+// @beta
+export interface PreImportCallbackResult<T = any> {
+    cachedData?: T;
+    // (undocumented)
+    transformStrategy: DataTransformationStrategy;
+}
+
+// @beta
+export interface PreImportContext<T = any> {
+    data?: T;
+    iModel: IModelDb;
+    schemaData: LocalFileName[] | string[];
+}
+
 // @internal
 export interface ProcessChangesetOptions {
     // (undocumented)
@@ -5517,10 +5576,22 @@ export class Schema {
     static toSemverString(paddedVersion: string): string;
 }
 
+// @beta
+export interface SchemaImportCallbacks<T = any> {
+    postSchemaImportCallback?: (context: PostImportContext) => Promise<void>;
+    preSchemaImportCallback?: (context: PreImportContext) => Promise<PreImportCallbackResult<T>>;
+}
+
 // @public
-export interface SchemaImportOptions {
+export interface SchemaImportOptions<T = any> {
+    // @beta
+    channelUpgrade?: ChannelUpgradeOptions;
+    // @beta
+    data?: T;
     // @internal
     ecSchemaXmlContext?: ECSchemaXmlContext;
+    // @beta
+    schemaImportCallbacks?: SchemaImportCallbacks;
 }
 
 // @internal (undocumented)

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -4923,11 +4923,11 @@ export class IModelApp {
     // @beta
     static get animationInterval(): BeDuration | undefined;
     static set animationInterval(interval: BeDuration | undefined);
-    // @beta
-    static appBuildIdLogoCard?: () => HTMLElement;
     static get applicationId(): string;
     // @beta
     static applicationLogoCard?: () => HTMLTableRowElement;
+    // @beta
+    static applicationLogoCardFooter?: () => HTMLElement;
     static get applicationVersion(): string;
     static authorizationClient?: AuthorizationClient;
     // @internal (undocumented)

--- a/common/api/ecschema-editing.api.md
+++ b/common/api/ecschema-editing.api.md
@@ -764,7 +764,7 @@ export enum DiagnosticType {
 }
 
 // @beta (undocumented)
-export function diagnosticTypeToString(type: DiagnosticType): "Schema" | "CustomAttributeContainer" | "None" | "Property" | "RelationshipConstraint" | "SchemaItem";
+export function diagnosticTypeToString(type: DiagnosticType): "CustomAttributeContainer" | "None" | "Property" | "RelationshipConstraint" | "Schema" | "SchemaItem";
 
 // @alpha
 export type DifferenceType = "add" | "modify";
@@ -1937,13 +1937,13 @@ export const SchemaCompareDiagnostics: {
         diagnosticType: DiagnosticType;
     };
     PresentationUnitMissing: {
-        new (ecDefinition: SchemaItem, messageArgs: [Format | OverrideFormat], category?: DiagnosticCategory): {
+        new (ecDefinition: SchemaItem, messageArgs: [OverrideFormat | Format], category?: DiagnosticCategory): {
             readonly code: string;
             readonly messageText: string;
             readonly schema: Schema;
             readonly diagnosticType: DiagnosticType;
             ecDefinition: KindOfQuantity;
-            messageArgs?: [Format | OverrideFormat] | undefined;
+            messageArgs?: [OverrideFormat | Format] | undefined;
             category: DiagnosticCategory;
         };
         diagnosticType: DiagnosticType;
@@ -1973,25 +1973,25 @@ export const SchemaCompareDiagnostics: {
         diagnosticType: DiagnosticType;
     };
     FormatUnitMissing: {
-        new (ecDefinition: SchemaItem, messageArgs: [InvertedUnit | Unit, string | undefined], category?: DiagnosticCategory): {
+        new (ecDefinition: SchemaItem, messageArgs: [Unit | InvertedUnit, string | undefined], category?: DiagnosticCategory): {
             readonly code: string;
             readonly messageText: string;
             readonly schema: Schema;
             readonly diagnosticType: DiagnosticType;
             ecDefinition: Format;
-            messageArgs?: [InvertedUnit | Unit, string | undefined] | undefined;
+            messageArgs?: [Unit | InvertedUnit, string | undefined] | undefined;
             category: DiagnosticCategory;
         };
         diagnosticType: DiagnosticType;
     };
     UnitLabelOverrideDelta: {
-        new (ecDefinition: SchemaItem, messageArgs: [InvertedUnit | Unit, string | undefined, string | undefined], category?: DiagnosticCategory): {
+        new (ecDefinition: SchemaItem, messageArgs: [Unit | InvertedUnit, string | undefined, string | undefined], category?: DiagnosticCategory): {
             readonly code: string;
             readonly messageText: string;
             readonly schema: Schema;
             readonly diagnosticType: DiagnosticType;
             ecDefinition: Format;
-            messageArgs?: [InvertedUnit | Unit, string | undefined, string | undefined] | undefined;
+            messageArgs?: [Unit | InvertedUnit, string | undefined, string | undefined] | undefined;
             category: DiagnosticCategory;
         };
         diagnosticType: DiagnosticType;

--- a/common/api/presentation-common.api.md
+++ b/common/api/presentation-common.api.md
@@ -24,7 +24,7 @@ import { UnitSystemKey } from '@itwin/core-quantity';
 export function addFieldHierarchy(rootHierarchies: FieldHierarchy[], hierarchy: FieldHierarchy): void;
 
 // @public
-export class ArrayPropertiesField extends PropertiesField {
+export class ArrayPropertiesField extends PropertiesField implements ArrayPropertiesFieldProps, IFieldsSource {
     // @deprecated
     constructor(category: CategoryDescription, name: string, label: string, type: TypeDescription, itemsField: PropertiesField, isReadonly: boolean, priority: number, properties: Property[], editor?: EditorDescription, renderer?: RendererDescription);
     constructor(props: ArrayPropertiesFieldProps);
@@ -35,10 +35,11 @@ export class ArrayPropertiesField extends PropertiesField {
     }, categories: CategoryDescription[]): ArrayPropertiesField;
     // @deprecated
     static fromJSON(json: ArrayPropertiesFieldJSON, categories: CategoryDescription[]): ArrayPropertiesField;
+    getFieldByName(name: string): Field | undefined;
     // (undocumented)
     isArrayPropertiesField(): this is ArrayPropertiesField;
-    // (undocumented)
-    itemsField: PropertiesField;
+    get itemsField(): PropertiesField;
+    set itemsField(field: PropertiesField);
     toCompressedJSON(classesMap: {
         [id: string]: CompressedClassInfoJSON;
     }): ArrayPropertiesFieldJSON<string>;
@@ -781,7 +782,7 @@ export interface ExtendedDataRule extends RuleBase {
 }
 
 // @public
-export class Field {
+export class Field implements FieldProps {
     // @deprecated
     constructor(category: CategoryDescription, name: string, label: string, type: TypeDescription, isReadonly: boolean, priority: number, editor?: EditorDescription, renderer?: RendererDescription, extendedData?: {
         [key: string]: unknown;
@@ -1415,7 +1416,7 @@ export interface NavigationRuleBase extends RuleBase {
 }
 
 // @public
-export class NestedContentField extends Field {
+export class NestedContentField extends Field implements NestedContentFieldProps, IFieldsSource {
     // @deprecated
     constructor(category: CategoryDescription, name: string, label: string, type: TypeDescription, isReadonly: boolean, priority: number, contentClassInfo: ClassInfo, pathToPrimaryClass: RelationshipPath, nestedFields: Field[], editor?: EditorDescription, autoExpand?: boolean, renderer?: RendererDescription);
     constructor(props: NestedContentFieldProps);
@@ -1727,7 +1728,7 @@ export interface ProcessPrimitiveValueProps {
 }
 
 // @public
-export class PropertiesField extends Field {
+export class PropertiesField extends Field implements PropertiesFieldProps {
     // @deprecated
     constructor(category: CategoryDescription, name: string, label: string, type: TypeDescription, isReadonly: boolean, priority: number, properties: Property[], editor?: EditorDescription, renderer?: RendererDescription);
     constructor(props: PropertiesFieldProps);
@@ -1742,7 +1743,12 @@ export class PropertiesField extends Field {
     isArrayPropertiesField(): this is ArrayPropertiesField;
     isStructPropertiesField(): this is StructPropertiesField;
     matchesDescriptor(descriptor: FieldDescriptor): boolean;
+    get parentArrayField(): ArrayPropertiesField | undefined;
+    set parentArrayField(field: ArrayPropertiesField | undefined);
+    get parentStructField(): StructPropertiesField | undefined;
+    set parentStructField(field: StructPropertiesField | undefined);
     properties: Property[];
+    rebuildParentship(parentField?: NestedContentField): void;
     toCompressedJSON(classesMap: {
         [id: string]: CompressedClassInfoJSON;
     }): PropertiesFieldJSON<string>;
@@ -2472,7 +2478,7 @@ export interface StructFieldMemberDescription {
 }
 
 // @public
-export class StructPropertiesField extends PropertiesField {
+export class StructPropertiesField extends PropertiesField implements StructPropertiesFieldProps, IFieldsSource {
     // @deprecated
     constructor(category: CategoryDescription, name: string, label: string, type: TypeDescription, memberFields: PropertiesField[], isReadonly: boolean, priority: number, properties: Property[], editor?: EditorDescription, renderer?: RendererDescription);
     constructor(props: StructPropertiesFieldProps);
@@ -2483,10 +2489,11 @@ export class StructPropertiesField extends PropertiesField {
     }, categories: CategoryDescription[]): StructPropertiesField;
     // @deprecated
     static fromJSON(json: StructPropertiesFieldJSON, categories: CategoryDescription[]): StructPropertiesField;
+    getFieldByName(name: string): Field | undefined;
     // (undocumented)
     isStructPropertiesField(): this is StructPropertiesField;
-    // (undocumented)
-    memberFields: PropertiesField[];
+    get memberFields(): PropertiesField[];
+    set memberFields(fields: PropertiesField[]);
     toCompressedJSON(classesMap: {
         [id: string]: CompressedClassInfoJSON;
     }): StructPropertiesFieldJSON<string>;

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -54,6 +54,8 @@ beta;namespace;ChannelControl
 beta;type;ChannelKey
 public;class;ChannelRootAspect
 preview;class;ChannelRootAspect
+beta;interface;ChannelUpgradeContext
+beta;interface;ChannelUpgradeOptions
 internal;class;CheckpointManager
 public;interface;CheckpointProps
 public;class;ClassRegistry
@@ -99,6 +101,8 @@ beta;interface;CreateNewWorkspaceDbVersionArgs
 public;interface;CreateSheetViewDefinitionArgs
 beta;function;createTerminatorGeometry
 beta;interface;CustomHandledProperty
+beta;interface;DataTransformationResources
+beta;enum;DataTransformationStrategy
 public;class;DefinitionContainer
 preview;class;DefinitionContainer
 public;class;DefinitionElement
@@ -437,6 +441,9 @@ preview;class;PhysicalType
 public;class;PhysicalTypeIsOfPhysicalMaterial
 public;class;PlanCallout
 public;class;Platform
+beta;interface;PostImportContext
+beta;interface;PreImportCallbackResult
+beta;interface;PreImportContext
 internal;interface;ProcessChangesetOptions
 beta;function;produceTextBlockGeometry
 public;type;ProgressFunction
@@ -477,6 +484,7 @@ public;class;RpcTrace
 beta;class;RunLayout
 alpha;interface;SaveChangesArgs
 public;class;Schema
+beta;interface;SchemaImportCallbacks
 public;interface;SchemaImportOptions
 internal;type;SchemaKey
 public;class;SchemaMap


### PR DESCRIPTION
Add applicationLogoCardFooter method to IModelApp for custom logo footer support (ie. application build id)

<img width="479" height="547" alt="image" src="https://github.com/user-attachments/assets/24de6881-9b82-4c1c-8faa-4604f3f9a177" />
