### PR TITLE
Add api-diff agent skill

### DIFF
--- a/.agents/skills/api-diff/REFERENCE.md
+++ b/.agents/skills/api-diff/REFERENCE.md
@@ -1,0 +1,75 @@
+# API Support Policy Reference
+
+Source: [api-support-policies.md](https://github.com/iTwin/itwinjs-core/blob/master/docs/learning/api-support-policies.md)
+
+## Release tags
+
+| Tag | Meaning | Breaking change policy |
+|---|---|---|
+| `@internal` | iTwin.js internals only, never for consumers | None — may change freely |
+| `@alpha` | Highly experimental, rare in this repo | None |
+| `@beta` | Under development, feedback welcome | May break at any time |
+| `@public` | Stable, production-ready | Only in major releases, after deprecation + 1-year grace period |
+| `@public @preview` | Production-ready **but** may change/be removed in the **next major version** | 3-month grace period before removal |
+
+`@preview` is **not** a synonym for `@beta`. It is used alongside `@public` to indicate an API that is production-ready within the current major version but not guaranteed across major versions.
+
+Missing release tags (`// (undocumented)`) are treated as `@internal`.
+
+## Promotion paths
+
+```
+@alpha  →  @beta  →  @public               (standard)
+                  ↘  @public @preview  →  @public   (intermediate: stable but not yet committed)
+```
+
+`@public @preview` is used when an API is ready for production use but the team wants to reserve the right to revise it before locking it in as fully `@public`.
+
+## Deprecation policy
+
+- **`@public` APIs**: must be `@deprecated` first with a removal date note; **1-year grace period** before removal in a major release.
+- **`@public @preview` APIs**: same but **3-month grace period**.
+- **`@beta` APIs**: no deprecation required; may be removed at any time.
+
+Deprecation note format (pipeline auto-adds date — do not add manually):
+```typescript
+/** @deprecated in 5.1 - will not be removed until after 2026-01-01. Use methodB instead. */
+```
+
+## What counts as a breaking change
+
+Per the support policy:
+
+**Interfaces**
+- Removing a property
+- Adding a new **required** property
+- Changing the type of a property
+- Adding an optional property likely to conflict with existing usage
+
+**Classes** (excluding `private`)
+- Removing a property or method
+- Adding a new required abstract property/method
+- Adding a property/method with a name likely to conflict with subclasses
+- Changing visibility or type of a property
+
+**Functions and methods**
+- Changing the signature (parameters and/or return type)
+  - ✅ Exception: appending new arguments **with default values**
+  - ✅ Exception: changing return type from `void` to something else
+
+**Enums and tagged unions**
+- Removing values
+- Adding new values (unless exhaustive testing is unlikely)
+
+## Changelog locations
+
+| Situation | File |
+|---|---|
+| Unreleased / in-progress work | `docs/changehistory/NextVersion.md` |
+| Released version | `docs/changehistory/{version}.md` (e.g. `5.10.0.md`) |
+
+Notable changes that must be documented:
+- New `@public` or `@beta` APIs
+- Any deprecation (with migration guidance)
+- Behavior changes (even without API signature change)
+- Breaking changes (with before/after code examples)

--- a/.agents/skills/api-diff/SKILL.md
+++ b/.agents/skills/api-diff/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: api-diff
+description: Compare public API changes between two branches or version tags in the iTwin.js Rush monorepo by diffing the extract-api generated `common/api/*.api.md` files. Categorizes additions, removals, deprecations, tag changes, and highlights potential breaking changes. Use when the user asks to review or compare API differences between versions, branches, or releases (e.g. "diff 5.9 vs 5.10", "what changed between release/5.9.0 and release/5.10.0", "review API changes", "what's new in master", "check NextVersion.md coverage").
+---
+
+# API Diff Skill
+
+Compares `common/api/*.api.md` files between two git refs to surface API changes in the iTwin.js monorepo.
+
+## Quick start
+
+```bash
+# Branch names follow the pattern: release/MAJOR.MINOR.0
+.agents/skills/api-diff/scripts/api-diff.sh release/5.9.0 release/5.10.0   # adjacent releases
+.agents/skills/api-diff/scripts/api-diff.sh release/4.11.0 release/5.10.0  # multi-minor span
+.agents/skills/api-diff/scripts/api-diff.sh release/5.10.0 master          # last release → master
+
+# Find the last release tag automatically
+LAST=$(git tag --sort=-version:refname | head -1)
+.agents/skills/api-diff/scripts/api-diff.sh "$LAST" master
+```
+
+## Identifying the right refs
+
+| Goal | Base ref | Head ref | Changelog to check |
+|---|---|---|---|
+| What's new in an upcoming release | latest `release/X.Y.0` branch | `master` | `docs/changehistory/NextVersion.md` |
+| What changed between two releases | `release/X.Y.0` | `release/X.Z.0` | All `docs/changehistory/{version}.md` in range |
+| Multi-minor span | `release/X.Y.0` | `release/A.B.0` | Script shows all changelogs automatically |
+
+## Workflow
+
+1. **Identify the refs** — see table above. Branch names follow `release/MAJOR.MINOR.0`. For unreleased work use `release/<latest>.0` → `master`.
+2. **Run the diff** — use the helper script or `git diff <base> <head> -- common/api/` directly.
+3. **Triage each changed package** — apply the categories below.
+4. **Highlight breaking changes** — surface them first in the summary.
+5. **Check changelog coverage** — for `master` diffs check `NextVersion.md`; for release diffs check `{version}.md`.
+6. **Present structured output** — one section per package, then a consolidated breaking-changes table.
+
+## Categorizing changes
+
+| Category | How to detect | Risk |
+|---|---|---|
+| **Breaking — removal** | `-export` or `-    methodName` on a `@public`/`@public @preview` symbol | 🔴 High |
+| **Breaking — signature** | `-` and `+` lines for same `@public` method, type changed | 🔴 High |
+| **Non-breaking — signature** | Optional parameter added, return type widened | 🟡 Low |
+| **Deprecation** | `+    // @deprecated` added to an existing member | 🟡 Planned removal |
+| **Tag promotion** | e.g. `-// @beta` / `+// @public` | 🟢 Additive |
+| **New addition** | `+export` on a new symbol | 🟢 Additive |
+| **Internal-only change** | Change only on `@internal` / `@alpha` / `@beta` symbols | ✅ Safe |
+
+> See [REFERENCE.md](REFERENCE.md) for full support policy, promotion paths, deprecation rules, and what counts as a breaking change.
+
+## Breaking change checklist
+
+- [ ] Is the symbol `@public` or `@public @preview`? (`@internal`, `@alpha`, `@beta` are safe to change)
+- [ ] Is the change structurally incompatible? (adding optional params is non-breaking per policy)
+- [ ] Callback type narrowed to a named alias? Check structural equivalence before flagging
+
+## Output format
+
+```
+## API Diff: <base> → <head>
+
+### ⚠️ Potential Breaking Changes
+| Package | Symbol | Change | Risk |
+
+### Changes by package
+#### <package-name>
+**Additions** (`@public`/`@beta`): ...
+**Deprecations**: ...
+**Tag promotions**: ...
+**Removals**: ...
+
+### Changelog gaps
+Items with no entry in docs/changehistory/NextVersion.md (or {version}.md): ...
+```
+
+## Running the tests
+
+```bash
+.agents/skills/api-diff/scripts/test-api-diff.sh
+```
+
+Tests cover `ref_to_minor_ver` parsing, Python changelog version filtering (boundary conditions, numeric sorting), and a smoke test of the full script. Run after any changes to the script.
+
+## Tips
+
+- Ignore `common/api/summary/*.exports.csv` — generated metadata only.
+- All packages use **lockstep versioning** — one version number for all packages.
+- `@public @preview` ≠ `@beta`. Preview APIs are production-ready but may change in the next major version (3-month removal grace period vs 1-year for plain `@public`).
+- Missing release tags (`// (undocumented)`) are treated as `@internal`.
+- `git diff release/5.9.0 release/5.10.0 -- common/api/core-backend.api.md | grep "^[+-]" | grep -v "^[+-][+-]"` for a quick per-file scan.

--- a/.agents/skills/api-diff/scripts/api-diff.sh
+++ b/.agents/skills/api-diff/scripts/api-diff.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# api-diff.sh — compare common/api/*.api.md between two git refs, and show the relevant changelogs.
+# Run from the repo root.
+# Usage: ./api-diff.sh <base-ref> <head-ref> [api-dir]
+#
+# Branch naming convention: release/MAJOR.MINOR.0  (e.g. release/5.9.0, release/5.10.0)
+#
+# Examples:
+#   # Between two releases:
+#   .agents/skills/api-diff/scripts/api-diff.sh release/5.9.0 release/5.10.0
+#
+#   # Multi-minor span (shows all changelogs in range):
+#   .agents/skills/api-diff/scripts/api-diff.sh release/4.11.0 release/5.10.0
+#
+#   # Last release → master (check NextVersion.md coverage):
+#   LAST=$(git tag --sort=-version:refname | head -1)
+#   .agents/skills/api-diff/scripts/api-diff.sh "$LAST" master
+
+set -euo pipefail
+
+CHANGELOG_DIR="docs/changehistory"
+
+# Exit-0 wrapper for grep — prevents pipefail from aborting on zero matches.
+safe_grep() { grep "$@" || true; }
+
+# Extract {major}.{minor} from a git ref string.
+ref_to_minor_ver() {
+  local ref="$1"
+  case "$ref" in
+    master|main)    echo "master" ;;
+    release/*.x)    echo "$ref" | sed 's|release/||; s|\.x$||' ;;     # 5.9.x  → 5.9
+    release/[0-9]*) echo "$ref" | sed 's|release/||; s|\.[0-9]*$||' ;; # 5.9.0 → 5.9
+    v[0-9]*)        echo "$ref" | sed 's|^v||; s|\.[0-9]*$||' ;;       # v5.9.5 → 5.9
+    *)              echo "" ;;
+  esac
+}
+
+# Print headings from all changelog files that fall strictly after BASE and up to HEAD.
+# Uses Python for reliable numeric version sorting.
+show_changelogs() {
+  local base="$1" head="$2"
+  local base_ver head_ver
+  base_ver=$(ref_to_minor_ver "$base")
+  head_ver=$(ref_to_minor_ver "$head")
+
+  local all_logs
+  all_logs=$(ls "${CHANGELOG_DIR}"/*.md 2>/dev/null \
+    | safe_grep -E '/[0-9]+\.[0-9]+\.0\.md$')
+
+  python3 - "$base_ver" "$head_ver" $all_logs << 'PYEOF'
+import sys, re
+
+base_ver = sys.argv[1]   # e.g. "4.11" or "master"
+head_ver = sys.argv[2]   # e.g. "5.10" or "master"
+files    = sys.argv[3:]  # list of changelog file paths
+
+def parse_ver(s):
+    m = re.match(r'^(\d+)\.(\d+)$', s)
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+def ver_from_path(p):
+    m = re.search(r'(\d+)\.(\d+)\.0\.md$', p)
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+base = parse_ver(base_ver)  # None → no lower bound (e.g. base is master)
+head = parse_ver(head_ver)  # None → no upper bound (e.g. head is master)
+
+selected = []
+for f in files:
+    v = ver_from_path(f)
+    if v is None:
+        continue
+    if base is not None and v <= base:
+        continue
+    if head is not None and v > head:
+        continue
+    selected.append((v, f))
+
+selected.sort()
+
+if not selected:
+    print("  (no changelog files found for this range)")
+else:
+    for v, f in selected:
+        label = f"{v[0]}.{v[1]}.0.md"
+        print(f"\n--- {label} ---")
+        try:
+            for line in open(f):
+                if line.startswith('#'):
+                    print(line.rstrip())
+        except Exception as e:
+            print(f"  (could not read: {e})")
+
+# Also show NextVersion.md when HEAD is master
+if head_ver == "master":
+    nv = "docs/changehistory/NextVersion.md"
+    import os
+    if os.path.exists(nv):
+        print(f"\n--- NextVersion.md ---")
+        for line in open(nv):
+            if line.startswith('#'):
+                print(line.rstrip())
+PYEOF
+}
+
+print_section() {
+  local tmp="$1"
+  if [[ ! -s "$tmp" ]]; then
+    echo "  (none)"
+    return
+  fi
+  sed 's/^/  /' "$tmp"
+}
+
+main() {
+  local BASE="${1:?Usage: api-diff.sh <base-ref> <head-ref> [api-dir]}"
+  local HEAD="${2:?Usage: api-diff.sh <base-ref> <head-ref> [api-dir]}"
+  local API_DIR="${3:-common/api}"
+
+  # Validate refs before doing any work — avoids silent empty-diff on bad refs.
+  if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+    echo "Error: '$BASE' is not a valid git ref (not fetched locally?)" >&2; exit 1
+  fi
+  if ! git rev-parse --verify "$HEAD" >/dev/null 2>&1; then
+    echo "Error: '$HEAD' is not a valid git ref (not fetched locally?)" >&2; exit 1
+  fi
+
+  local DIFF_TMP SECTION_TMP
+  DIFF_TMP=$(mktemp)
+  SECTION_TMP=$(mktemp)
+  trap 'rm -f "$DIFF_TMP" "$SECTION_TMP"' EXIT
+
+  echo "=== API diff: $BASE → $HEAD ==="
+  echo ""
+
+  # ── Changelogs in range ───────────────────────────────────────────────────
+  echo "========================================="
+  echo "Changelogs (headings)"
+  echo "========================================="
+  show_changelogs "$BASE" "$HEAD"
+  echo ""
+
+  # ── Collect changed .api.md files (pathspec limits the diff to API_DIR) ──
+  local changed_files=()
+  while IFS= read -r f; do
+    [[ -n "$f" ]] && changed_files+=("$f")
+  done < <(git --no-pager diff "$BASE" "$HEAD" --name-only -- "$API_DIR" \
+    | safe_grep '\.api\.md$')
+
+  if [[ ${#changed_files[@]} -eq 0 ]]; then
+    echo "No API files changed between $BASE and $HEAD."
+    echo "Tip: branch names follow the pattern release/MAJOR.MINOR.0 (e.g. release/5.9.0)."
+    return 0
+  fi
+
+  echo "========================================="
+  echo "Changed API files"
+  echo "========================================="
+  printf '%s\n' "${changed_files[@]}"
+  echo ""
+
+  # ── Per-package diff ──────────────────────────────────────────────────────
+  for f in "${changed_files[@]}"; do
+    local PKG
+    PKG=$(basename "$f" .api.md)
+    echo "========================================="
+    echo "Package: $PKG"
+    echo "========================================="
+
+    # Run git diff once per file; reuse the cached output for counts and display.
+    git --no-pager diff "$BASE" "$HEAD" -- "$f" > "$DIFF_TMP"
+
+    local RAW_ADDED RAW_REMOVED
+    RAW_ADDED=$(safe_grep "^+" "$DIFF_TMP" | safe_grep -v "^+++" \
+      | safe_grep -v "^+import " | safe_grep -v "^+[[:space:]]*//" | wc -l | tr -d ' ')
+    RAW_REMOVED=$(safe_grep "^-" "$DIFF_TMP" | safe_grep -v "^---" \
+      | safe_grep -v "^-import " | safe_grep -v "^-[[:space:]]*//" | wc -l | tr -d ' ')
+
+    if [[ "$RAW_ADDED" -gt 300 || "$RAW_REMOVED" -gt 300 ]]; then
+      echo "  ⚠️  Large diff ($RAW_ADDED additions, $RAW_REMOVED removals) — may include"
+      echo "  reformatted/reordered content, not all changes are necessarily new APIs."
+    fi
+
+    echo ""
+    echo "-- ADDITIONS ($RAW_ADDED raw lines) --"
+    safe_grep "^+" "$DIFF_TMP" | safe_grep -v "^+++" \
+      | safe_grep -v "^+import " | safe_grep -v "^+[[:space:]]*//" \
+      | sed 's/^+//' > "$SECTION_TMP"
+    print_section "$SECTION_TMP"
+
+    echo ""
+    echo "-- REMOVALS ($RAW_REMOVED raw lines) --"
+    safe_grep "^-" "$DIFF_TMP" | safe_grep -v "^---" \
+      | safe_grep -v "^-import " | safe_grep -v "^-[[:space:]]*//" \
+      | sed 's/^-//' > "$SECTION_TMP"
+    print_section "$SECTION_TMP"
+
+    echo ""
+  done
+}
+
+# Allow sourcing for unit tests without executing main.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.agents/skills/api-diff/scripts/test-api-diff.sh
+++ b/.agents/skills/api-diff/scripts/test-api-diff.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# test-api-diff.sh — unit tests for api-diff.sh logic.
+# Run from anywhere: .agents/skills/api-diff/scripts/test-api-diff.sh
+# No external test framework required.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the production script to test the real functions — not copies of them.
+# The BASH_SOURCE guard in api-diff.sh prevents main() from executing on source.
+# shellcheck source=api-diff.sh
+source "$SCRIPT_DIR/api-diff.sh"
+
+PASS=0; FAIL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  ✅  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  ❌  $desc"
+    echo "      expected: $(printf '%q' "$expected")"
+    echo "      actual:   $(printf '%q' "$actual")"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  ✅  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  ❌  $desc (did not find: $needle)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  ❌  $desc (unexpectedly found: $needle)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  ✅  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ── Test suite 1: ref_to_minor_ver (sourced from api-diff.sh) ─────────────
+echo ""
+echo "=== ref_to_minor_ver ==="
+assert_eq "release/5.9.0  → 5.9"    "5.9"    "$(ref_to_minor_ver "release/5.9.0")"
+assert_eq "release/5.10.0 → 5.10"   "5.10"   "$(ref_to_minor_ver "release/5.10.0")"
+assert_eq "release/4.11.0 → 4.11"   "4.11"   "$(ref_to_minor_ver "release/4.11.0")"
+assert_eq "release/5.9.x  → 5.9"    "5.9"    "$(ref_to_minor_ver "release/5.9.x")"
+assert_eq "release/5.10.x → 5.10"   "5.10"   "$(ref_to_minor_ver "release/5.10.x")"
+assert_eq "release/4.11.x → 4.11"   "4.11"   "$(ref_to_minor_ver "release/4.11.x")"
+assert_eq "v5.9.5         → 5.9"    "5.9"    "$(ref_to_minor_ver "v5.9.5")"
+assert_eq "v4.11.0        → 4.11"   "4.11"   "$(ref_to_minor_ver "v4.11.0")"
+assert_eq "master         → master"  "master" "$(ref_to_minor_ver "master")"
+assert_eq "main           → master"  "master" "$(ref_to_minor_ver "main")"
+assert_eq "unknown-ref    → empty"   ""       "$(ref_to_minor_ver "some-feature-branch")"
+
+# ── Test suite 2: Python changelog version filtering ──────────────────────
+echo ""
+echo "=== Python changelog version filtering ==="
+
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+for v in 4.11 5.0 5.1 5.2 5.9 5.10; do
+  printf "# %s Change Notes\n## Section A\n### Sub A\n" "$v" > "$TEST_TMPDIR/${v}.0.md"
+done
+
+# Run the same Python logic as show_changelogs uses, but returning just filenames
+# so test assertions stay simple (no file content noise).
+run_filter() {
+  local base="$1" head="$2"
+  shift 2
+  local files=("$@")
+  python3 - "$base" "$head" "${files[@]}" << 'PYEOF'
+import sys, re
+
+base_ver = sys.argv[1]
+head_ver = sys.argv[2]
+files    = sys.argv[3:]
+
+def parse_ver(s):
+    m = re.match(r'^(\d+)\.(\d+)$', s)
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+def ver_from_path(p):
+    m = re.search(r'(\d+)\.(\d+)\.0\.md$', p)
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+base = parse_ver(base_ver)
+head = parse_ver(head_ver)
+
+selected = []
+for f in files:
+    v = ver_from_path(f)
+    if v is None:
+        continue
+    if base is not None and v <= base:
+        continue
+    if head is not None and v > head:
+        continue
+    selected.append((v, f))
+
+selected.sort()
+
+if not selected:
+    print("(none)")
+else:
+    for v, f in selected:
+        print(f"{v[0]}.{v[1]}.0.md")
+PYEOF
+}
+
+ALL_LOGS=(
+  "$TEST_TMPDIR/4.11.0.md" "$TEST_TMPDIR/5.0.0.md" "$TEST_TMPDIR/5.1.0.md"
+  "$TEST_TMPDIR/5.2.0.md"  "$TEST_TMPDIR/5.9.0.md" "$TEST_TMPDIR/5.10.0.md"
+)
+
+OUT=$(run_filter "4.11" "5.10" "${ALL_LOGS[@]}")
+assert_contains     "4.11→5.10 includes 5.0"     "5.0.0.md"  "$OUT"
+assert_contains     "4.11→5.10 includes 5.10"    "5.10.0.md" "$OUT"
+assert_not_contains "4.11→5.10 excludes 4.11"    "4.11.0.md" "$OUT"
+
+OUT=$(run_filter "5.9" "5.10" "${ALL_LOGS[@]}")
+assert_contains     "5.9→5.10 includes 5.10"     "5.10.0.md" "$OUT"
+assert_not_contains "5.9→5.10 excludes 5.9"      "5.9.0.md"  "$OUT"
+assert_not_contains "5.9→5.10 excludes 5.0"      "5.0.0.md"  "$OUT"
+
+OUT=$(run_filter "5.0" "5.2" "${ALL_LOGS[@]}")
+assert_contains     "5.0→5.2 includes 5.1"       "5.1.0.md"  "$OUT"
+assert_contains     "5.0→5.2 includes 5.2"       "5.2.0.md"  "$OUT"
+assert_not_contains "5.0→5.2 excludes 5.0"       "5.0.0.md"  "$OUT"
+assert_not_contains "5.0→5.2 excludes 5.9"       "5.9.0.md"  "$OUT"
+
+OUT=$(run_filter "5.9" "master" "${ALL_LOGS[@]}")
+assert_contains     "5.9→master includes 5.10"   "5.10.0.md" "$OUT"
+assert_not_contains "5.9→master excludes 5.9"    "5.9.0.md"  "$OUT"
+
+OUT=$(run_filter "5.10" "5.10" "${ALL_LOGS[@]}")
+assert_contains     "equal base/head → (none)"   "(none)"     "$OUT"
+
+# Numeric sort: 5.9 must precede 5.10 (lexicographic order would fail this)
+OUT=$(run_filter "5.8" "5.10" "${ALL_LOGS[@]}")
+FIRST=$(echo "$OUT" | grep -E '5\.(9|10)\.0\.md$' | head -1)
+assert_eq           "5.9 sorts before 5.10"      "5.9.0.md"  "$FIRST"
+
+# ── Test suite 3: smoke test — script accepts args and runs ───────────────
+echo ""
+echo "=== Smoke test (requires git) ==="
+if command -v git &>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  OUT=$("$SCRIPT_DIR/api-diff.sh" "HEAD~1" "HEAD" 2>&1) || true
+  assert_contains "script runs on HEAD~1..HEAD" "API diff:" "$OUT"
+else
+  echo "  ⚠️  Skipping (not in a git repo)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
This pull request introduces a new `api-diff` skill for comparing public API changes between two branches or version tags in the iTwin.js monorepo. It provides a Bash script for diffing API files, a comprehensive skill documentation, a reference on API support and breaking change policies, and a test script to ensure correct behavior. The main improvements are structured API diffing, changelog coverage checking, and robust testability.

The most important changes are:

**Skill and Policy Documentation**
- Added `.agents/skills/api-diff/SKILL.md` with detailed instructions, usage scenarios, categorization of API changes, and output formatting for the new API diff skill.
- Added `.agents/skills/api-diff/REFERENCE.md` summarizing the iTwin.js API support policy, including tag meanings, promotion paths, deprecation rules, and what constitutes a breaking change.

**API Diff Script**
- Added `.agents/skills/api-diff/scripts/api-diff.sh`, a Bash script that compares `common/api/*.api.md` files between two git refs, summarizes API changes per package, and shows relevant changelog headings. Handles branch/tag naming conventions, large diffs, and changelog range computation.

**Testing**
- Added `.agents/skills/api-diff/scripts/test-api-diff.sh` to provide unit and integration tests for the diff script, including version parsing, changelog filtering, and a smoke test. Ensures reliability and correctness of the diff logic.