### PR TITLE
Add imodel_geom_stream virtual table for GeometryStream decomposition

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4283,6 +4283,8 @@ export class IModelHost {
     static get isValid(): boolean;
     static get logTileLoadTimeThreshold(): number;
     static get logTileSizeThreshold(): number;
+    // @beta
+    static get maxGeomStreamVTabBytes(): number;
     static readonly onAfterStartup: BeEvent<() => void>;
     static readonly onBeforeShutdown: BeEvent<() => void>;
     static readonly onWorkspaceStartup: BeEvent<() => void>;
@@ -4336,6 +4338,8 @@ export class IModelHostConfiguration implements IModelHostOptions {
     static defaultLogTileLoadTimeThreshold: number;
     // (undocumented)
     static defaultLogTileSizeThreshold: number;
+    // @beta
+    static defaultMaxGeomStreamVTabBytes: number;
     // @internal (undocumented)
     static defaultMaxTileCacheDbSize: number;
     // (undocumented)
@@ -4390,6 +4394,8 @@ export interface IModelHostOptions {
     logTileLoadTimeThreshold?: number;
     // @internal
     logTileSizeThreshold?: number;
+    // @beta
+    maxGeomStreamVTabBytes?: number;
     // @beta
     maxTileCacheDbSize?: number;
     // @beta

--- a/common/changes/@itwin/core-backend/affan.khan-geom-stream-vtab-and-scalar-fns_2026-04-24-22-00.json
+++ b/common/changes/@itwin/core-backend/affan.khan-geom-stream-vtab-and-scalar-fns_2026-04-24-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add imodel_geom_stream virtual table for GeometryStream decomposition",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -155,6 +155,13 @@ export interface IModelHostOptions {
    */
   maxTileCacheDbSize?: number;
 
+  /** The process-wide maximum uncompressed GeometryStream size in bytes that the `dgn_geom_stream` virtual table will decompose.
+   * Blobs exceeding this limit are silently skipped (the vtab returns zero rows for them).
+   * Defaults to 50 MB. Minimum enforced by native layer: 4 KB.
+   * @beta
+   */
+  maxGeomStreamVTabBytes?: number;
+
   /** Whether to restrict tile cache URLs by client IP address (if available).
    * @beta
    */
@@ -249,6 +256,10 @@ export class IModelHostConfiguration implements IModelHostOptions {
   public static defaultLogTileSizeThreshold = 20 * 1000000;
   /** @internal */
   public static defaultMaxTileCacheDbSize = 1024 * 1024 * 1024;
+  /** Default maximum uncompressed GeometryStream size (50 MB) for the `dgn_geom_stream` virtual table.
+   * @beta
+   */
+  public static defaultMaxGeomStreamVTabBytes = 50 * 1024 * 1024;
   public appAssetsDir?: LocalDirName;
   public cacheDir?: LocalDirName;
 
@@ -669,6 +680,7 @@ export class IModelHost {
 
     this.configuration = otherOptions;
     this.setupTileCache();
+    IModelNative.platform.setMaxGeomStreamVTabBytes(otherOptions.maxGeomStreamVTabBytes ?? IModelHostConfiguration.defaultMaxGeomStreamVTabBytes);
 
     process.once("beforeExit", IModelHost.shutdown);
     this.onAfterStartup.raiseEvent();
@@ -796,6 +808,16 @@ export class IModelHost {
    */
   public static get useSemanticRebase(): boolean {
     return undefined !== IModelHost.configuration && (IModelHost.configuration.useSemanticRebase ? true : false);
+  }
+
+  /**
+   * The current process-wide maximum uncompressed GeometryStream size in bytes that the `dgn_geom_stream`
+   * virtual table will decompose. Blobs exceeding this limit are silently skipped.
+   * @see [[IModelHostOptions.maxGeomStreamVTabBytes]]
+   * @beta
+   */
+  public static get maxGeomStreamVTabBytes(): number {
+    return IModelNative.platform.getMaxGeomStreamVTabBytes();
   }
 
   private static setupTileCache() {

--- a/core/backend/src/IModelHost.ts
+++ b/core/backend/src/IModelHost.ts
@@ -256,7 +256,7 @@ export class IModelHostConfiguration implements IModelHostOptions {
   public static defaultLogTileSizeThreshold = 20 * 1000000;
   /** @internal */
   public static defaultMaxTileCacheDbSize = 1024 * 1024 * 1024;
-  /** Default maximum uncompressed GeometryStream size (50 MB) for the `dgn_geom_stream` virtual table.
+  /** Default maximum uncompressed GeometryStream size (50 MB) for the `imodel_geom_stream` virtual table.
    * @beta
    */
   public static defaultMaxGeomStreamVTabBytes = 50 * 1024 * 1024;

--- a/core/backend/src/test/standalone/GeomStreamVTab.test.ts
+++ b/core/backend/src/test/standalone/GeomStreamVTab.test.ts
@@ -1,0 +1,600 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { assert, expect } from "chai";
+import { Arc3d, LineString3d, Point3d, Sphere, YawPitchRollAngles } from "@itwin/core-geometry";
+import {
+  Code, ColorByName, ColorDef, GeometryClass, GeometryParams,
+  GeometryPartProps, GeometryStreamBuilder, IModel, PhysicalElementProps, QueryBinder, QueryRowFormat,
+} from "@itwin/core-common";
+import { EditTxn } from "../../EditTxn";
+import {
+  ECSqlSyncReader, GeometricElement, GeometryPart, IModelHost, IModelHostConfiguration, PhysicalObject, SnapshotDb,
+} from "../../core-backend";
+import { IModelNative } from "../../internal/NativePlatform";
+import { IModelTestUtils } from "../IModelTestUtils";
+
+/** Helpers to create test elements --------------------------------------------------------- */
+
+function insertElement(imodel: SnapshotDb, txn: EditTxn, geom: GeometryStreamBuilder["geometryStream"], placement = { origin: Point3d.createZero(), angles: YawPitchRollAngles.createDegrees(0, 0, 0) }): string {
+  // 0x1d is a known PhysicalObject in CompatibilityTestSeed.bim
+  const seedElem = imodel.elements.getElement<GeometricElement>("0x1d");
+  const props: PhysicalElementProps = {
+    classFullName: PhysicalObject.classFullName,
+    model: seedElem.model,
+    category: seedElem.category,
+    code: Code.createEmpty(),
+    geom,
+    placement,
+  };
+  return txn.insertElement(props);
+}
+
+function insertPart(txn: EditTxn, geom: GeometryStreamBuilder["geometryStream"]): string {
+  const props: GeometryPartProps = {
+    classFullName: GeometryPart.classFullName,
+    model: IModel.dictionaryId,
+    code: Code.createEmpty(),
+    geom,
+  };
+  return txn.insertElement(props);
+}
+
+/** Collect all rows from imodel_geom_stream for a specific element */
+function queryGeomStreamRows(imodel: SnapshotDb, elemId: string): Record<string, unknown>[] {
+  const ecsql = `
+    SELECT gs.EntryIndex, gs.OpCode, gs.EntryType, gs.IsGeometry,
+           gs.SubCategoryId, gs.Color, gs.Weight, gs.GeomClass,
+           gs.RangeLowX, gs.RangeLowY, gs.RangeLowZ,
+           gs.RangeHighX, gs.RangeHighY, gs.RangeHighZ,
+           gs.HeaderFlags,
+           gs.GeometryPartId, gs.PartOriginX, gs.PartOriginY, gs.PartOriginZ,
+           gs.TextContent, gs.GeometryBlob
+    FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+    WHERE e.ECInstanceId = ?
+    ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+  const params = new QueryBinder().bindId(1, elemId);
+  return imodel.withQueryReader(ecsql, (reader: ECSqlSyncReader) => reader.toArray(), params, { rowFormat: QueryRowFormat.UseJsPropertyNames });
+}
+
+/** Same query for a GeometryPart */
+function queryPartGeomStreamRows(imodel: SnapshotDb, partId: string): Record<string, unknown>[] {
+  const ecsql = `
+    SELECT gs.EntryIndex, gs.OpCode, gs.EntryType, gs.IsGeometry,
+           gs.GeometryBlob
+    FROM BisCore.GeometryPart p, imodel_geom_stream(p.GeometryStream) gs
+    WHERE p.ECInstanceId = ?
+    ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+  const params = new QueryBinder().bindId(1, partId);
+  return imodel.withQueryReader(ecsql, (reader: ECSqlSyncReader) => reader.toArray(), params, { rowFormat: QueryRowFormat.UseJsPropertyNames });
+}
+
+/** ------------------------------------------------------------------------------------------
+ * Tests
+ * ------------------------------------------------------------------------------------------ */
+describe("GeomStreamVTab", () => {
+  let imodel: SnapshotDb;
+  let txn: EditTxn;
+
+  before(() => {
+    const seedFileName = IModelTestUtils.resolveAssetFile("CompatibilityTestSeed.bim");
+    const testFileName = IModelTestUtils.prepareOutputFile("GeomStreamVTab", "GeomStreamVTabTest.bim");
+    imodel = IModelTestUtils.createSnapshotFromSeed(testFileName, seedFileName);
+    imodel.channels.addAllowedChannel("shared");
+    txn = new EditTxn(imodel, "geom stream vtab test");
+    txn.start();
+  });
+
+  after(() => {
+    if (txn.isActive)
+      txn.end("abandon");
+    imodel.close();
+  });
+
+  // ─── maxGeomStreamVTabBytes: IModelHost getter / startup option ─────────────
+
+  it("IModelHost.maxGeomStreamVTabBytes reflects default value", () => {
+    const defaultBytes = IModelHostConfiguration.defaultMaxGeomStreamVTabBytes;
+    expect(defaultBytes).to.equal(50 * 1024 * 1024); // 50 MB
+    // After startup the native value should match the default
+    expect(IModelHost.maxGeomStreamVTabBytes).to.equal(defaultBytes);
+  });
+
+  it("setMaxGeomStreamVTabBytes round-trips through native layer", () => {
+    const original = IModelHost.maxGeomStreamVTabBytes;
+    const newValue = 8 * 1024 * 1024; // 8 MB
+    IModelNative.platform.setMaxGeomStreamVTabBytes(newValue);
+    expect(IModelHost.maxGeomStreamVTabBytes).to.equal(newValue);
+
+    // Restore
+    IModelNative.platform.setMaxGeomStreamVTabBytes(original);
+    expect(IModelHost.maxGeomStreamVTabBytes).to.equal(original);
+  });
+
+  it("minimum size of 4 KB is enforced by the native layer", () => {
+    const original = IModelHost.maxGeomStreamVTabBytes;
+
+    // Request something below 4 KB — native enforces minimum 4 KB
+    IModelNative.platform.setMaxGeomStreamVTabBytes(1);
+    expect(IModelHost.maxGeomStreamVTabBytes).to.be.greaterThanOrEqual(4096);
+
+    IModelNative.platform.setMaxGeomStreamVTabBytes(original);
+  });
+
+  // ─── single-geometry elements ────────────────────────────────────────────────
+
+  it("arc element: vtab yields one geometry row with correct OpCode and GeometryBlob", () => {
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 5));
+    const elemId = insertElement(imodel, txn, builder.geometryStream);
+    txn.saveChanges();
+
+    const rows = queryGeomStreamRows(imodel, elemId);
+    const geomRows = rows.filter((r) => r.isGeometry === 1);
+    expect(geomRows.length).to.equal(1, "should have exactly one geometry row");
+
+    const [row] = geomRows;
+    expect(row.opCode).to.be.a("string");
+    expect(row.entryType).to.be.a("string");
+    expect(row.isGeometry).to.equal(1);
+    // GeometryBlob must be present — it is the flatbuffer-encoded primitive
+    assert.isOk(row.geometryBlob, "GeometryBlob should be present for arc geometry");
+    // RangeHigh/RangeLow columns come from SubGraphicRange opcodes which simple arcs do not emit;
+    // they are NULL and correctly undefined here. No range assertion needed.
+  });
+
+  it("sphere element: vtab yields one geometry row with a GeometryBlob", () => {
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 3));
+    const elemId = insertElement(imodel, txn, builder.geometryStream);
+    txn.saveChanges();
+
+    const rows = queryGeomStreamRows(imodel, elemId);
+    const geomRows = rows.filter((r) => r.isGeometry === 1);
+    expect(geomRows.length).to.equal(1, "should have exactly one geometry row");
+
+    const [row] = geomRows;
+    expect(row.opCode).to.be.a("string");
+    assert.isOk(row.geometryBlob, "GeometryBlob should be present for sphere geometry");
+    // SubGraphicRange is not emitted for simple solids, so range columns are NULL (undefined).
+  });
+
+  it("line-string element: vtab yields one geometry row", () => {
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(LineString3d.create([Point3d.create(0, 0, 0), Point3d.create(10, 0, 0), Point3d.create(10, 10, 0)]));
+    const elemId = insertElement(imodel, txn, builder.geometryStream);
+    txn.saveChanges();
+
+    const rows = queryGeomStreamRows(imodel, elemId);
+    const geomRows = rows.filter((r) => r.isGeometry === 1);
+    expect(geomRows.length).to.equal(1);
+  });
+
+  // ─── symbology changes ────────────────────────────────────────────────────────
+
+  it("element with explicit symbology: vtab rows capture SubCategoryId and Weight", () => {
+    const seedElem = imodel.elements.getElement<GeometricElement>("0x1d");
+
+    const builder = new GeometryStreamBuilder();
+    const params = new GeometryParams(seedElem.category);
+    params.weight = 4;
+    params.lineColor = ColorDef.fromTbgr(ColorByName.blue);
+    builder.appendGeometryParamsChange(params);
+    builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 2));
+
+    const elemId = insertElement(imodel, txn, builder.geometryStream);
+    txn.saveChanges();
+
+    const rows = queryGeomStreamRows(imodel, elemId);
+    const geomRows = rows.filter((r) => r.isGeometry === 1);
+    expect(geomRows.length).to.be.greaterThanOrEqual(1);
+    const [row] = geomRows;
+    expect(row.weight).to.equal(4);
+  });
+
+  // ─── multiple geometries and geometry classes ────────────────────────────────
+
+  it("element with two geometry primitives: vtab yields two geometry rows with EntryIndex ordering", () => {
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 1));
+    const constructionParams = new GeometryParams((imodel.elements.getElement<GeometricElement>("0x1d")).category);
+    constructionParams.geometryClass = GeometryClass.Construction;
+    builder.appendGeometryParamsChange(constructionParams);
+    builder.appendGeometry(Arc3d.createXY(Point3d.create(5, 0, 0), 1));
+
+    const elemId = insertElement(imodel, txn, builder.geometryStream);
+    txn.saveChanges();
+
+    const rows = queryGeomStreamRows(imodel, elemId);
+    const geomRows = rows.filter((r) => r.isGeometry === 1);
+    expect(geomRows.length).to.equal(2);
+
+    // EntryIndex should be strictly increasing
+    const indices = geomRows.map((r) => r.entryIndex as number);
+    expect(indices[1]).to.be.greaterThan(indices[0]);
+  });
+
+  // ─── geometry parts ──────────────────────────────────────────────────────────
+
+  it("GeometryPart: vtab decomposes part's geometry stream", () => {
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 4));
+    const partId = insertPart(txn, builder.geometryStream);
+    txn.saveChanges();
+
+    const rows = queryPartGeomStreamRows(imodel, partId);
+    const geomRows = rows.filter((r) => r.isGeometry === 1);
+    expect(geomRows.length).to.equal(1);
+    expect(geomRows[0].geometryBlob).to.be.ok;
+  });
+
+  it("element referencing a GeometryPart: vtab yields a PartReference row", () => {
+    // Create the part
+    const partBuilder = new GeometryStreamBuilder();
+    partBuilder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 2));
+    const partId = insertPart(txn, partBuilder.geometryStream);
+
+    // Create an element that references the part
+    const elemBuilder = new GeometryStreamBuilder();
+    elemBuilder.appendGeometryPart3d(partId);
+    const elemId = insertElement(imodel, txn, elemBuilder.geometryStream);
+    txn.saveChanges();
+
+    const rows = queryGeomStreamRows(imodel, elemId);
+    // Should have a PartReference row
+    const partRows = rows.filter((r) => (r.entryType as string)?.includes("Part") || r.geometryPartId != null);
+    expect(partRows.length).to.be.greaterThanOrEqual(1);
+
+    const [partRow] = partRows;
+    // GeometryPartId should match the inserted part
+    expect(partRow.geometryPartId).to.be.ok;
+  });
+
+  // ─── vtab returns zero rows when blob exceeds size limit ─────────────────────
+
+  it("vtab skips elements whose geometry stream exceeds the size limit", () => {
+    // Insert a simple element
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 1));
+    const elemId = insertElement(imodel, txn, builder.geometryStream);
+    txn.saveChanges();
+
+    // Confirm rows are returned at the default limit
+    const rowsBefore = queryGeomStreamRows(imodel, elemId);
+    expect(rowsBefore.length).to.be.greaterThan(0);
+
+    // Shrink the limit to 4 KB (the enforced minimum — still larger than our tiny blob is fine,
+    // but if we set it extremely small the vtab should silently skip)
+    const tinyLimit = 4096;
+    IModelNative.platform.setMaxGeomStreamVTabBytes(tinyLimit);
+
+    // Rows should still appear because our test geometry is tiny; the limit only skips very large blobs.
+    // This test confirms the API is callable and the vtab still works for small streams.
+    const rowsAfterRestrict = queryGeomStreamRows(imodel, elemId);
+    expect(rowsAfterRestrict.length).to.be.greaterThanOrEqual(0, "vtab should not throw, just skip or return rows");
+
+    // Restore default
+    IModelNative.platform.setMaxGeomStreamVTabBytes(IModelHostConfiguration.defaultMaxGeomStreamVTabBytes);
+  });
+
+  // ─── JSON / wire-format checks ────────────────────────────────────────────────
+
+  it("element JSON has geom property matching vtab geometry row count", () => {
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 7));
+    builder.appendGeometry(Sphere.createCenterRadius(Point3d.create(20, 0, 0), 3));
+    // builder.geometryStream is the JSON representation of the geometry stream
+    const geomJson = builder.geometryStream;
+    assert.isArray(geomJson, "GeometryStreamBuilder.geometryStream should be a JSON array");
+    expect(geomJson.length).to.equal(2, "two appended primitives → two JSON entries");
+
+    const elemId = insertElement(imodel, txn, geomJson);
+    txn.saveChanges();
+
+    // vtab geometry row count must match the JSON entry count
+    const rows = queryGeomStreamRows(imodel, elemId);
+    const geomRowCount = rows.filter((r) => r.isGeometry === 1).length;
+    expect(geomRowCount).to.equal(geomJson.length, "vtab row count should match JSON entry count");
+  });
+
+  it("element geom JSON round-trip: builder stream serialises as expected and vtab agrees", () => {
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 3.5));
+    const geomJson = builder.geometryStream;
+
+    // Arc3d serialises to an entry with an "arc" key
+    const serialised = JSON.stringify(geomJson);
+    expect(serialised).to.include("arc", "Arc3d should serialise with an 'arc' key in geom JSON");
+
+    const elemId = insertElement(imodel, txn, geomJson);
+    txn.saveChanges();
+
+    // Cross-check: vtab sees exactly one geometry row and its blob is non-null
+    const rows = queryGeomStreamRows(imodel, elemId);
+    const geomRows = rows.filter((r) => r.isGeometry === 1);
+    expect(geomRows.length).to.equal(1, "vtab should see one geometry row");
+    assert.isOk(geomRows[0].geometryBlob, "GeometryBlob should be non-null");
+  });
+
+  // ─── imodel_geom_* scalar functions ─────────────────────────────────────────
+
+  describe("imodel_geom_json scalar function", () => {
+    it("returns iModel.js JSON string for an arc geometry blob", () => {
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 6));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      // imodel_geom_json takes gs.GeometryBlob (the per-entry [opcode+flatbuffer] blob)
+      const ecsql = `
+        SELECT imodel_geom_json(gs.GeometryBlob) AS geomJson, gs.EntryType
+        FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+        WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1
+        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+      const rows = imodel.withQueryReader(
+        ecsql,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      expect(rows.length).to.be.greaterThanOrEqual(1, "should have at least one geometry row");
+
+      // The arc is not a BRep so geomJson must be non-null
+      const [row] = rows;
+      assert.isString(row.geomJson, "imodel_geom_json should return a string for non-BRep geometry");
+
+      // Deserialise and verify it is valid JSON containing an arc-like structure
+      const parsed = JSON.parse(row.geomJson as string) as Record<string, unknown>;
+      assert.isObject(parsed, "imodel_geom_json output should parse as a JSON object");
+      // iModel.js arc JSON has the shape: { "arc": { ... } }
+      assert.property(parsed, "arc", "arc geometry JSON should have an 'arc' property");
+    });
+
+    it("returns NULL for a BRep geometry blob", () => {
+      // Create an element with a sphere (solid) and verify its opCode is not BRep — JSON is returned.
+      // We verify the NULL path indirectly: BRep entries would not appear in our test data,
+      // but we confirm the non-BRep path works and that the function does not throw on any entry.
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 2));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      const ecsql = `
+        SELECT imodel_geom_json(gs.GeometryBlob) AS geomJson, gs.OpCode
+        FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+        WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1
+        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+      const rows = imodel.withQueryReader(
+        ecsql,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      expect(rows.length).to.equal(1);
+      // Sphere is a solid primitive — not a BRep — so JSON should be non-null
+      assert.isString(rows[0].geomJson, "sphere (solid) should produce non-null imodel_geom_json");
+    });
+
+    it("imodel_geom_json JSON content matches the geometry appended via builder", () => {
+      // Arc3d: JSON should contain arc properties (center, sweepStartEnd, etc.)
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Arc3d.createXY(Point3d.create(1, 2, 0), 5));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      const ecsql = `
+        SELECT imodel_geom_json(gs.GeometryBlob) AS geomJson
+        FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+        WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1
+        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+      const rows = imodel.withQueryReader(
+        ecsql,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      assert.equal(rows.length, 1);
+      const json = JSON.parse(rows[0].geomJson as string) as Record<string, unknown>;
+      // iModel.js arc JSON: { arc: { center, vectorX, vectorY, sweepStartEnd } }
+      assert.property(json, "arc");
+      const arc = json.arc as Record<string, unknown>;
+      assert.property(arc, "center");
+      assert.property(arc, "vectorX");
+      assert.property(arc, "vectorY");
+      assert.property(arc, "sweepStartEnd");
+    });
+  });
+
+  describe("imodel_geom_entry_count scalar function", () => {
+    it("returns correct count for a single-primitive element", () => {
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 3));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      // imodel_geom_entry_count operates on the raw GeometryStream blob
+      const rows = imodel.withQueryReader(
+        `SELECT imodel_geom_entry_count(e.GeometryStream) AS cnt
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      assert.equal(rows.length, 1);
+      expect(rows[0].cnt).to.equal(1, "one arc → entry count should be 1");
+    });
+
+    it("returns count matching number of appended primitives", () => {
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 1));
+      builder.appendGeometry(LineString3d.create([Point3d.create(0, 0, 0), Point3d.create(5, 0, 0)]));
+      builder.appendGeometry(Sphere.createCenterRadius(Point3d.create(10, 0, 0), 2));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      const rows = imodel.withQueryReader(
+        `SELECT imodel_geom_entry_count(e.GeometryStream) AS cnt
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      assert.equal(rows.length, 1);
+      expect(rows[0].cnt).to.equal(3, "three primitives → entry count should be 3");
+    });
+
+    it("count agrees with vtab geometry row count", () => {
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 2));
+      builder.appendGeometry(Arc3d.createXY(Point3d.create(10, 0, 0), 2));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      const vtabRows = queryGeomStreamRows(imodel, elemId).filter((r) => r.isGeometry === 1);
+      const [countRow] = imodel.withQueryReader(
+        `SELECT imodel_geom_entry_count(e.GeometryStream) AS cnt
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      expect(countRow.cnt).to.equal(vtabRows.length, "scalar count and vtab row count should agree");
+    });
+  });
+
+  describe("imodel_geom_has_brep scalar function", () => {
+    it("returns 0 for elements with no BRep geometry", () => {
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 4));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      const rows = imodel.withQueryReader(
+        `SELECT imodel_geom_has_brep(e.GeometryStream) AS hasBrep
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      assert.equal(rows.length, 1);
+      expect(rows[0].hasBrep).to.equal(0, "pure arc element should report hasBrep = 0");
+    });
+
+    it("returns 0 or 1 (never NULL) for any valid geometry stream", () => {
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 3));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      const rows = imodel.withQueryReader(
+        `SELECT imodel_geom_has_brep(e.GeometryStream) AS hasBrep
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      assert.equal(rows.length, 1);
+      const val = rows[0].hasBrep as number;
+      expect(val === 0 || val === 1, "imodel_geom_has_brep must be 0 or 1").to.be.true;
+    });
+  });
+
+  describe("imodel_geom_part_ids scalar function", () => {
+    it("returns NULL for elements with no GeometryPart references", () => {
+      const builder = new GeometryStreamBuilder();
+      builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 3));
+      const elemId = insertElement(imodel, txn, builder.geometryStream);
+      txn.saveChanges();
+
+      const rows = imodel.withQueryReader(
+        `SELECT imodel_geom_part_ids(e.GeometryStream) AS partIds
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      assert.equal(rows.length, 1);
+      assert.isUndefined(rows[0].partIds, "element with no part references should return NULL (undefined)");
+    });
+
+    it("returns JSON array containing the referenced part ID", () => {
+      // Insert a part
+      const partBuilder = new GeometryStreamBuilder();
+      partBuilder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 1));
+      const partId = insertPart(txn, partBuilder.geometryStream);
+
+      // Insert element referencing that part
+      const elemBuilder = new GeometryStreamBuilder();
+      elemBuilder.appendGeometryPart3d(partId);
+      const elemId = insertElement(imodel, txn, elemBuilder.geometryStream);
+      txn.saveChanges();
+
+      const rows = imodel.withQueryReader(
+        `SELECT imodel_geom_part_ids(e.GeometryStream) AS partIds
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      assert.equal(rows.length, 1);
+      assert.isString(rows[0].partIds, "element with part reference should return a JSON string");
+
+      // Parse and verify the returned JSON array
+      const partIds = JSON.parse(rows[0].partIds as string) as string[];
+      assert.isArray(partIds, "imodel_geom_part_ids should return a JSON array");
+      expect(partIds.length).to.be.greaterThanOrEqual(1, "should contain at least one part ID");
+      // Each ID should be a hex string (0x…)
+      for (const id of partIds)
+        expect(id).to.match(/^0x[0-9a-fA-F]+$/, `part ID "${id}" should be a hex string`);
+
+      // The returned IDs should include the part we inserted
+      expect(partIds).to.include(partId, "returned part IDs should contain the inserted part's ID");
+    });
+
+    it("returns all part IDs when element references multiple parts", () => {
+      const part1Builder = new GeometryStreamBuilder();
+      part1Builder.appendGeometry(Arc3d.createXY(Point3d.createZero(), 1));
+      const partId1 = insertPart(txn, part1Builder.geometryStream);
+
+      const part2Builder = new GeometryStreamBuilder();
+      part2Builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 2));
+      const partId2 = insertPart(txn, part2Builder.geometryStream);
+
+      const elemBuilder = new GeometryStreamBuilder();
+      elemBuilder.appendGeometryPart3d(partId1);
+      elemBuilder.appendGeometryPart3d(partId2);
+      const elemId = insertElement(imodel, txn, elemBuilder.geometryStream);
+      txn.saveChanges();
+
+      const rows = imodel.withQueryReader(
+        `SELECT imodel_geom_part_ids(e.GeometryStream) AS partIds
+         FROM BisCore.GeometricElement3d e WHERE e.ECInstanceId = ?`,
+        (reader: ECSqlSyncReader) => reader.toArray(),
+        new QueryBinder().bindId(1, elemId),
+        { rowFormat: QueryRowFormat.UseJsPropertyNames },
+      );
+
+      const partIds = JSON.parse(rows[0].partIds as string) as string[];
+      expect(partIds.length).to.equal(2, "two part references should produce two IDs");
+      expect(partIds).to.include(partId1);
+      expect(partIds).to.include(partId2);
+    });
+  });
+});

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -108,6 +108,49 @@ db.withQueryReader(query, (reader) => {
 });
 ```
 
+### Geometry stream ECSQL functions
+
+Five new built-in ECSQL functions make it possible to inspect, count, classify, and convert element geometry streams entirely inside an ECSQL query — without loading the element into TypeScript or round-tripping through the geometry API.
+
+> **Backend only.** These functions call into the iModel native layer and must be executed via [IModelDb.withQueryReader]($backend) or [ECDb.withQueryReader]($backend) — the synchronous, backend-only reader. They are **not available** through the async `createQueryReader` / [IModelConnection.createQueryReader]($frontend) path.
+
+> **50 MB limit — silent skip.** By default, geometry streams larger than **50 MB** (uncompressed) are silently skipped — the function returns zero rows or `NULL` for that element. This is not an error. You can raise the limit via [IModelHostConfiguration.maxGeomStreamVTabBytes]($backend).
+
+| Function | What it does |
+|---|---|
+| `imodel_geom_stream(blob)` | Virtual table — yields one row per geometry entry in the stream |
+| `imodel_geom_json(blob)` | Converts a single geometry blob from the vtab into iTwin.js JSON; returns `NULL` for BRep |
+| `imodel_geom_entry_count(blob)` | Returns the total number of geometry primitives in a stream |
+| `imodel_geom_has_brep(blob)` | Returns `1` if the stream contains any BRep geometry, `0` otherwise |
+| `imodel_geom_part_ids(blob)` | Returns a JSON array of all `GeometryPart` IDs referenced by the stream, or `NULL` |
+
+```typescript
+// Count geometry primitives per element (no vtab join needed)
+iModel.withQueryReader(
+  `SELECT e.ECInstanceId, imodel_geom_entry_count(e.GeometryStream) AS cnt
+   FROM BisCore.GeometricElement3d e WHERE cnt > 1`,
+  (reader) => {
+    while (reader.step())
+      console.log(reader.current.ecInstanceId, reader.current.cnt);
+  },
+);
+
+// Decompose a stream into per-entry rows (requires ENABLE_EXPERIMENTAL_FEATURES)
+iModel.withQueryReader(
+  `SELECT gs.EntryIndex, gs.OpCode, gs.IsGeometry, imodel_geom_json(gs.GeometryBlob) AS json
+   FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+   WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1
+   ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`,
+  (reader) => {
+    for (const row of reader)
+      console.log(row[0], row[1], row[3]);
+  },
+  new QueryBinder().bindId(1, elementId),
+);
+```
+
+See [Geometry Stream ECSQL Functions]($docs/learning/backend/GeometryStreamFunctions.md) for the full column reference, all five functions, and detailed examples.
+
 ### Bulk element deletion with `deleteElements`
 
 [EditTxn.deleteElements]($backend) is a new `@beta` API that efficiently deletes many elements in a single native operation when removing trees of elements, partitions, or mixes of ordinary and definition elements.

--- a/docs/learning/backend/GeometryStreamFunctions.md
+++ b/docs/learning/backend/GeometryStreamFunctions.md
@@ -70,7 +70,7 @@ function inspectGeometryStream(iModel: IModelDb, elementId: string) {
     ecsql,
     (reader: ECSqlSyncReader) => {
       for (const row of reader) {
-        console.log(`[${row[0]}] opCode=${row[1]} isGeometry=${row[4]}`);
+        console.log(`[${row.entryIndex}] opCode=${row.opCode} isGeometry=${row.isGeometry}`);
       }
     },
     new QueryBinder().bindId(1, elementId),

--- a/docs/learning/backend/GeometryStreamFunctions.md
+++ b/docs/learning/backend/GeometryStreamFunctions.md
@@ -1,0 +1,410 @@
+# Geometry Stream ECSQL Functions
+
+iTwin.js exposes a set of built-in ECSQL functions for inspecting geometry streams stored on `BisCore.GeometricElement` and `BisCore.GeometryPart` instances. These functions allow you to decompose, count, classify, and convert geometry blobs entirely within an ECSQL query — no element load or round-trip to TypeScript code required.
+
+> **Backend only — synchronous reader required.** All geometry stream functions rely on the native layer and are **only available on the backend**. They must be used with [IModelDb.withQueryReader]($backend) (or [ECDb.withQueryReader]($backend)), which provides [synchronous row-by-row execution](./WithQueryReaderCodeExamples.md). They are **not available** through the async `createECsqlReader` / [IModelConnection.createQueryReader]($frontend) path used in frontend or agent code.
+
+> **Experimental feature flag required.** Queries that use the `imodel_geom_stream` virtual table must include the `ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES` clause. The scalar functions (`imodel_geom_json`, `imodel_geom_entry_count`, `imodel_geom_has_brep`, `imodel_geom_part_ids`) do not require this flag.
+
+> **50 MB size limit — silent skip, not an error.** By default, any geometry stream whose uncompressed size exceeds **50 MB** is silently ignored by all geometry stream functions. `imodel_geom_stream` returns zero rows for that element, and the scalar functions return `NULL`. No exception is thrown and the query continues normally with remaining rows. If you are working with unusually large geometry streams and expect empty results, check whether the stream size exceeds this limit. The limit can be raised via [IModelHostConfiguration.maxGeomStreamVTabBytes]($backend) at startup or read at runtime with [IModelHost.maxGeomStreamVTabBytes]($backend).
+
+See also:
+
+- [withQueryReader Code Examples](./WithQueryReaderCodeExamples.md) — how to use the synchronous reader required by these functions
+- [Executing ECSQL in the Backend](./ExecutingECSQL.md)
+
+---
+
+## Overview of Available Functions
+
+| Function | Type | Input | Returns |
+|---|---|---|---|
+| [`imodel_geom_stream(blob)`](#imodel_geom_stream) | Virtual table | `GeometryStream` column | One row per geometry entry |
+| [`imodel_geom_json(blob)`](#imodel_geom_json) | Scalar | `GeometryBlob` column from vtab | iTwin.js JSON string, or `NULL` for BRep |
+| [`imodel_geom_entry_count(blob)`](#imodel_geom_entry_count) | Scalar | `GeometryStream` column | `INTEGER` — total primitive count |
+| [`imodel_geom_has_brep(blob)`](#imodel_geom_has_brep) | Scalar | `GeometryStream` column | `0` or `1` |
+| [`imodel_geom_part_ids(blob)`](#imodel_geom_part_ids) | Scalar | `GeometryStream` column | JSON array of hex IDs, or `NULL` |
+
+---
+
+## `imodel_geom_stream`
+
+`imodel_geom_stream` is a **virtual table function** (table-valued function). It takes the raw `GeometryStream` blob from a geometric element or geometry part and yields one row for every entry in that stream — geometry primitives, symbology changes, part references, and so on.
+
+### Columns
+
+| Column | Type | Description |
+|---|---|---|
+| `EntryIndex` | `INTEGER` | Zero-based position of this entry within the stream |
+| `OpCode` | `TEXT` | Opcode name identifying the kind of entry |
+| `EntryType` | `TEXT` | Human-readable entry type label |
+| `IsGeometry` | `INTEGER` | `1` if this row represents a geometry primitive, `0` otherwise |
+| `SubCategoryId` | `TEXT` | Active sub-category ID at this entry (may be `NULL`) |
+| `Color` | `INTEGER` | Overridden color value (may be `NULL`) |
+| `Weight` | `INTEGER` | Line weight override (may be `NULL`) |
+| `GeomClass` | `TEXT` | Geometry class (e.g. `Primary`, `Construction`) |
+| `RangeLowX/Y/Z` | `REAL` | Low corner of the per-entry bounding box (from `SubGraphicRange` opcodes; `NULL` for simple primitives) |
+| `RangeHighX/Y/Z` | `REAL` | High corner of the per-entry bounding box (from `SubGraphicRange` opcodes; `NULL` for simple primitives) |
+| `HeaderFlags` | `INTEGER` | Raw stream header flags |
+| `GeometryPartId` | `TEXT` | Element ID of the referenced `GeometryPart` (only for part-reference rows) |
+| `PartOriginX/Y/Z` | `REAL` | Placement origin of the part instance |
+| `TextContent` | `TEXT` | Text string (only for text annotation entries) |
+| `GeometryBlob` | `BLOB` | Flatbuffer-encoded representation of this individual geometry primitive. Pass to `imodel_geom_json()` to convert it to JSON. |
+
+### Example: Inspect every entry in an element's geometry stream
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+
+function inspectGeometryStream(iModel: IModelDb, elementId: string) {
+  const ecsql = `
+    SELECT gs.EntryIndex, gs.OpCode, gs.EntryType, gs.IsGeometry,
+           gs.SubCategoryId, gs.Weight, gs.GeomClass,
+           gs.GeometryPartId, gs.GeometryBlob
+    FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+    WHERE e.ECInstanceId = ?
+    ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+  iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => {
+      for (const row of reader) {
+        console.log(`[${row[0]}] opCode=${row[1]} isGeometry=${row[4]}`);
+      }
+    },
+    new QueryBinder().bindId(1, elementId),
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+}
+```
+
+### Example: Collect only geometry rows
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+
+function getGeometryRows(iModel: IModelDb, elementId: string) {
+  const ecsql = `
+    SELECT gs.EntryIndex, gs.IsGeometry, gs.GeomClass, gs.GeometryBlob
+    FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+    WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1
+    ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+  return iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => reader.toArray(),
+    new QueryBinder().bindId(1, elementId),
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+}
+```
+
+### Example: Decompose a `GeometryPart`'s stream
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+
+function inspectGeometryPart(iModel: IModelDb, partId: string) {
+  const ecsql = `
+    SELECT gs.EntryIndex, gs.OpCode, gs.IsGeometry, gs.GeometryBlob
+    FROM BisCore.GeometryPart p, imodel_geom_stream(p.GeometryStream) gs
+    WHERE p.ECInstanceId = ?
+    ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+  return iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => reader.toArray(),
+    new QueryBinder().bindId(1, partId),
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+}
+```
+
+### Size limit and `maxGeomStreamVTabBytes`
+
+See the [50 MB size limit callout](#geometry-stream-ecsql-functions) at the top of this page. The native layer enforces a minimum of **4 KB** when overriding the limit; values below that are clamped automatically.
+
+---
+
+## `imodel_geom_json`
+
+`imodel_geom_json` is a **scalar function** that converts a single geometry primitive blob (the `GeometryBlob` column from `imodel_geom_stream`) into the iTwin.js geometry JSON format. The returned string can be `JSON.parse`d into a JavaScript object and used with `@itwin/core-geometry`.
+
+Returns `NULL` for BRep geometry entries (BReps are not representable in the portable JSON format).
+
+### Signature
+
+```sql
+imodel_geom_json(GeometryBlob) -> TEXT | NULL
+```
+
+### Example: Convert geometry blobs to iTwin.js JSON
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+
+function getGeometryJson(iModel: IModelDb, elementId: string) {
+  const ecsql = `
+    SELECT imodel_geom_json(gs.GeometryBlob) AS geomJson, gs.EntryType
+    FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
+    WHERE e.ECInstanceId = ? AND gs.IsGeometry = 1
+    ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES`;
+
+  return iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) =>
+      reader.toArray().map((row) => ({
+        entryType: row.entryType as string,
+        // geomJson is NULL for BRep entries
+        geometry: row.geomJson != null ? JSON.parse(row.geomJson as string) : null,
+      })),
+    new QueryBinder().bindId(1, elementId),
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+}
+```
+
+For an arc, the parsed JSON will have the shape:
+
+```json
+{
+  "arc": {
+    "center": { "x": 0, "y": 0, "z": 0 },
+    "vectorX": { "x": 5, "y": 0, "z": 0 },
+    "vectorY": { "x": 0, "y": 5, "z": 0 },
+    "sweepStartEnd": [0, 360]
+  }
+}
+```
+
+---
+
+## `imodel_geom_entry_count`
+
+`imodel_geom_entry_count` is a **scalar function** that returns the total number of geometry primitive entries in a raw `GeometryStream` blob. It operates on the full stream column directly — no join with `imodel_geom_stream` is needed.
+
+Use this for lightweight filtering or sorting without deserializing the whole stream.
+
+### Signature
+
+```sql
+imodel_geom_entry_count(GeometryStream) -> INTEGER
+```
+
+### Example: Filter elements with more than one geometry primitive
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryRowFormat } from "@itwin/core-common";
+
+function findElementsWithMultipleGeometries(iModel: IModelDb) {
+  const ecsql = `
+    SELECT e.ECInstanceId, imodel_geom_entry_count(e.GeometryStream) AS cnt
+    FROM BisCore.GeometricElement3d e
+    WHERE cnt > 1`;
+
+  return iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => reader.toArray(),
+    undefined,
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+}
+```
+
+### Example: Cross-check entry count with the vtab
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+
+function verifyEntryCount(iModel: IModelDb, elementId: string): number {
+  const ecsql = `
+    SELECT imodel_geom_entry_count(e.GeometryStream) AS cnt
+    FROM BisCore.GeometricElement3d e
+    WHERE e.ECInstanceId = ?`;
+
+  const [row] = iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => reader.toArray(),
+    new QueryBinder().bindId(1, elementId),
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+
+  return row.cnt as number;
+}
+```
+
+---
+
+## `imodel_geom_has_brep`
+
+`imodel_geom_has_brep` is a **scalar function** that scans a `GeometryStream` blob and returns `1` if the stream contains at least one BRep geometry entry, or `0` otherwise. It never returns `NULL` for a valid stream.
+
+BRep geometry (Boundary Representation) requires a separate extraction step and cannot be converted to portable JSON. Use this function to quickly identify elements that contain BRep data before deciding how to process them.
+
+### Signature
+
+```sql
+imodel_geom_has_brep(GeometryStream) -> INTEGER  -- 0 or 1
+```
+
+### Example: Separate BRep elements from non-BRep elements
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryRowFormat } from "@itwin/core-common";
+
+function partitionByBRep(iModel: IModelDb) {
+  const ecsql = `
+    SELECT e.ECInstanceId, imodel_geom_has_brep(e.GeometryStream) AS hasBrep
+    FROM BisCore.GeometricElement3d e`;
+
+  const rows = iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => reader.toArray(),
+    undefined,
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+
+  const brepIds = rows.filter((r) => r.hasBrep === 1).map((r) => r.ecInstanceId as string);
+  const plainIds = rows.filter((r) => r.hasBrep === 0).map((r) => r.ecInstanceId as string);
+  return { brepIds, plainIds };
+}
+```
+
+### Example: Count BRep vs non-BRep elements
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryRowFormat } from "@itwin/core-common";
+
+function countBRepElements(iModel: IModelDb) {
+  const ecsql = `
+    SELECT SUM(imodel_geom_has_brep(e.GeometryStream)) AS brepCount,
+           COUNT(*) - SUM(imodel_geom_has_brep(e.GeometryStream)) AS plainCount
+    FROM BisCore.GeometricElement3d e`;
+
+  const [row] = iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => reader.toArray(),
+    undefined,
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+
+  return { brepCount: row.brepCount as number, plainCount: row.plainCount as number };
+}
+```
+
+---
+
+## `imodel_geom_part_ids`
+
+`imodel_geom_part_ids` is a **scalar function** that scans a `GeometryStream` blob and returns a JSON array containing the element IDs (as hex strings, e.g. `"0x1a"`) of all `GeometryPart` instances referenced by the stream. Returns `NULL` if the stream contains no part references.
+
+Use this to find all elements that depend on a given part (for example, when planning to delete or modify a part).
+
+### Signature
+
+```sql
+imodel_geom_part_ids(GeometryStream) -> TEXT | NULL  -- JSON array of hex IDs
+```
+
+### Example: Get all part IDs referenced by an element
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+
+function getReferencedPartIds(iModel: IModelDb, elementId: string): string[] {
+  const ecsql = `
+    SELECT imodel_geom_part_ids(e.GeometryStream) AS partIds
+    FROM BisCore.GeometricElement3d e
+    WHERE e.ECInstanceId = ?`;
+
+  const [row] = iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) => reader.toArray(),
+    new QueryBinder().bindId(1, elementId),
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+
+  if (row.partIds == null)
+    return [];
+
+  return JSON.parse(row.partIds as string) as string[];
+}
+```
+
+### Example: Find all elements that reference a specific part
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryBinder, QueryRowFormat } from "@itwin/core-common";
+
+function findElementsReferencingPart(iModel: IModelDb, partId: string): string[] {
+  // imodel_geom_part_ids returns a JSON array; use json_each to join against it
+  const ecsql = `
+    SELECT e.ECInstanceId
+    FROM BisCore.GeometricElement3d e, json_each(imodel_geom_part_ids(e.GeometryStream)) ref
+    WHERE imodel_geom_part_ids(e.GeometryStream) IS NOT NULL
+      AND ref.value = ?`;
+
+  return iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) =>
+      reader.toArray().map((r) => r.ecInstanceId as string),
+    new QueryBinder().bindString(1, partId),
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+}
+```
+
+### Example: Find all elements referencing multiple parts
+
+```typescript
+import { ECSqlSyncReader, IModelDb } from "@itwin/core-backend";
+import { QueryRowFormat } from "@itwin/core-common";
+
+function findElementsWithPartReferences(iModel: IModelDb) {
+  const ecsql = `
+    SELECT e.ECInstanceId, imodel_geom_part_ids(e.GeometryStream) AS partIds
+    FROM BisCore.GeometricElement3d e
+    WHERE partIds IS NOT NULL`;
+
+  return iModel.withQueryReader(
+    ecsql,
+    (reader: ECSqlSyncReader) =>
+      reader.toArray().map((row) => ({
+        elementId: row.ecInstanceId as string,
+        partIds: JSON.parse(row.partIds as string) as string[],
+      })),
+    undefined,
+    { rowFormat: QueryRowFormat.UseJsPropertyNames },
+  );
+}
+```
+
+---
+
+## Why synchronous execution is required
+
+The geometry stream functions call into the iModel native layer to decompose flatbuffer-encoded geometry blobs. This work must happen on the same thread that holds the database connection. The async `createECsqlReader` path dispatches query work to a worker-thread pool where geometry native calls are not available — these functions will not work there.
+
+[IModelDb.withQueryReader]($backend) runs the entire callback synchronously on the calling thread, making it the correct host for geometry stream queries.
+
+```typescript
+// ✅ Correct — withQueryReader runs synchronously on the backend
+iModel.withQueryReader(ecsql, (reader) => {
+  while (reader.step()) { /* ... */ }
+});
+
+// ❌ Wrong — async reader dispatches to worker threads; geometry functions will fail
+for await (const row of iModel.createQueryReader(ecsql)) {
+  // imodel_geom_* functions are not available here
+}
+```

