### PR TITLE
Correct stale deprecation versions in API comments

### DIFF
--- a/common/changes/@itwin/core-backend/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
+++ b/common/changes/@itwin/core-backend/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@itwin/core-backend"
+    }
+  ],
+  "packageName": "@itwin/core-backend",
+  "email": "hoangnam.le@bentley.com"
+}

--- a/common/changes/@itwin/core-common/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
+++ b/common/changes/@itwin/core-common/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@itwin/core-common"
+    }
+  ],
+  "packageName": "@itwin/core-common",
+  "email": "hoangnam.le@bentley.com"
+}

--- a/common/changes/@itwin/core-frontend/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
+++ b/common/changes/@itwin/core-frontend/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@itwin/core-frontend"
+    }
+  ],
+  "packageName": "@itwin/core-frontend",
+  "email": "hoangnam.le@bentley.com"
+}

--- a/common/changes/@itwin/core-geometry/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
+++ b/common/changes/@itwin/core-geometry/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@itwin/core-geometry"
+    }
+  ],
+  "packageName": "@itwin/core-geometry",
+  "email": "hoangnam.le@bentley.com"
+}

--- a/common/changes/@itwin/linear-referencing-backend/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
+++ b/common/changes/@itwin/linear-referencing-backend/nam-fix-stale-5-1-9-deprecations_2026-05-12-20-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@itwin/linear-referencing-backend"
+    }
+  ],
+  "packageName": "@itwin/linear-referencing-backend",
+  "email": "hoangnam.le@bentley.com"
+}

