### PR TITLE
Disable Flaky GenerateUnits Units.json Tests

### DIFF
--- a/common/changes/@itwin/core-quantity/mike-fix-test-again_2026-05-22-17-46.json
+++ b/common/changes/@itwin/core-quantity/mike-fix-test-again_2026-05-22-17-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-quantity",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-quantity"
+}

--- a/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
+++ b/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
@@ -85,7 +85,6 @@ describe("Generated Units artifacts", () => {
   });
 
   // Disabled because the string compare can fail on different platforms due to differences in line endings.
-  // Tracking Issue: https://github.com/iTwin/itwinjs-backlog/issues/2099
   it.skip("rebuilds the checked-in Units identifiers artifact exactly from Units.json", () => {
     expect(buildGeneratedUnitsModule(unitsSchema)).toBe(generatedIdentifiersSource);
   });
@@ -96,7 +95,6 @@ describe("Generated Units artifacts", () => {
   });
 
   // Disabled because the string compare can fail on different platforms due to differences in line endings.
-  // Tracking Issue: https://github.com/iTwin/itwinjs-backlog/issues/2099
   it.skip("rebuilds the checked-in basic conversion artifact exactly from Units.json", () => {
     expect(buildGeneratedBasicConversionModule(unitsSchema, assertUniqueGeneratedKeys)).toBe(generatedBasicConversionsSource);
   });
@@ -116,7 +114,6 @@ describe("Generated Units artifacts", () => {
   });
 
   // Disabled because the string compare can fail on different platforms due to differences in line endings.
-  // Tracking Issue: https://github.com/iTwin/itwinjs-backlog/issues/2099
   it.skip("rebuilds the checked-in default persistence artifact exactly from Units.json", () => {
     expect(buildGeneratedDefaultPersistenceModule(unitsSchema, assertUniqueGeneratedKeys)).toBe(generatedDefaultPersistenceSource);
   });

--- a/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
+++ b/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
@@ -84,7 +84,9 @@ describe("Generated Units artifacts", () => {
     expect(generatedDefaultPersistenceSource).not.toContain("[Phenomena.LENGTH_RATIO]");
   });
 
-  it("rebuilds the checked-in Units identifiers artifact exactly from Units.json", () => {
+  // Disabled because the string compare can fail on different platforms due to differences in line endings.
+  // Tracking Issue: https://github.com/iTwin/itwinjs-backlog/issues/2099
+  it.skip("rebuilds the checked-in Units identifiers artifact exactly from Units.json", () => {
     expect(buildGeneratedUnitsModule(unitsSchema)).toBe(generatedIdentifiersSource);
   });
 
@@ -93,7 +95,9 @@ describe("Generated Units artifacts", () => {
     expect(rebuiltUnitsJson).toBe(`${JSON.stringify(unitsSchema, null, 2)}\n`);
   });
 
-  it("rebuilds the checked-in basic conversion artifact exactly from Units.json", () => {
+  // Disabled because the string compare can fail on different platforms due to differences in line endings.
+  // Tracking Issue: https://github.com/iTwin/itwinjs-backlog/issues/2099
+  it.skip("rebuilds the checked-in basic conversion artifact exactly from Units.json", () => {
     expect(buildGeneratedBasicConversionModule(unitsSchema, assertUniqueGeneratedKeys)).toBe(generatedBasicConversionsSource);
   });
 


### PR DESCRIPTION
Disables:
"rebuilds the checked-in basic conversion artifact exactly from Units.json"
"rebuilds the checked-in Units identifiers artifact exactly from Units.json"

For same issues as: https://github.com/iTwin/itwinjs-core/pull/9328
