### PR TITLE
docs: improve ECSQL meta queries tutorial with schema discovery workflow

### DIFF
--- a/docs/learning/CommonTableExp.md
+++ b/docs/learning/CommonTableExp.md
@@ -47,7 +47,7 @@ Here is a simple example of how we can write a CTE. In the following query we wa
   6
 ```
 
-As another example, we might want to traverse a class hierarchy starting from a base class down to all derived classes, generating a row for each class. Each row should could contain 2 columns: the depth of the derived class relative to the base class and a path string describing its relationship to the base class. Using `BisCore:GeometricElement2d` as the base class produces the following ECSQL and resultant output:
+As another example, we might want to traverse a class hierarchy starting from a base class down to all derived classes, generating a row for each class. Each row should contain 2 columns: the depth of the derived class relative to the base class and a path string describing its relationship to the base class. This builds on the [ECDbMeta](./ECDbMeta.ecschema.md) schema classes introduced in the [Meta Queries tutorial](./ECSQLTutorial/MetaQueries.md). Using `BisCore:GeometricElement2d` as the base class produces the following ECSQL and resultant output:
 
 ```sql
 WITH RECURSIVE

--- a/docs/learning/ECSQLTutorial/MetaQueries.md
+++ b/docs/learning/ECSQLTutorial/MetaQueries.md
@@ -2,6 +2,18 @@
 
 Every iModel includes the [ECDbMeta](../ECDbMeta.ecschema.md) ECSchema. It exposes the content of all schemas that the iModel contains. You can therefore use ECSQL against that schema to query for schemas, classes, properties etc.
 
