### PR TITLE
ci: fix skipped required rush checks

### DIFF
--- a/.github/workflows/status-check-override.yaml
+++ b/.github/workflows/status-check-override.yaml
@@ -55,12 +55,14 @@ jobs:
     name: Detect If Skip
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       # Check for certain paths having been modified
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v45    # See https://github.com/marketplace/actions/changed-files
+        # tj-actions/changed-files v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96    # See https://github.com/marketplace/actions/changed-files
         with:
           files: |
             **/*.md
@@ -71,17 +73,39 @@ jobs:
             **/CHANGELOG.md
 
       # Fake required checks if neccessary
-      - uses: LouisBrunner/checks-action@v2.0.0   # See https://github.com/marketplace/actions/github-checks
+      # LouisBrunner/checks-action v3.1.0
+      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff   # See https://github.com/marketplace/actions/github-checks
         if: steps.changed-files-specific.outputs.only_modified == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: extract-api
+          name: rush check
+          conclusion: success
+
+      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff
+        if: steps.changed-files-specific.outputs.only_modified == 'true'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: rush change
+          conclusion: success
+
+      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff
+        if: steps.changed-files-specific.outputs.only_modified == 'true'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: rush audit
+          conclusion: success
+
+      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff
+        if: steps.changed-files-specific.outputs.only_modified == 'true'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: rush lint + extract-api
           conclusion: success
 
       # Add more status checks below if necessary
 
       # TEMPLATE
-      # - uses: LouisBrunner/checks-action@v1.3.0
+      # - uses: LouisBrunner/checks-action@<full-length-commit-sha>   # vX.Y.Z
       #   if: steps.changed-files-specific.outputs.only_modified == 'true'
       #   with:
       #     token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## TL;DR

Docs-only and changelog-only PRs get stuck waiting for required checks that never need reporting, because the skip workflow still fakes **only** the old `extract-api` status, when we also need the new GH Actions workflows introduced in https://github.com/iTwin/itwinjs-core/pull/9334 . This updates the skip workflow to post success for the four new required checks and pins the helper actions to full SHAs so the workflow is aligned with current branch protection and locked down.

## What

| Asset | Why it exists |
| --- | --- |
| `.github/workflows/status-check-override.yaml` (workflow) | Docs-only PRs were skipping the real CI jobs but not satisfying the new required check names, so this workflow now fakes `rush check`, `rush change`, `rush audit`, and `rush lint + extract-api` instead of the stale `extract-api` status. |
| `.github/workflows/status-check-override.yaml` (workflow action pins) | This workflow still used floating action tags, so the action references are now pinned to full commit SHAs to match the repo's supply-chain hardening pattern. |

## Validation

- Targeted verification: Compared the current `CI` workflow job names against the required checks shown on blocked PRs (for example, [#9362](https://github.com/iTwin/itwinjs-core/pull/9362)) and confirmed the skip workflow only emitted the legacy `extract-api` status.

---

*Nambot 🤖 (powered by gpt-5.4)*