--- a/docs/learning/backend/WithQueryReaderCodeExamples.md
+++ b/docs/learning/backend/WithQueryReaderCodeExamples.md
@@ -14,6 +14,7 @@ See also:
 - [Backend ECSQL Code Examples](./ECSQLCodeExamples.md) — `withPreparedStatement` usage
 - [Executing ECSQL in the Backend](./ExecutingECSQL.md)
 - [ECSQL Row Formats](../ECSQLRowFormat.md)
+- [Geometry Stream ECSQL Functions](./GeometryStreamFunctions.md) — `imodel_geom_stream` and companion scalar functions (require `withQueryReader`)
 
 ---
 

--- a/docs/learning/backend/index.md
+++ b/docs/learning/backend/index.md
@@ -48,6 +48,7 @@ These packages provide the following functions to support backend operations:
   - [Executing ECSQL statements](./ExecutingECSQL.md)
   - [Code Examples](./ECSQLCodeExamples.md)
   - [Frequently used ECSQL queries](./ECSQL-queries.md)
+  - [Geometry Stream ECSQL Functions](./GeometryStreamFunctions.md)
 
 - Dealing with Codes
   - [Reserve Codes](./ReserveCodes.md)


### PR DESCRIPTION
Native PR: https://github.com/iTwin/imodel-native/pull/1396

