### PR TITLE
Update docs for to make it clear how to access meta data from TxnEntityChange and also make class compare case-insensitive 

### DIFF
--- a/common/changes/@itwin/core-frontend/khanaffan-txn-entity-metadata-case-insensitive_2026-06-16-16-24.json
+++ b/common/changes/@itwin/core-frontend/khanaffan-txn-entity-metadata-case-insensitive_2026-06-16-16-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "TxnEntityMetadata.is now compares class names case-insensitively.",
+      "type": "none",
+      "packageName": "@itwin/core-frontend"
+    }
+  ],
+  "packageName": "@itwin/core-frontend",
+  "email": "khanaffan@users.noreply.github.com"
+}

--- a/core/frontend/src/BriefcaseTxns.ts
+++ b/core/frontend/src/BriefcaseTxns.ts
@@ -44,12 +44,30 @@ export class BriefcaseTxns extends BriefcaseNotificationHandler implements TxnNo
   }
 
   /** Event raised after Txn validation or changeset application to indicate the set of changed elements.
+   * Iterate the `changes` argument to access each element's Id, change type, and ECClass — no additional
+   * RPC calls are required to determine class information.
    * @note If there are many changed elements in a single Txn, the notifications are sent in batches so this event *may be called multiple times* per Txn.
+   * @see [[TxnEntityChanges]] for the full iteration and filtering API.
+   * @example
+   * ```ts
+   * iModel.txns.onElementsChanged.addListener((changes) => {
+   *   // React only to inserted or updated PhysicalElements (and subclasses):
+   *   for (const change of changes.filter({
+   *     includeTypes: ["inserted", "updated"],
+   *     includeMetadata: (m) => m.is("BisCore:PhysicalElement"),
+   *   })) {
+   *     console.log(`${change.type}: ${change.id} (${change.metadata.classFullName})`);
+   *   }
+   * });
+   * ```
    */
   public readonly onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
 
   /** Event raised after Txn validation or changeset application to indicate the set of changed models.
+   * Iterate the `changes` argument to access each model's Id, change type, and ECClass — no additional
+   * RPC calls are required to determine class information.
    * @note If there are many changed models in a single Txn, the notifications are sent in batches so this event *may be called multiple times* per Txn.
+   * @see [[TxnEntityChanges]] for the full iteration and filtering API.
    */
   public readonly onModelsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
 

--- a/core/frontend/src/TxnEntityChanges.ts
+++ b/core/frontend/src/TxnEntityChanges.ts
@@ -14,11 +14,20 @@ import { NotifyEntitiesChangedArgs } from "@itwin/core-common";
  * @extensions
  */
 export interface TxnEntityMetadata {
-  /** The class's name in "Schema:Class" format. */
+  /** The class's name in "Schema:Class" format, e.g. `"BisCore:PhysicalElement"`. */
   readonly classFullName: string;
 
-  /** Returns true if this class is or is derived from the specified class.
-   * @note Class names are compared case-sensitively.
+  /** Returns true if this class is or is derived from `baseClassFullName`.
+   * Use this to match an element by base class without knowing its exact class name.
+   * @note The comparison is case-insensitive.
+   * @example
+   * ```ts
+   * // true for BisCore:PhysicalElement and any subclass thereof:
+   * metadata.is("BisCore:PhysicalElement")
+   *
+   * // also true — comparison is case-insensitive:
+   * metadata.is("biscore:physicalelement")
+   * ```
    */
   is(baseClassFullName: string): boolean;
 }
@@ -38,7 +47,18 @@ export interface TxnEntityChange {
   type: TxnEntityChangeType;
   /** The Id of the affected entity. */
   id: Id64String;
-  /** A representation of the BIS class of the affected entity. */
+  /** The BIS class of the affected entity.
+   * Use [[TxnEntityMetadata.classFullName]] to get the class name in "Schema:Class" format,
+   * or [[TxnEntityMetadata.is]] to test whether it derives from a given base class.
+   * @example
+   * ```ts
+   * // Exact class match:
+   * if (change.metadata.classFullName === "MySchema:MyElement") { ... }
+   *
+   * // Match any subclass of a base class:
+   * if (change.metadata.is("BisCore:GeometricElement")) { ... }
+   * ```
+   */
   metadata: TxnEntityMetadata;
 }
 
