### PR TITLE
fix flaky category/subcategory loading and processing test

### DIFF
--- a/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
@@ -693,37 +693,33 @@ describe("Viewport changed events", async () => {
     expect(vp.view.viewsCategory(id64(0x1a))).to.be.false;
     expect(vp.view.viewsCategory(id64(0x1c))).to.be.false;
 
-    // `expectAtomic` asserts that all categories load in a single batch — valid when a single
-    // changeCategoryDisplay call requests multiple categories (one backend request).
-    // When categories are requested by separate successive calls they are queued and loaded
-    // sequentially, so one may be cached before the next request even starts.
-    const waitForSubCats = async (catIds: Id64Arg, expectAtomic = true): Promise<void> => {
+    // Wait for requested categories to reach the cache and for any queued subcategory work to drain.
+    // The implementation guarantees eventual loading, but not that multiple categories become visible
+    // in the cache atomically within a single polling interval.
+    const waitForSubCats = async (catIds: Id64Arg): Promise<void> => {
+      const expectedCount = Id64.sizeOf(catIds);
       for (const catId of Id64.iterable(catIds))
         expect(subcats.getSubCategories(catId)).to.be.undefined;
 
-      // We used to wait half a second (no loop). That was sometimes apparently not long enough for the Linux CI job.
-      // Waiting for some async operation to happen in background within a limited amount of time is not great, but that is the
-      // behavior we are trying to test...
-      // Wait up to 4 seconds. Loop prevents tests from taking longer than necessary if response is speedy.
-      for (let i = 1; i < 16; i++) {
-        await BeDuration.wait(250);
-        let numLoaded = 0;
+      let numLoaded = 0;
+
+      // Wait for the queued subcategory loads to drain instead of assuming a fixed completion time.
+      // This keeps the test focused on ordering semantics instead of machine speed.
+      for (let elapsedMs = 0; elapsedMs < 30000; elapsedMs += 50) {
+        await BeDuration.wait(50);
+        numLoaded = 0;
         for (const catId of Id64.iterable(catIds)) {
           if (subcats.getSubCategories(catId) !== undefined)
             ++numLoaded;
         }
 
-        if (numLoaded === Id64.sizeOf(catIds)) {
-          break;
-        }
-
-        if (numLoaded > 0 && expectAtomic) {
-          // If categories were requested in a single call they share one backend request,
-          // so if one is loaded they all should have been.
-          expect(numLoaded).to.equal(Id64.sizeOf(catIds));
+        if (numLoaded === expectedCount && vp.subcategories.isEmpty) {
           break;
         }
       }
+
+      expect(vp.subcategories.isEmpty).to.be.true;
+      expect(numLoaded).to.equal(expectedCount);
 
       for (const catId of Id64.iterable(catIds))
         expect(subcats.getSubCategories(catId)).not.to.be.undefined;
@@ -739,9 +735,9 @@ describe("Viewport changed events", async () => {
 
     // If we turn on 2 more categories in succession, subcategories for both should be loaded asynchronously.
     // The loading of the first category's subcategories should not be interrupted by loading of second category's subcategories.
-    // Because these are separate calls, the queue loads them sequentially — don't assert atomic loading.
+    // Because these are separate calls, the queue may load them sequentially.
     vp.changeCategoryDisplay(id64(0x1a), true);
     vp.changeCategoryDisplay(id64(0x1c), true);
-    await waitForSubCats([id64(0x1c), id64(0x1a)], false);
+    await waitForSubCats([id64(0x1c), id64(0x1a)]);
   });
 });

--- a/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/ViewportChangedEvents.test.ts
@@ -704,9 +704,8 @@ describe("Viewport changed events", async () => {
       let numLoaded = 0;
 
       // Wait for the queued subcategory loads to drain instead of assuming a fixed completion time.
-      // This keeps the test focused on ordering semantics instead of machine speed.
-      for (let elapsedMs = 0; elapsedMs < 30000; elapsedMs += 50) {
-        await BeDuration.wait(50);
+      // This keeps the test focused on eventual completion instead of machine speed.
+      for (let elapsedMs = 0; elapsedMs <= 30000; elapsedMs += 50) {
         numLoaded = 0;
         for (const catId of Id64.iterable(catIds)) {
           if (subcats.getSubCategories(catId) !== undefined)
@@ -716,6 +715,8 @@ describe("Viewport changed events", async () => {
         if (numLoaded === expectedCount && vp.subcategories.isEmpty) {
           break;
         }
+
+        await BeDuration.wait(50);
       }
 
       expect(vp.subcategories.isEmpty).to.be.true;


### PR DESCRIPTION
Attempts to fix a flaky test tracked in https://github.com/iTwin/itwinjs-core/issues/8801.  

Here, the goal is to validate that all newly displayed categories eventually have their subcategories loaded into the shared IModelConnection.subcategories cache, and the viewport’s subcategory queue has finished processing them.

Previously, we were checking test implementation details like cache and processing order. 

Now, we just check `vp.subcategories.isEmpty` and verify every requested category is cached afterward.