### PR TITLE
Reproduce and suggest fix for desktop app move performance issues

### DIFF
--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -1745,7 +1745,13 @@ export abstract class Viewport implements Disposable, TileUser {
   /** @internal */
   public changeDynamics(dynamics: GraphicList | undefined, overlay: GraphicList | undefined): void {
     this.target.changeDynamics(dynamics, overlay);
-    this.invalidateDecorations();
+    if (ScreenViewport.regressMode.changeDynamics) {
+      // Old behavior (pre-fix): invalidateDecorations forces all decorators to rebuild.
+      this.invalidateDecorations();
+    } else {
+      // Fixed behavior: dynamics are not decorations — a redraw is sufficient.
+      this.requestRedraw();
+    }
   }
 
   private _assigningFlashedId = false;
@@ -3083,6 +3089,14 @@ export abstract class Viewport implements Disposable, TileUser {
  * @extensions
  */
 export class ScreenViewport extends Viewport {
+  /** @internal Temporary A/B toggles for issue #1659 perf testing. */
+  public static regressMode = {
+    /** When true, changeDynamics calls invalidateDecorations instead of requestRedraw (pre-fix behavior). */
+    changeDynamics: false,
+    /** When true, addDecorations iterates all getTileTreeRefs instead of map+provider only (pre-fix behavior). */
+    addDecorations: false,
+  };
+
   /** Settings that may be adjusted to control the way animations are applied to a [[ScreenViewport]] by methods like
    * [[changeView]] and [[synchWithView].
    */
@@ -3518,8 +3532,21 @@ export class ScreenViewport extends Viewport {
       this._decorationCache.prohibitRemoval = true;
 
       context.addFromDecorator(this.view);
-      for (const ref of this.getTileTreeRefs()) {
-        context.addFromDecorator(ref);
+
+      if (ScreenViewport.regressMode.addDecorations) {
+        // Old behavior (pre-fix): iterate ALL tile tree refs, including view model/displayStyle
+        // refs already decorated via this.view above. For A/B perf testing only.
+        for (const ref of this.getTileTreeRefs())
+          context.addFromDecorator(ref);
+      } else {
+        // Fixed behavior: decorate only map tile tree refs (e.g., Google Maps attribution)
+        // and tiled graphics providers. Do NOT use getTileTreeRefs() here — it includes
+        // view model/displayStyle refs already decorated via this.view above. See #1659.
+        for (const ref of this.mapTileTreeRefs)
+          context.addFromDecorator(ref);
+
+        for (const ref of this.tiledGraphicsProviderRefs())
+          context.addFromDecorator(ref);
       }
 
       for (const decorator of IModelApp.viewManager.decorators)

--- a/test-apps/display-test-app/public/locales/en/SVTTools.json
+++ b/test-apps/display-test-app/public/locales/en/SVTTools.json
@@ -112,6 +112,9 @@
     "RecordFps": {
       "keyin": "dta record fps"
     },
+    "ReproIssue1659": {
+      "keyin": "dta repro 1659"
+    },
     "AttachView": {
       "keyin": "dta attach view"
     },
@@ -153,6 +156,9 @@
     },
     "MoveElement": {
       "keyin": "dta move element"
+    },
+    "InteractiveMoveElements": {
+      "keyin": "dta interactive move"
     },
     "SetEditorToolSettings": {
       "keyin": "dta editor settings"

--- a/test-apps/display-test-app/src/backend/CreateReproIModel.ts
+++ b/test-apps/display-test-app/src/backend/CreateReproIModel.ts
@@ -1,0 +1,271 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Creates a test iModel - Desktop app move/copy performance regression.
+ *
+ * The generated iModel contains N physical models with M elements each.
+ * Each model becomes a separate tile tree reference in the viewport,
+ * which amplifies the cost of decoration rebuilds during dynamics.
+ */
+
+import * as os from "os";
+import * as path from "path";
+import { Id64String } from "@itwin/core-bentley";
+import {
+  CategorySelector, DisplayStyle3d, ModelSelector, PhysicalModel,
+  SpatialCategory, SpatialViewDefinition, StandaloneDb,
+} from "@itwin/core-backend";
+import {
+  Code, ColorByName, GeometricElement3dProps, GeometryStreamBuilder, IModel, SubCategoryAppearance,
+} from "@itwin/core-common";
+import {
+  Box, LineSegment3d, LineString3d, Loop, Point3d, Range3d, Vector3d, YawPitchRollAngles,
+} from "@itwin/core-geometry";
+
+export interface CreateReproIModelResult {
+  filePath: string;
+  numModels: number;
+  totalElements: number;
+}
+
+/**
+ * Create equipment-like geometry: a box body with wire stubs extending from each face.
+ * This produces enough geometry to generate meaningful tile trees.
+ */
+function buildEquipmentGeometry(
+  builder: GeometryStreamBuilder,
+  width: number,
+  depth: number,
+  height: number,
+): void {
+  // Main body — a solid box
+  const box = Box.createDgnBox(
+    Point3d.create(0, 0, 0),
+    Vector3d.unitX(),
+    Vector3d.unitY(),
+    Point3d.create(0, 0, height),
+    width, depth, width, depth, true,
+  );
+  if (box)
+    builder.appendGeometry(box);
+
+  // Wire stubs extending from sides (simulates cable connections)
+  const cx = width / 2;
+  const cy = depth / 2;
+  const stubLen = 0.8;
+
+  // Left side stubs
+  builder.appendGeometry(LineSegment3d.create(
+    Point3d.create(0, cy, height * 0.3),
+    Point3d.create(-stubLen, cy, height * 0.3),
+  ));
+  builder.appendGeometry(LineSegment3d.create(
+    Point3d.create(0, cy, height * 0.7),
+    Point3d.create(-stubLen, cy, height * 0.7),
+  ));
+  // Right side stubs
+  builder.appendGeometry(LineSegment3d.create(
+    Point3d.create(width, cy, height * 0.3),
+    Point3d.create(width + stubLen, cy, height * 0.3),
+  ));
+  builder.appendGeometry(LineSegment3d.create(
+    Point3d.create(width, cy, height * 0.7),
+    Point3d.create(width + stubLen, cy, height * 0.7),
+  ));
+
+  // Top connector plate — a closed loop polygon on top
+  builder.appendGeometry(Loop.createPolygon([
+    Point3d.create(cx - 0.2, cy - 0.2, height),
+    Point3d.create(cx + 0.2, cy - 0.2, height),
+    Point3d.create(cx + 0.2, cy + 0.2, height),
+    Point3d.create(cx - 0.2, cy + 0.2, height),
+    Point3d.create(cx - 0.2, cy - 0.2, height),
+  ]));
+}
+
+/**
+ * Create a simple bus bar geometry: a long rectangular profile with taps.
+ */
+function buildBusBarGeometry(
+  builder: GeometryStreamBuilder,
+  length: number,
+): void {
+  const barHeight = 0.15;
+  const barWidth = 0.05;
+
+  // Main bar
+  builder.appendGeometry(Box.createDgnBox(
+    Point3d.create(0, 0, 0),
+    Vector3d.unitX(),
+    Vector3d.unitY(),
+    Point3d.create(0, 0, barHeight),
+    length, barWidth, length, barWidth, true,
+  )!);
+
+  // Tap stubs every 2m
+  const numTaps = Math.floor(length / 2);
+  for (let t = 0; t < numTaps; t++) {
+    const tapX = (t + 1) * 2;
+    builder.appendGeometry(LineSegment3d.create(
+      Point3d.create(tapX, barWidth / 2, barHeight),
+      Point3d.create(tapX, barWidth / 2, barHeight + 0.5),
+    ));
+  }
+}
+
+/**
+ * Create cable routing geometry: a 3D polyline.
+ */
+function buildCableGeometry(
+  builder: GeometryStreamBuilder,
+  fromPt: Point3d,
+  toPt: Point3d,
+): void {
+  // Route with a vertical jog in the middle
+  const midX = (fromPt.x + toPt.x) / 2;
+  const maxZ = Math.max(fromPt.z, toPt.z) + 1.5;
+  builder.appendGeometry(LineString3d.create([
+    fromPt,
+    Point3d.create(fromPt.x, fromPt.y, maxZ),
+    Point3d.create(midX, (fromPt.y + toPt.y) / 2, maxZ),
+    Point3d.create(toPt.x, toPt.y, maxZ),
+    toPt,
+  ]));
+}
+
+export function createReproIModel(numModels: number, elementsPerModel: number): CreateReproIModelResult {
+  const filePath = path.join(os.tmpdir(), `repro-1659-${Date.now()}.bim`);
+
+  const db = StandaloneDb.createEmpty(filePath, {
+    rootSubject: { name: "Repro1659-DesktopAppSimulation" },
+    allowEdit: JSON.stringify({ txns: true }),
+  });
+
+  try {
+    // Create spatial categories for different equipment types
+    const equipmentCat = SpatialCategory.insert(db, IModel.dictionaryId, "Equipment",
+      new SubCategoryAppearance({ color: ColorByName.steelBlue }));
+    const busCat = SpatialCategory.insert(db, IModel.dictionaryId, "BusBars",
+      new SubCategoryAppearance({ color: ColorByName.peru }));
+    const cableCat = SpatialCategory.insert(db, IModel.dictionaryId, "Cables",
+      new SubCategoryAppearance({ color: ColorByName.darkGreen }));
+
+    const modelIds: Id64String[] = [];
+    const allRange = new Range3d();
+
+    // Element spacing constants
+    const elementSpacing = 5.0;  // meters between elements
+    const modelSpacing = 40.0;   // meters between model rows
+
+    for (let m = 0; m < numModels; m++) {
+      const modelId = PhysicalModel.insert(db, IModel.rootSubjectId, `ElectricalSystem-${m}`);
+      modelIds.push(modelId);
+
+      for (let e = 0; e < elementsPerModel; e++) {
+        const x = e * elementSpacing;
+        const y = m * modelSpacing;
+
+        // Vary element types based on index
+        const elementType = e % 5;
+        const builder = new GeometryStreamBuilder();
+        let category: Id64String;
+        let width: number, depth: number, height: number;
+
+        switch (elementType) {
+          case 0: // Transformer
+          case 1: // Switchgear
+            width = 1.2 + (e % 3) * 0.3;
+            depth = 0.8 + (e % 4) * 0.2;
+            height = 1.5 + (m % 5) * 0.3;
+            buildEquipmentGeometry(builder, width, depth, height);
+            category = equipmentCat;
+            break;
+          case 2: // Bus bar
+            buildBusBarGeometry(builder, 3.0 + (e % 3));
+            category = busCat;
+            width = 3.0 + (e % 3);
+            depth = 0.05;
+            height = 0.65;
+            break;
+          case 3: // Cable
+            buildCableGeometry(builder,
+              Point3d.create(0, 0, 0.5),
+              Point3d.create(elementSpacing * 0.8, 0, 0.5),
+            );
+            category = cableCat;
+            width = elementSpacing * 0.8;
+            depth = 0;
+            height = 2.0;
+            break;
+          default: // Small meter/sensor
+            width = 0.3;
+            depth = 0.3;
+            height = 0.4;
+            buildEquipmentGeometry(builder, width, depth, height);
+            category = equipmentCat;
+            break;
+        }
+
+        const elementProps: GeometricElement3dProps = {
+          classFullName: "Generic:PhysicalObject",
+          model: modelId,
+          category,
+          code: Code.createEmpty(),
+          placement: {
+            origin: Point3d.create(x, y, 0),
+            angles: YawPitchRollAngles.createDegrees(0, 0, 0),
+          },
+          geom: builder.geometryStream,
+        };
+
+        db.elements.insertElement(elementProps);
+
+        allRange.extendXYZ(x - 1, y - 1, -0.5);
+        allRange.extendXYZ(x + width + 1, y + depth + 1, height + 1);
+      }
+    }
+
+    // Create view definition showing all models
+    const dictionary = IModel.dictionaryId;
+    const modelSelectorId = ModelSelector.insert(db, dictionary, "Repro1659-AllModels", modelIds);
+    const categorySelectorId = CategorySelector.insert(db, dictionary, "Repro1659-AllCategories",
+      [equipmentCat, busCat, cableCat]);
+
+    const displayStyleId = db.elements.insertElement({
+      classFullName: DisplayStyle3d.classFullName,
+      code: DisplayStyle3d.createCode(db, dictionary, "Repro1659-Style"),
+      model: dictionary,
+      jsonProperties: {
+        styles: {
+          viewflags: {
+            renderMode: 6, // SmoothShade
+            visEdges: true,
+          },
+          backgroundColor: ColorByName.darkSlateGray,
+        },
+      },
+    });
+
+    // Create a top-down view of the full extent
+    const viewRange = allRange.clone();
+    viewRange.expandInPlace(200);
+
+    SpatialViewDefinition.insertWithCamera(db, dictionary, "Repro1659-View", modelSelectorId, categorySelectorId, displayStyleId, viewRange);
+
+    db.saveChanges("Created repro iModel for #1659");
+    db.close();
+
+    return {
+      filePath,
+      numModels,
+      totalElements: numModels * elementsPerModel,
+    };
+  } catch (e) {
+    db.abandonChanges();
+    db.close();
+    throw e;
+  }
+}

--- a/test-apps/display-test-app/src/backend/DtaElectronMain.ts
+++ b/test-apps/display-test-app/src/backend/DtaElectronMain.ts
@@ -5,11 +5,12 @@
 import * as path from "path";
 import { assert, Id64String } from "@itwin/core-bentley";
 import { ElectronHost } from "@itwin/core-electron/lib/cjs/ElectronBackend";
-import { CreateSectionDrawingViewArgs, CreateSectionDrawingViewResult, dtaChannel, DtaIpcInterface } from "../common/DtaIpcInterface";
+import { CreateReproIModelResult, CreateSectionDrawingViewArgs, CreateSectionDrawingViewResult, dtaChannel, DtaIpcInterface } from "../common/DtaIpcInterface";
 import { getRpcInterfaces, initializeDtaBackend, loadBackendConfig } from "./Backend";
 import { IpcHandler } from "@itwin/core-backend";
 import { getConfig } from "../common/DtaConfiguration";
 import { createSectionDrawing } from "./SectionDrawingImpl";
+import { createReproIModel } from "./CreateReproIModel";
 import { Placement2dProps, TextAnnotationProps, TextStyleSettingsProps } from "@itwin/core-common";
 import { deleteText, deleteTextStyle, insertText, insertTextStyle, setScaleFactor, updateText, updateTextStyle } from "./TextImpl";
 
@@ -41,6 +42,10 @@ class DtaHandler extends IpcHandler implements DtaIpcInterface {
 
   public async createSectionDrawing(args: CreateSectionDrawingViewArgs): Promise<CreateSectionDrawingViewResult> {
     return createSectionDrawing(args);
+  }
+
+  public async createReproIModel(numModels: number, elementsPerModel: number): Promise<CreateReproIModelResult> {
+    return createReproIModel(numModels, elementsPerModel);
   }
 
   public async insertTextStyle(iModelKey: string, name: string, settingProps: TextStyleSettingsProps): Promise<Id64String> {

--- a/test-apps/display-test-app/src/common/DtaIpcInterface.ts
+++ b/test-apps/display-test-app/src/common/DtaIpcInterface.ts
@@ -32,6 +32,13 @@ export interface CreateSectionDrawingViewResult {
   spatialViewId: Id64String;
 }
 
+/** Result of creating a reproduction iModel for issue #1659. */
+export interface CreateReproIModelResult {
+  filePath: string;
+  numModels: number;
+  totalElements: number;
+}
+
 export interface DtaIpcInterface {
   sayHello: () => Promise<string>;
 
@@ -39,6 +46,11 @@ export interface DtaIpcInterface {
    * Returns the Id of the section drawing view.
    */
   createSectionDrawing(args: CreateSectionDrawingViewArgs): Promise<CreateSectionDrawingViewResult>;
+
+  /** Creates a test iModel with many physical models and elements for reproducing issue #1659.
+   * Each model becomes a separate tile tree reference, amplifying decoration rebuild cost.
+   */
+  createReproIModel(numModels: number, elementsPerModel: number): Promise<CreateReproIModelResult>;
 
   /**
    * Inserts an annotation text style into the specified iModel.

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -31,7 +31,7 @@ import { ApplyModelClipTool } from "./ModelClipTools";
 import { GenerateElementGraphicsTool, GenerateTileContentTool } from "./TileContentTool";
 import { ViewClipByElementGeometryTool } from "./ViewClipByElementGeometryTool";
 import { DisplayTestAppShortcutsUI, DrawingAidTestTool } from "./DrawingAidTestTool";
-import { EditingScopeTool, MoveElementTool, PlaceLineStringTool, SetEditorToolSettingsTool } from "./EditingTools";
+import { EditingScopeTool, InteractiveMoveElementsTool, MoveElementTool, PlaceLineStringTool, SetEditorToolSettingsTool } from "./EditingTools";
 import { DynamicClassifierTool, DynamicClipMaskTool } from "./DynamicClassifierTool";
 import { FenceClassifySelectedTool } from "./Fence";
 import { RecordFpsTool } from "./FpsMonitor";
@@ -44,6 +44,7 @@ import { OutputShadersTool } from "./OutputShadersTool";
 import { PathDecorationTestTool } from "./PathDecorationTest";
 import { GltfDecorationTool } from "./GltfDecoration";
 import { TextDecorationTool } from "./TextDecoration";
+import { ReproIssue1659Tool } from "./ReproIssue1659";
 import { ToggleShadowMapTilesTool } from "./ShadowMapDecoration";
 import { signIn, signOut } from "./signIn";
 import {
@@ -389,12 +390,14 @@ export class DisplayTestApp {
       GltfDecorationTool,
       IncidentMarkerDemoTool,
       PathDecorationTestTool,
+      ReproIssue1659Tool,
       MacroTool,
       MarkupSelectTestTool,
       MarkupTool,
       MaximizeWindowTool,
       ModelClipTool,
       MoveElementTool,
+      InteractiveMoveElementsTool,
       OpenIModelTool,
       OpenRealityModelSettingsTool,
       OutputShadersTool,

--- a/test-apps/display-test-app/src/frontend/EditingTools.ts
+++ b/test-apps/display-test-app/src/frontend/EditingTools.ts
@@ -14,7 +14,7 @@ import {
 } from "@itwin/core-frontend";
 import { IModelJson, LineString3d, Point3d, Transform, Vector3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { editorBuiltInCmdIds } from "@itwin/editor-common";
-import { basicManipulationIpc, CreateElementWithDynamicsTool, EditTools } from "@itwin/editor-frontend";
+import { basicManipulationIpc, CreateElementWithDynamicsTool, EditTools, TransformElementsTool } from "@itwin/editor-frontend";
 import { setTitle } from "./Title";
 import { parseArgs } from "@itwin/frontend-devtools";
 
@@ -315,5 +315,21 @@ export class SetEditorToolSettingsTool extends Tool {
     }
 
     return true;
+  }
+}
+
+/** Interactive move tool — select elements then click two points to define translation. */
+export class InteractiveMoveElementsTool extends TransformElementsTool {
+  public static override toolId = "InteractiveMoveElements";
+  public static override iconSpec = "icon-move";
+
+  protected calculateTransform(ev: BeButtonEvent): Transform | undefined {
+    return this.anchorPoint ? Transform.createTranslation(ev.point.minus(this.anchorPoint)) : undefined;
+  }
+
+  public async onRestartTool(): Promise<void> {
+    const tool = new InteractiveMoveElementsTool();
+    if (!await tool.run())
+      return this.exitTool();
   }
 }

--- a/test-apps/display-test-app/src/frontend/ReproIssue1659.ts
+++ b/test-apps/display-test-app/src/frontend/ReproIssue1659.ts
@@ -1,0 +1,594 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Reproduction for desktop perf issue.
+ *   Move/copy operations on desktop app symbols became slow after upgrading 4.11 → 5.2.
+ *
+ * This reproduction closely mirrors the desktop app workflow:
+ *   - ConnectorPortDecorator: Matches the app's ConnectorDecorator pattern
+ *     (useCachedDecorations=false, WorldOverlay, line+arc geometry per connector port)
+ *   - AnnotationDecorator: Cached ViewOverlay labels (common in engineering apps)
+ *   - StatusBadgeDecorator: Canvas decorations for equipment status
+ *   - Programmatic iModel: Many physical models → many tile tree references
+ *
+ * ROOT CAUSE:
+ *   Commit ce418d16d8 (GoogleMaps support #7604) changed ScreenViewport.addDecorations()
+ *   to iterate getTileTreeRefs() instead of tiledGraphicsProviderRefs(). This iterates ALL
+ *   tile tree refs (view model + map + provider) on every decoration rebuild, instead of
+ *   just the external providers. Combined with multiple sources of invalidateDecorations()
+ *   firing on every mouse motion (AccuSnap, ToolAdmin locate circle, ToolAdmin.updateDynamics),
+ *   this makes decoration rebuilds during move/copy drag significantly more expensive.
+ *
+ * HOW TO USE (A/B test with real interactive move):
+ *   dta repro 1659 create [numModels] [elementsPerModel]
+ *       Create a test iModel. Defaults: 30 models, 50 elements each.
+ *
+ *   dta repro 1659 start        — add decorators + HUD, then use real tools (e.g. dta interactive move)
+ *   dta repro 1659 toggle       — toggle BOTH fixes between fixed/regressed (hits actual code)
+ *   dta repro 1659 toggle dynamics    — toggle only the changeDynamics fix
+ *   dta repro 1659 toggle decorations — toggle only the addDecorations fix
+ *   dta repro 1659 stop         — stop and remove all decorators
+ *
+ * WORKFLOW:
+ *   1. dta repro 1659 create 30 50
+ *   2. Open the .bim file
+ *   3. dta edit                    (start editing session)
+ *   4. dta repro 1659 start        (add desktop-app-like decorators + HUD)
+ *   5. Select some elements
+ *   6. dta interactive move         (real TransformElementsTool)
+ *   7. Click anchor → drag mouse → observe HUD metrics
+ *   8. dta repro 1659 toggle        (switch addDecorations to old getTileTreeRefs path)
+ *   9. Repeat step 6-7 → compare
+ *
+ * WHAT TO OBSERVE in the HUD overlay (top-left of viewport):
+ *   addDecorations:      "FIXED" or "REGRESSED" — toggles the ACTUAL code path
+ *   decorations/frame:   CPU ms spent rebuilding decorations on the latest frame
+ *   total frame:         CPU ms spent rendering the latest frame
+ *   connector dec/sec:   ConnectorPortDecorator.decorate() calls per second
+ *   annotation dec/sec:  AnnotationDecorator.decorate() calls per second
+ *   ref breakdown:       view vs map vs tiled-graphics-provider refs
+ */
+
+import { ColorDef } from "@itwin/core-common";
+import {
+  DecorateContext, Decorator,
+  type FrameStats,
+  GraphicType, IModelApp, NotifyMessageDetails, OutputMessagePriority,
+  ScreenViewport, Tool,
+} from "@itwin/core-frontend";
+import { Point3d } from "@itwin/core-geometry";
+import { dtaIpc } from "./App";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+interface ReproConfig {
+  /** Number of connector ports to simulate. Each port has spokes + circle arc. */
+  numConnectorPorts: number;
+  /** Number of annotation labels (ViewOverlay). */
+  numAnnotations: number;
+}
+
+const defaultConfig: ReproConfig = {
+  numConnectorPorts: 300,
+  numAnnotations: 50,
+};
+
+// ---------------------------------------------------------------------------
+// Rate tracker — calculates calls/sec with a sliding window
+// ---------------------------------------------------------------------------
+
+class RateTracker {
+  private _calls = 0;
+  private _windowStart = performance.now();
+  public rate = 0;
+
+  public count(): void {
+    this._calls++;
+    const now = performance.now();
+    const elapsed = now - this._windowStart;
+    if (elapsed >= 500) {
+      this.rate = (this._calls * 1000) / elapsed;
+      this._calls = 0;
+      this._windowStart = now;
+    }
+  }
+
+  public reset(): void {
+    this._calls = 0;
+    this._windowStart = performance.now();
+    this.rate = 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stats tracker + HUD
+// ---------------------------------------------------------------------------
+
+class ReproStats {
+  public config: ReproConfig = { ...defaultConfig };
+
+  public readonly connectorDecorate = new RateTracker();
+  public readonly annotationDecorate = new RateTracker();
+  public viewTileTreeRefCount = 0;
+  public mapTileTreeRefCount = 0;
+  public providerTileTreeRefCount = 0;
+  public decorationsTimeMs = 0;
+  public totalFrameTimeMs = 0;
+
+  public reset(): void {
+    this.connectorDecorate.reset();
+    this.annotationDecorate.reset();
+    this.viewTileTreeRefCount = 0;
+    this.mapTileTreeRefCount = 0;
+    this.providerTileTreeRefCount = 0;
+    this.decorationsTimeMs = 0;
+    this.totalFrameTimeMs = 0;
+  }
+
+  public updateFrameStats(stats: Readonly<FrameStats>): void {
+    this.decorationsTimeMs = stats.decorationsTime;
+    this.totalFrameTimeMs = stats.totalFrameTime;
+  }
+
+  public setTileTreeRefCounts(viewCount: number, mapCount: number, providerCount: number): void {
+    this.viewTileTreeRefCount = viewCount;
+    this.mapTileTreeRefCount = mapCount;
+    this.providerTileTreeRefCount = providerCount;
+  }
+
+  public drawHud(ctx: CanvasRenderingContext2D): void {
+    const x = 10;
+    let y = 24;
+    const lineH = 18;
+    const rm = ScreenViewport.regressMode;
+    const fixedRefCount = this.mapTileTreeRefCount + this.providerTileTreeRefCount;
+    const regressedRefCount = this.viewTileTreeRefCount + fixedRefCount;
+
+    ctx.save();
+    ctx.font = "bold 12px monospace";
+
+    // Background
+    const numLines = 10;
+    ctx.fillStyle = "rgba(0,0,0,0.82)";
+    ctx.fillRect(x - 6, y - 16, 760, lineH * numLines + 8);
+
+    // Title
+    ctx.fillStyle = "#00ff88";
+    ctx.fillText("Issue #1659 repro — desktop app simulation", x, y); y += lineH;
+
+    // changeDynamics toggle — reads ACTUAL state
+    ctx.fillStyle = rm.changeDynamics ? "#ff4444" : "#44ff44";
+    ctx.fillText(`changeDynamics: ${rm.changeDynamics ? "REGRESSED (invalidateDecorations)" : "FIXED (requestRedraw)"}`, x, y); y += lineH;
+
+    // addDecorations toggle — reads ACTUAL state
+    ctx.fillStyle = rm.addDecorations ? "#ff4444" : "#44ff44";
+    ctx.fillText(`addDecorations: ${rm.addDecorations ? "REGRESSED (old getTileTreeRefs iteration)" : "FIXED (map+provider only)"}`, x, y); y += lineH;
+
+    // Timing metrics
+    ctx.fillStyle = "#ffaa66";
+    ctx.fillText(`decorations/frame: ${this.decorationsTimeMs.toFixed(2)} ms`, x, y); y += lineH;
+
+    ctx.fillStyle = "#ff88cc";
+    ctx.fillText(`total frame: ${this.totalFrameTimeMs.toFixed(2)} ms`, x, y); y += lineH;
+
+    // Connector decorator rate
+    ctx.fillStyle = "#ffcc44";
+    ctx.fillText(`connector decorate/sec: ${this.connectorDecorate.rate.toFixed(0)}  (${this.config.numConnectorPorts} ports, uncached)`, x, y); y += lineH;
+
+    // Annotation decorator rate
+    ctx.fillStyle = "#aaaaff";
+    ctx.fillText(`annotation decorate/sec: ${this.annotationDecorate.rate.toFixed(0)}  (${this.config.numAnnotations} labels, cached)`, x, y); y += lineH;
+
+    // Tile tree ref breakdown + branch-specific iteration counts
+    ctx.fillStyle = "#ffff88";
+    ctx.fillText(`ref breakdown: view=${this.viewTileTreeRefCount}, map=${this.mapTileTreeRefCount}, provider=${this.providerTileTreeRefCount}`, x, y); y += lineH;
+
+    ctx.fillStyle = "#88ffff";
+    ctx.fillText(`addDecorations iterates: fixed=${fixedRefCount}, regressed=${regressedRefCount}`, x, y); y += lineH;
+
+    // Instructions
+    ctx.fillStyle = "#888888";
+    ctx.fillText(`Toggle: "dta repro 1659 toggle [dynamics|decorations|both]"`, x, y);
+
+    ctx.restore();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ConnectorPortDecorator — simulates the app's ConnectorDecorator
+//
+// Key: useCachedDecorations = false (matching the app exactly)
+// This means decorate() is called on EVERY frame when invalidateDecorations()
+// fires, rebuilding all port graphics from scratch.
+// ---------------------------------------------------------------------------
+
+interface ConnectorPort {
+  center: Point3d;
+  radius: number;
+}
+
+class ConnectorPortDecorator implements Decorator {
+  /** Matches the app's ConnectorDecorator: NO caching — omit useCachedDecorations
+   * so decorate() is called every frame when decorations are invalidated. */
+
+  private _ports: ConnectorPort[] = [];
+  private readonly _stats: ReproStats;
+
+  constructor(stats: ReproStats, numPorts: number) {
+    this._stats = stats;
+    this._generatePorts(numPorts);
+  }
+
+  private _generatePorts(numPorts: number): void {
+    this._ports = [];
+    const gridSize = Math.ceil(Math.sqrt(numPorts));
+    const spacing = 5.0;
+
+    for (let i = 0; i < numPorts; i++) {
+      const col = i % gridSize;
+      const row = Math.floor(i / gridSize);
+      this._ports.push({
+        center: Point3d.create(col * spacing, row * spacing, 0),
+        radius: 0.3 + (i % 3) * 0.1,
+      });
+    }
+  }
+
+  public decorate(context: DecorateContext): void {
+    this._stats.connectorDecorate.count();
+
+    const builder = context.createGraphic({ type: GraphicType.WorldOverlay });
+
+    for (const port of this._ports) {
+      const c = port.center;
+      const r = port.radius;
+
+      // 4 spoke lines radiating from center (matching the app's ConnectorDecorator pattern)
+      const spokeColor = ColorDef.from(80, 220, 80);
+      builder.setSymbology(spokeColor, ColorDef.black, 2);
+
+      builder.addLineString([
+        Point3d.create(c.x - r, c.y, c.z),
+        Point3d.create(c.x + r, c.y, c.z),
+      ]);
+      builder.addLineString([
+        Point3d.create(c.x, c.y - r, c.z),
+        Point3d.create(c.x, c.y + r, c.z),
+      ]);
+      // Diagonal spokes
+      const d = r * 0.707;
+      builder.addLineString([
+        Point3d.create(c.x - d, c.y - d, c.z),
+        Point3d.create(c.x + d, c.y + d, c.z),
+      ]);
+      builder.addLineString([
+        Point3d.create(c.x + d, c.y - d, c.z),
+        Point3d.create(c.x - d, c.y + d, c.z),
+      ]);
+
+      // Circle arc around the port
+      const circleColor = ColorDef.from(60, 200, 255);
+      builder.setSymbology(circleColor, ColorDef.black, 1);
+      const numSegments = 16;
+      const circlePts: Point3d[] = [];
+      for (let s = 0; s <= numSegments; s++) {
+        const angle = (s / numSegments) * Math.PI * 2;
+        circlePts.push(Point3d.create(
+          c.x + r * Math.cos(angle),
+          c.y + r * Math.sin(angle),
+          c.z,
+        ));
+      }
+      builder.addLineString(circlePts);
+    }
+
+    context.addDecoration(GraphicType.WorldOverlay, builder.finish());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AnnotationDecorator — cached ViewOverlay (simulates annotation labels)
+//
+// Key: useCachedDecorations = true — these survive invalidateDecorations()
+// until cache is explicitly cleared. Rebuilds are cheap comparatively.
+// ---------------------------------------------------------------------------
+
+interface AnnotationLabel {
+  worldPos: Point3d;
+  text: string;
+}
+
+class AnnotationDecorator implements Decorator {
+  public readonly useCachedDecorations = true;
+  private _labels: AnnotationLabel[] = [];
+  private readonly _stats: ReproStats;
+
+  constructor(stats: ReproStats, numLabels: number) {
+    this._stats = stats;
+    this._generateLabels(numLabels);
+  }
+
+  private _generateLabels(numLabels: number): void {
+    this._labels = [];
+    for (let i = 0; i < numLabels; i++) {
+      this._labels.push({
+        worldPos: Point3d.create((i % 10) * 8, Math.floor(i / 10) * 8, 0),
+        text: `EQ-${i.toString().padStart(3, "0")}`,
+      });
+    }
+  }
+
+  public decorate(context: DecorateContext): void {
+    this._stats.annotationDecorate.count();
+
+    // Build label underlines and tick marks in view overlay
+    const builder = context.createGraphic({ type: GraphicType.ViewOverlay });
+    builder.setSymbology(ColorDef.from(255, 255, 200), ColorDef.black, 1);
+
+    for (const label of this._labels) {
+      // Project world position to view coordinates for the overlay
+      const viewPt = context.viewport.worldToView(label.worldPos);
+      const x = viewPt.x;
+      const y = viewPt.y;
+
+      // Label underline
+      builder.addLineString([
+        Point3d.create(x, y, 0),
+        Point3d.create(x + 40, y, 0),
+      ]);
+      // Tick mark
+      builder.addLineString([
+        Point3d.create(x, y - 3, 0),
+        Point3d.create(x, y + 3, 0),
+      ]);
+    }
+
+    context.addDecoration(GraphicType.ViewOverlay, builder.finish());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StatusBadgeDecorator — canvas decorations for equipment status indicators
+// ---------------------------------------------------------------------------
+
+class StatusBadgeDecorator implements Decorator {
+  private readonly _badgeCount: number;
+
+  constructor(badgeCount: number) {
+    this._badgeCount = badgeCount;
+  }
+
+  public decorate(context: DecorateContext): void {
+    const count = this._badgeCount;
+    context.addCanvasDecoration({
+      drawDecoration: (ctx: CanvasRenderingContext2D) => {
+        ctx.save();
+        ctx.font = "9px monospace";
+        for (let i = 0; i < count; i++) {
+          const x = 460 + (i % 4) * 14;
+          const y = 20 + Math.floor(i / 4) * 14;
+          ctx.fillStyle = i % 3 === 0 ? "#44ff44" : i % 3 === 1 ? "#ffff44" : "#ff4444";
+          ctx.beginPath();
+          ctx.arc(x, y, 4, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.restore();
+      },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reproduction manager
+// ---------------------------------------------------------------------------
+
+class Repro1659Manager {
+  private readonly _stats = new ReproStats();
+  private readonly _registeredDecorators: Decorator[] = [];
+  private _vp?: ScreenViewport;
+  private _removeCloseListener?: () => void;
+  private _removeFrameStatsListener?: () => void;
+
+  private _updateTileTreeRefStats(vp: ScreenViewport): void {
+    let totalCount = 0;
+    for (const _ref of vp.getTileTreeRefs())
+      totalCount++;
+
+    let viewCount = 0;
+    for (const _ref of vp.view.getTileTreeRefs())
+      viewCount++;
+
+    let mapCount = 0;
+    for (const _ref of vp.mapTileTreeRefs)
+      mapCount++;
+
+    const providerCount = Math.max(0, totalCount - viewCount - mapCount);
+    this._stats.setTileTreeRefCounts(viewCount, mapCount, providerCount);
+  }
+
+  /** Add decorators + HUD. Then use real tools (dta interactive move) to test. */
+  public start(vp: ScreenViewport): void {
+    if (this._vp)
+      this.stop();
+
+    this._vp = vp;
+    this._stats.reset();
+    this._updateTileTreeRefStats(vp);
+    this._removeFrameStatsListener = vp.onFrameStats.addListener((frameStats) => this._stats.updateFrameStats(frameStats));
+
+    // --- HUD overlay decorator ---
+    const stats = this._stats;
+    const hudDec: Decorator = {
+      decorate(ctx: DecorateContext) {
+        ctx.addCanvasDecoration({ drawDecoration: (c) => stats.drawHud(c) });
+      },
+    };
+    IModelApp.viewManager.addDecorator(hudDec);
+    this._registeredDecorators.push(hudDec);
+
+    // --- ConnectorPortDecorator (matches the app's ConnectorDecorator) ---
+    // useCachedDecorations = false — decorate() called on every invalidation
+    const connectorDec = new ConnectorPortDecorator(stats, stats.config.numConnectorPorts);
+    IModelApp.viewManager.addDecorator(connectorDec);
+    this._registeredDecorators.push(connectorDec);
+
+    // --- AnnotationDecorator (cached ViewOverlay) ---
+    const annotationDec = new AnnotationDecorator(stats, stats.config.numAnnotations);
+    IModelApp.viewManager.addDecorator(annotationDec);
+    this._registeredDecorators.push(annotationDec);
+
+    // --- StatusBadgeDecorator (canvas decorations) ---
+    const statusDec = new StatusBadgeDecorator(20);
+    IModelApp.viewManager.addDecorator(statusDec);
+    this._registeredDecorators.push(statusDec);
+
+    this._removeCloseListener = vp.iModel.onClose.addOnce(() => this.stop());
+
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+      OutputMessagePriority.Info,
+      `[#1659] Started (view=${stats.viewTileTreeRefCount}, map=${stats.mapTileTreeRefCount}, provider=${stats.providerTileTreeRefCount}; ${stats.config.numConnectorPorts} ports). Use real tools (dta interactive move) to test. Toggle with "dta repro 1659 toggle".`,
+    ));
+  }
+
+  public stop(): void {
+    ScreenViewport.regressMode.changeDynamics = false;
+    ScreenViewport.regressMode.addDecorations = false;
+
+    if (this._vp) {
+      this._vp = undefined;
+    }
+
+    for (const dec of this._registeredDecorators)
+      IModelApp.viewManager.dropDecorator(dec);
+    this._registeredDecorators.length = 0;
+
+    this._removeCloseListener?.();
+    this._removeCloseListener = undefined;
+    this._removeFrameStatsListener?.();
+    this._removeFrameStatsListener = undefined;
+
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+      OutputMessagePriority.Info, "[#1659] Stopped."));
+  }
+
+  /** Toggle the actual code paths between old and fixed behavior.
+   * @param which - "dynamics" toggles changeDynamics, "decorations" toggles addDecorations, "both" toggles both.
+   */
+  public toggle(which: "dynamics" | "decorations" | "both" = "both"): void {
+    if (!this._vp) {
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+        OutputMessagePriority.Warning, "[#1659] Not running. Use 'start' first."));
+      return;
+    }
+
+    const rm = ScreenViewport.regressMode;
+    if (which === "dynamics" || which === "both")
+      rm.changeDynamics = !rm.changeDynamics;
+    if (which === "decorations" || which === "both")
+      rm.addDecorations = !rm.addDecorations;
+
+    this._updateTileTreeRefStats(this._vp);
+    this._vp.requestRedraw();
+
+    const dynStr = rm.changeDynamics ? "REGRESSED" : "FIXED";
+    const decStr = rm.addDecorations ? "REGRESSED" : "FIXED";
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+      OutputMessagePriority.Info, `[#1659] changeDynamics: ${dynStr}, addDecorations: ${decStr}`));
+  }
+
+  public get isRunning(): boolean { return this._vp !== undefined; }
+  public get config(): ReproConfig { return this._stats.config; }
+}
+
+const _manager = new Repro1659Manager();
+
+// ---------------------------------------------------------------------------
+// Tool — key-in: "dta repro 1659 [create|start|toggle|stop|config]"
+// ---------------------------------------------------------------------------
+
+export class ReproIssue1659Tool extends Tool {
+  public static override toolId = "ReproIssue1659";
+  public static override get minArgs() { return 0; }
+  public static override get maxArgs() { return 3; }
+
+  public override async run(action = "start", ...rest: string[]): Promise<boolean> {
+    if (action === "create")
+      return this._handleCreate(rest);
+
+    const vp = IModelApp.viewManager.selectedView;
+    if (!vp) {
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+        OutputMessagePriority.Warning, "No active viewport — open an iModel or the empty example first."));
+      return false;
+    }
+
+    switch (action) {
+      case "start":    _manager.start(vp); break;
+      case "toggle":   _manager.toggle(rest[0] as "dynamics" | "decorations" | "both" ?? "both"); break;
+      case "stop":     _manager.stop(); break;
+      case "config":   this._handleConfig(rest); break;
+      default:         _manager.isRunning ? _manager.stop() : _manager.start(vp); break;
+    }
+    return true;
+  }
+
+  private async _handleCreate(args: string[]): Promise<boolean> {
+    const numModels = args.length > 0 ? parseInt(args[0], 10) : 30;
+    const elementsPerModel = args.length > 1 ? parseInt(args[1], 10) : 50;
+
+    if (isNaN(numModels) || isNaN(elementsPerModel) || numModels < 1 || elementsPerModel < 1) {
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+        OutputMessagePriority.Warning, "Usage: dta repro 1659 create [numModels] [elementsPerModel]"));
+      return false;
+    }
+
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+      OutputMessagePriority.Info, `[#1659] Creating iModel: ${numModels} models × ${elementsPerModel} elements...`));
+
+    try {
+      const result = await dtaIpc.createReproIModel(numModels, elementsPerModel);
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+        OutputMessagePriority.Info,
+        `[#1659] Created: ${result.filePath} (${result.numModels} models, ${result.totalElements} elements). Use "dta file open ${result.filePath}" to open it.`,
+      ));
+      return true;
+    } catch (err: any) {
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+        OutputMessagePriority.Error, `[#1659] Failed to create iModel: ${err.message ?? err}`));
+      return false;
+    }
+  }
+
+  private _handleConfig(args: string[]): void {
+    if (args.length < 2) {
+      const currentConfig = _manager.config;
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+        OutputMessagePriority.Info,
+        `[#1659] Config: connectors=${currentConfig.numConnectorPorts}, annotations=${currentConfig.numAnnotations}`));
+      return;
+    }
+
+    const [param, value] = args;
+    const config = _manager.config;
+    switch (param) {
+      case "connectors":  config.numConnectorPorts = parseInt(value, 10); break;
+      case "annotations": config.numAnnotations = parseInt(value, 10); break;
+      default:
+        IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+          OutputMessagePriority.Warning, `[#1659] Unknown config param: ${param}. Use: connectors, annotations`));
+        return;
+    }
+
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(
+      OutputMessagePriority.Info, `[#1659] Config updated: ${param}=${value}. Restart repro to apply.`));
+  }
+
+  public override async parseAndRun(...args: string[]): Promise<boolean> {
+    return this.run(args[0], ...args.slice(1));
+  }
+}


### PR DESCRIPTION
This PR proposes two fixes to improve viewer rendering performance related to moving elements, surfaced in a desktop application. User noted performance was not great in 4.11 while moving elements, but that iTwin.js 5.2 exacerbated the issue.

#### Decouple dynamics and decoration invalidations

We believe the `invalidateDecorations()` call inside of `Viewport.changeDynamics()` is the root cause of these performance issues. This forces a full decoration rebuild on every mouse move during dynamics.

While dynamics and decorations are related concepts, and I'm ignorant of much of the history here, it seems like they are rendered separately. Maybe it's idealistic (or ignorant), I don't think the two should invalidate each others' calls. 

Assuming the idea behind this fix is on the right track, the next question is "are our consumers relying on this behavior"? In discussions with Mark and Erin, we don't think we can guarantee they are not. Thus, if we move forward, should probably make this behavior opt-in.

#### Issue exacerbated by https://github.com/iTwin/itwinjs-core/pull/7604

A change in the above PR corresponds to our user's complaint that the performance became extremely noticeable in 5.2. Looking [here](https://github.com/iTwin/itwinjs-core/pull/7604/changes#diff-af2a9ce1565eebee94633f79fed3c8f1fc09486e26c8b028d49d682da70d979bR3465), `screenViewport.addDecorations()` iterates `getTileTreeRefs()`, which yields view model refs + displayStyle refs + map refs + tiled graphics provider refs. But `this.view` is already decorated on the line above, so the view/displayStyle refs are seemingly redundant?

I've added a DTA reproduction with instructions in `display-test-app/src/frontend/ReproIssue1659.ts`. DTA repro tool - adds decorators matching the desktop app's patterns (uncached connector decorators, cached annotation overlays), then you use the real dta interactive move tool. dta repro 1659 toggle flips the actual code paths between fixed and regressed behavior so you can compare live. The first issue above seems to be the cause of most of the performance issues, but it is dependent on the complexity of the setup (num of models/elements/decorators).

@markschlosseratbentley @eringram have been involved in discussions.
@bbastings We're eager to know your thoughts when you have a chance.