@@ -75,9 +95,26 @@ export interface TxnEntityChangesFilterOptions {
 
 /** Describes a set of elements or models that were modified as part of a transaction in a [[BriefcaseConnection]],
  * serving as the payload for the [[BriefcaseTxns.onElementsChanged]] and [[BriefcaseTxns.onModelsChanged]] events.
- * The [[inserted]], [[deleted]], and [[updated]] compressed Id sets can be awkward to work with.
- * It can be more convenient to iterate over the individual [[TxnEntityChange]]s, especially if you wish to [[filter]] out some
- * changes.
+ *
+ * **Prefer iterating over accessing the raw [[inserted]], [[deleted]], and [[updated]] Id sets.**
+ * Iterating this object (or using [[filter]]) yields [[TxnEntityChange]] objects that include each
+ * entity's Id, change type, and ECClass — so you can filter by class without making any additional RPC calls.
+ *
+ * @example
+ * ```ts
+ * // Iterate all changes with class info:
+ * for (const change of changes) {
+ *   console.log(change.id, change.type, change.metadata.classFullName);
+ * }
+ *
+ * // Only process inserted GeometricElements (includes subclasses):
+ * for (const change of changes.filter({
+ *   includeTypes: ["inserted"],
+ *   includeMetadata: (m) => m.is("BisCore:GeometricElement"),
+ * })) {
+ *   console.log(change.id);
+ * }
+ * ```
  * @public
  * @extensions
  */
@@ -89,7 +126,11 @@ export interface TxnEntityChanges extends TxnEntityChangeIterable {
   /** The ids of entities that were modified during the Txn, including any [Element]($backend)s for which one of their [ElementAspect]($backend)s was changed. */
   readonly updated?: CompressedId64Set;
 
-  /** Obtain an iterator over changes meeting the criteria specified by `options`. */
+  /** Returns an iterable over only the changes that satisfy `options`.
+   * This is the recommended way to react to changes for a specific class or change type,
+   * as it avoids iterating irrelevant changes and requires no RPC calls to determine class information.
+   * @see [[TxnEntityChangesFilterOptions]]
+   */
   filter(options: TxnEntityChangesFilterOptions): TxnEntityChangeIterable;
 }
 
@@ -102,7 +143,7 @@ export class Metadata implements TxnEntityMetadata {
   }
 
   public is(baseName: string): boolean {
-    return baseName === this.classFullName || this.baseClasses.some((base) => base.is(baseName));
+    return baseName.toLowerCase() === this.classFullName.toLowerCase() || this.baseClasses.some((base) => base.is(baseName));
   }
 }
 

--- a/core/frontend/src/test/TxnEntityChanges.test.ts
+++ b/core/frontend/src/test/TxnEntityChanges.test.ts
@@ -19,6 +19,13 @@ describe("TxnEntityMetadata", () => {
       expect(a.is("a")).toBe(true);
     });
 
