### PR TITLE
Fix core-quantity generated artifact tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.bat                                         eol=crlf
 *.sh                                          eol=lf
 *.api.md                                      eol=lf
+*.generated.ts                                eol=lf
 presentation/common/Ruleset.schema.json text  eol=lf
 *.snap                                        eol=lf
 

--- a/common/changes/@itwin/core-quantity/nam-fix-generated-artifact-eol_2026-05-22-16-20.json
+++ b/common/changes/@itwin/core-quantity/nam-fix-generated-artifact-eol_2026-05-22-16-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-quantity",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-quantity"
+}

--- a/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
+++ b/core/quantity/src/test/GenerateUnitsArtifacts.test.ts
@@ -21,6 +21,10 @@ const generatedIdentifiersSource = readFileSync(require.resolve("../generated/Un
 const generatedBasicConversionsSource = readFileSync(require.resolve("../internal/BasicUnitConversions.generated.ts"), "utf8");
 const generatedDefaultPersistenceSource = readFileSync(require.resolve("../internal/DefaultPersistenceUnits.generated.ts"), "utf8");
 
+function normalizeLineEndings(source: string): string {
+  return source.replace(/\r\n/g, "\n");
+}
+
 function assertUniqueGeneratedKeys(entries: ReadonlyArray<{ key: string }>, description: string): void {
   const seen = new Set<string>();
   for (const entry of entries) {
@@ -84,9 +88,8 @@ describe("Generated Units artifacts", () => {
     expect(generatedDefaultPersistenceSource).not.toContain("[Phenomena.LENGTH_RATIO]");
   });
 
-  // Disabled because the string compare can fail on different platforms due to differences in line endings.
-  it.skip("rebuilds the checked-in Units identifiers artifact exactly from Units.json", () => {
-    expect(buildGeneratedUnitsModule(unitsSchema)).toBe(generatedIdentifiersSource);
+  it("rebuilds the checked-in Units identifiers artifact exactly from Units.json", () => {
+    expect(normalizeLineEndings(buildGeneratedUnitsModule(unitsSchema))).toBe(normalizeLineEndings(generatedIdentifiersSource));
   });
 
   it("rebuilds the checked-in Units.json artifact exactly from the source schema", () => {
@@ -94,9 +97,8 @@ describe("Generated Units artifacts", () => {
     expect(rebuiltUnitsJson).toBe(`${JSON.stringify(unitsSchema, null, 2)}\n`);
   });
 
-  // Disabled because the string compare can fail on different platforms due to differences in line endings.
-  it.skip("rebuilds the checked-in basic conversion artifact exactly from Units.json", () => {
-    expect(buildGeneratedBasicConversionModule(unitsSchema, assertUniqueGeneratedKeys)).toBe(generatedBasicConversionsSource);
+  it("rebuilds the checked-in basic conversion artifact exactly from Units.json", () => {
+    expect(normalizeLineEndings(buildGeneratedBasicConversionModule(unitsSchema, assertUniqueGeneratedKeys))).toBe(normalizeLineEndings(generatedBasicConversionsSource));
   });
 
   it("fails generation when a unit numerator is zero", () => {
@@ -113,8 +115,7 @@ describe("Generated Units artifacts", () => {
     expect(() => buildGeneratedBasicConversionModule(invalidSchema, assertUniqueGeneratedKeys)).toThrowError(/Invalid denominator for "FT"/);
   });
 
-  // Disabled because the string compare can fail on different platforms due to differences in line endings.
-  it.skip("rebuilds the checked-in default persistence artifact exactly from Units.json", () => {
-    expect(buildGeneratedDefaultPersistenceModule(unitsSchema, assertUniqueGeneratedKeys)).toBe(generatedDefaultPersistenceSource);
+  it("rebuilds the checked-in default persistence artifact exactly from Units.json", () => {
+    expect(normalizeLineEndings(buildGeneratedDefaultPersistenceModule(unitsSchema, assertUniqueGeneratedKeys))).toBe(normalizeLineEndings(generatedDefaultPersistenceSource));
   });
 });


### PR DESCRIPTION
## Why

Generated artifact tests should catch real drift without failing because a Windows checkout used CRLF line endings. The exact string comparisons were skipped to avoid Windows-only failures, but skipping them removed coverage for generated unit identifier, conversion, and persistence artifacts.

This PR hardens the core-quantity tests by normalizing line endings before comparison (Test hardening)
The PR also pins `*.generated.ts` files to LF across the repo so future generated TypeScript artifacts avoid the same checkout-dependent behavior (Repo hardening)

## Tests

Re-enabled the 3 skipped generated-artifact tests.

Validated with `rushx test`, `rushx lint`, `rushx cover`, `rush change -v`, `rush clean`, and `rush build`.

---
*Nambot 🤖 (powered by OpenAI GPT-5.5)*

Human note: I manually ran the CI pipeline and it passed
