### PR TITLE
Update MeasureTool to fallback to default formattings when KoQs not found

### DIFF
--- a/common/changes/@itwin/core-frontend/nam-dta-fix-measure_2026-02-27-17-27.json
+++ b/common/changes/@itwin/core-frontend/nam-dta-fix-measure_2026-02-27-17-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Update measure tool to fallback to QuantityType",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/tools/MeasureTool.ts
+++ b/core/frontend/src/tools/MeasureTool.ts
@@ -24,6 +24,7 @@ import { BeButtonEvent, BeModifierKeys, CoreTools, EventHandled, InputSource } f
 import { ToolAssistance, ToolAssistanceImage, ToolAssistanceInputMethod, ToolAssistanceInstruction, ToolAssistanceSection } from "./ToolAssistance";
 import { GraphicType } from "../common/render/GraphicType";
 import { FormatterSpec } from "@itwin/core-quantity";
+import { QuantityType } from "../quantity-formatting/QuantityFormatter";
 
 function translateBold(key: string) {
   return `<b>${CoreTools.translate(`Measure.Labels.${key}`)}:</b> `;
@@ -32,12 +33,30 @@ function translateBold(key: string) {
 async function getFormatterSpecByKoQAndPersistenceUnit(koq: string, persistenceUnitName: string): Promise<FormatterSpec | undefined> {
   const formatProps = await IModelApp.formatsProvider.getFormat(koq);
   if (undefined === formatProps)
-    return undefined;
+    return getFormatterSpecByQuantityType(koq);
+
   return IModelApp.quantityFormatter.createFormatterSpec({
     persistenceUnitName,
     formatProps,
     formatName: koq
   });
+}
+
+function getFormatterSpecByQuantityType(koq: string): FormatterSpec | undefined {
+  switch (koq) {
+    case "DefaultToolsUnits.LENGTH":
+      return IModelApp.quantityFormatter.findFormatterSpecByQuantityType(QuantityType.LengthEngineering);
+    case "DefaultToolsUnits.ANGLE":
+      return IModelApp.quantityFormatter.findFormatterSpecByQuantityType(QuantityType.Angle);
+    case "DefaultToolsUnits.AREA":
+      return IModelApp.quantityFormatter.findFormatterSpecByQuantityType(QuantityType.Area);
+    case "DefaultToolsUnits.VOLUME":
+      return IModelApp.quantityFormatter.findFormatterSpecByQuantityType(QuantityType.Volume);
+    case "DefaultToolsUnits.LENGTH_COORDINATE":
+      return IModelApp.quantityFormatter.findFormatterSpecByQuantityType(QuantityType.Coordinate);
+    default:
+      return undefined;
+  }
 }
 
 /** @internal */

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
-import { BeEvent, GuidString, ProcessDetector } from "@itwin/core-bentley";
+import { GuidString, ProcessDetector } from "@itwin/core-bentley";
 import { ElectronApp, ElectronAppOpts } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 import { BrowserAuthorizationClient } from "@itwin/browser-authorization";
 import { FrontendIModelsAccess } from "@itwin/imodels-access-frontend";
@@ -15,7 +15,7 @@ import {
 } from "@itwin/core-common";
 import { EditTools } from "@itwin/editor-frontend";
 import {
-  AccuDrawHintBuilder, AccuDrawViewportUI, AccuSnap, IModelApp, IModelConnection, IpcApp, LocalhostIpcApp, LocalHostIpcAppOpts, QuantityTypeFormatsProvider, RenderSystem, SelectionTool,
+  AccuDrawHintBuilder, AccuDrawViewportUI, AccuSnap, IModelApp, IModelConnection, IpcApp, LocalhostIpcApp, LocalHostIpcAppOpts, RenderSystem, SelectionTool,
   SnapMode, TileAdmin, Tool, ToolAdmin,
   ViewManager,
 } from "@itwin/core-frontend";
@@ -70,7 +70,6 @@ import { getConfigurationString } from "./DisplayTestApp";
 import { AddSeequentRealityModel } from "./RealityDataModel";
 import { SchemaFormatsProvider } from "@itwin/ecschema-metadata";
 import { ECSchemaRpcInterface } from '@itwin/ecschema-rpcinterface-common';
-import { FormatsChangedArgs, FormatsProvider } from "@itwin/core-quantity";
 
 class DisplayTestAppAccuSnap extends AccuSnap {
   private readonly _activeSnaps: SnapMode[] = [SnapMode.NearestKeypoint];
@@ -352,21 +351,10 @@ export class DisplayTestApp {
     IModelConnection.onOpen.addListener((imodel: IModelConnection) => {
       if (imodel.isBlankConnection()) return;
 
-      const schemaFormatsProvider = new SchemaFormatsProvider(imodel.schemaContext, IModelApp.quantityFormatter.activeUnitSystem);
-      const defaultFormatsProvider = new QuantityTypeFormatsProvider();
-      const onFormatsChanged = new BeEvent<(args: FormatsChangedArgs) => void>();
-      schemaFormatsProvider.onFormatsChanged.addListener((args) => onFormatsChanged.raiseEvent(args));
-      const formatsProvider: FormatsProvider = {
-        onFormatsChanged,
-        getFormat: async (name: string) => {
-          // Fall back to built-in quantity type formats (e.g., DefaultToolsUnits.*) when schema lookup doesn't resolve.
-          return (await schemaFormatsProvider.getFormat(name)) ?? defaultFormatsProvider.getFormat(name);
-        },
-      };
-
+      const formatsProvider = new SchemaFormatsProvider(imodel.schemaContext, IModelApp.quantityFormatter.activeUnitSystem);
       IModelApp.formatsProvider = formatsProvider;
       IModelApp.quantityFormatter.onActiveFormattingUnitSystemChanged.addListener((args) => {
-        schemaFormatsProvider.unitSystem = args.system;
+        formatsProvider.unitSystem = args.system;
       });
 
       IModelConnection.onClose.addOnce(() => {

--- a/test-apps/display-test-app/src/frontend/Viewer.ts
+++ b/test-apps/display-test-app/src/frontend/Viewer.ts
@@ -569,8 +569,7 @@ export class Viewer extends Window {
     const formatSet = await DtaRpcInterface.getClient().getFormatSetFromFile(filename)
 
     const localFormatsProvider = new FormatSetFormatsProvider({
-      formatSet,
-      fallbackProvider: IModelApp.formatsProvider,
+      formatSet
     });
     IModelApp.formatsProvider = localFormatsProvider;
   }


### PR DESCRIPTION
### Summary
This PR fixes the issue where Measure tools in display-test-app show no distance/measurement labels.
Closes #8982
### Problem

Measure tools request formatter specs by KOQ name (for example DefaultToolsUnits.LENGTH).
In display-test-app, `IModelApp.formatsProvider` is set to `SchemaFormatsProvider` on iModelOpen, which may not resolve to any `DefaultToolsUnits.*` for older iModels.
When KOQ lookup returns undefined, Measure tools skip formatting and labels/tooltips are blank.

### Root Cause
MeasureTool in core-frontend depended on KOQ lookup success and had no fallback path when a custom/app formats provider does not supply those KOQ names.

### Why this approach
Keeps fix at the source (Measure tools) instead of app-specific provider wiring.
Matches the fallback pattern used in [viewer-components-react formatter utilities](https://github.com/iTwin/viewer-components-react/blob/2696e32b26c0899105948e0889939989615c1676/packages/itwin/measure-tools/src/api/FormatterUtils.ts#L29).
Improves resilience for any app that supplies a custom formats provider, by ensuring the tool itself has a fallback.
