### PR TITLE
Remove linear-referencing use of core-backend _implicitTxn internals

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -4589,9 +4589,6 @@ export class IModelNative {
     static get platform(): typeof IModelJsNative;
 }
 
-// @internal (undocumented)
-export const _implicitTxn: unique symbol;
-
 // @beta
 export type ImplicitWriteEnforcement = "allow" | "log" | "throw";
 

--- a/common/api/summary/core-backend.exports.csv
+++ b/common/api/summary/core-backend.exports.csv
@@ -367,7 +367,6 @@ public;class;IModelJsFs
 public;class;IModelJsFsStats
 public;interface;IModelNameArg
 internal;class;IModelNative
-internal;const;_implicitTxn
 beta;type;ImplicitWriteEnforcement
 public;class;InformationContentElement
 preview;class;InformationContentElement

--- a/common/changes/@itwin/core-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
+++ b/common/changes/@itwin/core-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove linear-referencing-backend's dependency on core-backend _implicitTxn internals.",
+      "type": "none",
+      "packageName": "@itwin/core-backend"
+    }
+  ],
+  "packageName": "@itwin/core-backend",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/common/changes/@itwin/core-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
+++ b/common/changes/@itwin/core-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Remove linear-referencing-backend's dependency on core-backend _implicitTxn internals.",
+      "comment": "",
       "type": "none",
       "packageName": "@itwin/core-backend"
     }

--- a/common/changes/@itwin/linear-referencing-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
+++ b/common/changes/@itwin/linear-referencing-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove linear-referencing-backend's dependency on core-backend _implicitTxn internals.",
+      "type": "none",
+      "packageName": "@itwin/linear-referencing-backend"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-backend",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/common/changes/@itwin/linear-referencing-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
+++ b/common/changes/@itwin/linear-referencing-backend/nam-linear-referencing-remove-implicit-txn_2026-05-11-17-13.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Remove linear-referencing-backend's dependency on core-backend _implicitTxn internals.",
+      "comment": "",
       "type": "none",
       "packageName": "@itwin/linear-referencing-backend"
     }

--- a/core/backend/src/internal/cross-package.ts
+++ b/core/backend/src/internal/cross-package.ts
@@ -6,6 +6,5 @@
 export { IModelJsNative, NativeCloudSqlite, NativeLoggerCategory } from "@bentley/imodeljs-native";
 export { IModelNative } from "./NativePlatform";
 export {
-  _implicitTxn,
   _nativeDb,
 } from "./Symbols";

--- a/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
@@ -7,7 +7,7 @@
  */
 
 import { Id64String, JsonUtils } from "@itwin/core-bentley";
-import { _implicitTxn, EditTxn, ElementMultiAspect, IModelDb } from "@itwin/core-backend";
+import { EditTxn, ElementMultiAspect, IModelDb } from "@itwin/core-backend";
 import { RelatedElement } from "@itwin/core-common";
 import {
   DistanceExpressionProps, LinearlyReferencedAtLocationAspectProps, LinearlyReferencedFromToLocationAspectProps,
@@ -89,8 +89,13 @@ export class LinearlyReferencedAtLocation extends LinearlyReferencedLocation {
 
   public static insert(txnOrIModel: EditTxn | IModelDb, locatedElementId: Id64String,
     at: DistanceExpression, fromReferentId?: Id64String): void {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    txn.insertAspect(this.toProps(locatedElementId, at, fromReferentId));
+    const aspectProps = this.toProps(locatedElementId, at, fromReferentId);
+    if (txnOrIModel instanceof EditTxn)
+      txnOrIModel.insertAspect(aspectProps);
+    else {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+      txnOrIModel.elements.insertAspect(aspectProps);
+    }
   }
 }
 
@@ -147,7 +152,12 @@ export class LinearlyReferencedFromToLocation extends LinearlyReferencedLocation
 
   public static insert(txnOrIModel: EditTxn | IModelDb, locatedElementId: Id64String,
     from: DistanceExpression, to: DistanceExpression, fromReferentId?: Id64String, toReferentId?: Id64String): void {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    txn.insertAspect(this.toProps(locatedElementId, from, to, fromReferentId, toReferentId));
+    const aspectProps = this.toProps(locatedElementId, from, to, fromReferentId, toReferentId);
+    if (txnOrIModel instanceof EditTxn)
+      txnOrIModel.insertAspect(aspectProps);
+    else {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+      txnOrIModel.elements.insertAspect(aspectProps);
+    }
   }
 }

--- a/domains/linear-referencing/backend/src/LinearReferencingElements.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElements.ts
@@ -7,7 +7,7 @@
  */
 
 import { assert, DbResult, Id64String } from "@itwin/core-bentley";