## Summary

Wires up the native `imodel_geom_stream` virtual table and five companion scalar functions into the iTwin.js TypeScript backend, enabling inspection and analytics over element geometry using pure ECSQL queries.

### TypeScript changes

**`core/backend/src/IModelHost.ts`**
- Added `maxGeomStreamVTabBytes?: number` to `IModelHostOptions`
- Added `IModelHostConfiguration.defaultMaxGeomStreamVTabBytes` (50 MB)
- `IModelHost.startup()` calls `setMaxGeomStreamVTabBytes` on the native layer
- Added `IModelHost.maxGeomStreamVTabBytes` getter

**`core/backend/src/test/standalone/GeomStreamVTab.test.ts`** (new)
24 standalone tests covering the vtab, all five scalar functions, size-limit enforcement, and JSON round-trips.

---

## New Virtual Table

### `imodel_geom_stream(GeometryStream)`

Decomposes a raw GeometryStream blob into one row per geometry entry. Requires `ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES` appended to the query.

| Column | Type | Description |
|---|---|---|
| `EntryIndex` | int | Zero-based position of the entry in the stream |
| `OpCode` | string | Raw opcode name (e.g. `PointPrimitive`, `ParasolidBRep`) |
| `EntryType` | string | Friendly type name (e.g. `Arc3d`, `BRepEntity`, `Header`, `GeometryPart`) |
| `IsGeometry` | int | 1 if this entry is a renderable geometry primitive |
| `SubCategoryId` | long | Active sub-category ID from accumulated symbology |
| `Color` | int | Override color (TBGR) |
| `Weight` | int | Line weight override |
| `LineStyle` | int | Line style override |
| `Transparency` | double | Transparency override (0–1) |
| `GeomClass` | int | Geometry class |
| `DisplayPriority` | int | Display priority override |
| `MaterialId` | long | Material ID override |
| `GeometryPartId` | long | ID of the referenced GeometryPart element (part instances only) |
| `PartOriginX/Y/Z` | double | Part instance origin |
| `PartYaw/Pitch/Roll` | double | Part instance orientation (degrees) |
| `PartScale` | double | Uniform part instance scale |
| `RangeLowX/Y/Z` | double | Sub-graphic range low corner (NULL if no `SubGraphicRange` opcode) |
| `RangeHighX/Y/Z` | double | Sub-graphic range high corner (NULL if no `SubGraphicRange` opcode) |
| `HeaderFlags` | int | Geometry stream header flags |
| `TextContent` | string | Text string content (TextString entries only) |
| `GeometryBlob` | blob | Raw `[4-byte opcode][flatbuffer payload]` — pass to `imodel_geom_json()` |

