### PR TITLE
Security Fix: Fix rush lint + extract-api CI failure by updating core-frontend API report

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -5847,6 +5847,8 @@ export class LookAndMoveTool extends ViewManip {
     // (undocumented)
     protected get isExitAllowedOnReinitialize(): boolean;
     // (undocumented)
+    onPostInstall(): Promise<void>;
+    // (undocumented)
     protected provideInitialToolAssistance(): void;
     // (undocumented)
     provideToolAssistance(mainInstrKey: string): void;

--- a/common/changes/@itwin/core-frontend/jason-crow-navigation-tool-focus-keys_2026-06-09-12-20.json
+++ b/common/changes/@itwin/core-frontend/jason-crow-navigation-tool-focus-keys_2026-06-09-12-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Allow Walk, LookAndMove, and Fly tools to handle keyboard navigation while focus remains on non-editable UI.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend",
+  "email": "25822334+jason-crow@users.noreply.github.com"
+}

--- a/common/changes/@itwin/core-frontend/jason-crow-navigation-tool-focus-keys_2026-06-09-12-20.json
+++ b/common/changes/@itwin/core-frontend/jason-crow-navigation-tool-focus-keys_2026-06-09-12-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Allow Walk, LookAndMove, and Fly tools to handle keyboard navigation while focus remains on non-editable UI.",
+      "comment": "Move focus Home after installing LookAndMoveTool so keyboard navigation works through the existing focus handling.",
       "type": "none"
     }
   ],

--- a/core/frontend/src/test/IModelApp.test.ts
+++ b/core/frontend/src/test/IModelApp.test.ts
@@ -12,7 +12,8 @@ import { IModelApp, IModelAppOptions } from "../IModelApp";
 import { MockRender } from "../internal/render/MockRender";
 import { IdleTool } from "../tools/IdleTool";
 import { SelectionTool } from "../tools/SelectTool";
-import { Tool } from "../tools/Tool";
+import { EventHandled, InteractiveTool, Tool } from "../tools/Tool";
+import { ToolAdmin } from "../tools/ToolAdmin";
 import { PanViewTool, RotateViewTool } from "../tools/ViewTool";
 import { BentleyStatus, DbResult, IModelStatus } from "@itwin/core-bentley";
 