--- a/core/backend/src/Category.ts
+++ b/core/backend/src/Category.ts
@@ -138,7 +138,7 @@ export class SubCategory extends DefinitionElement {
   public static insert(txn: EditTxn, parentCategoryId: Id64String, name: string, appearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String;
   /**
    * Insert a new SubCategory
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use SubCategory.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use SubCategory.insert(txn, ...) instead.
    */
   public static insert(iModelDb: IModelDb, parentCategoryId: Id64String, name: string, appearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentCategoryId: Id64String, name: string, appearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {
@@ -215,7 +215,7 @@ export class Category extends DefinitionElement {
   public setDefaultAppearance(txn: EditTxn, props: SubCategoryAppearance.Props | SubCategoryAppearance): void;
   /**
    * Set the appearance of the default SubCategory for this Category
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Category.setDefaultAppearance(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Category.setDefaultAppearance(txn, ...) instead.
    */
   public setDefaultAppearance(props: SubCategoryAppearance.Props | SubCategoryAppearance): void;
   public setDefaultAppearance(txnOrProps: EditTxn | SubCategoryAppearance.Props | SubCategoryAppearance, props?: SubCategoryAppearance.Props | SubCategoryAppearance): void {
@@ -297,7 +297,7 @@ export class DrawingCategory extends Category {
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String;
   /**
    * Insert a new DrawingCategory
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use DrawingCategory.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use DrawingCategory.insert(txn, ...) instead.
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {
@@ -366,7 +366,7 @@ export class SpatialCategory extends Category {
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String;
   /**
    * Insert a new SpatialCategory
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use SpatialCategory.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use SpatialCategory.insert(txn, ...) instead.
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, defaultAppearance: SubCategoryAppearance.Props | SubCategoryAppearance): Id64String {

--- a/core/backend/src/ChangesetECAdaptor.ts
+++ b/core/backend/src/ChangesetECAdaptor.ts
@@ -354,7 +354,7 @@ class ECDbMap {
 /**
  * Record meta data for the change.
  * @beta
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use [ChangeMeta]($backend) with [ChangesetReader]($backend) instead.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use [ChangeMeta]($backend) with [ChangesetReader]($backend) instead.
  * */
 export interface ChangeMetaData {
   /** list of tables making up this EC change */
@@ -374,7 +374,7 @@ export interface ChangeMetaData {
 /**
  * Represent EC change derived from low level sqlite change
  * @beta
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use [ChangeInstance]($backend) with [ChangesetReader]($backend) instead.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use [ChangeInstance]($backend) with [ChangesetReader]($backend) instead.
  */
 export interface ChangedECInstance {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -388,7 +388,7 @@ export interface ChangedECInstance {
 /**
  * Helper function to convert between JS DateTime & SQLite JulianDay values.
  * @beta
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. The DateTime namespace is deprecated and will be removed in a future release.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. The DateTime namespace is deprecated and will be removed in a future release.
  * */
 namespace DateTime {
   /**
@@ -416,7 +416,7 @@ namespace DateTime {
 /**
  * Represents a cache for unifying EC changes.
  * @beta
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use [ChangeCache]($backend) with [ChangesetReader]($backend) instead.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use [ChangeCache]($backend) with [ChangesetReader]($backend) instead.
  */
 export interface ECChangeUnifierCache extends Disposable {
   /**
@@ -447,7 +447,7 @@ export interface ECChangeUnifierCache extends Disposable {
 }
 /**
  * @beta
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use [ChangeUnifierCache.createInMemoryCache]($backend) / [ChangeUnifierCache.createSqliteBackedCache]($backend) instead.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use [ChangeUnifierCache.createInMemoryCache]($backend) / [ChangeUnifierCache.createSqliteBackedCache]($backend) instead.
 */
 export namespace ECChangeUnifierCache {
   /**
@@ -657,7 +657,7 @@ class SqliteBackedInstanceCache implements ECChangeUnifierCache {
  * Partial changes is per table and a single instance can
  * span multiple tables.
  * @beta
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use [PartialChangeUnifier]($backend) with [ChangesetReader]($backend) instead.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use [PartialChangeUnifier]($backend) with [ChangesetReader]($backend) instead.
  */
 export class PartialECChangeUnifier implements Disposable {
   private _readonly = false;
@@ -825,7 +825,7 @@ export class PartialECChangeUnifier implements Disposable {
  * it is per table while a single instance can span multiple table.
  * @note PrimitiveArray and StructArray are not supported types.
  * @beta
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use [ChangesetReader]($backend) instead.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use [ChangesetReader]($backend) instead.
  *
 */
 export class ChangesetECAdaptor implements Disposable {

--- a/core/backend/src/CodeSpecs.ts
+++ b/core/backend/src/CodeSpecs.ts
@@ -151,7 +151,7 @@ export class CodeSpecs {
    * @returns The Id of the persistent CodeSpec.
    * @note If successful, this method will assign a valid CodeSpecId to the supplied CodeSpec
    * @throws IModelError if the insertion fails
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use CodeSpecs.insert(txn, codeSpec) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use CodeSpecs.insert(txn, codeSpec) instead.
    */
   public insert(codeSpec: CodeSpec): Id64String;
 
@@ -160,7 +160,7 @@ export class CodeSpecs {
    * @param properties The properties or the CodeSpec. For backwards compatibility this may also be a `CodeScopeSpec.Type`.
    * @returns The Id of the persistent CodeSpec.
    * @throws IModelError if the insertion fails
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use CodeSpecs.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use CodeSpecs.insert(txn, ...) instead.
    */
   public insert(name: string, properties: CodeSpecProperties | CodeScopeSpec.Type): Id64String;
   public insert(
@@ -213,7 +213,7 @@ export class CodeSpecs {
   /** Update the Json properties of an existing CodeSpec.
    * @param codeSpec The codeSpec holding Json properties values to update.
    * @throws if unable to update the codeSpec.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use CodeSpecs.updateProperties(txn, codeSpec) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use CodeSpecs.updateProperties(txn, codeSpec) instead.
    */
   public updateProperties(codeSpec: CodeSpec): void;
   public updateProperties(txnOrCodeSpec: EditTxn | CodeSpec, codeSpec?: CodeSpec): void {

--- a/core/backend/src/DisplayStyle.ts
+++ b/core/backend/src/DisplayStyle.ts
@@ -203,7 +203,7 @@ export class DisplayStyle2d extends DisplayStyle {
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string): Id64String;
   /**
    * Insert a DisplayStyle2d for use by a ViewDefinition.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use DisplayStyle2d.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use DisplayStyle2d.insert(txn, ...) instead.
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string): Id64String {
@@ -356,7 +356,7 @@ export class DisplayStyle3d extends DisplayStyle {
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, options?: DisplayStyleCreationOptions): Id64String;
   /**
    * Insert a DisplayStyle3d for use by a ViewDefinition.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use DisplayStyle3d.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use DisplayStyle3d.insert(txn, ...) instead.
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, options?: DisplayStyleCreationOptions): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, options?: DisplayStyleCreationOptions): Id64String {

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -510,7 +510,7 @@ export class Element extends Entity {
    * * none of the element's outputs have been processed.
    * @see [[ElementDrivesElement]] for more on element dependency graphs.
    * @beta
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use onBeforeOutputsHandledArg instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use onBeforeOutputsHandledArg instead.
    */
   protected static onBeforeOutputsHandled(_id: Id64String, _iModel: IModelDb): void { }
 
@@ -538,7 +538,7 @@ export class Element extends Entity {
    * This method is not called if none of the element's inputs were changed.
    * @see [[ElementDrivesElement]] for more on element dependency graphs.
    * @beta
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use onAllInputsHandledArg instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use onAllInputsHandledArg instead.
    */
   protected static onAllInputsHandled(_id: Id64String, _iModel: IModelDb): void { }
 
@@ -669,7 +669,7 @@ export class Element extends Entity {
   public insert(txn: EditTxn): Id64String;
   /**
    * Insert this Element into the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Element.insert(txn) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Element.insert(txn) instead.
    */
   public insert(): Id64String;
   public insert(txn?: EditTxn): Id64String {
@@ -683,7 +683,7 @@ export class Element extends Entity {
   public update(txn: EditTxn): void;
   /**
    * Update this Element in the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Element.update(txn) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Element.update(txn) instead.
    */
   public update(): void;
   public update(txn?: EditTxn): void {
@@ -697,7 +697,7 @@ export class Element extends Entity {
   public delete(txn: EditTxn): void;
   /**
    * Delete this Element from the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Element.delete(txn) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Element.delete(txn) instead.
    */
   public delete(): void;
   public delete(txn?: EditTxn): void {
@@ -1282,7 +1282,7 @@ export class Subject extends InformationReferenceElement {
    */
   public static insert(txn: EditTxn, parentSubjectId: Id64String, name: string, description?: string): Id64String;
   /** Insert a Subject
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Subject.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Subject.insert(txn, ...) instead.
    */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string, description?: string): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentSubjectId: Id64String, name: string, description?: string): Id64String {
@@ -1373,7 +1373,7 @@ export class Drawing extends Document {
    * @beta
    */
   public static insert(txn: EditTxn, documentListModelId: Id64String, name: string, scaleFactor?: number): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Drawing.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Drawing.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, documentListModelId: Id64String, name: string, scaleFactor?: number): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, documentListModelId: Id64String, name: string, scaleFactor?: number): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -1645,7 +1645,7 @@ export class DefinitionContainer extends DefinitionSet {
    * @beta
    */
   public static insert(txn: EditTxn, definitionModelId: Id64String, code: Code, isPrivate?: boolean): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use DefinitionContainer.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use DefinitionContainer.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, code: Code, isPrivate?: boolean): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, code: Code, isPrivate?: boolean): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -1805,7 +1805,7 @@ export class TemplateRecipe3d extends RecipeDefinitionElement {
    * @throws [[IModelError]] if there is a problem inserting the TemplateRecipe3d or its sub-model.
    */
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use TemplateRecipe3d.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use TemplateRecipe3d.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -1881,7 +1881,7 @@ export class TemplateRecipe2d extends RecipeDefinitionElement {
    * @throws [[IModelError]] if there is a problem inserting the TemplateRecipe2d or its sub-model.
    */
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use TemplateRecipe2d.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use TemplateRecipe2d.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, isPrivate?: boolean): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];

--- a/core/backend/src/ElementAspect.ts
+++ b/core/backend/src/ElementAspect.ts
@@ -218,7 +218,7 @@ export class SheetInformationAspect extends ElementUniqueAspect {
    * If `information` is `undefined`, any existing aspect will be deleted.
    * Otherwise, a new aspect will be inserted, or an existing aspect will be updated with the new metadata.
    * @throws Error if the iModel contains a version of the BisCore schema older than 01.00.25.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use SheetInformationAspect.setSheetInformation(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use SheetInformationAspect.setSheetInformation(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static setSheetInformation(information: SheetInformation | undefined, sheetId: Id64String, iModel: IModelDb): void;
 

--- a/core/backend/src/ElementTreeWalker.ts
+++ b/core/backend/src/ElementTreeWalker.ts
@@ -331,7 +331,7 @@ export class ElementTreeDeleter extends ElementTreeBottomUp {
   public constructor(txn: EditTxn);
   /**
    * Create an ElementTreeDeleter.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Supply an explicit EditTxn.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Supply an explicit EditTxn.
    */
   public constructor(iModel: IModelDb);
   public constructor(iModelOrTxn: IModelDb | EditTxn) {
@@ -459,7 +459,7 @@ export class ElementSubTreeDeleter extends ElementTreeTopDown {
    * @param iModel The iModel
    * @param topElement Where to start the search.
    * @param shouldPruneCb Callback that selects sub-trees that should be deleted.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Supply an explicit EditTxn.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Supply an explicit EditTxn.
    * @see deleteElementSubTrees for a simple way to use this class.
    */
   public constructor(iModel: IModelDb, shouldPruneCb: ElementSubTreeDeleteFilter);
@@ -518,7 +518,7 @@ export function deleteElementTree(txn: EditTxn, topElement: Id64String, maxPasse
 /** Deletes an element tree starting with the specified top element. The top element is also deleted. Uses ElementTreeDeleter.
  * @param iModel The iModel
  * @param topElement The parent of the sub-tree
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Supply an explicit `txn`.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Supply an explicit `txn`.
  * @beta
  */
 export function deleteElementTree(iModel: IModelDb, topElement: Id64String): void;
@@ -529,7 +529,7 @@ export function deleteElementTree(iModel: IModelDb, topElement: Id64String): voi
 export function deleteElementTree(args: DeleteElementTreeArgs): void;
 /** Deletes an element tree starting with the specified top element. The top element is also deleted. Uses ElementTreeDeleter.
  * @param args Specifies the iModel and top element.
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Supply `txn` via [[DeleteElementTreeArgs]].
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Supply `txn` via [[DeleteElementTreeArgs]].
  * @beta
  */
 export function deleteElementTree(args: { iModel: IModelDb, topElement: Id64String, maxPasses?: number }): void;
@@ -583,7 +583,7 @@ export function deleteElementSubTrees(txn: EditTxn, topElement: Id64String, filt
  * @param iModel The iModel
  * @param topElement Where to start the search.
  * @param filter Callback that selects sub-trees that should be deleted.
- * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Supply `txn` explicitly.
+ * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Supply `txn` explicitly.
  * @beta
  */
 export function deleteElementSubTrees(iModel: IModelDb, topElement: Id64String, filter: ElementSubTreeDeleteFilter): void;

--- a/core/backend/src/ExternalSource.ts
+++ b/core/backend/src/ExternalSource.ts
@@ -46,7 +46,7 @@ export class ExternalSource extends InformationReferenceElement {
    * @param txn The active EditTxn.
    */
   public static ensureCodeSpec(txn: EditTxn): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use ExternalSource.ensureCodeSpec(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use ExternalSource.ensureCodeSpec(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
   public static ensureCodeSpec(iModelDb: IModelDb): Id64String;
   public static ensureCodeSpec(txnOrIModel: EditTxn | IModelDb): Id64String {
     const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];
@@ -116,7 +116,7 @@ export class ExternalSourceAttachment extends InformationReferenceElement {
    * @param txn The active EditTxn.
    */
   public static ensureCodeSpec(txn: EditTxn): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use ExternalSourceAttachment.ensureCodeSpec(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use ExternalSourceAttachment.ensureCodeSpec(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
   public static ensureCodeSpec(iModelDb: IModelDb): Id64String;
   public static ensureCodeSpec(txnOrIModel: EditTxn | IModelDb): Id64String {
     const txn = txnOrIModel instanceof EditTxn ? txnOrIModel : txnOrIModel[_implicitTxn];

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1165,7 +1165,7 @@ export abstract class IModelDb extends IModel {
    * ``` ts
    * [[include:IModelDb.updateProjectExtents]]
    * ```
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.updateProjectExtents instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.updateProjectExtents instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public updateProjectExtents(newExtents: AxisAlignedBox3d) {
     this[_implicitTxn].updateProjectExtents(newExtents);
@@ -1191,14 +1191,14 @@ export abstract class IModelDb extends IModel {
   }
 
   /** Update the [EcefLocation]($docs/learning/glossary#eceflocation) of this iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.updateEcefLocation instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.updateEcefLocation instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public updateEcefLocation(ecef: EcefLocation) {
     this[_implicitTxn].updateEcefLocation(ecef);
   }
 
   /** Update the IModelProps of this iModel in the database.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.updateIModelProps instead, within an explicit EditTxn scope (or via withEditTxn).
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.updateIModelProps instead, within an explicit EditTxn scope (or via withEditTxn).
    */
   public updateIModelProps(): void {
     this[_implicitTxn].updateIModelProps();
@@ -1210,7 +1210,7 @@ export abstract class IModelDb extends IModel {
    * @note This will not push changes to the iModelHub.
    * @note This method should not be called from {TxnManager.withIndirectTxnModeAsync}, {TxnManager.withIndirectTxnMode} or {RebaseHandler.recompute}.
    * @see [[IModelDb.pushChanges]] to push changes to the iModelHub.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.saveChanges instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.saveChanges instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public saveChanges(description?: string): void;
 
@@ -1221,7 +1221,7 @@ export abstract class IModelDb extends IModel {
    * @note This will not push changes to the iModelHub.
    * @note This method should not be called from {TxnManager.withIndirectTxnModeAsync}, {TxnManager.withIndirectTxnMode} or {RebaseHandler.recompute}.
    * @see [[IModelDb.pushChanges]] to push changes to the iModelHub.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.saveChanges instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.saveChanges instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public saveChanges(args: SaveChangesArgs): void;
 
@@ -1230,7 +1230,7 @@ export abstract class IModelDb extends IModel {
   }
 
   /** Abandon changes in memory that have not been saved as a Txn to this iModelDb.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.abandonChanges instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.abandonChanges instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
   */
   public abandonChanges(): void {
     this[_implicitTxn].abandonChanges();
@@ -2024,7 +2024,7 @@ export abstract class IModelDb extends IModel {
    * @param prop the FilePropertyProps that describes the new property
    * @param value either a string or a blob to save as the file property
    * @note This method should not be called from {TxnManager.withIndirectTxnModeAsync} or {TxnManager.withIndirectTxnMode}.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.saveFileProperty instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.saveFileProperty instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public saveFileProperty(prop: FilePropertyProps, strValue: string | undefined, blobVal?: Uint8Array): void {
     this[_implicitTxn].saveFileProperty(prop, strValue, blobVal);
@@ -2033,7 +2033,7 @@ export abstract class IModelDb extends IModel {
   /** delete a "file property" from this iModel
    * @param prop the FilePropertyProps that describes the property
    * @note This method should not be called from {TxnManager.withIndirectTxnModeAsync} or {TxnManager.withIndirectTxnMode}.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.deleteFileProperty instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.deleteFileProperty instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public deleteFileProperty(prop: FilePropertyProps): void {
     this[_implicitTxn].deleteFileProperty(prop);
@@ -2260,7 +2260,7 @@ export abstract class IModelDb extends IModel {
    * @param dict The SettingDictionary object to stringify and save.
    * @note All saved `SettingDictionary`s are loaded into [[workspace.settings]] every time an iModel is opened.
    * @see [[Settings.addDictionary]] to register a dictionary for the current session only without persisting it.
-   * @beta @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.saveSettingDictionary instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @beta @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.saveSettingDictionary instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public saveSettingDictionary(name: string, dict: SettingsContainer) {
     this[_implicitTxn].saveSettingDictionary(name, dict);
@@ -2268,7 +2268,7 @@ export abstract class IModelDb extends IModel {
 
   /** Delete a SettingDictionary, previously added with [[saveSettingDictionary]], from this iModel.
    * @param name The name of the dictionary to delete.
-   * @beta @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.deleteSettingDictionary instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @beta @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.deleteSettingDictionary instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public deleteSettingDictionary(name: string) {
     this[_implicitTxn].deleteSettingDictionary(name);
@@ -2579,7 +2579,7 @@ export namespace IModelDb {
      * @param props The data for the new model.
      * @returns The newly inserted model's Id.
      * @throws [[IModelError]] if insertion fails.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.insertModel instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.insertModel instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public insertModel(props: ModelProps): Id64String {
       return this._iModel[_implicitTxn].insertModel(props);
@@ -2588,7 +2588,7 @@ export namespace IModelDb {
     /** Update an existing model.
      * @param props the properties of the model to change
      * @throws [[IModelError]] if update fails.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.updateModel instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.updateModel instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public updateModel(props: UpdateModelOptions): void {
       this._iModel[_implicitTxn].updateModel(props);
@@ -2600,7 +2600,7 @@ export namespace IModelDb {
      * Cached [Tile]($frontend)s are only invalidated after the geometry guid of the model changes.
      * @note This will throw IModelError with [IModelStatus.VersionTooOld]($core-bentley) if a version of the BisCore schema older than 1.0.11 is present in the iModel.
      * @throws [[IModelError]] if the update fails.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.updateGeometryGuid instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.updateGeometryGuid instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      * @see [[TxnManager.onModelGeometryChanged]] for the event emitted in response to such a change.
      */
     public updateGeometryGuid(modelId: Id64String): void {
@@ -2610,7 +2610,7 @@ export namespace IModelDb {
     /** Delete one or more existing models.
      * @param ids The Ids of the models to be deleted
      * @throws [[IModelError]] if deletion fails.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.deleteModel instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.deleteModel instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public deleteModel(ids: Id64Arg): void {
       this._iModel[_implicitTxn].deleteModel(ids);
@@ -2854,7 +2854,7 @@ export namespace IModelDb {
      * However when `elProps.federationGuid` is not present or undefined, a new Guid will be generated and stored on the resultant element. But
      * the value of `elProps.federationGuid` is *not* updated. Generally, it is best to re-read the element after inserting (e.g. via [[getElementProps]])
      * if you intend to continue working with it. That will ensure its values reflect the persistent state.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.insertElement instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.insertElement instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public insertElement(elProps: ElementProps, options?: InsertElementOptions): Id64String {
       return this._iModel[_implicitTxn].insertElement(elProps, options);
@@ -2870,7 +2870,7 @@ export namespace IModelDb {
      * @note The values of `classFullName` and `model` *may not be changed* by this method. Further, it will permute the `elProps` object by adding or
      * overwriting their values to the correct values.
      * @throws [[ITwinError]] if update fails.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.updateElement instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.updateElement instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public updateElement<T extends ElementProps>(elProps: Partial<T>): void {
       this._iModel[_implicitTxn].updateElement(elProps);
@@ -2880,7 +2880,7 @@ export namespace IModelDb {
      * @param ids The set of Ids of the element(s) to be deleted
      * @throws [[ITwinError]]
      * @see deleteDefinitionElements
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.deleteElement instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.deleteElement instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public deleteElement(ids: Id64Arg): void {
       this._iModel[_implicitTxn].deleteElement(ids);
@@ -2894,7 +2894,7 @@ export namespace IModelDb {
      * DefinitionElements rather than calling this method separately for each one. Ids that are not valid DefinitionElements will be ignored.
      * @returns An IdSet of the DefinitionElements that are used and were therefore not deleted.
      * @see deleteElement
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.deleteDefinitionElements instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.deleteDefinitionElements instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public deleteDefinitionElements(definitionElementIds: Id64Array): Id64Set {
       return this._iModel[_implicitTxn].deleteDefinitionElements(definitionElementIds);
@@ -3101,7 +3101,7 @@ export namespace IModelDb {
      * @returns the id of the newly inserted aspect.
      * @note Aspect Ids may collide with element Ids, so don't put both in a container like Set or Map
      *       use [EntityReference]($common) for that instead.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.insertAspect instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.insertAspect instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public insertAspect(aspectProps: ElementAspectProps): Id64String {
       return this._iModel[_implicitTxn].insertAspect(aspectProps);
@@ -3110,7 +3110,7 @@ export namespace IModelDb {
     /** Update an exist ElementAspect within the iModel.
      * @param aspectProps The properties to use to update the ElementAspect.
      * @throws [[IModelError]] if unable to update the ElementAspect.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.updateAspect instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.updateAspect instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public updateAspect(aspectProps: ElementAspectProps): void {
       this._iModel[_implicitTxn].updateAspect(aspectProps);
@@ -3119,7 +3119,7 @@ export namespace IModelDb {
     /** Delete one or more ElementAspects from this iModel.
      * @param aspectInstanceIds The set of instance Ids of the ElementAspect(s) to be deleted
      * @throws [[IModelError]] if unable to delete the ElementAspect.
-     * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.deleteAspect instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.deleteAspect instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public deleteAspect(aspectInstanceIds: Id64Arg): void {
       this._iModel[_implicitTxn].deleteAspect(aspectInstanceIds);
@@ -3167,7 +3167,7 @@ export namespace IModelDb {
     }
 
     /**
-     * @beta @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use EditTxn.saveDefaultViewStore instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+     * @beta @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use EditTxn.saveDefaultViewStore instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
      */
     public saveDefaultViewStore(arg: CloudSqlite.ContainerProps): void {
       this._iModel[_implicitTxn].saveDefaultViewStore(arg);

--- a/core/backend/src/LineStyle.ts
+++ b/core/backend/src/LineStyle.ts
@@ -329,7 +329,7 @@ export namespace LineStyleDefinition {
      */
     public static createStrokePatternComponent(txn: EditTxn, props: StrokePatternProps): StyleProps;
     /** Create a file property for a new stroke pattern component.
-     * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use createStrokePatternComponent(txn, ...) instead.
+     * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use createStrokePatternComponent(txn, ...) instead.
      */
     public static createStrokePatternComponent(iModel: IModelDb, props: StrokePatternProps): StyleProps;
     public static createStrokePatternComponent(txnOrIModel: EditTxn | IModelDb, props: StrokePatternProps): StyleProps {
@@ -347,7 +347,7 @@ export namespace LineStyleDefinition {
     public static createPointSymbolComponent(txn: EditTxn, props: PointSymbolProps): StyleProps | undefined;
     /** Create a file property for a new point symbol component.
      * If base and size parameters are not supplied, queries GeometryPart by id to set them.
-     * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use createPointSymbolComponent(txn, ...) instead.
+     * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use createPointSymbolComponent(txn, ...) instead.
      */
     public static createPointSymbolComponent(iModel: IModelDb, props: PointSymbolProps): StyleProps | undefined;
     public static createPointSymbolComponent(txnOrIModel: EditTxn | IModelDb, props: PointSymbolProps): StyleProps | undefined {
@@ -379,7 +379,7 @@ export namespace LineStyleDefinition {
      */
     public static createStrokePointComponent(txn: EditTxn, props: StrokePointProps): StyleProps;
     /** Create a file property for a new stroke point component.
-     * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use createStrokePointComponent(txn, ...) instead.
+     * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use createStrokePointComponent(txn, ...) instead.
      */
     public static createStrokePointComponent(iModel: IModelDb, props: StrokePointProps): StyleProps;
     public static createStrokePointComponent(txnOrIModel: EditTxn | IModelDb, props: StrokePointProps): StyleProps {
@@ -395,7 +395,7 @@ export namespace LineStyleDefinition {
      */
     public static createCompoundComponent(txn: EditTxn, props: CompoundProps): StyleProps;
     /** Create a file property for a new compound component.
-     * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use createCompoundComponent(txn, ...) instead.
+     * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use createCompoundComponent(txn, ...) instead.
      */
     public static createCompoundComponent(iModel: IModelDb, props: CompoundProps): StyleProps;
     public static createCompoundComponent(txnOrIModel: EditTxn | IModelDb, props: CompoundProps): StyleProps {
@@ -411,7 +411,7 @@ export namespace LineStyleDefinition {
      */
     public static createRasterComponent(txn: EditTxn, props: RasterImageProps, image: Uint8Array): StyleProps | undefined;
     /** Create a file property for a new raster image component.
-     * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use createRasterComponent(txn, ...) instead.
+     * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use createRasterComponent(txn, ...) instead.
      */
     public static createRasterComponent(iModel: IModelDb, props: RasterImageProps, image: Uint8Array): StyleProps | undefined;
     public static createRasterComponent(txnOrIModel: EditTxn | IModelDb, props: RasterImageProps, image: Uint8Array): StyleProps | undefined {
@@ -439,7 +439,7 @@ export namespace LineStyleDefinition {
     public static createStyle(txn: EditTxn, scopeModelId: Id64String, name: string, props: StyleProps): Id64String;
     /** Insert a new line style with the supplied name.
      * @throws [[IModelError]] if unable to insert the line style definition element.
-     * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use createStyle(txn, ...) instead.
+     * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use createStyle(txn, ...) instead.
      */
     public static createStyle(imodel: IModelDb, scopeModelId: Id64String, name: string, props: StyleProps): Id64String;
     public static createStyle(txnOrIModel: EditTxn | IModelDb, scopeModelId: Id64String, name: string, props: StyleProps): Id64String {

--- a/core/backend/src/Material.ts
+++ b/core/backend/src/Material.ts
@@ -218,7 +218,7 @@ export class RenderMaterialElement extends DefinitionElement {
   public static insert(txn: EditTxn, definitionModelId: Id64String, materialName: string, params: RenderMaterialElementParams): Id64String;
   /**
    * Insert a new RenderMaterial into a model.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use RenderMaterialElement.insert(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use RenderMaterialElement.insert(txn, ...) instead.
    */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, materialName: string, params: RenderMaterialElementParams): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, materialName: string, params: RenderMaterialElementParams): Id64String {

--- a/core/backend/src/Model.ts
+++ b/core/backend/src/Model.ts
@@ -329,7 +329,7 @@ export class Model extends Entity {
   public insert(txn: EditTxn): Id64String;
   /**
    * Insert this Model in the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Model.insert(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Model.insert(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public insert(): Id64String;
   public insert(txn?: EditTxn) { return this.id = (txn ?? this.iModel[_implicitTxn]).insertModel(this.toJSON()); }
@@ -341,7 +341,7 @@ export class Model extends Entity {
   public update(txn: EditTxn): void;
   /**
    * Update this Model in the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Model.update(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Model.update(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public update(): void;
   public update(txn?: EditTxn) { (txn ?? this.iModel[_implicitTxn]).updateModel(this.toJSON()); }
@@ -353,7 +353,7 @@ export class Model extends Entity {
   public delete(txn: EditTxn): void;
   /**
    * Delete this Model from the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Model.delete(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Model.delete(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public delete(): void;
   public delete(txn?: EditTxn) { (txn ?? this.iModel[_implicitTxn]).deleteModel(this.id); }
@@ -526,7 +526,7 @@ export class PhysicalModel extends SpatialModel {
     * @beta
    */
   public static insert(txn: EditTxn, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use PhysicalModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use PhysicalModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -563,7 +563,7 @@ export class SpatialLocationModel extends SpatialModel {
     * @beta
    */
   public static insert(txn: EditTxn, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use SpatialLocationModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use SpatialLocationModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -643,7 +643,7 @@ export class SheetIndexModel extends InformationModel {
    * @throws [[IModelError]] if there is an insert problem.
    */
   public static insert(txn: EditTxn, parentSubjectId: Id64String, name: string): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use SheetIndexModel.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use SheetIndexModel.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentSubjectId: Id64String, name: string): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];

--- a/core/backend/src/Relationship.ts
+++ b/core/backend/src/Relationship.ts
@@ -82,7 +82,7 @@ export class Relationship extends Entity {
    * A subclass of ElementDrivesElement can re-implement this static method to take some action. onRootChanged may modify the output element only.
    * @param _props The ElementDrivesElement relationship instance.
    * @param _iModel The iModel
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use onRootChangedArg instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use onRootChangedArg instead.
    */
   public static onRootChanged(_props: RelationshipProps, _iModel: IModelDb): void { }
 
@@ -101,7 +101,7 @@ export class Relationship extends Entity {
    * A subclass of ElementDrivesElement can re-implement this static method to take some action.
    * @param _props The deleted ElementDrivesElement relationship instance.
    * @param _iModel The iModel
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use onDeletedDependencyArg instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use onDeletedDependencyArg instead.
    */
   public static onDeletedDependency(_props: RelationshipProps, _iModel: IModelDb): void { }
 
@@ -112,7 +112,7 @@ export class Relationship extends Entity {
   public insert(txn: EditTxn): Id64String;
   /**
    * Insert this Relationship into the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use Relationship.insert(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use Relationship.insert(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public insert(): Id64String;
   public insert(txn?: EditTxn): Id64String { return this.id = (txn ?? this.iModel[_implicitTxn]).insertRelationship(this.toJSON()); }
@@ -124,7 +124,7 @@ export class Relationship extends Entity {
   public update(txn: EditTxn): void;
   /**
    * Update this Relationship in the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use Relationship.update(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use Relationship.update(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public update(): void;
   public update(txn?: EditTxn) { (txn ?? this.iModel[_implicitTxn]).updateRelationship(this.toJSON()); }
@@ -136,7 +136,7 @@ export class Relationship extends Entity {
   public delete(txn: EditTxn): void;
   /**
    * Delete this Relationship from the iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use Relationship.delete(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use Relationship.delete(txn) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public delete(): void;
   public delete(txn?: EditTxn) { (txn ?? this.iModel[_implicitTxn]).deleteRelationship(this.toJSON()); }
@@ -172,7 +172,7 @@ export class ElementRefersToElements extends Relationship {
    * @param sourceId The sourceId of the relationship, that is, the driver element.
    * @param targetId The targetId of the relationship, that is, the driven element.
    * @return The Id of the inserted Relationship.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use ElementRefersToElements.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use ElementRefersToElements.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insert(iModel: IModelDb, sourceId: Id64String, targetId: Id64String): Id64String;
   public static insert(txnOrIModel: EditTxn | IModelDb, sourceId: Id64String, targetId: Id64String): Id64String {
@@ -538,7 +538,7 @@ export class Relationships {
    * @param props The properties of the new relationship.
    * @returns The Id of the newly inserted relationship.
    * @note The id property of the props object is set as a side effect of this function.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.insertRelationship instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.insertRelationship instead.
    */
   public insertInstance(props: RelationshipProps): Id64String {
     return this._iModel[_implicitTxn].insertRelationship(props);
@@ -546,14 +546,14 @@ export class Relationships {
 
   /** Update the properties of an existing relationship instance in the iModel.
    * @param props the properties of the relationship instance to update. Any properties that are not present will be left unchanged.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.updateRelationship instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.updateRelationship instead.
    */
   public updateInstance(props: RelationshipProps): void {
     this._iModel[_implicitTxn].updateRelationship(props);
   }
 
   /** Delete an Relationship instance from this iModel.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.deleteRelationship instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.deleteRelationship instead.
    */
   public deleteInstance(props: RelationshipProps): void {
     this._iModel[_implicitTxn].deleteRelationship(props);
@@ -562,7 +562,7 @@ export class Relationships {
   /** Delete multiple Relationship instances from this iModel.
    * @param props The properties of the relationship instances to delete.
    * @remarks This method handles bulk deletion of relationships and supports mixed collections containing instances from different relationship classes.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use EditTxn.deleteRelationships instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use EditTxn.deleteRelationships instead.
    */
   public deleteInstances(props: ReadonlyArray<RelationshipProps>): void {
     this._iModel[_implicitTxn].deleteRelationships(props);

--- a/core/backend/src/SheetIndex.ts
+++ b/core/backend/src/SheetIndex.ts
@@ -88,7 +88,7 @@ export class SheetIndex extends InformationReferenceElement {
    * @throws [[IModelError]] if there is a problem inserting the SheetIndex
    */
   public static insert(txn: EditTxn, modelId: Id64String, name: string): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use SheetIndex.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use SheetIndex.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, modelId: Id64String, name: string): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, modelId: Id64String, name: string): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -165,7 +165,7 @@ export class SheetIndexFolder extends SheetIndexEntry {
    * @throws [[IModelError]] if unable to create the element.
    */
   public static insert(txn: EditTxn, arg: Omit<SheetIndexEntryCreateArgs, "iModelDb">): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use SheetIndexFolder.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use SheetIndexFolder.insert(txn, ...) instead. */
   public static insert(arg: SheetIndexEntryCreateArgs): Id64String;
   public static insert(txnOrArg: EditTxn | SheetIndexEntryCreateArgs, arg?: Omit<SheetIndexEntryCreateArgs, "iModelDb">): Id64String {
     const txn = txnOrArg instanceof EditTxn ? txnOrArg : txnOrArg.iModelDb[_implicitTxn];
@@ -229,7 +229,7 @@ export class SheetIndexReference extends SheetIndexEntry {
    * @throws [[IModelError]] if unable to create the element.
    */
   public static insert(txn: EditTxn, arg: Omit<SheetIndexReferenceCreateArgs, "iModelDb">): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use SheetIndexReference.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use SheetIndexReference.insert(txn, ...) instead. */
   public static insert(arg: SheetIndexReferenceCreateArgs): Id64String;
   public static insert(txnOrArg: EditTxn | SheetIndexReferenceCreateArgs, arg?: Omit<SheetIndexReferenceCreateArgs, "iModelDb">): Id64String {
     const txn = txnOrArg instanceof EditTxn ? txnOrArg : txnOrArg.iModelDb[_implicitTxn];
@@ -301,7 +301,7 @@ export class SheetReference extends SheetIndexEntry {
    * @throws [[IModelError]] if unable to create the element.
    */
   public static insert(txn: EditTxn, arg: Omit<SheetReferenceCreateArgs, "iModelDb">): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use SheetReference.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use SheetReference.insert(txn, ...) instead. */
   public static insert(arg: SheetReferenceCreateArgs): Id64String;
   public static insert(txnOrArg: EditTxn | SheetReferenceCreateArgs, arg?: Omit<SheetReferenceCreateArgs, "iModelDb">): Id64String {
     const txn = txnOrArg instanceof EditTxn ? txnOrArg : txnOrArg.iModelDb[_implicitTxn];

--- a/core/backend/src/Texture.ts
+++ b/core/backend/src/Texture.ts
@@ -98,7 +98,7 @@ export class Texture extends DefinitionElement {
    */
   public static insertTexture(txn: EditTxn, definitionModelId: Id64String, name: string, format: ImageSourceFormat, data: Uint8Array | Base64EncodedString, description?: string): Id64String;
   /** Insert a new texture into a [[DefinitionModel]].
-   * @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use Texture.insertTexture(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use Texture.insertTexture(txn, ...) instead.
    */
   public static insertTexture(iModelDb: IModelDb, definitionModelId: Id64String, name: string, format: ImageSourceFormat, data: Uint8Array | Base64EncodedString, description?: string): Id64String;
   public static insertTexture(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, format: ImageSourceFormat, data: Uint8Array | Base64EncodedString, description?: string): Id64String {

--- a/core/backend/src/ViewDefinition.ts
+++ b/core/backend/src/ViewDefinition.ts
@@ -119,7 +119,7 @@ export class ModelSelector extends DefinitionElement {
    * @beta
    */
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, models: Id64Array): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use ModelSelector.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use ModelSelector.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, models: Id64Array): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, models: Id64Array): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -224,7 +224,7 @@ export class CategorySelector extends DefinitionElement {
    * @beta
    */
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, categories: Id64Array): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use CategorySelector.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use CategorySelector.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, categories: Id64Array): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, categories: Id64Array): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -659,7 +659,7 @@ export class SpatialViewDefinition extends ViewDefinition3d {
    * @beta
    */
   public static insertWithCamera(txn: EditTxn, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView?: StandardViewIndex, cameraAngle?: number): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use SpatialViewDefinition.insertWithCamera(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use SpatialViewDefinition.insertWithCamera(txn, ...) instead. */
   public static insertWithCamera(iModelDb: IModelDb, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView?: StandardViewIndex, cameraAngle?: number): Id64String;
   public static insertWithCamera(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView = StandardViewIndex.Iso, cameraAngle = Angle.piOver2Radians): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -726,7 +726,7 @@ export class OrthographicViewDefinition extends SpatialViewDefinition {
    * @beta
    */
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView?: StandardViewIndex): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use OrthographicViewDefinition.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use OrthographicViewDefinition.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView?: StandardViewIndex): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, modelSelectorId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range3d, standardView = StandardViewIndex.Iso): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -905,7 +905,7 @@ export class DrawingViewDefinition extends ViewDefinition2d {
    * @beta
    */
   public static insert(txn: EditTxn, definitionModelId: Id64String, name: string, baseModelId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range2d): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use DrawingViewDefinition.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use DrawingViewDefinition.insert(txn, ...) instead. */
   public static insert(iModelDb: IModelDb, definitionModelId: Id64String, name: string, baseModelId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range2d): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, definitionModelId: Id64String, name: string, baseModelId: Id64String, categorySelectorId: Id64String, displayStyleId: Id64String, range: Range2d): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -966,7 +966,7 @@ export class SheetViewDefinition extends ViewDefinition2d {
    * @beta
    */
   public static insert(txn: EditTxn, args: Omit<CreateSheetViewDefinitionArgs, "iModel">): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2026-08-04. Use SheetViewDefinition.insert(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2026-08-04. Use SheetViewDefinition.insert(txn, ...) instead. */
   public static insert(args: CreateSheetViewDefinitionArgs): Id64String;
   public static insert(txnOrArgs: EditTxn | CreateSheetViewDefinitionArgs, args?: Omit<CreateSheetViewDefinitionArgs, "iModel">): Id64String {
     const txn = txnOrArgs instanceof EditTxn ? txnOrArgs : txnOrArgs.iModel[_implicitTxn];

--- a/core/backend/src/annotations/ElementDrivesTextAnnotation.ts
+++ b/core/backend/src/annotations/ElementDrivesTextAnnotation.ts
@@ -166,7 +166,7 @@ export class ElementDrivesTextAnnotation extends ElementDrivesElement {
   /** Examines all of the [FieldRun]($common)s within the specified [[ITextAnnotation]] and ensures that the appropriate
    * `ElementDrivesTextAnnotation` relationships exist between the fields' source elements and this target element.
    * It also deletes any stale relationships left over from fields that were deleted or whose source elements changed.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use ElementDrivesTextAnnotation.updateFieldDependencies(txn, ...) instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use ElementDrivesTextAnnotation.updateFieldDependencies(txn, ...) instead.
    */
   public static updateFieldDependencies(annotationElementId: Id64String, iModel: IModelDb): void;
 

--- a/core/backend/src/domains/FunctionalElements.ts
+++ b/core/backend/src/domains/FunctionalElements.ts
@@ -49,7 +49,7 @@ export class FunctionalModel extends RoleModel {
    * @beta
    */
   public static insert(txn: EditTxn, parentSubjectId: Id64String, name: string): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use FunctionalModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use FunctionalModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentSubjectId: Id64String, name: string): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];

--- a/core/backend/src/domains/GenericElements.ts
+++ b/core/backend/src/domains/GenericElements.ts
@@ -120,7 +120,7 @@ export class GenericGraphicalModel3d extends GraphicalModel3d {
    * @beta
    */
   public static insert(txn: EditTxn, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use GenericGraphicalModel3d.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use GenericGraphicalModel3d.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentSubjectId: Id64String, name: string, isPlanProjection?: boolean): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];
@@ -191,7 +191,7 @@ export class GroupModel extends GroupInformationModel {
    * @beta
    */
   public static insert(txn: EditTxn, parentSubjectId: Id64String, name: string): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use GroupModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use GroupModel.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help. */
   public static insert(iModelDb: IModelDb, parentSubjectId: Id64String, name: string): Id64String;
   public static insert(txnOrDb: EditTxn | IModelDb, parentSubjectId: Id64String, name: string): Id64String {
     const txn = txnOrDb instanceof EditTxn ? txnOrDb : txnOrDb[_implicitTxn];

--- a/core/backend/src/internal/ChannelAdmin.ts
+++ b/core/backend/src/internal/ChannelAdmin.ts
@@ -90,7 +90,7 @@ class ChannelAdmin implements ChannelControl {
   }
 
   public makeChannelRoot(args: { elementId: Id64String, channelKey: ChannelKey, txn: EditTxn }): void;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use makeChannelRoot and supply `txn`. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use makeChannelRoot and supply `txn`. */
   public makeChannelRoot(args: { elementId: Id64String, channelKey: ChannelKey }): void;
   public makeChannelRoot(args: { elementId: Id64String, channelKey: ChannelKey, txn?: EditTxn }): void {
     const txn = args.txn ?? this._iModel[_implicitTxn];
@@ -113,7 +113,7 @@ class ChannelAdmin implements ChannelControl {
   }
 
   public insertChannelSubject(args: { subjectName: string, channelKey: ChannelKey, parentSubjectId?: Id64String, description?: string, txn: EditTxn }): Id64String;
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use insertChannelSubject and supply `txn`. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use insertChannelSubject and supply `txn`. */
   public insertChannelSubject(args: { subjectName: string, channelKey: ChannelKey, parentSubjectId?: Id64String, description?: string }): Id64String;
   public insertChannelSubject(args: { subjectName: string, channelKey: ChannelKey, parentSubjectId?: Id64String, description?: string, txn?: EditTxn }): Id64String {
     const txn = args.txn ?? this._iModel[_implicitTxn];

--- a/core/common/src/IpcAppProps.ts
+++ b/core/common/src/IpcAppProps.ts
@@ -169,12 +169,12 @@ export interface IpcAppFunctions {
   /** see BriefcaseConnection.close */
   closeIModel: (key: string) => Promise<void>;
   /**
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
    * see BriefcaseConnection.saveChanges
    */
   saveChanges: (key: string, description?: string) => Promise<void>;
   /**
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
    * see BriefcaseConnection.abandonChanges
    */
   abandonChanges: (key: string) => Promise<void>;

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -369,14 +369,14 @@ export class BriefcaseConnection extends IModelConnection {
 
   /** Commit pending changes to this briefcase.
    * @param description Optional description of the changes.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
    */
   public async saveChanges(description?: string): Promise<void> {
     await IpcApp.appFunctionIpc.saveChanges(this.key, description); // eslint-disable-line @typescript-eslint/no-deprecated
   }
 
   /** Abandon pending changes to this briefcase.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use methods on EditCommand instead.
    */
   public async abandonChanges(): Promise<void> {
     await IpcApp.appFunctionIpc.abandonChanges(this.key); // eslint-disable-line @typescript-eslint/no-deprecated

--- a/core/frontend/src/tools/PrimitiveTool.ts
+++ b/core/frontend/src/tools/PrimitiveTool.ts
@@ -223,7 +223,7 @@ export abstract class PrimitiveTool extends InteractiveTool {
 
   /**
    * If this tool is editing a briefcase, commits any elements that the tool has changed, supplying the tool flyover for the undo description.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use methods on [[EditCommand]] IPC instead.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use methods on [[EditCommand]] IPC instead.
    */
   public async saveChanges(): Promise<void> {
     if (this.iModel.isBriefcaseConnection())

--- a/core/geometry/src/clipping/ClipPrimitive.ts
+++ b/core/geometry/src/clipping/ClipPrimitive.ts
@@ -425,7 +425,7 @@ export class ClipShape extends ClipPrimitive {
   }
   /**
    * Return true if this ClipShape has a local to world transform
-   * @deprecated in 5.1.9 - will not be removed until after 2027-01-05. Use duplicate property [[transformValid]] or
+   * @deprecated in 5.5.0 - will not be removed until after 2027-01-05. Use duplicate property [[transformValid]] or
    * type guard [[hasTransformFromClip]] instead.
    */
   public get transformIsValid(): boolean {

--- a/core/geometry/src/geometry3d/Ellipsoid.ts
+++ b/core/geometry/src/geometry3d/Ellipsoid.ts
@@ -547,7 +547,7 @@ export class Ellipsoid implements Clipper {
    * @param angleB end point of arc (given as angles on this ellipsoid)
    * @returns arc in the plane defined by the normal at the intermediate point. If calculation fails, return an
    * arc with zero matrix.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-01-05. Prefer [[sectionArcInPlaneOfInterpolatedNormal]],
+   * @deprecated in 5.5.0 - will not be removed until after 2027-01-05. Prefer [[sectionArcInPlaneOfInterpolatedNormal]],
    * which has expanded return type.
    */
   public sectionArcWithIntermediateNormal(angleA: LongitudeLatitudeNumber, intermediateNormalFraction: number, angleB: LongitudeLatitudeNumber): Arc3d {

--- a/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElementAspects.ts
@@ -82,7 +82,7 @@ export class LinearlyReferencedAtLocation extends LinearlyReferencedLocation {
     at: DistanceExpression, fromReferentId?: Id64String): void;
 
   /** Insert a new aspect.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearlyReferencedAtLocation.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearlyReferencedAtLocation.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insert(iModel: IModelDb, locatedElementId: Id64String,
     at: DistanceExpression, fromReferentId?: Id64String): void;
@@ -145,7 +145,7 @@ export class LinearlyReferencedFromToLocation extends LinearlyReferencedLocation
     from: DistanceExpression, to: DistanceExpression, fromReferentId?: Id64String, toReferentId?: Id64String): void;
 
   /** Insert a new aspect.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearlyReferencedFromToLocation.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearlyReferencedFromToLocation.insert(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insert(iModel: IModelDb, locatedElementId: Id64String,
     from: DistanceExpression, to: DistanceExpression, fromReferentId?: Id64String, toReferentId?: Id64String): void;

--- a/domains/linear-referencing/backend/src/LinearReferencingElements.ts
+++ b/domains/linear-referencing/backend/src/LinearReferencingElements.ts
@@ -85,7 +85,7 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
   public static insertFromTo(txn: EditTxn, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String;
   /** Insert a new `LinearLocation`.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearLocation.insertFromTo(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearLocation.insertFromTo(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insertFromTo(iModel: IModelDb, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String;
@@ -109,7 +109,7 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
    */
   public insertFromTo(txn: EditTxn, linearElementId: Id64String, fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String;
   /** Insert this `LinearLocation`.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearLocation.insertFromTo(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearLocation.insertFromTo(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public insertFromTo(iModel: IModelDb, linearElementId: Id64String, fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String;
   public insertFromTo(txnOrIModel: EditTxn | IModelDb, linearElementId: Id64String, fromToPosition: LinearlyReferencedFromToLocationProps, locatedElementId: Id64String): Id64String {
@@ -132,7 +132,7 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
   public static insertAt(txn: EditTxn, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String;
   /** Insert a new `LinearLocation`.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearLocation.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearLocation.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insertAt(iModel: IModelDb, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String;
@@ -156,7 +156,7 @@ export class LinearLocation extends LinearLocationElement implements LinearlyLoc
    */
   public insertAt(txn: EditTxn, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String;
   /** Insert this `LinearLocation`.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearLocation.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearLocation.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public insertAt(iModel: IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String;
   public insertAt(txnOrIModel: EditTxn | IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps, locatedElementId: Id64String): Id64String {
@@ -237,7 +237,7 @@ export class Referent extends ReferentElement {
   public static insertAt(txn: EditTxn, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps, referencedElementId: Id64String): Id64String;
   /** Insert a new `Referent`.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use Referent.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use Referent.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insertAt(iModel: IModelDb, modelId: Id64String, categoryId: Id64String, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps, referencedElementId: Id64String): Id64String;
@@ -255,7 +255,7 @@ export class Referent extends ReferentElement {
    */
   public insertAt(txn: EditTxn, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps): Id64String;
   /** Insert this `Referent`.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use Referent.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use Referent.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public insertAt(iModel: IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps): Id64String;
   public insertAt(txnOrIModel: EditTxn | IModelDb, linearElementId: Id64String, atPosition: LinearlyReferencedAtLocationProps): Id64String {
@@ -616,7 +616,7 @@ export class LinearlyLocated {
    * @param atPosition Linear position.
    * @returns The newly inserted element's Id.
    * @throws [[IModelError]] if unable to insert the element.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearlyLocated.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearlyLocated.insertAt(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insertAt(iModel: IModelDb, elProps: ElementProps, linearElementId: Id64String,
     atPosition: LinearlyReferencedAtLocationProps): Id64String;
@@ -651,7 +651,7 @@ export class LinearlyLocated {
    * @param fromToPosition Linear position.
    * @returns The newly inserted element's Id.
    * @throws [[IModelError]] if unable to insert the element.
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearlyLocated.insertFromTo(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearlyLocated.insertFromTo(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static insertFromTo(iModel: IModelDb, elProps: ElementProps, linearElementId: Id64String,
     fromToPosition: LinearlyReferencedFromToLocationProps): Id64String;
@@ -734,7 +734,7 @@ export class LinearlyLocated {
    * @param linearLocationProps The properties to use to update the LinearlyReferencedAtLocation aspect.
    * @param aspectId The Id of the aspect to update. If not known, the first aspectId will be looked-up.
    * @throws [[IModelError]]
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearlyLocated.updateAtLocation(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearlyLocated.updateAtLocation(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static updateAtLocation(iModel: IModelDb, linearlyLocatedElementId: Id64String, linearLocationProps: LinearlyReferencedAtLocationProps,
     aspectId?: Id64String): void;
@@ -777,7 +777,7 @@ export class LinearlyLocated {
    * @param linearLocationProps The properties to use to update the LinearlyReferencedFromToLocation aspect.
    * @param aspectId The Id of the aspect to update. If not known, the first aspectId will be looked-up.
    * @throws [[IModelError]]
-   * @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use LinearlyLocated.updateFromToLocation(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
+   * @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use LinearlyLocated.updateFromToLocation(txn, ...) instead, within an explicit EditTxn scope (or via withEditTxn). See EditTxn documentation for migration help.
    */
   public static updateFromToLocation(iModel: IModelDb, linearlyLocatedElementId: Id64String, linearLocationProps: LinearlyReferencedFromToLocationProps,
     aspectId?: Id64String): void;

--- a/domains/linear-referencing/backend/src/test/LinearReferencingSchema.test.ts
+++ b/domains/linear-referencing/backend/src/test/LinearReferencingSchema.test.ts
@@ -52,7 +52,7 @@ class TestLinearlyLocatedAttribution extends LinearlyLocatedAttribution implemen
     return LinearlyLocated.getFromToLocation(this.iModel, this.id);
   }
 
-  /** @deprecated in 5.1.9 - will not be removed until after 2027-05-04. Use updateFromToLocation(txn, ...) instead. */
+  /** @deprecated in 5.9.0 - will not be removed until after 2027-05-04. Use updateFromToLocation(txn, ...) instead. */
   public updateFromToLocation(linearLocation: LinearlyReferencedFromToLocationProps, aspectId?: Id64String): void;
 
   public updateFromToLocation(txn: EditTxn, linearLocation: LinearlyReferencedFromToLocationProps, aspectId?: Id64String): void;


### PR DESCRIPTION
Closes https://github.com/iTwin/itwinjs-core/issues/9287

## Why

Some deprecated API comments are still stamped as `@deprecated in 5.1.9` even when the replacement API was introduced later in `5.5.0` or `5.9.0`. That leaves users with the wrong migration timeline in editor warnings and generated docs, and it makes the deprecation metadata inconsistent with the actual history we already traced.

This PR manually corrects the already-triaged stale comments so the published deprecation guidance matches the release where those APIs were actually deprecated. It is intentionally separate from the pipeline fix that restores version syncing for future deprecation rewrites.

## What

| Asset | Why it exists |
|---|---|
| `core/backend` deprecation comment updates | Most stale `5.1.9` deprecations live here, so these edits realign backend API comments with the actual `5.9.0` deprecation wave and its existing removal-date buckets. |
| `core/common` and `core/frontend` deprecation comment updates | These comments pointed to replacement APIs introduced later than `5.1.9`, so they now match the same `5.9.0` migration timeline as the backend APIs they pair with. |
| `domains/linear-referencing/backend` deprecation comment updates | The linear-referencing editing APIs were part of the same later deprecation wave, so their comments now point to the correct `5.9.0` version. |
| `core/geometry` deprecation comment updates | These two geometry deprecations were introduced in `5.5.0`, so they need a separate version correction instead of being lumped into the `5.9.0` bucket. |

No runtime behavior changed; this is a comment-only cleanup of stale deprecation metadata across 28 files.

## Validation

- `node common/scripts/install-run-rush.js install --bypass-policy`
- `node common/scripts/install-run-rush.js build --to @itwin/core-backend --to @itwin/core-common --to @itwin/core-frontend --to @itwin/core-geometry --to @itwin/linear-referencing-backend`
- `cd core/geometry && node ../../common/scripts/install-run-rushx.js docs`
- `cd core/common && node ../../common/scripts/install-run-rushx.js docs`
- `cd core/backend && node ../../common/scripts/install-run-rushx.js docs`
- `cd core/frontend && node ../../common/scripts/install-run-rushx.js docs`
- `cd domains/linear-referencing/backend && node ../../../common/scripts/install-run-rushx.js docs`
- `node common/scripts/install-run-rush.js extract-api --to @itwin/core-backend --to @itwin/core-common --to @itwin/core-frontend --to @itwin/core-geometry --to @itwin/linear-referencing-backend`
- `rg -n "@deprecated in 5\.1\.9" core presentation domains editor extensions tools ui utils full-stack-tests common` → no matches in the targeted source roots after the cleanup

---
*Nambot 🤖 (powered by gpt-5.4)*
