### PR TITLE
Strict schema loading

### DIFF
--- a/common/api/ecschema-metadata.api.md
+++ b/common/api/ecschema-metadata.api.md
@@ -1944,6 +1944,9 @@ export class SchemaContext {
     // (undocumented)
     get locaters(): ReadonlyArray<ISchemaLocater>;
     schemaExists(schemaKey: SchemaKey): boolean;
+    // @beta
+    get strictSchemaValidation(): boolean;
+    set strictSchemaValidation(value: boolean);
 }
 
 // @beta

--- a/common/changes/@itwin/core-backend/rschili-strict-schema-loading_2026-03-17-09-08.json
+++ b/common/changes/@itwin/core-backend/rschili-strict-schema-loading_2026-03-17-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/ecschema-metadata/rschili-strict-schema-loading_2026-03-17-09-08.json
+++ b/common/changes/@itwin/ecschema-metadata/rschili-strict-schema-loading_2026-03-17-09-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-metadata",
+      "comment": "strict schema loading mode to enforce correctness",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-metadata"
+}

--- a/core/backend/src/test/ecdb/StrictSchemaImport.test.ts
+++ b/core/backend/src/test/ecdb/StrictSchemaImport.test.ts
@@ -12,8 +12,9 @@ import { ECDbTestHelper } from "./ECDbTestHelper";
 describe("StrictSchemaImport", () => {
   const outDir = KnownTestLocations.outputDir;
 
-  // Helper to write schema XML and attempt import into a fresh ECDb
-  function importSchemaXml(testName: string, schemaXml: string): { ecdb: ECDb; succeeded: boolean } {
+  // Helper to write schema XML and attempt import into a fresh ECDb.
+  // Returns the error message on failure so tests can assert on the specific rejection reason.
+  function importSchemaXml(testName: string, schemaXml: string): { ecdb: ECDb; succeeded: boolean; error?: string } {
     const ecdb = ECDbTestHelper.createECDb(outDir, `${testName}.ecdb`);
 
     const schemaPath = path.join(outDir, `${testName}.ecschema.xml`);
@@ -24,13 +25,23 @@ describe("StrictSchemaImport", () => {
     try {
       ecdb.importSchema(schemaPath);
       return { ecdb, succeeded: true };
-    } catch {
-      return { ecdb, succeeded: false };
+    } catch (e: unknown) {
+      return { ecdb, succeeded: false, error: e instanceof Error ? e.message : String(e) };
     }
   }
 
+  // NOTE: All tests using xmlns 3.99.99 hit ECDb's version gate
+  // (OriginalECXmlVersion > Latest) before any construct-level validation runs.
+  // The ecobjects parser reads tolerantly (strict=false) during initial parse,
+  // silently defaulting unknown constructs. Then SchemaWriter rejects the schema
+  // purely because of the future version. We assert on the version-gate error
+  // message to be transparent about what's actually being tested.
+  // These tests remain valuable as regression coverage: if the version gate is
+  // ever relaxed, they'll start passing and signal that construct-level strict
+  // validation needs its own coverage.
+
   it("should reject a future-version schema with unknown class modifier", () => {
-    const { ecdb, succeeded } = importSchemaXml("strictImportModifier", `<?xml version="1.0" encoding="utf-8" ?>
+    const { ecdb, succeeded, error } = importSchemaXml("strictImportModifier", `<?xml version="1.0" encoding="utf-8" ?>
       <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
         <ECEntityClass typeName="TestClass" modifier="FutureModifier">
           <ECProperty propertyName="Prop1" typeName="string" />
@@ -39,10 +50,12 @@ describe("StrictSchemaImport", () => {
     ecdb.closeDb();
 
     assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown class modifier");
+    assert.isDefined(error);
+    assert.match(error!, /higher ECXml version/i, "Expected rejection at the version gate, not at the construct level");
   });
 
   it("should reject a future-version schema with unknown property type", () => {
-    const { ecdb, succeeded } = importSchemaXml("strictImportPropType", `<?xml version="1.0" encoding="utf-8" ?>
+    const { ecdb, succeeded, error } = importSchemaXml("strictImportPropType", `<?xml version="1.0" encoding="utf-8" ?>
       <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
         <ECEntityClass typeName="TestClass" modifier="None">
           <ECProperty propertyName="FutureProp" typeName="FuturePrimitiveType" />
@@ -51,10 +64,12 @@ describe("StrictSchemaImport", () => {
     ecdb.closeDb();
 
     assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown property type");
+    assert.isDefined(error);
+    assert.match(error!, /higher ECXml version/i, "Expected rejection at the version gate, not at the construct level");
   });
 
   it("should reject a future-version schema with unknown enum backing type", () => {
-    const { ecdb, succeeded } = importSchemaXml("strictImportEnum", `<?xml version="1.0" encoding="utf-8" ?>
+    const { ecdb, succeeded, error } = importSchemaXml("strictImportEnum", `<?xml version="1.0" encoding="utf-8" ?>
       <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
         <ECEnumeration typeName="TestEnum" backingTypeName="FutureType" isStrict="true">
           <ECEnumerator name="Val1" value="1" displayLabel="Value One" />
@@ -63,10 +78,12 @@ describe("StrictSchemaImport", () => {
     ecdb.closeDb();
 
     assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown enum backing type");
+    assert.isDefined(error);
+    assert.match(error!, /higher ECXml version/i, "Expected rejection at the version gate, not at the construct level");
   });
 
   it("should reject a future-version schema with unknown relationship strength", () => {
-    const { ecdb, succeeded } = importSchemaXml("strictImportStrength", `<?xml version="1.0" encoding="utf-8" ?>
+    const { ecdb, succeeded, error } = importSchemaXml("strictImportStrength", `<?xml version="1.0" encoding="utf-8" ?>
       <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
         <ECEntityClass typeName="SourceClass" modifier="None">
           <ECProperty propertyName="Prop1" typeName="string" />
@@ -86,10 +103,12 @@ describe("StrictSchemaImport", () => {
     ecdb.closeDb();
 
     assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown relationship strength");
+    assert.isDefined(error);
+    assert.match(error!, /higher ECXml version/i, "Expected rejection at the version gate, not at the construct level");
   });
 
   it("should reject a future-version schema even with only known constructs", () => {
-    const { ecdb, succeeded } = importSchemaXml("strictImportFutureKnown", `<?xml version="1.0" encoding="utf-8" ?>
+    const { ecdb, succeeded, error } = importSchemaXml("strictImportFutureKnown", `<?xml version="1.0" encoding="utf-8" ?>
       <ECSchema schemaName="FutureButValid" alias="fv" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
         <ECEntityClass typeName="TestClass" modifier="None">
           <ECProperty propertyName="Prop1" typeName="string" />
@@ -97,8 +116,9 @@ describe("StrictSchemaImport", () => {
       </ECSchema>`);
     ecdb.closeDb();
 
-    // ECDb has a version check that rejects OriginalECXmlVersion > Latest
     assert.isFalse(succeeded, "ECDb should reject any schema with future ECXml version");
+    assert.isDefined(error);
+    assert.match(error!, /higher ECXml version/i, "Expected rejection at the version gate");
   });
 
   it("should accept a valid current-version schema", () => {
@@ -112,5 +132,76 @@ describe("StrictSchemaImport", () => {
     ecdb.closeDb();
 
     assert.isTrue(succeeded, "A valid current-version schema should import successfully");
+  });
+
+  // Current-version (3.2) schemas with unknown constructs.
+  // For 3.2, OriginalECXmlVersionGreaterThan(Latest) is false, so no tolerance path
+  // is entered. Unknown constructs are rejected during XML parse by the ecobjects layer,
+  // before SchemaWriter is even reached.
+
+  it("should reject a current-version schema with unknown class modifier", () => {
+    const { ecdb, succeeded, error } = importSchemaXml("strictCurrentModifier", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="BadModifier" alias="bm" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECEntityClass typeName="TestClass" modifier="FutureModifier">
+          <ECProperty propertyName="Prop1" typeName="string" />
+        </ECEntityClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "Should reject unknown modifier in a 3.2 schema");
+    assert.isDefined(error);
+    assert.match(error!, /invalid modifier|FutureModifier/i, "Expected construct-level rejection for unknown modifier");
+  });
+
+  it("should reject a current-version schema with unknown property type", () => {
+    const { ecdb, succeeded, error } = importSchemaXml("strictCurrentPropType", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="BadPropType" alias="bp" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECEntityClass typeName="TestClass" modifier="None">
+          <ECProperty propertyName="FutureProp" typeName="FuturePrimitiveType" />
+        </ECEntityClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "Should reject unknown property type in a 3.2 schema");
+    assert.isDefined(error);
+    assert.match(error!, /FuturePrimitiveType/i, "Expected construct-level rejection for unknown property type");
+  });
+
+  it("should reject a current-version schema with unknown enum backing type", () => {
+    const { ecdb, succeeded, error } = importSchemaXml("strictCurrentEnum", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="BadEnum" alias="be" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECEnumeration typeName="TestEnum" backingTypeName="FutureType" isStrict="true">
+          <ECEnumerator name="Val1" value="1" displayLabel="Value One" />
+        </ECEnumeration>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "Should reject unknown enum backing type in a 3.2 schema");
+    assert.isDefined(error);
+    assert.match(error!, /FutureType|invalid.*type/i, "Expected construct-level rejection for unknown enum backing type");
+  });
+
+  it("should reject a current-version schema with unknown relationship strength", () => {
+    const { ecdb, succeeded, error } = importSchemaXml("strictCurrentStrength", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="BadStrength" alias="bs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECEntityClass typeName="SourceClass" modifier="None">
+          <ECProperty propertyName="Prop1" typeName="string" />
+        </ECEntityClass>
+        <ECEntityClass typeName="TargetClass" modifier="None">
+          <ECProperty propertyName="Prop1" typeName="string" />
+        </ECEntityClass>
+        <ECRelationshipClass typeName="TestRel" strength="FutureStrength" strengthDirection="Forward" modifier="None">
+          <Source multiplicity="(0..*)" roleLabel="source" polymorphic="true">
+            <Class class="SourceClass" />
+          </Source>
+          <Target multiplicity="(0..*)" roleLabel="target" polymorphic="true">
+            <Class class="TargetClass" />
+          </Target>
+        </ECRelationshipClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "Should reject unknown relationship strength in a 3.2 schema");
+    assert.isDefined(error);
   });
 });

--- a/core/backend/src/test/ecdb/StrictSchemaImport.test.ts
+++ b/core/backend/src/test/ecdb/StrictSchemaImport.test.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { assert } from "chai";
+import * as path from "path";
+import { IModelJsFs } from "../../IModelJsFs";
+import { ECDb } from "../../core-backend";
+import { KnownTestLocations } from "../KnownTestLocations";
+import { ECDbTestHelper } from "./ECDbTestHelper";
+
+describe("StrictSchemaImport", () => {
+  const outDir = KnownTestLocations.outputDir;
+
+  // Helper to write schema XML and attempt import into a fresh ECDb
+  function importSchemaXml(testName: string, schemaXml: string): { ecdb: ECDb; succeeded: boolean } {
+    const ecdb = ECDbTestHelper.createECDb(outDir, `${testName}.ecdb`);
+
+    const schemaPath = path.join(outDir, `${testName}.ecschema.xml`);
+    if (IModelJsFs.existsSync(schemaPath))
+      IModelJsFs.unlinkSync(schemaPath);
+    IModelJsFs.writeFileSync(schemaPath, schemaXml);
+
+    try {
+      ecdb.importSchema(schemaPath);
+      return { ecdb, succeeded: true };
+    } catch {
+      return { ecdb, succeeded: false };
+    }
+  }
+
+  it("should reject a future-version schema with unknown class modifier", () => {
+    const { ecdb, succeeded } = importSchemaXml("strictImportModifier", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
+        <ECEntityClass typeName="TestClass" modifier="FutureModifier">
+          <ECProperty propertyName="Prop1" typeName="string" />
+        </ECEntityClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown class modifier");
+  });
+
+  it("should reject a future-version schema with unknown property type", () => {
+    const { ecdb, succeeded } = importSchemaXml("strictImportPropType", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
+        <ECEntityClass typeName="TestClass" modifier="None">
+          <ECProperty propertyName="FutureProp" typeName="FuturePrimitiveType" />
+        </ECEntityClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown property type");
+  });
+
+  it("should reject a future-version schema with unknown enum backing type", () => {
+    const { ecdb, succeeded } = importSchemaXml("strictImportEnum", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
+        <ECEnumeration typeName="TestEnum" backingTypeName="FutureType" isStrict="true">
+          <ECEnumerator name="Val1" value="1" displayLabel="Value One" />
+        </ECEnumeration>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown enum backing type");
+  });
+
+  it("should reject a future-version schema with unknown relationship strength", () => {
+    const { ecdb, succeeded } = importSchemaXml("strictImportStrength", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="FutureSchema" alias="fs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
+        <ECEntityClass typeName="SourceClass" modifier="None">
+          <ECProperty propertyName="Prop1" typeName="string" />
+        </ECEntityClass>
+        <ECEntityClass typeName="TargetClass" modifier="None">
+          <ECProperty propertyName="Prop1" typeName="string" />
+        </ECEntityClass>
+        <ECRelationshipClass typeName="TestRel" strength="FutureStrength" strengthDirection="Forward" modifier="None">
+          <Source multiplicity="(0..*)" roleLabel="source" polymorphic="true">
+            <Class class="SourceClass" />
+          </Source>
+          <Target multiplicity="(0..*)" roleLabel="target" polymorphic="true">
+            <Class class="TargetClass" />
+          </Target>
+        </ECRelationshipClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isFalse(succeeded, "ECDb should reject a future-version schema with unknown relationship strength");
+  });
+
+  it("should reject a future-version schema even with only known constructs", () => {
+    const { ecdb, succeeded } = importSchemaXml("strictImportFutureKnown", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="FutureButValid" alias="fv" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.99.99">
+        <ECEntityClass typeName="TestClass" modifier="None">
+          <ECProperty propertyName="Prop1" typeName="string" />
+        </ECEntityClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    // ECDb has a version check that rejects OriginalECXmlVersion > Latest
+    assert.isFalse(succeeded, "ECDb should reject any schema with future ECXml version");
+  });
+
+  it("should accept a valid current-version schema", () => {
+    const { ecdb, succeeded } = importSchemaXml("strictImportValid", `<?xml version="1.0" encoding="utf-8" ?>
+      <ECSchema schemaName="ValidSchema" alias="vs" version="1.0.0" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+        <ECEntityClass typeName="TestClass" modifier="None">
+          <ECProperty propertyName="Prop1" typeName="string" />
+          <ECProperty propertyName="Prop2" typeName="int" />
+        </ECEntityClass>
+      </ECSchema>`);
+    ecdb.closeDb();
+
+    assert.isTrue(succeeded, "A valid current-version schema should import successfully");
+  });
+});

--- a/core/ecschema-metadata/src/Context.ts
+++ b/core/ecschema-metadata/src/Context.ts
@@ -246,6 +246,7 @@ export class SchemaContext {
   private _knownSchemas: SchemaCache;
   private _fallbackLocaterDefined: boolean;
   private _classHierarchy: ECClassHierarchy;
+  private _strictSchemaValidation: boolean;
 
   constructor() {
     this._locaters = [];
@@ -254,7 +255,16 @@ export class SchemaContext {
     this._locaters.push(this._knownSchemas);
     this._fallbackLocaterDefined = false;
     this._classHierarchy = new ECClassHierarchy();
+    this._strictSchemaValidation = false;
   }
+
+  /**
+   * If true, unknown constructs in schemas with a version newer than the current EC spec version
+   * will cause errors instead of silently substituting defaults. Default is false (tolerant mode).
+   * @beta
+   */
+  public get strictSchemaValidation(): boolean { return this._strictSchemaValidation; }
+  public set strictSchemaValidation(value: boolean) { this._strictSchemaValidation = value; }
 
   public get locaters(): ReadonlyArray<ISchemaLocater> { return this._locaters; }
 

--- a/core/ecschema-metadata/src/Deserialization/Helper.ts
+++ b/core/ecschema-metadata/src/Deserialization/Helper.ts
@@ -938,8 +938,11 @@ export class SchemaReadHelper<T = unknown> {
 
     const loadTypeName = async (typeName: string): Promise<ECSchemaStatus> => {
       if (undefined === parsePrimitiveType(typeName)) {
-        if (SchemaReadHelper.isECSpecVersionNewer(this._parser.getECSpecVersion))
+        if (SchemaReadHelper.isECSpecVersionNewer(this._parser.getECSpecVersion)) {
+          if (this._context.strictSchemaValidation)
+            throw new ECSchemaError(ECSchemaStatus.NewerECSpecVersion, `Property ${classObj.name}.${propName} has an unknown type '${typeName}' from a newer EC spec version. Strict schema validation rejects unknown types.`);
           return ECSchemaStatus.NewerECSpecVersion;
+        }
         await this.findSchemaItem(typeName);
       }
       return ECSchemaStatus.Success;
@@ -995,8 +998,11 @@ export class SchemaReadHelper<T = unknown> {
   private loadPropertyTypesSync(classObj: AnyClass, propName: string, propType: string, rawProperty: Readonly<unknown>): void {
     const loadTypeName = (typeName: string): ECSchemaStatus => {
       if (undefined === parsePrimitiveType(typeName)) {
-        if (SchemaReadHelper.isECSpecVersionNewer(this._parser.getECSpecVersion))
+        if (SchemaReadHelper.isECSpecVersionNewer(this._parser.getECSpecVersion)) {
+          if (this._context.strictSchemaValidation)
+            throw new ECSchemaError(ECSchemaStatus.NewerECSpecVersion, `Property ${classObj.name}.${propName} has an unknown type '${typeName}' from a newer EC spec version. Strict schema validation rejects unknown types.`);
           return ECSchemaStatus.NewerECSpecVersion;
+        }
         this.findSchemaItemSync(typeName);
       }
       return ECSchemaStatus.Success;

--- a/core/ecschema-metadata/src/test/Deserialization/StrictSchemaValidation.test.ts
+++ b/core/ecschema-metadata/src/test/Deserialization/StrictSchemaValidation.test.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { assert, describe, expect, it } from "vitest";
+import { SchemaContext } from "../../Context";
+import { deserializeXml, deserializeXmlSync } from "../TestUtils/DeserializationHelpers";
+
+
+
+/**
+ * Tests for strict schema validation on SchemaContext.
+ * In tolerant mode (default), unknown property types from schemas with a newer EC spec version
+ * are silently defaulted to "string". In strict mode, they throw ECSchemaError.
+ *
+ * Schemas use xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.3" (newer than current 3.2)
+ * to trigger the isECSpecVersionNewer() path.
+ */
+describe("StrictSchemaValidation", () => {
+
+  // Schema XML with a future EC spec version and an unknown property type
+  const futureSchemaWithUnknownType = `<?xml version="1.0" encoding="utf-8"?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00"
+      xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.3">
+      <ECEntityClass typeName="TestClass">
+        <ECProperty propertyName="FutureProp" typeName="FuturePrimitiveType" />
+        <ECProperty propertyName="KnownProp" typeName="string" />
+      </ECEntityClass>
+    </ECSchema>`;
+
+  // Schema XML with current EC spec version and valid types
+  const currentSchemaValid = `<?xml version="1.0" encoding="utf-8"?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00"
+      xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+      <ECEntityClass typeName="TestClass">
+        <ECProperty propertyName="Prop1" typeName="string" />
+        <ECProperty propertyName="Prop2" typeName="int" />
+      </ECEntityClass>
+    </ECSchema>`;
+
+  // Schema XML with current EC spec version but an unknown property type.
+  // This should fail regardless of strict mode since the tolerance path
+  // is only entered for schemas with version > current (3.2).
+  const currentSchemaWithUnknownType = `<?xml version="1.0" encoding="utf-8"?>
+    <ECSchema schemaName="TestSchema" alias="ts" version="01.00.00"
+      xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+      <ECEntityClass typeName="TestClass">
+        <ECProperty propertyName="FutureProp" typeName="FuturePrimitiveType" />
+        <ECProperty propertyName="KnownProp" typeName="string" />
+      </ECEntityClass>
+    </ECSchema>`;
+
+  describe("strictSchemaValidation flag", () => {
+    it("should default to false", () => {
+      const context = new SchemaContext();
+      expect(context.strictSchemaValidation).toBe(false);
+    });
+
+    it("should be settable and gettable", () => {
+      const context = new SchemaContext();
+      context.strictSchemaValidation = true;
+      expect(context.strictSchemaValidation).toBe(true);
+      context.strictSchemaValidation = false;
+      expect(context.strictSchemaValidation).toBe(false);
+    });
+  });
+
+  describe("async deserialization", () => {
+    it("tolerant mode defaults unknown property type to string", async () => {
+      const context = new SchemaContext();
+      assert.isFalse(context.strictSchemaValidation);
+
+      const schema = await deserializeXml(futureSchemaWithUnknownType, context);
+      expect(schema).toBeDefined();
+
+      const testClass = await schema.getItem("TestClass");
+      expect(testClass).toBeDefined();
+    });
+
+    it("strict mode rejects unknown property type from future schema", async () => {
+      const context = new SchemaContext();
+      context.strictSchemaValidation = true;
+
+      await expect(deserializeXml(futureSchemaWithUnknownType, context))
+        .rejects.toThrow(/unknown type.*FuturePrimitiveType.*Strict/i);
+    });
+
+    it("strict mode accepts valid current-version schema", async () => {
+      const context = new SchemaContext();
+      context.strictSchemaValidation = true;
+
+      const schema = await deserializeXml(currentSchemaValid, context);
+      expect(schema).toBeDefined();
+
+      const testClass = await schema.getItem("TestClass");
+      expect(testClass).toBeDefined();
+    });
+  });
+
+  describe("sync deserialization", () => {
+    it("tolerant mode defaults unknown property type to string", () => {
+      const context = new SchemaContext();
+
+      const schema = deserializeXmlSync(futureSchemaWithUnknownType, context);
+      expect(schema).toBeDefined();
+
+      const testClass = schema.getItemSync("TestClass");
+      expect(testClass).toBeDefined();
+    });
+
+    it("strict mode rejects unknown property type from future schema", () => {
+      const context = new SchemaContext();
+      context.strictSchemaValidation = true;
+
+      expect(() => deserializeXmlSync(futureSchemaWithUnknownType, context))
+        .toThrow(/unknown type.*FuturePrimitiveType.*Strict/i);
+    });
+
+    it("strict mode accepts valid current-version schema", () => {
+      const context = new SchemaContext();
+      context.strictSchemaValidation = true;
+
+      const schema = deserializeXmlSync(currentSchemaValid, context);
+      expect(schema).toBeDefined();
+
+      const testClass = schema.getItemSync("TestClass");
+      expect(testClass).toBeDefined();
+    });
+  });
+
+  describe("current-version schema with unknown types", () => {
+    it("async: rejects unknown type in tolerant mode (no version-based tolerance for 3.2)", async () => {
+      const context = new SchemaContext();
+      assert.isFalse(context.strictSchemaValidation);
+
+      await expect(deserializeXml(currentSchemaWithUnknownType, context))
+        .rejects.toThrow(/FuturePrimitiveType/i);
+    });
+
+    it("async: rejects unknown type in strict mode", async () => {
+      const context = new SchemaContext();
+      context.strictSchemaValidation = true;
+
+      await expect(deserializeXml(currentSchemaWithUnknownType, context))
+        .rejects.toThrow(/FuturePrimitiveType/i);
+    });
+
+    it("sync: rejects unknown type in tolerant mode (no version-based tolerance for 3.2)", () => {
+      const context = new SchemaContext();
+
+      expect(() => deserializeXmlSync(currentSchemaWithUnknownType, context))
+        .toThrow(/FuturePrimitiveType/i);
+    });
+
+    it("sync: rejects unknown type in strict mode", () => {
+      const context = new SchemaContext();
+      context.strictSchemaValidation = true;
+
+      expect(() => deserializeXmlSync(currentSchemaWithUnknownType, context))
+        .toThrow(/FuturePrimitiveType/i);
+    });
+  });
+});

--- a/docs/bis/ec/ec-schema.md
+++ b/docs/bis/ec/ec-schema.md
@@ -98,7 +98,35 @@ Circular references are not supported and will result in a failure to load the s
     }
   ],
   "items": {
-    ...
+    // ...
   }
 }
 ```
+
+## Serialization Formats
+
+EC schemas can be represented in two serialization formats: **XML** (`.ecschema.xml`) and **JSON** (EC JSON). The XML format is the canonical source format used by BIS schemas, while JSON is used for interchange between layers.
+
+### Format Support by Layer
+
+| Operation      | imodel-native (C++) | ecschema-metadata (TypeScript) |
+| -------------- | :-----------------: | :----------------------------: |
+| **Read XML**   |          ✅          |               ✅                |
+| **Write XML**  |          ✅          |               ✅                |
+| **Read JSON**  |          —          |               ✅                |
+| **Write JSON** |          ✅          |               ✅                |
+
+The native C++ layer reads schemas from XML and can serialize to both XML and JSON, but cannot deserialize from JSON. The TypeScript `ecschema-metadata` package supports both formats for both reading and writing.
+
+### Version Identification
+
+Each format encodes the EC specification version differently:
+
+- **XML**: The `xmlns` attribute on the root `<ECSchema>` element contains the version, e.g. `xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2"`.
+- **JSON**: The `$schema` property contains a URI with the version, e.g. `"$schema": "https://dev.bentley.com/json_schemas/ec/32/ecschema"`.
+
+### Version Tolerance
+
+When deserializing a schema whose EC specification version is newer than the version understood by the current software, both formats apply **tolerance logic** to avoid hard failures. Unknown constructs — such as unrecognized property types, class modifiers, or enumeration backing types — are silently accepted with default values (e.g. unknown primitive types default to `string`, unknown class modifiers default to `None`).
+
+This tolerance allows older software to partially read schemas authored against a newer specification. However, when importing schemas into an ECDb (e.g. during `importSchemas`), **strict validation** is enabled: unknown constructs from future-version schemas are rejected rather than silently defaulted, to prevent corrupted or incomplete data from being persisted.


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/1356

Preparation work for EC 3.3.
See linked story for details