### PR TITLE
Fix edit scope single-element flickering by retaining stale graphics until edited geometry is ready

### DIFF
--- a/core/frontend/src/internal/tile/DynamicIModelTile.ts
+++ b/core/frontend/src/internal/tile/DynamicIModelTile.ts
@@ -185,6 +185,8 @@ class RootTile extends DynamicIModelTile implements FeatureAppearanceProvider {
  * Its contentId is the element's Id.
  */
 class ElementTile extends Tile {
+  private _staleChildren: GraphicsTile[] = [];
+
   public constructor(parent: RootTile, elementId: Id64String, range: Range3d) {
     super({
       parent,
@@ -196,6 +198,11 @@ class ElementTile extends Tile {
 
     this.loadChildren();
     this.setIsReady();
+  }
+
+  public override [Symbol.dispose](): void {
+    this._disposeStaleChildren();
+    super[Symbol.dispose]();
   }
 
   protected _loadChildren(resolve: (children: Tile[] | undefined) => void, _reject: (error: Error) => void): void {
@@ -283,10 +290,18 @@ class ElementTile extends Tile {
       if (closestMatch) {
         selected.push(closestMatch);
         args.markUsed(closestMatch);
+      } else if (this._staleChildren.length > 0) {
+        // Use a stale graphic from before the geometry update as a fallback while new graphics load.
+        // This prevents the element from flickering out of existence between edits.
+        const stale = this._staleChildren[0];
+        selected.push(stale);
+        args.markUsed(stale);
       }
     } else if (exactMatch.hasGraphics) {
       selected.push(exactMatch);
       args.markUsed(exactMatch);
+      // Fresh graphics are ready — discard stale fallbacks.
+      this._disposeStaleChildren();
     }
   }
 
@@ -296,12 +311,41 @@ class ElementTile extends Tile {
     const radius = 0.5 * this.range.low.distance(this.range.high);
     this.boundingSphere.init(center, radius);
 
-    // Discard out-dated graphics.
     assert(undefined !== this.children);
-    for (const child of this.children)
-      child[Symbol.dispose]();
+
+    if (!IModelApp.tileAdmin.retainStaleDynamicTileChildren) {
+      // Original behavior: discard all children immediately.
+      for (const child of this.children)
+        child[Symbol.dispose]();
+
+      this.children.length = 0;
+      return;
+    }
+
+    // Retain children that have graphics as stale fallbacks so the element remains visible while new graphics load.
+    // Only replace existing stale fallbacks if current children actually have loaded graphics;
+    // otherwise keep the previous stale fallback across rapid updates.
+    const freshGraphics: GraphicsTile[] = [];
+    for (const child of this.children as GraphicsTile[]) {
+      if (child.hasGraphics)
+        freshGraphics.push(child);
+      else
+        child[Symbol.dispose]();
+    }
+
+    if (freshGraphics.length > 0) {
+      this._disposeStaleChildren();
+      this._staleChildren.push(...freshGraphics);
+    }
 
     this.children.length = 0;
+  }
+
+  private _disposeStaleChildren(): void {
+    for (const child of this._staleChildren)
+      child[Symbol.dispose]();
+
+    this._staleChildren.length = 0;
   }
 }
 

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -147,6 +147,10 @@ export class TileAdmin {
   public readonly optimizeBRepProcessing: boolean;
   /** @internal */
   public readonly disablePolyfaceDecimation: boolean;
+  /** When true, dynamic tiles retain stale graphics as fallback during regeneration to prevent flicker.
+   * @internal
+   */
+  public retainStaleDynamicTileChildren: boolean = true;
   /** @internal */
   public readonly useLargerTiles: boolean;
   /** @internal */

--- a/test-apps/display-test-app/public/locales/en/SVTTools.json
+++ b/test-apps/display-test-app/public/locales/en/SVTTools.json
@@ -154,8 +154,14 @@
     "MoveElement": {
       "keyin": "dta move element"
     },
+    "DeformElement": {
+      "keyin": "dta deform element"
+    },
     "SetEditorToolSettings": {
       "keyin": "dta editor settings"
+    },
+    "ToggleStaleChildren": {
+      "keyin": "dta toggle stale children"
     },
     "SyncViewports": {
       "keyin": "dta viewport sync"

--- a/test-apps/display-test-app/src/frontend/App.ts
+++ b/test-apps/display-test-app/src/frontend/App.ts
@@ -31,7 +31,7 @@ import { ApplyModelClipTool } from "./ModelClipTools";
 import { GenerateElementGraphicsTool, GenerateTileContentTool } from "./TileContentTool";
 import { ViewClipByElementGeometryTool } from "./ViewClipByElementGeometryTool";
 import { DisplayTestAppShortcutsUI, DrawingAidTestTool } from "./DrawingAidTestTool";
-import { EditingScopeTool, MoveElementTool, PlaceLineStringTool, SetEditorToolSettingsTool } from "./EditingTools";
+import { EditingScopeTool, MoveElementTool, PlaceLineStringTool, SetEditorToolSettingsTool, DeformElementTool, ToggleStaleChildrenTool } from "./EditingTools";
 import { DynamicClassifierTool, DynamicClipMaskTool } from "./DynamicClassifierTool";
 import { FenceClassifySelectedTool } from "./Fence";
 import { RecordFpsTool } from "./FpsMonitor";
@@ -379,6 +379,7 @@ export class DisplayTestApp {
       DisableModelTransformsTool,
       DockWindowTool,
       DrawingAidTestTool,
+      DeformElementTool,
       EditingScopeTool,
       ExitTool,
       FenceClassifySelectedTool,
@@ -423,6 +424,7 @@ export class DisplayTestApp {
       TextDecorationTool,
       ToggleAspectRatioSkewDecoratorTool,
       ToggleSecondaryIModelTool,
+      ToggleStaleChildrenTool,
       TimePointComparisonTool,
       ToggleShadowMapTilesTool,
       ViewClipByElementGeometryTool,

--- a/test-apps/display-test-app/src/frontend/EditingTools.ts
+++ b/test-apps/display-test-app/src/frontend/EditingTools.ts
@@ -3,12 +3,13 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { CompressedId64Set, Id64String } from "@itwin/core-bentley";
+import { BentleyError, CompressedId64Set, Id64String } from "@itwin/core-bentley";
 import {
-  Code, ElementGeometry, FlatBufferGeometryStream, GeometricElementProps, GeometryStreamProps, PlacementProps,
+  Code, ElementGeometry, ElementGeometryDataEntry, FlatBufferGeometryStream, GeometricElementProps, GeometryStreamProps, PlacementProps,
 } from "@itwin/core-common";
 import {
-  AccuDrawHintBuilder, BeButton, BeButtonEvent, BriefcaseConnection, DecorateContext, GraphicType, HitDetail, IModelApp,
+  AccuDrawHintBuilder, BeButton, BeButtonEvent, BriefcaseConnection, DecorateContext, EventHandled, GraphicType, HitDetail, IModelApp,
+  NotifyMessageDetails, OutputMessagePriority, PrimitiveTool,
   Tool, ToolAssistance, ToolAssistanceImage, ToolAssistanceInputMethod, ToolAssistanceInstruction,
   ToolAssistanceSection,
 } from "@itwin/core-frontend";
@@ -19,6 +20,24 @@ import { setTitle } from "./Title";
 import { parseArgs } from "@itwin/frontend-devtools";
 
 // Simple tools for testing interactive editing. They require the iModel to have been opened in read-write mode.
+
+/** Toggles whether dynamic tiles retain stale children as visual fallback during regeneration.
+ * When enabled (default), prevents flicker but shows slightly stale graphics during edits.
+ * When disabled, exhibits the original flicker behavior.
+ */
+export class ToggleStaleChildrenTool extends Tool {
+  public static override toolId = "ToggleStaleChildren";
+  public static override get minArgs() { return 0; }
+  public static override get maxArgs() { return 0; }
+
+  public override async run(): Promise<boolean> {
+    const ta = IModelApp.tileAdmin as any;
+    ta.retainStaleDynamicTileChildren = !ta.retainStaleDynamicTileChildren;
+    const state = ta.retainStaleDynamicTileChildren ? "ON (no flicker)" : "OFF (original flicker)";
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, `Retain stale dynamic tile children: ${state}`));
+    return true;
+  }
+}
 
 /** If an editing scope is currently in progress, end it; otherwise, begin a new one. */
 export class EditingScopeTool extends Tool {
@@ -315,5 +334,149 @@ export class SetEditorToolSettingsTool extends Tool {
     }
 
     return true;
+  }
+}
+
+/** Interactively modifies the geometry stream of selected elements by dragging.
+ * Unlike MoveElementTool (which only changes placement), this rewrites the GeometryStream
+ * on every mouse motion — continuously committing changes so that dynamic tiles must
+ * regenerate in real time. This exercises the code path that causes flicker.
+ *
+ * Usage: Select element(s), run "dta deform element", click anchor point, move mouse to
+ * continuously deform. Click or reset to stop.
+ */
+export class DeformElementTool extends PrimitiveTool {
+  public static override toolId = "DeformElement";
+  public static override get minArgs() { return 0; }
+  public static override get maxArgs() { return 0; }
+
+  private _anchorPoint?: Point3d;
+  private _originalGeometry = new Map<Id64String, ElementGeometryDataEntry[]>();
+  private _elementIds: Id64String[] = [];
+  private _updating = false;
+  private _pendingPoint?: Point3d;
+
+  public override requireWriteableTarget(): boolean { return true; }
+
+  public override async onPostInstall(): Promise<void> {
+    await super.onPostInstall();
+
+    const imodel = this.iModel;
+    if (!imodel.isBriefcaseConnection()) {
+      await this.exitTool();
+      return;
+    }
+
+    this._elementIds = Array.from(imodel.selectionSet.elements);
+    if (this._elementIds.length === 0) {
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Warning, "DeformElement: select element(s) first"));
+      await this.exitTool();
+      return;
+    }
+
+    // Cache original geometry for all selected elements.
+    await startCommand(imodel);
+    for (const id of this._elementIds) {
+      const geomInfo = await basicManipulationIpc.requestElementGeometry(id);
+      if (geomInfo)
+        this._originalGeometry.set(id, geomInfo.entryArray);
+    }
+
+    if (this._originalGeometry.size === 0) {
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Warning, "DeformElement: no geometry found"));
+      await this.exitTool();
+      return;
+    }
+
+    IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info,
+      `DeformElement: click anchor point (${this._originalGeometry.size} element(s))`));
+  }
+
+  public override async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
+    if (!this._anchorPoint) {
+      this._anchorPoint = ev.point.clone();
+      IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, "DeformElement: move mouse to deform, click or reset to stop"));
+      return EventHandled.Yes;
+    }
+
+    // Second click — apply final position and restart.
+    await this._applyTransform(ev.point);
+    await this.onReinitialize();
+    return EventHandled.Yes;
+  }
+
+  public override async onMouseMotion(ev: BeButtonEvent): Promise<void> {
+    if (!this._anchorPoint)
+      return;
+
+    if (this._updating) {
+      // Capture latest position so we apply it when the current update finishes.
+      this._pendingPoint = ev.point.clone();
+      return;
+    }
+
+    await this._applyTransform(ev.point);
+  }
+
+  public override async onResetButtonUp(_ev: BeButtonEvent): Promise<EventHandled> {
+    await this.onReinitialize();
+    return EventHandled.Yes;
+  }
+
+  private async _applyTransform(currentPoint: Point3d): Promise<void> {
+    if (!this._anchorPoint || this._updating)
+      return;
+
+    this._updating = true;
+    try {
+      const offset = currentPoint.minus(this._anchorPoint);
+      const transform = Transform.createTranslationXYZ(offset.x, offset.y, offset.z);
+      const imodel = this.iModel;
+      if (!imodel.isBriefcaseConnection())
+        return;
+
+      await startCommand(imodel);
+      for (const [id, originalEntries] of this._originalGeometry) {
+        const newEntries = DeformElementTool._transformEntries(originalEntries, transform);
+        if (newEntries)
+          await basicManipulationIpc.updateGeometricElement(id, { entryArray: newEntries });
+      }
+      await basicManipulationIpc.saveChanges(DeformElementTool.toolId);
+    } finally {
+      this._updating = false;
+    }
+
+    // If mouse moved while we were busy, immediately apply the latest position.
+    const pending = this._pendingPoint;
+    if (pending) {
+      this._pendingPoint = undefined;
+      await this._applyTransform(pending);
+    }
+  }
+
+  private static _transformEntries(entryArray: ElementGeometryDataEntry[], transform: Transform): ElementGeometryDataEntry[] | undefined {
+    const builder = new ElementGeometry.Builder();
+    let anyTransformed = false;
+
+    for (const entry of entryArray) {
+      const geom = ElementGeometry.toGeometryQuery(entry);
+      if (geom) {
+        const cloned = geom.clone();
+        if (cloned && cloned.tryTransformInPlace(transform)) {
+          builder.appendGeometryQuery(cloned);
+          anyTransformed = true;
+          continue;
+        }
+      }
+      builder.entries.push(entry);
+    }
+
+    return anyTransformed ? builder.entries : undefined;
+  }
+
+  public override async onRestartTool(): Promise<void> {
+    const tool = new DeformElementTool();
+    if (!await tool.run())
+      return this.exitTool();
   }
 }