+## Schema discovery workflow
+
+When working with an unfamiliar iModel, you typically explore it in three steps:
+
+1. **What schemas exist?** — Query [ECSchemaDef](../ECDbMeta.ecschema.md#ecschemadef) to list all schemas in the iModel.
+2. **What classes does a schema have?** — Query [ECClassDef](../ECDbMeta.ecschema.md#ecclassdef) joined to `ECSchemaDef` via `Schema.Id` to list entity, relationship, and struct classes.
+3. **What properties does a class have?** — Query [ECPropertyDef](../ECDbMeta.ecschema.md#ecpropertydef) joined to `ECClassDef` via `Class.Id` to inspect property names, types, and order.
+
+The examples below walk through each of these steps.
+
+### Step 1: List schemas
+
 > **Try it yourself**
 >
 > _Goal:_ Return the name, alias and version of all [schemas](../ECDbMeta.ecschema.md#ecschemadef) in the iModel
@@ -12,19 +24,51 @@ Every iModel includes the [ECDbMeta](../ECDbMeta.ecschema.md) ECSchema. It expos
 > SELECT Name, Alias, VersionMajor, VersionWrite, VersionMinor FROM meta.ECSchemaDef ORDER BY Name
 > ```
 
----
+### Step 2: List classes in a schema
 
 > **Try it yourself**
 >
-> _Goal:_ Return the properties and their types for the [Element](../../bis/domains/BisCore.ecschema.md#element) class
+> _Goal:_ Return all classes in the `Generic` schema with their [type](../ECDbMeta.ecschema.md#ecclasstype) (Entity, Relationship, Struct, or CustomAttribute)
 >
 > _ECSQL_
 >
 > ```sql
-> SELECT p.Name from meta.ECPropertyDef p JOIN meta.ECClassDef c ON c.ECInstanceId=p.Class.Id WHERE c.Name='Element' ORDER BY p.Ordinal
+> SELECT c.Name, c.Type FROM meta.ECClassDef c JOIN meta.ECSchemaDef s ON s.ECInstanceId = c.Schema.Id WHERE s.Name = 'Generic' ORDER BY c.Name
+> ```
+
+You can also filter by class type. For example, to see only entity classes, add `AND c.Type = 0` to the `WHERE` clause. See [ECClassType](../ECDbMeta.ecschema.md#ecclasstype) for the full list of type values.
+
+### Step 3: List properties of a class
+
+> **Try it yourself**
+>
+> _Goal:_ Return the properties of the [Element](../../bis/domains/BisCore.ecschema.md#element) class in their original definition order
+>
+> _ECSQL_
+>
+> ```sql
+> SELECT p.Name, p.Description FROM meta.ECPropertyDef p JOIN meta.ECClassDef c ON c.ECInstanceId = p.Class.Id WHERE c.Name = 'Element' ORDER BY p.Ordinal
 > ```
 
 Note the `ORDER BY` clause in the previous example. The property `Ordinal` of the [ECPropertyDef](../ECDbMeta.ecschema.md#ecpropertydef) class contains the position of the property in the class as it was originally defined.
+
+For a more detailed view, you can also return each property's kind and primitive type:
+
+> **Try it yourself**
+>
+> _Goal:_ Return the properties of the `BisCore:Element` class with their [kind](../ECDbMeta.ecschema.md#ecpropertykind) (Primitive, Struct, Navigation, etc.) and [primitive type](../ECDbMeta.ecschema.md#primitivetype)
+>
+> _ECSQL_
+>
+> ```sql
+> SELECT p.Name, p.Description, p.Kind, p.PrimitiveType, p.ExtendedTypeName FROM meta.ECPropertyDef p JOIN meta.ECClassDef c ON c.ECInstanceId = p.Class.Id JOIN meta.ECSchemaDef s ON s.ECInstanceId = c.Schema.Id WHERE s.Name = 'BisCore' AND c.Name = 'Element' ORDER BY p.Ordinal
+> ```
+
+The schema-qualified filter (`s.Name = 'BisCore' AND c.Name = 'Element'`) ensures you get the exact class even if another schema defines a class with the same name.
+
+---
+
+## Combining meta queries with data queries
 
 Another advantage of accessing the schemas via ECSQL is that you can combine that with ordinary ECSQL queries. The next examples shows how you can do that.
 
@@ -50,6 +94,13 @@ were a `Building` subclass in another schema, those instances would also be retu
 > ```sql
 > SELECT class.Name ClassName, element.ECInstanceId ElementId, element.UserLabel FROM bis.SpatialElement element JOIN meta.ECClassDef class ON element.ECClassId=class.ECInstanceId JOIN meta.ECSchemaDef schema ON schema.ECInstanceId=class.Schema.Id WHERE schema.Name = 'Generic' AND class.Name IN ('PhysicalObject')
 > ```
+
+---
+
+## See also
+
+- [ECDbMeta ECSchema reference](../ECDbMeta.ecschema.md) — full documentation of all meta schema classes, relationships, and enumerations.
+- [Common Table Expressions](../CommonTableExp.md) — includes a recursive CTE example that uses `meta.ClassHasBaseClasses` to traverse a class inheritance hierarchy.
 
 ---
 

--- a/docs/learning/backend/ECSQL-queries.md
+++ b/docs/learning/backend/ECSQL-queries.md
@@ -26,4 +26,19 @@ The following ECSQL select statements are examples of useful queries that an app
 [[include:ECSQL-backend-queries.select-element-by-code-value]]
 ```
 
+## Discover element classes in an iModel
+
+When exploring an unfamiliar iModel, it is useful to see which element classes are present and how many instances of each exist. This query joins element data with the [ECDbMeta](../ECDbMeta.ecschema.md) schema to produce a summary:
+
+```sql
+SELECT s.Name || ':' || c.Name ClassName, count(*) InstanceCount
+FROM bis.Element e
+JOIN meta.ECClassDef c ON e.ECClassId = c.ECInstanceId
+JOIN meta.ECSchemaDef s ON s.ECInstanceId = c.Schema.Id
+GROUP BY s.Name, c.Name
+ORDER BY InstanceCount DESC
+```
+
+For more meta query patterns, see the [Meta Queries tutorial](../ECSQLTutorial/MetaQueries.md) and the [ECDbMeta ECSchema reference](../ECDbMeta.ecschema.md).
+
 As an alternative, you can use the [IModelDb.queryEntityIds]($backend) convenience method for simple cases.


### PR DESCRIPTION
Resolves #9145

## Summary

The [Meta Queries tutorial (Lesson 7)](https://www.itwinjs.org/learning/ecsqltutorial/metaqueries/) had only 4 examples focused on two narrow patterns (listing schemas and filtering elements by class name). Developers exploring unfamiliar iModels — common for tooling, connectors, and AI-assisted workflows — lacked documented patterns for iterative schema discovery.

## Changes

### `docs/learning/ECSQLTutorial/MetaQueries.md`
- Added a **Schema Discovery Workflow** section with a 3-step guide (schemas → classes → properties) giving developers a mental model before the examples
- Added **"List classes in a schema"** example — the natural middle step between listing schemas and listing properties
- Added **richer property listing** example showing `Description`, `Kind`, `PrimitiveType`, and `ExtendedTypeName`
- Reorganized existing examples under clear headings (Step 1/2/3, Combining meta queries with data queries)
- Added **"See also"** section cross-linking to the ECDbMeta reference and the CTE inheritance hierarchy example

### `docs/learning/backend/ECSQL-queries.md`
- Added **"Discover element classes in an iModel"** section with a practical instance-count-per-class query
- Cross-links back to the Meta Queries tutorial and ECDbMeta reference

### `docs/learning/CommonTableExp.md`
- Added cross-link from the `ClassHasBaseClasses` CTE example back to the Meta Queries tutorial and ECDbMeta reference (previously only discoverable from the CTE page)

## What's NOT changed
- `ECDbMeta.ecschema.md` — auto-generated reference, already comprehensive
- `ECSqlReference/MetaQueries.md` — separate reference page, out of scope
- No code, API, or test changes — pure documentation