### PR TITLE
fix: IpcHandler error serialization not culling unserializable properties

### DIFF
--- a/common/changes/@itwin/core-backend/simihartstein-fix-ipc-nested-error-serialization_2026-03-27-18-54.json
+++ b/common/changes/@itwin/core-backend/simihartstein-fix-ipc-nested-error-serialization_2026-03-27-18-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Fix nested Error objects losing non-enumerable properties (message, stack) during IPC serialization in IpcHandler",
+      "type": "none",
+      "packageName": "@itwin/core-backend"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IpcHost.ts
+++ b/core/backend/src/IpcHost.ts
@@ -185,20 +185,44 @@ export abstract class IpcHandler {
           visited.add(e);
           try {
             const serialized: any = { ...e };
+
+            for (const sym of Object.getOwnPropertySymbols(serialized))
+              delete serialized[sym]; // symbol-keyed properties cannot be structured-cloned
+
             if (e instanceof Error) {
               serialized.message = e.message; // NB: .message and .stack are non-enumerable on Error instances
               if (includeStack)
                 serialized.stack = e.stack;
+
+              // Error.cause is typically non-enumerable and must be copied explicitly.
+              if (Object.prototype.hasOwnProperty.call(e, "cause"))
+                serialized.cause = (e as { cause?: unknown }).cause;
             }
+
+            if (e instanceof BentleyError) {
+              serialized.iTwinErrorId = e.iTwinErrorId;
+              if (e.hasMetaData)
+                serialized.loggingMetadata = e.loggingMetadata;
+              delete serialized._metaData;
+            }
+
             // Only recurse into Error instances and plain objects — not class instances like Date or Buffer.
             const shouldRecurse = (val: any) => val instanceof Error || (JsonUtils.isObject(val) && Object.getPrototypeOf(val) === Object.prototype);
+            const isSerializableLeaf = (val: unknown): boolean => {
+              const t = typeof val;
+              return val === null || val === undefined || val instanceof Date
+                || t === "string" || t === "number" || t === "boolean";
+            };
             for (const key of Object.keys(serialized)) {
               const val = serialized[key];
               if (Array.isArray(val))
-                serialized[key] = val.map((item) => shouldRecurse(item) ? serializeError(item, includeStack, visited) : item);
+                serialized[key] = val.map((item) => shouldRecurse(item) ? serializeError(item, includeStack, visited) : isSerializableLeaf(item) ? item : undefined);
               else if (shouldRecurse(val))
                 serialized[key] = serializeError(val, includeStack, visited);
+              else if (!isSerializableLeaf(val))
+                delete serialized[key]; // strip non-cloneable values (functions, class instances, etc.)
             }
+
             return serialized;
           } finally {
             // Remove from the stack so a sibling branch can still serialize this object.
@@ -206,15 +230,7 @@ export abstract class IpcHandler {
           }
         };
 
-        const ret = { error: serializeError(err, !IpcHost.noStack) };
-
-        if (err instanceof BentleyError) {
-          ret.error.iTwinErrorId = err.iTwinErrorId;
-          if (err.hasMetaData)
-            ret.error.loggingMetadata = err.loggingMetadata;
-          delete ret.error._metaData;
-        }
-        return ret;
+        return { error: serializeError(err, !IpcHost.noStack) };
       }
     });
   }

--- a/core/backend/src/test/IpcHost.test.ts
+++ b/core/backend/src/test/IpcHost.test.ts
@@ -1,5 +1,6 @@
 import * as sinon from "sinon";
 import { expect } from "chai";
+import { BentleyError, IModelStatus } from "@itwin/core-bentley";
 import { IpcInvokeReturn, IpcSocketBackend } from "@itwin/core-common";
 import { IpcHandler, IpcHost } from "../IpcHost";
 
