### PR TITLE
Security: ignore dev-only vitest UI advisory CVE-2026-47429 (GHSA-5xrq-8626-4rwp)

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -33,7 +33,8 @@
           "CVE-2024-45296", // https://github.com/advisories/GHSA-9wv6-86v2-598j sinon>nise>path-to-regexp
           "CVE-2025-27152", // https://github.com/advisories/GHSA-jr5f-v2jv-69x6 azurite>@azure/ms-rest-js>axios
           "CVE-2025-58754", // https://github.com/advisories/GHSA-4hjh-wcwx-xvwj azurite>@azure/ms-rest-js>axios
-          "CVE-2026-26996" // https://github.com/advisories/GHSA-3ppc-4f35-3m26 mocha>glob>minimatch
+          "CVE-2026-26996", // https://github.com/advisories/GHSA-3ppc-4f35-3m26 mocha>glob>minimatch
+          "CVE-2026-47429" // https://github.com/advisories/GHSA-5xrq-8626-4rwp vitest (dev-only). Only exploitable when the Vitest UI server is running; this repo never uses @vitest/ui or `vitest --ui`. Temporary until vitest is bumped to >=4.1.0. core/bentley>vitest, core/frontend>vitest
         ]
       }
     }


### PR DESCRIPTION
## Why
`rush audit --audit-level high` is failing on a single Critical advisory:
vitest `<4.1.0` — GHSA-5xrq-8626-4rwp / CVE-2026-47429 ("arbitrary file
can be read and executed when the Vitest UI server is listening").

The advisory is only exploitable when the **Vitest UI server** is running.
This repo does not depend on `@vitest/ui` and no script runs `vitest --ui`
(verified: zero `@vitest/ui` references, no `--ui` flags). vitest is a
dev-only dependency with no production code path, so the practical risk here
is nil. The remaining gap is purely an audit-gate failure.

The proper fix — upgrading vitest to `>=4.1.0` — is a v4 major bump across 7
packages (browser provider rework, `minWorkers` removal, spy/mock rewrite,
v8 coverage remapping affecting `core/geometry` thresholds) and is tracked
in #9352. This PR is the temporary unblock, matching how the repo already
handles dev-only advisories.

## What
- `common/config/rush/pnpm-config.json`: add `CVE-2026-47429` to
  `unsupportedPackageJsonSettings.pnpm.auditConfig.ignoreCves` with advisory
  link, dev-only rationale, and the consuming paths
  (`core/bentley>vitest`, `core/frontend>vitest`).
- No dependency versions changed; `pnpm-lock.yaml` is unchanged.
- Remediates (suppresses): CVE-2026-47429 / GHSA-5xrq-8626-4rwp.

## Validation
- `rush update` → clean, no lockfile changes.
- `rush audit --audit-level high` → now exits 0 (critical suppressed; no
  actionable High/Critical tables remain). Moderate/low findings are below
  the gate and unchanged.
- `rush change --verify -b origin/master` → "No changes detected to relevant
  packages" (pnpm-config.json is not a publishable package; no change file
  required).
- Not run (intentionally): `rush build`/`rush test`/`rush extract-api` — this
  change touches only an audit-suppression config entry with no code, API, or
  resolved-dependency impact.

---
Nambot 🤖 (powered by Opus 4.8)