-import { _implicitTxn, ECSqlStatement, EditTxn, ElementAspect, IModelDb, PhysicalElement, SpatialLocationElement } from "@itwin/core-backend";
+import { ECSqlStatement, EditTxn, ElementAspect, IModelDb, PhysicalElement, SpatialLocationElement } from "@itwin/core-backend";
 import { Code, ElementProps, GeometricElement3dProps, IModelError, PhysicalElementProps, RelatedElement } from "@itwin/core-common";
 import {
   ComparisonOption, LinearLocationReference, LinearlyLocatedAttributionProps, LinearlyReferencedAtLocationAspectProps,
@@ -91,10 +91,17 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
     fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String;
   public static insertFromTo(txnOrIModel: EditTxn | IModelDb, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const newId = LinearlyLocated.insertFromTo(txn, this.toProps(modelId, categoryId), linearElementId, fromToPosition);
-    ILinearLocationLocatesElement.insert(txn, newId, locatedElementId);
-    return newId;
+    if (txnOrIModel instanceof EditTxn) {
+      const newId = LinearlyLocated.insertFromTo(txnOrIModel, this.toProps(modelId, categoryId), linearElementId, fromToPosition);
+      ILinearLocationLocatesElement.insert(txnOrIModel, newId, locatedElementId);
+      return newId;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    const iModelNewId = LinearlyLocated.insertFromTo(txnOrIModel, this.toProps(modelId, categoryId), linearElementId, fromToPosition);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    ILinearLocationLocatesElement.insert(txnOrIModel, iModelNewId, locatedElementId);
+    return iModelNewId;
   }
 
   /** Insert this `LinearLocation` using an explicit transaction.
@@ -106,10 +113,17 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
    */
   public insertFromTo(iModel: IModelDb, linearElementId: Id64String, fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String;
   public insertFromTo(txnOrIModel: EditTxn | IModelDb, linearElementId: Id64String, fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const newId = LinearlyLocated.insertFromTo(txn, this.toJSON(), linearElementId, fromToPosition);
-    ILinearLocationLocatesElement.insert(txn, newId, locatedElementId);
-    return newId;
+    if (txnOrIModel instanceof EditTxn) {
+      const newId = LinearlyLocated.insertFromTo(txnOrIModel, this.toJSON(), linearElementId, fromToPosition);
+      ILinearLocationLocatesElement.insert(txnOrIModel, newId, locatedElementId);
+      return newId;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    const iModelNewId = LinearlyLocated.insertFromTo(txnOrIModel, this.toJSON(), linearElementId, fromToPosition);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    ILinearLocationLocatesElement.insert(txnOrIModel, iModelNewId, locatedElementId);
+    return iModelNewId;
   }
 
   /** Insert a new `LinearLocation` using an explicit transaction.
@@ -124,10 +138,17 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
     atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String;
   public static insertAt(txnOrIModel: EditTxn | IModelDb, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const newId = LinearlyLocated.insertAt(txn, this.toProps(modelId, categoryId), linearElementId, atPosition);
-    ILinearLocationLocatesElement.insert(txn, newId, locatedElementId);
-    return newId;
+    if (txnOrIModel instanceof EditTxn) {
+      const newId = LinearlyLocated.insertAt(txnOrIModel, this.toProps(modelId, categoryId), linearElementId, atPosition);
+      ILinearLocationLocatesElement.insert(txnOrIModel, newId, locatedElementId);
+      return newId;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    const iModelNewId = LinearlyLocated.insertAt(txnOrIModel, this.toProps(modelId, categoryId), linearElementId, atPosition);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    ILinearLocationLocatesElement.insert(txnOrIModel, iModelNewId, locatedElementId);
+    return iModelNewId;
   }
 
   /** Insert this `LinearLocation` using an explicit transaction.
@@ -139,10 +160,17 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
    */
   public insertAt(iModel: IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String;
   public insertAt(txnOrIModel: EditTxn | IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const newId = LinearlyLocated.insertAt(txn, this.toJSON(), linearElementId, atPosition);
-    ILinearLocationLocatesElement.insert(txn, newId, locatedElementId);
-    return newId;
+    if (txnOrIModel instanceof EditTxn) {
+      const newId = LinearlyLocated.insertAt(txnOrIModel, this.toJSON(), linearElementId, atPosition);
+      ILinearLocationLocatesElement.insert(txnOrIModel, newId, locatedElementId);
+      return newId;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    const iModelNewId = LinearlyLocated.insertAt(txnOrIModel, this.toJSON(), linearElementId, atPosition);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    ILinearLocationLocatesElement.insert(txnOrIModel, iModelNewId, locatedElementId);
+    return iModelNewId;
   }
 }
 
@@ -215,8 +243,11 @@ export class Referent extends ReferentElement {
     atPosition: LinearlyReferencedAtLocationProps, referencedElementId: Id64String): Id64String;
   public static insertAt(txnOrIModel: EditTxn | IModelDb, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps, referencedElementId: Id64String): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    return LinearlyLocated.insertAt(txn, this.toProps(modelId, categoryId, referencedElementId), linearElementId, atPosition);
+    if (txnOrIModel instanceof EditTxn)
+      return LinearlyLocated.insertAt(txnOrIModel, this.toProps(modelId, categoryId, referencedElementId), linearElementId, atPosition);
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    return LinearlyLocated.insertAt(txnOrIModel, this.toProps(modelId, categoryId, referencedElementId), linearElementId, atPosition);
   }
 
   /** Insert this `Referent` using an explicit transaction.
@@ -228,8 +259,11 @@ export class Referent extends ReferentElement {
    */
   public insertAt(iModel: IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps): Id64String;
   public insertAt(txnOrIModel: EditTxn | IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    return LinearlyLocated.insertAt(txn, this.toJSON(), linearElementId, atPosition);
+    if (txnOrIModel instanceof EditTxn)
+      return LinearlyLocated.insertAt(txnOrIModel, this.toJSON(), linearElementId, atPosition);
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+    return LinearlyLocated.insertAt(txnOrIModel, this.toJSON(), linearElementId, atPosition);
   }
 }
 
@@ -547,12 +581,20 @@ class QueryLinearLocationsECSQLGen {
  * @beta
  */
 export class LinearlyLocated {
-  private static insertBasic(txn: EditTxn, elProps: ElementProps, linearElementId: Id64String): Id64String {
-    const newId = txn.insertElement(elProps);
+  private static insertBasic(txnOrIModel: EditTxn | IModelDb, elProps: ElementProps, linearElementId: Id64String): Id64String {
+    const newId = txnOrIModel instanceof EditTxn
+      ? txnOrIModel.insertElement(elProps)
+      : (() => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+        return txnOrIModel.elements.insertElement(elProps);
+      })();
 
-    const linearlyLocatedAlongLinearElement =
-      ILinearlyLocatedAlongILinearElement.create(txn.iModel, newId, linearElementId);
-    linearlyLocatedAlongLinearElement.insert(txn);
+    if (txnOrIModel instanceof EditTxn)
+      ILinearlyLocatedAlongILinearElement.insert(txnOrIModel, newId, linearElementId);
+    else {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+      ILinearlyLocatedAlongILinearElement.insert(txnOrIModel, newId, linearElementId);
+    }
 
     return newId;
   }
@@ -580,10 +622,15 @@ export class LinearlyLocated {
     atPosition: LinearlyReferencedAtLocationProps): Id64String;
   public static insertAt(txnOrIModel: EditTxn | IModelDb, elProps: ElementProps, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const newId: Id64String = this.insertBasic(txn, elProps, linearElementId);
-    LinearlyReferencedAtLocation.insert(txn, newId, atPosition.atPosition,
-      atPosition.fromReferent === undefined ? undefined : atPosition.fromReferent.id);
+    const newId: Id64String = this.insertBasic(txnOrIModel, elProps, linearElementId);
+    if (txnOrIModel instanceof EditTxn)
+      LinearlyReferencedAtLocation.insert(txnOrIModel, newId, atPosition.atPosition,
+        atPosition.fromReferent === undefined ? undefined : atPosition.fromReferent.id);
+    else {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+      LinearlyReferencedAtLocation.insert(txnOrIModel, newId, atPosition.atPosition,
+        atPosition.fromReferent === undefined ? undefined : atPosition.fromReferent.id);
+    }
     return newId;
   }
 
@@ -610,12 +657,19 @@ export class LinearlyLocated {
     fromToPosition: LinearlyReferencedFromToLocationProps): Id64String;
   public static insertFromTo(txnOrIModel: EditTxn | IModelDb, elProps: ElementProps, linearElementId: Id64String,
     fromToPosition: LinearlyReferencedFromToLocationProps): Id64String {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const newId: Id64String = this.insertBasic(txn, elProps, linearElementId);
-    LinearlyReferencedFromToLocation.insert(txn, newId,
-      fromToPosition.fromPosition, fromToPosition.toPosition,
-      fromToPosition.fromPositionFromReferent === undefined ? undefined : fromToPosition.fromPositionFromReferent.id,
-      fromToPosition.toPositionFromReferent === undefined ? undefined : fromToPosition.toPositionFromReferent.id);
+    const newId: Id64String = this.insertBasic(txnOrIModel, elProps, linearElementId);
+    if (txnOrIModel instanceof EditTxn)
+      LinearlyReferencedFromToLocation.insert(txnOrIModel, newId,
+        fromToPosition.fromPosition, fromToPosition.toPosition,
+        fromToPosition.fromPositionFromReferent === undefined ? undefined : fromToPosition.fromPositionFromReferent.id,
+        fromToPosition.toPositionFromReferent === undefined ? undefined : fromToPosition.toPositionFromReferent.id);
+    else {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+      LinearlyReferencedFromToLocation.insert(txnOrIModel, newId,
+        fromToPosition.fromPosition, fromToPosition.toPosition,
+        fromToPosition.fromPositionFromReferent === undefined ? undefined : fromToPosition.fromPositionFromReferent.id,
+        fromToPosition.toPositionFromReferent === undefined ? undefined : fromToPosition.toPositionFromReferent.id);
+    }
     return newId;
   }
 
@@ -689,8 +743,7 @@ export class LinearlyLocated {
     aspectId?: Id64String): void;
   public static updateAtLocation(txnOrIModel: EditTxn | IModelDb, linearlyLocatedElementId: Id64String, linearLocationProps: LinearlyReferencedAtLocationProps,
     aspectId?: Id64String): void {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const iModel = txn.iModel;
+    const iModel = txnOrIModel instanceof EditTxn ? txnOrIModel.iModel : txnOrIModel;
     let linearLocAspectId: Id64String;
     if (aspectId !== undefined)
       linearLocAspectId = aspectId;
@@ -710,7 +763,12 @@ export class LinearlyLocated {
       fromReferent: linearLocationProps.fromReferent,
     };
 
-    txn.updateAspect(linearLocationAspectProps);
+    if (txnOrIModel instanceof EditTxn)
+      txnOrIModel.updateAspect(linearLocationAspectProps);
+    else {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+      txnOrIModel.elements.updateAspect(linearLocationAspectProps);
+    }
   }
 
   /** Update an existing LinearlyReferencedFromToLocation aspect within the iModel.
@@ -728,8 +786,7 @@ export class LinearlyLocated {
     aspectId?: Id64String): void;
   public static updateFromToLocation(txnOrIModel: EditTxn | IModelDb, linearlyLocatedElementId: Id64String, linearLocationProps: LinearlyReferencedFromToLocationProps,
     aspectId?: Id64String): void {
-    const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
-    const iModel = txn.iModel;
+    const iModel = txnOrIModel instanceof EditTxn ? txnOrIModel.iModel : txnOrIModel;
     let linearLocAspectId: Id64String;
     if (aspectId !== undefined)
       linearLocAspectId = aspectId;
@@ -751,7 +808,12 @@ export class LinearlyLocated {
       toPositionFromReferent: linearLocationProps.toPositionFromReferent,
     };
 
-    txn.updateAspect(linearLocationAspectProps);
+    if (txnOrIModel instanceof EditTxn)
+      txnOrIModel.updateAspect(linearLocationAspectProps);
+    else {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated IModelDb overload is intentionally preserved for backward compatibility.
+      txnOrIModel.elements.updateAspect(linearLocationAspectProps);
+    }
   }
 
   /** Query for the Id of the Linear-Element along which the specified LinearlyLocated Element is located.


### PR DESCRIPTION
## Why

`@itwin/linear-referencing-backend` was still depending on core-backend's implicit transaction internals to preserve deprecated `IModelDb` write overloads. That surfaced as a migration blocker because it relied on unsupported internal access patterns.

The previous fix direction made that dependency legal by re-exporting `_implicitTxn` from core-backend. That solves the immediate build problem in the wrong layer. Implicit transaction handling should stay encapsulated inside core-backend, while linear-referencing should use the existing public deprecated write paths that already preserve that behavior.

## What

| Asset | Why it exists |
|---|---|
| `domains/linear-referencing/backend/src/LinearReferencingElements.ts` | Deprecated linear-referencing element insert and update paths still need backward-compatible `IModelDb` behavior without reaching into core-backend internals. |
| `domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts` | Deprecated aspect insert paths still need to bridge `EditTxn` and `IModelDb` callers through public APIs only. |
| `core/backend/src/internal/cross-package.ts` | The rejected fix exposed `_implicitTxn` across package boundaries, so this file now stops re-exporting it. |
| `common/api/core-backend.api.md` and `common/api/summary/core-backend.exports.csv` | Removing the cross-package export changes the generated core-backend API surface and needs the reports to match. |
| `common/changes/@itwin/core-backend/...` and `common/changes/@itwin/linear-referencing-backend/...` | Both touched packages need `rush change` entries even though this is compatibility and internal-surface cleanup work. |

## Validation

- `rush install --bypass-policy`
- `rush build`
- `rush lint`
- `rush extract-api`
- `cd domains/linear-referencing/backend && rushx build && rushx test`
- Verified no spurious api-extractor ordering diffs in `common/api/ecschema-metadata.api.md` or `common/api/ecschema-editing.api.md`

Known baseline:
- `rush lint` still reports existing repo warnings in unrelated packages, but this branch adds no lint failures.

---
*Nambot 🤖 (powered by GPT5.4)*
