### PR TITLE
Minor bump on `IModelReadRpcInterface.interfaceVersion`

### DIFF
--- a/common/changes/@itwin/core-common/master_2026-03-26-14-26.json
+++ b/common/changes/@itwin/core-common/master_2026-03-26-14-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Minor bump on `IModelReadRpcInterface.interfaceVersion`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/rpc/IModelReadRpcInterface.ts
+++ b/core/common/src/rpc/IModelReadRpcInterface.ts
@@ -84,7 +84,7 @@ export abstract class IModelReadRpcInterface extends RpcInterface {
   public static readonly interfaceName = "IModelReadRpcInterface";
 
   /** The semantic version of the interface. */
-  public static interfaceVersion = "3.7.0";
+  public static interfaceVersion = "3.8.0";
 
   /*===========================================================================================
     NOTE: Any add/remove/change to the methods below requires an update of the interface version.


### PR DESCRIPTION
iTwin.js Core @ 5.7 fixed [a critical `IdSet` issue](https://github.com/iTwin/itwinjs-core/issues/8968), which allows us to use that ECSQL feature in our queries. However, it didn't bump RPC version, so there's no guarantee that RPC requests sent using `core-frontend @ 5.7+` will land in a `core-backend @ 5.7` - in theory it could be `5.5` or even `5.0`. To avoid that, we need to bump RPC minor version, which will prevent newer frontend sending requests to older backends, and will let us safely use the `IdSet` ECSQL language feature.

cc @aruniverse @khanaffan 