### PR TITLE
Expose settings schema group metadata

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -6482,6 +6482,7 @@ export interface SettingsSchemas {
     addFile(fileName: LocalFileName): void;
     addGroup(settingsGroup: SettingGroupSchema | SettingGroupSchema[]): void;
     addJson(settingSchema: string): void;
+    readonly groups: ReadonlyMap<string, SettingGroupSchema>;
     readonly onSchemaChanged: BeEvent<() => void>;
     removeGroup(schemaPrefix: string): void;
     readonly settingDefs: ReadonlyMap<SettingName, SettingSchema>;

--- a/common/changes/@itwin/core-backend/john-expose-settings-schema_2026-05-20-14-02.json
+++ b/common/changes/@itwin/core-backend/john-expose-settings-schema_2026-05-20-14-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Add SettingsSchemas.groups to expose registered SettingGroupSchema metadata, including user-facing titles and descriptions",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -20,6 +20,7 @@ const makeSettingKey = (prefix: string, key: string) => `${prefix}/${key}`;
 class SettingsSchemasImpl implements SettingsSchemas {
   public readonly [_implementationProhibited] = undefined;
   private readonly _allGroups = new Map<string, SettingGroupSchema>();
+  public get groups(): ReadonlyMap<string, SettingGroupSchema> { return this._allGroups; }
   /** a map of all registered Setting Definitions  */
   public readonly settingDefs = new Map<string, SettingSchema>();
   /** a map of all registered TypeDefs  */

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -38,9 +38,13 @@ describe("SettingsSchemas", () => {
         },
       },
     });
+    expect(schemas.groups.get("title-test")?.title).equals("Title Test");
+    expect(schemas.groups.get("title-test")?.description).equals("schema with a user-facing title");
     expect(schemas.settingDefs.get("title-test/setting")!.type).equals("string");
 
     schemas.addFile(IModelTestUtils.resolveAssetFile("TestSettings.schema.json"));
+    expect(schemas.groups.get("testApp")?.title).equals("Test App");
+    expect(schemas.groups.get("testApp")?.description).equals("the settings for test application 1");
     expect(schemas.settingDefs.get("testApp/list/openMode")!.type).equals("string");
     expect(schemas.settingDefs.get("testApp/list/openMode")!.default).equals("singleClick");
     expect(schemas.settingDefs.get("testApp/tree/blah")!.default).equals(true);

--- a/core/backend/src/workspace/SettingsSchemas.ts
+++ b/core/backend/src/workspace/SettingsSchemas.ts
@@ -106,6 +106,9 @@ export interface SettingsSchemas {
   /** @internal */
   readonly [_implementationProhibited]: unknown;
 
+  /** The map of each registered [[SettingGroupSchema]], accessed by its [[SettingGroupSchema.schemaPrefix]]. */
+  readonly groups: ReadonlyMap<string, SettingGroupSchema>;
+
   /** The map of each individual registered [[SettingSchema]] defining a [[Setting]], accessed by its fully-qualified name (including its [[SettingGroupSchema.schemaPrefix]]). */
   readonly settingDefs: ReadonlyMap<SettingName, SettingSchema>;
 


### PR DESCRIPTION
Users of `IModelHost.settingsSchemas` had no public way to get schema metadata after adding a schema.

So, we expose settings schema groups through `SettingsSchemas.groups` so that settings editors can access schema metadata such as title and description.

 ```ts
   IModelHost.settingsSchemas.addGroup({
     schemaPrefix: "my-app/general",
     title: "General",
     description: "General application settings",
     settingDefs: {
       theme: {
         type: "string",
         default: "system",
         title: "Theme",
         description: "The active application theme",
       },
     },
   });

   const group = IModelHost.settingsSchemas.groups.get("my-app/general");
   const title = group?.title;
   const description = group?.description;
 ```