### PR TITLE
fix(@itwin/build-tools): remediate CVE vulnerabilities in transitive deps

### DIFF
--- a/common/changes/@itwin/build-tools/hoangnamle-fix-cve-build-tools-deps_2026-04-24-16-35.json
+++ b/common/changes/@itwin/build-tools/hoangnamle-fix-cve-build-tools-deps_2026-04-24-16-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update @microsoft/api-extractor to ~7.58.7 (removes lodash CVE GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh). Tighten serialize-javascript globalOverride to ^7.0.5 (GHSA-5c6j-r48x-rmvq, GHSA-qj8w-gfj5-8c6v).",
+      "type": "none",
+      "packageName": "@itwin/build-tools"
+    }
+  ],
+  "packageName": "@itwin/build-tools",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/common/changes/@itwin/build-tools/hoangnamle-fix-cve-build-tools-deps_2026-04-24-16-35.json
+++ b/common/changes/@itwin/build-tools/hoangnamle-fix-cve-build-tools-deps_2026-04-24-16-35.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update @microsoft/api-extractor to ~7.58.7 (removes lodash CVE GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh). Tighten serialize-javascript globalOverride to ^7.0.5 (GHSA-5c6j-r48x-rmvq, GHSA-qj8w-gfj5-8c6v).",
+      "comment": "Update @microsoft/api-extractor to ~7.58.7 (removes lodash CVE GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh).",
       "type": "none",
       "packageName": "@itwin/build-tools"
     }

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -17,7 +17,7 @@
     "browserslist": "latest", // https://github.com/browserslist/update-db#readme
     "glob@>=11.0.0 <11.1.0": "^11.1.0", // https://github.com/advisories/GHSA-5j98-mcp5-4vw2 cpx2>glob
     "axios@<1.0.0": "^1.13.5", // https://github.com/advisories/GHSA-43fc-jf86-j433
-    "serialize-javascript": "^7.0.3", // https://github.com/advisories/GHSA-5c6j-r48x-rmvq mocha>serialize-javascript (related to CVE-2020-7660)
+    "serialize-javascript": "^7.0.5", // https://github.com/advisories/GHSA-5c6j-r48x-rmvq https://github.com/advisories/GHSA-qj8w-gfj5-8c6v mocha>serialize-javascript
     "lodash@>=4.0.0 <=4.17.23": "^4.18.0" // https://github.com/advisories/GHSA-r5fr-rjxr-66jc api-extractor>lodash, node-simctl>asyncbox>lodash, etc.
   },
   // A list of temporary advisories excluded from the High and Critical list.

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -17,7 +17,7 @@
     "browserslist": "latest", // https://github.com/browserslist/update-db#readme
     "glob@>=11.0.0 <11.1.0": "^11.1.0", // https://github.com/advisories/GHSA-5j98-mcp5-4vw2 cpx2>glob
     "axios@<1.0.0": "^1.13.5", // https://github.com/advisories/GHSA-43fc-jf86-j433
-    "serialize-javascript": "^7.0.5", // https://github.com/advisories/GHSA-5c6j-r48x-rmvq https://github.com/advisories/GHSA-qj8w-gfj5-8c6v mocha>serialize-javascript
+    "serialize-javascript": "^7.0.5", // https://github.com/advisories/GHSA-5c6j-r48x-rmvq and https://github.com/advisories/GHSA-qj8w-gfj5-8c6v mocha>serialize-javascript
     "lodash@>=4.0.0 <=4.17.23": "^4.18.0" // https://github.com/advisories/GHSA-r5fr-rjxr-66jc api-extractor>lodash, node-simctl>asyncbox>lodash, etc.
   },
   // A list of temporary advisories excluded from the High and Critical list.

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   browserslist: latest
   glob@>=11.0.0 <11.1.0: ^11.1.0
   axios@<1.0.0: ^1.13.5
-  serialize-javascript: ^7.0.3
+  serialize-javascript: ^7.0.5
   lodash@>=4.0.0 <=4.17.23: ^4.18.0
 
 pnpmfileChecksum: sha256-E1T7OJ3DLTjpDqf4RdJzK9VDtAxgm4gDEQCLYdHD8nI=
@@ -4131,8 +4131,8 @@ importers:
   ../../tools/build:
     dependencies:
       '@microsoft/api-extractor':
-        specifier: ~7.57.6
-        version: 7.57.6(@types/node@20.17.0)
+        specifier: ~7.58.7
+        version: 7.58.7(@types/node@20.17.0)
       chalk:
         specifier: ^3.0.0
         version: 3.0.0
@@ -5357,11 +5357,11 @@ packages:
     peerDependencies:
       '@loaders.gl/core': ^4.3.0
 
-  '@microsoft/api-extractor-model@7.33.4':
-    resolution: {integrity: sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==}
+  '@microsoft/api-extractor-model@7.33.8':
+    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
 
-  '@microsoft/api-extractor@7.57.6':
-    resolution: {integrity: sha512-0rFv/D8Grzw1Mjs2+8NGUR+o4h9LVm5zKRtMeWnpdB5IMJF4TeHCL1zR5LMCIudkOvyvjbhMG5Wjs0B5nqsrRQ==}
+  '@microsoft/api-extractor@7.58.7':
+    resolution: {integrity: sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==}
     hasBin: true
 
   '@microsoft/applicationinsights-web-snippet@1.0.1':
