### PR TITLE
Add support for Electron 42

### DIFF
--- a/.github/agents/electron-version-bump.agent.md
+++ b/.github/agents/electron-version-bump.agent.md
@@ -115,7 +115,9 @@ grep -r '"electron":' --include='package.json' -l .
 
 Compare the results with the list above and include any additional files found.
 
-### Step 3: Review and apply breaking changes
+### Step 3: Review breaking changes and get approval
+
+**This step requires explicit invoker approval before proceeding to file modifications.**
 
 Fetch the Electron breaking changes documentation. Use the raw URL to avoid GitHub rate limiting:
 
@@ -144,10 +146,7 @@ grep -r "require(\"electron\")" --include='*.ts' --include='*.js' -l .
 For each breaking change listed in the Electron docs for the new major version:
 
 1. **Identify** whether the breaking change affects any API used in this codebase.
-2. **If affected**, apply the necessary code fix:
-   - Search the codebase for all usages of the affected API.
-   - Update the code to use the new API or pattern as prescribed by the Electron breaking changes doc.
-   - Ensure backward compatibility with the minimum supported Electron version (currently ^35.0.0) — use feature detection or version checks when the old API is removed and a polyfill is needed.
+2. **If affected**, describe the required code fix and which files need modification.
 3. **If not affected**, note it and move on.
 
 **Common breaking change categories to watch for:**
@@ -158,6 +157,24 @@ For each breaking change listed in the Electron docs for the new major version:
 - Changes to `contextBridge` behavior
 - New required permissions or security policy changes
 - Deprecated APIs that are now removed
+
+#### Present findings and wait for approval
+
+After completing the analysis, present a summary table to the invoker:
+
+| Breaking change | Affected? | Proposed fix |
+| --- | --- | --- |
+| (change description) | Yes / No | (fix description or "N/A") |
+
+**STOP here and wait for the invoker's explicit go-ahead before making any file changes.** If the invoker requests modifications to the proposed approach, incorporate their feedback before proceeding.
+
+#### Apply breaking change fixes (after approval)
+
+Once approved, for each affected breaking change:
+
+- Search the codebase for all usages of the affected API.
+- Update the code to use the new API or pattern as prescribed by the Electron breaking changes doc.
+- Ensure backward compatibility with the minimum supported Electron version (currently ^35.0.0) — use feature detection or version checks when the old API is removed and a polyfill is needed.
 
 If a breaking change requires a non-trivial migration (e.g., architectural changes), document the issue in the report. If triggered from a GitHub issue, add a comment to the issue describing the blocker and wait for guidance. Otherwise, ask the invoker before proceeding with the fix.
 

--- a/.github/agents/electron-version-bump.agent.md
+++ b/.github/agents/electron-version-bump.agent.md
@@ -174,7 +174,7 @@ Once approved, for each affected breaking change:
 
 - Search the codebase for all usages of the affected API.
 - Update the code to use the new API or pattern as prescribed by the Electron breaking changes doc.
-- Ensure backward compatibility with the minimum supported Electron version (currently ^35.0.0) — use feature detection or version checks when the old API is removed and a polyfill is needed.
+- Ensure backward compatibility with the minimum supported Electron version documented in docs/learning/SupportedPlatforms.md — use feature detection or version checks when the old API is removed and a polyfill is needed.
 
 If a breaking change requires a non-trivial migration (e.g., architectural changes), document the issue in the report. If triggered from a GitHub issue, add a comment to the issue describing the blocker and wait for guidance. Otherwise, ask the invoker before proceeding with the fix.
 

--- a/.github/agents/electron-version-bump.agent.md
+++ b/.github/agents/electron-version-bump.agent.md
@@ -307,10 +307,13 @@ gh pr create \
   --head electron-<NEW_MAJOR> \
   --title "Add support for Electron <NEW_MAJOR>" \
   --body "$(cat <<'EOF'
-Adds support for Electron <NEW_MAJOR>.
-
 ### Breaking changes review
