### PR TITLE
docs: remove duplicate QuantityFormatter migration sample

### DIFF
--- a/docs/quantity-formatting/usage/QuantityFormatterAdvanced.md
+++ b/docs/quantity-formatting/usage/QuantityFormatterAdvanced.md
@@ -206,9 +206,7 @@ Each of these events covers a different reload trigger, but they all mean the sa
 
 Replace all subscriptions with [QuantityFormatter.onBeforeFormattingReady]($frontend). Register your async loading work via the [FormattingReadyCollector]($quantity) — the formatter awaits all pending work before emitting [QuantityFormatter.onFormattingReady]($frontend).
 
-```ts
-[[include:Quantity_Formatting.BeforeFormattingReady]]
-```
+See the earlier examples in this guide, especially **"Example: Domain spec provider that re-registers on reload"**, for the full provider lifecycle pattern.
 
 **Option B — For tool developers and UI components** (recommended):
 

--- a/docs/quantity-formatting/usage/QuantityFormatterAdvanced.md
+++ b/docs/quantity-formatting/usage/QuantityFormatterAdvanced.md
@@ -207,15 +207,7 @@ Each of these events covers a different reload trigger, but they all mean the sa
 Replace all subscriptions with [QuantityFormatter.onBeforeFormattingReady]($frontend). Register your async loading work via the [FormattingReadyCollector]($quantity) — the formatter awaits all pending work before emitting [QuantityFormatter.onFormattingReady]($frontend).
 
 ```ts
-// ✅ Provider work is awaited before formatting is considered ready
-const removeListener = IModelApp.quantityFormatter.onBeforeFormattingReady.addListener((collector) => {
-  collector.addPendingWork(
-    IModelApp.quantityFormatter.addFormattingSpecsToRegistry("MyDomain.PRESSURE", "Units.PA")
-  );
-});
-
-// Single unsubscribe on teardown
-removeListener();
+[[include:Quantity_Formatting.BeforeFormattingReady]]
 ```
 
 **Option B — For tool developers and UI components** (recommended):


### PR DESCRIPTION
## Why

The advanced QuantityFormatter guide mixed compiled examples with a hand-written migration sample. That left the migration path with a second source of truth, so the guide could drift when the API changed even if the extracted examples stayed correct.

This matters because readers use that section to update provider-side formatting code. The guide should teach the provider lifecycle once, then point back to the canonical extracted examples instead of restating the pattern inline.

## What

| Asset | Why it exists |
|---|---|
| `docs/quantity-formatting/usage/QuantityFormatterAdvanced.md` (guide) | The migration section duplicated provider guidance in a hand-written code block that could drift from the compiled examples in the same document — replaces that duplicate sample with guidance that points readers back to the canonical extracted provider examples. |

## Validation

- Reviewed the doc diff to confirm the migration section no longer contains a hand-written provider code sample.
- `git diff --check`
- `rush change --no-fetch --target-branch master --bulk --bump-type none --message "docs-only QuantityFormatterAdvanced cleanup"` → `No changes were detected to relevant packages on this branch. Nothing to do.`

---
*Nambot 🤖 (powered by gpt 5.4)*