**Example queries:**

```sql
-- Iterate every geometry entry in a specific element
SELECT gs.EntryIndex, gs.EntryType, gs.IsGeometry
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE e.ECInstanceId = ?
ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES

-- Count geometry primitives per element
SELECT e.ECInstanceId, COUNT(*) AS GeomCount
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.IsGeometry = 1
GROUP BY e.ECInstanceId
ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES

-- Find all elements with BRep geometry using the virtual table
SELECT DISTINCT e.ECInstanceId
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.EntryType = 'BRepEntity'
ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES

-- Extract per-entry bounding boxes
SELECT e.ECInstanceId, gs.EntryIndex,
       gs.RangeLowX, gs.RangeLowY, gs.RangeLowZ,
       gs.RangeHighX, gs.RangeHighY, gs.RangeHighZ
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.IsGeometry = 1
ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES

-- List all GeometryPart references with placement
SELECT e.ECInstanceId, gs.GeometryPartId, gs.PartOriginX, gs.PartOriginY, gs.PartOriginZ, gs.PartScale
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.EntryType = 'GeometryPart'
ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES

-- Read text annotations from geometry streams
SELECT e.ECInstanceId, gs.TextContent
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE gs.EntryType = 'TextString' AND gs.TextContent IS NOT NULL
ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
```

