### PR TITLE
Fix DTA startup: raise optimizeDeps esbuild target to es2022

### DIFF
--- a/test-apps/display-test-app/vite.config.mts
+++ b/test-apps/display-test-app/vite.config.mts
@@ -179,6 +179,7 @@ export default defineConfig(() => {
         "@itwin/core-common", //prevents rpc errors
       ],
       esbuildOptions: {
+        target: "es2022", // allow modern syntax (e.g. typed-array destructuring in flatbush) during dep pre-bundling
         plugins: [
           {
             name: "externalize-electron",


### PR DESCRIPTION
Fixes #9408

## Problem

After the esbuild bump in #9398 (https://github.com/iTwin/itwinjs-core/issues/9398), esbuild 0.28.x hard-errors when pre-bundling flatbush because it uses typed-array destructuring (const [magic, versionAndType] = new Uint8Array(...)) not allowed by the es2020 browserslist target. DTA fails to start for everyone on master.

## Fix

Set optimizeDeps.esbuildOptions.target to "es2022" in DTA's vite.config.mts so the destructuring is permitted during dependency pre-bundling.

Scope: DTA is the only affected app — flatbush is pulled in solely via @itwin/map-layers-formats, which no other Vite app depends on.

## Validation

 - Targeted verification: Started DTA's Vite dev server; no esbuild transform error, server serves 200.