### PR TITLE
Presentation: Fix fields' filtering utils used in example full stack tests

### DIFF
--- a/full-stack-tests/presentation/src/IModelSetupUtils.ts
+++ b/full-stack-tests/presentation/src/IModelSetupUtils.ts
@@ -13,11 +13,14 @@ import {
   CategoryProps,
   Code,
   ElementAspectProps,
+  ElementProps,
+  ExternalSourceProps,
   GeometricModel3dProps,
   IModel,
   InformationPartitionElementProps,
   LocalFileName,
   PhysicalElementProps,
+  RepositoryLinkProps,
 } from "@itwin/core-common";
 import { IModelConnection } from "@itwin/core-frontend";
 
@@ -114,7 +117,7 @@ export function importSchema(mochaContext: Mocha.Context, imodel: { importSchema
 }
 
 /** Insert a document partition element into created imodel. Return created element's className and Id. */
-export function insertDocumentPartitionTxn(txn: EditTxn, db: IModelDb, code: string, label?: string, federationGuid?: GuidString) {
+function insertDocumentPartitionTxn(txn: EditTxn, db: IModelDb, code: string, label?: string, federationGuid?: GuidString) {
   const id = txn.insertElement({
     classFullName: "BisCore:DocumentPartition",
     model: IModel.repositoryModelId,
@@ -136,7 +139,7 @@ export function insertPhysicalModelWithPartition(props: { db: IModelDb; codeValu
   return insertPhysicalSubModel({ ...baseProps, modeledElementId: partitionKey.id });
 }
 
-export function insertPhysicalPartitionTxn(
+function insertPhysicalPartitionTxn(
   txn: EditTxn,
   props: { db: IModelDb; codeValue: string; parentId: Id64String } & Partial<Omit<InformationPartitionElementProps, "id" | "parent" | "code">>,
 ) {
@@ -162,7 +165,7 @@ export function insertPhysicalPartition(
   return withEditTxn(props.db, (txn) => insertPhysicalPartitionTxn(txn, props));
 }
 
-export function insertPhysicalSubModelTxn(
+function insertPhysicalSubModelTxn(
   txn: EditTxn,
   props: { db: IModelDb; modeledElementId: Id64String } & Partial<Omit<GeometricModel3dProps, "id" | "modeledElement" | "parentModel">>,
 ) {
@@ -184,7 +187,7 @@ export function insertPhysicalSubModel(
 }
 
 /** Insert a spatial category element into created imodel. Return created element's className and Id. */
-export function insertSpatialCategoryTxn(
+function insertSpatialCategoryTxn(
   txn: EditTxn,
   props: { db: IModelDb; codeValue: string; modelId?: Id64String } & Partial<Omit<CategoryProps, "id" | "model" | "parent" | "code">>,
 ) {
@@ -208,7 +211,7 @@ export function insertSpatialCategory(
 }
 
 /** Insert a physical element into created imodel. Return created element's className and Id. */
-export function insertPhysicalElementTxn<TAdditionalProps extends object>(
+function insertPhysicalElementTxn<TAdditionalProps extends object>(
   txn: EditTxn,
   props: { db: IModelDb; modelId: Id64String; categoryId: Id64String; parentId?: Id64String } & Partial<
     Omit<PhysicalElementProps, "id" | "model" | "category" | "parent">
@@ -225,11 +228,11 @@ export function insertPhysicalElementTxn<TAdditionalProps extends object>(
     code: Code.createEmpty(),
     ...(parentId
       ? {
-        parent: {
-          id: parentId,
-          relClassName: `BisCore:PhysicalElementAssemblesElements`,
-        },
-      }
+          parent: {
+            id: parentId,
+            relClassName: `BisCore:PhysicalElementAssemblesElements`,
+          },
+        }
       : undefined),
     ...elementProps,
   });
@@ -246,7 +249,7 @@ export function insertPhysicalElement<TAdditionalProps extends object>(
 }
 
 /** Insert an aspect into created imodel, return its key */
-export function insertElementAspectTxn<TAdditionalProps extends object>(
+function insertElementAspectTxn<TAdditionalProps extends object>(
   txn: EditTxn,
   props: { db: IModelDb; elementId: Id64String } & Partial<Omit<ElementAspectProps, "element">> & TAdditionalProps,
 ) {
@@ -258,6 +261,9 @@ export function insertElementAspectTxn<TAdditionalProps extends object>(
     element: {
       id: elementId,
     },
+    scope: {
+      id: elementId,
+    },
     ...aspectProps,
   });
   return { className, id };
@@ -267,6 +273,58 @@ export function insertElementAspect<TAdditionalProps extends object>(
   props: { db: IModelDb; elementId: Id64String } & Partial<Omit<ElementAspectProps, "element">> & TAdditionalProps,
 ) {
   return withEditTxn(props.db, (txn) => insertElementAspectTxn(txn, props));
+}
+
+export function insertExternalSource(
+  props: { db: IModelDb; classFullName?: string; parentId?: Id64String; repositoryLinkId?: Id64String } & Partial<
+    Omit<ExternalSourceProps, "id" | "repository" | "parent">
+  >,
+) {
+  const { db, classFullName, parentId, repositoryLinkId, ...externalSourceProps } = props;
+  const defaultClassName = "BisCore:ExternalSource";
+  const className = classFullName ?? defaultClassName;
+  return withEditTxn(db, (txn) => {
+    const id = txn.insertElement({
+      classFullName: className,
+      model: IModel.repositoryModelId,
+      code: Code.createEmpty(),
+      parent: parentId
+        ? {
+            relClassName: "BisCore:ElementOwnsChildElements",
+            id: parentId,
+          }
+        : undefined,
+      repository: repositoryLinkId
+        ? {
+            id: repositoryLinkId,
+            relClassName: "BisCore:ExternalSourceIsInRepository",
+          }
+        : undefined,
+      ...externalSourceProps,
+    } as RepositoryLinkProps);
+    return { className, id };
+  });
+}
+
+export function insertRepositoryLink(
+  props: { db: IModelDb; classFullName?: string; repositoryUrl?: string; repositoryLabel?: string } & Partial<
+    Omit<RepositoryLinkProps, "id" | "model" | "url" | "userLabel">
+  >,
+) {
+  const { db, classFullName, repositoryUrl, repositoryLabel, ...repoLinkProps } = props;
+  const defaultClassName = "BisCore:RepositoryLink";
+  const className = classFullName ?? defaultClassName;
+  return withEditTxn(db, (txn) => {
+    const id = txn.insertElement({
+      classFullName: className,
+      model: IModel.repositoryModelId,
+      url: repositoryUrl,
+      userLabel: repositoryLabel,
+      code: Code.createEmpty(),
+      ...repoLinkProps,
+    } satisfies RepositoryLinkProps as ElementProps);
+    return { className, id };
+  });
 }
 
 function setupOutputFileLocation(fileName: string): LocalFileName {

--- a/full-stack-tests/presentation/src/frontend/content/ClassDescriptor.test.ts
+++ b/full-stack-tests/presentation/src/frontend/content/ClassDescriptor.test.ts
@@ -9,30 +9,41 @@ import { ContentSpecificationTypes, DefaultContentDisplayTypes, KeySet, Ruleset,
 import { Presentation } from "@itwin/presentation-frontend";
 import { describeContentTestSuite, filterFieldsByClass, filterFieldsByClassIntersection, getFieldLabels } from "./Utils.js";
 import { getFieldByLabel } from "../../Utils.js";
+import {
+  buildTestIModelConnection,
+  importSchema,
+  insertElementAspect,
+  insertExternalSource,
+  insertPhysicalElement,
+  insertPhysicalModelWithPartition,
+  insertRepositoryLink,
+  insertSpatialCategory,
+} from "../../IModelSetupUtils.js";
 
 describeContentTestSuite("Class descriptor", ({ getDefaultSuiteIModel }) => {
+  const createRuleset = (schemaName: string, className: string): Ruleset => ({
+    id: Guid.createValue(),
+    rules: [
+      {
+        ruleType: RuleTypes.Content,
+        specifications: [
+          {
+            specType: ContentSpecificationTypes.ContentInstancesOfSpecificClasses,
+            classes: {
+              schemaName,
+              classNames: [className],
+              arePolymorphic: true,
+            },
+            handlePropertiesPolymorphically: true,
+          },
+        ],
+      },
+    ],
+  });
+
   it("creates base class descriptor usable for subclasses", async () => {
     const imodel = await getDefaultSuiteIModel();
     const schemaView = await imodel.getSchemaView();
-    const createRuleset = (schemaName: string, className: string): Ruleset => ({
-      id: Guid.createValue(),
-      rules: [
-        {
-          ruleType: RuleTypes.Content,
-          specifications: [
-            {
-              specType: ContentSpecificationTypes.ContentInstancesOfSpecificClasses,
-              classes: {
-                schemaName,
-                classNames: [className],
-                arePolymorphic: true,
-              },
-              handlePropertiesPolymorphically: true,
-            },
-          ],
-        },
-      ],
-    });
 
     const descriptorGeometricElement = await Presentation.presentation.getContentDescriptor({
       imodel,
@@ -75,6 +86,116 @@ describeContentTestSuite("Class descriptor", ({ getDefaultSuiteIModel }) => {
       "Model",
       "User Label",
       ...getFieldLabels([getFieldByLabel(fieldsPhysicalObject, "area"), getFieldByLabel(fieldsPhysicalObject, "Repository Link")]),
+    ]);
+  });
+
+  it("filters nested related properties from class descriptor based on source class", async function () {
+    let schema!: ReturnType<typeof importSchema>;
+    const imodel = await buildTestIModelConnection(this.test!.title, async (db) => {
+      schema = importSchema(
+        this,
+        db,
+        `
+          <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
+          <ECEntityClass typeName="RepositoryLink1">
+            <BaseClass>bis:RepositoryLink</BaseClass>
+            <ECProperty propertyName="RepositoryLinkPropertyName1" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="RepositoryLink2">
+            <BaseClass>bis:RepositoryLink</BaseClass>
+            <ECProperty propertyName="RepositoryLinkPropertyName2" typeName="string" />
+          </ECEntityClass>
+          <ECEntityClass typeName="X">
+            <BaseClass>bis:PhysicalElement</BaseClass>
+          </ECEntityClass>
+          <ECEntityClass typeName="Y">
+            <BaseClass>bis:PhysicalElement</BaseClass>
+          </ECEntityClass>
+        `,
+      );
+      const model = insertPhysicalModelWithPartition({ db, codeValue: "model" });
+      const category = insertSpatialCategory({ db, codeValue: "category" });
+      const elementX1 = insertPhysicalElement({
+        db,
+        classFullName: schema.items.X.fullName,
+        modelId: model.id,
+        categoryId: category.id,
+      });
+      insertElementAspect({
+        db,
+        elementId: elementX1.id,
+        classFullName: "BisCore:ExternalSourceAspect",
+        kind: "Not a 'Relationship'",
+        source: {
+          id: insertExternalSource({ db, repositoryLinkId: insertRepositoryLink({ db, classFullName: schema.items.RepositoryLink1.fullName }).id }).id,
+          relClassName: `BisCore:ElementIsFromSource`,
+        },
+      });
+      const elementX2 = insertPhysicalElement({
+        db,
+        classFullName: schema.items.X.fullName,
+        modelId: model.id,
+        categoryId: category.id,
+      });
+      insertElementAspect({
+        db,
+        elementId: elementX2.id,
+        classFullName: "BisCore:ExternalSourceAspect",
+        kind: "Not a 'Relationship'",
+        source: {
+          id: insertExternalSource({ db, repositoryLinkId: insertRepositoryLink({ db, classFullName: schema.items.RepositoryLink2.fullName }).id }).id,
+          relClassName: `BisCore:ElementIsFromSource`,
+        },
+      });
+      const elementY = insertPhysicalElement({
+        db,
+        classFullName: schema.items.Y.fullName,
+        modelId: model.id,
+        categoryId: category.id,
+      });
+      insertElementAspect({
+        db,
+        elementId: elementY.id,
+        classFullName: "BisCore:ExternalSourceAspect",
+        kind: "Not a 'Relationship'",
+        source: {
+          id: insertExternalSource({ db, repositoryLinkId: insertRepositoryLink({ db, classFullName: schema.items.RepositoryLink2.fullName }).id }).id,
+          relClassName: `BisCore:ElementIsFromSource`,
+        },
+      });
+    });
+    const schemaView = await imodel.getSchemaView();
+
+    const descriptorGeometricElement = await Presentation.presentation.getContentDescriptor({
+      imodel,
+      rulesetOrId: createRuleset("BisCore", "GeometricElement"),
+      displayType: DefaultContentDisplayTypes.PropertyPane,
+      keys: new KeySet(),
+    });
+
+    // filter descriptor fields by intersection of X and Y classes
+    const fieldsIntersection = filterFieldsByClassIntersection(descriptorGeometricElement!.fields, [
+      schemaView.findClass(schema.items.X.fullName)!,
+      schemaView.findClass(schema.items.Y.fullName)!,
+    ]);
+    // class X is related to both - RepositoryLink1 and RepositoryLink2, while class Y is related only to RepositoryLink2, so
+    // we should see all properties of RepositoryLink2 and no properties of RepositoryLink1
+    expect(getFieldLabels(fieldsIntersection)).to.deep.eq([
+      "Category",
+      "Code",
+      "Model",
+      "Physical Material",
+      "User Label",
+      {
+        label: "External Source Aspect",
+        nested: [
+          "Source Element ID",
+          {
+            label: "RepositoryLink2",
+            nested: ["Code", "Description", "Format", "Name", "Path", "RepositoryLinkPropertyName2"],
+          },
+        ],
+      },
     ]);
   });
 });

--- a/full-stack-tests/presentation/src/frontend/content/Utils.ts
+++ b/full-stack-tests/presentation/src/frontend/content/Utils.ts
@@ -112,7 +112,7 @@ function filterNestedContentFields(fields: Field[], predicate: (field: NestedCon
       if (clone.nestedFields.length > 0) {
         filteredFields.push(clone);
       }
-    } else {
+    } else if (!f.isNestedContentField()) {
       filteredFields.push(f);
     }
   });


### PR DESCRIPTION
Needs to wait until https://github.com/iTwin/imodel-native/pull/1452 merges.

- Add an extra test that exercises filtering nested related content fields.
- Fix `filterFieldsByClassIntersection` utility - it should not include nested fields that don't pass the predicate.