### PR TITLE
Fix quantity formatter unit system lookups

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -8220,7 +8220,7 @@ export class QuantityTypeFormatsProvider implements FormatsProvider {
     [Symbol.dispose](): void;
     constructor();
     // (undocumented)
-    getFormat(name: string, _system?: UnitSystemKey): Promise<FormatDefinition | undefined>;
+    getFormat(name: string, system?: UnitSystemKey): Promise<FormatDefinition | undefined>;
     // (undocumented)
     onFormatsChanged: BeEvent<(args: FormatsChangedArgs) => void>;
 }

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -8137,7 +8137,9 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     getQuantityDefinition(type: QuantityTypeArg): QuantityTypeDefinition | undefined;
     getQuantityTypeKey(type: QuantityTypeArg): string;
     // @beta
-    getSpecsByName(name: string): ReadonlyMap<string, FormattingSpecEntry> | undefined;
+    getSpecsByName(name: string, options?: {
+        system?: UnitSystemKey;
+    }): ReadonlyMap<string, FormattingSpecEntry> | undefined;
     // @beta
     getSpecsByNameAndUnit(args: FormattingSpecArgs): FormattingSpecEntry | undefined;
     getUnitsByFamily(phenomenon: string): Promise<UnitProps[]>;

--- a/common/changes/@itwin/core-frontend/hl662-create-worktree_2026-06-08-12-00.json
+++ b/common/changes/@itwin/core-frontend/hl662-create-worktree_2026-06-08-12-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "QuantityTypeFormatsProvider.getFormat now honors the requested UnitSystemKey instead of always using the active system, and QuantityFormatter.getSpecsByName accepts an optional options argument to query a non-active unit system.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -342,11 +342,11 @@ export class QuantityTypeFormatsProvider implements FormatsProvider {
     ["AecUnits.LENGTH", QuantityType.LengthEngineering]
   ]);
 
-  public async getFormat(name: string, _system?: UnitSystemKey): Promise<FormatDefinition | undefined> {
+  public async getFormat(name: string, system?: UnitSystemKey): Promise<FormatDefinition | undefined> {
     const quantityType = this._kindOfQuantityMap.get(name);
     if (!quantityType) return undefined;
 
-    return IModelApp.quantityFormatter.getFormatPropsByQuantityType(quantityType);
+    return IModelApp.quantityFormatter.getFormatPropsByQuantityType(quantityType, system);
   }
 }
 
@@ -1347,14 +1347,17 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   /**
    * @beta
    * Returns a map of [[FormattingSpecEntry]] keyed by persistence unit for a given name, typically a KindOfQuantity full name.
+   * @param name - The KoQ name to look up.
+   * @param options - Optional lookup options. When `options.system` is omitted, the active unit system is used.
    */
