### PR TITLE
Add CesiumAccessClient interface for pluggable Cesium ion authentication

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2018,6 +2018,18 @@ export class CategorySelectorState extends ElementState {
     toJSON(): CategorySelectorProps;
 }
 
+// @beta
+export interface CesiumAccessClient {
+    getAssetEndpoint(assetId: number, iTwinId?: GuidString): Promise<CesiumAssetEndpoint>;
+}
+
+// @beta
+export interface CesiumAssetEndpoint {
+    accessToken?: string;
+    expiresAt?: Date;
+    url?: string;
+}
+
 // @public
 export enum ChangeFlag {
     All = 268435455,
@@ -10797,6 +10809,8 @@ export interface TerrainMeshProviderOptions {
     dataSource?: string;
     exaggeration: number;
     // @beta
+    iTwinId?: string;
+    // @beta
     produceGeometry?: boolean;
     wantNormals: boolean;
     wantSkirts: boolean;
@@ -11000,6 +11014,8 @@ export class TileAdmin {
     // @internal (undocumented)
     readonly alwaysSubdivideIncompleteTiles: boolean;
     // @beta (undocumented)
+    readonly cesiumAccess?: CesiumAccessClient;
+    // @beta (undocumented)
     readonly cesiumIonKey?: string;
     // (undocumented)
     readonly channels: TileRequestChannels;
@@ -11070,6 +11086,8 @@ export class TileAdmin {
     getTileUserSetForRequest(user: TileUser, users?: ReadonlyTileUserSet): ReadonlyTileUserSet;
     get gpuMemoryLimit(): GpuMemoryLimit;
     set gpuMemoryLimit(limit: GpuMemoryLimit);
+    // @beta
+    get hasCesiumAccess(): boolean;
     // @internal (undocumented)
     readonly ignoreAreaPatterns: boolean;
     // @internal (undocumented)
@@ -11149,6 +11167,8 @@ export namespace TileAdmin {
         alwaysSubdivideIncompleteTiles?: boolean;
         // @internal
         cacheTileMetadata?: boolean;
+        // @beta
+        cesiumAccess?: CesiumAccessClient;
         cesiumIonKey?: string;
         // @alpha
         contextPreloadParentDepth?: number;

--- a/common/changes/@itwin/core-frontend/anmolshres98-cesium-access-client_2026-06-15-10-09.json
+++ b/common/changes/@itwin/core-frontend/anmolshres98-cesium-access-client_2026-06-15-10-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Added `CesiumAccessClient` interface and `TileAdmin.Props.cesiumAccess` to allow pluggable authentication for Cesium ion assets via the iTwin Platform Cesium Curated Content API. Added `TileAdmin.hasCesiumAccess` getter. Added `iTwinId` to `TerrainMeshProviderOptions`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend",
+  "email": "anmol.shrestha@bentley.com"
+}

--- a/common/changes/@itwin/core-frontend/anmolshres98-cesium-access-client_2026-06-15-15-14.json
+++ b/common/changes/@itwin/core-frontend/anmolshres98-cesium-access-client_2026-06-15-15-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "none\\n",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/CesiumAccessClient.ts
+++ b/core/frontend/src/CesiumAccessClient.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Tiles
+ */
+
+import { GuidString } from "@itwin/core-bentley";
+
+/** Describes the endpoint for a resolved Cesium ion asset.
+ * @beta
+ */
+export interface CesiumAssetEndpoint {
+  /** Access token for authenticating tile requests. */
+  accessToken?: string;
+  /** Root URL for fetching tile data. */
+  url?: string;
+  /** When the access token expires. If not set, a 30-minute default is assumed. */
+  expiresAt?: Date;
+}
+
+/** Pluggable resolver for Cesium ion asset endpoints. Implement this interface to supply
+ * authentication for Cesium ion assets via the iTwin Platform Cesium Curated Content API
+ * or any other mechanism.
+ * @see [[TileAdmin.Props.cesiumAccess]] to configure this at startup.
+ * @beta
+ */
+export interface CesiumAccessClient {
+  /** Resolves the endpoint for a given Cesium ion asset.
+   * @param assetId The numeric Cesium ion asset identifier.
+   * @param iTwinId Optional iTwin identifier providing context, if available.
+   */
+  getAssetEndpoint(assetId: number, iTwinId?: GuidString): Promise<CesiumAssetEndpoint>;
+}

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -9,7 +9,7 @@ import { assert, BeEvent, Id64, Id64Arg, Id64String } from "@itwin/core-bentley"
 import { Range1d, Vector3d } from "@itwin/core-geometry";
 import {
   BackgroundMapProps, BackgroundMapProvider, BackgroundMapProviderProps, BackgroundMapSettings,
-  BaseLayerSettings, BaseMapLayerSettings, ColorDef, ContextRealityModelProps, DisplayStyle3dSettings, DisplayStyle3dSettingsProps,
+  BaseLayerSettings, BaseMapLayerSettings, CesiumIonAssetId, ColorDef, ContextRealityModelProps, DisplayStyle3dSettings, DisplayStyle3dSettingsProps,
   DisplayStyleProps, DisplayStyleSettings, Environment, FeatureAppearance, GlobeMode, ImageMapLayerSettings, LightSettings, MapLayerProps,
   MapLayerSettings, MapSubLayerProps, RenderSchedule, RenderTimelineProps,
   SolarShadowSettings, SubCategoryOverride, SubLayerId, TerrainHeightOriginMode, ThematicDisplay, ThematicDisplayMode, ThematicGradientMode, ViewFlags,
@@ -436,7 +436,9 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     if (undefined === url)
       return undefined;
 
-    return this.contextRealityModelStates.find((x) => x.url === url);
+    // Use startsWith to match both key-bearing URLs (legacy) and keyless URLs (cesiumAccess path).
+    const osmPrefix = `$CesiumIonAsset=${CesiumIonAssetId.OSMBuildings}:`;
+    return this.contextRealityModelStates.find((x) => x.url?.startsWith(osmPrefix));
   }
 
   /** Set the display of the OpenStreetMap worldwide building layer in this display style by attaching or detaching the reality model displaying the buildings.
@@ -451,7 +453,9 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     if (undefined === url)
       return false;
 
-    let model = this.settings.contextRealityModels.models.find((x) => x.url === url);
+    // Use startsWith to match both key-bearing URLs (legacy) and keyless URLs (cesiumAccess path).
+    const osmPrefix = `$CesiumIonAsset=${CesiumIonAssetId.OSMBuildings}:`;
+    let model = this.settings.contextRealityModels.models.find((x) => x.url?.startsWith(osmPrefix));
     if (options.onOff === false) {
       const turnedOff = undefined !== model && this.settings.contextRealityModels.delete(model);
       if (turnedOff)

--- a/core/frontend/src/RealityDataSourceCesiumIonAssetImpl.ts
+++ b/core/frontend/src/RealityDataSourceCesiumIonAssetImpl.ts
@@ -10,6 +10,7 @@ import { assert, BentleyStatus, GuidString } from "@itwin/core-bentley";
 import { IModelError, RealityData, RealityDataProvider, RealityDataSourceKey, RealityDataSourceProps } from "@itwin/core-common";
 import { CesiumIonAssetProvider, getCesiumAccessTokenAndEndpointUrl, getCesiumAssetUrl, getCesiumOSMBuildingsUrl } from "./tile/internal";
 import { PublisherProductInfo, RealityDataSource, SpatialLocationAndExtents } from "./RealityDataSource";
+import { IModelApp } from "./IModelApp";
 
 /** This class provides access to the reality data provider services.
  * It encapsulates access to a reality data weiter it be from local access, http or ProjectWise Context Share.
@@ -111,10 +112,20 @@ export class RealityDataSourceCesiumIonAssetImpl implements RealityDataSource {
     // The following is only if the reality data is not stored on PW Context Share.
     const cesiumAsset = CesiumIonAssetProvider.parseCesiumUrl(url);
     if (cesiumAsset) {
-      const tokenAndUrl = await getCesiumAccessTokenAndEndpointUrl(`${cesiumAsset.id}`, cesiumAsset.key);
-      if (tokenAndUrl.url && tokenAndUrl.token) {
-        url = tokenAndUrl.url;
-        this._requestAuthorization = `Bearer ${tokenAndUrl.token}`;
+      if (cesiumAsset.key) {
+        // Legacy path: key-bearing URL — use Cesium ion REST API directly.
+        const tokenAndUrl = await getCesiumAccessTokenAndEndpointUrl(`${cesiumAsset.id}`, cesiumAsset.key);
+        if (tokenAndUrl.url && tokenAndUrl.token) {
+          url = tokenAndUrl.url;
+          this._requestAuthorization = `Bearer ${tokenAndUrl.token}`;
+        }
+      } else if (IModelApp.tileAdmin.cesiumAccess) {
+        // New path: keyless URL — delegate to the configured cesiumAccess client.
+        const endpoint = await IModelApp.tileAdmin.cesiumAccess.getAssetEndpoint(cesiumAsset.id, iTwinId);
+        if (endpoint.url && endpoint.accessToken) {
+          url = endpoint.url;
+          this._requestAuthorization = `Bearer ${endpoint.accessToken}`;
+        }
       }
     }
 

--- a/core/frontend/src/core-frontend.ts
+++ b/core/frontend/src/core-frontend.ts
@@ -11,6 +11,7 @@ export * from "./BriefcaseConnection";
 export * from "./BriefcaseTxns";
 export * from "./CatalogConnection";
 export * from "./CategorySelectorState";
+export * from "./CesiumAccessClient";
 export * from "./ChangeFlags";
 export * from "./CheckpointConnection";
 export * from "./common";

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -16,6 +16,7 @@ import { IModelApp } from "../IModelApp";
 import { IpcApp } from "../IpcApp";
 import { IModelConnection } from "../IModelConnection";
 import { Viewport } from "../Viewport";
+import type { CesiumAccessClient } from "../CesiumAccessClient";
 import {
   DisclosedTileTreeSet, FetchCloudStorage, IModelTileTree, LRUTileList, ReadonlyTileUserSet, Tile, TileContentDecodingStatistics, TileLoadStatus,
   TileRequest, TileRequestChannels, TileStorage, TileTree, TileTreeOwner, TileUsageMarker, TileUser, UniqueTileUserSets,
@@ -163,6 +164,8 @@ export class TileAdmin {
   public readonly contextPreloadParentSkip: number;
   /** @beta */
   public readonly cesiumIonKey?: string;
+  /** @beta */
+  public readonly cesiumAccess?: CesiumAccessClient;
   private readonly _removeIModelConnectionOnCloseListener: () => void;
   private _totalElided = 0;
   private _rpcInitialized = false;
@@ -189,6 +192,13 @@ export class TileAdmin {
 
   /** @internal */
   public get emptyTileUserSet(): ReadonlyTileUserSet { return UniqueTileUserSets.emptySet; }
+
+  /** Returns true if Cesium ion assets can be accessed, either via [[cesiumIonKey]] or [[cesiumAccess]].
+   * @beta
+   */
+  public get hasCesiumAccess(): boolean {
+    return undefined !== this.cesiumAccess || undefined !== this.cesiumIonKey;
+  }
 
   /** Returns basic statistics about the TileAdmin's current state. */
   public get statistics(): TileAdmin.Statistics {
@@ -249,6 +259,7 @@ export class TileAdmin {
     this.useLargerTiles = options.useLargerTiles ?? defaultTileOptions.useLargerTiles;
     this.mobileRealityTileMinToleranceRatio = Math.max(options.mobileRealityTileMinToleranceRatio ?? 3.0, 1.0);
     this.cesiumIonKey = options.cesiumIonKey;
+    this.cesiumAccess = options.cesiumAccess;
     this._cloudStorage = options.tileStorage;
 
     const gpuMemoryLimits = options.gpuMemoryLimits;
@@ -1262,6 +1273,13 @@ export namespace TileAdmin {
      * @public
      */
     cesiumIonKey?: string;
+
+    /** A pluggable client for resolving Cesium ion asset endpoints. When supplied, this takes precedence over [[cesiumIonKey]].
+     * Use this to access Cesium ion assets via the iTwin Platform Cesium Curated Content API or any custom authentication mechanism.
+     * If neither `cesiumAccess` nor `cesiumIonKey` is supplied, Cesium ion content like terrain and OSM Buildings cannot be displayed.
+     * @beta
+     */
+    cesiumAccess?: CesiumAccessClient;
 
     /** If true, when applying a schedule script to a view, ordinary tiles will be requested and then reprocessed on the frontend to align with the script's
      * animation nodes. This permits the use of schedule scripts not stored in the iModel and improves utilization of the tile cache for animated views.

--- a/core/frontend/src/tile/map/CesiumTerrainProvider.ts
+++ b/core/frontend/src/tile/map/CesiumTerrainProvider.ts
@@ -6,7 +6,7 @@
 /** @packageDocumentation
  * @module Tiles
  */
-import { assert, BeDuration, BeTimePoint, ByteStream, JsonUtils, utf8ToString } from "@itwin/core-bentley";
+import { assert, BeDuration, BeTimePoint, ByteStream, GuidString, JsonUtils, utf8ToString } from "@itwin/core-bentley";
 import { Point2d, Point3d, Range1d, Vector3d } from "@itwin/core-geometry";
 import { CesiumIonAssetId, CesiumTerrainAssetId, nextPoint3d64FromByteStream, OctEncodedNormal, QPoint2d } from "@itwin/core-common";
 import { MessageSeverity } from "@itwin/appui-abstract";
@@ -19,6 +19,7 @@ import {
   TerrainMeshProviderOptions, Tile, TileAvailability,
 } from "../internal";
 import { ScreenViewport } from "../../Viewport";
+import type { CesiumAccessClient, CesiumAssetEndpoint } from "../../CesiumAccessClient";
 
 /** @internal */
 enum QuantizedMeshExtensionIds {
@@ -36,11 +37,35 @@ export function getCesiumAssetUrl(osmAssetId: number, requestKey: string): strin
 
 /** @internal */
 export function getCesiumOSMBuildingsUrl(): string | undefined {
-  const key = IModelApp.tileAdmin.cesiumIonKey;
-  if (undefined === key)
+  if (!IModelApp.tileAdmin.hasCesiumAccess)
     return undefined;
 
+  const key = IModelApp.tileAdmin.cesiumIonKey ?? "";
   return getCesiumAssetUrl(+CesiumIonAssetId.OSMBuildings, key);
+}
+
+/** Default [[CesiumAccessClient]] implementation that fetches endpoints directly from the Cesium ion REST API.
+ * @internal
+ */
+class CesiumIonClient implements CesiumAccessClient {
+  public async getAssetEndpoint(assetId: number): Promise<CesiumAssetEndpoint> {
+    const requestKey = IModelApp.tileAdmin.cesiumIonKey;
+    if (undefined === requestKey)
+      return {};
+
+    const apiUrl = `https://api.cesium.com/v1/assets/${assetId}/endpoint?access_token=${requestKey}`;
+    try {
+      const apiResponse = await request(apiUrl, "json");
+      if (undefined === apiResponse || undefined === apiResponse.url) {
+        assert(false);
+        return {};
+      }
+      return { accessToken: apiResponse.accessToken, url: apiResponse.url };
+    } catch {
+      assert(false);
+      return {};
+    }
+  }
 }
 
 /** @internal */
@@ -80,16 +105,18 @@ function notifyTerrainError(detailedDescription?: string): void {
 
 /** @internal */
 export async function getCesiumTerrainProvider(opts: TerrainMeshProviderOptions): Promise<TerrainMeshProvider | undefined> {
-  const accessTokenAndEndpointUrl = await getCesiumAccessTokenAndEndpointUrl(opts.dataSource || CesiumTerrainAssetId.Default);
-  if (!accessTokenAndEndpointUrl.token || !accessTokenAndEndpointUrl.url) {
+  const cesiumClient: CesiumAccessClient = IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
+  const assetId = opts.dataSource ? parseInt(opts.dataSource, 10) : parseInt(CesiumTerrainAssetId.Default, 10);
+  const endpoint = await cesiumClient.getAssetEndpoint(assetId, opts.iTwinId);
+  if (!endpoint.accessToken || !endpoint.url) {
     notifyTerrainError(IModelApp.localization.getLocalizedString(`iModelJs:BackgroundMap.MissingCesiumToken`));
     return undefined;
   }
 
   let layers;
   try {
-    const layerRequestOptions: RequestOptions = { headers: { authorization: `Bearer ${accessTokenAndEndpointUrl.token}` } };
-    const layerUrl = `${accessTokenAndEndpointUrl.url}layer.json`;
+    const layerRequestOptions: RequestOptions = { headers: { authorization: `Bearer ${endpoint.accessToken}` } };
+    const layerUrl = `${endpoint.url}layer.json`;
     layers = await request(layerUrl, "json", layerRequestOptions);
   } catch {
     notifyTerrainError();
@@ -120,14 +147,14 @@ export async function getCesiumTerrainProvider(opts: TerrainMeshProviderOptions)
     }
   }
 
-  let tileUrlTemplate = accessTokenAndEndpointUrl.url + layers.tiles[0].replace("{version}", layers.version);
+  let tileUrlTemplate = endpoint.url + layers.tiles[0].replace("{version}", layers.version);
   if (opts.wantNormals)
     tileUrlTemplate = tileUrlTemplate.replace("?", "?extensions=octvertexnormals-watermask-metadata&");
 
   const maxDepth = JsonUtils.asInt(layers.maxzoom, 19);
 
   // TBD -- When we have  an API extract the heights for the project from the terrain tiles - for use temporary Bing elevation.
-  return new CesiumTerrainProvider(opts, accessTokenAndEndpointUrl.token, tileUrlTemplate, maxDepth, tilingScheme, tileAvailability, layers.metadataAvailability);
+  return new CesiumTerrainProvider(opts, endpoint.accessToken, endpoint.expiresAt, tileUrlTemplate, maxDepth, tilingScheme, tileAvailability, layers.metadataAvailability);
 }
 
 function zigZagDecode(value: number) {
@@ -168,13 +195,14 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
   private readonly _metaDataAvailableLevel?: number;
   private readonly _exaggeration: number;
   private readonly _assetId: string;
+  private readonly _iTwinId: GuidString | undefined;
 
   private static _scratchQPoint2d = QPoint2d.fromScalars(0, 0);
   private static _scratchPoint2d = Point2d.createZero();
   private static _scratchPoint = Point3d.createZero();
   private static _scratchNormal = Vector3d.createZero();
   private static _scratchHeightRange = Range1d.createNull();
-  private static _tokenTimeoutInterval = BeDuration.fromSeconds(60 * 30);      // Request a new access token every 30 minutes...
+  private static _defaultTokenTimeoutInterval = BeDuration.fromSeconds(60 * 30); // 30-minute fallback when expiresAt is not provided
   private _tokenTimeOut: BeTimePoint;
 
   public override forceTileLoad(tile: Tile): boolean {
@@ -183,7 +211,7 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     return undefined !== this._metaDataAvailableLevel && mapTile.quadId.level === this._metaDataAvailableLevel && !mapTile.everLoaded;
   }
 
-  constructor(opts: TerrainMeshProviderOptions, accessToken: string, tileUrlTemplate: string, maxDepth: number, tilingScheme: MapTilingScheme,
+  constructor(opts: TerrainMeshProviderOptions, accessToken: string, expiresAt: Date | undefined, tileUrlTemplate: string, maxDepth: number, tilingScheme: MapTilingScheme,
     tileAvailability: TileAvailability | undefined, metaDataAvailableLevel: number | undefined) {
     super();
     this._wantSkirts = opts.wantSkirts;
@@ -195,9 +223,12 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     this._tilingScheme = tilingScheme;
     this._tileAvailability = tileAvailability;
     this._metaDataAvailableLevel = metaDataAvailableLevel;
-    this._assetId = opts.dataSource || CesiumTerrainAssetId.Default;
+    this._assetId = opts.dataSource ?? CesiumTerrainAssetId.Default;
+    this._iTwinId = opts.iTwinId;
 
-    this._tokenTimeOut = BeTimePoint.now().plus(CesiumTerrainProvider._tokenTimeoutInterval);
+    this._tokenTimeOut = expiresAt
+      ? BeTimePoint.fromNow(BeDuration.fromMilliseconds(Math.max(0, expiresAt.getTime() - Date.now())))
+      : BeTimePoint.now().plus(CesiumTerrainProvider._defaultTokenTimeoutInterval);
   }
 
   /** @deprecated in 5.0 - will not be removed until after 2026-06-13. Use [addAttributions] instead. */
@@ -253,12 +284,15 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     // ###TODO why does he update the access token when reading the mesh instead of when requesting it?
     // This function only returns undefined if it fails to acquire token - but it doesn't need the token...
     if (BeTimePoint.now().milliseconds > this._tokenTimeOut.milliseconds) {
-      const accessTokenAndEndpointUrl = await getCesiumAccessTokenAndEndpointUrl(this._assetId);
-      if (!accessTokenAndEndpointUrl.token || args.isCanceled())
+      const cesiumClient: CesiumAccessClient = IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
+      const endpoint = await cesiumClient.getAssetEndpoint(parseInt(this._assetId, 10), this._iTwinId);
+      if (!endpoint.accessToken || args.isCanceled())
         return undefined;
 
-      this._accessToken = accessTokenAndEndpointUrl.token;
-      this._tokenTimeOut = BeTimePoint.now().plus(CesiumTerrainProvider._tokenTimeoutInterval);
+      this._accessToken = endpoint.accessToken;
+      this._tokenTimeOut = endpoint.expiresAt
+        ? BeTimePoint.fromNow(BeDuration.fromMilliseconds(Math.max(0, endpoint.expiresAt.getTime() - Date.now())))
+        : BeTimePoint.now().plus(CesiumTerrainProvider._defaultTokenTimeoutInterval);
     }
 
     const { data, tile } = args;

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -694,6 +694,7 @@ class MapTreeSupplier implements TileTreeSupplier {
       wantNormals: id.wantNormals,
       dataSource: id.terrainDataSource,
       produceGeometry: id.produceGeometry,
+      iTwinId: iModel.iTwinId,
     };
 
     if (id.applyTerrain) {

--- a/core/frontend/src/tile/map/TerrainMeshProvider.ts
+++ b/core/frontend/src/tile/map/TerrainMeshProvider.ts
@@ -39,6 +39,11 @@ export interface TerrainMeshProviderOptions {
   /** Optionally identifies a specific terrain data source supplied by the [[TerrainMeshProvider]]. */
   dataSource?: string;
 
+  /** Optional iTwin identifier providing context for resolving Cesium ion asset access tokens.
+   * @beta
+   */
+  iTwinId?: string;
+
   /** If true, the provider is being used to collect tiles from the tile tree.
    * @beta
    */

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -9,6 +9,7 @@ publish: false
     - [`IModelConnection.createQueryReader` now terminates gracefully if the connection is closed](#imodelconnectioncreatequeryreader-now-terminates-gracefully-if-the-connection-is-closed)
     - [Quantity property description classes deprecated](#quantity-property-description-classes-deprecated)
     - [Bing Maps imagery is deprecated](#bing-maps-imagery-is-deprecated)
+    - [Pluggable Cesium ion authentication via `CesiumAccessClient`](#pluggable-cesium-ion-authentication-via-cesiumaccessclient)
   - [@itwin/map-layers-formats](#itwinmap-layers-formats)
     - [Azure Maps basemap support is available through map-layers-formats](#azure-maps-basemap-support-is-available-through-map-layers-formats)
 
@@ -68,6 +69,47 @@ Bing Maps imagery-specific APIs are now deprecated. This release does not change
 For new basemap imagery, prefer Azure Maps via `@itwin/map-layers-formats`.
 
 > This imagery-only deprecation does not deprecate `BingLocationProvider` or `BingElevationProvider`, and it does not add a built-in replacement for Bing elevation or location services. Applications that continue using those Bing services must continue supplying `MapLayerOptions.BingMaps`. 
+
+### Pluggable Cesium ion authentication via `CesiumAccessClient`
+
+A new [`CesiumAccessClient`]($frontend) interface and [`TileAdmin.Props.cesiumAccess`]($frontend) option enable pluggable authentication for [Cesium ion](https://cesium.com/platform/cesium-ion/) assets such as Cesium World Terrain and OSM Buildings. When configured, `cesiumAccess` takes precedence over the existing [`cesiumIonKey`]($frontend), and the existing `cesiumIonKey` option remains fully supported.
+
+This is the integration point for the **iTwin Platform Cesium Curated Content API**, which allows iTwin subscribers to access public Cesium assets using an iTwin access token without needing a personal Cesium ion subscription.
+
+```typescript
+// Example: implement CesiumAccessClient backed by the iTwin Platform Curated Content API.
+import { CesiumAccessClient, CesiumAssetEndpoint } from "@itwin/core-frontend";
+
+class ITPCesiumClient implements CesiumAccessClient {
+  constructor(private readonly getAccessToken: () => Promise<string>) {}
+
+  async getAssetEndpoint(assetId: number, iTwinId?: string): Promise<CesiumAssetEndpoint> {
+    const token = await this.getAccessToken();
+    const url = `https://api.bentley.com/curated-content/cesium/${assetId}`;
+    const params = iTwinId ? `?iTwinId=${iTwinId}` : "";
+    const res = await fetch(`${url}${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    return {
+      url: data.tilesetUrl,
+      accessToken: data.token,
+      expiresAt: data.expiresAt ? new Date(data.expiresAt) : undefined,
+    };
+  }
+}
+
+// Configure at startup:
+IModelApp.startup({
+  tileAdmin: {
+    cesiumAccess: new ITPCesiumClient(() => myApp.getITwinAccessToken()),
+  },
+});
+```
+
+The new [`TileAdmin.hasCesiumAccess`]($frontend) getter returns `true` if either `cesiumAccess` or `cesiumIonKey` is configured, making it easy to conditionally enable Cesium-backed features.
+
+The optional [`iTwinId`]($frontend) field on `TerrainMeshProviderOptions` is now populated from the active `IModelConnection.iTwinId` so that `CesiumAccessClient.getAssetEndpoint` implementations can scope requests to the correct iTwin context.
 
 ## @itwin/map-layers-formats
 


### PR DESCRIPTION
## Summary

Integrates the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/) into `@itwin/core-frontend` via a pluggable `CesiumAccessClient` interface.

### Problem

Cesium World Terrain and OSM Buildings are currently gated behind a hard-coded `cesiumIonKey`. The iTwin Platform now provides a Cesium Curated Content API that lets iTwin subscribers access those assets using an iTwin access token — without requiring their own Cesium ion subscription.

### Solution

A new `CesiumAccessClient` interface + `TileAdmin.Props.cesiumAccess` option that:
- Takes precedence over `cesiumIonKey` when both are configured
- Passes `iTwinId` from the active `IModelConnection` for scoped requests
- Supports `expiresAt`-aware token refresh (shorter-lived iTP tokens)
- Keeps the existing `cesiumIonKey` path fully working (no deprecation)

### Files changed

| File | Change |
|---|---|
| `core/frontend/src/CesiumAccessClient.ts` | **NEW** — `CesiumAssetEndpoint` + `CesiumAccessClient` interfaces (`@beta`) |
| `core/frontend/src/tile/TileAdmin.ts` | `cesiumAccess` field + `hasCesiumAccess` getter + `Props.cesiumAccess` |
| `core/frontend/src/tile/map/CesiumTerrainProvider.ts` | `CesiumIonClient` (internal default); use `cesiumAccess` at all call sites; `expiresAt`-aware refresh; store `_iTwinId` |
| `core/frontend/src/tile/map/TerrainMeshProvider.ts` | `iTwinId?: string` added to `TerrainMeshProviderOptions` |
| `core/frontend/src/tile/map/MapTileTree.ts` | Populate `iTwinId` from `IModelConnection.iTwinId` |
| `core/frontend/src/DisplayStyleState.ts` | `startsWith` instead of `===` for OSM Buildings URL matching (backward compat with persisted key-bearing URLs) |
| `core/frontend/src/RealityDataSourceCesiumIonAssetImpl.ts` | Delegate to `cesiumAccess` when URL has no embedded key |
| `core/frontend/src/core-frontend.ts` | Export `CesiumAccessClient` + `CesiumAssetEndpoint` |
| `common/api/core-frontend.api.md` | Updated via `rush extract-api` — additions only, zero breaking changes |
| `docs/changehistory/NextVersion.md` | New section with usage example |

## Validation

**Targeted verification:**
- `rushx build` in `core/frontend` — clean build, zero TypeScript errors
- `rushx test` in `core/frontend` — 951 passed, 1 pre-existing flaky timeout (`RenderInstances` — confirmed failing on master before this change)
- `rush extract-api` — confirms additions-only, no breaking changes to `@public` APIs

**Known baseline issues:**
- `RenderInstances > renders multiple instances of glTF model with different features and color overrides` — pre-existing timeout flake, fails on master too

Closes https://github.com/iTwin/itwinjs-backlog/issues/1306