### PR TITLE
chore: update current minor release branch in mergify.yml

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -39,6 +39,6 @@ pull_request_rules:
       backport:
         branches:
           # current minor release branch
-          - "release/5.2.x"
+          - "release/5.6.x"
           # previous major release branch
           - "release/4.11.x"


### PR DESCRIPTION
This should have automatically updated by our automation scripts but it seems that not been the case for a bit in the master branch. However, the release branch is getting auto-updated: https://github.com/iTwin/itwinjs-core/blob/6ba9d08a381c5503b964a568b043fc65236ad75c/.github/mergify.yml#L42

I will look into the automation but creating this PR for fix in the meantime.

Possibly related to https://github.com/iTwin/itwinjs-core/pull/8840