+    it("is case-insensitive", () => {
+      const a = new Metadata("BisCore:PhysicalElement");
+      expect(a.is("biscore:physicalelement")).toBe(true);
+      expect(a.is("BISCORE:PHYSICALELEMENT")).toBe(true);
+      expect(a.is("BisCore:PhysicalElement")).toBe(true);
+    });
+
     it("returns true for direct base class", () => {
       const a = new Metadata("a");
       const b = new Metadata("b");

--- a/docs/learning/InteractiveEditing.md
+++ b/docs/learning/InteractiveEditing.md
@@ -22,6 +22,56 @@ While Txns themselves hold net changes for a single transaction, they are stored
 
 Every [BriefcaseDb]($backend) has a [TxnManager]($backend) associated that is used for operations on Txns. Likewise, every [BriefcaseConnection]($frontend) has a [BriefcaseTxns]($frontend). `TxnManager` and `BriefcaseTxns` emit events with information about "what happened" as changes are made to the database, permitting applications to remain synchronized with the persistent state of the iModel by, for example, updating in-memory state or (on the frontend) refreshing the contents of [Viewport]($frontend)s and UI components.
 
+### Reacting to element changes on the frontend
+
+[BriefcaseTxns.onElementsChanged]($frontend) fires after every transaction (and after applying changesets) with a [TxnEntityChanges]($frontend) object describing which elements were inserted, deleted, or updated.
+
+**Iterating** the changes object yields [TxnEntityChange]($frontend) objects that include each element's `id`, `type` (`"inserted"` | `"deleted"` | `"updated"`), and ECClass via `metadata`. This means you can filter by class **without making any additional RPC calls** — the class information is already embedded in the notification.
+
+#### ❌ Anti-pattern — fetching props just to check the class
+
+```ts
+iModel.txns.onElementsChanged.addListener(async (changes) => {
+  for (const id of CompressedId64Set.iterable(changes.inserted ?? "")) {
+    // Bad: unnecessary RPC round-trip just to get the class name
+    const props = await iModel.elements.loadProps(id);
+    if (props.classFullName === "MySchema:MyElement") {
+      // handle it
+    }
+  }
+});
+```
+
+#### ✅ Correct approach — use the iteration API
+
+```ts
+iModel.txns.onElementsChanged.addListener((changes) => {
+  // Exact class match:
+  for (const change of changes) {
+    if (change.metadata.classFullName === "MySchema:MyElement") {
+      console.log(change.id, change.type);
+    }
+  }
+});
+```
+
+#### ✅ Filter by base class (includes all subclasses)
+
+Use [TxnEntityChanges.filter]($frontend) with `includeMetadata` and [TxnEntityMetadata.is]($frontend) to efficiently restrict iteration to a class hierarchy. The comparison is **case-insensitive**:
+
+```ts
+iModel.txns.onElementsChanged.addListener((changes) => {
+  for (const change of changes.filter({
+    includeTypes: ["inserted", "updated"],
+    includeMetadata: (m) => m.is("BisCore:GeometricElement"),
+  })) {
+    console.log(`${change.type}: ${change.id} (${change.metadata.classFullName})`);
+  }
+});
+```
+
+The `filter` method evaluates the class criterion once per unique class in the change set — not once per entity — making it efficient even for large transactions.
+
 ## Pushing Changesets to IModelHub
 
 Txns hold local changes to a single briefcase. When users are ready to send the result of all their local changes to IModelHub, the local Txns must be merged together to form a Changeset. Changesets hold the *net changes* made during the session. As above, if an element is added in one Txn and then deleted in a subsequent Txn, the result is no change in the Changeset.

--- a/docs/learning/InteractiveEditing.md
+++ b/docs/learning/InteractiveEditing.md
@@ -28,7 +28,7 @@ Every [BriefcaseDb]($backend) has a [TxnManager]($backend) associated that is us
 
 **Iterating** the changes object yields [TxnEntityChange]($frontend) objects that include each element's `id`, `type` (`"inserted"` | `"deleted"` | `"updated"`), and ECClass via `metadata`. This means you can filter by class **without making any additional RPC calls** — the class information is already embedded in the notification.
 
-#### ❌ Anti-pattern — fetching props just to check the class
+#### Anti-pattern — fetching props just to check the class
 
 ```ts
 iModel.txns.onElementsChanged.addListener(async (changes) => {
@@ -42,7 +42,7 @@ iModel.txns.onElementsChanged.addListener(async (changes) => {
 });
 ```
 
-#### ✅ Correct approach — use the iteration API
+#### Correct approach — use the iteration API
 
 ```ts
 iModel.txns.onElementsChanged.addListener((changes) => {
@@ -55,7 +55,7 @@ iModel.txns.onElementsChanged.addListener((changes) => {
 });
 ```
 
-#### ✅ Filter by base class (includes all subclasses)
+#### Filter by base class (includes all subclasses)
 
 Use [TxnEntityChanges.filter]($frontend) with `includeMetadata` and [TxnEntityMetadata.is]($frontend) to efficiently restrict iteration to a class hierarchy. The comparison is **case-insensitive**:
 


### PR DESCRIPTION
Make `TxnEntityMetadata.is` compare class names case-insensitively. Adds a test and updates docs.

## Validation
- Targeted verification: `vitest --run TxnEntityChanges` (8 passed); `rushx docs` builds clean.
- Known baseline issues: none.