-<Include the breaking changes assessment here — list each change with "affected" / "not affected" status>
+
+<Include the breaking changes assessment table from Step 3 here>
+
+### Notes
+
+<Include any relevant notes, e.g. unmet peer dependencies>
 
 See [Electron <NEW_MAJOR> release blog](https://www.electronjs.org/blog/electron-<NEW_MAJOR>-0) for details.
 EOF

--- a/common/changes/@itwin/certa/electron-42_2026-05-07-09-14.json
+++ b/common/changes/@itwin/certa/electron-42_2026-05-07-09-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/certa",
+      "comment": "Add support for Electron 42",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/certa"
+}

--- a/common/changes/@itwin/core-electron/electron-42_2026-05-07-09-14.json
+++ b/common/changes/@itwin/core-electron/electron-42_2026-05-07-09-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Add support for Electron 42",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -34,6 +34,23 @@ steps:
       node ./common/scripts/install-run-rush webpack:test -v
     displayName: "Rush build"
 
+  # Electron 42+ no longer downloads the binary during npm install (postinstall removed).
+  # Ensure the binary is present before configuring the AppArmor profile.
+  - script: |
+      ELECTRON_DIR=$(find $PWD/common/temp/node_modules/.pnpm -path "*/electron@*/node_modules/electron" -type d 2>/dev/null | head -n 1)
+      if [ ! -d "$ELECTRON_DIR" ]; then
+        echo "##vso[task.logissue type=warning]Unable to find Electron package directory"
+      elif [ -f "$ELECTRON_DIR/dist/electron" ]; then
+        echo "Electron binary already present"
+      elif [ -f "$ELECTRON_DIR/install.js" ]; then
+        echo "Downloading Electron binary..."
+        node "$ELECTRON_DIR/install.js"
+      else
+        echo "##vso[task.logissue type=warning]Unable to find Electron install script at $ELECTRON_DIR/install.js"
+      fi
+    displayName: "Ensure Electron binary is downloaded"
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+
   # Starting Ubuntu 24.04, unprivileged user namespaces are restricted by default via AppArmor.
   # Electron's sandbox requires user namespaces, so we create an AppArmor profile that grants the 'userns' permission to the Electron binary.
   # See: https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#p-99950-unprivileged-user-namespace-restrictions-15

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -695,8 +695,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       electron:
-        specifier: ^41.0.0
-        version: 41.0.0
+        specifier: ^42.0.0
+        version: 42.0.0
       eslint:
         specifier: ^9.31.0
         version: 9.31.0
@@ -1736,8 +1736,8 @@ importers:
         specifier: workspace:*
         version: link:../../core/geometry
       electron:
-        specifier: ^41.0.0
-        version: 41.0.0
+        specifier: ^42.0.0
+        version: 42.0.0
     devDependencies:
       '@itwin/build-tools':
         specifier: workspace:*
@@ -2432,7 +2432,7 @@ importers:
         version: link:../../editor/frontend
       '@itwin/electron-authorization':
         specifier: ^0.22.2
-        version: 0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@41.0.0)
+        version: 0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@42.0.0)
       '@itwin/express-server':
         specifier: workspace:*
         version: link:../../core/express-server
@@ -2467,8 +2467,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1(chai@4.3.10)
       electron:
-        specifier: ^41.0.0
-        version: 41.0.0
+        specifier: ^42.0.0
+        version: 42.0.0
       fs-extra:
         specifier: ^8.1.0
         version: 8.1.0
@@ -2919,8 +2919,8 @@ importers:
         specifier: workspace:*
         version: link:../../core/express-server
       electron:
-        specifier: ^41.0.0
-        version: 41.0.0
+        specifier: ^42.0.0
+        version: 42.0.0
       express:
         specifier: ^4.22.1
         version: 4.22.1
@@ -3543,7 +3543,7 @@ importers:
         version: link:../../core/quantity
       '@itwin/electron-authorization':
         specifier: ^0.22.2
