### PR TITLE
Add DataTestId support to PropertyEditorParams

### DIFF
--- a/ui/appui-abstract/src/appui-abstract/properties/EditorParams.ts
+++ b/ui/appui-abstract/src/appui-abstract/properties/EditorParams.ts
@@ -70,6 +70,7 @@ export enum PropertyEditorParamTypes {
   // SuppressUnitLabel = "UiAbstract-SuppressUnitLabel",
   SuppressEditorLabel = "UiAbstract-SuppressEditorLabel",
   CheckBoxImages = "UiAbstract-CheckBoxImages",
+  DataTestId = "UiAbstract-DataTestId",
 }
 
 /**
@@ -78,6 +79,7 @@ export enum PropertyEditorParamTypes {
  */
 export interface BasePropertyEditorParams {
   type: string;
+  "data-testid"?: string;
 }
 
 /**
@@ -295,7 +297,6 @@ export interface ImageCheckBoxParams extends BasePropertyEditorParams {
   type: PropertyEditorParamTypes.CheckBoxImages;
   imageOn: string;
   imageOff: string;
-
 }
 
 // /**
@@ -330,6 +331,22 @@ export interface CustomFormattedNumberParams extends BasePropertyEditorParams {
  */
 export const isCustomFormattedNumberParams = (item: BasePropertyEditorParams): item is CustomFormattedNumberParams => {
   return item.type === PropertyEditorParamTypes.CustomFormattedNumber;
+};
+
+/**
+ * Parameters used to add test id to property editors.
+ * @public
+ */
+export interface DataTestIdParams extends BasePropertyEditorParams {
+  type: PropertyEditorParamTypes.DataTestId;
+  "data-testid": string;
+}
+
+/** DataTestIdParams type guard.
+ * @public
+ */
+export const isDataTestIdParams = (item: BasePropertyEditorParams): item is DataTestIdParams => {
+  return item.type === PropertyEditorParamTypes.DataTestId;
 };
 
 /**

--- a/ui/appui-abstract/src/appui-abstract/properties/EditorParams.ts
+++ b/ui/appui-abstract/src/appui-abstract/properties/EditorParams.ts
@@ -79,7 +79,6 @@ export enum PropertyEditorParamTypes {
  */
 export interface BasePropertyEditorParams {
   type: string;
-  "data-testid"?: string;
 }
 
 /**

--- a/ui/appui-abstract/src/test/properties/EditorParams.test.ts
+++ b/ui/appui-abstract/src/test/properties/EditorParams.test.ts
@@ -1,67 +1,35 @@
 /*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import {
-  ButtonGroupEditorParams,
-  ColorEditorParams,
-  CustomFormattedNumberParams,
-  DataTestIdParams,
-  IconListEditorParams,
-  InputEditorSizeParams,
-  isButtonGroupEditorParams,
-  isColorEditorParams,
-  isCustomFormattedNumberParams,
-  isDataTestIdParams,
-  isIconListEditorParams,
-  isInputEditorSizeParams,
-  isSuppressLabelEditorParams,
-  PropertyEditorParamTypes,
-  SuppressLabelEditorParams,
+  ButtonGroupEditorParams, ColorEditorParams, CustomFormattedNumberParams, DataTestIdParams, IconListEditorParams, InputEditorSizeParams, isButtonGroupEditorParams,
+  isColorEditorParams, isCustomFormattedNumberParams, isDataTestIdParams, isIconListEditorParams, isInputEditorSizeParams, isSuppressLabelEditorParams,
+  PropertyEditorParamTypes, SuppressLabelEditorParams,
 } from "../../appui-abstract";
 
 describe("EditorParams", () => {
   it("should evaluate types correctly", () => {
-    const ieParams: InputEditorSizeParams = {
-      type: PropertyEditorParamTypes.InputEditorSize,
-      size: 20,
-      maxLength: 50,
-    };
+    const ieParams: InputEditorSizeParams = { type: PropertyEditorParamTypes.InputEditorSize, size: 20, maxLength: 50 };
     expect(isInputEditorSizeParams(ieParams)).to.be.true;
 
-    const colorParams: ColorEditorParams = {
-      type: PropertyEditorParamTypes.ColorData,
-      colorValues: [5, 6, 7],
-      numColumns: 3,
-    };
+    const colorParams: ColorEditorParams = { type: PropertyEditorParamTypes.ColorData, colorValues: [5, 6, 7], numColumns: 3 };
     expect(isColorEditorParams(colorParams)).to.be.true;
 
-    const iconListParams: IconListEditorParams = {
-      type: PropertyEditorParamTypes.IconListData,
-      iconValue: "icon-placeholder",
-      iconValues: ["icon-placeholder", "icon-2", "icon-3"],
-      numColumns: 1,
-    };
+    const iconListParams: IconListEditorParams = { type: PropertyEditorParamTypes.IconListData, iconValue: "icon-placeholder", iconValues: ["icon-placeholder", "icon-2", "icon-3"], numColumns: 1 };
     expect(isIconListEditorParams(iconListParams)).to.be.true;
 
-    const bgParams: ButtonGroupEditorParams = {
-      type: PropertyEditorParamTypes.ButtonGroupData,
-      buttons: [{ iconSpec: "iconspec-1" }, { iconSpec: "iconspec-2" }],
-    };
+    const bgParams: ButtonGroupEditorParams = { type: PropertyEditorParamTypes.ButtonGroupData, buttons: [{ iconSpec: "iconspec-1" }, { iconSpec: "iconspec-2" }] };
     expect(isButtonGroupEditorParams(bgParams)).to.be.true;
 
-    const suppressParams: SuppressLabelEditorParams = {
-      type: PropertyEditorParamTypes.SuppressEditorLabel,
-    };
+    const suppressParams: SuppressLabelEditorParams = { type: PropertyEditorParamTypes.SuppressEditorLabel };
     expect(isSuppressLabelEditorParams(suppressParams)).to.be.true;
 
     const customParams: CustomFormattedNumberParams = {
       type: PropertyEditorParamTypes.CustomFormattedNumber,
       formatFunction: (numberValue: number) => `${numberValue}`,
-      parseFunction: (_stringValue: string) => {
-        return { value: 1.0 };
-      },
+      parseFunction: (_stringValue: string) => { return { value: 1.0 }; },
     };
     expect(isCustomFormattedNumberParams(customParams)).to.be.true;
 

--- a/ui/appui-abstract/src/test/properties/EditorParams.test.ts
+++ b/ui/appui-abstract/src/test/properties/EditorParams.test.ts
@@ -1,36 +1,74 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import {
-  ButtonGroupEditorParams, ColorEditorParams, CustomFormattedNumberParams, IconListEditorParams, InputEditorSizeParams, isButtonGroupEditorParams,
-  isColorEditorParams, isCustomFormattedNumberParams, isIconListEditorParams, isInputEditorSizeParams, isSuppressLabelEditorParams,
-  PropertyEditorParamTypes, SuppressLabelEditorParams,
+  ButtonGroupEditorParams,
+  ColorEditorParams,
+  CustomFormattedNumberParams,
+  DataTestIdParams,
+  IconListEditorParams,
+  InputEditorSizeParams,
+  isButtonGroupEditorParams,
+  isColorEditorParams,
+  isCustomFormattedNumberParams,
+  isDataTestIdParams,
+  isIconListEditorParams,
+  isInputEditorSizeParams,
+  isSuppressLabelEditorParams,
+  PropertyEditorParamTypes,
+  SuppressLabelEditorParams,
 } from "../../appui-abstract";
 
 describe("EditorParams", () => {
   it("should evaluate types correctly", () => {
-    const ieParams: InputEditorSizeParams = { type: PropertyEditorParamTypes.InputEditorSize, size: 20, maxLength: 50 };
+    const ieParams: InputEditorSizeParams = {
+      type: PropertyEditorParamTypes.InputEditorSize,
+      size: 20,
+      maxLength: 50,
+    };
     expect(isInputEditorSizeParams(ieParams)).to.be.true;
 
-    const colorParams: ColorEditorParams = { type: PropertyEditorParamTypes.ColorData, colorValues: [5, 6, 7], numColumns: 3 };
+    const colorParams: ColorEditorParams = {
+      type: PropertyEditorParamTypes.ColorData,
+      colorValues: [5, 6, 7],
+      numColumns: 3,
+    };
     expect(isColorEditorParams(colorParams)).to.be.true;
 
-    const iconListParams: IconListEditorParams = { type: PropertyEditorParamTypes.IconListData, iconValue: "icon-placeholder", iconValues: ["icon-placeholder", "icon-2", "icon-3"], numColumns: 1 };
+    const iconListParams: IconListEditorParams = {
+      type: PropertyEditorParamTypes.IconListData,
+      iconValue: "icon-placeholder",
+      iconValues: ["icon-placeholder", "icon-2", "icon-3"],
+      numColumns: 1,
+    };
     expect(isIconListEditorParams(iconListParams)).to.be.true;
 
-    const bgParams: ButtonGroupEditorParams = { type: PropertyEditorParamTypes.ButtonGroupData, buttons: [{ iconSpec: "iconspec-1" }, { iconSpec: "iconspec-2" }] };
+    const bgParams: ButtonGroupEditorParams = {
+      type: PropertyEditorParamTypes.ButtonGroupData,
+      buttons: [{ iconSpec: "iconspec-1" }, { iconSpec: "iconspec-2" }],
+    };
     expect(isButtonGroupEditorParams(bgParams)).to.be.true;
 
-    const suppressParams: SuppressLabelEditorParams = { type: PropertyEditorParamTypes.SuppressEditorLabel };
+    const suppressParams: SuppressLabelEditorParams = {
+      type: PropertyEditorParamTypes.SuppressEditorLabel,
+    };
     expect(isSuppressLabelEditorParams(suppressParams)).to.be.true;
 
     const customParams: CustomFormattedNumberParams = {
       type: PropertyEditorParamTypes.CustomFormattedNumber,
       formatFunction: (numberValue: number) => `${numberValue}`,
-      parseFunction: (_stringValue: string) => { return { value: 1.0 }; },
+      parseFunction: (_stringValue: string) => {
+        return { value: 1.0 };
+      },
     };
     expect(isCustomFormattedNumberParams(customParams)).to.be.true;
+
+    const dataTestIdParams: DataTestIdParams = {
+      type: PropertyEditorParamTypes.DataTestId,
+      "data-testid": "property-editor-test-id",
+    };
+    expect(isDataTestIdParams(dataTestIdParams)).to.be.true;
   });
 });


### PR DESCRIPTION
When multiple enum list are used in one tool, they all share the same data-testid. I'm adding an option to provide data-testid as an additional params so it can be passed to the editor