### PR TITLE
Add WorkspaceDb manifest lastEditedAt

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -8508,6 +8508,7 @@ export interface WorkspaceDbLoadErrors extends ITwinError {
 export interface WorkspaceDbManifest {
     readonly contactName?: string;
     readonly description?: string;
+    readonly lastEditedAt?: string;
     readonly lastEditedBy?: string;
     readonly workspaceName: string;
 }

--- a/common/changes/@itwin/core-backend/nam-workspace-manifest-last-edited-at_2026-05-26-18-30.json
+++ b/common/changes/@itwin/core-backend/nam-workspace-manifest-last-edited-at_2026-05-26-18-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add lastEditedAt metadata to WorkspaceDb manifests.",
+      "type": "none",
+      "packageName": "@itwin/core-backend"
+    }
+  ],
+  "packageName": "@itwin/core-backend",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/core/backend/src/internal/workspace/WorkspaceImpl.ts
+++ b/core/backend/src/internal/workspace/WorkspaceImpl.ts
@@ -561,15 +561,7 @@ class EditorImpl implements WorkspaceEditor {
   }
 }
 
-interface EditCloudContainer extends WorkspaceCloudContainer {
-  writeLockHeldBy?: string;  // added by acquireWriteLock
-}
-
 class EditorContainerImpl extends WorkspaceContainerImpl implements EditableWorkspaceContainer {
-  public override get cloudContainer(): EditCloudContainer | undefined {
-    return super.cloudContainer;
-  }
-
   public get cloudProps(): WorkspaceContainerProps | undefined {
     const cloudContainer = this.cloudContainer;
     if (undefined === cloudContainer)
@@ -608,22 +600,23 @@ class EditorContainerImpl extends WorkspaceContainerImpl implements EditableWork
   }
 
   public acquireWriteLock(user: string): void {
-    if (this.cloudContainer) {
-      this.cloudContainer.acquireWriteLock(user);
-      this.cloudContainer.writeLockHeldBy = user;
+    const cloudContainer = this.cloudContainer;
+    if (cloudContainer) {
+      cloudContainer.acquireWriteLock(user);
+      CloudSqlite.addHiddenProperty(cloudContainer, "writeLockHeldBy", user);
     }
   }
   public releaseWriteLock() {
-    if (this.cloudContainer) {
-      this.cloudContainer.releaseWriteLock();
-      this.cloudContainer.writeLockHeldBy = undefined;
-    }
+    const cloudContainer = this.cloudContainer;
+    if (cloudContainer)
+      CloudSqlite.releaseWriteLock(cloudContainer);
   }
 
   public abandonChanges() {
-    if (this.cloudContainer) {
-      this.cloudContainer.abandonChanges();
-      this.cloudContainer.writeLockHeldBy = undefined;
+    const cloudContainer = this.cloudContainer;
+    if (cloudContainer) {
+      cloudContainer.abandonChanges();
+      CloudSqlite.addHiddenProperty(cloudContainer, "writeLockHeldBy", undefined);
     }
   }
 
@@ -712,9 +705,10 @@ class EditableDbImpl extends WorkspaceDbImpl implements EditableWorkspaceDb {
   public override close() {
     if (this.isOpen) {
       // whenever we close an EditableDb, update the name of the last editor in the manifest
-      const lastEditedBy = (this._container.cloudContainer as any)?.writeLockHeldBy;
+      const cloudContainer = this.container.cloudContainer;
+      const lastEditedBy = cloudContainer === undefined ? undefined : CloudSqlite.getWriteLockHeldBy(cloudContainer);
       if (lastEditedBy !== undefined)
-        this.updateManifest({ ...this.manifest, lastEditedBy });
+        this.updateManifest({ ...this.manifest, lastEditedBy, lastEditedAt: new Date().toISOString() });
 
       // make sure all changes were saved before we close
       this.sqliteDb.saveChanges();

--- a/core/backend/src/internal/workspace/WorkspaceImpl.ts
+++ b/core/backend/src/internal/workspace/WorkspaceImpl.ts
@@ -600,23 +600,20 @@ class EditorContainerImpl extends WorkspaceContainerImpl implements EditableWork
   }
 
   public acquireWriteLock(user: string): void {
-    const cloudContainer = this.cloudContainer;
-    if (cloudContainer) {
-      cloudContainer.acquireWriteLock(user);
-      CloudSqlite.addHiddenProperty(cloudContainer, "writeLockHeldBy", user);
+    if (this.cloudContainer) {
+      this.cloudContainer.acquireWriteLock(user);
+      CloudSqlite.addHiddenProperty(this.cloudContainer, "writeLockHeldBy", user);
     }
   }
   public releaseWriteLock() {
-    const cloudContainer = this.cloudContainer;
-    if (cloudContainer)
-      CloudSqlite.releaseWriteLock(cloudContainer);
+    if (this.cloudContainer)
+      CloudSqlite.releaseWriteLock(this.cloudContainer);
   }
 
   public abandonChanges() {
-    const cloudContainer = this.cloudContainer;
-    if (cloudContainer) {
-      cloudContainer.abandonChanges();
-      CloudSqlite.addHiddenProperty(cloudContainer, "writeLockHeldBy", undefined);
+    if (this.cloudContainer) {
+      this.cloudContainer.abandonChanges();
+      CloudSqlite.addHiddenProperty(this.cloudContainer, "writeLockHeldBy", undefined);
     }
   }
 

--- a/core/backend/src/test/standalone/Workspace.test.ts
+++ b/core/backend/src/test/standalone/Workspace.test.ts
@@ -174,43 +174,27 @@ describe("WorkspaceFile", () => {
     compareFiles(inFile2, outFile);
   });
 
-  it("stamps lastEditedAt when closing an editable WorkspaceDb with a write-lock holder even if no resource changed", async () => {
+  it("stamps lastEditedAt and lastEditedBy when closing an editable WorkspaceDb during a write-lock session", async () => {
     const clock = sinon.useFakeTimers(Date.parse("2026-05-12T16:05:00.000Z"));
-    let wsFile: EditableWorkspaceDb | undefined;
-    let restoreCloudContainer: (() => void) | undefined;
+    const wsFile = await makeEditableDb({ containerId: "last-edited-at-test", dbName: "db1", baseUri: "", storageType: "azure" }, { workspaceName: "last edited at test" });
     try {
-      wsFile = await makeEditableDb({ containerId: "last-edited-at-test", dbName: "db1", baseUri: "", storageType: "azure" }, { workspaceName: "last edited at test" });
-      const cloudContainer = {};
-
-      // This intentionally avoids mutating WorkspaceDb resources. `lastEditedAt` follows
-      // the existing `lastEditedBy` semantics: stamp when the editable close path finalizes
-      // with a write-lock holder, not only when resource content changed.
-      //
-      // Avoid acquiring a real CloudSqlite write lock in this unit test. The close path only
-      // needs the same writeLockHeldBy state that acquireWriteLock records on the container.
-      CloudSqlite.addHiddenProperty(cloudContainer, "writeLockHeldBy", "Unit Test User");
-
-      const workspaceDb = wsFile;
-      const originalCloudContainer = Object.getOwnPropertyDescriptor(workspaceDb.container, "cloudContainer");
-      restoreCloudContainer = () => {
-        if (originalCloudContainer !== undefined)
-          Object.defineProperty(workspaceDb.container, "cloudContainer", originalCloudContainer);
-        else
-          Reflect.deleteProperty(workspaceDb.container, "cloudContainer");
-      };
-      Object.defineProperty(wsFile.container, "cloudContainer", { configurable: true, get: () => cloudContainer });
+      // Local (`baseUri: ""`) workspaces have no real cloud container. Inject a fake carrying the
+      // hidden `writeLockHeldBy` that `acquireWriteLock` would normally set on a real container;
+      // the close path reads it via `CloudSqlite.getWriteLockHeldBy`.
+      const fakeCloudContainer: { writeLockHeldBy?: string } = {};
+      CloudSqlite.addHiddenProperty(fakeCloudContainer, "writeLockHeldBy", "Unit Test User");
+      Object.defineProperty(wsFile.container, "cloudContainer", { configurable: true, get: () => fakeCloudContainer });
 
       wsFile.close();
-      restoreCloudContainer();
-      restoreCloudContainer = undefined;
-      wsFile.open();
+
+      // Drop the override so the lazy manifest reload below opens the local file normally
+      // (with no cloud container) and does not re-stamp on its internal close.
+      Reflect.deleteProperty(wsFile.container, "cloudContainer");
 
       expect(wsFile.manifest.lastEditedBy).equals("Unit Test User");
       expect(wsFile.manifest.lastEditedAt).equals("2026-05-12T16:05:00.000Z");
-      wsFile.close();
     } finally {
-      restoreCloudContainer?.();
-      if (wsFile?.isOpen)
+      if (wsFile.isOpen)
         wsFile.close();
       clock.restore();
     }

--- a/core/backend/src/test/standalone/Workspace.test.ts
+++ b/core/backend/src/test/standalone/Workspace.test.ts
@@ -174,6 +174,48 @@ describe("WorkspaceFile", () => {
     compareFiles(inFile2, outFile);
   });
 
+  it("stamps lastEditedAt when closing an editable WorkspaceDb with a write-lock holder even if no resource changed", async () => {
+    const clock = sinon.useFakeTimers(Date.parse("2026-05-12T16:05:00.000Z"));
+    let wsFile: EditableWorkspaceDb | undefined;
+    let restoreCloudContainer: (() => void) | undefined;
+    try {
+      wsFile = await makeEditableDb({ containerId: "last-edited-at-test", dbName: "db1", baseUri: "", storageType: "azure" }, { workspaceName: "last edited at test" });
+      const cloudContainer = {};
+
+      // This intentionally avoids mutating WorkspaceDb resources. `lastEditedAt` follows
+      // the existing `lastEditedBy` semantics: stamp when the editable close path finalizes
+      // with a write-lock holder, not only when resource content changed.
+      //
+      // Avoid acquiring a real CloudSqlite write lock in this unit test. The close path only
+      // needs the same writeLockHeldBy state that acquireWriteLock records on the container.
+      CloudSqlite.addHiddenProperty(cloudContainer, "writeLockHeldBy", "Unit Test User");
+
+      const workspaceDb = wsFile;
+      const originalCloudContainer = Object.getOwnPropertyDescriptor(workspaceDb.container, "cloudContainer");
+      restoreCloudContainer = () => {
+        if (originalCloudContainer !== undefined)
+          Object.defineProperty(workspaceDb.container, "cloudContainer", originalCloudContainer);
+        else
+          Reflect.deleteProperty(workspaceDb.container, "cloudContainer");
+      };
+      Object.defineProperty(wsFile.container, "cloudContainer", { configurable: true, get: () => cloudContainer });
+
+      wsFile.close();
+      restoreCloudContainer();
+      restoreCloudContainer = undefined;
+      wsFile.open();
+
+      expect(wsFile.manifest.lastEditedBy).equals("Unit Test User");
+      expect(wsFile.manifest.lastEditedAt).equals("2026-05-12T16:05:00.000Z");
+      wsFile.close();
+    } finally {
+      restoreCloudContainer?.();
+      if (wsFile?.isOpen)
+        wsFile.close();
+      clock.restore();
+    }
+  });
+
   it("load workspace settings", async () => {
     const settingsFile = IModelTestUtils.resolveAssetFile("test.setting.json5");
     const defaultDb = await makeEditableDb({ containerId: "default", dbName: "db1", baseUri: "", storageType: "azure" }, { workspaceName: "default resources", contactName: "contact 123" });

--- a/core/backend/src/workspace/Workspace.ts
+++ b/core/backend/src/workspace/Workspace.ts
@@ -129,13 +129,9 @@ export interface WorkspaceDbManifest {
   readonly description?: string;
   /** The name of the person to contact with questions about this [[WorkspaceDb]]. */
   readonly contactName?: string;
-  /** The write-lock holder recorded when an editable [[WorkspaceDb]] is closed.
-   * @note This follows the existing write-lock holder semantics and does not guarantee that resource content changed.
-   */
+  /** The user who held the write lock during the most recent edit session that closed this [[WorkspaceDb]]. */
   readonly lastEditedBy?: string;
-  /** The UTC ISO-8601 time recorded when an editable [[WorkspaceDb]] is closed.
-   * @note This follows [[lastEditedBy]] semantics and does not guarantee that resource content changed.
-   */
+  /** The UTC ISO-8601 time of the most recent edit session close for this [[WorkspaceDb]]. */
   readonly lastEditedAt?: string;
 }
 

--- a/core/backend/src/workspace/Workspace.ts
+++ b/core/backend/src/workspace/Workspace.ts
@@ -129,8 +129,14 @@ export interface WorkspaceDbManifest {
   readonly description?: string;
   /** The name of the person to contact with questions about this [[WorkspaceDb]]. */
   readonly contactName?: string;
-  /** The name of the person who last modified this [[WorkspaceDb]]. */
+  /** The write-lock holder recorded when an editable [[WorkspaceDb]] is closed.
+   * @note This follows the existing write-lock holder semantics and does not guarantee that resource content changed.
+   */
   readonly lastEditedBy?: string;
+  /** The UTC ISO-8601 time recorded when an editable [[WorkspaceDb]] is closed.
+   * @note This follows [[lastEditedBy]] semantics and does not guarantee that resource content changed.
+   */
+  readonly lastEditedAt?: string;
 }
 
 /**


### PR DESCRIPTION
## Why
> Note: I am open to porting this to catalogDbs too, pending colleague feedback. Catalogs are missing this too


`WorkspaceDbManifest` already records who held the write lock during the last edit session that closed an editable WorkspaceDb (`lastEditedBy`), but not **when**. 

Anyone inspecting a published workspace via the admin tooling, or any consumer reading the manifest, can see the person but not the time. There's no public getter, to get the last modified metadata for workspaces. This PR adds one called `lastEditedAt`).

It follows `lastEditedBy` semantics: it follows the same close path and the same guard.

Also, the existing `writeLockHeldBy` logic was inconsistent — some sites reached through a local interface shim called `EditCloudContainer`, and used direct assignment, others through an `as any` cast. This PR routes every read and write of that hidden field through the canonical `CloudSqlite` helpers and deletes the shim.

**Note**: I found that this 'stamping' of lastEditedBy/At happens at close() of EditableWorkspaceDb, so  if an admin:
 1. opens an EditableWorkspaceDb (read-only doesn't go through this)
 2. a write lock is already held earlier.
 3. Neither releaseWriteLock() nor abandonChanges() has run (thus clearing `writeLockHeldBy`)
 If all 3 of the above is true, then the stamp happens anyway even if nothing was edited. A very slim edge case, that if our devs use the public-facing APIs we documented (`withEditableDb`) should never happen. But just to be aware.

## What

| Asset | Why it exists |
|---|---|
| `WorkspaceDbManifest.lastEditedAt?: string` (`core/backend/src/workspace/Workspace.ts`) | Adds the missing time half of the `lastEditedBy` pair so consumers can see when an editable workspace was last closed during an active write-lock session. |
| `EditableDbImpl.close()` stamping (`core/backend/src/internal/workspace/WorkspaceImpl.ts`) | Stamps `lastEditedAt` in the same close-path branch that already stamps `lastEditedBy`, so the two fields cannot drift. |
| `writeLockHeldBy` access cleanup (`core/backend/src/internal/workspace/WorkspaceImpl.ts`) | Deletes the local `EditCloudContainer` interface shim and its narrowing getter override; routes every read/write of the hidden `writeLockHeldBy` field through `CloudSqlite.getWriteLockHeldBy`, `CloudSqlite.addHiddenProperty`, and `CloudSqlite.releaseWriteLock` instead of direct mutation and `as any` casts. |
| `common/api/core-backend.api.md` | Regenerated API report reflecting the new optional field. |

Rush change file added under `common/changes/@itwin/core-backend/`. Lockstep version bumps across package.json files come from the master merge, not this work.

## Tests

<details>
<summary>New and updated test coverage</summary>

| Test | What it covers |
|---|---|
| `Workspace.test.ts` — stamps lastEditedAt and lastEditedBy when closing an editable WorkspaceDb during a write-lock session | Guards the contract that both manifest fields are written together on the editable close path while a write-lock holder is present. |

</details>

---
*Nambot 🤖 (powered by claude-sonnet-4.5) and Nam*