--- a/test-apps/display-test-app/src/frontend/openIModel.ts
+++ b/test-apps/display-test-app/src/frontend/openIModel.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { BentleyError, GuidString, IModelStatus, ProcessDetector } from "@itwin/core-bentley";
+import { BentleyError, GuidString, IModelStatus, OpenMode, ProcessDetector } from "@itwin/core-bentley";
 import { BriefcaseDownloader, IModelError, LocalBriefcaseProps, SyncMode } from "@itwin/core-common";
 import { BriefcaseConnection, DownloadBriefcaseOptions, IModelConnection, NativeApp, SnapshotConnection } from "@itwin/core-frontend";
 import { getConfigurationBoolean } from "./DisplayTestApp";
@@ -70,10 +70,13 @@ export async function openIModel(props: OpenIModelProps): Promise<IModelConnecti
 }
 
 async function openIModelFile(fileName: string, writable: boolean): Promise<IModelConnection> {
+  if (writable)
+    return BriefcaseConnection.openStandalone(fileName, OpenMode.ReadWrite, { key: fileName });
+
   try {
-    return await BriefcaseConnection.openFile({ fileName, readonly: !writable, key: fileName });
+    return await BriefcaseConnection.openFile({ fileName, readonly: true, key: fileName });
   } catch (err) {
-    if (writable && err instanceof IModelError && err.errorNumber === IModelStatus.ReadOnly)
+    if (err instanceof IModelError && err.errorNumber === IModelStatus.ReadOnly)
       return SnapshotConnection.openFile(fileName);
     else
       throw err;


### PR DESCRIPTION
## Problem

When an element's geometry is modified during a GraphicalEditingScope, the dynamic tile system immediately discards the old graphics and requests new ones. Until the new graphics arrive (which requires tile generation), the element disappears for one or more frames, causing a visible flicker. This is especially noticeable during rapid/continuous edits of complex geometry where new geometry changes arrive before previous tile requests complete.

## Solution

When an ElementTile's geometry is updated, retain children that have loaded graphics as stale fallbacks instead of disposing them. During tile selection, fall back to a stale child when no current match is available. Dispose stale children once fresh graphics arrive. When edits arrive faster than graphics can load, preserve the existing stale fallback rather than discarding it.

WIP: The behavior is gated by TileAdmin.retainStaleDynamicTileChildren (`@internal`, default true) so it can be toggled at runtime for comparison testing. **Not proposing this become a permanent toggle! Just for testing this PR!**

## DTA tooling

 - `dta deform element`: New interactive PrimitiveTool that continuously rewrites the GeometryStream of selected elements on every mouse motion (not just placement transform). This exercises the exact code path that triggers flicker — select elements, click an anchor point, then move the mouse to see continuous geometry commits.
 - `dta toggle stale children`: Toggles the retainStaleDynamicTileChildren flag on/off to A/B compare the old (flicker) vs new (stale fallback) behavior.
 - openIModel.ts: Use BriefcaseConnection.openStandalone for writable mode to support editing tools.

## Tradeoffs

With the fix enabled, there is a visual lag — the stale graphic shows the element at its previous committed position until the new graphic loads. This is an inherent tradeoff vs. the element disappearing entirely. The toggle keyin makes it easy to compare both behaviors.

## Dataset / Repro Steps

Download testcase: [flicker-test-simple-orig.bim.zip](https://github.com/user-attachments/files/26798951/flicker-test-simple-orig.bim.zip)

1. `cd test-apps/display-test-app`
1. `export IMJS_READ_WRITE=1`
1. `npm run start`
1. Open above bim file.
1. In keyin field: `dta edit`
1. Select an element.
1. In keyin field `dta deform element`. Click element. Begin dragging it around.
1. Observe no flickering, but a bit of delay.
1. Right click to stop
1. In keyin field: `dta toggle stale children`
1. Select an element.
1. In keyin field `dta deform element`. Click element. Begin dragging it around.
1. Observe lots of flickering.

## Videos

The flickering:

https://github.com/user-attachments/assets/700c52c5-c1ed-4fb4-a099-44a15e20531c

Avoiding the flickering using this PR's approach:

https://github.com/user-attachments/assets/5cd33db1-6cea-4ad2-961d-065a8a86f2ad