-        version: 0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@41.0.0)
+        version: 0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@42.0.0)
       '@itwin/frontend-tiles':
         specifier: workspace:*
         version: link:../../extensions/frontend-tiles
@@ -3618,8 +3618,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       electron:
-        specifier: ^41.0.0
-        version: 41.0.0
+        specifier: ^42.0.0
+        version: 42.0.0
       eslint:
         specifier: ^9.31.0
         version: 9.31.0
@@ -3742,7 +3742,7 @@ importers:
         version: link:../../editor/frontend
       '@itwin/electron-authorization':
         specifier: ^0.22.2
-        version: 0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@41.0.0)
+        version: 0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@42.0.0)
       '@itwin/frontend-devtools':
         specifier: workspace:*
         version: link:../../core/frontend-devtools
@@ -3835,8 +3835,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       electron:
-        specifier: ^41.0.0
-        version: 41.0.0
+        specifier: ^42.0.0
+        version: 42.0.0
       eslint:
         specifier: ^9.31.0
         version: 9.31.0
@@ -4247,8 +4247,8 @@ importers:
         specifier: 17.0.19
         version: 17.0.19
       electron:
-        specifier: ^41.0.0
-        version: 41.0.0
+        specifier: ^42.0.0
+        version: 42.0.0
       eslint:
         specifier: ^9.31.0
         version: 9.31.0
@@ -7234,9 +7234,9 @@ packages:
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
-  electron@41.0.0:
-    resolution: {integrity: sha512-U7QueSj1cFj9QM0Qamgh/MK08662FVK555iMfapqU7mcAmIm4A8bZuZptpjMXrT4JNAMGjgWu9sOeO1+RPCJNw==}
-    engines: {node: '>= 12.20.55'}
+  electron@42.0.0:
+    resolution: {integrity: sha512-in5jnW/Ywy3Rh3FPr4MR80exPEkywKYAmDJRZ/gIKlr8VXEi3zXgiAZbf0Si7KRccHTF2y8euVMRz7M6HqTjMA==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   emitter-listener@1.1.2:
@@ -11651,12 +11651,12 @@ snapshots:
 
   '@itwin/core-bentley@5.9.0': {}
 
-  '@itwin/electron-authorization@0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@41.0.0)':
+  '@itwin/electron-authorization@0.22.2(@itwin/core-bentley@..+core+bentley)(@itwin/core-common@..+core+common)(electron@42.0.0)':
     dependencies:
       '@itwin/core-bentley': link:../../core/bentley
       '@itwin/core-common': link:../../core/common
       '@openid/appauth': 1.3.2
-      electron: 41.0.0
+      electron: 42.0.0
       electron-store: 8.2.0
       username: 7.0.0
     transitivePeerDependencies:
@@ -12611,7 +12611,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.17.0
+      '@types/node': 20.17.58
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.31.0)(typescript@5.6.2))(eslint@9.31.0)(typescript@5.6.2)':
@@ -14009,7 +14009,7 @@ snapshots:
 
   electron-to-chromium@1.5.349: {}
 
-  electron@41.0.0:
+  electron@42.0.0:
     dependencies:
       '@electron/get': 3.1.0
       '@types/node': 24.12.2

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -38,7 +38,7 @@
     "@itwin/core-bentley": "workspace:*",
     "@itwin/core-common": "workspace:*",
     "@itwin/core-frontend": "workspace:*",
-    "electron": "^35.0.0 || ^36.0.0 || ^37.0.0 || ^38.0.0 || ^39.0.0 || ^40.0.0 || ^41.0.0"
+    "electron": "^35.0.0 || ^36.0.0 || ^37.0.0 || ^38.0.0 || ^39.0.0 || ^40.0.0 || ^41.0.0 || ^42.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",
@@ -53,7 +53,7 @@
     "@types/node": "~20.17.0",
     "chai": "^4.3.10",
     "cpx2": "^8.0.0",