@@ -7,6 +8,15 @@ interface MockIpcInterface {
   mockMethod: () => string;
   throwNestedError: () => never;
   throwCircularError: () => never;
+  throwErrorWithNativeCause: () => never;
+  throwBentleyErrorWithFunctionMetaData: () => never;
+  throwBentleyErrorWithObjectMetaData: () => never;
+  throwNestedBentleyErrorWithFunctionMetaData: () => never;
+  throwErrorWithFunctionProperty: () => never;
+  throwErrorWithSymbolProperty: () => never;
+  throwErrorWithDateProperty: () => never;
+  throwErrorWithClassInstanceProperty: () => never;
+  throwErrorWithMixedArray: () => never;
 }
 
 class OuterError extends Error {
@@ -34,6 +44,55 @@ class MockIpcHandler extends IpcHandler implements MockIpcInterface {
   public throwCircularError(): never {
     const err = new Error("circular") as any;
     err.cause = err; // circular reference
+    throw err;
+  }
+
+  public throwErrorWithNativeCause(): never {
+    throw new Error("native-cause-outer", { cause: new Error("native-cause-inner") });
+  }
+
+  public throwBentleyErrorWithFunctionMetaData(): never {
+    throw new BentleyError(IModelStatus.BadArg, "bentley-fn-meta", () => ({ detail: "computed" }));
+  }
+
+  public throwBentleyErrorWithObjectMetaData(): never {
+    throw new BentleyError(IModelStatus.BadArg, "bentley-obj-meta", { detail: "static" });
+  }
+
+  public throwNestedBentleyErrorWithFunctionMetaData(): never {
+    const inner = new BentleyError(IModelStatus.BadArg, "inner-bentley", () => ({ detail: "nested-computed" }));
+    const outer = new Error("outer") as any;
+    outer.cause = inner;
+    throw outer;
+  }
+
+  public throwErrorWithFunctionProperty(): never {
+    const err = new Error("fn-prop") as any;
+    err.retry = () => {};
+    throw err;
+  }
+
+  public throwErrorWithSymbolProperty(): never {
+    const err = new Error("sym-prop") as any;
+    err[Symbol("tag")] = "should-be-dropped";
+    throw err;
+  }
+
+  public throwErrorWithDateProperty(): never {
+    const err = new Error("date-prop") as any;
+    err.timestamp = new Date("2024-01-01");
+    throw err;
+  }
+
+  public throwErrorWithClassInstanceProperty(): never {
+    const err = new Error("class-instance-prop") as any;
+    err.request = new URL("https://example.com"); // arbitrary non-plain class instance
+    throw err;
+  }
+
+  public throwErrorWithMixedArray(): never {
+    const err = new Error("mixed-array") as any;
+    err.items = ["string-value", 42, new Date("2024-01-01"), new URL("https://example.com"), new Error("array-error")];
     throw err;
   }
 
@@ -121,6 +180,86 @@ describe("IpcHost", () => {
       const error = ipcReturn.error as any;
       expect(error.message).to.equal("circular");
       expect(error.cause).to.be.undefined;
+    });
+
+    it("should serialize native Error.cause even though it is non-enumerable", async () => {
+      const ipcReturn = await handler(undefined, "throwErrorWithNativeCause");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("native-cause-outer");
+      expect(error.cause).to.not.be.undefined;
+      expect(error.cause.message).to.equal("native-cause-inner");
+      expect(error.cause.stack).to.be.a("string");
+    });
+
+    it("should drop _metaData and expose loggingMetadata when BentleyError has a GetMetaDataFunction", async () => {
+      const ipcReturn = await handler(undefined, "throwBentleyErrorWithFunctionMetaData");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("bentley-fn-meta");
+      // _metaData is a function — must not survive serialization
+      expect(error._metaData).to.be.undefined;
+      // loggingMetadata should be the resolved object
+      expect(error.loggingMetadata).to.deep.equal({ detail: "computed" });
+    });
+
+    it("should drop _metaData and expose loggingMetadata when BentleyError has an object metaData", async () => {
+      const ipcReturn = await handler(undefined, "throwBentleyErrorWithObjectMetaData");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("bentley-obj-meta");
+      expect(error._metaData).to.be.undefined;
+      expect(error.loggingMetadata).to.deep.equal({ detail: "static" });
+    });
+
+    it("should drop function-valued _metaData on a nested BentleyError and still expose loggingMetadata", async () => {
+      const ipcReturn = await handler(undefined, "throwNestedBentleyErrorWithFunctionMetaData");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("outer");
+      // The nested BentleyError inside .cause must also have _metaData stripped and loggingMetadata populated
+      expect(error.cause).to.not.be.undefined;
+      expect(error.cause.message).to.equal("inner-bentley");
+      expect(error.cause._metaData).to.be.undefined;
+      expect(error.cause.loggingMetadata).to.deep.equal({ detail: "nested-computed" });
+    });
+
+    it("should drop arbitrary function-valued properties from a thrown Error", async () => {
+      const ipcReturn = await handler(undefined, "throwErrorWithFunctionProperty");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("fn-prop");
+      expect(error.retry).to.be.undefined;
+    });
+
+    it("should not include symbol-keyed properties from a thrown Error", async () => {
+      const ipcReturn = await handler(undefined, "throwErrorWithSymbolProperty");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("sym-prop");
+      // { ...e } copies enumerable own symbol-keyed properties too.
+      // The serializer explicitly strips them (they cannot be structured-cloned).
+      expect(Object.getOwnPropertySymbols(error)).to.have.length(0);
+    });
+
+    it("should preserve Date properties", async () => {
+      const ipcReturn = await handler(undefined, "throwErrorWithDateProperty");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("date-prop");
+      expect(error.timestamp).to.deep.equal(new Date("2024-01-01"));
+    });
+
+    it("should drop non-plain class instance properties", async () => {
+      const ipcReturn = await handler(undefined, "throwErrorWithClassInstanceProperty");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("class-instance-prop");
+      expect(error.request).to.be.undefined;
+    });
+
+    it("should sanitize mixed arrays: preserve primitives and Dates, drop non-plain class instances, recurse into Errors", async () => {
+      const ipcReturn = await handler(undefined, "throwErrorWithMixedArray");
+      const error = ipcReturn.error as any;
+      expect(error.message).to.equal("mixed-array");
+      expect(Array.isArray(error.items)).to.be.true;
+      expect(error.items[0]).to.equal("string-value");      // primitive: preserved
+      expect(error.items[1]).to.equal(42);                   // primitive: preserved
+      expect(error.items[2]).to.deep.equal(new Date("2024-01-01")); // Date: preserved
+      expect(error.items[3]).to.be.undefined;                // class instance: dropped (→ undefined)
+      expect(error.items[4].message).to.equal("array-error"); // Error: recursed
     });
   });
 });