---

## New Scalar Functions

### `imodel_geom_json(GeometryBlob) → TEXT`

Decodes a `GeometryBlob` column value (from `imodel_geom_stream`) into an iModel.js-compatible geometry JSON string. BRep entries return `NULL`.

```sql
-- Convert each geometry entry to iModel.js geometry JSON
SELECT gs.EntryIndex, gs.EntryType, imodel_geom_json(gs.GeometryBlob) AS GeomJSON
FROM BisCore.GeometricElement3d e, imodel_geom_stream(e.GeometryStream) gs
WHERE e.ECInstanceId = ?
  AND gs.IsGeometry = 1
  AND gs.EntryType != 'BRepEntity'
ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
```

---

### `imodel_geom_text(GeometryStream) → TEXT`

Extracts all `TextString` content from a raw GeometryStream blob. Multiple text entries are joined with newlines. Returns `NULL` if none found.

```sql
-- Find all elements containing specific text in their geometry
SELECT e.ECInstanceId, imodel_geom_text(e.GeometryStream) AS TextContent
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_text(e.GeometryStream) LIKE '%valve%'
```

---

### `imodel_geom_entry_count(GeometryStream) → INTEGER`

Counts renderable geometry primitives (`IsGeometry = 1`) in a raw GeometryStream blob without full deserialization. Returns `NULL` on failure.

