### PR TITLE
Change CloudSqlite `validateDbVersion` to fallback to default when ve…

### DIFF
--- a/common/changes/@itwin/core-backend/nam-fix-csqlite-versioning_2026-02-16-22-32.json
+++ b/common/changes/@itwin/core-backend/nam-fix-csqlite-versioning_2026-02-16-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Change CloudSqlite `validateDbVersion` to fallback to default when version is any falsy value",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -880,7 +880,7 @@ export namespace CloudSqlite {
   }
 
   export function validateDbVersion(version?: DbVersion) {
-    version = version ?? "0.0.0";
+    version = version || "0.0.0";
     const opts = { loose: true, includePrerelease: true };
     // clean allows prerelease, so try it first. If that fails attempt to coerce it (coerce strips prerelease even if you say not to.)
     const semVersion = semver.clean(version, opts) ?? semver.coerce(version, opts)?.version;

--- a/core/backend/src/test/standalone/Workspace.test.ts
+++ b/core/backend/src/test/standalone/Workspace.test.ts
@@ -106,6 +106,12 @@ describe("WorkspaceFile", () => {
     CloudSqlite.validateDbName(Guid.createValue()); // guids should be valid
   });
 
+  it("WorkspaceDb version fallback", () => {
+    expect(CloudSqlite.validateDbVersion("" as CloudSqlite.DbVersion)).equals("0.0.0");
+    expect(CloudSqlite.makeSemverName("db1", "" as CloudSqlite.DbVersion)).equals("db1:0.0.0");
+    expect(() => CloudSqlite.validateDbVersion(" " as CloudSqlite.DbVersion)).to.throw("invalid version specification");
+  });
+
   it("create new WorkspaceDb", async () => {
     const manifest: WorkspaceDbManifest = { workspaceName: "resources for acme users", contactName: "contact me" };
     const wsFile = await makeEditableDb({ containerId: "acme-engineering-inc-2", dbName: "db1", baseUri: "", storageType: "azure" }, manifest);

--- a/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
+++ b/full-stack-tests/backend/src/integration/CloudSqlite.test.ts
@@ -390,6 +390,11 @@ describe("CloudSqlite", () => {
       }
     }
 
+    const parsed = CloudSqlite.parseDbFileName("emptyVersionDb");
+    expect(parsed.version).equals("");
+    expect(CloudSqlite.validateDbVersion(parsed.version)).equals("0.0.0");
+    expect(CloudSqlite.makeSemverName(parsed.dbName, parsed.version)).equals("emptyVersionDb:0.0.0");
+
     await expect(BriefcaseDb.open({ fileName: "testBim2", container: contain1 })).rejectedWith("write lock not held");
     await CloudSqlite.withWriteLock({ user: user1, container: contain1 }, async () => {
       expect(contain1.hasWriteLock).to.be.true;


### PR DESCRIPTION
This pull request updates the CloudSqlite version handling logic in the `@itwin/core-backend` package to ensure that any falsy database version value (now including an empty string) will now default to `"0.0.0"`. This improves robustness when dealing with missing or empty version strings. The update also includes new tests to verify this fallback behavior.


* Changed the `validateDbVersion` function in `CloudSqlite.ts` to use a fallback to `"0.0.0"` for any falsy version value, not just `undefined` or null.


Little tidbit on difference between `??` and `||`:
`a ?? b` uses `b` only when a is `null` or `undefined`
`a || b` uses `b` when `a` is any falsy value: `undefined`, `null`, `""`, 0, `false`, `NaN`.