### PR TITLE
fix background map geometry crash on iModels without ecefLocation

### DIFF
--- a/common/changes/@itwin/core-frontend/benpolinsky-fix-background-map-geometry-crash_2026-05-13-16-33.json
+++ b/common/changes/@itwin/core-frontend/benpolinsky-fix-background-map-geometry-crash_2026-05-13-16-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix crash in BackgroundMapGeometry.getFrustumIntersectionDepthRange when an iModel without an ecefLocation has a global context reality model.",
+      "type": "none",
+      "packageName": "@itwin/core-frontend"
+    }
+  ],
+  "packageName": "@itwin/core-frontend",
+  "email": "ben-polinsky@users.noreply.github.com"
+}

--- a/core/frontend/src/BackgroundMapGeometry.ts
+++ b/core/frontend/src/BackgroundMapGeometry.ts
@@ -325,7 +325,14 @@ export class BackgroundMapGeometry {
 
       for (const radiusOffset of radiusOffsets) {
         const ellipsoid = this.getEarthEllipsoid(radiusOffset);
-        const isInside = eyePoint && expectDefined(ellipsoid.worldToLocal(eyePoint)).magnitude() < 1.0;
+        const eyeLocal = eyePoint ? ellipsoid.worldToLocal(eyePoint) : undefined;
+        if (eyePoint && undefined === eyeLocal) {
+          // If the globe transform cannot map the eye point into ellipsoid-local
+          // space, treat the globe as unavailable here and let the caller fall
+          // back to its extents-based depth fitting.
+          return Range1d.createNull();
+        }
+        const isInside = eyeLocal !== undefined && eyeLocal.magnitude() < 1.0;
         const center = ellipsoid.localToWorld(scratchZeroPoint, scratchCenterPoint);
         const clipPlaneCount = clipPlanes.planes.length;
 
@@ -355,9 +362,22 @@ export class BackgroundMapGeometry {
               if (Vector3d.createStartEnd(silhouette.center, bimRange.center).dotProduct(scratchSilhouetteNormal) < 0)
                 scratchSilhouetteNormal.negate(scratchSilhouetteNormal);
             }
-            clipPlanes.planes.push(expectDefined(ClipPlane.createNormalAndDistance(scratchSilhouetteNormal, scratchSilhouetteNormal.dotProduct(silhouette.center))));
+            // The silhouette arc is the horizon between the visible and hidden
+            // halves of the globe. Its perpendicular vector is the normal of the
+            // clip plane that keeps us on the visible side. If that plane cannot
+            // be constructed, fall back to a view-aligned plane through the
+            // ellipsoid center instead of pushing an invalid entry.
+            const silhouettePlane =
+              ClipPlane.createNormalAndDistance(scratchSilhouetteNormal, scratchSilhouetteNormal.dotProduct(silhouette.center))
+              ?? ClipPlane.createNormalAndPoint(viewZ, center);
+            if (undefined === silhouettePlane)
+              return Range1d.createNull();
+            clipPlanes.planes.push(silhouettePlane);
           } else {
-            clipPlanes.planes.push(expectDefined(ClipPlane.createNormalAndPoint(viewZ, center)));
+            const centerPlane = ClipPlane.createNormalAndPoint(viewZ, center);
+            if (undefined === centerPlane)
+              return Range1d.createNull();
+            clipPlanes.planes.push(centerPlane);
           }
         }
         if (!isInside || radiusOffset === radiusOffsets[0]) {

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -731,9 +731,13 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     return false;
   }
 
