### PR TITLE
Security: bump multiparty to 4.3.0

### DIFF
--- a/common/changes/@itwin/core-backend/security-GHSA-65x3-rw7q-gx94_2026-05-18-19-11.json
+++ b/common/changes/@itwin/core-backend/security-GHSA-65x3-rw7q-gx94_2026-05-18-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@itwin/core-backend"
+    }
+  ],
+  "packageName": "@itwin/core-backend",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       multiparty:
-        specifier: ^4.2.1
-        version: 4.2.1
+        specifier: ^4.3.0
+        version: 4.3.0
       semver:
         specifier: ^7.5.2
         version: 7.5.2
@@ -7112,10 +7112,6 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
-  depd@1.1.2:
-    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
-    engines: {node: '>= 0.6'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -8067,9 +8063,9 @@ packages:
   http-deceiver@1.2.7:
     resolution: {integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==}
 
-  http-errors@1.7.3:
-    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
-    engines: {node: '>= 0.6'}
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -8958,8 +8954,8 @@ packages:
       typescript:
         optional: true
 
-  multiparty@4.2.1:
-    resolution: {integrity: sha512-AvESCnNoQlZiOfP9R4mxN8M9csy2L16EIbWIkt3l4FuGti9kXBS8QVzlfyg4HEnarJhrzZilgNFlZtqmoiAIIA==}
+  multiparty@4.3.0:
+    resolution: {integrity: sha512-LD3YDFI9KrDoOGHsPM+hNraPDQQDPLe8Un/kvJfsZCsHKriA4mphg6Ctc2Cuup/59DtHMdAPm6ICXlUmhwTiug==}
     engines: {node: '>= 0.10'}
 
   multistream@2.1.1:
@@ -9851,9 +9847,6 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  setprototypeof@1.1.1:
-    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
-
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -9990,9 +9983,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  statuses@1.5.0:
-    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
-    engines: {node: '>= 0.6'}
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -10265,10 +10258,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  toidentifier@1.0.0:
-    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
-    engines: {node: '>=0.6'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -13956,8 +13945,6 @@ snapshots:
 
   denque@2.1.0: {}
 
-  depd@1.1.2: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -15153,13 +15140,13 @@ snapshots:
 
   http-deceiver@1.2.7: {}
 
-  http-errors@1.7.3:
+  http-errors@2.0.0:
     dependencies:
-      depd: 1.1.2
+      depd: 2.0.0
       inherits: 2.0.4
-      setprototypeof: 1.1.1
-      statuses: 1.5.0
-      toidentifier: 1.0.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
 
   http-errors@2.0.1:
     dependencies:
@@ -16092,11 +16079,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  multiparty@4.2.1:
+  multiparty@4.3.0:
     dependencies:
-      fd-slicer: 1.1.0
-      http-errors: 1.7.3
-      safe-buffer: 5.1.2
+      http-errors: 2.0.0
+      safe-buffer: 5.2.1
       uid-safe: 2.1.5
 
   multistream@2.1.1:
@@ -17087,8 +17073,6 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  setprototypeof@1.1.1: {}
-
   setprototypeof@1.2.0: {}
 
   shallow-clone@3.0.1:
@@ -17244,7 +17228,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@1.5.0: {}
+  statuses@2.0.1: {}
 
   statuses@2.0.2: {}
 
@@ -17542,8 +17526,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toidentifier@1.0.0: {}
 
   toidentifier@1.0.1: {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -120,7 +120,7 @@
     "fs-extra": "^8.1.0",
     "json5": "^2.2.3",
     "linebreak": "^1.1.0",
-    "multiparty": "^4.2.1",
+    "multiparty": "^4.3.0",
     "semver": "^7.5.2",
     "touch": "^3.1.0",
     "ws": "^7.5.10"


### PR DESCRIPTION
## Why

`rush audit` on the default branch reports three high-severity advisories through `@itwin/core-backend`'s direct `multiparty` dependency. Leaving this as-is keeps the security signal red and continues to ship a backend package on a vulnerable multipart parser version even though an upstream patched release already exists.

This change keeps the fix narrow. The issue is resolved by moving the direct dependency to the first patched line instead of adding another repository-wide override or ignore entry.

## What

| Asset | Why it exists |
|---|---|
| `core/backend/package.json` (dependency update) | `@itwin/core-backend` was pulling in vulnerable `multiparty` `^4.2.1` — bumping to `^4.3.0` moves the package onto the patched release line. |
| `common/config/rush/pnpm-lock.yaml` (lockfile) | The workspace lockfile must reflect the patched `multiparty` resolution so `rush audit` and installs use the remediated dependency graph. |
| `common/changes/@itwin/core-backend/security-GHSA-65x3-rw7q-gx94_2026-05-18-19-11.json` (changefile) | `@itwin/core-backend` is a publishable package, so the direct dependency change needs a Rush change description even though the bump type is `none`. |

Remediates: `GHSA-65x3-rw7q-gx94`, `GHSA-xh3c-6gcq-g4rv`, and `GHSA-qxch-whhj-8956`.

## Validation

- `rush audit`
- `rush build -t @itwin/core-backend`
- `rush test -t @itwin/core-backend`
- `rush extract-api -t @itwin/core-backend`
- `rush change --verify -b origin/master`

`rush audit` after the change reports no remaining high/critical findings in this path; remaining audit output is 8 moderate and 3 low.

---
*Nambot 🤖 (powered by GPB 5.4)*
