### PR TITLE
Add getResolvedSettingDef method for resolving SettingSchema extends

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -6482,10 +6482,10 @@ export interface SettingsSchemas {
     addFile(fileName: LocalFileName): void;
     addGroup(settingsGroup: SettingGroupSchema | SettingGroupSchema[]): void;
     addJson(settingSchema: string): void;
+    getResolvedSettingDef(settingName: SettingName): SettingSchema | undefined;
     readonly groups: ReadonlyMap<string, SettingGroupSchema>;
     readonly onSchemaChanged: BeEvent<() => void>;
     removeGroup(schemaPrefix: string): void;
-    resolveSchema(schema: Readonly<SettingSchema>): SettingSchema;
     readonly settingDefs: ReadonlyMap<SettingName, SettingSchema>;
     readonly typeDefs: ReadonlyMap<SettingName, SettingSchema>;
     validateSetting<T>(value: T, settingName: SettingName): T;

--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -6485,6 +6485,7 @@ export interface SettingsSchemas {
     readonly groups: ReadonlyMap<string, SettingGroupSchema>;
     readonly onSchemaChanged: BeEvent<() => void>;
     removeGroup(schemaPrefix: string): void;
+    resolveSchema(schema: Readonly<SettingSchema>): SettingSchema;
     readonly settingDefs: ReadonlyMap<SettingName, SettingSchema>;
     readonly typeDefs: ReadonlyMap<SettingName, SettingSchema>;
     validateSetting<T>(value: T, settingName: SettingName): T;

--- a/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
+++ b/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Added SettingsSchemas.resolveSchema for resolving nested object properties and array items",
+      "comment": "Added `SettingsSchemas.resolveSchema` for resolving nested object properties and array items",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
+++ b/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
@@ -2,7 +2,12 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Added `SettingsSchemas.resolveSchema` for resolving nested object properties and array items",
+      "comment": "Added `SettingsSchemas.resolveSchema` for resolving nested object properties and array items.",
+      "type": "none"
+    },
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fixed `SettingsSchemas.removeGroup` to remove registered type definitions correctly.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
+++ b/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Added SettingsSchemas.resolveSchema for resolving nexted object properties and array items",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
+++ b/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Added SettingsSchemas.resolveSchema for resolving nexted object properties and array items",
+      "comment": "Added SettingsSchemas.resolveSchema for resolving nested object properties and array items",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
+++ b/common/changes/@itwin/core-backend/john-resolve-schemas_2026-05-22-12-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Added `SettingsSchemas.resolveSchema` for resolving nested object properties and array items.",
+      "comment": "Added `SettingsSchemas.getResolvedSettingDef` for resolving nested object properties and array items.",
       "type": "none"
     },
     {

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -54,9 +54,10 @@ class SettingsSchemasImpl implements SettingsSchemas {
   }
 
   /** @internal */
-  public getObjectProperties(propDef: Readonly<SettingSchema>, scope: string, visited: string[] = []): { required?: string[], properties: { [name: string]: SettingSchema } } {
+  public getObjectProperties(propDef: Readonly<SettingSchema>, scope: string, visited: string[] = []): { required?: string[], properties: { [name: string]: SettingSchema }, visited: string[] } {
     let required = propDef.required;
     let properties = propDef.properties;
+    let nextVisited = visited;
 
     // if this object extends a typeDef, add typeDef's properties and required values, recursively
     if (propDef.extends !== undefined) {
@@ -67,6 +68,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
       if (undefined === typeDef)
         throw new Error(`typeDef ${propDef.extends} does not exist${scope ? ` for ${scope}` : ""}`);
       const expanded = this.getObjectProperties(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends, [...visited, propDef.extends]);
+      nextVisited = expanded.visited;
       if (expanded.required)
         required = required ? [...new Set([...required, ...expanded.required])] : expanded.required;
       if (expanded.properties) {
@@ -74,7 +76,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
       }
     }
     properties = properties ?? {};
-    return { required, properties };
+    return { required, properties, visited: nextVisited };
   }
 
   /** @internal */
@@ -188,7 +190,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
 
     switch (schema.type) {
       case "object": {
-        const { required, properties } = this.getObjectProperties(schema, scope, visited);
+        const { required, properties, visited: resolvedVisited } = this.getObjectProperties(schema, scope, visited);
 
         return {
           ...resolved,
@@ -196,7 +198,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
           properties: Object.fromEntries(
             Object.entries(properties).map(([key, value]) => [
               key,
-              this.resolveSchema(value, scope ? `${scope}.${key}` : key, visited),
+              this.resolveSchema(value, scope ? `${scope}.${key}` : key, resolvedVisited),
             ])
           ),
         };

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -196,7 +196,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
           properties: Object.fromEntries(
             Object.entries(properties).map(([key, value]) => [
               key,
-              this.resolveSchema(value, scope ? `${scope}.${key}` : key),
+              this.resolveSchema(value, scope ? `${scope}.${key}` : key, visited),
             ])
           ),
         };
@@ -220,7 +220,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
 
         return {
           ...resolvedSchema,
-          items: this.resolveSchema(items, scope ? `${scope}.items` : "items"),
+          items: this.resolveSchema(items, scope ? `${scope}.items` : "items", visited),
         };
       }
 

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -48,6 +48,11 @@ class SettingsSchemasImpl implements SettingsSchemas {
     return value;
   }
 
+  public getResolvedSettingDef(settingName: string): SettingSchema | undefined {
+    const schema = this.settingDefs.get(settingName);
+    return schema ? this.resolveSchema(schema, settingName) : undefined;
+  }
+
   /** @internal */
   public getObjectProperties(propDef: Readonly<SettingSchema>, scope: string, visited: string[] = []): { required?: string[], properties: { [name: string]: SettingSchema } } {
     let required = propDef.required;
@@ -178,7 +183,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
     this.onSchemaChanged.raiseEvent();
   }
 
-  public resolveSchema(schema: Readonly<SettingSchema>, scope = "", visited: string[] = []): SettingSchema {
+  private resolveSchema(schema: Readonly<SettingSchema>, scope = "", visited: string[] = []): SettingSchema {
     const { extends: _extends, ...resolved } = schema;
 
     switch (schema.type) {

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -49,19 +49,19 @@ class SettingsSchemasImpl implements SettingsSchemas {
   }
 
   /** @internal */
-  public getObjectProperties(propDef: Readonly<SettingSchema>, scope: string): { required?: string[], properties: { [name: string]: SettingSchema } } {
+  public getObjectProperties(propDef: Readonly<SettingSchema>, scope: string, visited: string[] = []): { required?: string[], properties: { [name: string]: SettingSchema } } {
     let required = propDef.required;
     let properties = propDef.properties;
 
     // if this object extends a typeDef, add typeDef's properties and required values, recursively
     if (propDef.extends !== undefined) {
-      if (scope.split(".").includes(propDef.extends))
-        throw new Error(`circular typeDef reference detected: ${scope}.${propDef.extends}`);
+      if (visited.includes(propDef.extends))
+        throw new Error(`circular typeDef reference detected: ${[...visited, propDef.extends].join(" -> ")}`);
 
       const typeDef = this.typeDefs.get(propDef.extends);
       if (undefined === typeDef)
         throw new Error(`typeDef ${propDef.extends} does not exist${scope ? ` for ${scope}` : ""}`);
-      const expanded = this.getObjectProperties(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends);
+      const expanded = this.getObjectProperties(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends, [...visited, propDef.extends]);
       if (expanded.required)
         required = required ? [...new Set([...required, ...expanded.required])] : expanded.required;
       if (expanded.properties) {
@@ -73,13 +73,16 @@ class SettingsSchemasImpl implements SettingsSchemas {
   }
 
   /** @internal */
-  public getArrayItems(propDef: Readonly<SettingSchema>, scope: string): SettingSchema {
+  public getArrayItems(propDef: Readonly<SettingSchema>, scope: string, visited: string[] = []): SettingSchema {
     let items = propDef.items;
     if (undefined === items && propDef.extends) {
+      if (visited.includes(propDef.extends))
+        throw new Error(`circular typeDef reference detected: ${[...visited, propDef.extends].join(" -> ")}`);
+
       const typeDef = this.typeDefs.get(propDef.extends);
       if (undefined === typeDef)
         throw new Error(`typeDef ${propDef.extends} does not exist${scope ? ` for ${scope}` : ""}`);
-      items = typeDef.items;
+      items = this.getArrayItems(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends, [...visited, propDef.extends]);
     }
     if (undefined === items)
       throw new Error(`array ${scope} has no items definition`);
@@ -175,12 +178,12 @@ class SettingsSchemasImpl implements SettingsSchemas {
     this.onSchemaChanged.raiseEvent();
   }
 
-  public resolveSchema(schema: Readonly<SettingSchema>, scope = ""): SettingSchema {
+  public resolveSchema(schema: Readonly<SettingSchema>, scope = "", visited: string[] = []): SettingSchema {
     const { extends: _extends, ...resolved } = schema;
 
     switch (schema.type) {
       case "object": {
-        const { required, properties } = this.getObjectProperties(schema, scope);
+        const { required, properties } = this.getObjectProperties(schema, scope, visited);
 
         return {
           ...resolved,
@@ -195,18 +198,18 @@ class SettingsSchemasImpl implements SettingsSchemas {
       }
 
       case "array": {
-        const items = this.getArrayItems(schema, scope);
+        const items = this.getArrayItems(schema, scope, visited);
         let resolvedSchema = resolved;
 
         if (schema.extends) {
-          if (scope.split(".").includes(schema.extends))
-            throw new Error(`circular typeDef reference detected: ${scope}.${schema.extends}`);
+          if (visited.includes(schema.extends))
+            throw new Error(`circular typeDef reference detected: ${[...visited, schema.extends].join(" -> ")}`);
 
           const typeDef = this.typeDefs.get(schema.extends);
           if (undefined === typeDef)
             throw new Error(`typeDef ${schema.extends} does not exist${scope ? ` for ${scope}` : ""}`);
 
-          const inheritedProps = this.resolveSchema(typeDef, scope ? `${scope}.${schema.extends}` : schema.extends);
+          const inheritedProps = this.resolveSchema(typeDef, scope ? `${scope}.${schema.extends}` : schema.extends, [...visited, schema.extends]);
           resolvedSchema = { ...inheritedProps, ...resolvedSchema };
         }
 

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -196,8 +196,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
 
       case "array": {
         const items = this.getArrayItems(schema, scope);
-        const { extends: _extends, ...schemaProps } = schema;
-        let resolvedSchema = schemaProps;
+        let resolvedSchema = resolved;
 
         if (schema.extends) {
           if (scope.split(".").includes(schema.extends))

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -86,29 +86,6 @@ class SettingsSchemasImpl implements SettingsSchemas {
     return items;
   }
 
-  /** @internal */
-  public getArrayProperties(propDef: Readonly<SettingSchema>, scope: string): { items: SettingSchema, schema: SettingSchema } {
-    const { extends: _extends, ...resolved } = propDef;
-    let schema: SettingSchema = resolved;
-
-    if (propDef.extends) {
-      if (scope.split(".").includes(propDef.extends))
-        throw new Error(`circular typeDef reference detected: ${scope}.${propDef.extends}`);
-
-      const typeDef = this.typeDefs.get(propDef.extends);
-      if (undefined === typeDef)
-        throw new Error(`typeDef ${propDef.extends} does not exist for ${scope}`);
-
-      const { items: _items, ...typeDefSchema } = this.resolveSchema(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends);
-      schema = { ...typeDefSchema, ...schema };
-    }
-
-    return {
-      schema,
-      items: this.getArrayItems(propDef, scope),
-    };
-  }
-
   private validateProperty<T>(val: T, propDef: Readonly<SettingSchema>, path: string) {
     switch (propDef.type) {
       case "boolean":
@@ -218,9 +195,24 @@ class SettingsSchemasImpl implements SettingsSchemas {
       }
 
       case "array": {
-        const { schema: arraySchema, items } = this.getArrayProperties(schema, scope);
+        const items = this.getArrayItems(schema, scope);
+        const { extends: _extends, ...schemaProps } = schema;
+        let resolvedSchema = schemaProps;
+
+        if (schema.extends) {
+          if (scope.split(".").includes(schema.extends))
+            throw new Error(`circular typeDef reference detected: ${scope}.${schema.extends}`);
+
+          const typeDef = this.typeDefs.get(schema.extends);
+          if (undefined === typeDef)
+            throw new Error(`typeDef ${schema.extends} does not exist for ${scope}`);
+
+          const inheritedProps = this.resolveSchema(typeDef, scope ? `${scope}.${schema.extends}` : schema.extends);
+          resolvedSchema = { ...inheritedProps, ...resolvedSchema };
+        }
+
         return {
-          ...arraySchema,
+          ...resolvedSchema,
           items: this.resolveSchema(items, scope ? `${scope}.items` : "items"),
         };
       }

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -191,14 +191,17 @@ class SettingsSchemasImpl implements SettingsSchemas {
         };
       }
 
-      case "array":
+      case "array": {
+        const items = this.getArrayItems(schema, scope);
+        const typeDef = schema.extends ? this.typeDefs.get(schema.extends) : undefined;
+        const base = typeDef ? this.resolveSchema(typeDef) : undefined;
+
         return {
+          ...base,
           ...resolved,
-          items: this.resolveSchema(
-            this.getArrayItems(schema, scope),
-            scope ? `${scope}.items` : "items"
-          ),
+          items: this.resolveSchema(items, scope ? `${scope}.items` : "items"),
         };
+      }
 
       default:
         return resolved;

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -63,7 +63,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
         throw new Error(`typeDef ${propDef.extends} does not exist for ${scope}`);
       const expanded = this.getObjectProperties(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends);
       if (expanded.required)
-        required = required ? [...required, ...expanded.required] : expanded.required;
+        required = required ? [...new Set([...required, ...expanded.required])] : expanded.required;
       if (expanded.properties) {
         properties = properties ? { ...expanded.properties, ...properties } : expanded.properties;
       }

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -173,40 +173,36 @@ class SettingsSchemasImpl implements SettingsSchemas {
   }
 
   public resolveSchema(schema: Readonly<SettingSchema>, scope = ""): SettingSchema {
-    const resolve = (current: Readonly<SettingSchema>, currentScope: string): SettingSchema => {
-      const { extends: _extends, ...resolved } = current;
+    const { extends: _extends, ...resolved } = schema;
 
-      switch (current.type) {
-        case "object": {
-          const { required, properties } = this.getObjectProperties(current, currentScope);
+    switch (schema.type) {
+      case "object": {
+        const { required, properties } = this.getObjectProperties(schema, scope);
 
-          return {
-            ...resolved,
-            required,
-            properties: Object.fromEntries(
-              Object.entries(properties).map(([key, value]) => [
-                key,
-                resolve(value, currentScope ? `${currentScope}.${key}` : key),
-              ])
-            ),
-          };
-        }
-
-        case "array":
-          return {
-            ...resolved,
-            items: resolve(
-              this.getArrayItems(current, currentScope),
-              currentScope ? `${currentScope}.items` : "items"
-            ),
-          };
-
-        default:
-          return resolved;
+        return {
+          ...resolved,
+          required,
+          properties: Object.fromEntries(
+            Object.entries(properties).map(([key, value]) => [
+              key,
+              this.resolveSchema(value, scope ? `${scope}.${key}` : key),
+            ])
+          ),
+        };
       }
-    };
 
-    return resolve(schema, scope);
+      case "array":
+        return {
+          ...resolved,
+          items: this.resolveSchema(
+            this.getArrayItems(schema, scope),
+            scope ? `${scope}.items` : "items"
+          ),
+        };
+
+      default:
+        return resolved;
+    }
   }
 
   private doAdd(settingsGroup: SettingGroupSchema[]) {

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -55,10 +55,13 @@ class SettingsSchemasImpl implements SettingsSchemas {
 
     // if this object extends a typeDef, add typeDef's properties and required values, recursively
     if (propDef.extends !== undefined) {
+      if (scope.split(".").includes(propDef.extends))
+        throw new Error(`circular typeDef reference detected: ${scope}.${propDef.extends}`);
+
       const typeDef = this.typeDefs.get(propDef.extends);
       if (undefined === typeDef)
         throw new Error(`typeDef ${propDef.extends} does not exist for ${scope}`);
-      const expanded = this.getObjectProperties(typeDef, `${scope}.${propDef.extends}`);
+      const expanded = this.getObjectProperties(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends);
       if (expanded.required)
         required = required ? [...required, ...expanded.required] : expanded.required;
       if (expanded.properties) {
@@ -81,6 +84,29 @@ class SettingsSchemasImpl implements SettingsSchemas {
     if (undefined === items)
       throw new Error(`array ${scope} has no items definition`);
     return items;
+  }
+
+  /** @internal */
+  public getArrayProperties(propDef: Readonly<SettingSchema>, scope: string): { items: SettingSchema, schema: SettingSchema } {
+    const { extends: _extends, ...resolved } = propDef;
+    let schema: SettingSchema = resolved;
+
+    if (propDef.extends) {
+      if (scope.split(".").includes(propDef.extends))
+        throw new Error(`circular typeDef reference detected: ${scope}.${propDef.extends}`);
+
+      const typeDef = this.typeDefs.get(propDef.extends);
+      if (undefined === typeDef)
+        throw new Error(`typeDef ${propDef.extends} does not exist for ${scope}`);
+
+      const { items: _items, ...typeDefSchema } = this.resolveSchema(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends);
+      schema = { ...typeDefSchema, ...schema };
+    }
+
+    return {
+      schema,
+      items: this.getArrayItems(propDef, scope),
+    };
   }
 
   private validateProperty<T>(val: T, propDef: Readonly<SettingSchema>, path: string) {
@@ -192,13 +218,9 @@ class SettingsSchemasImpl implements SettingsSchemas {
       }
 
       case "array": {
-        const items = this.getArrayItems(schema, scope);
-        const typeDef = schema.extends ? this.typeDefs.get(schema.extends) : undefined;
-        const base = typeDef ? this.resolveSchema(typeDef) : undefined;
-
+        const { schema: arraySchema, items } = this.getArrayProperties(schema, scope);
         return {
-          ...base,
-          ...resolved,
+          ...arraySchema,
           items: this.resolveSchema(items, scope ? `${scope}.items` : "items"),
         };
       }

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -60,7 +60,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
 
       const typeDef = this.typeDefs.get(propDef.extends);
       if (undefined === typeDef)
-        throw new Error(`typeDef ${propDef.extends} does not exist for ${scope}`);
+        throw new Error(`typeDef ${propDef.extends} does not exist${scope ? ` for ${scope}` : ""}`);
       const expanded = this.getObjectProperties(typeDef, scope ? `${scope}.${propDef.extends}` : propDef.extends);
       if (expanded.required)
         required = required ? [...new Set([...required, ...expanded.required])] : expanded.required;
@@ -78,7 +78,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
     if (undefined === items && propDef.extends) {
       const typeDef = this.typeDefs.get(propDef.extends);
       if (undefined === typeDef)
-        throw new Error(`typeDef ${propDef.extends} does not exist for ${scope}`);
+        throw new Error(`typeDef ${propDef.extends} does not exist${scope ? ` for ${scope}` : ""}`);
       items = typeDef.items;
     }
     if (undefined === items)
@@ -205,7 +205,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
 
           const typeDef = this.typeDefs.get(schema.extends);
           if (undefined === typeDef)
-            throw new Error(`typeDef ${schema.extends} does not exist for ${scope}`);
+            throw new Error(`typeDef ${schema.extends} does not exist${scope ? ` for ${scope}` : ""}`);
 
           const inheritedProps = this.resolveSchema(typeDef, scope ? `${scope}.${schema.extends}` : schema.extends);
           resolvedSchema = { ...inheritedProps, ...resolvedSchema };

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -172,6 +172,43 @@ class SettingsSchemasImpl implements SettingsSchemas {
     this.onSchemaChanged.raiseEvent();
   }
 
+  public resolveSchema(schema: Readonly<SettingSchema>, scope = ""): SettingSchema {
+    const resolve = (current: Readonly<SettingSchema>, currentScope: string): SettingSchema => {
+      const { extends: _extends, ...resolved } = current;
+
+      switch (current.type) {
+        case "object": {
+          const { required, properties } = this.getObjectProperties(current, currentScope);
+
+          return {
+            ...resolved,
+            required,
+            properties: Object.fromEntries(
+              Object.entries(properties).map(([key, value]) => [
+                key,
+                resolve(value, currentScope ? `${currentScope}.${key}` : key),
+              ])
+            ),
+          };
+        }
+
+        case "array":
+          return {
+            ...resolved,
+            items: resolve(
+              this.getArrayItems(current, currentScope),
+              currentScope ? `${currentScope}.items` : "items"
+            ),
+          };
+
+        default:
+          return resolved;
+      }
+    };
+
+    return resolve(schema, scope);
+  }
+
   private doAdd(settingsGroup: SettingGroupSchema[]) {
     settingsGroup.forEach((group) => {
       if (undefined === group.schemaPrefix)

--- a/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
+++ b/core/backend/src/internal/workspace/SettingsSchemasImpl.ts
@@ -241,7 +241,7 @@ class SettingsSchemasImpl implements SettingsSchemas {
     }
     if (undefined !== group?.typeDefs) {
       for (const key of Object.keys(group.typeDefs))
-        this.settingDefs.delete(makeSettingKey(schemaPrefix, key));
+        this.typeDefs.delete(makeSettingKey(schemaPrefix, key));
     }
     this._allGroups.delete(schemaPrefix);
   }

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -147,6 +147,30 @@ describe("SettingsSchemas", () => {
     }
   });
 
+  it("resolveSchema resolves built-in workspaceDb and workspaceDbList typedefs", () => {
+    const schemas = IModelHost.settingsSchemas;
+
+    const workspaceDb = schemas.typeDefs.get("itwin/core/workspace/workspaceDb");
+    expect(workspaceDb).to.not.be.undefined;
+
+    const resolvedWorkspaceDb = schemas.resolveSchema(workspaceDb!);
+    expect(resolvedWorkspaceDb.type).to.equal("object");
+    expect(resolvedWorkspaceDb.required).to.have.members(["containerId", "baseUri"]);
+    expect(resolvedWorkspaceDb.properties).to.include.keys("dbName", "baseUri", "containerId", "storageType");
+    expect(resolvedWorkspaceDb.properties?.storageType.default).to.equal("azure");
+
+    const workspaceDbList = schemas.typeDefs.get("itwin/core/workspace/workspaceDbList");
+    expect(workspaceDbList).to.not.be.undefined;
+
+    const resolvedWorkspaceDbList = schemas.resolveSchema(workspaceDbList!);
+    expect(resolvedWorkspaceDbList.type).to.equal("array");
+    expect(resolvedWorkspaceDbList.combineArray).to.equal(true);
+    expect(resolvedWorkspaceDbList.items?.type).to.equal("object");
+    expect(resolvedWorkspaceDbList.items).to.not.have.property("extends");
+    expect(resolvedWorkspaceDbList.items?.required).to.have.members(["containerId", "baseUri"]);
+    expect(resolvedWorkspaceDbList.items?.properties).to.include.keys("dbName", "baseUri", "containerId", "storageType");
+  });
+
   it("resolveSchema throws when an extends target cannot be found", () => {
     const schemas = IModelHost.settingsSchemas;
     expect(() => schemas.resolveSchema({ type: "object", extends: "missing/type" })).to.throw("typeDef missing/type does not exist");

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -50,4 +50,106 @@ describe("SettingsSchemas", () => {
     expect(schemas.settingDefs.get("testApp/tree/blah")!.default).equals(true);
   });
 
+  it("resolveSchema resolves object extends chains recursively", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-object";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test object resolution",
+      typeDefs: {
+        nestedBase: {
+          type: "object",
+          required: ["nestedReq"],
+          properties: {
+            nestedReq: { type: "integer" },
+            nestedBaseOnly: { type: "string" },
+          },
+        },
+        baseThing: {
+          type: "object",
+          required: ["baseReq"],
+          properties: {
+            baseReq: { type: "string" },
+            overridden: { type: "string" },
+            baseOnly: { type: "number" },
+            nested: {
+              type: "object",
+              extends: `${prefix}/nestedBase`,
+              properties: {
+                nestedChildOnly: { type: "boolean" },
+              },
+            },
+          },
+        },
+      },
+      settingDefs: {
+        thing: {
+          type: "object",
+          extends: `${prefix}/baseThing`,
+          required: ["derivedReq"],
+          properties: {
+            derivedReq: { type: "boolean" },
+            overridden: { type: "number" },
+          },
+        },
+      },
+    });
+
+    try {
+      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!);
+      expect(resolved.type).to.equal("object");
+      expect(resolved).to.not.have.property("extends");
+      expect(resolved.required).to.have.members(["baseReq", "derivedReq"]);
+      expect(resolved.properties).to.include.keys("baseReq", "baseOnly", "derivedReq", "overridden", "nested");
+      expect(resolved.properties?.overridden.type).to.equal("number");
+      expect(resolved.properties?.baseOnly.type).to.equal("number");
+
+      const nested = resolved.properties?.nested;
+      expect(nested?.type).to.equal("object");
+      expect(nested).to.not.have.property("extends");
+      expect(nested?.required).to.have.members(["nestedReq"]);
+      expect(nested?.properties).to.include.keys("nestedReq", "nestedBaseOnly", "nestedChildOnly");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
+  it("resolveSchema resolves array items through extends", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-array";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test array resolution",
+      typeDefs: {
+        stringList: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      settingDefs: {
+        names: {
+          type: "array",
+          extends: `${prefix}/stringList`,
+        },
+      },
+    });
+
+    try {
+      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/names`)!);
+      expect(resolved.type).to.equal("array");
+      expect(resolved).to.not.have.property("extends");
+      expect(resolved.items?.type).to.equal("string");
+      expect(resolved.items).to.not.have.property("extends");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
+  it("resolveSchema throws when an extends target cannot be found", () => {
+    const schemas = IModelHost.settingsSchemas;
+    expect(() => schemas.resolveSchema({ type: "object", extends: "missing/type" })).to.throw("typeDef missing/type does not exist");
+  });
+
 });

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -339,31 +339,20 @@ describe("SettingsSchemas", () => {
     }
   });
 
-  it("resolveSchema resolves built-in workspaceDb and workspaceDbList typedefs", () => {
+  it("getResolvedSettingDef resolves built-in workspace settings schemas", () => {
     const schemas = IModelHost.settingsSchemas;
 
-    const workspaceDb = schemas.typeDefs.get("itwin/core/workspace/workspaceDb");
-    expect(workspaceDb).to.not.be.undefined;
-
-    const resolvedWorkspaceDb = (schemas as any).resolveSchema(workspaceDb!);
-    expect(resolvedWorkspaceDb.type).to.equal("object");
-    expect(resolvedWorkspaceDb.required).to.have.members(["containerId", "baseUri"]);
-    expect(resolvedWorkspaceDb.properties).to.include.keys("dbName", "baseUri", "containerId", "storageType");
-    expect(resolvedWorkspaceDb.properties?.storageType.default).to.equal("azure");
-
-    const workspaceDbList = schemas.typeDefs.get("itwin/core/workspace/workspaceDbList");
-    expect(workspaceDbList).to.not.be.undefined;
-
-    const resolvedWorkspaceDbList = (schemas as any).resolveSchema(workspaceDbList!);
-    expect(resolvedWorkspaceDbList.type).to.equal("array");
-    expect(resolvedWorkspaceDbList.combineArray).to.equal(true);
-    expect(resolvedWorkspaceDbList.items?.type).to.equal("object");
-    expect(resolvedWorkspaceDbList.items).to.not.have.property("extends");
-    expect(resolvedWorkspaceDbList.items?.required).to.have.members(["containerId", "baseUri"]);
-    expect(resolvedWorkspaceDbList.items?.properties).to.include.keys("dbName", "baseUri", "containerId", "storageType");
+    const resolved = schemas.getResolvedSettingDef("itwin/core/workspace/settingsWorkspaces");
+    expect(resolved).to.not.be.undefined;
+    expect(resolved?.type).to.equal("array");
+    expect(resolved?.items?.type).to.equal("object");
+    expect(resolved?.items).to.not.have.property("extends");
+    expect(resolved?.items?.required).to.have.members(["containerId", "baseUri"]);
+    expect(resolved?.items?.properties).to.include.keys("dbName", "baseUri", "containerId", "storageType", "resourceName", "priority");
+    expect(resolved?.items?.properties?.storageType.default).to.equal("azure");
   });
 
-  it("resolveSchema throws on circular typedef references", () => {
+  it("getResolvedSettingDef throws on circular typedef references", () => {
     const schemas = IModelHost.settingsSchemas;
     const prefix = "resolve-schema-cycle";
     schemas.removeGroup(prefix);
@@ -401,9 +390,59 @@ describe("SettingsSchemas", () => {
     }
   });
 
-  it("resolveSchema throws when an extends target cannot be found", () => {
+  it("getResolvedSettingDef throws on nested recursive typedef references", () => {
     const schemas = IModelHost.settingsSchemas;
-    expect(() => (schemas as any).resolveSchema({ type: "object", extends: "missing/type" })).to.throw("typeDef missing/type does not exist");
+    const prefix = "resolve-schema-nested-cycle";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test nested recursive typedef resolution",
+      typeDefs: {
+        node: {
+          type: "object",
+          properties: {
+            child: {
+              type: "object",
+              extends: `${prefix}/node`,
+            },
+          },
+        },
+      },
+      settingDefs: {
+        root: {
+          type: "object",
+          extends: `${prefix}/node`,
+        },
+      },
+    });
+
+    try {
+      expect(() => schemas.getResolvedSettingDef(`${prefix}/root`)).to.throw("circular typeDef reference detected");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
+  it("getResolvedSettingDef throws when an extends target cannot be found", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-missing-typedef";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test missing typedef resolution",
+      settingDefs: {
+        thing: {
+          type: "object",
+          extends: `${prefix}/missingType`,
+        },
+      },
+    });
+
+    try {
+      expect(() => schemas.getResolvedSettingDef(`${prefix}/thing`)).to.throw(`typeDef ${prefix}/missingType does not exist`);
+    } finally {
+      schemas.removeGroup(prefix);
+    }
   });
 
 });

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -97,7 +97,7 @@ describe("SettingsSchemas", () => {
     });
 
     try {
-      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!);
+      const resolved = schemas.getResolvedSettingDef(`${prefix}/thing`)!;
       expect(resolved.type).to.equal("object");
       expect(resolved).to.not.have.property("extends");
       expect(resolved.required).to.have.members(["baseReq", "derivedReq"]);
@@ -143,7 +143,7 @@ describe("SettingsSchemas", () => {
     });
 
     try {
-      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!);
+      const resolved = schemas.getResolvedSettingDef(`${prefix}/thing`)!;
       expect(resolved.properties).to.include.keys("inheritedName", "inheritedEnabled", "localCount");
       expect(resolved.properties?.inheritedName.type).to.equal("string");
       expect(resolved.properties?.inheritedEnabled.type).to.equal("boolean");
@@ -185,7 +185,7 @@ describe("SettingsSchemas", () => {
     });
 
     try {
-      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!);
+      const resolved = schemas.getResolvedSettingDef(`${prefix}/thing`)!;
       expect(resolved.required).to.have.members(["sharedReq", "baseReq", "derivedReq"]);
       expect(resolved.required?.filter((name) => name === "sharedReq")).to.have.lengthOf(1);
     } finally {
@@ -218,7 +218,7 @@ describe("SettingsSchemas", () => {
     });
 
     try {
-      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/names`)!);
+      const resolved = schemas.getResolvedSettingDef(`${prefix}/names`)!;
       expect(resolved.type).to.equal("array");
       expect(resolved).to.not.have.property("extends");
       expect(resolved.combineArray).to.equal(true);
@@ -259,7 +259,7 @@ describe("SettingsSchemas", () => {
     });
 
     try {
-      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/names`)!);
+      const resolved = schemas.getResolvedSettingDef(`${prefix}/names`)!;
       expect(resolved.combineArray).to.equal(false);
       expect(resolved.minItems).to.equal(3);
       expect(resolved.description).to.equal("derived array schema");
@@ -296,9 +296,44 @@ describe("SettingsSchemas", () => {
     });
 
     try {
-      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/names`)!);
+      const resolved = schemas.getResolvedSettingDef(`${prefix}/names`)!;
       expect(resolved.combineArray).to.equal(true);
       expect(resolved.items?.type).to.equal("string");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
+  it("getResolvedSettingDef returns a resolved setting schema by name", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-setting-schema";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test resolved setting schema lookup",
+      typeDefs: {
+        stringList: {
+          type: "array",
+          combineArray: true,
+          items: { type: "string" },
+        },
+      },
+      settingDefs: {
+        names: {
+          type: "array",
+          extends: `${prefix}/stringList`,
+        },
+      },
+    });
+
+    try {
+      const resolved = schemas.getResolvedSettingDef(`${prefix}/names`);
+      expect(resolved).to.not.be.undefined;
+      expect(resolved?.type).to.equal("array");
+      expect(resolved).to.not.have.property("extends");
+      expect(resolved?.combineArray).to.equal(true);
+      expect(resolved?.items?.type).to.equal("string");
+      expect(schemas.getResolvedSettingDef(`${prefix}/missing`)).to.be.undefined;
     } finally {
       schemas.removeGroup(prefix);
     }
@@ -310,7 +345,7 @@ describe("SettingsSchemas", () => {
     const workspaceDb = schemas.typeDefs.get("itwin/core/workspace/workspaceDb");
     expect(workspaceDb).to.not.be.undefined;
 
-    const resolvedWorkspaceDb = schemas.resolveSchema(workspaceDb!);
+    const resolvedWorkspaceDb = (schemas as any).resolveSchema(workspaceDb!);
     expect(resolvedWorkspaceDb.type).to.equal("object");
     expect(resolvedWorkspaceDb.required).to.have.members(["containerId", "baseUri"]);
     expect(resolvedWorkspaceDb.properties).to.include.keys("dbName", "baseUri", "containerId", "storageType");
@@ -319,7 +354,7 @@ describe("SettingsSchemas", () => {
     const workspaceDbList = schemas.typeDefs.get("itwin/core/workspace/workspaceDbList");
     expect(workspaceDbList).to.not.be.undefined;
 
-    const resolvedWorkspaceDbList = schemas.resolveSchema(workspaceDbList!);
+    const resolvedWorkspaceDbList = (schemas as any).resolveSchema(workspaceDbList!);
     expect(resolvedWorkspaceDbList.type).to.equal("array");
     expect(resolvedWorkspaceDbList.combineArray).to.equal(true);
     expect(resolvedWorkspaceDbList.items?.type).to.equal("object");
@@ -360,7 +395,7 @@ describe("SettingsSchemas", () => {
     });
 
     try {
-      expect(() => schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!)).to.throw("circular typeDef reference detected");
+      expect(() => schemas.getResolvedSettingDef(`${prefix}/thing`)).to.throw("circular typeDef reference detected");
     } finally {
       schemas.removeGroup(prefix);
     }
@@ -368,7 +403,7 @@ describe("SettingsSchemas", () => {
 
   it("resolveSchema throws when an extends target cannot be found", () => {
     const schemas = IModelHost.settingsSchemas;
-    expect(() => schemas.resolveSchema({ type: "object", extends: "missing/type" })).to.throw("typeDef missing/type does not exist");
+    expect(() => (schemas as any).resolveSchema({ type: "object", extends: "missing/type" })).to.throw("typeDef missing/type does not exist");
   });
 
 });

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -153,6 +153,45 @@ describe("SettingsSchemas", () => {
     }
   });
 
+  it("resolveSchema deduplicates required properties inherited from object typedefs", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-object-required";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test required property deduplication",
+      typeDefs: {
+        baseThing: {
+          type: "object",
+          required: ["sharedReq", "baseReq"],
+          properties: {
+            sharedReq: { type: "string" },
+            baseReq: { type: "boolean" },
+            derivedReq: { type: "integer" },
+          },
+        },
+      },
+      settingDefs: {
+        thing: {
+          type: "object",
+          extends: `${prefix}/baseThing`,
+          required: ["sharedReq", "derivedReq"],
+          properties: {
+            derivedReq: { type: "integer" },
+          },
+        },
+      },
+    });
+
+    try {
+      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!);
+      expect(resolved.required).to.have.members(["sharedReq", "baseReq", "derivedReq"]);
+      expect(resolved.required?.filter((name) => name === "sharedReq")).to.have.lengthOf(1);
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
   it("resolveSchema resolves array items through extends", () => {
     const schemas = IModelHost.settingsSchemas;
     const prefix = "resolve-schema-array";

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -115,6 +115,44 @@ describe("SettingsSchemas", () => {
     }
   });
 
+  it("resolveSchema includes inherited properties from object typedefs", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-object-inherited-props";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test inherited object properties",
+      typeDefs: {
+        baseThing: {
+          type: "object",
+          properties: {
+            inheritedName: { type: "string" },
+            inheritedEnabled: { type: "boolean" },
+          },
+        },
+      },
+      settingDefs: {
+        thing: {
+          type: "object",
+          extends: `${prefix}/baseThing`,
+          properties: {
+            localCount: { type: "integer" },
+          },
+        },
+      },
+    });
+
+    try {
+      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!);
+      expect(resolved.properties).to.include.keys("inheritedName", "inheritedEnabled", "localCount");
+      expect(resolved.properties?.inheritedName.type).to.equal("string");
+      expect(resolved.properties?.inheritedEnabled.type).to.equal("boolean");
+      expect(resolved.properties?.localCount.type).to.equal("integer");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
   it("resolveSchema resolves array items through extends", () => {
     const schemas = IModelHost.settingsSchemas;
     const prefix = "resolve-schema-array";
@@ -125,6 +163,9 @@ describe("SettingsSchemas", () => {
       typeDefs: {
         stringList: {
           type: "array",
+          combineArray: true,
+          minItems: 1,
+          description: "base array typedef",
           items: { type: "string" },
         },
       },
@@ -140,6 +181,9 @@ describe("SettingsSchemas", () => {
       const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/names`)!);
       expect(resolved.type).to.equal("array");
       expect(resolved).to.not.have.property("extends");
+      expect(resolved.combineArray).to.equal(true);
+      expect(resolved.minItems).to.equal(1);
+      expect(resolved.description).to.equal("base array typedef");
       expect(resolved.items?.type).to.equal("string");
       expect(resolved.items).to.not.have.property("extends");
     } finally {
@@ -169,6 +213,44 @@ describe("SettingsSchemas", () => {
     expect(resolvedWorkspaceDbList.items).to.not.have.property("extends");
     expect(resolvedWorkspaceDbList.items?.required).to.have.members(["containerId", "baseUri"]);
     expect(resolvedWorkspaceDbList.items?.properties).to.include.keys("dbName", "baseUri", "containerId", "storageType");
+  });
+
+  it("resolveSchema throws on circular typedef references", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-cycle";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test circular typedef resolution",
+      typeDefs: {
+        a: {
+          type: "object",
+          extends: `${prefix}/b`,
+          properties: {
+            aOnly: { type: "string" },
+          },
+        },
+        b: {
+          type: "object",
+          extends: `${prefix}/a`,
+          properties: {
+            bOnly: { type: "string" },
+          },
+        },
+      },
+      settingDefs: {
+        thing: {
+          type: "object",
+          extends: `${prefix}/a`,
+        },
+      },
+    });
+
+    try {
+      expect(() => schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/thing`)!)).to.throw("circular typeDef reference detected");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
   });
 
   it("resolveSchema throws when an extends target cannot be found", () => {

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -177,6 +177,7 @@ describe("SettingsSchemas", () => {
           extends: `${prefix}/baseThing`,
           required: ["sharedReq", "derivedReq"],
           properties: {
+            sharedReq: { type: "string" },
             derivedReq: { type: "integer" },
           },
         },

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -191,6 +191,44 @@ describe("SettingsSchemas", () => {
     }
   });
 
+  it("resolveSchema lets derived array schema properties override inherited typedef properties", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-array-overrides";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test array override precedence",
+      typeDefs: {
+        stringList: {
+          type: "array",
+          combineArray: true,
+          minItems: 1,
+          description: "base array typedef",
+          items: { type: "string" },
+        },
+      },
+      settingDefs: {
+        names: {
+          type: "array",
+          extends: `${prefix}/stringList`,
+          combineArray: false,
+          minItems: 3,
+          description: "derived array schema",
+        },
+      },
+    });
+
+    try {
+      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/names`)!);
+      expect(resolved.combineArray).to.equal(false);
+      expect(resolved.minItems).to.equal(3);
+      expect(resolved.description).to.equal("derived array schema");
+      expect(resolved.items?.type).to.equal("string");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
   it("resolveSchema resolves built-in workspaceDb and workspaceDbList typedefs", () => {
     const schemas = IModelHost.settingsSchemas;
 

--- a/core/backend/src/test/standalone/SettingsSchemas.test.ts
+++ b/core/backend/src/test/standalone/SettingsSchemas.test.ts
@@ -269,6 +269,41 @@ describe("SettingsSchemas", () => {
     }
   });
 
+  it("resolveSchema resolves array items through multi-level typedef inheritance", () => {
+    const schemas = IModelHost.settingsSchemas;
+    const prefix = "resolve-schema-array-multilevel";
+    schemas.removeGroup(prefix);
+    schemas.addGroup({
+      schemaPrefix: prefix,
+      description: "schema used to test multi-level array typedef inheritance",
+      typeDefs: {
+        c: {
+          type: "array",
+          combineArray: true,
+          items: { type: "string" },
+        },
+        b: {
+          type: "array",
+          extends: `${prefix}/c`,
+        },
+      },
+      settingDefs: {
+        names: {
+          type: "array",
+          extends: `${prefix}/b`,
+        },
+      },
+    });
+
+    try {
+      const resolved = schemas.resolveSchema(schemas.settingDefs.get(`${prefix}/names`)!);
+      expect(resolved.combineArray).to.equal(true);
+      expect(resolved.items?.type).to.equal("string");
+    } finally {
+      schemas.removeGroup(prefix);
+    }
+  });
+
   it("resolveSchema resolves built-in workspaceDb and workspaceDbList typedefs", () => {
     const schemas = IModelHost.settingsSchemas;
 

--- a/core/backend/src/workspace/SettingsSchemas.ts
+++ b/core/backend/src/workspace/SettingsSchemas.ts
@@ -109,7 +109,10 @@ export interface SettingsSchemas {
   /** The map of each registered [[SettingGroupSchema]], accessed by its [[SettingGroupSchema.schemaPrefix]]. */
   readonly groups: ReadonlyMap<string, SettingGroupSchema>;
 
-  /** The map of each individual registered [[SettingSchema]] defining a [[Setting]], accessed by its fully-qualified name (including its [[SettingGroupSchema.schemaPrefix]]). */
+  /** The map of each individual registered [[SettingSchema]] defining a [[Setting]], accessed by its fully-qualified name (including its [[SettingGroupSchema.schemaPrefix]]).
+   * Schemas in this map may include an [[SettingSchema.extends]] property referring to a registered type definition.
+   * Use [[resolveSchema]] to obtain the fully expanded schema.
+   */
   readonly settingDefs: ReadonlyMap<SettingName, SettingSchema>;
 
   /** The map of each individual registered [[SettingSchema]] defining a type that can be extended by other [[SettingSchema]]s via [[SettingSchema.extends]],
@@ -153,6 +156,12 @@ export interface SettingsSchemas {
    * If the schema does not have an `extends` property, it is returned as-is.
    * Otherwise, the schema is recursively merged with the schema(s) it extends,
    * with properties from this schema taking precedence over those from the extended schema(s).
+   *
+   * @example
+   * ```ts
+   * const schema = IModelHost.settingsSchemas.settingDefs.get("app/font");
+   * const resolved = IModelHost.settingsSchemas.resolveSchema(schema);
+   * ```
    *
    * @throws Error if a referenced [[typeDefs]] cannot be found or the schema cannot be resolved.
    */

--- a/core/backend/src/workspace/SettingsSchemas.ts
+++ b/core/backend/src/workspace/SettingsSchemas.ts
@@ -152,16 +152,14 @@ export interface SettingsSchemas {
   removeGroup(schemaPrefix: string): void;
 
   /**
-   * Resolves a setting schema using the currently registered [[typeDefs]].
-   * Any `extends` chain on the schema, its object properties, or its array item schema is recursively resolved,
-   * with properties from the supplied schema taking precedence over those from the extended schema(s).
+   * Looks up a setting schema in [[settingDefs]] and returns its resolved form.
+   * Resolution uses the [[typeDefs]] currently registered with this [[SettingsSchemas]] instance.
+   * @returns The resolved schema for `settingName`, or `undefined` if no schema has been registered for that setting.
    * @example
    * ```ts
-   * const schema = IModelHost.settingsSchemas.settingDefs.get("app/font");
-   * const resolved = IModelHost.settingsSchemas.resolveSchema(schema);
+   * const resolved = IModelHost.settingsSchemas.getResolvedSettingDef("app/font");
    * ```
-   *
-   * @throws Error if a referenced [[typeDefs]] cannot be found or the schema cannot be resolved.
    */
-  resolveSchema(schema: Readonly<SettingSchema>): SettingSchema;
+  getResolvedSettingDef(settingName: SettingName): SettingSchema | undefined;
+
 }

--- a/core/backend/src/workspace/SettingsSchemas.ts
+++ b/core/backend/src/workspace/SettingsSchemas.ts
@@ -155,6 +155,7 @@ export interface SettingsSchemas {
    * Looks up a setting schema in [[settingDefs]] and returns its resolved form.
    * Resolution uses the [[typeDefs]] currently registered with this [[SettingsSchemas]] instance.
    * @returns The resolved schema for `settingName`, or `undefined` if no schema has been registered for that setting.
+   * @throws Error if a registered setting schema cannot be resolved because a referenced type definition is missing or circular.
    * @example
    * ```ts
    * const resolved = IModelHost.settingsSchemas.getResolvedSettingDef("app/font");

--- a/core/backend/src/workspace/SettingsSchemas.ts
+++ b/core/backend/src/workspace/SettingsSchemas.ts
@@ -147,4 +147,14 @@ export interface SettingsSchemas {
 
   /** Unregisters all [[settingDefs]] and [[typeDefs]] with the specified [[SettingGroupSchema.schemaPrefix]]. */
   removeGroup(schemaPrefix: string): void;
+
+  /**
+   * Resolves a setting schema's `extends` chain using the currently registered [[typeDefs]].
+   * If the schema does not have an `extends` property, it is returned as-is.
+   * Otherwise, the schema is recursively merged with the schema(s) it extends,
+   * with properties from this schema taking precedence over those from the extended schema(s).
+   *
+   * @throws Error if a referenced [[typeDefs]] cannot be found or the schema cannot be resolved.
+   */
+  resolveSchema(schema: Readonly<SettingSchema>): SettingSchema;
 }

--- a/core/backend/src/workspace/SettingsSchemas.ts
+++ b/core/backend/src/workspace/SettingsSchemas.ts
@@ -152,11 +152,9 @@ export interface SettingsSchemas {
   removeGroup(schemaPrefix: string): void;
 
   /**
-   * Resolves a setting schema's `extends` chain using the currently registered [[typeDefs]].
-   * If the schema does not have an `extends` property, it is returned as-is.
-   * Otherwise, the schema is recursively merged with the schema(s) it extends,
-   * with properties from this schema taking precedence over those from the extended schema(s).
-   *
+   * Resolves a setting schema using the currently registered [[typeDefs]].
+   * Any `extends` chain on the schema, its object properties, or its array item schema is recursively resolved,
+   * with properties from the supplied schema taking precedence over those from the extended schema(s).
    * @example
    * ```ts
    * const schema = IModelHost.settingsSchemas.settingDefs.get("app/font");


### PR DESCRIPTION
Adds SettingsSchemas.getResolvedSettingDef, a method for looking up a registered setting schema and expanding its extends chain using the currently registered typeDefs. This is useful for settings editor user interfaces that need the effective schema for a setting rather than the raw registered definition. For example, if a setting definition extends app/baseFont and that type defines common object properties like fontName and fontFamily,
 getResolvedSettingDef returns a single schema containing those inherited properties plus any properties defined directly on the setting itself:

 ```ts
   IModelHost.settingsSchemas.addGroup({
     schemaPrefix: "app",
     description: "example schemas",
     typeDefs: {
       baseFont: {
         type: "object",
         required: ["fontName"],
         properties: {
           fontName: { type: "string" },
           fontFamily: { type: "string" },
         },
       },
     },
     settingDefs: {
       font: {
         type: "object",
         extends: "app/baseFont",
         properties: {
           fontType: { type: "string" },
         },
       },
     },
   });

   const resolved = IModelHost.settingsSchemas.getResolvedSettingDef("app/font");

   console.log(resolved);
 ```

 This would produce:

 ```ts
   {
     type: "object",
     required: ["fontName"],
     properties: {
       fontName: { type: "string" },
       fontFamily: { type: "string" },
       fontType: { type: "string" },
     },
   }
 ```