### PR TITLE
Improve `Id64.iterable` performance

### DIFF
--- a/common/changes/@itwin/core-bentley/JonasD-iterable-perf-improvement_2026-04-24-09-34.json
+++ b/common/changes/@itwin/core-bentley/JonasD-iterable-perf-improvement_2026-04-24-09-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Improved `Id64.iterable` performance >10x.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/core/bentley/src/Id.ts
+++ b/core/bentley/src/Id.ts
@@ -366,9 +366,7 @@ export namespace Id64 {
    * ```
    */
   export function iterable(ids: Id64Arg): Iterable<Id64String> {
-    return {
-      [Symbol.iterator]: () => iterator(ids),
-    };
+    return typeof ids === "string" ? [ids] : ids;
   }
 
   /** Return the first [[Id64String]] of an [[Id64Arg]]. */


### PR DESCRIPTION
Benchmark: https://jsbm.dev/L3r4M8cHvQLZS