### PR TITLE
WorkspaceDb offline fixes

### DIFF
--- a/common/changes/@itwin/core-backend/john-offline-workspaces-in-studio_2026-06-13-02-23.json
+++ b/common/changes/@itwin/core-backend/john-offline-workspaces-in-studio_2026-06-13-02-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Fix offline workspace open in Electron: CloudSqlite.requestToken now catches network errors and returns an empty token as documented; NativeHost.overrideInternetConnectivity now calls setOnlineStatus for Electron backends (not just Mobile); getOnlineStatus defaults to false so connectivity is not assumed until explicitly confirmed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-backend/john-offline-workspaces-in-studio_2026-06-13-02-23.json
+++ b/common/changes/@itwin/core-backend/john-offline-workspaces-in-studio_2026-06-13-02-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Fix offline workspace open in Electron: CloudSqlite.requestToken now catches network errors and returns an empty token as documented; NativeHost.overrideInternetConnectivity now calls setOnlineStatus for Electron backends (not just Mobile); getOnlineStatus defaults to false so connectivity is not assumed until explicitly confirmed.",
+      "comment": "Fix offline workspace open in Electron: CloudSqlite.requestToken returns an empty token if we are offline; NativeHost.overrideInternetConnectivity now calls setOnlineStatus for Electron backends (not just Mobile) so checkForChanges is correctly skipped when offline.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-frontend/john-offline-workspaces-in-studio_2026-06-15-15-22.json
+++ b/common/changes/@itwin/core-frontend/john-offline-workspaces-in-studio_2026-06-15-15-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "NativeApp.startup now always reports the initial connectivity to the backend. Previously, if if `window.navigator.onLine` was false at startup, setConnectivity was never called, leaving the backend incorrectly assuming it was online.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -68,8 +68,8 @@ export namespace CloudSqlite {
     try {
       const response = await getBlobService().requestToken({ ...args, userToken });
       return response.token;
-    } catch {
-      logError(`Could not get token for container [${args.containerId}]. Returning empty token.`);
+    } catch (error) {
+      logError(`Error requesting token for container [${args.containerId}]: ${(error as Error).message}`);
       return "";
     }
   }

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -62,8 +62,13 @@ export namespace CloudSqlite {
     let userToken = args.userToken ? args.userToken : await IModelHost.getAccessToken();
     if (userToken === "")
       userToken = RpcTrace.currentActivity?.accessToken ?? "";
-    const response = await getBlobService().requestToken({ ...args, userToken });
-    return response?.token ?? "";
+    try {
+      const response = await getBlobService().requestToken({ ...args, userToken });
+      return response.token;
+    } catch {
+      logInfo(`Could not get token for container [${args.containerId}]. We might be offline, so returning an empty token.`);
+      return "";
+    }
   }
 
   interface CloudContainerInternal extends CloudContainer {

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -18,6 +18,7 @@ import { BlobContainer } from "./BlobContainerService";
 import { IModelHost, KnownLocations } from "./IModelHost";
 import { IModelJsFs } from "./IModelJsFs";
 import { RpcTrace } from "./rpc/tracing";
+import { getOnlineStatus } from "./internal/OnlineStatus";
 
 import type { SQLiteDb, VersionedSqliteDb } from "./SQLiteDb";
 
@@ -62,11 +63,13 @@ export namespace CloudSqlite {
     let userToken = args.userToken ? args.userToken : await IModelHost.getAccessToken();
     if (userToken === "")
       userToken = RpcTrace.currentActivity?.accessToken ?? "";
+    if (!getOnlineStatus())
+      return "";
     try {
       const response = await getBlobService().requestToken({ ...args, userToken });
       return response.token;
     } catch {
-      logInfo(`Could not get token for container [${args.containerId}]. We might be offline, so returning an empty token.`);
+      logError(`Could not get token for container [${args.containerId}]. Returning empty token.`);
       return "";
     }
   }

--- a/core/backend/src/CloudSqlite.ts
+++ b/core/backend/src/CloudSqlite.ts
@@ -56,7 +56,7 @@ export namespace CloudSqlite {
 
   /**
    * Request a new AccessToken for a cloud container using the [[BlobContainer]] service.
-   * If the service is unavailable or returns an error, an empty token is returned.
+   * If the backend is considered offline, this returns an empty token without calling the service.
    */
   export async function requestToken(args: RequestTokenArgs): Promise<AccessToken> {
     // allow the userToken to be supplied via args. If not supplied, or blank, use the backend's accessToken. If that fails, use the value from the current RPC request
@@ -65,13 +65,9 @@ export namespace CloudSqlite {
       userToken = RpcTrace.currentActivity?.accessToken ?? "";
     if (!getOnlineStatus())
       return "";
-    try {
-      const response = await getBlobService().requestToken({ ...args, userToken });
-      return response.token;
-    } catch (error) {
-      logError(`Error requesting token for container [${args.containerId}]: ${(error as Error).message}`);
-      return "";
-    }
+
+    const response = await getBlobService().requestToken({ ...args, userToken });
+    return response?.token ?? "";
   }
 
   interface CloudContainerInternal extends CloudContainer {

--- a/core/backend/src/NativeHost.ts
+++ b/core/backend/src/NativeHost.ts
@@ -200,7 +200,7 @@ export class NativeHost {
     if (this._reachability !== status) {
       this._reachability = status;
       this.onInternetConnectivityChanged.raiseEvent(status);
-      if (ProcessDetector.isMobileAppBackend) {
+      if (ProcessDetector.isMobileAppBackend || ProcessDetector.isElectronAppBackend) {
         // Merely referencing NativeHost from a non-native backend causes a runtime exception (even
         // inside an if statement that checks that the backend is a mobile backend). This allows code
         // that needs to check connectivity to do so without referencing NativeHost directly.

--- a/core/backend/src/internal/OnlineStatus.ts
+++ b/core/backend/src/internal/OnlineStatus.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-let isOnline = true;
+let isOnline = false;
 
 /**
  * Sets the online status of the backend that will be returned by `getOnlineStatus`.
@@ -18,7 +18,7 @@ export function setOnlineStatus(online: boolean) {
  * Determine whether the backend is currently considered online.
  * @note This only works if `setOnlineStatus` has been called by something to update the status.
  * `NativeHost` does this whenever the connectivity changes. If `setOnlineStatus` has never been
- * called, this will return `true`.
+ * called, this will return `false`.
  * @internal
  */
 export function getOnlineStatus(): boolean {

--- a/core/backend/src/internal/OnlineStatus.ts
+++ b/core/backend/src/internal/OnlineStatus.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-let isOnline = false;
+let isOnline = true;
 
 /**
  * Sets the online status of the backend that will be returned by `getOnlineStatus`.

--- a/core/backend/src/internal/OnlineStatus.ts
+++ b/core/backend/src/internal/OnlineStatus.ts
@@ -18,7 +18,7 @@ export function setOnlineStatus(online: boolean) {
  * Determine whether the backend is currently considered online.
  * @note This only works if `setOnlineStatus` has been called by something to update the status.
  * `NativeHost` does this whenever the connectivity changes. If `setOnlineStatus` has never been
- * called, this will return `false`.
+ * called, this will return `true`.
  * @internal
  */
 export function getOnlineStatus(): boolean {

--- a/core/backend/src/test/standalone/CloudSqlite.test.ts
+++ b/core/backend/src/test/standalone/CloudSqlite.test.ts
@@ -17,7 +17,14 @@ describe("CloudSqlite.requestToken", () => {
     userToken: "test-user-token",
   };
 
+  let originalService: BlobContainer.ContainerService | undefined;
+
+  beforeEach(() => {
+    originalService = BlobContainer.service;
+  });
+
   afterEach(() => {
+    BlobContainer.service = originalService;
     sinon.restore();
     setOnlineStatus(true);
   });

--- a/core/backend/src/test/standalone/CloudSqlite.test.ts
+++ b/core/backend/src/test/standalone/CloudSqlite.test.ts
@@ -40,17 +40,6 @@ describe("CloudSqlite.requestToken", () => {
     expect(requestTokenStub.called).to.be.false;
   });
 
-  it("returns empty token when BlobContainer.service.requestToken rejects", async () => {
-    setOnlineStatus(true);
-    BlobContainer.service = {
-      requestToken: sinon.stub().rejects(new Error("getaddrinfo ENOTFOUND api.bentley.com")),
-    } as any;
-
-    const token = await CloudSqlite.requestToken(args);
-
-    expect(token).to.equal("");
-  });
-
   it("returns the token from BlobContainer.service when online and request succeeds", async () => {
     setOnlineStatus(true);
     BlobContainer.service = {

--- a/core/backend/src/test/standalone/CloudSqlite.test.ts
+++ b/core/backend/src/test/standalone/CloudSqlite.test.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { CloudSqlite } from "../../CloudSqlite";
+import { BlobContainer } from "../../BlobContainerService";
+import { setOnlineStatus } from "../../internal/OnlineStatus";
+
+describe("CloudSqlite.requestToken", () => {
+  // Supply userToken directly so IModelHost.getAccessToken is never called
+  const args: CloudSqlite.RequestTokenArgs = {
+    containerId: "test-container",
+    accessLevel: "read",
+    userToken: "test-user-token",
+  };
+
+  afterEach(() => {
+    sinon.restore();
+    setOnlineStatus(true);
+  });
+
+  it("returns empty token and does not call BlobContainer.service when offline", async () => {
+    setOnlineStatus(false);
+    const requestTokenStub = sinon.stub().rejects(new Error("should not be called"));
+    BlobContainer.service = { requestToken: requestTokenStub } as any;
+
+    const token = await CloudSqlite.requestToken(args);
+
+    expect(token).to.equal("");
+    expect(requestTokenStub.called).to.be.false;
+  });
+
+  it("returns empty token when BlobContainer.service.requestToken rejects", async () => {
+    setOnlineStatus(true);
+    BlobContainer.service = {
+      requestToken: sinon.stub().rejects(new Error("getaddrinfo ENOTFOUND api.bentley.com")),
+    } as any;
+
+    const token = await CloudSqlite.requestToken(args);
+
+    expect(token).to.equal("");
+  });
+
+  it("returns the token from BlobContainer.service when online and request succeeds", async () => {
+    setOnlineStatus(true);
+    BlobContainer.service = {
+      requestToken: sinon.stub().resolves({ token: "my-sas-token" }),
+    } as any;
+
+    const token = await CloudSqlite.requestToken(args);
+
+    expect(token).to.equal("my-sas-token");
+  });
+});

--- a/core/frontend/src/NativeApp.ts
+++ b/core/frontend/src/NativeApp.ts
@@ -118,9 +118,7 @@ export class NativeApp {
     NativeApp.hookBrowserConnectivityEvents();
 
     // initialize current online state.
-    if (window.navigator.onLine) {
-      await this.setConnectivity(OverriddenBy.Browser, window.navigator.onLine ? InternetConnectivityStatus.Online : InternetConnectivityStatus.Offline);
-    }
+    await this.setConnectivity(OverriddenBy.Browser, window.navigator.onLine ? InternetConnectivityStatus.Online : InternetConnectivityStatus.Offline);
   }
 
   /** @internal */
@@ -204,7 +202,7 @@ export class NativeApp {
       storage = new Storage(await this.nativeAppIpc.storageMgrOpen(name));
       this._storages.set(storage.id, storage);
     }
-    
+
     return storage;
   }
 


### PR DESCRIPTION
Noticed a couple issues trying to get offline mode working for workspaces/settings in studio. The settings workspace overload intended for offline use `getITwinWorkspace(settingsSources)` was not actually working offline for three reasons:

 1. `CloudSqlite.requestToken` - `BlobContainerService.requestToken` throws on network failure rather than returning null/undefined, so the documented "returns empty token on service not available" behaviour was not actually happening. Updated to check connectivity and return empty token before sending a request.
 2. `NativeHost.overrideInternetConnectivity` - `setOnlineStatus` was only called for `isMobileAppBackend`, so `getOnlineStatus()` always returned true in Electron. Added `isElectronAppBackend` to the condition.
 3. OnlineStatus - `NativeApp` has a guard to only send the connectivity event if online. So if we start offline, the event never fires... so, I removed the guard