### PR TITLE
Add ECSchema JSON documentation and update references

### DIFF
--- a/docs/bis/ec/ec-schema-json.md
+++ b/docs/bis/ec/ec-schema-json.md
@@ -29,7 +29,7 @@ Every ECSchema JSON document has a required `$schema` property naming the JSON S
 | ECSchema JSON (3.2) | `https://dev.bentley.com/json_schemas/ec/32/ecschema` |
 | SchemaItem JSON (3.2) | `https://dev.bentley.com/json_schemas/ec/32/schemaitem` |
 
-The version digit in the URL (`/ec/32/`) is the EC/JSON spec version, not the schema version. The `version` property is the schema version in `RR.ww.mm` form described by [ECSchema](./ec-schema.md). (The XML namespace `http://www.bentley.com/schemas/Bentley.ECXML.3.2` is the XML equivalent of `$schema` - see [ECSchema XML](./ec-schema-xml.md#namespace-and-version).)
+The version digit in the URL (`/ec/32/`) is the EC/JSON spec version, not the schema version. The `version` property is the schema version in `RR.WW.mm` form described by [ECSchema](./ec-schema.md). (The XML namespace `http://www.bentley.com/schemas/Bentley.ECXML.3.2` is the XML equivalent of `$schema` - see [ECSchema XML](./ec-schema-xml.md#namespace-and-version).)
 
 ## Root Object
 

--- a/docs/bis/ec/ec-schema-json.md
+++ b/docs/bis/ec/ec-schema-json.md
@@ -9,7 +9,7 @@ This page documents the ECSchema JSON 3.2 shape used by current iTwin schemas. T
 JSON supports two related shapes:
 
 - **ECSchema JSON** - the whole schema in one object, with its items in a name-keyed `items` object. This is the JSON analogue of an ECSchema XML document.
-- **SchemaItem JSON** - a single schema item (one class, enumeration, KindOfQuantity, etc.) described on its own, outside its schema. Used to move a single item compactly (for example over the wire) without serializing the whole schema. A SchemaItem JSON object is identical to the in-schema item object, plus three locating properties (`$schema`, `schema`, `name`) and an optional `schemaVersion` that identify the schema it came from. It does not redefine or change the item.
+- **SchemaItem JSON** - a single schema item (one class, enumeration, KindOfQuantity, etc.) described on its own, outside its schema. Used to move a single item compactly (for example over the wire) without serializing the whole schema. A SchemaItem JSON object is identical to the in-schema item object, plus a format discriminator (`$schema`, the schemaitem spec URL), two provenance properties (`schema` and `name`) and an optional `schemaVersion` that identify the schema it came from. It does not redefine or change the item.
 
 ## `$schema` and Version
 
@@ -304,9 +304,12 @@ The two formats describe the same model; the shape differs. Summary (see [ECSche
 
 This page documents the shape of the JSON; the JSON itself is produced from an in-memory `Schema`. Standard schemas (`BisCore`, etc.) are distributed with iTwin.js as ECSchema XML and are loaded into a `SchemaContext` at runtime; the same JSON shape applies regardless of how a schema was originally authored.
 
-- **From an iModel.** On the backend, `IModelDb.schemaContext` (`@itwin/core-backend`) resolves a schema by name into a `Schema` object. Calling `Schema.toJSON()` (`@itwin/ecschema-metadata`) returns the `SchemaProps` object documented here.
+- **From an iModel.** On the backend, `IModelDb.schemaContext` (`@itwin/core-backend`) returns a `SchemaContext` for the iModel; call `schemaContext.getSchema(schemaKey, matchType)` to obtain a `Schema` object. Calling `Schema.toJSON()` (`@itwin/ecschema-metadata`) returns the `SchemaProps` object documented here.
 - **From files.** `@itwin/ecschema-locaters` provides locaters - `SchemaJsonFileLocater` for `.ecschema.json` and `SchemaXmlFileLocater` for `.ecschema.xml` - that you register on a `SchemaContext` to load schemas from disk. Once loaded, `Schema.toJSON()` serializes to JSON regardless of the source format.
+- **Authoring programmatically.** `@itwin/ecschema-editing` builds and edits a `Schema` in memory; serialize the result with `Schema.toJSON()`.
 - **A single item.** `SchemaItem.toJSON(true)` serializes one item as a standalone **SchemaItem JSON** object; pass `SchemaItem.toJSON(true, true)` to also include `schemaVersion`.
+
+**Importing into an iModel requires XML.** `IModelDb.importSchemas()` and `importSchemaStrings()` accept ECSchema XML only. If your schema is authored as JSON, serialize it to XML first before importing - see [Serializing schemas to XML](../../learning/serializing-xml-schemas.md).
 
 For fast read-only access that does not require full-fidelity JSON, prefer [SchemaView](../../learning/metadata/SchemaView.md) (see [See also](#see-also)).
 
@@ -317,5 +320,6 @@ ECSchema JSON tracks the EC information model the same way [ECSchema XML](./ec-s
 ## See also
 
 - [ECSchema XML](./ec-schema-xml.md) - the XML representation of the same EC model.
-- `SchemaContext` (`@itwin/ecschema-metadata`) - the API-layer entry point for loading, authoring, validating, and serializing ECSchema JSON at full fidelity.
+- [SchemaContext]($ecschema-metadata) (`@itwin/ecschema-metadata`) - the API-layer entry point for loading, authoring, validating, and serializing ECSchema JSON at full fidelity.
+
 - [SchemaView](../../learning/metadata/SchemaView.md) and its [binary format](../../learning/metadata/SchemaViewBinaryFormat.md) - a separate, **lossy runtime** representation used by `@itwin/ecschema-metadata` for fast in-memory access. Unlike ECSchema XML and JSON, it is an iTwin.js implementation format, not an EC interchange format: it drops units, formats, and custom attribute instances and is versioned independently of the EC spec.

--- a/docs/bis/ec/ec-schema-json.md
+++ b/docs/bis/ec/ec-schema-json.md
@@ -1,0 +1,302 @@
+# ECSchema JSON
+
+ECSchema JSON is the JSON representation of an [ECSchema](./ec-schema.md). Like [ECSchema XML](./ec-schema-xml.md), it is a persistent interchange format for EC metadata: schemas, classes, properties, relationships, custom attributes, enumerations, quantities, units, and formats. The two formats describe the same EC information model; this page is the JSON counterpart to [ECSchema XML](./ec-schema-xml.md) and links back to it where the two diverge.
+
+This page documents the ECSchema JSON 3.2 shape used by current iTwin schemas. The semantic rules for each EC item are documented on the linked EC pages and enforced by EC schema validation; this page covers the JSON document shape only.
+
+## Two JSON forms
+
+JSON supports two related shapes:
+
+- **ECSchema JSON** - the whole schema in one object, with its items in a name-keyed `items` object. This is the JSON analogue of an ECSchema XML document.
+- **SchemaItem JSON** - a single schema item (one class, enumeration, KindOfQuantity, etc.) described on its own, outside its schema. Used to move a single item compactly (for example over the wire) without serializing the whole schema. A SchemaItem JSON object is identical to the in-schema item object, plus four locating properties (`$schema`, `schema`, `schemaVersion`, `name`) that identify the schema it came from. It does not redefine or change the item.
+
+## `$schema` and Version
+
+Every ECSchema JSON document has a required `$schema` property naming the JSON Schema for the spec version. The EC version is parsed from this URL.
+
+```json
+{
+  "$schema": "https://dev.bentley.com/json_schemas/ec/32/ecschema",
+  "name": "Example",
+  "version": "01.00.00",
+  "alias": "ex"
+}
+```
+
+| Form | `$schema` URL |
+| --- | --- |
+| ECSchema JSON (3.2) | `https://dev.bentley.com/json_schemas/ec/32/ecschema` |
+| SchemaItem JSON (3.2) | `https://dev.bentley.com/json_schemas/ec/32/schemaitem` |
+
+The version digit in the URL (`/ec/32/`) is the EC/JSON spec version, not the schema version. The `version` property is the schema version in `RR.ww.mm` form described by [ECSchema](./ec-schema.md). (The XML namespace `http://www.bentley.com/schemas/Bentley.ECXML.3.2` is the XML equivalent of `$schema` - see [ECSchema XML](./ec-schema-xml.md#namespace-and-version).)
+
+## Root Object
+
+The root object holds schema-level metadata, references, custom attributes, and the items object.
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `$schema` | Yes | string | JSON Schema URL identifying the spec version. |
+| `name` | Yes | string | Schema name and namespace for its items. Must be an [ECName](./ec-name.md). |
+| `version` | Yes | string | Schema version in `RR.ww.mm` form. |
+| `alias` | Yes | string | Short alias for the schema. |
+| `label` | No | string | Localizable display label. |
+| `description` | No | string | Localizable description. |
+| `references` | No | array | Schema references (see below). |
+| `customAttributes` | No | array | Custom attribute instances applied to the schema (see [Custom Attributes](#custom-attributes)). |
+| `items` | No | object | Schema items keyed by item name (see below). |
+
+### The `items` object
+
+Schema items are properties of an `items` object, keyed by item name:
+
+```json
+"items": {
+  "Pump":   { "schemaItemType": "EntityClass", "...": "..." },
+  "Tank":   { "schemaItemType": "EntityClass", "...": "..." },
+  "Length": { "schemaItemType": "KindOfQuantity", "...": "..." }
+}
+```
+
+The key is the item name, so an in-schema item object omits the `name`, `schema`, and `schemaVersion` properties (those are implied by the key and the enclosing schema). Item names must be unique across all item kinds in a schema - an entity class and an enumeration cannot share a name. This differs from XML, where each item is an element of a specific kind and ordering is positional; in JSON the items are object members. (See [ECName](./ec-name.md) for naming and uniqueness rules.)
+
+## Schema References
+
+A reference identifies another schema this schema depends on:
+
+```json
+"references": [
+  { "name": "BisCore", "version": "01.00.25" }
+]
+```
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `name` | Yes | string | Referenced schema name. |
+| `version` | Yes | string | Referenced schema version. |
+
+A JSON reference carries **no alias** - this is a deliberate difference from [ECSchema XML](./ec-schema-xml.md#schema-references), where the reference carries a required `alias`. JSON references items in other schemas by full schema name, not alias (see below), so no per-reference alias is needed.
+
+## Schema Items
+
+Every item object shares these properties:
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `schemaItemType` | Yes | string | Item kind (see values below). |
+| `label` | No | string | Localizable display label. |
+| `description` | No | string | Localizable description. |
+
+A **SchemaItem JSON** object (an item serialized on its own) additionally carries `$schema` (the schemaitem URL), `schema` (its schema name), `name` (its item name), and optionally `schemaVersion`. In-schema item objects omit all four.
+
+`schemaItemType` values: `EntityClass`, `Mixin`, `StructClass`, `CustomAttributeClass`, `RelationshipClass`, `Enumeration`, `KindOfQuantity`, `PropertyCategory`, `Unit`, `InvertedUnit`, `Constant`, `Phenomenon`, `UnitSystem`, `Format`.
+
+> **References use the full schema name with a `.` separator**, such as `"BisCore.PhysicalElement"` - not the alias-qualified `bis:PhysicalElement` form used in XML. An item in the same schema may be referenced by its bare name. This applies to every cross-reference property below (`baseClass`, `mixins`, `appliesTo`, `typeName`, `relationshipName`, `category`, `kindOfQuantity`, constraint classes, units, phenomena, and so on).
+
+## Classes
+
+The class item kinds are `EntityClass`, `Mixin`, `StructClass`, `CustomAttributeClass`, and `RelationshipClass`. See [ECClass](./ec-class.md), [ECEntityClass](./ec-entity-class.md), [ECMixinClass](./ec-mixin-class.md), [ECStructClass](./ec-struct-class.md), [ECCustomAttributeClass](./ec-custom-attribute-class.md), and [ECRelationshipClass](./ec-relationship-class.md) for semantics.
+
+Common class properties:
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `modifier` | No | string | `none` (default), `abstract`, or `sealed`. |
+| `baseClass` | No | string | Full base class name `{schema}.{class}`. Relationship classes support at most one base class semantically. |
+| `properties` | No | array | Property objects (see [Properties](#properties)). |
+| `customAttributes` | No | array | Custom attribute instances applied to the class. |
+
+`EntityClass` adds an optional `mixins` array of full class names. `Mixin` is always abstract (the `modifier` is implied) and adds a required `appliesTo` (full entity class name). See [ECMixinClass](./ec-mixin-class.md) for the mixin rules.
+
+```json
+"Pump": {
+  "schemaItemType": "EntityClass",
+  "modifier": "sealed",
+  "label": "Pump",
+  "baseClass": "BisCore.PhysicalElement",
+  "mixins": ["Example.IServiceable"],
+  "properties": [
+    { "type": "PrimitiveProperty", "name": "Manufacturer", "typeName": "string" },
+    { "type": "PrimitiveProperty", "name": "RatedFlow", "typeName": "double", "kindOfQuantity": "Example.Flow" }
+  ]
+}
+```
+
+### Custom Attribute Classes
+
+`CustomAttributeClass` adds a required `appliesTo` listing the container types where instances may be applied. The value is a list separated by `,`, `;`, or `|`. See [ECCustomAttributeClass](./ec-custom-attribute-class.md) and [CustomAttribute container types](./customattribute-container-types.md).
+
+```json
+"ReviewInfo": {
+  "schemaItemType": "CustomAttributeClass",
+  "appliesTo": "Schema, EntityClass, PrimitiveProperty",
+  "properties": [
+    { "type": "PrimitiveProperty", "name": "Owner", "typeName": "string" }
+  ]
+}
+```
+
+## Relationship Classes
+
+`RelationshipClass` adds `strength`, `strengthDirection`, and `source` / `target` constraint objects. See [ECRelationshipClass](./ec-relationship-class.md) for semantics.
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `strength` | Yes | string | `referencing`, `holding`, or `embedding`. |
+| `strengthDirection` | Yes | string | `forward` or `backward`. |
+| `source` | Yes | object | Source constraint (see below). |
+| `target` | Yes | object | Target constraint (see below). |
+
+> `strength` and `strengthDirection` are **required in JSON** (the deserializer rejects an object that omits them). This differs from [ECSchema XML](./ec-schema-xml.md#relationship-classes), where both are optional and default to `referencing` / `forward`.
+
+`source` and `target` constraint objects:
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `multiplicity` | Yes | string | UML-style, such as `(0..*)`, `(0..1)`, `(1..1)`, `(2..5)`. |
+| `roleLabel` | Yes | string | Label for the endpoint's role. |
+| `polymorphic` | Yes | boolean | Whether the endpoint accepts subclasses. |
+| `abstractConstraint` | Conditional | string | Full class name. Required when an endpoint has more than one constraint class and no inherited abstract constraint. |
+| `constraintClasses` | Yes | array | One or more full class names allowed at the endpoint. |
+| `customAttributes` | No | array | Custom attribute instances on the constraint. |
+
+```json
+"PumpFeedsTank": {
+  "schemaItemType": "RelationshipClass",
+  "modifier": "sealed",
+  "strength": "referencing",
+  "strengthDirection": "forward",
+  "source": {
+    "multiplicity": "(0..*)", "roleLabel": "feeds", "polymorphic": true,
+    "constraintClasses": ["Example.Pump"]
+  },
+  "target": {
+    "multiplicity": "(0..1)", "roleLabel": "is fed by", "polymorphic": true,
+    "constraintClasses": ["Example.Tank"]
+  }
+}
+```
+
+## Properties
+
+Property objects live in a class's `properties` array. The `type` property is the discriminator; there are five kinds. See [ECProperty](./ec-property.md) for semantics.
+
+Common property properties:
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `name` | Yes | string | Property name. Must be an [ECName](./ec-name.md). |
+| `type` | Yes | string | `PrimitiveProperty`, `StructProperty`, `PrimitiveArrayProperty`, `StructArrayProperty`, or `NavigationProperty`. |
+| `label` | No | string | Localizable display label. |
+| `description` | No | string | Localizable description. |
+| `isReadOnly` | No | boolean | Whether the property is read-only. |
+| `category` | No | string | Full PropertyCategory name. |
+| `priority` | No | number | Integer sorting priority. |
+| `kindOfQuantity` | No | string | Full KindOfQuantity name (primitive and primitive-array kinds). |
+| `customAttributes` | No | array | Custom attribute instances on the property. |
+| `inherited` | No | boolean | Marks a property surfaced from a base class (informational; typically only set on read). |
+
+Per-kind additions:
+
+| `type` | Adds | Notes |
+| --- | --- | --- |
+| `PrimitiveProperty` | `typeName`, `extendedTypeName`, `minValue`/`maxValue`, `minLength`/`maxLength` | `typeName` is a [primitive type](./primitive-types.md) keyword **or** a full enumeration name. An enumeration-backed property has no distinct `type` - it is a `PrimitiveProperty` whose `typeName` is an enumeration. |
+| `StructProperty` | `typeName` (full struct class name) | |
+| `PrimitiveArrayProperty` | `typeName`, `extendedTypeName`, value/length bounds, `minOccurs`/`maxOccurs` | enum-backed arrays use this kind with an enumeration `typeName`. |
+| `StructArrayProperty` | `typeName` (full struct class name), `minOccurs`/`maxOccurs` | |
+| `NavigationProperty` | `relationshipName` (full relationship name), `direction` (`forward`/`backward`) | |
+
+```json
+{ "type": "StructProperty", "name": "Address", "typeName": "Example.PostalAddress" }
+{ "type": "PrimitiveArrayProperty", "name": "Tags", "typeName": "string", "minOccurs": 0, "maxOccurs": 2147483647 }
+{ "type": "NavigationProperty", "name": "Tank", "relationshipName": "Example.PumpFeedsTank", "direction": "forward" }
+```
+
+> Unbounded arrays serialize `maxOccurs` as the integer `2147483647` in JSON, where XML uses the string `"unbounded"`.
+
+## Enumerations
+
+`ECEnumeration` has an integer or string backing type and a required `enumerators` array. See [ECEnumeration](./ec-enumeration.md).
+
+| Property | Required | JSON type | Description |
+| --- | --- | --- | --- |
+| `type` | Yes | string | `int` or `string`. (XML names this attribute `backingTypeName`.) |
+| `isStrict` | No | boolean | Defaults to `true`. When `false`, values outside the declared set are allowed. |
+| `enumerators` | Yes | array | Array of enumerator objects (may be empty). |
+
+Each enumerator object: `name` (required), `value` (required; number or string matching `type`, unique within the enumeration), `label` (optional), `description` (optional).
+
+```json
+"PumpState": {
+  "schemaItemType": "Enumeration",
+  "type": "int",
+  "isStrict": true,
+  "enumerators": [
+    { "name": "Off", "value": 0, "label": "Off" },
+    { "name": "On",  "value": 1, "label": "On" }
+  ]
+}
+```
+
+## Quantities, Units, and Formats
+
+ECSchema JSON 3.2 includes units and formats as schema items. See [KindOfQuantity](./kindofquantity.md), [Unit](./ec-unit.md), [Constant](./ec-constant.md), [Phenomenon](./ec-phenomenon.md), [UnitSystem](./ec-unitsystem.md), and [Format](./ec-format.md) for semantics.
+
+```json
+"Length": {
+  "schemaItemType": "KindOfQuantity",
+  "persistenceUnit": "Units.M",
+  "relativeError": 0.0001,
+  "presentationUnits": ["Formats.DefaultRealU(4)[Units.M|m]"]
+}
+```
+
+- **KindOfQuantity**: `persistenceUnit` (required, full unit name), `relativeError` (required, number), `presentationUnits` (optional; an array of format strings, or a single `;`-separated string). The first presentation format is the default. See [KindOfQuantity format overrides](./kindofquantity.md) for the override grammar.
+- **Unit**: `phenomenon`, `unitSystem`, `definition` (all required); `numerator`, `denominator`, `offset` (optional).
+- **InvertedUnit**: `invertsUnit`, `unitSystem` (both required).
+- **Constant**: `phenomenon`, `definition` (required); `numerator`, `denominator` (optional).
+- **Phenomenon**: `definition` (required).
+- **UnitSystem**: label/description only.
+- **Format**: `type` (required), `precision`, `roundFactor`, `minWidth`, `showSignOption`, `formatTraits` (array or delimited string), `decimalSeparator`, `thousandSeparator`, `uomSeparator`, `scientificType` (required when `type` is `scientific`), `stationOffsetSize` (required when `type` is `station`), `stationSeparator`, and an optional `composite`. A `composite` has `spacer`, `includeZero`, and a `units` array of 1-4 `{ name, label }` objects (`name` is a full unit name). See [Format](./ec-format.md).
+
+## Custom Attributes
+
+A custom attribute instance is a JSON object with a `className` (full custom attribute class name) plus a property for each value. See [ECCustomAttributes](./ec-custom-attributes.md) for semantics and the [ECInstance representation](./ec-schema-xml.md#ecinstance-xml-in-custom-attributes) for value shapes.
+
+```json
+"customAttributes": [
+  { "className": "CoreCustomAttributes.ProductionStatus", "SupportedUse": "NotForProduction" }
+]
+```
+
+A container may carry multiple custom attributes, but only one instance of a given custom attribute class. Unlike schema items, custom attribute order is not significant.
+
+## Validation
+
+The JSON Schema for ECSchema JSON validates document shape: allowed properties, value types, and simple patterns. It does not express every semantic EC rule; semantic rules (relationship constraint compatibility, reference resolution, property override compatibility, custom attribute applicability) are covered by [EC Schema Validation](./ec-schema-validation.md).
+
+The 3.2 JSON Schema files live in the BIS schemas repository under `System/json_schema/ec32/`.
+
+## Differences from ECSchema XML
+
+The two formats describe the same model; the shape differs. Summary (see [ECSchema XML](./ec-schema-xml.md) for the XML side):
+
+| Aspect | ECSchema XML | ECSchema JSON |
+| --- | --- | --- |
+| Spec/version marker | `xmlns` namespace | `$schema` URL |
+| Item name | `typeName` attribute | object key (or `name` in SchemaItem JSON) |
+| Label / description | `displayLabel` / `description` | `label` / `description` |
+| Enumeration backing type | `backingTypeName` | `type` |
+| Read-only flag | `readOnly` | `isReadOnly` |
+| Constraint polymorphic flag | `polymorphic` | `polymorphic` |
+| Cross-references | alias-qualified, `bis:Class`, `:` separator | full schema name, `BisCore.Class`, `.` separator |
+| Reference alias | required `alias` on each `ECSchemaReference` | none (no alias in JSON) |
+| Items | one element per kind, order positional | `items` object keyed by name |
+| Relationship `strength` / `strengthDirection` | optional, default `referencing` / `forward` | **required** |
+| Unbounded array `maxOccurs` | `"unbounded"` | `2147483647` |
+| Standalone single item | not supported | SchemaItem JSON |
+
+## Version Notes
+
+ECSchema JSON tracks the EC information model the same way [ECSchema XML](./ec-schema-xml.md#version-notes) does. For current schemas, prefer the 3.2 form. The `$schema` URL's version segment identifies the spec version; readers parse it to select the matching rules.

--- a/docs/bis/ec/ec-schema-json.md
+++ b/docs/bis/ec/ec-schema-json.md
@@ -9,7 +9,7 @@ This page documents the ECSchema JSON 3.2 shape used by current iTwin schemas. T
 JSON supports two related shapes:
 
 - **ECSchema JSON** - the whole schema in one object, with its items in a name-keyed `items` object. This is the JSON analogue of an ECSchema XML document.
-- **SchemaItem JSON** - a single schema item (one class, enumeration, KindOfQuantity, etc.) described on its own, outside its schema. Used to move a single item compactly (for example over the wire) without serializing the whole schema. A SchemaItem JSON object is identical to the in-schema item object, plus four locating properties (`$schema`, `schema`, `schemaVersion`, `name`) that identify the schema it came from. It does not redefine or change the item.
+- **SchemaItem JSON** - a single schema item (one class, enumeration, KindOfQuantity, etc.) described on its own, outside its schema. Used to move a single item compactly (for example over the wire) without serializing the whole schema. A SchemaItem JSON object is identical to the in-schema item object, plus three locating properties (`$schema`, `schema`, `name`) and an optional `schemaVersion` that identify the schema it came from. It does not redefine or change the item.
 
 ## `$schema` and Version
 

--- a/docs/bis/ec/ec-schema-json.md
+++ b/docs/bis/ec/ec-schema-json.md
@@ -300,3 +300,8 @@ The two formats describe the same model; the shape differs. Summary (see [ECSche
 ## Version Notes
 
 ECSchema JSON tracks the EC information model the same way [ECSchema XML](./ec-schema-xml.md#version-notes) does. For current schemas, prefer the 3.2 form. The `$schema` URL's version segment identifies the spec version; readers parse it to select the matching rules.
+
+## See also
+
+- [ECSchema XML](./ec-schema-xml.md) - the XML representation of the same EC model.
+- [SchemaView](../../learning/metadata/SchemaView.md) and its [binary format](../../learning/metadata/SchemaViewBinaryFormat.md) - a separate, **lossy runtime** representation used by `@itwin/ecschema-metadata` for fast in-memory access. Unlike ECSchema XML and JSON, it is an iTwin.js implementation format, not an EC interchange format: it drops units, formats, and custom attribute instances and is versioned independently of the EC spec.

--- a/docs/bis/ec/ec-schema-json.md
+++ b/docs/bis/ec/ec-schema-json.md
@@ -39,7 +39,7 @@ The root object holds schema-level metadata, references, custom attributes, and 
 | --- | --- | --- | --- |
 | `$schema` | Yes | string | JSON Schema URL identifying the spec version. |
 | `name` | Yes | string | Schema name and namespace for its items. Must be an [ECName](./ec-name.md). |
-| `version` | Yes | string | Schema version in `RR.ww.mm` form. |
+| `version` | Yes | string | Schema version in `RR.WW.mm` form. |
 | `alias` | Yes | string | Short alias for the schema. |
 | `label` | No | string | Localizable display label. |
 | `description` | No | string | Localizable description. |

--- a/docs/bis/ec/ec-schema-json.md
+++ b/docs/bis/ec/ec-schema-json.md
@@ -1,6 +1,6 @@
 # ECSchema JSON
 
-ECSchema JSON is the JSON representation of an [ECSchema](./ec-schema.md). Like [ECSchema XML](./ec-schema-xml.md), it is a persistent interchange format for EC metadata: schemas, classes, properties, relationships, custom attributes, enumerations, quantities, units, and formats. The two formats describe the same EC information model; this page is the JSON counterpart to [ECSchema XML](./ec-schema-xml.md) and links back to it where the two diverge.
+ECSchema JSON is the JSON representation of an [ECSchema](./ec-schema.md). Like [ECSchema XML](./ec-schema-xml.md), it is a persistent interchange format for EC metadata: schemas, classes, properties, relationships, custom attributes, enumerations, quantities, units, and formats. The two formats describe the same EC information model; this page is the JSON counterpart to [ECSchema XML](./ec-schema-xml.md) and cross-references it where the two diverge.
 
 This page documents the ECSchema JSON 3.2 shape used by current iTwin schemas. The semantic rules for each EC item are documented on the linked EC pages and enforced by EC schema validation; this page covers the JSON document shape only.
 
@@ -59,7 +59,7 @@ Schema items are properties of an `items` object, keyed by item name:
 }
 ```
 
-The key is the item name, so an in-schema item object omits the `name`, `schema`, and `schemaVersion` properties (those are implied by the key and the enclosing schema). Item names must be unique across all item kinds in a schema - an entity class and an enumeration cannot share a name. This differs from XML, where each item is an element of a specific kind and ordering is positional; in JSON the items are object members. (See [ECName](./ec-name.md) for naming and uniqueness rules.)
+The key is the item name, so an in-schema item object omits the `$schema`, `name`, `schema`, and `schemaVersion` properties (those are implied by the enclosing document, the key, and the schema). Item names must be unique across all item kinds in a schema - an entity class and an enumeration cannot share a name. This differs from XML, where each item is an element of a specific kind and ordering is positional; in JSON the items are object members. (See [ECName](./ec-name.md) for naming and uniqueness rules.)
 
 ## Schema References
 
@@ -102,7 +102,7 @@ Common class properties:
 
 | Property | Required | JSON type | Description |
 | --- | --- | --- | --- |
-| `modifier` | No | string | `none` (default), `abstract`, or `sealed`. |
+| `modifier` | No | string | `None` (default), `Abstract`, or `Sealed`. Values are serialized in this casing; parsers accept casing variations. |
 | `baseClass` | No | string | Full base class name `{schema}.{class}`. Relationship classes support at most one base class semantically. |
 | `properties` | No | array | Property objects (see [Properties](#properties)). |
 | `customAttributes` | No | array | Custom attribute instances applied to the class. |
@@ -112,7 +112,7 @@ Common class properties:
 ```json
 "Pump": {
   "schemaItemType": "EntityClass",
-  "modifier": "sealed",
+  "modifier": "Sealed",
   "label": "Pump",
   "baseClass": "BisCore.PhysicalElement",
   "mixins": ["Example.IServiceable"],
@@ -143,12 +143,12 @@ Common class properties:
 
 | Property | Required | JSON type | Description |
 | --- | --- | --- | --- |
-| `strength` | Yes | string | `referencing`, `holding`, or `embedding`. |
-| `strengthDirection` | Yes | string | `forward` or `backward`. |
+| `strength` | Yes | string | `Referencing`, `Holding`, or `Embedding`. |
+| `strengthDirection` | Yes | string | `Forward` or `Backward`. |
 | `source` | Yes | object | Source constraint (see below). |
 | `target` | Yes | object | Target constraint (see below). |
 
-> `strength` and `strengthDirection` are **required in JSON** (the deserializer rejects an object that omits them). This differs from [ECSchema XML](./ec-schema-xml.md#relationship-classes), where both are optional and default to `referencing` / `forward`.
+> `strength` and `strengthDirection` are **required in JSON** (the deserializer rejects an object that omits them). This differs from [ECSchema XML](./ec-schema-xml.md#relationship-classes), where both are optional and default to `Referencing` / `Forward`. Like the other enumerated values, they are serialized in the casing shown but parsed case-insensitively.
 
 `source` and `target` constraint objects:
 
@@ -164,9 +164,9 @@ Common class properties:
 ```json
 "PumpFeedsTank": {
   "schemaItemType": "RelationshipClass",
-  "modifier": "sealed",
-  "strength": "referencing",
-  "strengthDirection": "forward",
+  "modifier": "Sealed",
+  "strength": "Referencing",
+  "strengthDirection": "Forward",
   "source": {
     "multiplicity": "(0..*)", "roleLabel": "feeds", "polymorphic": true,
     "constraintClasses": ["Example.Pump"]
@@ -205,12 +205,12 @@ Per-kind additions:
 | `StructProperty` | `typeName` (full struct class name) | |
 | `PrimitiveArrayProperty` | `typeName`, `extendedTypeName`, value/length bounds, `minOccurs`/`maxOccurs` | enum-backed arrays use this kind with an enumeration `typeName`. |
 | `StructArrayProperty` | `typeName` (full struct class name), `minOccurs`/`maxOccurs` | |
-| `NavigationProperty` | `relationshipName` (full relationship name), `direction` (`forward`/`backward`) | |
+| `NavigationProperty` | `relationshipName` (full relationship name), `direction` (`Forward`/`Backward`) | |
 
 ```json
 { "type": "StructProperty", "name": "Address", "typeName": "Example.PostalAddress" }
 { "type": "PrimitiveArrayProperty", "name": "Tags", "typeName": "string", "minOccurs": 0, "maxOccurs": 2147483647 }
-{ "type": "NavigationProperty", "name": "Tank", "relationshipName": "Example.PumpFeedsTank", "direction": "forward" }
+{ "type": "NavigationProperty", "name": "Tank", "relationshipName": "Example.PumpFeedsTank", "direction": "Forward" }
 ```
 
 > Unbounded arrays serialize `maxOccurs` as the integer `2147483647` in JSON, where XML uses the string `"unbounded"`.
@@ -252,7 +252,7 @@ ECSchema JSON 3.2 includes units and formats as schema items. See [KindOfQuantit
 }
 ```
 
-- **KindOfQuantity**: `persistenceUnit` (required, full unit name), `relativeError` (required, number), `presentationUnits` (optional; an array of format strings, or a single `;`-separated string). The first presentation format is the default. See [KindOfQuantity format overrides](./kindofquantity.md) for the override grammar.
+- **KindOfQuantity**: `persistenceUnit` (required, full unit name), `relativeError` (required, number), `presentationUnits` (optional; an array of format strings, or a single `;`-separated string). The first presentation format is the default. See [KindOfQuantity format overrides](./kindofquantity.md#format-overrides) for the override grammar.
 - **Unit**: `phenomenon`, `unitSystem`, `definition` (all required); `numerator`, `denominator`, `offset` (optional).
 - **InvertedUnit**: `invertsUnit`, `unitSystem` (both required).
 - **Constant**: `phenomenon`, `definition` (required); `numerator`, `denominator` (optional).
@@ -276,7 +276,7 @@ A container may carry multiple custom attributes, but only one instance of a giv
 
 The JSON Schema for ECSchema JSON validates document shape: allowed properties, value types, and simple patterns. It does not express every semantic EC rule; semantic rules (relationship constraint compatibility, reference resolution, property override compatibility, custom attribute applicability) are covered by [EC Schema Validation](./ec-schema-validation.md).
 
-The 3.2 JSON Schema files live in the BIS schemas repository under `System/json_schema/ec32/`.
+The 3.2 JSON Schema files live in the BIS schemas repository at [System/json_schema/ec32/](https://github.com/iTwin/bis-schemas/tree/master/System/json_schema/ec32/). The `$schema` URL (`https://dev.bentley.com/json_schemas/...`) is a formal identifier for the spec version, not a live HTTP validation endpoint - the canonical schema files are the ones in the BIS schemas repository.
 
 ## Differences from ECSchema XML
 
@@ -285,17 +285,30 @@ The two formats describe the same model; the shape differs. Summary (see [ECSche
 | Aspect | ECSchema XML | ECSchema JSON |
 | --- | --- | --- |
 | Spec/version marker | `xmlns` namespace | `$schema` URL |
+| Schema name | `schemaName` attribute | `name` |
 | Item name | `typeName` attribute | object key (or `name` in SchemaItem JSON) |
+| Property name | `propertyName` attribute | `name` |
 | Label / description | `displayLabel` / `description` | `label` / `description` |
 | Enumeration backing type | `backingTypeName` | `type` |
 | Read-only flag | `readOnly` | `isReadOnly` |
-| Constraint polymorphic flag | `polymorphic` | `polymorphic` |
+| Mixin representation | `ECEntityClass` element + `IsMixin` custom attribute (`AppliesToEntityClass`) | dedicated `Mixin` `schemaItemType` with top-level `appliesTo` |
+| Constraint polymorphic flag | `polymorphic` string attribute (casing-tolerant) | `polymorphic` JSON boolean |
 | Cross-references | alias-qualified, `bis:Class`, `:` separator | full schema name, `BisCore.Class`, `.` separator |
 | Reference alias | required `alias` on each `ECSchemaReference` | none (no alias in JSON) |
 | Items | one element per kind, order positional | `items` object keyed by name |
-| Relationship `strength` / `strengthDirection` | optional, default `referencing` / `forward` | **required** |
+| Relationship `strength` / `strengthDirection` | optional, default `Referencing` / `Forward` | **required** |
 | Unbounded array `maxOccurs` | `"unbounded"` | `2147483647` |
 | Standalone single item | not supported | SchemaItem JSON |
+
+## Obtaining ECSchema JSON
+
+This page documents the shape of the JSON; the JSON itself is produced from an in-memory `Schema`. Standard schemas (`BisCore`, etc.) are distributed with iTwin.js as ECSchema XML and are loaded into a `SchemaContext` at runtime; the same JSON shape applies regardless of how a schema was originally authored.
+
+- **From an iModel.** On the backend, `IModelDb.schemaContext` (`@itwin/core-backend`) resolves a schema by name into a `Schema` object. Calling `Schema.toJSON()` (`@itwin/ecschema-metadata`) returns the `SchemaProps` object documented here.
+- **From files.** `@itwin/ecschema-locaters` provides locaters - `SchemaJsonFileLocater` for `.ecschema.json` and `SchemaXmlFileLocater` for `.ecschema.xml` - that you register on a `SchemaContext` to load schemas from disk. Once loaded, `Schema.toJSON()` serializes to JSON regardless of the source format.
+- **A single item.** `SchemaItem.toJSON(true)` serializes one item as a standalone **SchemaItem JSON** object; pass `SchemaItem.toJSON(true, true)` to also include `schemaVersion`.
+
+For fast read-only access that does not require full-fidelity JSON, prefer [SchemaView](../../learning/metadata/SchemaView.md) (see [See also](#see-also)).
 
 ## Version Notes
 
@@ -304,4 +317,5 @@ ECSchema JSON tracks the EC information model the same way [ECSchema XML](./ec-s
 ## See also
 
 - [ECSchema XML](./ec-schema-xml.md) - the XML representation of the same EC model.
+- `SchemaContext` (`@itwin/ecschema-metadata`) - the API-layer entry point for loading, authoring, validating, and serializing ECSchema JSON at full fidelity.
 - [SchemaView](../../learning/metadata/SchemaView.md) and its [binary format](../../learning/metadata/SchemaViewBinaryFormat.md) - a separate, **lossy runtime** representation used by `@itwin/ecschema-metadata` for fast in-memory access. Unlike ECSchema XML and JSON, it is an iTwin.js implementation format, not an EC interchange format: it drops units, formats, and custom attribute instances and is versioned independently of the EC spec.

--- a/docs/bis/ec/ec-schema-xml.md
+++ b/docs/bis/ec/ec-schema-xml.md
@@ -6,6 +6,8 @@ ECXML historically covered both metadata and instance data. Current iTwin schema
 
 This page documents the ECSchema XML 3.2 shape used by current iTwin schemas. The XML format describes the persisted schema document. The semantic rules for each EC item are documented on the linked EC pages and enforced by EC schema validation.
 
+[ECSchema JSON](./ec-schema-json.md) is the JSON representation of the same model; see its [Differences from ECSchema XML](./ec-schema-json.md#differences-from-ecschema-xml) section for how the two shapes diverge (alias-qualified vs full-name references, `typeName`/`displayLabel` vs `name`/`label`, element ordering vs the `items` object, and a few required/optional differences).
+
 ## Namespace and Version
 
 An ECSchema XML document has an `ECSchema` root element in an ECXML namespace.

--- a/docs/bis/ec/ec-schema-xml.md
+++ b/docs/bis/ec/ec-schema-xml.md
@@ -299,3 +299,8 @@ ECXML has evolved with ECObjects:
 | 3.2 | Adds units, constants, phenomena, unit systems, formats, and ECEnumerator names as first-class schema XML concepts. |
 
 For current schemas, prefer ECXML 3.2 unless a repository or product explicitly requires an older format.
+
+## See also
+
+- [ECSchema JSON](./ec-schema-json.md) - the JSON representation of the same EC model.
+- [SchemaView](../../learning/metadata/SchemaView.md) and its [binary format](../../learning/metadata/SchemaViewBinaryFormat.md) - a separate, **lossy runtime** representation used by `@itwin/ecschema-metadata` for fast in-memory access. Unlike ECSchema XML and JSON, it is an iTwin.js implementation format, not an EC interchange format: it drops units, formats, and custom attribute instances and is versioned independently of the EC spec.

--- a/docs/bis/ec/ec-schema.md
+++ b/docs/bis/ec/ec-schema.md
@@ -2,7 +2,7 @@
 
 An ECSchema is the root container of all other ECObject items and provides the namespace for every item it contains. A schema may be referenced by another schema but may not be embedded within another schema. Therefore, namespaces in ECObjects do not have a hierarchy.
 
-For the XML representation of an ECSchema document, see [ECSchema XML](./ec-schema-xml.md).
+For the XML representation of an ECSchema document, see [ECSchema XML](./ec-schema-xml.md). For the JSON representation, see [ECSchema JSON](./ec-schema-json.md).
 
 ## Attributes
 

--- a/docs/bis/ec/index.md
+++ b/docs/bis/ec/index.md
@@ -8,6 +8,8 @@ The root of any domain is an *ECSchema* itself.
 
 - **[ECSchema XML](./ec-schema-xml.md)** is the XML representation used to persist and interchange ECSchema metadata.
 
+- **[ECSchema JSON](./ec-schema-json.md)** is the JSON representation of the same metadata, including the standalone SchemaItem JSON form.
+
 ECSchemas cannot contain other ECSchemas but they can reference ECSchemas:
 
 - **ECSchemaReference** is a member of an ECSchema that expresses a reference another ECSchema. ECSchemaReferences are necessary when an ECSchema contains items that depend on the referenced ECSchema in some way (e.g., its ECClasses subclass from ECClasses in the referenced ECSchema.)

--- a/docs/bis/leftNav.md
+++ b/docs/bis/leftNav.md
@@ -135,6 +135,7 @@ defaultState: activeOpen
 - [Overview](./ec/index.md)
 - [ECSchema](./ec/ec-schema.md)
 - [ECSchema XML](./ec/ec-schema-xml.md)
+- [ECSchema JSON](./ec/ec-schema-json.md)
 - [EC Schema Validation](./ec/ec-schema-validation.md)
 - [ECClass](./ec/ec-class.md)
 - [ECEntityClass](./ec/ec-entity-class.md)

--- a/docs/learning/metadata/SchemaView.md
+++ b/docs/learning/metadata/SchemaView.md
@@ -6,6 +6,8 @@ It lives in `@itwin/ecschema-metadata` and should be the first choice for access
 
 For the binary transport format specification, see [SchemaViewBinaryFormat.md](./SchemaViewBinaryFormat.md).
 
+`SchemaView` is a **lossy runtime** projection - it omits units, formats, and custom attribute instances. For the full, authoritative EC schema model and its interchange formats, see [ECSchema XML](../../bis/ec/ec-schema-xml.md) and [ECSchema JSON](../../bis/ec/ec-schema-json.md).
+
 ## When to use SchemaView
 
 Use `SchemaView` when you need fast, synchronous, repeated lookups at runtime:

--- a/docs/learning/metadata/SchemaViewBinaryFormat.md
+++ b/docs/learning/metadata/SchemaViewBinaryFormat.md
@@ -2,6 +2,8 @@
 
 This document specifies the binary blob format produced by `SchemaViewWriter` (C++, imodel-native) and consumed by [SchemaView.fromBinary]($ecschema-metadata) (TypeScript, ecschema-metadata). It is the transport format for `SchemaView` - see [SchemaView](./SchemaView.md) for the consumer API.
 
+This is a **lossy runtime** format and an iTwin.js implementation detail, distinct from the EC schema interchange formats. For the full, authoritative EC schema model and its persistence formats, see [ECSchema XML](../../bis/ec/ec-schema-xml.md) and [ECSchema JSON](../../bis/ec/ec-schema-json.md); this format drops units, formats, and custom attribute instances and is versioned independently of the EC spec.
+
 All multi-byte integers are **little-endian**. String references (SRef) are uint32 indices into the string table at the end of the blob. A SRef of 0 always refers to the empty string.
 
 Foreign-key references to `ec_` table rows use uint32 row IDs. A value of 0 means "no reference" (ec_ IDs are 1-based). A value of 0xFFFFFFFF means "not specified" (used for optional array bounds).


### PR DESCRIPTION
Similar to what I recently did for XML, documented our current json format.
No guarantee it's 100% accurate, the fact that we had several implementations, and outdated spec repo and independent info in bis-schemas means things could have diverged. My goal is to have these spec documents be the reference source of truth.

@diegoalexdiaz @aruniverse 