### PR TITLE
Restore deprecation version sync in the version bump pipeline

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -27,11 +27,6 @@ parameters:
       - patch
       - releaseCandidate
 
-  - name: DryRunDeprecationOnly
-    displayName: Dry run only the deprecation rewrite flow (no commit or push)
-    type: boolean
-    default: false
-
 trigger: none
 pr: none
 schedules:
@@ -65,7 +60,7 @@ jobs:
   - job: CreateBranch
     displayName: Create branch for next release
     dependsOn: CheckPrevCommit
-    condition: and(not(${{ parameters.DryRunDeprecationOnly }}), eq('${{ parameters.BumpType }}', 'releaseCandidate'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(eq('${{ parameters.BumpType }}', 'releaseCandidate'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     steps:
       - checkout: self
       - bash: |
@@ -180,56 +175,6 @@ jobs:
         displayName: Update mergify.yml variables on master
         continueOnError: true # If this step fails, we don't want to block the release branch creation
 
-  - job: DryRunDeprecationSmoke
-    displayName: Dry Run Deprecation Smoke Test
-    condition: and(${{ parameters.DryRunDeprecationOnly }}, or(eq('${{ parameters.BumpType }}', 'minor'), eq('${{ parameters.BumpType }}', 'patch')))
-    steps:
-      - checkout: self
-
-      - task: UseNode@1
-        displayName: Use Node 24.x
-        inputs:
-          version: 24.x
-          checkLatest: true
-
-      - bash: |
-          git config --local user.email imodeljs-admin@users.noreply.github.com
-          git config --local user.name imodeljs-admin
-        displayName: Setup Git
-
-      - script: node common/scripts/install-run-rush.js install
-        displayName: rush install
-
-      - bash: node common/scripts/install-run-rush.js audit
-        displayName: rush audit
-
-      - bash: |
-          currentVersion=$(jq -r '.[] | .version' common/config/rush/version-policies.json | head -n 1)
-          deprecationVersion=${currentVersion%%-*}
-          sed -i "s/\(addVersion: \"\)[^\"]*/\1$deprecationVersion/" common/config/eslint/eslint.config.deprecation-policy.js
-          echo "Using deprecation addVersion=$deprecationVersion"
-          echo "##vso[task.setvariable variable=deprecationVersion]$deprecationVersion"
-        displayName: Sync deprecation policy addVersion to current version
-
-      - bash: node common/scripts/install-run-rush.js lint-deprecation
-        displayName: rush lint-deprecation
-
-      - bash: node common/scripts/install-run-rush.js build
-        displayName: rush build
-        env:
-          VERSION_BUMP: "true"
-
-      - bash: |
-          echo "Changed files:"
-          git diff --name-only
-          echo
-          echo "Diff stat:"
-          git diff --stat
-          echo
-          echo "Representative diff output:"
-          git diff -- common/config/eslint/eslint.config.deprecation-policy.js core/backend/src/IModelDb.ts core/backend/src/ChangesetECAdaptor.ts core/geometry/src/geometry3d/Ellipsoid.ts core/geometry/src/clipping/ClipPrimitive.ts | sed -n '1,240p'
-        displayName: Print diff the pipeline would commit
-
   - job: Bump
     displayName: Bump Version
     dependsOn:
@@ -238,7 +183,7 @@ jobs:
     # Include 'SucceededWithIssues' here because the CreateBranch job's mergify.yml update step
     # uses 'continueOnError: true' above. That step may fail without blocking the overall
     # version bump, so we still want the Bump job to run when CreateBranch completes with issues.
-    condition: and(not(${{ parameters.DryRunDeprecationOnly }}), in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped', 'SucceededWithIssues'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'))
+    condition: and(in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped', 'SucceededWithIssues'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'))
     variables:
       releaseBranchName: $[ dependencies.CreateBranch.outputs['getBranchName.releaseBranchName'] ]
       deprecationCommentChangesMade: "false"
@@ -480,7 +425,7 @@ jobs:
   - job: UpdateMaster
     displayName: Update master to next minor version
     dependsOn: Bump
-    condition: and(not(${{ parameters.DryRunDeprecationOnly }}), eq('${{ parameters.BumpType }}', 'releaseCandidate'), eq(dependencies.Bump.result, 'Succeeded'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(eq('${{ parameters.BumpType }}', 'releaseCandidate'), eq(dependencies.Bump.result, 'Succeeded'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     steps:
       - checkout: self
       - task: UseNode@1

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -65,7 +65,7 @@ jobs:
   - job: CreateBranch
     displayName: Create branch for next release
     dependsOn: CheckPrevCommit
-    condition: and(eq('${{ parameters.BumpType }}', 'releaseCandidate'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(not(${{ parameters.DryRunDeprecationOnly }}), eq('${{ parameters.BumpType }}', 'releaseCandidate'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     steps:
       - checkout: self
       - bash: |
@@ -182,10 +182,7 @@ jobs:
 
   - job: DryRunDeprecationSmoke
     displayName: Dry Run Deprecation Smoke Test
-    dependsOn:
-    - CreateBranch
-    - CheckPrevCommit
-    condition: and(${{ parameters.DryRunDeprecationOnly }}, or(eq('${{ parameters.BumpType }}', 'minor'), eq('${{ parameters.BumpType }}', 'patch')), in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped', 'SucceededWithIssues'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'))
+    condition: and(${{ parameters.DryRunDeprecationOnly }}, or(eq('${{ parameters.BumpType }}', 'minor'), eq('${{ parameters.BumpType }}', 'patch')))
     steps:
       - checkout: self
 
@@ -483,7 +480,7 @@ jobs:
   - job: UpdateMaster
     displayName: Update master to next minor version
     dependsOn: Bump
-    condition: and(eq('${{ parameters.BumpType }}', 'releaseCandidate'), eq(dependencies.Bump.result, 'Succeeded'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(not(${{ parameters.DryRunDeprecationOnly }}), eq('${{ parameters.BumpType }}', 'releaseCandidate'), eq(dependencies.Bump.result, 'Succeeded'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     steps:
       - checkout: self
       - task: UseNode@1

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -217,10 +217,18 @@ jobs:
 
       - ${{ if or(eq(parameters.BumpType, 'minor'), eq(parameters.BumpType, 'patch')) }}:
           - bash: |
-              currentVersion=$(jq -r '.[] | .version' common/config/rush/version-policies.json | head -n 1)
+              # Keep this aligned with the version policy used by the release version bump steps below.
+              versionPolicyName=prerelease-monorepo-lockStep
+              currentVersion=$(jq -r --arg policyName "$versionPolicyName" '.[] | select(.policyName == $policyName) | .version' common/config/rush/version-policies.json)
+              if [ -z "$currentVersion" ] || [ "$currentVersion" = "null" ]; then
+                echo "Failed to find version policy '$versionPolicyName' in common/config/rush/version-policies.json" >&2
+                exit 1
+              fi
+              # Deprecation comments require a released minor/patch version like 5.10.0, not a prerelease suffix like 5.10.0-dev.10.
+              # For non-prerelease versions, this parameter expansion leaves the version unchanged.
               deprecationVersion=${currentVersion%%-*}
               sed -i "s/\(addVersion: \"\)[^\"]*/\1$deprecationVersion/" common/config/eslint/eslint.config.deprecation-policy.js
-              echo "Using deprecation addVersion=$deprecationVersion"
+              echo "Using deprecation addVersion=$deprecationVersion from version policy $versionPolicyName"
               echo "##vso[task.setvariable variable=deprecationVersion]$deprecationVersion"
             displayName: Sync deprecation policy addVersion to current version
 

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -27,6 +27,11 @@ parameters:
       - patch
       - releaseCandidate
 
+  - name: DryRunDeprecationOnly
+    displayName: Dry run only the deprecation rewrite flow (no commit or push)
+    type: boolean
+    default: false
+
 trigger: none
 pr: none
 schedules:
@@ -175,6 +180,59 @@ jobs:
         displayName: Update mergify.yml variables on master
         continueOnError: true # If this step fails, we don't want to block the release branch creation
 
+  - job: DryRunDeprecationSmoke
+    displayName: Dry Run Deprecation Smoke Test
+    dependsOn:
+    - CreateBranch
+    - CheckPrevCommit
+    condition: and(${{ parameters.DryRunDeprecationOnly }}, or(eq('${{ parameters.BumpType }}', 'minor'), eq('${{ parameters.BumpType }}', 'patch')), in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped', 'SucceededWithIssues'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'))
+    steps:
+      - checkout: self
+
+      - task: UseNode@1
+        displayName: Use Node 24.x
+        inputs:
+          version: 24.x
+          checkLatest: true
+
+      - bash: |
+          git config --local user.email imodeljs-admin@users.noreply.github.com
+          git config --local user.name imodeljs-admin
+        displayName: Setup Git
+
+      - script: node common/scripts/install-run-rush.js install
+        displayName: rush install
+
+      - bash: node common/scripts/install-run-rush.js audit
+        displayName: rush audit
+
+      - bash: |
+          currentVersion=$(jq -r '.[] | .version' common/config/rush/version-policies.json | head -n 1)
+          deprecationVersion=${currentVersion%%-*}
+          sed -i "s/\(addVersion: \"\)[^\"]*/\1$deprecationVersion/" common/config/eslint/eslint.config.deprecation-policy.js
+          echo "Using deprecation addVersion=$deprecationVersion"
+          echo "##vso[task.setvariable variable=deprecationVersion]$deprecationVersion"
+        displayName: Sync deprecation policy addVersion to current version
+
+      - bash: node common/scripts/install-run-rush.js lint-deprecation
+        displayName: rush lint-deprecation
+
+      - bash: node common/scripts/install-run-rush.js build
+        displayName: rush build
+        env:
+          VERSION_BUMP: "true"
+
+      - bash: |
+          echo "Changed files:"
+          git diff --name-only
+          echo
+          echo "Diff stat:"
+          git diff --stat
+          echo
+          echo "Representative diff output:"
+          git diff -- common/config/eslint/eslint.config.deprecation-policy.js core/backend/src/IModelDb.ts core/backend/src/ChangesetECAdaptor.ts core/geometry/src/geometry3d/Ellipsoid.ts core/geometry/src/clipping/ClipPrimitive.ts | sed -n '1,240p'
+        displayName: Print diff the pipeline would commit
+
   - job: Bump
     displayName: Bump Version
     dependsOn:
@@ -183,7 +241,7 @@ jobs:
     # Include 'SucceededWithIssues' here because the CreateBranch job's mergify.yml update step
     # uses 'continueOnError: true' above. That step may fail without blocking the overall
     # version bump, so we still want the Bump job to run when CreateBranch completes with issues.
-    condition: and(in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped', 'SucceededWithIssues'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'))
+    condition: and(not(${{ parameters.DryRunDeprecationOnly }}), in(dependencies.CreateBranch.result, 'Succeeded', 'Skipped', 'SucceededWithIssues'), in(dependencies.CheckPrevCommit.result, 'Succeeded', 'Skipped'))
     variables:
       releaseBranchName: $[ dependencies.CreateBranch.outputs['getBranchName.releaseBranchName'] ]
       deprecationCommentChangesMade: "false"
@@ -216,6 +274,14 @@ jobs:
         displayName: rush audit
 
       - ${{ if or(eq(parameters.BumpType, 'minor'), eq(parameters.BumpType, 'patch')) }}:
+          - bash: |
+              currentVersion=$(jq -r '.[] | .version' common/config/rush/version-policies.json | head -n 1)
+              deprecationVersion=${currentVersion%%-*}
+              sed -i "s/\(addVersion: \"\)[^\"]*/\1$deprecationVersion/" common/config/eslint/eslint.config.deprecation-policy.js
+              echo "Using deprecation addVersion=$deprecationVersion"
+              echo "##vso[task.setvariable variable=deprecationVersion]$deprecationVersion"
+            displayName: Sync deprecation policy addVersion to current version
+
           - bash: node common/scripts/install-run-rush.js lint-deprecation
             displayName: rush lint-deprecation
 
@@ -236,7 +302,7 @@ jobs:
             displayName: Determine whether ESLint rule made any changes
 
           - bash: |
-              git commit -m "Apply deprecation date rule"
+              git commit -m "Apply deprecation date rule for v$(deprecationVersion)"
             displayName: Commit deprecation comment changes to release branch
             condition: eq(variables['deprecationCommentChangesMade'], 'true')
 


### PR DESCRIPTION
## Why

The version-bump automation stopped propagating the current release version into the deprecation-policy config, so deprecation rewrites kept using a stale hardcoded `5.1.9`. That makes the automation stamp the wrong minor version onto newly rewritten `@deprecated` comments and obscures which release the deprecation pass actually corresponded to.

This PR fixes the pipeline plumbing only. It does not try to retroactively correct already-stale source comments; that cleanup can happen in a separate PR with a narrower review surface.

## What

| Asset | Why it exists |
|---|---|
| `common/config/azure-pipelines/jobs/version-bump.yaml` (pipeline job template) | Minor and patch version bumps need to sync `common/config/eslint/eslint.config.deprecation-policy.js` from `common/config/rush/version-policies.json` before `rush lint-deprecation` runs so the deprecation fixer uses the current stable version instead of stale `5.1.9`. |
| `common/config/azure-pipelines/jobs/version-bump.yaml` (deprecation commit message) | The deprecation-only commit needs to include the resolved version again so history shows which release the automated deprecation rewrite was generated for. |

## Validation

Performed a dry-run smoke on our version-bump pipeline to verify the synced deprecation version changed as expected:

```text
Changed files:
common/config/eslint/eslint.config.deprecation-policy.js

Diff stat:
 common/config/eslint/eslint.config.deprecation-policy.js | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Representative diff output:
diff --git a/common/config/eslint/eslint.config.deprecation-policy.js b/common/config/eslint/eslint.config.deprecation-policy.js
index ff337dd433..78a3f0b365 100644
--- a/common/config/eslint/eslint.config.deprecation-policy.js
+++ b/common/config/eslint/eslint.config.deprecation-policy.js
@@ -23,7 +23,7 @@ module.exports = [
         "warn",
         {
           removeOldDates: true,
-          addVersion: "5.1.9"
+          addVersion: "5.10.0"
         }
       ]
     }
```

Also validated the pipeline YAML parses successfully:

```sh
ruby -e 'require "yaml"; YAML.load_file("common/config/azure-pipelines/jobs/version-bump.yaml")'
```

---
*Nambot 🤖*
