### PR TITLE
Add user facing title to settings schema

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -6345,6 +6345,7 @@ export interface SettingGroupSchema {
     readonly settingDefs?: {
         [name: string]: SettingSchema | undefined;
     };
+    readonly title?: string;
     readonly typeDefs?: {
         [name: string]: SettingSchema | undefined;
     };

--- a/common/changes/@itwin/core-backend/john-settings-schema-user-facing-title_2026-05-19-20-35.json
+++ b/common/changes/@itwin/core-backend/john-settings-schema-user-facing-title_2026-05-19-20-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add an optional user-facing title to SettingGroupSchema so settings UIs do not need to rely on schemaPrefix for display text",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/assets/Settings/Schemas/Base.Schema.json
+++ b/core/backend/src/assets/Settings/Schemas/Base.Schema.json
@@ -19,11 +19,15 @@
     },
     "schemaPrefix": {
       "type": "string",
-      "description": "The unique prefix of the schema."
+      "description": "The stable unique prefix of the schema."
+    },
+    "title": {
+      "type": "string",
+      "description": "A user-facing title for the schema."
     },
     "description": {
       "type": "string",
-      "description": "A description of the schema."
+      "description": "A description of the schema, for example as help text accompanying the title."
     },
     "order": {
       "type": "integer",

--- a/core/backend/src/assets/Settings/Schemas/Gcs.schema.json
+++ b/core/backend/src/assets/Settings/Schemas/Gcs.schema.json
@@ -2,6 +2,7 @@
   "$schema": "./Base.Schema.json",
   "description": "settings for geocoordinate services",
   "schemaPrefix": "itwin/core/gcs",
+  "title": "Geocoordinate Services",
   "settingDefs": {
     "default/databases": {
       "type": "array",

--- a/core/backend/src/test/assets/TestSettings.schema.json
+++ b/core/backend/src/test/assets/TestSettings.schema.json
@@ -2,6 +2,7 @@
   "$schema": "../../assets/Settings/Base.Schema.json",
   "description": "the settings for test application 1",
   "schemaPrefix": "testApp",
+  "title": "Test App",
   "settingDefs": {
     "list/multiSelectModifier": {
       "type": "string",

--- a/core/backend/src/test/standalone/Settings.test.ts
+++ b/core/backend/src/test/standalone/Settings.test.ts
@@ -30,6 +30,7 @@ describe("Settings", () => {
   const app1: SettingGroupSchema = {
     description: "",
     schemaPrefix: "app1",
+    title: "App 1",
     settingDefs: {
       sub1: {
         type: "string",
@@ -320,6 +321,7 @@ describe("Settings", () => {
       const group: SettingGroupSchema = {
         description: "",
         schemaPrefix,
+        title: schemaPrefix,
         settingDefs: {
           array: {
             type: "array",

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -28,6 +28,18 @@ describe("SettingsSchemas", () => {
     // can't add a group with no name
     expect(() => schemas.addGroup({} as any)).throws(`has no "schemaPrefix" member`);
 
+    schemas.addGroup({
+      schemaPrefix: "title-test",
+      title: "Title Test",
+      description: "schema with a user-facing title",
+      settingDefs: {
+        setting: {
+          type: "string",
+        },
+      },
+    });
+    expect(schemas.settingDefs.get("title-test/setting")!.type).equals("string");
+
     schemas.addFile(IModelTestUtils.resolveAssetFile("TestSettings.schema.json"));
     expect(schemas.settingDefs.get("testApp/list/openMode")!.type).equals("string");
     expect(schemas.settingDefs.get("testApp/list/openMode")!.default).equals("singleClick");

--- a/core/backend/src/workspace/SettingsSchemas.ts
+++ b/core/backend/src/workspace/SettingsSchemas.ts
@@ -45,7 +45,7 @@ export interface SettingSchema extends Readonly<JSONSchema> {
   * remove them via [[SettingsSchemas.removeGroup]].
   *
   * All of the settings share the same [[schemaPrefix]], which must be unique amongst all other groups.
-  * The prefix is combined with the name of each [[SettingSchema]] in the group to form the fully-qualified name used to refer
+  * The prefix is a stable identifier combined with the name of each [[SettingSchema]] in the group to form the fully-qualified name used to refer
   * to the setting outside of the group, e.g., when accessing [[SettingsSchemas.settingDefs]] or in [[SettingSchema.extends]].
   * In the following example, the fully-qualified name of the setting named "metric" is "format/units/metric".
   *
@@ -65,11 +65,12 @@ export interface SettingSchema extends Readonly<JSONSchema> {
 export interface SettingGroupSchema {
   /** Uniquely identifies this group amongst all other groups.
    * The prefix can use forward-slashes to define logical subgroups - for example, two related groups with the prefixes "units/metric" and "units/imperial".
-   * The user interface may parse these prefixes to display both groups under a "units" tab or expandable tree view node.
    *
    * @note Schema prefixes beginning with "itwin" are reserved for use by iTwin.js.
    */
   readonly schemaPrefix: string;
+  /** A title of this group suitable for displaying to a user. */
+  readonly title?: string;
   /** Metadata for each [[Setting]] in this group. */
   readonly settingDefs?: { [name: string]: SettingSchema | undefined };
   /** Metadata for types that can be extended by other [[Setting]]s via [[SettingSchema.extends]]. */


### PR DESCRIPTION
Add an optional title to `ettingGroupSchema` so a settings editor can show a user-facing label without relying on schemaPrefix. This keeps schemaPrefix as the stable identifier for settings, and we won't need to migrate settings if the user facing label changes