### PR DESCRIPTION
## Problem

`IpcHandler.register`'s `serializeError` function throws a `DataCloneError` when a backend IPC handler rejects with an error containing non-cloneable values. Two paths trigger this:

1. **Class instances in nested errors** — `serializeError` spreads `{ ...err }` and recurses into `Error` instances and plain objects, but left unrecognized class instances (e.g. `XMLHttpRequest`, `AbortSignal`, `AxiosHeaders` carried by an `AxiosError`) in place. The structured-clone step in `socket.send` then throws `DataCloneError`.

2. **`BentleyError._metaData` on nested errors** — The post-`serializeError` cleanup that strips `_metaData` and promotes `loggingMetadata` only ran on the *top-level* error. Nested `BentleyError`s with a `GetMetaDataFunction` retained the function-valued `_metaData`, causing the same crash.

## Fix

- Add an `isSerializableLeaf` whitelist inside `serializeError` — primitives, `null`, `undefined`, and `Date` pass through; everything else that isn't a recursion target is deleted.
- Move the `BentleyError` → `iTwinErrorId` / `loggingMetadata` / `delete _metaData` logic *inside* `serializeError` so it applies at every depth in the error chain.
- Explicitly copy `Error.cause` (non-enumerable) when present.
- Strip symbol-keyed properties (not structured-cloneable).

## Tests

15 cases in `IpcHost.test.ts` covering nested `Error.cause`, `BentleyError` with `GetMetaDataFunction` at root and nested depth, symbol-keyed property stripping, `Date` preservation, non-plain class instance stripping, mixed-type array sanitization, and circular reference safety.