### PR TITLE
Make FormatSpecHandle read current specs on access

### DIFF
--- a/common/changes/@itwin/core-frontend/nam-format-spec-handle-fix-spec_2026-05-05-19-55.json
+++ b/common/changes/@itwin/core-frontend/nam-format-spec-handle-fix-spec_2026-05-05-19-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix FormatSpecHandle stale state during onFormattingReady",
+      "type": "none",
+      "packageName": "@itwin/core-frontend"
+    }
+  ],
+  "packageName": "@itwin/core-frontend",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/common/changes/@itwin/core-quantity/nam-format-spec-handle-fix-spec_2026-05-05-19-55.json
+++ b/common/changes/@itwin/core-quantity/nam-format-spec-handle-fix-spec_2026-05-05-19-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix FormatSpecHandle stale state during onFormattingReady",
+      "type": "none",
+      "packageName": "@itwin/core-quantity"
+    }
+  ],
+  "packageName": "@itwin/core-quantity",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -1369,12 +1369,12 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     return this._formatSpecsRegistry.get(args.name)?.get(args.persistenceUnitName)?.get(effectiveSystem);
   }
 
-  /** Create a cacheable handle to formatting specs for a specific KoQ and persistence unit.
-   * The handle auto-refreshes when the QuantityFormatter reloads. Call `dispose()` when done.
+  /** Create a handle to formatting specs for a specific KoQ and persistence unit.
+   * The handle reads the current specs from the formatter on access. Call `dispose()` when done.
    *
    * @param koqName - The KindOfQuantity name (e.g., "DefaultToolsUnits.LENGTH")
    * @param persistenceUnit - The persistence unit name (e.g., "Units.M")
-   * @returns A FormatSpecHandle that auto-updates on reload
+   * @returns A FormatSpecHandle that reflects current formatter state
    * @beta
    */
   public getFormatSpecHandle(koqName: string, persistenceUnit: string, system?: UnitSystemKey): FormatSpecHandle {

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -1403,12 +1403,19 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
         formatProps,
         formatName: name,
       });
-      if (!this._formatSpecsRegistry.has(name))
-        this._formatSpecsRegistry.set(name, new Map());
-      const unitMap = this._formatSpecsRegistry.get(name)!;
-      if (!unitMap.has(persistenceUnitName))
-        unitMap.set(persistenceUnitName, new Map());
-      unitMap.get(persistenceUnitName)!.set(effectiveSystem, { formatterSpec, parserSpec });
+      let unitMap = this._formatSpecsRegistry.get(name);
+      if (!unitMap) {
+        unitMap = new Map();
+        this._formatSpecsRegistry.set(name, unitMap);
+      }
+
+      let systemMap = unitMap.get(persistenceUnitName);
+      if (!systemMap) {
+        systemMap = new Map();
+        unitMap.set(persistenceUnitName, systemMap);
+      }
+
+      systemMap.set(effectiveSystem, { formatterSpec, parserSpec });
     } else {
       throw new Error(`Unable to find format properties for ${name} with persistence unit ${persistenceUnitName}`);
     }

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -6,7 +6,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { assert as bAssert } from "@itwin/core-bentley";
 import { EmptyLocalization } from "@itwin/core-common";
-import { FormattingReadyCollector, ParsedQuantity, Parser, UnitProps } from "@itwin/core-quantity";
+import { FormatterSpec, FormattingReadyCollector, ParsedQuantity, Parser, UnitProps } from "@itwin/core-quantity";
 import { IModelApp } from "../IModelApp";
 import { LocalUnitFormatProvider } from "../quantity-formatting/LocalUnitFormatProvider";
 import { OverrideFormatEntry, QuantityFormatter, QuantityType, QuantityTypeArg, QuantityTypeFormatsProvider } from "../quantity-formatting/QuantityFormatter";
@@ -973,7 +973,7 @@ describe("FormatSpecHandle", () => {
     expect(qf.onFormattingReady.numberOfListeners).toBe(initialCount);
   });
 
