### PR TITLE
`FavoritePropertiesManager`: Fix `changeFieldPriority` failing due to invalid ECSQL query being used internally

### DIFF
--- a/common/changes/@itwin/presentation-frontend/presentation-fix-invalid-query-in-favorites-manager_2026-06-01-08-57.json
+++ b/common/changes/@itwin/presentation-frontend/presentation-fix-invalid-query-in-favorites-manager_2026-06-01-08-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "`FavoritePropertiesManager`: Fix `changeFieldPriority` failing due to invalid ECSQL query being used internally.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/full-stack-tests/presentation/src/frontend/FavoriteProperties.test.ts
+++ b/full-stack-tests/presentation/src/frontend/FavoriteProperties.test.ts
@@ -1,0 +1,215 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import { DefaultContentDisplayTypes, Descriptor, KeySet, Ruleset } from "@itwin/presentation-common";
+import { TestIModelConnection } from "../IModelSetupUtils.js";
+import { initialize, terminate } from "../IntegrationTests.js";
+import { IModelConnection } from "@itwin/core-frontend";
+import { FavoritePropertiesScope, Presentation } from "@itwin/presentation-frontend";
+import { getFieldByLabel } from "../Utils.js";
+
+describe("Favorite properties", () => {
+  const ruleset: Ruleset = {
+    id: "ruleset",
+    rules: [
+      {
+        ruleType: "Content",
+        specifications: [{ specType: "SelectedNodeInstances" }],
+      },
+    ],
+  };
+
+  let imodel: IModelConnection;
+  function openIModel() {
+    imodel = TestIModelConnection.openFile("assets/datasets/Properties_60InstancesWithUrl2.ibim");
+    expect(imodel).to.not.be.null;
+  }
+
+  before(async () => {
+    await initialize();
+    openIModel();
+  });
+
+  after(async () => {
+    await imodel.close();
+    await terminate();
+  });
+
+  describe("favoriting different types of properties", () => {
+    beforeEach(async () => {
+      // note: Presentation is initialized without client services, so favorite properties are stored locally - clearing
+      // them doesn't affect what's stored in user settings service
+      await Presentation.favoriteProperties.clear(imodel, FavoritePropertiesScope.Global);
+      await Presentation.favoriteProperties.clear(imodel, FavoritePropertiesScope.ITwin);
+      await Presentation.favoriteProperties.clear(imodel, FavoritePropertiesScope.IModel);
+    });
+
+    it("favorites direct property", async () => {
+      const descriptor = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([{ className: "PCJ_TestSchema:TestClass", id: "0x38" }]),
+      });
+      const field = getFieldByLabel(descriptor!.fields, "Country");
+      expect(await Presentation.favoriteProperties.hasAsync(field, imodel, FavoritePropertiesScope.Global)).to.be.false;
+
+      await Presentation.favoriteProperties.add(field, imodel, FavoritePropertiesScope.Global);
+      expect(await Presentation.favoriteProperties.hasAsync(field, imodel, FavoritePropertiesScope.Global)).to.be.true;
+    });
+
+    it("favorites nested content field", async () => {
+      const descriptor = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([{ className: "Generic:PhysicalObject", id: "0x74" }]),
+      });
+      const field = getFieldByLabel(descriptor!.fields, "area");
+      expect(await Presentation.favoriteProperties.hasAsync(field, imodel, FavoritePropertiesScope.Global)).to.be.false;
+
+      await Presentation.favoriteProperties.add(field, imodel, FavoritePropertiesScope.Global);
+      expect(await Presentation.favoriteProperties.hasAsync(field, imodel, FavoritePropertiesScope.Global)).to.be.true;
+    });
+
+    it("favorites common properties of different element types", async () => {
+      const descriptor1 = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([{ className: "Generic:PhysicalObject", id: "0x74" }]),
+      });
+      const field1 = getFieldByLabel(descriptor1!.fields, "Model");
+      await Presentation.favoriteProperties.add(field1, imodel, FavoritePropertiesScope.Global);
+      expect(await Presentation.favoriteProperties.hasAsync(field1, imodel, FavoritePropertiesScope.Global)).to.be.true;
+
+      // verify the same property is now in favorites group when requesting content for another type of element
+      const descriptor2 = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([{ className: "PCJ_TestSchema:TestClass", id: "0x38" }]),
+      });
+      const field2 = getFieldByLabel(descriptor2!.fields, "Model");
+      expect(await Presentation.favoriteProperties.hasAsync(field2, imodel, FavoritePropertiesScope.Global)).to.be.true;
+    });
+  });
+
+  describe("ordering", () => {
+    beforeEach(async () => {
+      // note: Presentation is initialized without client services, so favorite properties are stored locally - clearing
+      // them doesn't affect what's stored in user settings service
+      await Presentation.favoriteProperties.clear(imodel, FavoritePropertiesScope.Global);
+      await Presentation.favoriteProperties.clear(imodel, FavoritePropertiesScope.ITwin);
+      await Presentation.favoriteProperties.clear(imodel, FavoritePropertiesScope.IModel);
+    });
+
+    const makeFieldFavorite = async (descriptor: Descriptor, fieldLabel: string) => {
+      const field = getFieldByLabel(descriptor.fields, fieldLabel);
+      await Presentation.favoriteProperties.add(field, imodel, FavoritePropertiesScope.Global);
+      return field;
+    };
+
+    it("moves a field to the top", async () => {
+      const descriptor = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([{ className: "PCJ_TestSchema:TestClass", id: "0x65" }]),
+      });
+      const fields = await Promise.all([
+        makeFieldFavorite(descriptor!, "Model"),
+        makeFieldFavorite(descriptor!, "Category"),
+      ]);
+      expect((await Presentation.favoriteProperties.sortFieldsAsync(imodel, fields)).map((f) => f.label)).to.deep.equal(["Model", "Category"]);
+
+      await Presentation.favoriteProperties.changeFieldPriority(
+        imodel,
+        fields[1],
+        undefined,
+        fields,
+      );
+      expect((await Presentation.favoriteProperties.sortFieldsAsync(imodel, fields)).map((f) => f.label)).to.deep.equal(["Category", "Model"]);
+    });
+
+    it("keeps the logical order of non-visible fields when there are relevant fields", async () => {
+      const multiElementDescriptor = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([
+          { className: "PCJ_TestSchema:TestClass", id: "0x65" },
+          { className: "Generic:PhysicalObject", id: "0x74" },
+        ]),
+      });
+      const multiElementFields = await Promise.all([
+        makeFieldFavorite(multiElementDescriptor!, "Code"),
+        makeFieldFavorite(multiElementDescriptor!, "area"),
+        makeFieldFavorite(multiElementDescriptor!, "Model"), // `Model` is relevant for property `area`
+      ]);
+      expect((await Presentation.favoriteProperties.sortFieldsAsync(imodel, multiElementFields)).map((f) => f.label)).to.deep.equal(["Code", "area", "Model"]);
+
+      const singleElementDescriptor = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([
+          { className: "PCJ_TestSchema:TestClass", id: "0x65" }, // element without `area` property
+        ]),
+      });
+      const singleElementFields = await Promise.all([
+        makeFieldFavorite(singleElementDescriptor!, "Code"),
+        makeFieldFavorite(singleElementDescriptor!, "Model"),
+      ]);
+      await Presentation.favoriteProperties.changeFieldPriority(
+        imodel,
+        singleElementFields[0],
+        singleElementFields[1],
+        singleElementFields,
+      );
+      expect((await Presentation.favoriteProperties.sortFieldsAsync(imodel, multiElementFields)).map((f) => f.label)).to.deep.equal(["area", "Model", "Code"]);
+    });
+
+    it("keeps the logical order of non-visible fields when there are no relevant fields", async () => {
+      const multiElementDescriptor = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([
+          { className: "PCJ_TestSchema:TestClass", id: "0x65" },
+          { className: "Generic:PhysicalObject", id: "0x74" },
+        ]),
+      });
+      const multiElementFields = await Promise.all([
+        makeFieldFavorite(multiElementDescriptor!, "Code"),
+        makeFieldFavorite(multiElementDescriptor!, "area"),
+        makeFieldFavorite(multiElementDescriptor!, "Country"), // `Country` is irrelevant for property `area`
+      ]);
+      expect((await Presentation.favoriteProperties.sortFieldsAsync(imodel, multiElementFields)).map((f) => f.label)).to.deep.equal(["Code", "area", "Country"]);
+
+      const singleElementDescriptor = await Presentation.presentation.getContentDescriptor({
+        imodel,
+        rulesetOrId: ruleset,
+        displayType: DefaultContentDisplayTypes.PropertyPane,
+        keys: new KeySet([
+          { className: "PCJ_TestSchema:TestClass", id: "0x65" }, // element without `area` property
+        ]),
+      });
+      const singleElementFields = await Promise.all([
+        makeFieldFavorite(singleElementDescriptor!, "Code"),
+        makeFieldFavorite(singleElementDescriptor!, "Country"),
+      ]);
+
+      await Presentation.favoriteProperties.changeFieldPriority(
+        imodel,
+        singleElementFields[0],
+        singleElementFields[1],
+        singleElementFields,
+      );
+      expect((await Presentation.favoriteProperties.sortFieldsAsync(imodel, multiElementFields)).map((f) => f.label)).to.deep.equal(["Country", "Code", "area"]);
+    });
+  });
+});

