### PR TITLE
Presentation: Fix content traverser (`createContentTraverser`) creating invalid fields hierarchy when array properties are nested under `NestedContentField`

### DIFF
--- a/common/changes/@itwin/presentation-common/presentation-fix-content-traverser-failing-to-handle-array-properties_2026-04-10-08-23.json
+++ b/common/changes/@itwin/presentation-common/presentation-fix-content-traverser-failing-to-handle-array-properties_2026-04-10-08-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "Fix content traverser (`createContentTraverser`) creating invalid fields hierarchy when array properties are nested under `NestedContentField`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/presentation/common/src/presentation-common/content/ContentTraverser.ts
+++ b/presentation/common/src/presentation-common/content/ContentTraverser.ts
@@ -11,8 +11,9 @@ import { LabelDefinition } from "../LabelDefinition.js";
 import { CategoryDescription } from "./Category.js";
 import { Content } from "./Content.js";
 import { Descriptor } from "./Descriptor.js";
-import { Field, NestedContentField } from "./Fields.js";
+import { ArrayPropertiesField, Field, NestedContentField, PropertiesField, StructPropertiesField } from "./Fields.js";
 import { Item } from "./Item.js";
+import { Property } from "./Property.js";
 import { PropertyValueFormat, TypeDescription } from "./TypeDescription.js";
 import {
   DisplayValue,
@@ -410,9 +411,12 @@ function traverseContentItemField(visitor: IContentVisitor, fieldHierarchy: Fiel
   try {
     const rootToThisField = createFieldPath(fieldHierarchy.field);
     let parentFieldName: string | undefined;
-    const pathUpToField = rootToThisField.slice(undefined, -1);
+    const pathUpToField: NestedContentField[] = rootToThisField.slice(undefined, -1).map((f) => {
+      assert(f.isNestedContentField());
+      return f;
+    });
     for (let i = 0; i < pathUpToField.length; ++i) {
-      const parentField = pathUpToField[i] as NestedContentField;
+      const parentField = pathUpToField[i];
       const nextField = rootToThisField[i + 1];
 
       if (item.isFieldMerged(parentField.name)) {
@@ -434,6 +438,7 @@ function traverseContentItemField(visitor: IContentVisitor, fieldHierarchy: Fiel
       return;
     }
 
+    let valuesAccessor = fieldHierarchy.field.name;
     if (fieldHierarchy.field.isNestedContentField()) {
       fieldHierarchy = convertNestedContentFieldHierarchyToStructArrayHierarchy(fieldHierarchy, parentFieldName);
       const { emptyNestedItem, convertedItem } = convertNestedContentFieldHierarchyItemToStructArrayItem(item, fieldHierarchy);
@@ -441,18 +446,11 @@ function traverseContentItemField(visitor: IContentVisitor, fieldHierarchy: Fiel
         return;
       }
       item = convertedItem;
+      valuesAccessor = fieldHierarchy.field.name;
     } else if (pathUpToField.length > 0) {
       fieldHierarchy = {
         ...fieldHierarchy,
-        field: (function () {
-          const clone = fieldHierarchy.field.clone();
-          clone.type = {
-            valueFormat: PropertyValueFormat.Array,
-            typeName: `${fieldHierarchy.field.type.typeName}[]`,
-            memberType: fieldHierarchy.field.type,
-          };
-          return clone;
-        })(),
+        field: new NestedContentArrayPropertiesField(fieldHierarchy.field, pathUpToField[pathUpToField.length - 1]),
       };
     }
 
@@ -462,8 +460,8 @@ function traverseContentItemField(visitor: IContentVisitor, fieldHierarchy: Fiel
       item.mergedFieldNames,
       fieldHierarchy.field.type,
       parentFieldName,
-      item.values[fieldHierarchy.field.name],
-      item.displayValues[fieldHierarchy.field.name],
+      item.values[valuesAccessor],
+      item.displayValues[valuesAccessor],
     );
   } finally {
     visitor.finishField();
@@ -744,7 +742,13 @@ export const FIELD_NAMES_SEPARATOR = "$";
  * @public
  */
 export function combineFieldNames(fieldName: string, parentFieldName?: string) {
-  return parentFieldName ? `${parentFieldName}${FIELD_NAMES_SEPARATOR}${fieldName}` : fieldName;
+  if (parentFieldName) {
+    if (fieldName) {
+      return `${parentFieldName}${FIELD_NAMES_SEPARATOR}${fieldName}`;
+    }
+    return parentFieldName;
+  }
+  return fieldName;
 }
 /**
  * Parses given combined field names string, constructed using [[combineFieldNames]], into a list of individual field names.
@@ -875,4 +879,51 @@ function convertNestedContentFieldHierarchyItemToStructArrayItem(item: Readonly<
     mergedFieldNames: converted.mergedFieldNames,
   });
   return { emptyNestedItem: false, convertedItem };
+}
+
+/**
+ * A synthetic field that extends `NestedContentField` and adds `ArrayPropertiesField` /
+ * `PropertiesField` surface so that consumers who narrow via `isNestedContentField()`,
+ * `isPropertiesField()`, and `isArrayPropertiesField()` get a genuine object.
+ *
+ * It's needed to properly propagate properties of nested content fields when they're converted
+ * into struct/array fields, so that consumers can use those properties when processing values.
+ */
+class NestedContentArrayPropertiesField extends NestedContentField {
+  public readonly properties: Property[];
+  public readonly itemsField: Field;
+
+  public constructor(sourceItemsField: Field, parentNestedField: NestedContentField) {
+    super({
+      ...parentNestedField,
+      ...sourceItemsField,
+      name: "",
+      type: {
+        valueFormat: PropertyValueFormat.Array,
+        typeName: `${sourceItemsField.type.typeName}[]`,
+        memberType: sourceItemsField.type,
+      },
+    });
+    this.properties = sourceItemsField.isPropertiesField() ? sourceItemsField.properties : [];
+    this.itemsField = sourceItemsField.clone();
+    this.itemsField.resetParentship();
+  }
+
+  public override isPropertiesField(): this is PropertiesField {
+    return true;
+  }
+
+  public isArrayPropertiesField(): this is ArrayPropertiesField {
+    return true;
+  }
+
+  public isStructPropertiesField(): this is StructPropertiesField {
+    return false;
+  }
+
+  public override clone() {
+    const clone = new NestedContentArrayPropertiesField(this.itemsField.clone(), this);
+    clone.rebuildParentship(this.parent);
+    return clone;
+  }
 }

--- a/presentation/common/src/test/content/ContentTraverser.test.ts
+++ b/presentation/common/src/test/content/ContentTraverser.test.ts
@@ -36,7 +36,7 @@ import {
   createTestSimpleContentField,
   createTestStructPropertiesContentField,
 } from "../_helpers/Content.js";
-import { createTestECInstanceKey } from "../_helpers/EC.js";
+import { createTestECInstanceKey, createTestPropertyInfo } from "../_helpers/EC.js";
 
 describe("ContentTraverser", () => {
   class TestContentVisitor implements IContentVisitor {
@@ -543,7 +543,7 @@ describe("ContentTraverser", () => {
       expect(startArraySpy.firstCall.firstArg).to.containSubset({
         hierarchy: {
           field: {
-            name: primitiveField.name,
+            name: "",
           },
         },
         valueType: {
@@ -573,6 +573,102 @@ describe("ContentTraverser", () => {
         displayValue: "display value 2",
       });
       expect(finishArraySpy).to.be.calledOnce;
+    });
+
+    it("processes array value nested under nested content item as array-of-arrays value", () => {
+      const startArraySpy = sinon.spy(visitor, "startArray");
+      const finishArraySpy = sinon.spy(visitor, "finishArray");
+      const processPrimitiveValueSpy = sinon.spy(visitor, "processPrimitiveValue");
+      const nestedContentCategory = createTestCategoryDescription({ name: "nested-content", label: "Nested content" });
+      const arrayItemField = createTestPropertiesContentField({
+        name: "ArrayItemField",
+        category: nestedContentCategory,
+        properties: [{ property: createTestPropertyInfo({ name: "ArrayProperty", type: "string" }) }],
+        type: { valueFormat: PropertyValueFormat.Primitive, typeName: "string" },
+      });
+      const arrayField = createTestArrayPropertiesContentField({
+        name: "ArrayField",
+        category: nestedContentCategory,
+        properties: [{ property: createTestPropertyInfo({ name: "ArrayProperty", type: "string" }) }],
+        type: {
+          valueFormat: PropertyValueFormat.Array,
+          typeName: `${arrayItemField.type.typeName}[]`,
+          memberType: arrayItemField.type,
+        },
+        itemsField: arrayItemField,
+      });
+      const rootField = createTestNestedContentField({
+        name: "RootField",
+        category: createTestCategoryDescription({ name: "root", label: "Root category" }),
+        nestedFields: [arrayField],
+      });
+      const descriptor = createTestContentDescriptor({ fields: [rootField] });
+      const item = createTestContentItem({
+        values: {
+          [rootField.name]: [
+            {
+              primaryKeys: [createTestECInstanceKey()],
+              values: {
+                [arrayField.name]: ["value1"],
+              },
+              displayValues: {
+                [arrayField.name]: ["display value 1"],
+              },
+              mergedFieldNames: [],
+            },
+          ],
+        },
+        displayValues: {
+          [rootField.name]: undefined,
+        },
+      });
+      const traverser = createContentTraverser(visitor, descriptor);
+      traverser([item]);
+
+      expect(startArraySpy).to.be.calledTwice;
+      expect(startArraySpy.firstCall.firstArg).to.containSubset({
+        hierarchy: {
+          field: {
+            name: "",
+            itemsField: {
+              name: arrayField.name,
+              type: arrayField.type,
+            },
+            type: {
+              valueFormat: PropertyValueFormat.Array,
+              typeName: `${arrayField.type.typeName}[]`,
+              memberType: arrayField.type,
+            },
+          },
+        },
+        valueType: {
+          valueFormat: PropertyValueFormat.Array,
+          typeName: `${arrayField.type.typeName}[]`,
+          memberType: arrayField.type,
+        },
+        parentFieldName: rootField.name,
+      });
+      expect(startArraySpy.secondCall.firstArg).to.containSubset({
+        hierarchy: {
+          field: {
+            name: arrayField.name,
+            type: arrayField.type,
+          },
+        },
+        valueType: arrayField.type,
+        parentFieldName: `${rootField.name}`,
+      });
+      expect(processPrimitiveValueSpy).to.be.calledOnce;
+      expect(processPrimitiveValueSpy.firstCall.firstArg).to.containSubset({
+        field: {
+          name: arrayItemField.name,
+        },
+        valueType: arrayItemField.type,
+        parentFieldName: `${rootField.name}${FIELD_NAMES_SEPARATOR}${arrayField.name}`,
+        rawValue: "value1",
+        displayValue: "display value 1",
+      });
+      expect(finishArraySpy).to.be.calledTwice;
     });
 
     it("processes nested content item as struct array value", () => {
@@ -794,7 +890,7 @@ describe("ContentTraverser", () => {
       expect(startArraySpy).to.be.calledOnce;
       expect(startArraySpy.firstCall.firstArg).to.containSubset({
         hierarchy: {
-          field: { name: primitiveField.name },
+          field: { name: "" },
           childFields: [],
         },
         valueType: {
@@ -1524,7 +1620,7 @@ describe("ContentTraverser", () => {
                       [childPrimitiveField.name]: "ChildPrimitiveValue",
                     },
                     displayValues: {
-                      [childNestedContentField.name]: "ChildPrimitiveDisplayValue",
+                      [childPrimitiveField.name]: "ChildPrimitiveDisplayValue",
                     },
                     mergedFieldNames: [],
                   } satisfies NestedContentValue,
@@ -1532,7 +1628,7 @@ describe("ContentTraverser", () => {
               },
               displayValues: {
                 [parentPrimitiveField.name]: "ChildPrimitiveDisplayValue",
-                [childNestedContentField.name]: "ChildNestedContentDisplayValue",
+                [childNestedContentField.name]: undefined,
               },
               mergedFieldNames: [],
             } satisfies NestedContentValue,


### PR DESCRIPTION
The traverser was creating an invalid array properties field, resulting in an error in `@itwin/presentation-components`, when creating property grid data.