### PR TITLE
Add new config to DPTA 

### DIFF
--- a/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
@@ -180,10 +180,10 @@ export interface TestConfigProps {
    * Logged exceptions will include the string "DPTA_EXCEPTION" for easy grepping.
    */
   onException?: "terminate";
-  /** An optional string appended to the generated file name for this test, useful for distinguishing tests
+  /** An optional string that replaces iModelName in the generated file name for this test, useful for distinguishing tests
    * that would otherwise produce the same name (e.g. same iModel/view but different frontendTilesUrlTemplate).
    */
-  extraLabel?: string;
+  iModelNameAlias?: string;
 }
 
 export const defaultHilite = new Hilite.Settings();
@@ -230,7 +230,7 @@ export class TestConfig {
   public readonly backgroundMap?: BackgroundMapProps;
   public readonly hyperModeling?: HyperModelingProps;
   public readonly onException?: "terminate";
-  public readonly extraLabel?: string;
+  public readonly iModelNameAlias?: string;
 
   /** Construct a new TestConfig with properties initialized by following priority:
    *  As defined by `props`; or
@@ -258,7 +258,7 @@ export class TestConfig {
     this.hyperModeling = props.hyperModeling ?? prevConfig?.hyperModeling;
     this.useDisjointTimer = props.useDisjointTimer ?? prevConfig?.useDisjointTimer ?? true;
     this.onException = props.onException ?? prevConfig?.onException;
-    this.extraLabel = props.extraLabel ?? prevConfig?.extraLabel;
+    this.iModelNameAlias = props.iModelNameAlias ?? prevConfig?.iModelNameAlias;
     this.frontendTilesUrlTemplate = props.frontendTilesUrlTemplate ?? prevConfig?.frontendTilesUrlTemplate;
     this.frontendTilesNopFallback = props.frontendTilesNopFallback ?? prevConfig?.frontendTilesNopFallback;
 

--- a/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
@@ -180,6 +180,10 @@ export interface TestConfigProps {
    * Logged exceptions will include the string "DPTA_EXCEPTION" for easy grepping.
    */
   onException?: "terminate";
+  /** An optional string appended to the generated file name for this test, useful for distinguishing tests
+   * that would otherwise produce the same name (e.g. same iModel/view but different frontendTilesUrlTemplate).
+   */
+  extraLabel?: string;
 }
 
 export const defaultHilite = new Hilite.Settings();
@@ -253,6 +257,8 @@ export class TestConfig {
     this.hyperModeling = props.hyperModeling ?? prevConfig?.hyperModeling;
     this.useDisjointTimer = props.useDisjointTimer ?? prevConfig?.useDisjointTimer ?? true;
     this.onException = props.onException ?? prevConfig?.onException;
+    this.extraLabel = props.extraLabel ?? prevConfig?.extraLabel;
+    this.iModelNameAlias = props.iModelNameAlias ?? prevConfig?.iModelNameAlias;
     this.frontendTilesUrlTemplate = props.frontendTilesUrlTemplate ?? prevConfig?.frontendTilesUrlTemplate;
     this.frontendTilesNopFallback = props.frontendTilesNopFallback ?? prevConfig?.frontendTilesNopFallback;
 

--- a/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
@@ -230,6 +230,7 @@ export class TestConfig {
   public readonly backgroundMap?: BackgroundMapProps;
   public readonly hyperModeling?: HyperModelingProps;
   public readonly onException?: "terminate";
+  public readonly extraLabel?: string;
 
   /** Construct a new TestConfig with properties initialized by following priority:
    *  As defined by `props`; or

--- a/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestConfig.ts
@@ -259,7 +259,6 @@ export class TestConfig {
     this.useDisjointTimer = props.useDisjointTimer ?? prevConfig?.useDisjointTimer ?? true;
     this.onException = props.onException ?? prevConfig?.onException;
     this.extraLabel = props.extraLabel ?? prevConfig?.extraLabel;
-    this.iModelNameAlias = props.iModelNameAlias ?? prevConfig?.iModelNameAlias;
     this.frontendTilesUrlTemplate = props.frontendTilesUrlTemplate ?? prevConfig?.frontendTilesUrlTemplate;
     this.frontendTilesNopFallback = props.frontendTilesNopFallback ?? prevConfig?.frontendTilesNopFallback;
 

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -826,10 +826,12 @@ export class TestRunner {
     let testName = prefix ?? "";
     const configs = this.curConfig;
 
-    testName += configs.iModelName.replace(/\.[^/.]+$/, "");
+    if (configs.iModelNameAlias)
+      testName += configs.iModelNameAlias.replace(/\.[^/.]+$/, "");
+    else
+      testName += configs.iModelName.replace(/\.[^/.]+$/, "");
     testName += `_${configs.viewName}`;
     testName += configs.displayStyle ? `_${configs.displayStyle.trim()}` : "";
-    testName += configs.extraLabel ? `_${configs.extraLabel.trim()}` : "";
     testName = testName.replace(/[/\\?%*:|"<>]/g, "-");
 
     const renderMode = getRenderMode(test.viewport);

--- a/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
+++ b/test-apps/display-performance-test-app/src/frontend/TestRunner.ts
@@ -829,6 +829,7 @@ export class TestRunner {
     testName += configs.iModelName.replace(/\.[^/.]+$/, "");
     testName += `_${configs.viewName}`;
     testName += configs.displayStyle ? `_${configs.displayStyle.trim()}` : "";
+    testName += configs.extraLabel ? `_${configs.extraLabel.trim()}` : "";
     testName = testName.replace(/[/\\?%*:|"<>]/g, "-");
 
     const renderMode = getRenderMode(test.viewport);


### PR DESCRIPTION
Add new optional DPTA config "iModelNameAlias" that replaces iModelName in the generated file name for this test, useful for distinguishing tests that would otherwise produce the same name (e.g. same iModel/view but different frontendTilesUrlTemplate).