### PR TITLE
Optimize `DisplayStyleSettings` performance

### DIFF
--- a/common/changes/@itwin/core-common/core-optimize-OverridesMap-performance_2026-02-25-09-39.json
+++ b/common/changes/@itwin/core-common/core-optimize-OverridesMap-performance_2026-02-25-09-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Optimize `DisplayStyleSettings` performance, when modifying sub-category and model appearance overrides, reality model display settings and planar clip masks.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}


### PR DESCRIPTION
Noticed the performance problem in one of our performance tests, where we change sub-category visibility for a large number of sub-categories (possibly unrealistically large - 50k). Tracked down the issue to `OverridesMap` having to iterate the whole sub-categories array on each delete/set.

The tests I used for measuring performance:
```ts
describe.only("perf", () => {
  const count = 50_000;
  const subCategoryIds = new Array(count).fill(0).map((_, i) => `0x${(i + 1).toString(16)}`);
  let settings: DisplayStyleSettings;

  beforeAll(() => {
    settings = new DisplayStyleSettings({
      styles: {
        subCategoryOvr: subCategoryIds.map((id) => ({
          subCategory: id,
          priority: 1,
        })),
      },
    });
  });

  it("override", () => {
    const timer = new StopWatch(undefined, true);
    for (const id of subCategoryIds) {
      settings.overrideSubCategory(id, SubCategoryOverride.fromJSON({ invisible: true }));
    }
    // eslint-disable-next-line no-console
    console.log(`Time to override ${count} subcategories: ${timer.currentSeconds.toFixed(2)} s.`);
  });

  it("drop", () => {
    const timer = new StopWatch(undefined, true);
    for (const id of subCategoryIds) {
      settings.dropSubCategoryOverride(id);
    }
    // eslint-disable-next-line no-console
    console.log(`Time to drop ${count} subcategories: ${timer.currentSeconds.toFixed(2)} s.`);
  });
});
```

Results before / after (3 runs each):
```
## Before

stdout | src/test/DisplayStyle.test.ts > DisplayStyleSettings overrides > perf > override
Time to override 50000 subcategories: 5.83 s.
Time to override 50000 subcategories: 5.62 s.
Time to override 50000 subcategories: 6.58 s.

stdout | src/test/DisplayStyle.test.ts > DisplayStyleSettings overrides > perf > drop
Time to drop 50000 subcategories: 4.00 s.
Time to drop 50000 subcategories: 3.89 s.
Time to drop 50000 subcategories: 4.28 s.

## After

stdout | src/test/DisplayStyle.test.ts > DisplayStyleSettings overrides > perf > override
Time to override 50000 subcategories: 0.02 s.
Time to override 50000 subcategories: 0.02 s.
Time to override 50000 subcategories: 0.02 s.

stdout | src/test/DisplayStyle.test.ts > DisplayStyleSettings overrides > perf > drop
Time to drop 50000 subcategories: 0.01 s.
Time to drop 50000 subcategories: 0.01 s.
Time to drop 50000 subcategories: 0.01 s.
```

**Note:** Previously, `delete` used `splice`, which removed the override from the array without changing the order of elements. Now, it moves the last element in removed element's place, which changes the ordering. To me it looks like the order is not important, but pointing this out just to make sure it's not overlooked by reviewers (@iTwin/itwinjs-core-display).