### PR TITLE
Fixed arc-line tangency intersection issue

### DIFF
--- a/common/changes/@itwin/core-geometry/saeed-torabi-fillet-line-intersection-bug_2026-06-08-17-45.json
+++ b/common/changes/@itwin/core-geometry/saeed-torabi-fillet-line-intersection-bug_2026-06-08-17-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "Fixed arc-line tangency intersection issue",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/curve/internalContexts/CurveCurveIntersectXY.ts
+++ b/core/geometry/src/curve/internalContexts/CurveCurveIntersectXY.ts
@@ -405,14 +405,14 @@ export class CurveCurveIntersectXY extends RecurseToCurvesGeometryHandler {
     const cosines = new GrowableFloat64Array(2);
     const sines = new GrowableFloat64Array(2);
     const radians = new GrowableFloat64Array(2);
-    // Arc: X = C + cU + sV
+    // Arc:  X(theta) = C + cos(theta)·U + sin(theta)·V
     // Line:  contains points A0,A1
-    // Arc point colinear with line if det (A0, A1, X) = 0
-    // with homogeneous xyw points and vectors.
-    // With equational X: det (A0, A1, C) + c det (A0, A1,U) + s det (A0, A1, V) = 0.
-    // solve for theta.
-    // evaluate points.
-    // project back to line.
+    // Arc point X is colinear (intersects) with line if det(A0, A1, X) = 0 with homogeneous xyw points and vectors
+    // This leads to
+    // det(A0, A1, C) + cos(theta) det(A0, A1, U) + sin(theta) det(A0, A1, V) = 0
+    // or
+    // alpha + beta cos(theta) + gamma sin(theta) = 0
+    // solve for theta; evaluate points; project back to line
     if (this._worldToLocalPerspective) {
       const data = arc.toTransformedPoint4d(this._worldToLocalPerspective);
       const radians0 = data.sweep.fractionToRadians(0);
@@ -424,7 +424,7 @@ export class CurveCurveIntersectXY extends RecurseToCurvesGeometryHandler {
       const alpha = Geometry.tripleProductPoint4dXYW(pointA0H, pointA1H, data.center);
       const beta = Geometry.tripleProductPoint4dXYW(pointA0H, pointA1H, data.vector0);
       const gamma = Geometry.tripleProductPoint4dXYW(pointA0H, pointA1H, data.vector90);
-      let numRoots = AnalyticRoots.appendImplicitLineUnitCircleIntersections(alpha, beta, gamma, cosines, sines, radians);
+      let numRoots = AnalyticRoots.appendImplicitLineUnitCircleIntersections(alpha, beta, gamma, cosines, sines, radians, tol2);
       const closeApproach = (0 === numRoots);
       if (closeApproach)
         numRoots = 1; // we returned the arc's closest approach as the first "root"; if within tolerance and at endpoints, we record it
@@ -464,7 +464,7 @@ export class CurveCurveIntersectXY extends RecurseToCurvesGeometryHandler {
       const alpha = Geometry.tripleProductXYW(pointA0Local, 1, pointA1Local, 1, data.center, 1);
       const beta = Geometry.tripleProductXYW(pointA0Local, 1, pointA1Local, 1, data.vector0, 0);
       const gamma = Geometry.tripleProductXYW(pointA0Local, 1, pointA1Local, 1, data.vector90, 0);
-      let numRoots = AnalyticRoots.appendImplicitLineUnitCircleIntersections(alpha, beta, gamma, cosines, sines, radians);
+      let numRoots = AnalyticRoots.appendImplicitLineUnitCircleIntersections(alpha, beta, gamma, cosines, sines, radians, tol2);
       const closeApproach = (0 === numRoots);
       if (closeApproach)
         numRoots = 1; // we returned the arc's closest approach as the first "root"; if within tolerance and at endpoints, we record it
@@ -1168,10 +1168,10 @@ export class CurveCurveIntersectXY extends RecurseToCurvesGeometryHandler {
     this.appendDiscreteCloseApproachResults(cpA, cpB, maxError, reversed); // seeds for finding tangent intersections
     this.refineSpiralResultsByNewton(curveA, spiralB, index0, reversed);
   }
-   /**
-   * Invoke dispatch on each child of `g` as "geometryA".
-   * * If `g` is a `Path` or `Loop`, adjust extension flags for geometryA accordingly.
-   */
+  /**
+  * Invoke dispatch on each child of `g` as "geometryA".
+  * * If `g` is a `Path` or `Loop`, adjust extension flags for geometryA accordingly.
+  */
   public override handleChildren(g: GeometryQuery): any {
     const children = g.children;
     if (!children)

--- a/core/geometry/src/geometry4d/Matrix4d.ts
+++ b/core/geometry/src/geometry4d/Matrix4d.ts
@@ -52,12 +52,12 @@ export class Matrix4d implements BeJSONFunctions {
       result._coffs[i] = this._coffs[i];
     return result;
   }
-  /** zero this matrix4d in place. */
+  /** Zero this matrix4d in place. */
   public setZero(): void {
     for (let i = 0; i < 16; i++)
       this._coffs[i] = 0;
   }
-  /** set to identity. */
+  /** Set to identity. */
   public setIdentity(): void {
     for (let i = 0; i < 16; i++)
       this._coffs[i] = 0;
@@ -69,14 +69,14 @@ export class Matrix4d implements BeJSONFunctions {
       && Math.abs(c) <= tol
       && Math.abs(d) <= tol;
   }
-  /** set to identity. */
+  /** Check if this matrix is identity. */
   public isIdentity(tol: number = 1.0e-10): boolean {
     return Matrix4d.is1000(this._coffs[0], this._coffs[1], this._coffs[2], this._coffs[3], tol)
       && Matrix4d.is1000(this._coffs[5], this._coffs[6], this._coffs[7], this._coffs[4], tol)
       && Matrix4d.is1000(this._coffs[10], this._coffs[11], this._coffs[8], this._coffs[9], tol)
       && Matrix4d.is1000(this._coffs[15], this._coffs[12], this._coffs[13], this._coffs[14], tol);
   }
-  /** create a Matrix4d filled with zeros. */
+  /** Create a Matrix4d filled with zeros. */
   public static createZero(result?: Matrix4d): Matrix4d {
     if (result) {
       result.setZero();
@@ -84,8 +84,14 @@ export class Matrix4d implements BeJSONFunctions {
     }
     return new Matrix4d(); // this is zero.
   }
-  /** create a Matrix4d with values supplied "across the rows" */
-  public static createRowValues(cxx: number, cxy: number, cxz: number, cxw: number, cyx: number, cyy: number, cyz: number, cyw: number, czx: number, czy: number, czz: number, czw: number, cwx: number, cwy: number, cwz: number, cww: number, result?: Matrix4d): Matrix4d {
+  /** Create a Matrix4d with values supplied "across the rows" */
+  public static createRowValues(
+    cxx: number, cxy: number, cxz: number, cxw: number,
+    cyx: number, cyy: number, cyz: number, cyw: number,
+    czx: number, czy: number, czz: number, czw: number,
+    cwx: number, cwy: number, cwz: number, cww: number,
+    result?: Matrix4d
+  ): Matrix4d {
     result = result ? result : new Matrix4d();
     result._coffs[0] = cxx;
     result._coffs[1] = cxy;
@@ -111,12 +117,14 @@ export class Matrix4d implements BeJSONFunctions {
       rowX.x, rowX.y, rowX.z, rowX.w,
       rowY.x, rowY.y, rowY.z, rowY.w,
       rowZ.x, rowZ.y, rowZ.z, rowZ.w,
-      rowW.x, rowW.y, rowW.z, rowW.w, result);
+      rowW.x, rowW.y, rowW.z, rowW.w,
+      result
+    );
   }
-  /** directly set columns from typical 3d data:
-   *
+  /**
+   * Directly set columns from typical 3d data:
    * * vectorX, vectorY, vectorZ as columns 0,1,2, with weight0.
-   * * origin as column3, with weight 1
+   * * origin as column3, with weight 1.
    */
   public setOriginAndVectors(origin: XYZ, vectorX: Vector3d, vectorY: Vector3d, vectorZ: Vector3d) {
     this._coffs[0] = vectorX.x;
@@ -136,13 +144,13 @@ export class Matrix4d implements BeJSONFunctions {
     this._coffs[14] = 0.0;
     this._coffs[15] = 1.0;
   }
-  /** promote a transform to full Matrix4d (with 0001 in final row) */
+  /** Promote a transform to full Matrix4d (with 0001 in final row) */
   public static createTransform(source: Transform, result?: Matrix4d): Matrix4d {
     const matrix = source.matrix;
     const point = source.origin;
     return Matrix4d.createRowValues(matrix.coffs[0], matrix.coffs[1], matrix.coffs[2], point.x, matrix.coffs[3], matrix.coffs[4], matrix.coffs[5], point.y, matrix.coffs[6], matrix.coffs[7], matrix.coffs[8], point.z, 0, 0, 0, 1, result);
   }
-  /** return an identity matrix. */
+  /** Return an identity matrix. */
   public static createIdentity(result?: Matrix4d): Matrix4d {
     result = Matrix4d.createZero(result);
     result._coffs[0] = 1.0;
@@ -151,7 +159,7 @@ export class Matrix4d implements BeJSONFunctions {
     result._coffs[15] = 1.0;
     return result;
   }
-  /** return matrix with translation directly inserted (along with 1 on diagonal) */
+  /** Return matrix with translation directly inserted (along with 1 on diagonal) */
   public static createTranslationXYZ(x: number, y: number, z: number, result?: Matrix4d): Matrix4d {
     result = Matrix4d.createZero(result);
     result._coffs[0] = 1.0;
@@ -163,8 +171,7 @@ export class Matrix4d implements BeJSONFunctions {
     result._coffs[11] = z;
     return result;
   }
-
-  /** return this matrix plus scale times matrixB. */
+  /** Return this matrix plus scale times matrixB. */
   public plusScaled(matrixB: Matrix4d, scale: number, result?: Matrix4d): Matrix4d {
     // If result is undefined, a real clone is created.
     // If result is "this" we get the pointer to this right back.
@@ -175,7 +182,6 @@ export class Matrix4d implements BeJSONFunctions {
       result._coffs[i] += scale * matrixB._coffs[i];
     return result;
   }
-
   /**
    * Create a Matrix4d with translation and scaling values directly inserted (along with 1 as final diagonal entry)
    * @param tx x entry for translation column
@@ -184,7 +190,7 @@ export class Matrix4d implements BeJSONFunctions {
    * @param scaleX x diagonal entry
    * @param scaleY y diagonal entry
    * @param scaleZ z diagonal entry
-   * @param result optional result.
+   * @param result optional result
    */
   public static createTranslationAndScaleXYZ(tx: number, ty: number, tz: number, scaleX: number, scaleY: number, scaleZ: number, result?: Matrix4d): Matrix4d {
     return Matrix4d.createRowValues(scaleX, 0, 0, tx, 0, scaleY, 0, ty, 0, 0, scaleZ, tz, 0, 0, 0, 1, result);
@@ -575,7 +581,7 @@ export class Matrix4d implements BeJSONFunctions {
       return;
     let iA = rowIndexA * 4 + firstColumnIndex;
     let iB = rowIndexB * 4 + firstColumnIndex;
-    for (let i = firstColumnIndex; i < 4; i++ , iA++ , iB++)
+    for (let i = firstColumnIndex; i < 4; i++, iA++, iB++)
       this._coffs[iB] += scale * this._coffs[iA];
   }
   /** Return the determinant of the matrix. */
@@ -765,7 +771,7 @@ export class Matrix4d implements BeJSONFunctions {
    * @param ay y part of translation.
    * @param az z part of translation.
    */
-  public multiplyTranslationSandwichInPlace(ax: number, ay: number, az: number) : void {
+  public multiplyTranslationSandwichInPlace(ax: number, ay: number, az: number): void {
     const bx = this._coffs[3];
     const by = this._coffs[7];
     const bz = this._coffs[11];

--- a/core/geometry/src/numerics/Polynomials.ts
+++ b/core/geometry/src/numerics/Polynomials.ts
@@ -1041,7 +1041,7 @@ export class AnalyticRoots {
     if (delta2 <= 0.0) {
       solutionType = (alpha === 0) ? -2 : -1;
     } else {
-      const lambda = - alpha / delta2;
+      const lambda = -alpha / delta2;
       const a2 = alpha2 / delta2;
       const D2 = 1.0 - a2;
       if (D2 < -twoTol) {

--- a/core/geometry/src/test/curve/CurveCurveIntersectXY.test.ts
+++ b/core/geometry/src/test/curve/CurveCurveIntersectXY.test.ts
@@ -2862,4 +2862,52 @@ describe("CurveCurveIntersectXY", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectionXY", "BSplineIntersection");
     expect(ck.getNumErrors()).toBe(0);
   });
+
+  it("FilletLineIntersection", () => {
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    const lineSegment0 = LineString3d.create(
+      Point3d.create(207109.26432514057, 503380.8318704772, 0),
+      Point3d.create(207158.75937608397, 503380.8318704772, 0)
+    );
+    const lineSegment1 = LineString3d.create(
+      Point3d.create(207158.75937608397, 503380.8318704772, 0),
+      Point3d.create(207158.75937608397, 503346.97388452647, 0)
+    );
+    const fillet = Arc3d.create(
+      Point3d.create(207148.09137608396, 503370.1638704772, 0),
+      Vector3d.create(10.668000000000001, 0, 0),
+      Vector3d.create(0, 10.668000000000001, 0),
+      AngleSweep.createStartEndDegrees(0, 90)
+    );
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, lineSegment0);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, lineSegment1);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, fillet);
+
+    const worldToLocal = Matrix4d.createRowValues(
+      1, 0, 0, -207109.26432514057,
+      0, 1, 0, -503380.8318704772,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    );
+
+    const testFilletLineIntersection = (lineSegment: LineString3d, expectedPoint: Point3d, noIntersections: number) => {
+      const intersections = CurveCurve.intersectionProjectedXYPairs(worldToLocal, lineSegment, true, fillet, true);
+      if (ck.testExactNumber(noIntersections, intersections.length, "Expected one intersection between the fillet and line")) {
+        const intersection = intersections[0].detailA.point;
+        if (ck.testPoint3d(intersection, intersections[0].detailB.point, "report same intersection point on both fillet and line")) {
+          GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, intersection, 1);
+          if (expectedPoint)
+            ck.testPoint3d(expectedPoint, intersection, "expected intersection point");
+        }
+      }
+    };
+
+    testFilletLineIntersection(lineSegment0, Point3d.create(207148.09137608396, 503380.8318704772), 1);
+    testFilletLineIntersection(lineSegment1, Point3d.create(207158.75937608397, 503370.1638704772), 1);
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "CurveCurveIntersectionXY", "FilletLineIntersection");
+    expect(ck.getNumErrors()).toBe(0);
+  });
 });

--- a/core/geometry/src/test/curve/CurveCurveIntersectXY.test.ts
+++ b/core/geometry/src/test/curve/CurveCurveIntersectXY.test.ts
@@ -2892,14 +2892,13 @@ describe("CurveCurveIntersectXY", () => {
       0, 0, 0, 1
     );
 
-    const testFilletLineIntersection = (lineSegment: LineString3d, expectedPoint: Point3d, noIntersections: number) => {
+    const testFilletLineIntersection = (lineSegment: LineString3d, expectedPoint: Point3d, expectedNumIntersections: number) => {
       const intersections = CurveCurve.intersectionProjectedXYPairs(worldToLocal, lineSegment, true, fillet, true);
-      if (ck.testExactNumber(noIntersections, intersections.length, "Expected one intersection between the fillet and line")) {
+      if (ck.testExactNumber(expectedNumIntersections, intersections.length, "computed expected number of intersections between the fillet and line")) {
         const intersection = intersections[0].detailA.point;
         if (ck.testPoint3d(intersection, intersections[0].detailB.point, "report same intersection point on both fillet and line")) {
           GeometryCoreTestIO.createAndCaptureXYCircle(allGeometry, intersection, 1);
-          if (expectedPoint)
-            ck.testPoint3d(expectedPoint, intersection, "expected intersection point");
+          ck.testPoint3d(expectedPoint, intersection, "expected intersection point");
         }
       }
     };


### PR DESCRIPTION
The default `CurveCurveIntersectXY` tol (1e-12) was not used in the line-arc intersection code. Instead a smaller tol (1e-14) of `AnalyticRoots.appendImplicitLineUnitCircleIntersections` was used leading the code to not find the root. 

When I passed `CurveCurveIntersectXY` tol to `AnalyticRoots.appendImplicitLineUnitCircleIntersections` it was able to find the root.