+  private get _hasEarthLocation(): boolean {
+    return undefined !== this.iModel.ecefLocation;
+  }
+
   /** @internal */
   public getIsBackgroundMapVisible(): boolean {
-    return undefined !== this.iModel.ecefLocation && (this.viewFlags.backgroundMap || this.anyMapLayersVisible(false));
+    return this._hasEarthLocation && (this.viewFlags.backgroundMap || this.anyMapLayersVisible(false));
   }
   /** @internal */
   public get backgroundMapElevationBias(): number | undefined {
@@ -757,7 +761,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
 
   /** @internal */
   public getBackgroundMapGeometry(): BackgroundMapGeometry | undefined {
-    if (undefined === this.iModel.ecefLocation)
+    if (!this._hasEarthLocation)
       return undefined;
 
     const bimElevationBias = this.backgroundMapElevationBias;
@@ -785,7 +789,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     let geometry = this.getIsBackgroundMapVisible() ? this.getBackgroundMapGeometry() : undefined;
     const terrainRange = ApproximateTerrainHeights.instance.globalHeightRange;
     let heightRange = this.displayTerrain ? terrainRange : Range1d.createXX(-1, 1);
-    if (this.globeMode === GlobeMode.Ellipsoid && this.contextRealityModelStates.find((model) => model.isGlobal)) {
+    if (this.globeMode === GlobeMode.Ellipsoid && this._hasEarthLocation && this.contextRealityModelStates.find((model) => model.isGlobal)) {
       if (!geometry) {
         if (!this._ellipsoidMapGeometry)
           this._ellipsoidMapGeometry = new BackgroundMapGeometry(0, GlobeMode.Ellipsoid, this.iModel);

--- a/core/frontend/src/test/BackgroundMapGeometry.test.ts
+++ b/core/frontend/src/test/BackgroundMapGeometry.test.ts
@@ -5,14 +5,27 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IModelApp } from "../IModelApp";
-import { Cartographic, EmptyLocalization, GlobeMode } from "@itwin/core-common";
+import { Cartographic, EmptyLocalization, Frustum, GlobeMode, Npc } from "@itwin/core-common";
 import { BlankConnection, IModelConnection } from "../IModelConnection";
-import { Point3d, Range3d, XYAndZ } from "@itwin/core-geometry";
+import { ClipPlane, Ellipsoid, Matrix3d, Point3d, Range3d, Transform, Vector3d, XYAndZ } from "@itwin/core-geometry";
 import { BackgroundMapGeometry } from "../BackgroundMapGeometry";
 import { createBlankConnection } from "./createBlankConnection";
 import { Guid } from "@itwin/core-bentley";
 
 describe("BackgroundMapGeometry", () => {
+  function createPerspectiveFrustum(): Frustum {
+    const frustum = new Frustum();
+    const frontCenter = frustum.frontCenter;
+    const shrinkFront = (corner: Npc) => {
+      frontCenter.interpolate(0.5, frustum.points[corner], frustum.points[corner]);
+    };
+
+    shrinkFront(Npc.LeftBottomFront);
+    shrinkFront(Npc.RightBottomFront);
+    shrinkFront(Npc.LeftTopFront);
+    shrinkFront(Npc.RightTopFront);
+    return frustum;
+  }
 
   beforeEach(async () => {
     await IModelApp.startup({ localization: new EmptyLocalization() });
@@ -63,5 +76,50 @@ describe("BackgroundMapGeometry", () => {
 
     const geometry = new BackgroundMapGeometry(0, 0, imodel);
     expect(geometry).to.not.be.undefined;
+  });
+
+  it("returns a null range when the eye point cannot be transformed into ellipsoid space", () => {
+    const imodel = createBlankConnection();
+    const bgGeom = new BackgroundMapGeometry(0, GlobeMode.Ellipsoid, imodel);
+
+    const degenerate = Ellipsoid.create(Transform.createRefs(Point3d.createZero(), Matrix3d.createZero()));
+    vi.spyOn(bgGeom, "getEarthEllipsoid").mockReturnValue(degenerate);
+
+    const frustum = createPerspectiveFrustum();
+    const eyePoint = frustum.getEyePoint();
+    expect(eyePoint).toBeDefined();
+    expect(() => degenerate.worldToLocal(eyePoint!)!.magnitude()).toThrow();
+
+    const bimRange = Range3d.createXYZXYZ(-100, -100, -10, 100, 100, 10);
+    const result = bgGeom.getFrustumIntersectionDepthRange(frustum, bimRange);
+    expect(result.isNull).toBe(true);
+  });
+
+  it("falls back to a center plane when the silhouette plane cannot be created", () => {
+    const imodel = createBlankConnection();
+    const bgGeom = new BackgroundMapGeometry(0, GlobeMode.Ellipsoid, imodel);
+    const frustum = createPerspectiveFrustum();
+    const bimRange = Range3d.createXYZXYZ(-100, -100, -10, 100, 100, 10);
+
+    const undefinedSilhouettePlane = ClipPlane.createNormalAndDistance(Vector3d.createZero(), 0);
+    expect(undefinedSilhouettePlane).toBeUndefined();
+
+    const oldClipPlanes = frustum.getRangePlanes(false, false, 0);
+    oldClipPlanes.planes.push(undefinedSilhouettePlane as any);
+    expect(() => {
+      for (const clipPlane of oldClipPlanes.planes)
+        clipPlane.getPlane3d();
+    }).toThrow();
+
+    vi.spyOn(bgGeom, "getEarthEllipsoid").mockReturnValue({
+      worldToLocal: (_point: XYAndZ, result?: Point3d) => Point3d.create(0, 0, 2, result),
+      localToWorld: (_point: XYAndZ, result?: Point3d) => Point3d.create(0, 0, 0, result),
+      surfaceNormalToAngles: () => undefined,
+      radiansToPoint: () => undefined,
+      silhouetteArc: () => ({ center: Point3d.createZero(), perpendicularVector: Vector3d.createZero() }),
+      createPlaneSection: () => undefined,
+    } as unknown as Ellipsoid);
+
+    expect(() => bgGeom.getFrustumIntersectionDepthRange(frustum, bimRange)).not.toThrow();
   });
 });

--- a/core/frontend/src/test/DisplayStyleState.test.ts
+++ b/core/frontend/src/test/DisplayStyleState.test.ts
@@ -3,9 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { Code, DisplayStyle3dProps, EmptyLocalization, RenderSchedule, RenderTimelineProps } from "@itwin/core-common";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { Code, DisplayStyle3dProps, EmptyLocalization, GlobeMode, RenderSchedule, RenderTimelineProps } from "@itwin/core-common";
+import { BackgroundMapGeometry } from "../BackgroundMapGeometry";
 import { DisplayStyle3dState } from "../DisplayStyleState";
+import { ContextRealityModelState } from "../ContextRealityModelState";
 import { IModelConnection } from "../IModelConnection";
 import { IModelApp } from "../IModelApp";
 import { createBlankConnection } from "./createBlankConnection";
@@ -232,6 +234,59 @@ describe("DisplayStyleState", () => {
 
       await style.changeRenderTimeline("0x3");
       expect(style[_scheduleScriptReference]).toBeUndefined();
+    });
+  });
+
+  describe("getGlobalGeometryAndHeightRange", () => {
+    let iModel: IModelConnection;
+
+    beforeAll(async () => {
+      await IModelApp.startup({ localization: new EmptyLocalization() });
+      iModel = createBlankConnection();
+    });
+
+    afterAll(async () => {
+      await iModel.close();
+      await IModelApp.shutdown();
+    });
+
+    function makeStyle(): DisplayStyle3dState {
+      const props: DisplayStyle3dProps = {
+        id: "0xbeef",
+        code: Code.createEmpty(),
+        model: IModelConnection.dictionaryId,
+        classFullName: "BisCore:DisplayStyle3d",
+      };
+      return new DisplayStyle3dState(props, iModel);
+    }
+
+    it("does not construct an ellipsoid fallback when the iModel has no Earth anchor", () => {
+      const style = makeStyle();
+      expect(style.globeMode).toBe(GlobeMode.Ellipsoid);
+
+      const fakeGlobalModel = { isGlobal: true } as unknown as ContextRealityModelState;
+      vi.spyOn(style, "contextRealityModelStates", "get").mockReturnValue([fakeGlobalModel]);
+
+      expect(iModel.ecefLocation).toBeDefined();
+      expect(style.getGlobalGeometryAndHeightRange()).toBeDefined();
+
+      const originalEcefLocation = iModel.ecefLocation;
+      try {
+        (iModel as any).ecefLocation = undefined;
+
+        const oldFallback = (() => {
+          let geometry = style.getIsBackgroundMapVisible() ? style.getBackgroundMapGeometry() : undefined;
+          if (style.globeMode === GlobeMode.Ellipsoid && style.contextRealityModelStates.find((model) => model.isGlobal))
+            geometry ??= new BackgroundMapGeometry(0, GlobeMode.Ellipsoid, iModel);
+
+          return geometry;
+        })();
+
+        expect(oldFallback).toBeDefined();
+        expect(style.getGlobalGeometryAndHeightRange()).toBeUndefined();
+      } finally {
+        (iModel as any).ecefLocation = originalEcefLocation;
+      }
     });
   });
 });


### PR DESCRIPTION
Fixes a crash when a viewport opens on an iModel with no `ecefLocation` but a global reality model is present. Before #8391 , same path would throw `TypeError: Cannot read properties of undefined (reading 
'getPlane3d')`. After, the error was caught by  an `expectDefined` call.

This PR is an attempt to handle this gracefully - an iModel with this affliction does render in DTA after the change. 
 
 - Stop constructing ellipsoid-backed `BackgroundMapGeometry` in `DisplayStyleState` when the iModel has no Earth anchor.
 - Make `BackgroundMapGeometry.getFrustumIntersectionDepthRange` return a null range instead of throwing when degenerate ellipsoid/clip-plane math cannot produce a valid plane.
 - Add regression tests covering both the missing-`ecefLocation` fallback path and the degenerate clip-plane path.