-  public getSpecsByName(name: string): ReadonlyMap<string, FormattingSpecEntry> | undefined {
+  public getSpecsByName(name: string, options?: { system?: UnitSystemKey }): ReadonlyMap<string, FormattingSpecEntry> | undefined {
+    const effectiveSystem = options?.system ?? this._activeUnitSystem;
     const unitMap = this._formatSpecsRegistry.get(name);
     if (!unitMap) return undefined;
-    // Return active-system projection
+    // Return projection for the effective system
     const result = new Map<string, FormattingSpecEntry>();
     for (const [persistenceUnit, systemMap] of unitMap) {
-      const entry = systemMap.get(this._activeUnitSystem);
+      const entry = systemMap.get(effectiveSystem);
       if (entry) result.set(persistenceUnit, entry);
     }
     return result.size > 0 ? result : undefined;

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -636,6 +636,16 @@ describe("Quantity formatter", async () => {
 
     });
 
+    it("getFormat should honor the requested unit system (#9371)", async () => {
+      const provider = new QuantityTypeFormatsProvider();
+      const metricFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "metric");
+      const imperialFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "imperial");
+      expect(metricFormat).toBeDefined();
+      expect(imperialFormat).toBeDefined();
+      // Before the fix, the requested system was ignored and both returned the active-system format.
+      expect(metricFormat).not.toEqual(imperialFormat);
+    });
+
     it("should not leak listeners when formatsProvider is replaced multiple times", () => {
       const provider1 = new QuantityTypeFormatsProvider();
       const provider2 = new QuantityTypeFormatsProvider();
@@ -1090,6 +1100,24 @@ describe("Multi-system KoQ registry", () => {
     // Active system is "imperial", so should see both persistence units for imperial
     expect(nameMap!.has("Units.M")).toBe(true);
     expect(nameMap!.has("Units.FT")).toBe(true);
+  });
+
+  it("getSpecsByName returns the requested system projection (#9372)", async () => {
+    const qf = new QuantityFormatter();
+    await qf.onInitialized();
+    // qf active system defaults to "imperial".
+    await qf.addFormattingSpecsToRegistry({ name: "TestKoQ.LENGTH", persistenceUnitName: "Units.M", formatProps: simpleDecimalFormat, system: "metric" });
+    await qf.addFormattingSpecsToRegistry({ name: "TestKoQ.LENGTH", persistenceUnitName: "Units.FT", formatProps: simpleDecimalFormat, system: "imperial" });
+
+    // No options → active (imperial) projection: only the imperial-registered persistence unit.
+    const activeMap = qf.getSpecsByName("TestKoQ.LENGTH");
+    expect(activeMap?.has("Units.FT")).toBe(true);
+    expect(activeMap?.has("Units.M")).toBe(false);
+
+    // Explicit metric option → metric projection: only the metric-registered persistence unit.
+    const metricMap = qf.getSpecsByName("TestKoQ.LENGTH", { system: "metric" });
+    expect(metricMap?.has("Units.M")).toBe(true);
+    expect(metricMap?.has("Units.FT")).toBe(false);
   });
 
   it("getSpecsByNameAndUnit returns undefined for unregistered system", async () => {

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -636,7 +636,7 @@ describe("Quantity formatter", async () => {
 
     });
 
-    it("getFormat should honor the requested unit system (#9371)", async () => {
+    it("getFormat should honor the requested unit system", async () => {
       const provider = new QuantityTypeFormatsProvider();
       const metricFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "metric");
       const imperialFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "imperial");
@@ -1102,7 +1102,7 @@ describe("Multi-system KoQ registry", () => {
     expect(nameMap!.has("Units.FT")).toBe(true);
   });
 
-  it("getSpecsByName returns the requested system projection (#9372)", async () => {
+  it("getSpecsByName returns the requested system projection", async () => {
     const qf = new QuantityFormatter();
     await qf.onInitialized();
     // qf active system defaults to "imperial".


### PR DESCRIPTION
## TL;DR

Closes https://github.com/iTwin/itwinjs-core/issues/9372 and https://github.com/iTwin/itwinjs-core/issues/9371
Quantity formatting lookups accepted a target unit system in some paths but still fell back to the active system, which made metric/imperial lookups drift from the caller's request. The fix threads the requested unit system through the format provider and lets named-spec lookups project the registry for a specific system.

## What

| Asset | Why it exists |
| --- | --- |
| `QuantityTypeFormatsProvider.getFormat` | Callers could request a non-active unit system but still receive the active-system format, so the lookup now passes the requested system through to the formatter. |
| `QuantityFormatter.getSpecsByName` | Named spec lookup only returned the active-system projection, so the method now accepts an inline optional `system` option for non-active system queries. |
| `core-frontend.api.md` | The beta API signature changed, so the generated API report records the new optional lookup parameter. |

## Tests

<details>
<summary>New and updated test coverage</summary>

| Test | What it covers |
| --- | --- |
| `QuantityFormatter.test.ts` — `getFormat should honor the requested unit system` | Guards against `QuantityTypeFormatsProvider.getFormat` ignoring the requested unit system and returning the active-system format. |
| `QuantityFormatter.test.ts` — `getSpecsByName returns the requested system projection` | Guards against named-spec lookups returning the active-system registry projection when a specific system is requested. |

</details>

---

*Nambot 🤖 (powered by GPT-5.5)*