--- a/presentation/frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts
+++ b/presentation/frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts
@@ -6,9 +6,9 @@
  * @module Core
  */
 
-import { BeEvent, isDisposable, isIDisposable } from "@itwin/core-bentley";
-import { QueryRowFormat } from "@itwin/core-common";
+import { assert, BeEvent, isDisposable, isIDisposable } from "@itwin/core-bentley";
 import { IModelConnection } from "@itwin/core-frontend";
+import { SchemaView } from "@itwin/ecschema-metadata";
 import { ClassId, Field, NestedContentField, PropertiesField } from "@itwin/presentation-common";
 import { IFavoritePropertiesStorage } from "./FavoritePropertiesStorage.js";
 import { IModelConnectionInitializationHandler, imodelInitializationHandlers } from "../IModelConnectionInitialization.js";
@@ -438,47 +438,18 @@ export class FavoritePropertiesManager implements Disposable {
   }
 
   private _getBaseClassesByClass = async (imodel: IModelConnection, neededClasses: Set<string>): Promise<{ [className: string]: string[] }> => {
-    const iTwinId = imodel.iTwinId!;
-    const imodelId = imodel.iModelId!;
-
-    const imodelInfo = getiModelInfo(iTwinId, imodelId);
-    let baseClasses: { [className: string]: string[] };
-    if (this._imodelBaseClassesByClass.has(imodelInfo)) {
-      baseClasses = this._imodelBaseClassesByClass.get(imodelInfo)!;
-    } else {
-      this._imodelBaseClassesByClass.set(imodelInfo, (baseClasses = {}));
+    const schemaView = await imodel.getSchemaView();
+    const getBaseClassNames = (currClass: SchemaView.Class): string[] => {
+      const base = currClass.baseClass;
+      return base ? [base.fullName, ...getBaseClassNames(base)] : [];
     }
-
-    const missingClasses = new Set<string>();
-    neededClasses.forEach((className) => {
-      if (!baseClasses.hasOwnProperty(className)) {
-        missingClasses.add(className);
-      }
-    });
-    if (missingClasses.size === 0) {
-      return baseClasses;
+    const result: { [className: string]: string[] } = {};
+    for (const className of neededClasses) {
+      const currClass = schemaView.findClass(className);
+      assert(!!currClass);
+      result[className] = getBaseClassNames(currClass);
     }
-
-    const query = `
-      SELECT
-        ec_classname(baseClassRels.SourceECInstanceId, "s:c"),
-        ec_classname(baseClassRels.TargetECInstanceId, "s:c")
-      FROM ECDbMeta.ClassHasAllBaseClasses baseClassRels
-      INNER JOIN ECDbMeta.ECClassDef derivedClass ON derivedClass.ECInstanceId = baseClassRels.SourceECInstanceId
-      INNER JOIN ECDbMeta.ECSchemaDef derivedSchema ON derivedSchema.ECInstanceId = derivedClass.Schema.Id
-      INNER JOIN ECDbMeta.ECClassDef baseClass ON baseClass.ECInstanceId = baseClassRels.TargetECInstanceId
-      INNER JOIN ECDbMeta.ECSchemaDef baseSchema ON baseSchema.ECInstanceId = baseClass.Schema.Id
-      WHERE ec_classname(baseClassRels.SourceECInstanceId, "s:c") IN (${[...missingClasses].map((className) => `'${className}'`).join(",")})
-    `;
-    const reader = imodel.createQueryReader(query, undefined, { rowFormat: QueryRowFormat.UseECSqlPropertyIndexes });
-    while (await reader.step()) {
-      const [derivedClassName, baseClassName] = reader.current.toArray();
-      if (!(derivedClassName in baseClasses)) {
-        baseClasses[derivedClassName] = [];
-      }
-      baseClasses[derivedClassName].push(baseClassName);
-    }
-    return baseClasses;
+    return result;
   };
 
   /** Changes field properties priorities to lower than another fields priority

--- a/presentation/frontend/src/test/favorite-properties/FavoritePropertiesManager.test.ts
+++ b/presentation/frontend/src/test/favorite-properties/FavoritePropertiesManager.test.ts
@@ -5,6 +5,7 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import { IModelConnection } from "@itwin/core-frontend";
+import { SchemaView } from "@itwin/ecschema-metadata";
 import { Field, NestedContentField, PropertiesField, PropertyInfo } from "@itwin/presentation-common";
 import {
   createTestECClassInfo,
@@ -69,7 +70,7 @@ describe("FavoritePropertiesManager", () => {
     return {
       iModelId: imodelId,
       iTwinId,
-      createQueryReader: sinon.stub(),
+      getSchemaView: sinon.stub().resolves(stubSchemaViewForBaseClasses([])),
     };
   }
 
@@ -83,19 +84,28 @@ describe("FavoritePropertiesManager", () => {
     };
   }
 
-  function setupMocksForQueryingBaseClasses(classBaseClass: Array<{ classFullName: string; baseClassFullName: string }>) {
-    let currIndex = -1;
-    const ecSqlReader = {
-      step: sinon.stub().callsFake(async () => ++currIndex < classBaseClass.length),
-      get current() {
-        return {
-          toRow: () => classBaseClass[currIndex],
-          toArray: () => [classBaseClass[currIndex].classFullName, classBaseClass[currIndex].baseClassFullName],
-        };
-      },
-    };
-    imodelMock.createQueryReader.returns(ecSqlReader);
-    return imodelMock.createQueryReader;
+  function stubSchemaViewForBaseClasses(classBaseClass: Array<{ classFullName: string; baseClassFullName: string }>): SchemaView {
+    interface SchemaViewClass {
+      fullName: string;
+      baseClass: SchemaViewClass | undefined;
+    }
+    const map = new Map<string, SchemaViewClass>();
+    function getOrCreateClass(fullName: string): SchemaViewClass {
+      let cls = map.get(fullName);
+      if (!cls) {
+        cls = { fullName, baseClass: undefined };
+        map.set(fullName, cls);
+      }
+      return cls;
+    }
+    classBaseClass.forEach(({ classFullName, baseClassFullName }) => {
+      const derived = getOrCreateClass(classFullName);
+      const base = getOrCreateClass(baseClassFullName);
+      derived.baseClass = base;
+    });
+    return {
+      findClass: (fullName: string) => map.get(fullName),
+    } as SchemaView;
   }
 
   /* eslint-disable @typescript-eslint/no-deprecated */
@@ -652,12 +662,9 @@ describe("FavoritePropertiesManager", () => {
       });
       const allFields = [a, b];
 
-      const classBaseClass = [
-        { classFullName: "S:A", baseClassFullName: "S:A" },
-        { classFullName: "S:B", baseClassFullName: "S:B" },
+      imodelMock.getSchemaView.resolves(stubSchemaViewForBaseClasses([
         { classFullName: "S:B", baseClassFullName: "S:A" },
-      ];
-      const createQueryReaderStub = setupMocksForQueryingBaseClasses(classBaseClass);
+      ]));
 
       const fieldInfos = getFieldsInfos(allFields);
       storageMock.loadProperties.resolves(new Set<PropertyFullName>(fieldInfos));
@@ -672,7 +679,6 @@ describe("FavoritePropertiesManager", () => {
       await manager.changeFieldPriority(imodel, b, a, allFields);
       expect(orderInfos[0]).to.eq(oldOrderInfo[0]); // a
       expect(orderInfos[1]).to.eq(oldOrderInfo[1]); // b
-      expect(createQueryReaderStub).to.have.been.calledOnce;
     });
   });
 
