### PR TITLE
Decrease coordinate compare tolerance (follow up to 69573cd)

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/GeoCoord.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/GeoCoord.test.ts
@@ -194,7 +194,7 @@ describe("GeoCoord", () => {
     const expectedPt = Point3d.fromJSON({x: 282707.7064282134, y: -3640811.0118976748, z: -73.01288342685298});
     const outPt = Point3d.fromJSON(response.geoCoords[0].p);
 
-    expect(Geometry.isSamePoint3dXY(expectedPt, outPt)).to.be.true;
+    expect(Geometry.isSamePoint3dXY(expectedPt, outPt, 0.001)).to.be.true;
     expect(response.geoCoords[0].s === 0);
   });
 });


### PR DESCRIPTION
One more test requires the reduced tolerance.

From #9016 
> Reduced tolerance for coordinate compare operation for Coordinate Reference System from default (0.000001) to a more valid value of 0.001 which is plenty in terrain coordinates

imodel-native: https://github.com/iTwin/imodel-native/pull/1308