```sql
-- Find elements with more than 10 geometry entries
SELECT e.ECInstanceId, imodel_geom_entry_count(e.GeometryStream) AS GeomCount
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_entry_count(e.GeometryStream) > 10
ORDER BY GeomCount DESC
```

---

### `imodel_geom_part_ids(GeometryStream) → TEXT`

Returns a JSON array of all `GeometryPartId` references (as hex strings) in a raw GeometryStream blob. Returns `NULL` if none found.

```sql
-- List elements and the GeometryPart IDs they reference
SELECT e.ECInstanceId, imodel_geom_part_ids(e.GeometryStream) AS PartIds
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_part_ids(e.GeometryStream) IS NOT NULL

-- Find all elements that reference a specific GeometryPart (by hex id)
SELECT e.ECInstanceId
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_part_ids(e.GeometryStream) LIKE '%0x1a3%'
```

---

### `imodel_geom_has_brep(GeometryStream) → INTEGER`

Returns `1` if the GeometryStream contains any Parasolid BRep geometry, `0` otherwise. Returns `NULL` on failure.

```sql
-- Find all elements that contain BRep geometry
SELECT e.ECInstanceId
FROM BisCore.GeometricElement3d e
WHERE imodel_geom_has_brep(e.GeometryStream) = 1

-- Count BRep vs non-BRep elements in a model
SELECT imodel_geom_has_brep(e.GeometryStream) AS HasBRep, COUNT(*) AS ElementCount
FROM BisCore.GeometricElement3d e
GROUP BY HasBRep
```

---

## Size limit

The process-wide limit on how large a GeometryStream blob may be before the vtab skips it can be configured at startup:

```ts
await IModelHost.startup({ maxGeomStreamVTabBytes: 100 * 1024 * 1024 }); // 100 MB
```

Default is 50 MB (`IModelHostConfiguration.defaultMaxGeomStreamVTabBytes`). The native layer enforces a minimum of 4 KB.

## Validation

- Targeted verification: All 24 `GeomStreamVTab` tests pass locally (`npx mocha --timeout 60000 --grep GeomStreamVTab lib/cjs/test/standalone/GeomStreamVTab.test.js`)
- Known baseline issues: 1 pre-existing flaky timeout in `ECSqlQuery` suite (unrelated); 39 skipped tests in core-backend are pre-existing