@@ -5687,8 +5687,8 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@rushstack/node-core-library@5.20.3':
-    resolution: {integrity: sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==}
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -5703,19 +5703,19 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/rig-package@0.7.2':
-    resolution: {integrity: sha512-9XbFWuqMYcHUso4mnETfhGVUSaADBRj6HUAAEYk50nMPn8WRICmBuCphycQGNB3duIR6EEZX3Xj3SYc2XiP+9A==}
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
 
-  '@rushstack/terminal@0.22.3':
-    resolution: {integrity: sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==}
+  '@rushstack/terminal@0.24.0':
+    resolution: {integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/ts-command-line@5.3.3':
-    resolution: {integrity: sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==}
+  '@rushstack/ts-command-line@5.3.9':
+    resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
 
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
@@ -9825,11 +9825,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -11986,28 +11981,27 @@ snapshots:
     dependencies:
       '@loaders.gl/core': 4.3.4
 
-  '@microsoft/api-extractor-model@7.33.4(@types/node@20.17.0)':
+  '@microsoft/api-extractor-model@7.33.8(@types/node@20.17.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@20.17.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@20.17.0)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.57.6(@types/node@20.17.0)':
+  '@microsoft/api-extractor@7.58.7(@types/node@20.17.0)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.4(@types/node@20.17.0)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@20.17.0)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@20.17.0)
-      '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.3(@types/node@20.17.0)
-      '@rushstack/ts-command-line': 5.3.3(@types/node@20.17.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@20.17.0)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.0(@types/node@20.17.0)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@20.17.0)
       diff: 8.0.4
-      lodash: 4.18.1
       minimatch: 10.2.5
       resolve: 1.22.12
-      semver: 7.5.4
+      semver: 7.7.4
       source-map: 0.6.1
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -12267,7 +12261,7 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rushstack/node-core-library@5.20.3(@types/node@20.17.0)':
+  '@rushstack/node-core-library@5.23.1(@types/node@20.17.0)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -12276,7 +12270,7 @@ snapshots:
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.12
-      semver: 7.5.4
+      semver: 7.7.4
     optionalDependencies:
       '@types/node': 20.17.0
 
@@ -12284,22 +12278,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.0
 
-  '@rushstack/rig-package@0.7.2':
+  '@rushstack/rig-package@0.7.3':
     dependencies:
+      jju: 1.4.0
       resolve: 1.22.12
-      strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.22.3(@types/node@20.17.0)':
+  '@rushstack/terminal@0.24.0(@types/node@20.17.0)':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3(@types/node@20.17.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@20.17.0)
       '@rushstack/problem-matcher': 0.2.1(@types/node@20.17.0)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.17.0
 
-  '@rushstack/ts-command-line@5.3.3(@types/node@20.17.0)':
+  '@rushstack/ts-command-line@5.3.9(@types/node@20.17.0)':
     dependencies:
-      '@rushstack/terminal': 0.22.3(@types/node@20.17.0)
+      '@rushstack/terminal': 0.24.0(@types/node@20.17.0)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -17059,10 +17053,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.5.2:
-    dependencies:
-      lru-cache: 6.0.0
-
-  semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
 

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -30,7 +30,7 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
-    "@microsoft/api-extractor": "~7.57.6",
+    "@microsoft/api-extractor": "~7.58.7",
     "chalk": "^3.0.0",
     "cpx2": "^8.0.0",
     "cross-spawn": "^7.0.5",


### PR DESCRIPTION
Partially addresses #9232

## Why

External consumers of the published `@itwin/build-tools` npm package encounter 4 CVE audit alerts on install. Two affect `serialize-javascript` (via `mocha`) — a high-severity RCE ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq), patched ≥7.0.3) and a moderate DoS ([GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v), patched ≥7.0.5). Two affect `lodash` (via `@microsoft/api-extractor`) — a high-severity code injection ([GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc)) and a moderate prototype pollution ([GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh)), both patched ≥4.18.0.

The monorepo itself never surfaces these because `pnpm-config.json` `globalOverrides` force-install patched versions during development. Those overrides are not part of the published package, so any project that installs `@itwin/build-tools` inherits the vulnerable versions.

The `serialize-javascript` advisories cannot be fully eliminated from the published package at this time — `mocha@11.x` still pins `serialize-javascript@^6.0.2` and has not shipped a fix upstream. The longer-term resolution is the ongoing migration off Mocha entirely: see #9094 (Migrate full-stack-tests/core from Certa+Mocha+webpack to Vitest via vitest-certa-bridge).

## What

| Asset | Why it exists |
|---|---|
| `tools/build/package.json` (dep bump) | `@microsoft/api-extractor@7.57.x` depends on `lodash ~4.17.23` (vulnerable); bumping to `7.58.x` drops lodash entirely, fixing both lodash CVEs at the source rather than relying on the pre-existing monorepo-level override. |
| `common/config/rush/pnpm-config.json` (override tighten) | `mocha@11.x` still pins `serialize-javascript@^6.0.2` with no upstream fix; tightening the existing override from `^7.0.3` to `^7.0.5` covers both the RCE and DoS advisories. The pre-existing `lodash@>=4.0.0 <=4.17.23: ^4.18.0` override is unchanged — it remains necessary for `node-simctl` (declares `lodash: ^4.2.1`, which resolves to the vulnerable `4.17.21` without the override) and other consumers. |

Lockfile regenerated via `rush update`; changelog entry added for `@itwin/build-tools`.

## Validation

- Targeted verification: `rush audit` passes with no high/critical vulnerabilities after these changes.
- Known limitation: the `serialize-javascript` fix applies only within the monorepo — downstream consumers must add their own `pnpm` override until mocha bumps their dep upstream or the migration to Vitest (#9094) lands.

After merge: `@Mergifyio backport release/5.8.x`