### PR TITLE
Disable Flaky GenerateUnits Test

### DIFF
--- a/common/changes/@itwin/core-quantity/mike-fix-test_2026-05-22-15-08.json
+++ b/common/changes/@itwin/core-quantity/mike-fix-test_2026-05-22-15-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-quantity",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-quantity"
+}

--- a/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
+++ b/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
@@ -111,7 +111,8 @@ describe("Generated Units artifacts", () => {
     expect(() => buildGeneratedBasicConversionModule(invalidSchema, assertUniqueGeneratedKeys)).toThrowError(/Invalid denominator for "FT"/);
   });
 
-  it("rebuilds the checked-in default persistence artifact exactly from Units.json", () => {
+  // Disabled because the string compare can fail on different platforms due to differences in line endings.
+  it.skip("rebuilds the checked-in default persistence artifact exactly from Units.json", () => {
     expect(buildGeneratedDefaultPersistenceModule(unitsSchema, assertUniqueGeneratedKeys)).toBe(generatedDefaultPersistenceSource);
   });
 });

--- a/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
+++ b/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
@@ -112,6 +112,7 @@ describe("Generated Units artifacts", () => {
   });
 
   // Disabled because the string compare can fail on different platforms due to differences in line endings.
+  // Tracking Issue: https://github.com/iTwin/itwinjs-backlog/issues/2099
   it.skip("rebuilds the checked-in default persistence artifact exactly from Units.json", () => {
     expect(buildGeneratedDefaultPersistenceModule(unitsSchema, assertUniqueGeneratedKeys)).toBe(generatedDefaultPersistenceSource);
   });


### PR DESCRIPTION
Skips "rebuilds the checked-in default persistence artifact exactly from Units.json" Test that is blocking windows pipeline