-    "electron": "^41.0.0",
+    "electron": "^42.0.0",
     "eslint": "^9.31.0",
     "glob": "^10.5.0",
     "mocha": "^11.1.0",

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -6,6 +6,7 @@ publish: false
 - [NextVersion](#nextversion)
   - [@itwin/core-backend](#itwincore-backend)
     - [ECSQL CROSS JOIN now supports optional ON clause](#ecsql-cross-join-now-supports-optional-on-clause)
+  - [Electron 42 support](#electron-42-support)
 
 ## @itwin/core-backend
 
@@ -23,3 +24,7 @@ SELECT * FROM ts.Person p CROSS JOIN ts.Identifier i ON p.PersonalID = i.PersonI
 ```
 
 This is equivalent in result to an `INNER JOIN`, but the optimizer is not permitted to swap the table order, which can be important for performance-sensitive queries.
+
+## Electron 42 support
+
+In addition to [already supported Electron versions](../learning/SupportedPlatforms.md#electron), iTwin.js now supports [Electron 42](https://www.electronjs.org/blog/electron-42-0).

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -24,7 +24,7 @@
     "@itwin/core-electron": "workspace:*",
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-geometry": "workspace:*",
-    "electron": "^41.0.0"
+    "electron": "^42.0.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "workspace:*",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -62,7 +62,7 @@
     "azurite": "^3.35.0",
     "chai-as-promised": "^7.1.1",
     "chai": "^4.3.10",
-    "electron": "^41.0.0",
+    "electron": "^42.0.0",
     "fs-extra": "^8.1.0",
     "sinon-chai": "^3.7.0",
     "sinon": "^17.0.2"

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -27,7 +27,7 @@
     "@itwin/core-frontend": "workspace:*",
     "@itwin/core-mobile": "workspace:*",
     "@itwin/express-server": "workspace:*",
-    "electron": "^41.0.0",
+    "electron": "^42.0.0",
     "express": "^4.22.1",
     "semver": "^7.5.2",
     "spdy": "^4.0.1"

--- a/test-apps/display-performance-test-app/package.json
+++ b/test-apps/display-performance-test-app/package.json
@@ -71,7 +71,7 @@
     "cpx2": "^8.0.0",
     "dotenv": "^16.4.5",
     "dotenv-expand": "^5.1.0",
-    "electron": "^41.0.0",
+    "electron": "^42.0.0",
     "eslint": "^9.31.0",
     "express": "^4.22.1",
     "internal-tools": "workspace:*",

--- a/test-apps/display-performance-test-app/vite.config.mts
+++ b/test-apps/display-performance-test-app/vite.config.mts
@@ -86,6 +86,7 @@ export default defineConfig(() => {
         transformMixedEsModules: true, // transforms require statements
       },
       rollupOptions: {
+        external: ["electron"],
         input: path.resolve(__dirname, "index.html"),
         // run `rushx build --stats` to view stats
         plugins: [

--- a/test-apps/display-performance-test-app/vite.config.mts
+++ b/test-apps/display-performance-test-app/vite.config.mts
@@ -109,7 +109,18 @@ export default defineConfig(() => {
       },
     },
     plugins: [
-      ignore(["electron"]), // equivalent to webpack externals
+      // Externalize electron in both dev and build — resolves to window['electron']
+      {
+        name: "vite-plugin-electron-external",
+        resolveId(id) {
+          if (id === "electron") return "\0electron-external";
+        },
+        load(id) {
+          if (id === "\0electron-external")
+            return "export default window['electron'];";
+        },
+      },
+      ignore(["electron"]), // equivalent to webpack externals (build only fallback)
       // copy static assets to .static-assets folder
       copy({
         targets: [
@@ -149,9 +160,23 @@ export default defineConfig(() => {
         "@itwin/core-mobile/lib/cjs/MobileFrontend", // import from module error
       ],
       exclude: [
+        "electron",
         "@itwin/core-frontend", //prevents import not resolved errors
         "@itwin/core-common", //prevents rpc errors
       ],
+      esbuildOptions: {
+        plugins: [
+          {
+            name: "externalize-electron",
+            setup(build) {
+              build.onResolve({ filter: /^electron$/ }, () => ({
+                path: "electron",
+                external: true,
+              }));
+            },
+          },
+        ],
+      },
     },
   };
 });

--- a/test-apps/display-test-app/package.json
+++ b/test-apps/display-test-app/package.json
@@ -98,7 +98,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "dotenv-expand": "^5.1.0",
-    "electron": "^41.0.0",
+    "electron": "^42.0.0",
     "eslint": "^9.31.0",
     "express": "^4.22.1",
     "express-ws": "^5.0.2",

--- a/test-apps/display-test-app/vite.config.mts
+++ b/test-apps/display-test-app/vite.config.mts
@@ -114,7 +114,18 @@ export default defineConfig(() => {
       },
     },
     plugins: [
-      ignore(["electron"]), // equivalent to webpack externals
+      // Externalize electron in both dev and build — resolves to window['electron']
+      {
+        name: "vite-plugin-electron-external",
+        resolveId(id) {
+          if (id === "electron") return "\0electron-external";
+        },
+        load(id) {
+          if (id === "\0electron-external")
+            return "export default window['electron'];";
+        },
+      },
+      ignore(["electron"]), // equivalent to webpack externals (build only fallback)
       // copy static assets to .static-assets folder
       copy({
         targets: [
@@ -163,9 +174,23 @@ export default defineConfig(() => {
         "@itwin/core-mobile/lib/cjs/MobileFrontend", // import from module error
       ],
       exclude: [
+        "electron",
         "@itwin/core-frontend", //prevents import not resolved errors
         "@itwin/core-common", //prevents rpc errors
       ],
+      esbuildOptions: {
+        plugins: [
+          {
+            name: "externalize-electron",
+            setup(build) {
+              build.onResolve({ filter: /^electron$/ }, () => ({
+                path: "electron",
+                external: true,
+              }));
+            },
+          },
+        ],
+      },
     },
   };
 });

--- a/test-apps/display-test-app/vite.config.mts
+++ b/test-apps/display-test-app/vite.config.mts
@@ -91,6 +91,7 @@ export default defineConfig(() => {
         transformMixedEsModules: true, // transforms require statements
       },
       rollupOptions: {
+        external: ["electron"],
         input: path.resolve(__dirname, "index.html"),
         // run `rushx build --stats` to view stats
         plugins: [

--- a/tools/certa/package.json
+++ b/tools/certa/package.json
@@ -53,14 +53,14 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "~20.17.0",
     "@types/yargs": "17.0.19",
-    "electron": "^41.0.0",
+    "electron": "^42.0.0",
     "eslint": "^9.31.0",
     "nyc": "^17.1.0",
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   },
   "peerDependencies": {
-    "electron": "^35.0.0 || ^36.0.0 || ^37.0.0 || ^38.0.0 || ^39.0.0 || ^40.0.0 || ^41.0.0"
+    "electron": "^35.0.0 || ^36.0.0 || ^37.0.0 || ^38.0.0 || ^39.0.0 || ^40.0.0 || ^41.0.0 || ^42.0.0"
   },
   "peerDependenciesMeta": {
     "electron": {


### PR DESCRIPTION
Adds support for Electron 42.

### Breaking changes review

| Breaking change | Affected? | Fix |
| --- | --- | --- |
| macOS notifications use `UNNotification` API | No | N/A |
| OSR default device scale factor → `1.0` | No | N/A |
| `electron` no longer downloads via `postinstall` | Yes | Added `external: ["electron"]` to Vite rollup config in test apps |
| Removed `quotas` from `Session.clearStorageData` | No | N/A |
| Deprecated `nativeImage.createFromNamedImage()` array param | No | N/A |

### Notes
- `@itwin/electron-authorization@0.22.3` does not yet support Electron 42 (peer range `>=35.0.0 <42.0.0`). Produces a non-blocking warning.

See [Electron 42 release blog](https://www.electronjs.org/blog/electron-42-0) for details.