### PR TITLE
fix: correct @depreacted typo to @deprecated in ConcurrentQuery.ts

### DIFF
--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -27,7 +27,7 @@ export enum QueryRowFormat {
   UseECSqlPropertyIndexes,
   /** Each row is an object in which each non-null column value can be accessed by a [remapped property name]($docs/learning/ECSqlRowFormat.md).
    * This format is backwards-compatible with the format produced by iTwin.js 2.x. Null values are omitted.
-   * @depreacted in 4.11.  Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
+   * @deprecated in 4.11. Switch to UseECSqlPropertyIndexes for best performance, and UseECSqlPropertyNames if you want a JSON object as the result.
    */
   UseJsPropertyNames,
 }


### PR DESCRIPTION
## Summary

Fixes #9294

The TSDoc deprecation tag on `QueryRowFormat.UseJsPropertyNames` was misspelled as `@depreacted` instead of `@deprecated`. This one-character fix restores proper IDE deprecation warnings, ESLint rule detection, and migration tooling support for this enum member.

## Change

`core/common/src/ConcurrentQuery.ts` line 30:
- Before: `@depreacted in 4.11.`
- After: `@deprecated in 4.11.`

No functional code change.