### PR TITLE
fix: correct misspelled @deprecated TSDoc tag on UseJsPropertyNames

### DIFF
--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -27,7 +27,7 @@ export enum QueryRowFormat {
   UseECSqlPropertyIndexes,
   /** Each row is an object in which each non-null column value can be accessed by a [remapped property name]($docs/learning/ECSqlRowFormat.md).
    * This format is backwards-compatible with the format produced by iTwin.js 2.x. Null values are omitted.
-   * @depreacted in 4.11.  Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
+   * @deprecated in 4.11.  Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
    */
   UseJsPropertyNames,
 }


### PR DESCRIPTION
## Summary
Fixes #9294 — the `@deprecated` TSDoc tag on `QueryRowFormat.UseJsPropertyNames` was misspelled as `@depreacted`, preventing IDE deprecation warnings and ESLint rules from flagging the deprecated API.

## Change
`core/common/src/ConcurrentQuery.ts` line 30:
```
- * @depreacted in 4.11.  Switch to UseECSqlPropertyIndexes...
+ * @deprecated in 4.11.  Switch to UseECSqlPropertyIndexes...
```

## Impact
After this fix, TypeScript compilers, VS Code, and ESLint `@typescript-eslint/no-deprecated` rules will correctly flag usage of `QueryRowFormat.UseJsPropertyNames` as deprecated.

## Type of Change
- [x] Bug fix (TSDoc correction)