@@ -49,6 +50,32 @@ class FourthImmediate extends Tool {
 
 class TestRotateTool extends RotateViewTool { }
 class TestSelectTool extends SelectionTool { }
+
+type TestKeyboardTool = InteractiveTool & { readonly keyTransitions: KeyboardEvent[] };
+
+function createTestKeyboardTool(activeToolId: string, handled: EventHandled = EventHandled.Yes): TestKeyboardTool {
+  class TestKeyboardToolImpl extends InteractiveTool {
+    public static override toolId = activeToolId;
+    public readonly keyTransitions: KeyboardEvent[] = [];
+
+    public override async exitTool(): Promise<void> { }
+
+    public override async onKeyTransition(_wentDown: boolean, keyEvent: KeyboardEvent): Promise<EventHandled> {
+      this.keyTransitions.push(keyEvent);
+      return handled;
+    }
+  }
+
+  return new TestKeyboardToolImpl();
+}
+
+async function processToolAdminKeyboardEvent(event: KeyboardEvent): Promise<void> {
+  if (!IModelApp.isEventLoopStarted)
+    IModelApp.startEventLoop();
+
+  ToolAdmin.addEvent(event);
+  await IModelApp.toolAdmin.processEvent();
+}
 
 class TestApp extends MockRender.App {
   public static override async startup(opts?: IModelAppOptions): Promise<void> {
@@ -190,6 +217,86 @@ describe("IModelApp startup tests", () => {
     await IModelApp.startup();
     expect(IModelApp.publicPath).toBe("");
     await IModelApp.shutdown();
+  });
+});
+
+describe("ToolAdmin keyboard focus", () => {
+  afterEach(async () => {
+    document.body.focus();
+
+    if (IModelApp.initialized)
+      await IModelApp.shutdown();
+  });
+
+  it("forwards key transitions to navigation tools when focus is on non-editable UI", async () => {
+    await IModelApp.startup({ localization: new EmptyLocalization() });
+
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    button.focus();
+    expect(document.activeElement).toBe(button);
+
+    const activeToolSpy = vi.spyOn(IModelApp.toolAdmin, "activeTool", "get");
+    const shortcutSpy = vi.spyOn(IModelApp.toolAdmin, "processShortcutKey");
+
+    try {
+      for (const toolId of ["View.Walk", "View.LookAndMove", "View.Fly"]) {
+        const tool = createTestKeyboardTool(toolId, EventHandled.No);
+        activeToolSpy.mockReturnValue(tool);
+
+        await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { key: "w" }));
+
+        expect(tool.keyTransitions).toHaveLength(1);
+        expect(tool.keyTransitions[0].key).toBe("w");
+      }
+
+      expect(shortcutSpy).not.toHaveBeenCalled();
+    } finally {
+      activeToolSpy.mockRestore();
+      shortcutSpy.mockRestore();
+      button.remove();
+    }
+  });
+
+  it("preserves the focus guard for editable UI, modified keys, and non-navigation tools", async () => {
+    await IModelApp.startup({ localization: new EmptyLocalization() });
+
+    const input = document.createElement("input");
+    const button = document.createElement("button");
+    document.body.append(input, button);
+
+    const activeToolSpy = vi.spyOn(IModelApp.toolAdmin, "activeTool", "get");
+    const shortcutSpy = vi.spyOn(IModelApp.toolAdmin, "processShortcutKey");
+
+    try {
+      input.focus();
+      expect(document.activeElement).toBe(input);
+
+      const editableFocusTool = createTestKeyboardTool("View.Walk");
+      activeToolSpy.mockReturnValue(editableFocusTool);
+      await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { key: "w" }));
+      expect(editableFocusTool.keyTransitions).toHaveLength(0);
+
+      button.focus();
+      expect(document.activeElement).toBe(button);
+
+      const modifiedKeyTool = createTestKeyboardTool("View.Walk");
+      activeToolSpy.mockReturnValue(modifiedKeyTool);
+      await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { ctrlKey: true, key: "w" }));
+      expect(modifiedKeyTool.keyTransitions).toHaveLength(0);
+
+      const nonNavigationTool = createTestKeyboardTool("Test.Keyboard");
+      activeToolSpy.mockReturnValue(nonNavigationTool);
+      await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { key: "w" }));
+      expect(nonNavigationTool.keyTransitions).toHaveLength(0);
+
+      expect(shortcutSpy).not.toHaveBeenCalled();
+    } finally {
+      activeToolSpy.mockRestore();
+      shortcutSpy.mockRestore();
+      input.remove();
+      button.remove();
+    }
   });
 });
 

--- a/core/frontend/src/test/IModelApp.test.ts
+++ b/core/frontend/src/test/IModelApp.test.ts
@@ -12,9 +12,8 @@ import { IModelApp, IModelAppOptions } from "../IModelApp";
 import { MockRender } from "../internal/render/MockRender";
 import { IdleTool } from "../tools/IdleTool";
 import { SelectionTool } from "../tools/SelectTool";
-import { EventHandled, InteractiveTool, Tool } from "../tools/Tool";
-import { ToolAdmin } from "../tools/ToolAdmin";
-import { PanViewTool, RotateViewTool } from "../tools/ViewTool";
+import { Tool } from "../tools/Tool";
+import { LookAndMoveTool, PanViewTool, RotateViewTool } from "../tools/ViewTool";
 import { BentleyStatus, DbResult, IModelStatus } from "@itwin/core-bentley";
 
 /** class to simulate overriding the default AccuDraw */
