### PR TITLE
Add optional `includePrerelease` field to DbCloudContainerInfo

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2190,6 +2190,7 @@ export interface DbCloudContainerInfo {
     readonly containerId: string;
     readonly dbName?: string;
     readonly description?: string;
+    readonly includePrerelease?: boolean;
     readonly isPublic?: boolean;
     readonly storageType: "azure" | "google";
     readonly version?: string;

--- a/common/changes/@itwin/core-common/nam-add-include-prerelease-db-cloud-info_2026-06-02-00-00.json
+++ b/common/changes/@itwin/core-common/nam-add-include-prerelease-db-cloud-info_2026-06-02-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "Add includePrerelease to DbCloudContainerInfo.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/core/common/src/DbCloudContainerInfo.ts
+++ b/core/common/src/DbCloudContainerInfo.ts
@@ -25,6 +25,8 @@ export interface DbCloudContainerInfo {
   readonly dbName?: string;
   /** The range of acceptable versions of the database (semver range, e.g., ">=1.2.0 <2.0.0"). */
   readonly version?: string;
+  /** If true, allow semver prerelease versions, e.g., "1.4.2-beta.0". */
+  readonly includePrerelease?: boolean;
   /** An alias for the container. Defaults to `containerId` if not specified. */
   readonly alias?: string;
   /** A user-friendly description of the container's contents. */

--- a/core/common/src/DbCloudContainerInfo.ts
+++ b/core/common/src/DbCloudContainerInfo.ts
@@ -25,7 +25,9 @@ export interface DbCloudContainerInfo {
   readonly dbName?: string;
   /** The range of acceptable versions of the database (semver range, e.g., ">=1.2.0 <2.0.0"). */
   readonly version?: string;
-  /** If true, allow semver prerelease versions, e.g., "1.4.2-beta.0". */
+  /** If true, allow semver prerelease versions, e.g., "1.4.2-beta.0".
+   * By default, prerelease versions are not allowed.
+   */
   readonly includePrerelease?: boolean;
   /** An alias for the container. Defaults to `containerId` if not specified. */
   readonly alias?: string;


### PR DESCRIPTION
## TL;DR
A little dogfooding in our downstream apps revealed a little improvement we can do. `DbCloudContainerInfo` is the common frontend-safe shape for WorkspaceDb setting values, but it was missing `includePrerelease` even though core workspace loading and settings schemas already support that option. This adds the optional field to the common type so downstream apps do not need local type shims for prerelease WorkspaceDb selection.

This PR has no tests because we already have tests set up for this one optional field.


<details> 
<summary>Existing support/evidence:</summary>

- The settings schema already accepts `includePrerelease`: https://github.com/iTwin/itwinjs-core/blob/dfca6e9b1623ad8015160aba59d946ffaa21ba59/core/backend/src/assets/Settings/Schemas/Workspace.Schema.json#L71-L74

- `WorkspaceDbProps` already exposes `includePrerelease` for workspace loading: https://github.com/iTwin/itwinjs-core/blob/dfca6e9b1623ad8015160aba59d946ffaa21ba59/core/backend/src/workspace/Workspace.ts#L82-L87
- `CloudSqlite.LoadProps` carries the flag, and version resolution passes it to `semver.maxSatisfying`: https://github.com/iTwin/itwinjs-core/blob/dfca6e9b1623ad8015160aba59d946ffaa21ba59/core/backend/src/CloudSqlite.ts#L308-L311 and https://github.com/iTwin/itwinjs-core/blob/dfca6e9b1623ad8015160aba59d946ffaa21ba59/core/backend/src/CloudSqlite.ts#L960-L977
- Existing test coverage verifies cloud `getWorkspaceDb` respects `includePrerelease` when it changes the resolved version: https://github.com/iTwin/itwinjs-core/blob/dfca6e9b1623ad8015160aba59d946ffaa21ba59/core/backend/src/test/standalone/Workspace.test.ts#L349-L356
- Existing test coverage also exercises passing `includePrerelease` through `getITwinWorkspace` props while loading settings: https://github.com/iTwin/itwinjs-core/blob/dfca6e9b1623ad8015160aba59d946ffaa21ba59/core/backend/src/test/standalone/ITwinWorkspace.test.ts#L151-L160
</details>