-  it("refreshes specs when onFormattingReady fires", async () => {
+  it("FormatSpecHandle reflects registry additions without waiting for onFormattingReady", async () => {
     const qf = new QuantityFormatter();
     await qf.onInitialized();
 
@@ -981,9 +981,7 @@ describe("FormatSpecHandle", () => {
     const handle = qf.getFormatSpecHandle("TestKoQ.LENGTH", "Units.M");
     expect(handle.formatterSpec).toBeUndefined();
 
-    // Populate registry then trigger the event
     await qf.addFormattingSpecsToRegistry({ name: "TestKoQ.LENGTH", persistenceUnitName: "Units.M", formatProps: testFormatProps });
-    qf.onFormattingReady.emit();
 
     expect(handle.formatterSpec).toBeDefined();
     expect(handle.parserSpec).toBeDefined();
@@ -1125,6 +1123,43 @@ describe("Multi-system KoQ registry", () => {
     const handle = qf.getFormatSpecHandle("TestKoQ.LENGTH", "Units.M");
     expect(handle.system).toBeUndefined();
     expect(handle.formatterSpec).toBeDefined();
+    handle[Symbol.dispose]();
+  });
+
+  it("FormatSpecHandle read inside onFormattingReady observes current system state", async () => {
+    const qf = new QuantityFormatter();
+    await qf.onInitialized();
+
+    await qf.addFormattingSpecsToRegistry({ name: "TestKoQ.LENGTH", persistenceUnitName: "Units.M", formatProps: simpleDecimalFormat, system: "imperial" });
+    await qf.addFormattingSpecsToRegistry({ name: "TestKoQ.LENGTH", persistenceUnitName: "Units.M", formatProps: simpleDecimalFormat, system: "metric" });
+
+    let handle: ReturnType<typeof qf.getFormatSpecHandle>;
+    const observedSpecs: FormatterSpec[] = [];
+    qf.onFormattingReady.addListener(() => {
+      observedSpecs.push(handle.formatterSpec!);
+    });
+
+    handle = qf.getFormatSpecHandle("TestKoQ.LENGTH", "Units.M");
+    const imperialFormatterSpec = qf.getSpecsByNameAndUnit({
+      name: "TestKoQ.LENGTH",
+      persistenceUnitName: "Units.M",
+      system: "imperial",
+    })?.formatterSpec;
+    const metricFormatterSpec = qf.getSpecsByNameAndUnit({
+      name: "TestKoQ.LENGTH",
+      persistenceUnitName: "Units.M",
+      system: "metric",
+    })?.formatterSpec;
+
+    expect(imperialFormatterSpec).toBeDefined();
+    expect(metricFormatterSpec).toBeDefined();
+    expect(handle.formatterSpec).toBe(imperialFormatterSpec);
+
+    await qf.setActiveUnitSystem("metric");
+
+    expect(observedSpecs).toHaveLength(1);
+    expect(observedSpecs[0]).toBe(metricFormatterSpec);
+    expect(observedSpecs[0]).not.toBe(imperialFormatterSpec);
     handle[Symbol.dispose]();
   });
 });

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -1133,13 +1133,17 @@ describe("Multi-system KoQ registry", () => {
     await qf.addFormattingSpecsToRegistry({ name: "TestKoQ.LENGTH", persistenceUnitName: "Units.M", formatProps: simpleDecimalFormat, system: "imperial" });
     await qf.addFormattingSpecsToRegistry({ name: "TestKoQ.LENGTH", persistenceUnitName: "Units.M", formatProps: simpleDecimalFormat, system: "metric" });
 
-    let handle: ReturnType<typeof qf.getFormatSpecHandle>;
-    const observedSpecs: FormatterSpec[] = [];
-    qf.onFormattingReady.addListener(() => {
-      observedSpecs.push(handle.formatterSpec!);
+    const handleRef: { current: ReturnType<typeof qf.getFormatSpecHandle> | undefined } = { current: undefined };
+    const observedSpecs: Array<FormatterSpec | undefined> = [];
+    const removeReadyListener = qf.onFormattingReady.addListener(() => {
+      if (!handleRef.current)
+        throw new Error("Expected FormatSpecHandle to be created before onFormattingReady fired");
+
+      observedSpecs.push(handleRef.current.formatterSpec);
     });
 
-    handle = qf.getFormatSpecHandle("TestKoQ.LENGTH", "Units.M");
+    const handle = qf.getFormatSpecHandle("TestKoQ.LENGTH", "Units.M");
+    handleRef.current = handle;
     const imperialFormatterSpec = qf.getSpecsByNameAndUnit({
       name: "TestKoQ.LENGTH",
       persistenceUnitName: "Units.M",
@@ -1160,6 +1164,8 @@ describe("Multi-system KoQ registry", () => {
     expect(observedSpecs).toHaveLength(1);
     expect(observedSpecs[0]).toBe(metricFormatterSpec);
     expect(observedSpecs[0]).not.toBe(imperialFormatterSpec);
+
+    removeReadyListener();
     handle[Symbol.dispose]();
   });
 });

--- a/core/quantity/src/FormatSpecHandle.ts
+++ b/core/quantity/src/FormatSpecHandle.ts
@@ -16,23 +16,21 @@ import type { UnitSystemKey } from "./Interfaces";
  * @internal
  */
 export interface FormatSpecHandleArgs extends FormattingSpecArgs {
-  /** The provider that supplies spec lookups and reload events. */
+  /** The provider that supplies current formatting spec lookups. */
   provider: FormattingSpecProvider;
 }
 
-/** A cacheable handle to formatting and parsing specs for a specific KoQ and persistence unit.
- * Automatically refreshes when the QuantityFormatter reloads. Use [[QuantityFormatter.getFormatSpecHandle]]
+/** A handle to formatting and parsing specs for a specific KoQ and persistence unit.
+ * Reads the current specs from the provider on access. Use [[QuantityFormatter.getFormatSpecHandle]]
  * to create instances.
  *
  * When formatting is not yet ready, [[format]] returns a `value.toString()` fallback.
- * Call [[dispose]] when the handle is no longer needed to unsubscribe from reload events.
+ * Dispose the handle when it is no longer needed to invalidate it.
  *
  * @beta
  */
 export class FormatSpecHandle implements Disposable {
-  private _formatterSpec: FormatterSpec | undefined;
-  private _parserSpec: ParserSpec | undefined;
-  private _removeListener: (() => void) | undefined;
+  private _disposed = false;
   private readonly _provider: FormattingSpecProvider;
   private readonly _koqName: string;
   private readonly _persistenceUnit: string;
@@ -44,10 +42,6 @@ export class FormatSpecHandle implements Disposable {
     this._koqName = args.name;
     this._persistenceUnit = args.persistenceUnitName;
     this._system = args.system;
-    this._removeListener = args.provider.onFormattingReady.addListener(() => {
-      this._refresh();
-    });
-    this._refresh();
   }
 
   /** The KoQ name this handle is keyed to. */
@@ -60,10 +54,10 @@ export class FormatSpecHandle implements Disposable {
   public get system(): UnitSystemKey | undefined { return this._system; }
 
   /** The current FormatterSpec, or undefined if not yet loaded. */
-  public get formatterSpec(): FormatterSpec | undefined { return this._formatterSpec; }
+  public get formatterSpec(): FormatterSpec | undefined { return this._getEntry()?.formatterSpec; }
 
   /** The current ParserSpec, or undefined if not yet loaded. */
-  public get parserSpec(): ParserSpec | undefined { return this._parserSpec; }
+  public get parserSpec(): ParserSpec | undefined { return this._getEntry()?.parserSpec; }
 
   /** Format a quantity value using the current spec.
    * If the formatter is not yet ready, returns `value.toString()` as a fallback.
@@ -71,38 +65,28 @@ export class FormatSpecHandle implements Disposable {
    * @returns The formatted string.
    */
   public format(value: number): string {
-    if (!this._formatterSpec)
+    const formatterSpec = this.formatterSpec;
+    if (!formatterSpec)
       return value.toString();
-    return this._provider.formatQuantity(value, this._formatterSpec);
+    return this._provider.formatQuantity(value, formatterSpec);
   }
 
-  /** Unsubscribe from reload events and clear cached specs.
-   * Idempotent and safe to call during a pending reload.
+  /** Invalidate this handle.
+   * Idempotent and safe to call multiple times.
+   * No additional teardown is required because the handle owns no external resources.
    */
   public [Symbol.dispose](): void {
-    if (this._removeListener) {
-      this._removeListener();
-      this._removeListener = undefined;
-    }
-    this._formatterSpec = undefined;
-    this._parserSpec = undefined;
+    this._disposed = true;
   }
 
-  private _refresh(): void {
-    // Guard against mid-emission callbacks after dispose() — event may still fire during iteration.
-    if (!this._removeListener)
-      return;
-    const entry: FormattingSpecEntry | undefined = this._provider.getSpecsByNameAndUnit({
+  private _getEntry(): FormattingSpecEntry | undefined {
+    if (this._disposed)
+      return undefined;
+
+    return this._provider.getSpecsByNameAndUnit({
       name: this._koqName,
       persistenceUnitName: this._persistenceUnit,
       system: this._system,
     });
-    if (entry) {
-      this._formatterSpec = entry.formatterSpec;
-      this._parserSpec = entry.parserSpec;
-    } else {
-      this._formatterSpec = undefined;
-      this._parserSpec = undefined;
-    }
   }
 }

--- a/core/quantity/src/Formatter/Interfaces.ts
+++ b/core/quantity/src/Formatter/Interfaces.ts
@@ -258,7 +258,7 @@ export interface AddFormattingSpecArgs extends FormattingSpecArgs {
   formatProps?: FormatProps;
 }
 
-/** Minimal contract required by [[FormatSpecHandle]] to look up specs and subscribe to reloads.
+/** Minimal contract required by [[FormatSpecHandle]] to look up current specs and expose formatting readiness.
  * Implemented by [[QuantityFormatter]] in `@itwin/core-frontend`.
  * @beta
  */

--- a/core/quantity/src/test/FormatSpecHandle.test.ts
+++ b/core/quantity/src/test/FormatSpecHandle.test.ts
@@ -67,17 +67,17 @@ describe("FormatSpecHandle", () => {
     handle[Symbol.dispose]();
   });
 
-  it("refreshes specs when onFormattingReady fires", () => {
+  it("reflects provider changes without waiting for onFormattingReady", () => {
     const provider = createMockProvider(undefined);
     const handle = new FormatSpecHandle({ provider, name: "TestKoQ", persistenceUnitName: "Units.M" });
     expect(handle.formatterSpec).toBeUndefined();
 
-    // Now make the provider return an entry and fire ready
     const entry = createMockEntry();
     vi.mocked(provider.getSpecsByNameAndUnit).mockReturnValue(entry);
-    provider.ready.emit();
 
     expect(handle.formatterSpec).toBe(entry.formatterSpec);
+    expect(handle.parserSpec).toBe(entry.parserSpec);
+    expect(handle.format(42)).toBe("formatted:42");
     handle[Symbol.dispose]();
   });
 
@@ -87,6 +87,7 @@ describe("FormatSpecHandle", () => {
     const handle = new FormatSpecHandle({ provider, name: "TestKoQ", persistenceUnitName: "Units.M", system: "imperial" });
 
     expect(handle.system).toBe("imperial");
+    void handle.formatterSpec;
     expect(provider.getSpecsByNameAndUnit).toHaveBeenCalledWith({
       name: "TestKoQ",
       persistenceUnitName: "Units.M",
@@ -95,19 +96,20 @@ describe("FormatSpecHandle", () => {
     handle[Symbol.dispose]();
   });
 
-  it("[Symbol.dispose] clears specs and unsubscribes from events", () => {
+  it("does not perform provider lookups after dispose", () => {
     const entry = createMockEntry();
     const provider = createMockProvider(entry);
     const handle = new FormatSpecHandle({ provider, name: "TestKoQ", persistenceUnitName: "Units.M" });
 
     handle[Symbol.dispose]();
+    vi.mocked(provider.getSpecsByNameAndUnit).mockClear();
+    vi.mocked(provider.formatQuantity).mockClear();
+
     expect(handle.formatterSpec).toBeUndefined();
     expect(handle.parserSpec).toBeUndefined();
-
-    // Fire ready after dispose — should NOT repopulate
-    vi.mocked(provider.getSpecsByNameAndUnit).mockClear();
-    provider.ready.emit();
+    expect(handle.format(42)).toBe("42");
     expect(provider.getSpecsByNameAndUnit).not.toHaveBeenCalled();
+    expect(provider.formatQuantity).not.toHaveBeenCalled();
   });
 
   it("[Symbol.dispose] is idempotent", () => {

--- a/example-code/snippets/src/frontend/Formatting.ts
+++ b/example-code/snippets/src/frontend/Formatting.ts
@@ -148,7 +148,7 @@ export function useFormatSpecHandle() {
   const formatted = handle.format(1.5);
   assert(formatted.length > 0);
 
-  // Explicitly dispose when done to unsubscribe from reload events
+  // Explicitly dispose when done to invalidate the handle
   handle[Symbol.dispose]();
 }
 // __PUBLISH_EXTRACT_END__
@@ -161,7 +161,7 @@ export function useFormatSpecHandleWithUsing() {
     "Units.M",
   );
 
-  // The handle auto-refreshes when the formatter reloads
+  // The handle reads the current formatter state on access
   const formatted = handle.format(2.75);
   assert(formatted.length > 0);
   // handle is automatically disposed at end of scope


### PR DESCRIPTION
## Why
`FormatSpecHandle` was refreshing its cached spec state by listening to the same `QuantityFormatter.onFormattingReady` event that downstream consumers are expected to listen to.

That meant handle refresh and consumer work were both happening off the same event emission, so correctness depended on listener ordering. If a consumer read from a handle inside `onFormattingReady` before the handle refreshed itself, formatting could still use stale spec state even though the formatter had already signaled it was ready.

This made runtime formatting updates less reliable and forced downstream code to add extra deferral just to get past the ordering hazard.

## What
| Asset | Why it exists |
| --- | --- |
| `FormatSpecHandle` access pattern | Ensure callers always read the latest spec state from the handle instead of holding onto stale data after updates. |
| formatter interface typing | Keep the formatter contract aligned with reading current spec data so downstream consumers use the refreshed values consistently. |
| frontend quantity formatting integration | Make displayed quantities honor spec changes made through a handle at the time formatting occurs. |
| example formatting snippet | Show the supported usage pattern so sample code reflects the current handle behavior. |
| change files | Record the fix for package release notes and downstream consumers. |

## Tests
- Updated handle tests to verify spec reads reflect the current state after changes.
- Updated frontend formatter tests to verify formatted output uses updated specs instead of cached values.

---
*Nambot 🤖*