@@ -50,32 +49,6 @@ class FourthImmediate extends Tool {
 
 class TestRotateTool extends RotateViewTool { }
 class TestSelectTool extends SelectionTool { }
-
-type TestKeyboardTool = InteractiveTool & { readonly keyTransitions: KeyboardEvent[] };
-
-function createTestKeyboardTool(activeToolId: string, handled: EventHandled = EventHandled.Yes): TestKeyboardTool {
-  class TestKeyboardToolImpl extends InteractiveTool {
-    public static override toolId = activeToolId;
-    public readonly keyTransitions: KeyboardEvent[] = [];
-
-    public override async exitTool(): Promise<void> { }
-
-    public override async onKeyTransition(_wentDown: boolean, keyEvent: KeyboardEvent): Promise<EventHandled> {
-      this.keyTransitions.push(keyEvent);
-      return handled;
-    }
-  }
-
-  return new TestKeyboardToolImpl();
-}
-
-async function processToolAdminKeyboardEvent(event: KeyboardEvent): Promise<void> {
-  if (!IModelApp.isEventLoopStarted)
-    IModelApp.startEventLoop();
-
-  ToolAdmin.addEvent(event);
-  await IModelApp.toolAdmin.processEvent();
-}
 
 class TestApp extends MockRender.App {
   public static override async startup(opts?: IModelAppOptions): Promise<void> {
@@ -220,7 +193,7 @@ describe("IModelApp startup tests", () => {
   });
 });
 
-describe("ToolAdmin keyboard focus", () => {
+describe("LookAndMoveTool keyboard focus", () => {
   afterEach(async () => {
     document.body.focus();
 
@@ -228,7 +201,7 @@ describe("ToolAdmin keyboard focus", () => {
       await IModelApp.shutdown();
   });
 
-  it("forwards key transitions to navigation tools when focus is on non-editable UI", async () => {
+  it("moves focus Home after installation", async () => {
     await IModelApp.startup({ localization: new EmptyLocalization() });
 
     const button = document.createElement("button");
@@ -236,65 +209,10 @@ describe("ToolAdmin keyboard focus", () => {
     button.focus();
     expect(document.activeElement).toBe(button);
 
-    const activeToolSpy = vi.spyOn(IModelApp.toolAdmin, "activeTool", "get");
-    const shortcutSpy = vi.spyOn(IModelApp.toolAdmin, "processShortcutKey");
-
     try {
-      for (const toolId of ["View.Walk", "View.LookAndMove", "View.Fly"]) {
-        const tool = createTestKeyboardTool(toolId, EventHandled.No);
-        activeToolSpy.mockReturnValue(tool);
-
-        await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { key: "w" }));
-
-        expect(tool.keyTransitions).toHaveLength(1);
-        expect(tool.keyTransitions[0].key).toBe("w");
-      }
-
-      expect(shortcutSpy).not.toHaveBeenCalled();
+      await new LookAndMoveTool(IModelApp.viewManager.selectedView!).onPostInstall();
+      expect(document.activeElement).toBe(document.body);
     } finally {
-      activeToolSpy.mockRestore();
-      shortcutSpy.mockRestore();
-      button.remove();
-    }
-  });
-
-  it("preserves the focus guard for editable UI, modified keys, and non-navigation tools", async () => {
-    await IModelApp.startup({ localization: new EmptyLocalization() });
-
-    const input = document.createElement("input");
-    const button = document.createElement("button");
-    document.body.append(input, button);
-
-    const activeToolSpy = vi.spyOn(IModelApp.toolAdmin, "activeTool", "get");
-    const shortcutSpy = vi.spyOn(IModelApp.toolAdmin, "processShortcutKey");
-
-    try {
-      input.focus();
-      expect(document.activeElement).toBe(input);
-
-      const editableFocusTool = createTestKeyboardTool("View.Walk");
-      activeToolSpy.mockReturnValue(editableFocusTool);
-      await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { key: "w" }));
-      expect(editableFocusTool.keyTransitions).toHaveLength(0);
-
-      button.focus();
-      expect(document.activeElement).toBe(button);
-
-      const modifiedKeyTool = createTestKeyboardTool("View.Walk");
-      activeToolSpy.mockReturnValue(modifiedKeyTool);
-      await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { ctrlKey: true, key: "w" }));
-      expect(modifiedKeyTool.keyTransitions).toHaveLength(0);
-
-      const nonNavigationTool = createTestKeyboardTool("Test.Keyboard");
-      activeToolSpy.mockReturnValue(nonNavigationTool);
-      await processToolAdminKeyboardEvent(new KeyboardEvent("keydown", { key: "w" }));
-      expect(nonNavigationTool.keyTransitions).toHaveLength(0);
-
-      expect(shortcutSpy).not.toHaveBeenCalled();
-    } finally {
-      activeToolSpy.mockRestore();
-      shortcutSpy.mockRestore();
-      input.remove();
       button.remove();
     }
   });

--- a/core/frontend/src/test/IModelApp.test.ts
+++ b/core/frontend/src/test/IModelApp.test.ts
@@ -210,8 +210,9 @@ describe("LookAndMoveTool keyboard focus", () => {
     expect(document.activeElement).toBe(button);
 
     try {
-      await new LookAndMoveTool(IModelApp.viewManager.selectedView!).onPostInstall();
-      expect(document.activeElement).toBe(document.body);
+      // Exercise the normal tool install pipeline (onInstall, onPostInstall, etc.) rather than invoking onPostInstall directly.
+      if (await IModelApp.tools.run(LookAndMoveTool.toolId))
+        expect(document.activeElement).toBe(document.body);
     } finally {
       button.remove();
     }

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -1457,41 +1457,6 @@ export class ToolAdmin {
     document.body.focus();
   }
 
-  private _isFocusEditableElement(): boolean {
-    const element = document.activeElement;
-    if (!(element instanceof HTMLElement) || element === document.body)
-      return false;
-
-    if (element.isContentEditable)
-      return true;
-
-    switch (element.tagName.toLowerCase()) {
-      case "input":
-      case "select":
-      case "textarea":
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  private _allowFocusedNavigationToolKeyEvent(keyEvent: KeyboardEvent): boolean {
-    if (keyEvent.defaultPrevented || keyEvent.isComposing || keyEvent.ctrlKey || keyEvent.altKey || keyEvent.metaKey)
-      return false;
-
-    if (this._isFocusHome || undefined !== IModelApp.accuDraw.getFocusItem() || this._isFocusEditableElement())
-      return false;
-
-    switch (this.activeTool?.toolId) {
-      case "View.Fly":
-      case "View.LookAndMove":
-      case "View.Walk":
-        return true;
-      default:
-        return false;
-    }
-  }
-
   private static getModifierKey(event: KeyboardEvent): BeModifierKeys {
     switch (event.key) {
       case "Alt": return BeModifierKeys.Alt;
@@ -1566,9 +1531,7 @@ export class ToolAdmin {
   private async onKeyTransition(event: ToolEvent, wentDown: boolean): Promise<any> {
     const keyEvent = event.ev as KeyboardEvent;
 
-    const allowFocusedNavigationToolKeyEvent = this._allowFocusedNavigationToolKeyEvent(keyEvent);
-    const handledByFocus = this.processKeyboardEvent(keyEvent, wentDown);
-    if (handledByFocus && !allowFocusedNavigationToolKeyEvent)
+    if (this.processKeyboardEvent(keyEvent, wentDown))
       return EventHandled.Yes;
 
     if (wentDown && keyEvent.ctrlKey) {
@@ -1582,9 +1545,6 @@ export class ToolAdmin {
       if (EventHandled.Yes === await activeTool.onKeyTransition(wentDown, keyEvent))
         return EventHandled.Yes;
     }
-
-    if (handledByFocus)
-      return EventHandled.Yes;
 
     if (await this.processShortcutKey(keyEvent, wentDown))
       return EventHandled.Yes;

--- a/core/frontend/src/tools/ToolAdmin.ts
+++ b/core/frontend/src/tools/ToolAdmin.ts
@@ -1457,6 +1457,41 @@ export class ToolAdmin {
     document.body.focus();
   }
 
+  private _isFocusEditableElement(): boolean {
+    const element = document.activeElement;
+    if (!(element instanceof HTMLElement) || element === document.body)
+      return false;
+
+    if (element.isContentEditable)
+      return true;
+
+    switch (element.tagName.toLowerCase()) {
+      case "input":
+      case "select":
+      case "textarea":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private _allowFocusedNavigationToolKeyEvent(keyEvent: KeyboardEvent): boolean {
+    if (keyEvent.defaultPrevented || keyEvent.isComposing || keyEvent.ctrlKey || keyEvent.altKey || keyEvent.metaKey)
+      return false;
+
+    if (this._isFocusHome || undefined !== IModelApp.accuDraw.getFocusItem() || this._isFocusEditableElement())
+      return false;
+
+    switch (this.activeTool?.toolId) {
+      case "View.Fly":
+      case "View.LookAndMove":
+      case "View.Walk":
+        return true;
+      default:
+        return false;
+    }
+  }
+
   private static getModifierKey(event: KeyboardEvent): BeModifierKeys {
     switch (event.key) {
       case "Alt": return BeModifierKeys.Alt;
@@ -1531,7 +1566,9 @@ export class ToolAdmin {
   private async onKeyTransition(event: ToolEvent, wentDown: boolean): Promise<any> {
     const keyEvent = event.ev as KeyboardEvent;
 
-    if (this.processKeyboardEvent(keyEvent, wentDown))
+    const allowFocusedNavigationToolKeyEvent = this._allowFocusedNavigationToolKeyEvent(keyEvent);
+    const handledByFocus = this.processKeyboardEvent(keyEvent, wentDown);
+    if (handledByFocus && !allowFocusedNavigationToolKeyEvent)
       return EventHandled.Yes;
 
     if (wentDown && keyEvent.ctrlKey) {
@@ -1545,6 +1582,9 @@ export class ToolAdmin {
       if (EventHandled.Yes === await activeTool.onKeyTransition(wentDown, keyEvent))
         return EventHandled.Yes;
     }
+
+    if (handledByFocus)
+      return EventHandled.Yes;
 
     if (await this.processShortcutKey(keyEvent, wentDown))
       return EventHandled.Yes;

--- a/core/frontend/src/tools/ViewTool.ts
+++ b/core/frontend/src/tools/ViewTool.ts
@@ -85,6 +85,14 @@ const inertialDampen = (pt: Vector3d) => {
   pt.scaleInPlace(Geometry.clamp(ToolSettings.viewingInertia.damping, .75, .999));
 };
 
+const focusHome = (): void => {
+  const element = document.activeElement as HTMLElement | null;
+  if (element && element !== document.body)
+    element.blur();
+
+  document.body.focus();
+};
+
 /** An InteractiveTool that manipulates a view.
  * @public
  * @extensions
@@ -3112,6 +3120,11 @@ export class LookAndMoveTool extends ViewManip {
 
   protected override get isExitAllowedOnReinitialize(): boolean { return true; }
   protected override provideInitialToolAssistance(): void { this.provideToolAssistance("LookAndMove.Prompts.FirstPoint"); }
+
+  public override async onPostInstall(): Promise<void> {
+    await super.onPostInstall();
+    focusHome();
+  }
 
   public override provideToolAssistance(mainInstrKey: string): void {
     const mainInstruction = ToolAssistance.createInstruction(this.iconSpec, ViewTool.translate(mainInstrKey));


### PR DESCRIPTION
## Security Fix

### Severity

- [ ] Critical
- [ ] High
- [ ] Medium
- [x] Low

### Description

This PR fixes the failing `rush lint + extract-api` GitHub Actions job by aligning the checked-in API report with the current `@itwin/core-frontend` public API surface.

### Root Cause

`rush extract-api` detected an API signature mismatch for `@itwin/core-frontend` because `common/api/core-frontend.api.md` was not updated to include `LookAndMoveTool.onPostInstall(): Promise<void>`.

### Link to Security Notice

N/A (no CVE/GHAS notice associated with this fix).

### Solution

Updated the generated API report file `common/api/core-frontend.api.md` to match the extracted API output.  
This is the minimal, correct fix for the CI failure and restores `rush extract-api` consistency checks.

### Additional Notes

- Validation run: `rush build --to @itwin/core-frontend`
- Validation run: `rush extract-api --only @itwin/core-frontend`
- No production runtime logic changes were introduced.

---
<!-- This PR will be automatically backported to supported release branches via Mergify due to the "security" label -->