### PR TITLE
Pin Azure pipelines to Node 24.15.0

### DIFF
--- a/common/config/azure-pipelines/ci.yaml
+++ b/common/config/azure-pipelines/ci.yaml
@@ -46,4 +46,4 @@ jobs:
       - checkout: self
       - template: ./templates/core-build.yaml
         parameters:
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0

--- a/common/config/azure-pipelines/integration-client-regression-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-client-regression-pr-validation.yaml
@@ -23,4 +23,4 @@ jobs:
 
       - template: templates/integration-test-steps.yaml
         parameters:
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -40,4 +40,4 @@ jobs:
 
       - template: templates/integration-test-steps.yaml
         parameters:
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -48,15 +48,15 @@ jobs:
         Linux_node_24_x:
           imageName: ubuntu-latest
           poolName:
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0
         Windows_node_24_x:
           imageName: windows-latest
           poolName:
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0
         MacOS_node_24_x:
           imageName: macos-latest
           poolName: "iModelTechMacArm"
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0
     pool:
       name: $(poolName)
       vmImage: $(imageName)

--- a/common/config/azure-pipelines/jobs/docs-build.yaml
+++ b/common/config/azure-pipelines/jobs/docs-build.yaml
@@ -58,9 +58,9 @@ jobs:
         path: itwinjs-core
         clean: true
       - task: UseNode@1
-        displayName: Use Node 24
+        displayName: Use Node 24.15.0
         inputs:
-          version: 24.x
+          version: 24.15.0
           checkLatest: false
       - script: |
           git config --local user.email imodeljs-admin@users.noreply.github.com

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -76,7 +76,7 @@ jobs:
         persistCredentials: true
       - task: UseNode@1
         inputs:
-          version: "24.x"
+          version: "24.15.0"
 
       - bash: |
           if [[ "$(Build.Reason)" == "PullRequest" ]]; then
@@ -218,12 +218,12 @@ jobs:
         retryCountOnTaskFailure: 1
       - template: ../templates/core-build.yaml
         parameters:
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0
           buildMobile: true
       # Will run if even there is a failure somewhere else in the pipeline.
       - template: ../templates/publish-test-results.yaml
         parameters:
-          nodeVersion: 24.x
+          nodeVersion: 24.15.0
       # The publish script identifies any new packages not previously published and tags the build
       - template: ../templates/publish.yaml
 

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -193,9 +193,9 @@ jobs:
       - checkout: self
 
       - task: UseNode@1
-        displayName: Use Node 24.x
+        displayName: Use Node 24.15.0
         inputs:
-          version: 24.x
+          version: 24.15.0
           checkLatest: true
 
       - bash: |
@@ -437,9 +437,9 @@ jobs:
     steps:
       - checkout: self
       - task: UseNode@1
-        displayName: "Use Node 24.x"
+        displayName: "Use Node 24.15.0"
         inputs:
-          version: 24.x
+          version: 24.15.0
           checkLatest: true
 
       - bash: |

--- a/common/config/azure-pipelines/valgrind.yaml
+++ b/common/config/azure-pipelines/valgrind.yaml
@@ -27,9 +27,9 @@ jobs:
         clean: true
 
       - task: UseNode@1
-        displayName: "Use Node 24.x"
+        displayName: "Use Node 24.15.0"
         inputs:
-          version: 24.x
+          version: 24.15.0
           checkLatest: true
 
       - task: npmAuthenticate@0


### PR DESCRIPTION
## Why

Recent Azure CI failures correlated with Node 24.16.0, while build 5209018 passed on Node 24.15.0. This change temporarily pins the Azure pipeline paths that were still using `24.x` so we can stabilize CI while a separate investigation continues.

## What

- pin Azure `nodeVersion: 24.x` usages to `24.15.0`
- pin direct `UseNode@1` `version: 24.x` usages to `24.15.0`
- update the affected job display names where they explicitly said `Use Node 24.x`

## Validation

- inspected and updated all current `24.x` Node selections under `common/config/azure-pipelines`
- no product code changes; YAML-only CI pin
