### PR TITLE
fix: stop deep-importing core-backend internals in linear-referencing

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4589,6 +4589,9 @@ export class IModelNative {
     static get platform(): typeof IModelJsNative;
 }
 
+// @internal (undocumented)
+export const _implicitTxn: unique symbol;
+
 // @beta
 export type ImplicitWriteEnforcement = "allow" | "log" | "throw";
 

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -367,6 +367,7 @@ public;class;IModelJsFs
 public;class;IModelJsFsStats
 public;interface;IModelNameArg
 internal;class;IModelNative
+internal;const;_implicitTxn
 beta;type;ImplicitWriteEnforcement
 public;class;InformationContentElement
 preview;class;InformationContentElement

--- a/common/changes/@itwin/core-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
+++ b/common/changes/@itwin/core-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Export _implicitTxn as a crossPackage internal symbol",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
+++ b/common/changes/@itwin/core-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Export _implicitTxn as a crossPackage internal symbol",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/linear-referencing-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
+++ b/common/changes/@itwin/linear-referencing-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/linear-referencing-backend",
+      "comment": "Export _implicitTxn as a crossPackage internal symbol",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-backend"
+}

--- a/common/changes/@itwin/linear-referencing-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
+++ b/common/changes/@itwin/linear-referencing-backend/nam-fix-linear-referencing-deep-import_2026-05-08-15-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/linear-referencing-backend",
-      "comment": "Export _implicitTxn as a crossPackage internal symbol",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/core/backend/src/internal/cross-package.ts
+++ b/core/backend/src/internal/cross-package.ts
@@ -6,5 +6,6 @@
 export { IModelJsNative, NativeCloudSqlite, NativeLoggerCategory } from "@bentley/imodeljs-native";
 export { IModelNative } from "./NativePlatform";
 export {
+  _implicitTxn,
   _nativeDb,
 } from "./Symbols";

--- a/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
@@ -7,8 +7,7 @@
  */
 
 import { Id64String, JsonUtils } from "@itwin/core-bentley";
-import { EditTxn, ElementMultiAspect, IModelDb } from "@itwin/core-backend";
-import { _implicitTxn } from "@itwin/core-backend/lib/cjs/internal/Symbols";
+import { _implicitTxn, EditTxn, ElementMultiAspect, IModelDb } from "@itwin/core-backend";
 import { RelatedElement } from "@itwin/core-common";
 import {
   DistanceExpressionProps, LinearlyReferencedAtLocationAspectProps, LinearlyReferencedFromToLocationAspectProps,

--- a/domains/linear-referencing/backend/src/LinearReferencingElements.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElements.ts
@@ -7,8 +7,7 @@
  */
 
 import { assert, DbResult, Id64String } from "@itwin/core-bentley";
-import { ECSqlStatement, EditTxn, ElementAspect, IModelDb, PhysicalElement, SpatialLocationElement } from "@itwin/core-backend";
-import { _implicitTxn } from "@itwin/core-backend/lib/cjs/internal/Symbols";
+import { _implicitTxn, ECSqlStatement, EditTxn, ElementAspect, IModelDb, PhysicalElement, SpatialLocationElement } from "@itwin/core-backend";
 import { Code, ElementProps, GeometricElement3dProps, IModelError, PhysicalElementProps, RelatedElement } from "@itwin/core-common";
 import {
   ComparisonOption, LinearLocationReference, LinearlyLocatedAttributionProps, LinearlyReferencedAtLocationAspectProps,


### PR DESCRIPTION
## Why

The 5.9 EditTxn migration left `@itwin/linear-referencing-backend` importing `@itwin/core-backend/lib/cjs/internal/Symbols` to reach `_implicitTxn`. That makes the package depend on another package's built internal path instead of a sanctioned export, which is exactly the kind of coupling downstream consumers and import guards reject.

That break is not just theoretical. Downstream 5.9 adoption work surfaced it as a real blocker because the published package output still referenced the deep internal path. This PR keeps the deprecated overload behavior intact, but moves the dependency onto the supported cross-package surface owned by `@itwin/core-backend`.

## What

| Asset | Why it exists |
|---|---|
| `core/backend/src/internal/cross-package.ts` | `linear-referencing-backend` needs `_implicitTxn`, so `core-backend` must expose that internal symbol through its sanctioned cross-package surface instead of forcing a `lib/cjs/internal/...` import. |
| `domains/linear-referencing/backend/src/LinearReferencingElements.ts` | The deprecated `IModelDb` overload path still needs `_implicitTxn`, so this import must come from `@itwin/core-backend` rather than a built internal file path. |
| `domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts` | The aspect-side overload path has the same unsupported dependency and must be switched to the sanctioned `@itwin/core-backend` export for consistency. |
| `common/api/core-backend.api.md` | Re-exporting `_implicitTxn` changes the package surface, so the API report must record that internal export explicitly. |
| `common/api/summary/core-backend.exports.csv` | The exports summary must reflect the new internal cross-package export so package surface checks stay accurate. |

## Validation

- `rush build -t @itwin/core-common -t @itwin/core-backend -t @itwin/linear-referencing-backend -t @itwin/core-frontend -t @itwin/workspace-editor`
- `rush extract-api`
- Verified the branch diff is narrowed to the intended linear-referencing/core-backend/API-report files only.


---
*Nambot 🤖 (powered by gpt 5.4)*