@@ -706,15 +712,10 @@ describe("FavoritePropertiesManager", () => {
     const allFields = [a1, b1, a2, b2, c];
     const visibleFields = [a1, a2, c]; // imitating a selection of a class C instance
 
-    // data of table ECDbMeta.ClassHasAllBaseClasses
-    const classBaseClass = [
-      { classFullName: "S:A", baseClassFullName: "S:A" },
-      { classFullName: "S:B", baseClassFullName: "S:B" },
+    imodelMock.getSchemaView.resolves(stubSchemaViewForBaseClasses([
       { classFullName: "S:B", baseClassFullName: "S:A" },
-      { classFullName: "S:C", baseClassFullName: "S:C" },
       { classFullName: "S:C", baseClassFullName: "S:A" },
-    ];
-    setupMocksForQueryingBaseClasses(classBaseClass);
+    ]));
 
     const fieldInfos = getFieldsInfos(allFields);
     storageMock.loadProperties.resolves(new Set<PropertyFullName>(fieldInfos));
@@ -761,15 +762,10 @@ describe("FavoritePropertiesManager", () => {
     const allFields = [c, b2, a2, b1, a1];
     const visibleFields = [c, a2, a1]; // imitating a selection of a class C instance
 
-    // data of table ECDbMeta.ClassHasAllBaseClasses
-    const classBaseClass = [
-      { classFullName: "S:A", baseClassFullName: "S:A" },
-      { classFullName: "S:B", baseClassFullName: "S:B" },
+    imodelMock.getSchemaView.resolves(stubSchemaViewForBaseClasses([
       { classFullName: "S:B", baseClassFullName: "S:A" },
-      { classFullName: "S:C", baseClassFullName: "S:C" },
       { classFullName: "S:C", baseClassFullName: "S:A" },
-    ];
-    setupMocksForQueryingBaseClasses(classBaseClass);
+    ]));
 
     const fieldInfos = getFieldsInfos(allFields);
     storageMock.loadProperties.resolves(new Set<PropertyFullName>(fieldInfos));
@@ -816,15 +812,10 @@ describe("FavoritePropertiesManager", () => {
     const allFields = [c, b2, a2, b1, a1];
     const visibleFields = [c, a2, a1]; // imitating a selection of a class C instance
 
-    // data of table ECDbMeta.ClassHasAllBaseClasses
-    const classBaseClass = [
-      { classFullName: "S:A", baseClassFullName: "S:A" },
-      { classFullName: "S:B", baseClassFullName: "S:B" },
+    imodelMock.getSchemaView.resolves(stubSchemaViewForBaseClasses([
       { classFullName: "S:B", baseClassFullName: "S:A" },
-      { classFullName: "S:C", baseClassFullName: "S:C" },
       { classFullName: "S:C", baseClassFullName: "S:A" },
-    ];
-    setupMocksForQueryingBaseClasses(classBaseClass);
+    ]));
 
     const fieldInfos = getFieldsInfos(allFields);
     storageMock.loadProperties.resolves(new Set<PropertyFullName>(fieldInfos));
@@ -872,15 +863,10 @@ describe("FavoritePropertiesManager", () => {
     const allFields = [a, b1, prim, b2, c];
     const visibleFields = [a, c]; // imitating a selection of a class C instance
 
-    // data of table ECDbMeta.ClassHasAllBaseClasses
-    const classBaseClass = [
-      { classFullName: "S:A", baseClassFullName: "S:A" },
-      { classFullName: "S:B", baseClassFullName: "S:B" },
+    imodelMock.getSchemaView.resolves(stubSchemaViewForBaseClasses([
       { classFullName: "S:B", baseClassFullName: "S:A" },
-      { classFullName: "S:C", baseClassFullName: "S:C" },
       { classFullName: "S:C", baseClassFullName: "S:A" },
-    ];
-    setupMocksForQueryingBaseClasses(classBaseClass);
+    ]));
 
     const fieldInfos = getFieldsInfos(allFields);
     storageMock.loadProperties.resolves(new Set<PropertyFullName>(fieldInfos));
@@ -944,15 +930,10 @@ describe("FavoritePropertiesManager", () => {
     const allFields = [a1, b, caa2];
     const visibleFields = [a1, caa2]; // imitating a selection of a class C instance
 
-    // data of table ECDbMeta.ClassHasAllBaseClasses
-    const classBaseClass = [
-      { classFullName: "S:A", baseClassFullName: "S:A" },
-      { classFullName: "S:B", baseClassFullName: "S:B" },
+    imodelMock.getSchemaView.resolves(stubSchemaViewForBaseClasses([
       { classFullName: "S:B", baseClassFullName: "S:A" },
-      { classFullName: "S:C", baseClassFullName: "S:C" },
       { classFullName: "S:C", baseClassFullName: "S:A" },
-    ];
-    setupMocksForQueryingBaseClasses(classBaseClass);
+    ]));
 
     const fieldInfos = getFieldsInfos(allFields);
     storageMock.loadProperties.resolves(new Set<PropertyFullName>(fieldInfos));


### PR DESCRIPTION
Detected in `presentation` repo CI when bumping deps to `5.10.0-dev.22`:
```
Error:  FAIL   Full-stack tests  src/components/favorites/FavoriteProperties.test.ts > Favorite properties > ordering > moves a field to the top
Error: BE_SQLITE_ERROR: No property or enumeration found for expression 's:c'.
Error:  ❯ DbQueryError.throwIfError ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ConcurrentQuery.ts:777:12
Error:  ❯ ECSqlReader.runWithRetry ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:198:17
Error:  ❯ ECSqlReader.readRows ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:167:17
Error:  ❯ ECSqlReader.fetchRows ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:230:22
Error:  ❯ ECSqlReader.step ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:250:6
Error:  ❯ FavoritePropertiesManager._getBaseClassesByClass ../../node_modules/.pnpm/@itwin+presentation-frontend@5.10.0-dev.22_e987f5e09290fcf354a873c9bad2c999/node_modules/@itwin/presentation-frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts:474:11
Error:  ❯ FavoritePropertiesManager.changeFieldPriority ../../node_modules/.pnpm/@itwin+presentation-frontend@5.10.0-dev.22_e987f5e09290fcf354a873c9bad2c999/node_modules/@itwin/presentation-frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts:559:31
Error:  ❯ src/components/favorites/FavoriteProperties.test.ts:205:7
Error:     203|       const record = getPropertyRecordByLabel(propertyData, "Category"…
Error:     204|       const field = await propertiesDataProvider.getFieldByPropertyDes…
Error:     205|       await Presentation.favoriteProperties.changeFieldPriority(
Error:        |       ^
Error:     206|         imodel,
Error:     207|         field!,
Error: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯
Error:  FAIL   Full-stack tests  src/components/favorites/FavoriteProperties.test.ts > Favorite properties > ordering > keeps the logical order of non-visible fields when there are relevant fields
Error: BE_SQLITE_ERROR: No property or enumeration found for expression 's:c'.
Error:  ❯ DbQueryError.throwIfError ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ConcurrentQuery.ts:777:12
Error:  ❯ ECSqlReader.runWithRetry ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:198:17
Error:  ❯ ECSqlReader.readRows ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:167:17
Error:  ❯ ECSqlReader.fetchRows ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:230:22
Error:  ❯ ECSqlReader.step ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:250:6
Error:  ❯ FavoritePropertiesManager._getBaseClassesByClass ../../node_modules/.pnpm/@itwin+presentation-frontend@5.10.0-dev.22_e987f5e09290fcf354a873c9bad2c999/node_modules/@itwin/presentation-frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts:474:11
Error:  ❯ FavoritePropertiesManager.changeFieldPriority ../../node_modules/.pnpm/@itwin+presentation-frontend@5.10.0-dev.22_e987f5e09290fcf354a873c9bad2c999/node_modules/@itwin/presentation-frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts:559:31
Error:  ❯ src/components/favorites/FavoriteProperties.test.ts:248:7
Error:     246|       record = getPropertyRecordByLabel(propertyData, "Model")!;
Error:     247|       const modelField = (await propertiesDataProvider.getFieldByPrope…
Error:     248|       await Presentation.favoriteProperties.changeFieldPriority(
Error:        |       ^
Error:     249|         imodel,
Error:     250|         codeField,
Error: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯
Error:  FAIL   Full-stack tests  src/components/favorites/FavoriteProperties.test.ts > Favorite properties > ordering > keeps the logical order of non-visible fields when there are no relevant fields
Error: BE_SQLITE_ERROR: No property or enumeration found for expression 's:c'.
Error:  ❯ DbQueryError.throwIfError ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ConcurrentQuery.ts:777:12
Error:  ❯ ECSqlReader.runWithRetry ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:198:17
Error:  ❯ ECSqlReader.readRows ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:167:17
Error:  ❯ ECSqlReader.fetchRows ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:230:22
Error:  ❯ ECSqlReader.step ../../node_modules/.pnpm/@itwin+core-common@5.10.0-dev.22_@itwin+core-bentley@5.10.0-dev.22_@itwin+core-geometry@5.10.0-dev.22/node_modules/@itwin/core-common/src/ECSqlReader.ts:250:6
Error:  ❯ FavoritePropertiesManager._getBaseClassesByClass ../../node_modules/.pnpm/@itwin+presentation-frontend@5.10.0-dev.22_e987f5e09290fcf354a873c9bad2c999/node_modules/@itwin/presentation-frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts:474:11
Error:  ❯ FavoritePropertiesManager.changeFieldPriority ../../node_modules/.pnpm/@itwin+presentation-frontend@5.10.0-dev.22_e987f5e09290fcf354a873c9bad2c999/node_modules/@itwin/presentation-frontend/src/presentation-frontend/favorite-properties/FavoritePropertiesManager.ts:559:31
Error:  ❯ src/components/favorites/FavoriteProperties.test.ts:296:7
Error:     294|       record = getPropertyRecordByLabel(propertyData, "Country")!;
Error:     295|       const modelField = (await propertiesDataProvider.getFieldByPrope…
Error:     296|       await Presentation.favoriteProperties.changeFieldPriority(
Error:        |       ^
Error:     297|         imodel,
Error:     298|         codeField,
Error: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯
Error:  Test Files  1 failed | 51 passed | 1 skipped (53)
Error:       Tests  3 failed | 316 passed | 7 skipped (326)
```

Added full stack tests to exercise the code against a real iModel and refactored the code to use the new `SchemaView` interface to get the necessary information without running queries.