### PR TITLE
feat: pluggable Cesium ion authentication via CesiumAccessClient

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2018,6 +2018,18 @@ export class CategorySelectorState extends ElementState {
     toJSON(): CategorySelectorProps;
 }
 
+// @beta
+export interface CesiumAccessClient {
+    getAssetEndpoint(assetId: string, iTwinId?: GuidString): Promise<CesiumAssetEndpoint>;
+}
+
+// @beta
+export interface CesiumAssetEndpoint {
+    accessToken?: string;
+    expiresAt?: Date;
+    url?: string;
+}
+
 // @public
 export enum ChangeFlag {
     All = 268435455,
@@ -10797,6 +10809,8 @@ export interface TerrainMeshProviderOptions {
     dataSource?: string;
     exaggeration: number;
     // @beta
+    iTwinId?: string;
+    // @beta
     produceGeometry?: boolean;
     wantNormals: boolean;
     wantSkirts: boolean;
@@ -11000,6 +11014,8 @@ export class TileAdmin {
     // @internal (undocumented)
     readonly alwaysSubdivideIncompleteTiles: boolean;
     // @beta (undocumented)
+    readonly cesiumAccess?: CesiumAccessClient;
+    // @beta (undocumented)
     readonly cesiumIonKey?: string;
     // (undocumented)
     readonly channels: TileRequestChannels;
@@ -11070,6 +11086,8 @@ export class TileAdmin {
     getTileUserSetForRequest(user: TileUser, users?: ReadonlyTileUserSet): ReadonlyTileUserSet;
     get gpuMemoryLimit(): GpuMemoryLimit;
     set gpuMemoryLimit(limit: GpuMemoryLimit);
+    // @beta
+    get hasCesiumAccess(): boolean;
     // @internal (undocumented)
     readonly ignoreAreaPatterns: boolean;
     // @internal (undocumented)
@@ -11149,6 +11167,8 @@ export namespace TileAdmin {
         alwaysSubdivideIncompleteTiles?: boolean;
         // @internal
         cacheTileMetadata?: boolean;
+        // @beta
+        cesiumAccess?: CesiumAccessClient;
         cesiumIonKey?: string;
         // @alpha
         contextPreloadParentDepth?: number;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -10854,7 +10854,7 @@ export interface TerrainMeshProviderOptions {
     dataSource?: string;
     exaggeration: number;
     // @beta
-    iTwinId?: string;
+    iTwinId?: GuidString;
     // @beta
     produceGeometry?: boolean;
     wantNormals: boolean;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -2020,14 +2020,14 @@ export class CategorySelectorState extends ElementState {
 
 // @beta
 export interface CesiumAccessClient {
-    getAssetEndpoint(assetId: string, iTwinId?: GuidString): Promise<CesiumAssetEndpoint>;
+    getAssetEndpoint(assetId: string, iTwinId?: GuidString): Promise<CesiumAssetEndpoint | undefined>;
 }
 
 // @beta
 export interface CesiumAssetEndpoint {
-    accessToken?: string;
+    accessToken: string;
     expiresAt?: Date;
-    url?: string;
+    url: string;
 }
 
 // @public
@@ -11015,9 +11015,11 @@ export class TileAdmin {
     readonly alwaysRequestEdges: boolean;
     // @internal (undocumented)
     readonly alwaysSubdivideIncompleteTiles: boolean;
-    // @beta (undocumented)
+    // @beta
+    get canAccessCesium(): boolean;
+    // @beta
     readonly cesiumAccess?: CesiumAccessClient;
-    // @beta (undocumented)
+    // @beta
     readonly cesiumIonKey?: string;
     // (undocumented)
     readonly channels: TileRequestChannels;
@@ -11088,8 +11090,6 @@ export class TileAdmin {
     getTileUserSetForRequest(user: TileUser, users?: ReadonlyTileUserSet): ReadonlyTileUserSet;
     get gpuMemoryLimit(): GpuMemoryLimit;
     set gpuMemoryLimit(limit: GpuMemoryLimit);
-    // @beta
-    get hasCesiumAccess(): boolean;
     // @internal (undocumented)
     readonly ignoreAreaPatterns: boolean;
     // @internal (undocumented)

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -88,6 +88,8 @@ public;function;canvasToResizedCanvasWithBars
 beta;interface;CatalogConnection
 beta;namespace;CatalogConnection
 public;class;CategorySelectorState
+beta;interface;CesiumAccessClient
+beta;interface;CesiumAssetEndpoint
 public;enum;ChangeFlag
 public;class;ChangeFlags
 public;interface;ChangeViewedModel2dOptions

--- a/common/changes/@itwin/core-frontend/anmolshres98-cesium-curated-content_2026-06-17-00-37.json
+++ b/common/changes/@itwin/core-frontend/anmolshres98-cesium-curated-content_2026-06-17-00-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add CesiumAccessClient interface to allow applications to plug in custom Cesium ion authentication, with CesiumIonClient as the built-in fallback.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/anmolshres98-cesium-curated-content_2026-06-17-00-37.json
+++ b/common/changes/@itwin/core-frontend/anmolshres98-cesium-curated-content_2026-06-17-00-37.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Add CesiumAccessClient interface to allow applications to plug in custom Cesium ion authentication, with CesiumIonClient as the built-in fallback.",
+      "comment": "Add CesiumAccessClient interface to allow applications to plug in custom Cesium Ion authentication, with CesiumIonClient as the built-in fallback.",
       "type": "none"
     }
   ],

--- a/core/frontend/src/CesiumAccessClient.ts
+++ b/core/frontend/src/CesiumAccessClient.ts
@@ -8,7 +8,7 @@
 
 import { GuidString } from "@itwin/core-bentley";
 
-/** Describes the endpoint for accessing a Cesium ion asset.
+/** Describes the endpoint for accessing a Cesium Ion asset.
  * @see [[CesiumAccessClient.getAssetEndpoint]]
  * @beta
  */
@@ -23,12 +23,12 @@ export interface CesiumAssetEndpoint {
   expiresAt?: Date;
 }
 
-/** Provides access tokens and endpoint URLs for [Cesium ion](https://cesium.com/platform/cesium-ion/) assets.
+/** Provides access tokens and endpoint URLs for [Cesium Ion](https://cesium.com/platform/cesium-ion/) assets.
  * Supply an implementation via [[TileAdmin.Props.cesiumAccess]] to control how Cesium assets are resolved.
  *
  * Two authentication paths:
- * - **Direct Cesium ion**: set [[TileAdmin.Props.cesiumIonKey]] — uses the built-in [[CesiumIonClient]] and
- *   authenticates directly with Cesium ion. Suitable for apps with their own Cesium ion subscription.
+ * - **Direct Cesium Ion**: set [[TileAdmin.Props.cesiumIonKey]] — uses the built-in [[CesiumIonClient]] and
+ *   authenticates directly with Cesium Ion. Suitable for apps with their own Cesium Ion subscription.
  * - **Custom / iTwin Platform proxy**: supply a `CesiumAccessClient` implementation — for example, one that
  *   calls the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)
  *   using an iTwin access token.
@@ -39,8 +39,8 @@ export interface CesiumAssetEndpoint {
  * @beta
  */
 export interface CesiumAccessClient {
-  /** Obtain an endpoint URL and access token for the specified Cesium ion asset.
-   * @param assetId The Cesium ion asset identifier (e.g. `"1"` for Cesium World Terrain).
+  /** Obtain an endpoint URL and access token for the specified Cesium Ion asset.
+   * @param assetId The Cesium Ion asset identifier (e.g. `"1"` for Cesium World Terrain).
    * @param iTwinId Optional iTwin context identifier. May be used by implementations to scope requests
    * to a specific iTwin context, but is not required by the iTwin Platform Cesium Curated Content API.
    * @returns The resolved endpoint. Return an empty object `{}` if the asset cannot be accessed.

--- a/core/frontend/src/CesiumAccessClient.ts
+++ b/core/frontend/src/CesiumAccessClient.ts
@@ -15,8 +15,12 @@ import { GuidString } from "@itwin/core-bentley";
 export interface CesiumAssetEndpoint {
   /** The access token to use for authenticated requests to [[url]]. */
   accessToken: string;
-  /** The base URL for the asset's tiles. Callers append resource paths (e.g. `layer.json`) directly to it;
-   * a trailing `/` is added automatically if not already present.
+  /** The endpoint URL for the asset, used together with [[accessToken]] to fetch its tiles.
+   * The exact shape depends on the asset type:
+   * - For terrain assets, this is the base URL to which callers append resource paths (e.g. `layer.json`);
+   *   a trailing `/` is added automatically if not already present.
+   * - For 3D Tiles assets, this is the URL of the tileset's root document (e.g. `tileset.json`), requested
+   *   directly, with child resources resolved relative to it.
    */
   url: string;
   /** The time at which [[accessToken]] expires, if known.

--- a/core/frontend/src/CesiumAccessClient.ts
+++ b/core/frontend/src/CesiumAccessClient.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Tiles
+ */
+
+import { GuidString } from "@itwin/core-bentley";
+
+/** Describes the endpoint for accessing a Cesium ion asset.
+ * @see [[CesiumAccessClient.getAssetEndpoint]]
+ * @beta
+ */
+export interface CesiumAssetEndpoint {
+  /** The access token to use for authenticated requests to [[url]]. */
+  accessToken?: string;
+  /** The base URL for the asset's tiles. */
+  url?: string;
+  /** The time at which [[accessToken]] expires, if known.
+   * Used by callers to schedule proactive token refresh before expiry.
+   */
+  expiresAt?: Date;
+}
+
+/** Provides access tokens and endpoint URLs for [Cesium ion](https://cesium.com/platform/cesium-ion/) assets.
+ * Supply an implementation via [[TileAdmin.Props.cesiumAccess]] to control how Cesium assets are resolved.
+ *
+ * Two authentication paths:
+ * - **Direct Cesium ion**: set [[TileAdmin.Props.cesiumIonKey]] — uses the built-in [[CesiumIonClient]] and
+ *   authenticates directly with Cesium ion. Suitable for apps with their own Cesium ion subscription.
+ * - **Custom / iTwin Platform proxy**: supply a `CesiumAccessClient` implementation — for example, one that
+ *   calls the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)
+ *   using an iTwin access token.
+ *
+ * If both `cesiumIonKey` and `cesiumAccess` are supplied, `cesiumAccess` takes precedence.
+ * @see [[TileAdmin.Props.cesiumAccess]]
+ * @see [[TileAdmin.Props.cesiumIonKey]]
+ * @beta
+ */
+export interface CesiumAccessClient {
+  /** Obtain an endpoint URL and access token for the specified Cesium ion asset.
+   * @param assetId The Cesium ion asset identifier (e.g. `"1"` for Cesium World Terrain).
+   * @param iTwinId Optional iTwin context identifier. May be used by implementations to scope requests
+   * to a specific iTwin context, but is not required by the iTwin Platform Cesium Curated Content API.
+   * @returns The resolved endpoint. Return an empty object `{}` if the asset cannot be accessed.
+   */
+  getAssetEndpoint(assetId: string, iTwinId?: GuidString): Promise<CesiumAssetEndpoint>;
+}

--- a/core/frontend/src/CesiumAccessClient.ts
+++ b/core/frontend/src/CesiumAccessClient.ts
@@ -14,9 +14,11 @@ import { GuidString } from "@itwin/core-bentley";
  */
 export interface CesiumAssetEndpoint {
   /** The access token to use for authenticated requests to [[url]]. */
-  accessToken?: string;
-  /** The base URL for the asset's tiles. */
-  url?: string;
+  accessToken: string;
+  /** The base URL for the asset's tiles. Callers append resource paths (e.g. `layer.json`) directly to it;
+   * a trailing `/` is added automatically if not already present.
+   */
+  url: string;
   /** The time at which [[accessToken]] expires, if known.
    * Used by callers to schedule proactive token refresh before expiry.
    */
@@ -27,13 +29,16 @@ export interface CesiumAssetEndpoint {
  * Supply an implementation via [[TileAdmin.Props.cesiumAccess]] to control how Cesium assets are resolved.
  *
  * Two authentication paths:
- * - **Direct Cesium Ion**: set [[TileAdmin.Props.cesiumIonKey]] — uses the built-in [[CesiumIonClient]] and
+ * - **Direct Cesium Ion**: set [[TileAdmin.Props.cesiumIonKey]] — uses a built-in client that
  *   authenticates directly with Cesium Ion. Suitable for apps with their own Cesium Ion subscription.
  * - **Custom / iTwin Platform proxy**: supply a `CesiumAccessClient` implementation — for example, one that
  *   calls the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)
  *   using an iTwin access token.
  *
- * If both `cesiumIonKey` and `cesiumAccess` are supplied, `cesiumAccess` takes precedence.
+ * If both `cesiumIonKey` and `cesiumAccess` are supplied, `cesiumAccess` takes precedence. Note that this
+ * precedence applies when resolving an asset by id; reality models persisted with a legacy key-bearing URL
+ * (e.g. `$CesiumIonAsset=<id>:<key>`) continue to authenticate directly with the embedded key and are not
+ * routed through a registered `cesiumAccess` client.
  * @see [[TileAdmin.Props.cesiumAccess]]
  * @see [[TileAdmin.Props.cesiumIonKey]]
  * @beta
@@ -43,7 +48,7 @@ export interface CesiumAccessClient {
    * @param assetId The Cesium Ion asset identifier (e.g. `"1"` for Cesium World Terrain).
    * @param iTwinId Optional iTwin context identifier. May be used by implementations to scope requests
    * to a specific iTwin context, but is not required by the iTwin Platform Cesium Curated Content API.
-   * @returns The resolved endpoint. Return an empty object `{}` if the asset cannot be accessed.
+   * @returns The resolved endpoint, or `undefined` if the asset cannot be accessed.
    */
-  getAssetEndpoint(assetId: string, iTwinId?: GuidString): Promise<CesiumAssetEndpoint>;
+  getAssetEndpoint(assetId: string, iTwinId?: GuidString): Promise<CesiumAssetEndpoint | undefined>;
 }

--- a/core/frontend/src/DisplayStyleState.ts
+++ b/core/frontend/src/DisplayStyleState.ts
@@ -436,7 +436,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     if (undefined === url)
       return undefined;
 
-    return this.contextRealityModelStates.find((x) => x.url === url);
+    return this.contextRealityModelStates.find((x) => x.url?.startsWith(url));
   }
 
   /** Set the display of the OpenStreetMap worldwide building layer in this display style by attaching or detaching the reality model displaying the buildings.
@@ -451,7 +451,7 @@ export abstract class DisplayStyleState extends ElementState implements DisplayS
     if (undefined === url)
       return false;
 
-    let model = this.settings.contextRealityModels.models.find((x) => x.url === url);
+    let model = this.settings.contextRealityModels.models.find((x) => x.url?.startsWith(url));
     if (options.onOff === false) {
       const turnedOff = undefined !== model && this.settings.contextRealityModels.delete(model);
       if (turnedOff)

--- a/core/frontend/src/RealityDataSourceCesiumIonAssetImpl.ts
+++ b/core/frontend/src/RealityDataSourceCesiumIonAssetImpl.ts
@@ -8,11 +8,11 @@
 import { request } from "./request/Request";
 import { assert, BentleyStatus, GuidString } from "@itwin/core-bentley";
 import { IModelError, RealityData, RealityDataProvider, RealityDataSourceKey, RealityDataSourceProps } from "@itwin/core-common";
-import { CesiumIonAssetProvider, getCesiumAccessTokenAndEndpointUrl, getCesiumAssetUrl, getCesiumOSMBuildingsUrl } from "./tile/internal";
+import { CesiumIonAssetProvider, getCesiumAccessClient, getCesiumAccessTokenAndEndpointUrl, getCesiumAssetUrl, getCesiumOSMBuildingsUrl } from "./tile/internal";
 import { PublisherProductInfo, RealityDataSource, SpatialLocationAndExtents } from "./RealityDataSource";
 
 /** This class provides access to the reality data provider services.
- * It encapsulates access to a reality data weiter it be from local access, http or ProjectWise Context Share.
+ * It encapsulates access to a reality data whether it be from local access, http or ProjectWise Context Share.
  * The key provided at the creation determines if this is ProjectWise Context Share reference.
  * If not then it is considered local (ex: C:\temp\TileRoot.json) or plain http access (http://someserver.com/data/TileRoot.json)
  * There is a one to one relationship between a reality data and the instances of present class.
@@ -111,10 +111,23 @@ export class RealityDataSourceCesiumIonAssetImpl implements RealityDataSource {
     // The following is only if the reality data is not stored on PW Context Share.
     const cesiumAsset = CesiumIonAssetProvider.parseCesiumUrl(url);
     if (cesiumAsset) {
-      const tokenAndUrl = await getCesiumAccessTokenAndEndpointUrl(`${cesiumAsset.id}`, cesiumAsset.key);
-      if (tokenAndUrl.url && tokenAndUrl.token) {
-        url = tokenAndUrl.url;
-        this._requestAuthorization = `Bearer ${tokenAndUrl.token}`;
+      let resolvedToken: string | undefined;
+      let resolvedUrl: string | undefined;
+      if (cesiumAsset.key) {
+        // key-bearing URL - use the Ion key directly
+        const tokenAndUrl = await getCesiumAccessTokenAndEndpointUrl(`${cesiumAsset.id}`, cesiumAsset.key);
+        resolvedToken = tokenAndUrl.token;
+        resolvedUrl = tokenAndUrl.url;
+      } else {
+        // delegate to the registered CesiumAccessClient
+        const client = getCesiumAccessClient();
+        const endpoint = await client.getAssetEndpoint(`${cesiumAsset.id}`, iTwinId);
+        resolvedToken = endpoint.accessToken;
+        resolvedUrl = endpoint.url;
+      }
+      if (resolvedUrl && resolvedToken) {
+        url = resolvedUrl;
+        this._requestAuthorization = `Bearer ${resolvedToken}`;
       }
     }
 

--- a/core/frontend/src/RealityDataSourceCesiumIonAssetImpl.ts
+++ b/core/frontend/src/RealityDataSourceCesiumIonAssetImpl.ts
@@ -114,7 +114,9 @@ export class RealityDataSourceCesiumIonAssetImpl implements RealityDataSource {
       let resolvedToken: string | undefined;
       let resolvedUrl: string | undefined;
       if (cesiumAsset.key) {
-        // key-bearing URL - use the Ion key directly
+        // Legacy key-bearing URL (e.g. persisted saved view) - authenticate directly with the embedded Ion key.
+        // Such URLs are intentionally exempt from the cesiumAccess-over-cesiumIonKey precedence rule and are not
+        // routed through a registered CesiumAccessClient; see [[CesiumAccessClient]].
         const tokenAndUrl = await getCesiumAccessTokenAndEndpointUrl(`${cesiumAsset.id}`, cesiumAsset.key);
         resolvedToken = tokenAndUrl.token;
         resolvedUrl = tokenAndUrl.url;
@@ -122,8 +124,10 @@ export class RealityDataSourceCesiumIonAssetImpl implements RealityDataSource {
         // delegate to the registered CesiumAccessClient
         const client = getCesiumAccessClient();
         const endpoint = await client.getAssetEndpoint(`${cesiumAsset.id}`, iTwinId);
-        resolvedToken = endpoint.accessToken;
-        resolvedUrl = endpoint.url;
+        if (endpoint) {
+          resolvedToken = endpoint.accessToken;
+          resolvedUrl = endpoint.url;
+        }
       }
       if (resolvedUrl && resolvedToken) {
         url = resolvedUrl;

--- a/core/frontend/src/core-frontend.ts
+++ b/core/frontend/src/core-frontend.ts
@@ -11,6 +11,7 @@ export * from "./BriefcaseConnection";
 export * from "./BriefcaseTxns";
 export * from "./CatalogConnection";
 export * from "./CategorySelectorState";
+export * from "./CesiumAccessClient";
 export * from "./ChangeFlags";
 export * from "./CheckpointConnection";
 export * from "./common";

--- a/core/frontend/src/test/DisplayStyleState.test.ts
+++ b/core/frontend/src/test/DisplayStyleState.test.ts
@@ -11,6 +11,7 @@ import { ContextRealityModelState } from "../ContextRealityModelState";
 import { IModelConnection } from "../IModelConnection";
 import { IModelApp } from "../IModelApp";
 import { createBlankConnection } from "./createBlankConnection";
+import { getCesiumOSMBuildingsUrl } from "../tile/internal";
 import { _onScheduleScriptReferenceChanged, _scheduleScriptReference } from './../common/internal/Symbols';
 
 describe("DisplayStyleState", () => {
@@ -287,6 +288,52 @@ describe("DisplayStyleState", () => {
       } finally {
         (iModel as any).ecefLocation = originalEcefLocation;
       }
+    });
+  });
+
+  describe("getOSMBuildingRealityModel", () => {
+    let iModel: IModelConnection;
+
+    beforeAll(async () => {
+      await IModelApp.startup({ localization: new EmptyLocalization(), tileAdmin: { cesiumIonKey: "my-ion-key" } });
+      iModel = createBlankConnection();
+    });
+
+    afterAll(async () => {
+      await iModel.close();
+      await IModelApp.shutdown();
+    });
+
+    function makeStyle(): DisplayStyle3dState {
+      const props: DisplayStyle3dProps = {
+        id: "0xbeef",
+        code: Code.createEmpty(),
+        model: IModelConnection.dictionaryId,
+        classFullName: "BisCore:DisplayStyle3d",
+      };
+      return new DisplayStyle3dState(props, iModel);
+    }
+
+    it("matches a reality model persisted with a legacy key-bearing URL", () => {
+      // getCesiumOSMBuildingsUrl now returns a keyless prefix (e.g. `$CesiumIonAsset=96188:`). Reality models
+      // saved before this change embed the Ion key (`$CesiumIonAsset=96188:<key>`); the `startsWith` match must
+      // still find them so toggling OSM buildings off keeps working for legacy saved views.
+      const style = makeStyle();
+      const keylessPrefix = getCesiumOSMBuildingsUrl();
+      expect(keylessPrefix).toBeDefined();
+
+      const legacyModel = { url: `${keylessPrefix}LEGACY_EMBEDDED_KEY` } as unknown as ContextRealityModelState;
+      vi.spyOn(style, "contextRealityModelStates", "get").mockReturnValue([legacyModel]);
+
+      expect(style.getOSMBuildingRealityModel()).toBe(legacyModel);
+    });
+
+    it("returns undefined when no reality model matches the OSM buildings URL", () => {
+      const style = makeStyle();
+      const unrelatedModel = { url: "https://example.com/some-other-tileset/" } as unknown as ContextRealityModelState;
+      vi.spyOn(style, "contextRealityModelStates", "get").mockReturnValue([unrelatedModel]);
+
+      expect(style.getOSMBuildingRealityModel()).toBeUndefined();
     });
   });
 });

--- a/core/frontend/src/test/tile/TileAdmin.test.ts
+++ b/core/frontend/src/test/tile/TileAdmin.test.ts
@@ -11,8 +11,9 @@ import { ScreenViewport, Viewport } from "../../Viewport";
 import { MockRender } from "../../internal/render/MockRender";
 import { RenderGraphic } from "../../render/RenderGraphic";
 import { RenderMemory } from "../../render/RenderMemory";
-import { GpuMemoryLimit, GpuMemoryLimits, Tile, TileAdmin, TileContent, TiledGraphicsProvider, TileDrawArgs, TileLoadPriority, TileRequest, TileTree, TileTreeOwner, TileTreeReference, TileTreeSupplier } from "../../tile/internal";
+import { getCesiumAccessClient, getCesiumOSMBuildingsUrl, GpuMemoryLimit, GpuMemoryLimits, Tile, TileAdmin, TileContent, TiledGraphicsProvider, TileDrawArgs, TileLoadPriority, TileRequest, TileTree, TileTreeOwner, TileTreeReference, TileTreeSupplier } from "../../tile/internal";
 import { createBlankConnection } from "../createBlankConnection";
+import { CesiumAccessClient, CesiumAssetEndpoint } from "../../CesiumAccessClient";
 
 describe("TileAdmin", () => {
   describe("memory limit configuration", () => {
@@ -603,6 +604,106 @@ describe("TileAdmin", () => {
       await MockRender.App.shutdown();
       expect(IModelApp.tileAdmin.totalTileContentBytes).toEqual(0);
       expect(isLinked(tile)).toBe(false);
+    });
+  });
+
+  describe("hasCesiumAccess", () => {
+    const mockCesiumAccess: CesiumAccessClient = {
+      async getAssetEndpoint(_assetId: string): Promise<CesiumAssetEndpoint> {
+        return { accessToken: "token", url: "https://example.com" };
+      },
+    };
+
+    it("returns false when neither cesiumIonKey nor cesiumAccess is configured", () => {
+      const admin = new TileAdmin(false, undefined, undefined);
+      expect(admin.hasCesiumAccess).toBe(false);
+    });
+
+    it("returns true when cesiumIonKey is configured", () => {
+      const admin = new TileAdmin(false, undefined, { cesiumIonKey: "my-ion-key" });
+      expect(admin.hasCesiumAccess).toBe(true);
+    });
+
+    it("returns true when cesiumAccess is configured", () => {
+      const admin = new TileAdmin(false, undefined, { cesiumAccess: mockCesiumAccess });
+      expect(admin.hasCesiumAccess).toBe(true);
+    });
+
+    it("returns true when both cesiumIonKey and cesiumAccess are configured", () => {
+      const admin = new TileAdmin(false, undefined, { cesiumIonKey: "my-ion-key", cesiumAccess: mockCesiumAccess });
+      expect(admin.hasCesiumAccess).toBe(true);
+    });
+  });
+
+  describe("getCesiumAccessClient", () => {
+    afterEach(async () => {
+      if (IModelApp.initialized)
+        await MockRender.App.shutdown();
+    });
+
+    it("returns a default client fallback when only cesiumIonKey is configured", async () => {
+      await MockRender.App.startup({ tileAdmin: { cesiumIonKey: "my-ion-key" } });
+      // getCesiumAccessClient returns cesiumAccess ?? new CesiumIonClient() internally.
+      // With no cesiumAccess set, a new internal fallback client is created each call.
+      expect(IModelApp.tileAdmin.cesiumAccess).toBeUndefined();
+      const client = getCesiumAccessClient();
+      expect(client).toBeDefined();
+      // It's a new fallback instance, not the registered cesiumAccess (which is undefined)
+      expect(client).not.toBe(IModelApp.tileAdmin.cesiumAccess);
+    });
+
+    it("returns the registered cesiumAccess client when configured", async () => {
+      const mockAccess: CesiumAccessClient = {
+        async getAssetEndpoint(_assetId: string): Promise<CesiumAssetEndpoint> {
+          return { accessToken: "token", url: "https://example.com" };
+        },
+      };
+      await MockRender.App.startup({ tileAdmin: { cesiumAccess: mockAccess } });
+      expect(getCesiumAccessClient()).toBe(mockAccess);
+    });
+
+    it("cesiumAccess takes precedence over cesiumIonKey when both are configured", async () => {
+      const mockAccess: CesiumAccessClient = {
+        async getAssetEndpoint(_assetId: string): Promise<CesiumAssetEndpoint> {
+          return { accessToken: "token", url: "https://example.com" };
+        },
+      };
+      await MockRender.App.startup({ tileAdmin: { cesiumIonKey: "my-ion-key", cesiumAccess: mockAccess } });
+      // getCesiumAccessClient() must return the registered client, not a CesiumIonClient fallback
+      expect(getCesiumAccessClient()).toBe(mockAccess);
+    });
+  });
+
+  describe("getCesiumOSMBuildingsUrl", () => {
+    afterEach(async () => {
+      if (IModelApp.initialized)
+        await MockRender.App.shutdown();
+    });
+
+    it("returns undefined when no Cesium access is configured", async () => {
+      await MockRender.App.startup({ tileAdmin: {} });
+      expect(getCesiumOSMBuildingsUrl()).toBeUndefined();
+    });
+
+    it("returns a keyless URL when only cesiumIonKey is configured", async () => {
+      await MockRender.App.startup({ tileAdmin: { cesiumIonKey: "my-ion-key" } });
+      const url = getCesiumOSMBuildingsUrl();
+      expect(url).toBeDefined();
+      // URL is always keyless — key is resolved internally by CesiumIonClient at fetch time
+      expect(url).toMatch(/^\$CesiumIonAsset=\d+:$/);
+    });
+
+    it("returns a keyless URL when cesiumAccess is configured", async () => {
+      const mockAccess: CesiumAccessClient = {
+        async getAssetEndpoint(_assetId: string): Promise<CesiumAssetEndpoint> {
+          return { accessToken: "token", url: "https://example.com" };
+        },
+      };
+      await MockRender.App.startup({ tileAdmin: { cesiumAccess: mockAccess } });
+      const url = getCesiumOSMBuildingsUrl();
+      expect(url).toBeDefined();
+      // keyless: ends with colon and empty key
+      expect(url).toMatch(/^\$CesiumIonAsset=\d+:$/);
     });
   });
 });

--- a/core/frontend/src/test/tile/TileAdmin.test.ts
+++ b/core/frontend/src/test/tile/TileAdmin.test.ts
@@ -648,10 +648,8 @@ describe("TileAdmin", () => {
       expect(IModelApp.tileAdmin.cesiumAccess).toBeUndefined();
       const client = getCesiumAccessClient();
       expect(client).toBeDefined();
-      // The fallback must implement the CesiumAccessClient contract...
+      // The fallback must implement the CesiumAccessClient contract.
       expect(typeof client.getAssetEndpoint).toBe("function");
-      // ...and, lacking a registered client, each call constructs a fresh fallback instance.
-      expect(getCesiumAccessClient()).not.toBe(client);
     });
 
     it("returns the registered cesiumAccess client when configured", async () => {

--- a/core/frontend/src/test/tile/TileAdmin.test.ts
+++ b/core/frontend/src/test/tile/TileAdmin.test.ts
@@ -11,7 +11,7 @@ import { ScreenViewport, Viewport } from "../../Viewport";
 import { MockRender } from "../../internal/render/MockRender";
 import { RenderGraphic } from "../../render/RenderGraphic";
 import { RenderMemory } from "../../render/RenderMemory";
-import { getCesiumAccessClient, getCesiumOSMBuildingsUrl, GpuMemoryLimit, GpuMemoryLimits, Tile, TileAdmin, TileContent, TiledGraphicsProvider, TileDrawArgs, TileLoadPriority, TileRequest, TileTree, TileTreeOwner, TileTreeReference, TileTreeSupplier } from "../../tile/internal";
+import { computeCesiumTokenTimeoutInterval, getCesiumAccessClient, getCesiumOSMBuildingsUrl, getCesiumTerrainProvider, GpuMemoryLimit, GpuMemoryLimits, Tile, TileAdmin, TileContent, TiledGraphicsProvider, TileDrawArgs, TileLoadPriority, TileRequest, TileTree, TileTreeOwner, TileTreeReference, TileTreeSupplier } from "../../tile/internal";
 import { createBlankConnection } from "../createBlankConnection";
 import { CesiumAccessClient, CesiumAssetEndpoint } from "../../CesiumAccessClient";
 
@@ -607,31 +607,31 @@ describe("TileAdmin", () => {
     });
   });
 
-  describe("hasCesiumAccess", () => {
+  describe("canAccessCesium", () => {
     const mockCesiumAccess: CesiumAccessClient = {
       async getAssetEndpoint(_assetId: string): Promise<CesiumAssetEndpoint> {
-        return { accessToken: "token", url: "https://example.com" };
+        return { accessToken: "token", url: "https://example.com/" };
       },
     };
 
     it("returns false when neither cesiumIonKey nor cesiumAccess is configured", () => {
       const admin = new TileAdmin(false, undefined, undefined);
-      expect(admin.hasCesiumAccess).toBe(false);
+      expect(admin.canAccessCesium).toBe(false);
     });
 
     it("returns true when cesiumIonKey is configured", () => {
       const admin = new TileAdmin(false, undefined, { cesiumIonKey: "my-ion-key" });
-      expect(admin.hasCesiumAccess).toBe(true);
+      expect(admin.canAccessCesium).toBe(true);
     });
 
     it("returns true when cesiumAccess is configured", () => {
       const admin = new TileAdmin(false, undefined, { cesiumAccess: mockCesiumAccess });
-      expect(admin.hasCesiumAccess).toBe(true);
+      expect(admin.canAccessCesium).toBe(true);
     });
 
     it("returns true when both cesiumIonKey and cesiumAccess are configured", () => {
       const admin = new TileAdmin(false, undefined, { cesiumIonKey: "my-ion-key", cesiumAccess: mockCesiumAccess });
-      expect(admin.hasCesiumAccess).toBe(true);
+      expect(admin.canAccessCesium).toBe(true);
     });
   });
 
@@ -644,12 +644,14 @@ describe("TileAdmin", () => {
     it("returns a default client fallback when only cesiumIonKey is configured", async () => {
       await MockRender.App.startup({ tileAdmin: { cesiumIonKey: "my-ion-key" } });
       // getCesiumAccessClient returns cesiumAccess ?? new CesiumIonClient() internally.
-      // With no cesiumAccess set, a new internal fallback client is created each call.
+      // With no cesiumAccess registered, it must hand back a usable fallback client (not undefined).
       expect(IModelApp.tileAdmin.cesiumAccess).toBeUndefined();
       const client = getCesiumAccessClient();
       expect(client).toBeDefined();
-      // It's a new fallback instance, not the registered cesiumAccess (which is undefined)
-      expect(client).not.toBe(IModelApp.tileAdmin.cesiumAccess);
+      // The fallback must implement the CesiumAccessClient contract...
+      expect(typeof client.getAssetEndpoint).toBe("function");
+      // ...and, lacking a registered client, each call constructs a fresh fallback instance.
+      expect(getCesiumAccessClient()).not.toBe(client);
     });
 
     it("returns the registered cesiumAccess client when configured", async () => {
@@ -696,7 +698,7 @@ describe("TileAdmin", () => {
     it("returns a keyless URL when cesiumAccess is configured", async () => {
       const mockAccess: CesiumAccessClient = {
         async getAssetEndpoint(_assetId: string): Promise<CesiumAssetEndpoint> {
-          return { accessToken: "token", url: "https://example.com" };
+          return { accessToken: "token", url: "https://example.com/" };
         },
       };
       await MockRender.App.startup({ tileAdmin: { cesiumAccess: mockAccess } });
@@ -704,6 +706,56 @@ describe("TileAdmin", () => {
       expect(url).toBeDefined();
       // keyless: ends with colon and empty key
       expect(url).toMatch(/^\$CesiumIonAsset=\d+:$/);
+    });
+  });
+
+  describe("computeCesiumTokenTimeoutInterval", () => {
+    const defaultMs = 30 * 60 * 1000;
+    const minMs = 60 * 1000;
+
+    it("falls back to the default interval when expiry is unknown", () => {
+      expect(computeCesiumTokenTimeoutInterval(undefined).milliseconds).toEqual(defaultMs);
+    });
+
+    it("falls back to the default interval when expiry is an invalid Date", () => {
+      // An invalid Date's getTime() is NaN; without a guard this would disable refresh entirely.
+      expect(computeCesiumTokenTimeoutInterval(new Date("not-a-date")).milliseconds).toEqual(defaultMs);
+    });
+
+    it("clamps an already-expired token to the minimum interval", () => {
+      expect(computeCesiumTokenTimeoutInterval(new Date(Date.now() - 60_000)).milliseconds).toEqual(minMs);
+    });
+
+    it("clamps a near-immediate expiry to the minimum interval", () => {
+      // Without clamping this would re-resolve the endpoint on essentially every tile read.
+      expect(computeCesiumTokenTimeoutInterval(new Date(Date.now() + 100)).milliseconds).toEqual(minMs);
+    });
+
+    it("honors a valid future expiry", () => {
+      const tenMinutes = 10 * 60 * 1000;
+      const result = computeCesiumTokenTimeoutInterval(new Date(Date.now() + tenMinutes)).milliseconds;
+      // Allow a small tolerance for the elapsed time between Date.now() calls.
+      expect(result).toBeGreaterThan(tenMinutes - 5_000);
+      expect(result).toBeLessThanOrEqual(tenMinutes);
+    });
+  });
+
+  describe("getCesiumTerrainProvider", () => {
+    afterEach(async () => {
+      if (IModelApp.initialized)
+        await MockRender.App.shutdown();
+    });
+
+    const terrainOpts = { exaggeration: 1, wantSkirts: false, wantNormals: false };
+
+    it("returns undefined when the access client cannot resolve an endpoint", async () => {
+      const mockAccess: CesiumAccessClient = {
+        async getAssetEndpoint(): Promise<CesiumAssetEndpoint | undefined> {
+          return undefined;
+        },
+      };
+      await MockRender.App.startup({ tileAdmin: { cesiumAccess: mockAccess } });
+      expect(await getCesiumTerrainProvider(terrainOpts)).toBeUndefined();
     });
   });
 });

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -8,6 +8,7 @@
 import {
   assert, BeDuration, BeEvent, BentleyStatus, BeTimePoint, Id64, Id64Array, Id64String, IModelStatus, ProcessDetector,
 } from "@itwin/core-bentley";
+import { CesiumAccessClient } from "../CesiumAccessClient";
 import {
   BackendError, defaultTileOptions, EdgeOptions, ElementGraphicsRequestProps, getMaximumMajorTileFormatVersion, IModelError, IModelTileRpcInterface,
   IModelTileTreeProps, RenderSchedule, RpcOperation, RpcResponseCacheControl, ServerTimeoutError, TileContentSource, TileVersionInfo,
@@ -163,6 +164,8 @@ export class TileAdmin {
   public readonly contextPreloadParentSkip: number;
   /** @beta */
   public readonly cesiumIonKey?: string;
+  /** @beta */
+  public readonly cesiumAccess?: CesiumAccessClient;
   private readonly _removeIModelConnectionOnCloseListener: () => void;
   private _totalElided = 0;
   private _rpcInitialized = false;
@@ -208,6 +211,14 @@ export class TileAdmin {
     };
   }
 
+  /** Returns `true` if a custom [[CesiumAccessClient]] has been registered via [[TileAdmin.Props.cesiumAccess]],
+   * or if [[cesiumIonKey]] is set.
+   * @beta
+   */
+  public get hasCesiumAccess(): boolean {
+    return this.cesiumAccess !== undefined || this.cesiumIonKey !== undefined;
+  }
+
   /** Resets the cumulative (per-session) statistics like totalCompletedRequests, totalEmptyTiles, etc. */
   public resetStatistics(): void {
     this.channels.resetStatistics();
@@ -249,6 +260,7 @@ export class TileAdmin {
     this.useLargerTiles = options.useLargerTiles ?? defaultTileOptions.useLargerTiles;
     this.mobileRealityTileMinToleranceRatio = Math.max(options.mobileRealityTileMinToleranceRatio ?? 3.0, 1.0);
     this.cesiumIonKey = options.cesiumIonKey;
+    this.cesiumAccess = options.cesiumAccess;
     this._cloudStorage = options.tileStorage;
 
     const gpuMemoryLimits = options.gpuMemoryLimits;
@@ -1262,6 +1274,15 @@ export namespace TileAdmin {
      * @public
      */
     cesiumIonKey?: string;
+
+    /** Client that resolves Cesium asset endpoints for apps that need to authenticate via a custom resolver,
+     * such as the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/).
+     * When supplied, this takes precedence over [[cesiumIonKey]].
+     *
+     * @see [[TileAdmin.hasCesiumAccess]]
+     * @beta
+     */
+    cesiumAccess?: CesiumAccessClient;
 
     /** If true, when applying a schedule script to a view, ordinary tiles will be requested and then reprocessed on the frontend to align with the script's
      * animation nodes. This permits the use of schedule scripts not stored in the iModel and improves utilization of the tile cache for animated views.

--- a/core/frontend/src/tile/TileAdmin.ts
+++ b/core/frontend/src/tile/TileAdmin.ts
@@ -162,9 +162,15 @@ export class TileAdmin {
   public readonly contextPreloadParentDepth: number;
   /** @internal */
   public readonly contextPreloadParentSkip: number;
-  /** @beta */
+  /** The Cesium Ion API key supplied via [[TileAdmin.Props.cesiumIonKey]], used by the built-in client to
+   * authenticate directly with Cesium Ion. See [[canAccessCesium]] to test whether any Cesium access is configured.
+   * @beta
+   */
   public readonly cesiumIonKey?: string;
-  /** @beta */
+  /** The custom [[CesiumAccessClient]] registered via [[TileAdmin.Props.cesiumAccess]], used to resolve Cesium
+   * asset endpoints. When defined, it takes precedence over [[cesiumIonKey]].
+   * @beta
+   */
   public readonly cesiumAccess?: CesiumAccessClient;
   private readonly _removeIModelConnectionOnCloseListener: () => void;
   private _totalElided = 0;
@@ -211,11 +217,11 @@ export class TileAdmin {
     };
   }
 
-  /** Returns `true` if a custom [[CesiumAccessClient]] has been registered via [[TileAdmin.Props.cesiumAccess]],
-   * or if [[cesiumIonKey]] is set.
+  /** Returns `true` if any Cesium access is configured — that is, if a custom [[CesiumAccessClient]] has been
+   * registered via [[TileAdmin.Props.cesiumAccess]], or if [[cesiumIonKey]] is set.
    * @beta
    */
-  public get hasCesiumAccess(): boolean {
+  public get canAccessCesium(): boolean {
     return this.cesiumAccess !== undefined || this.cesiumIonKey !== undefined;
   }
 
@@ -1279,7 +1285,7 @@ export namespace TileAdmin {
      * such as the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/).
      * When supplied, this takes precedence over [[cesiumIonKey]].
      *
-     * @see [[TileAdmin.hasCesiumAccess]]
+     * @see [[TileAdmin.canAccessCesium]]
      * @beta
      */
     cesiumAccess?: CesiumAccessClient;

--- a/core/frontend/src/tile/map/CesiumTerrainProvider.ts
+++ b/core/frontend/src/tile/map/CesiumTerrainProvider.ts
@@ -6,12 +6,13 @@
 /** @packageDocumentation
  * @module Tiles
  */
-import { assert, BeDuration, BeTimePoint, ByteStream, JsonUtils, utf8ToString } from "@itwin/core-bentley";
+import { assert, BeDuration, BeTimePoint, ByteStream, GuidString, JsonUtils, utf8ToString } from "@itwin/core-bentley";
 import { Point2d, Point3d, Range1d, Vector3d } from "@itwin/core-geometry";
 import { CesiumIonAssetId, CesiumTerrainAssetId, nextPoint3d64FromByteStream, OctEncodedNormal, QPoint2d } from "@itwin/core-common";
 import { MessageSeverity } from "@itwin/appui-abstract";
 import { request, RequestOptions } from "../../request/Request";
 import { ApproximateTerrainHeights } from "../../ApproximateTerrainHeights";
+import { CesiumAccessClient, CesiumAssetEndpoint } from "../../CesiumAccessClient";
 import { IModelApp } from "../../IModelApp";
 import { RealityMeshParams, RealityMeshParamsBuilder } from "../../render/RealityMeshParams";
 import {
@@ -36,11 +37,17 @@ export function getCesiumAssetUrl(osmAssetId: number, requestKey: string): strin
 
 /** @internal */
 export function getCesiumOSMBuildingsUrl(): string | undefined {
-  const key = IModelApp.tileAdmin.cesiumIonKey;
-  if (undefined === key)
+  if (!IModelApp.tileAdmin.hasCesiumAccess)
     return undefined;
 
-  return getCesiumAssetUrl(+CesiumIonAssetId.OSMBuildings, key);
+  return getCesiumAssetUrl(+CesiumIonAssetId.OSMBuildings, "");
+}
+
+/** Returns the registered [[CesiumAccessClient]], or a default [[CesiumIonClient]] if none is registered.
+ * @internal
+ */
+export function getCesiumAccessClient(): CesiumAccessClient {
+  return IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
 }
 
 /** @internal */
@@ -80,16 +87,18 @@ function notifyTerrainError(detailedDescription?: string): void {
 
 /** @internal */
 export async function getCesiumTerrainProvider(opts: TerrainMeshProviderOptions): Promise<TerrainMeshProvider | undefined> {
-  const accessTokenAndEndpointUrl = await getCesiumAccessTokenAndEndpointUrl(opts.dataSource || CesiumTerrainAssetId.Default);
-  if (!accessTokenAndEndpointUrl.token || !accessTokenAndEndpointUrl.url) {
+  const assetId = opts.dataSource || CesiumTerrainAssetId.Default;
+  const client = IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
+  const endpoint = await client.getAssetEndpoint(assetId, opts.iTwinId);
+  if (!endpoint.accessToken || !endpoint.url) {
     notifyTerrainError(IModelApp.localization.getLocalizedString(`iModelJs:BackgroundMap.MissingCesiumToken`));
     return undefined;
   }
 
   let layers;
   try {
-    const layerRequestOptions: RequestOptions = { headers: { authorization: `Bearer ${accessTokenAndEndpointUrl.token}` } };
-    const layerUrl = `${accessTokenAndEndpointUrl.url}layer.json`;
+    const layerRequestOptions: RequestOptions = { headers: { authorization: `Bearer ${endpoint.accessToken}` } };
+    const layerUrl = `${endpoint.url}layer.json`;
     layers = await request(layerUrl, "json", layerRequestOptions);
   } catch {
     notifyTerrainError();
@@ -120,14 +129,14 @@ export async function getCesiumTerrainProvider(opts: TerrainMeshProviderOptions)
     }
   }
 
-  let tileUrlTemplate = accessTokenAndEndpointUrl.url + layers.tiles[0].replace("{version}", layers.version);
+  let tileUrlTemplate = endpoint.url + layers.tiles[0].replace("{version}", layers.version);
   if (opts.wantNormals)
     tileUrlTemplate = tileUrlTemplate.replace("?", "?extensions=octvertexnormals-watermask-metadata&");
 
   const maxDepth = JsonUtils.asInt(layers.maxzoom, 19);
 
   // TBD -- When we have  an API extract the heights for the project from the terrain tiles - for use temporary Bing elevation.
-  return new CesiumTerrainProvider(opts, accessTokenAndEndpointUrl.token, tileUrlTemplate, maxDepth, tilingScheme, tileAvailability, layers.metadataAvailability);
+  return new CesiumTerrainProvider(opts, endpoint.accessToken, endpoint.expiresAt, tileUrlTemplate, maxDepth, tilingScheme, tileAvailability, layers.metadataAvailability);
 }
 
 function zigZagDecode(value: number) {
@@ -168,6 +177,7 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
   private readonly _metaDataAvailableLevel?: number;
   private readonly _exaggeration: number;
   private readonly _assetId: string;
+  private readonly _iTwinId?: GuidString;
 
   private static _scratchQPoint2d = QPoint2d.fromScalars(0, 0);
   private static _scratchPoint2d = Point2d.createZero();
@@ -183,7 +193,7 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     return undefined !== this._metaDataAvailableLevel && mapTile.quadId.level === this._metaDataAvailableLevel && !mapTile.everLoaded;
   }
 
-  constructor(opts: TerrainMeshProviderOptions, accessToken: string, tileUrlTemplate: string, maxDepth: number, tilingScheme: MapTilingScheme,
+  constructor(opts: TerrainMeshProviderOptions, accessToken: string, expiresAt: Date | undefined, tileUrlTemplate: string, maxDepth: number, tilingScheme: MapTilingScheme,
     tileAvailability: TileAvailability | undefined, metaDataAvailableLevel: number | undefined) {
     super();
     this._wantSkirts = opts.wantSkirts;
@@ -196,8 +206,12 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     this._tileAvailability = tileAvailability;
     this._metaDataAvailableLevel = metaDataAvailableLevel;
     this._assetId = opts.dataSource || CesiumTerrainAssetId.Default;
+    this._iTwinId = opts.iTwinId;
 
-    this._tokenTimeOut = BeTimePoint.now().plus(CesiumTerrainProvider._tokenTimeoutInterval);
+    const initialTimeoutInterval = expiresAt
+      ? BeDuration.fromMilliseconds(Math.max(0, expiresAt.getTime() - Date.now()))
+      : CesiumTerrainProvider._tokenTimeoutInterval;
+    this._tokenTimeOut = BeTimePoint.now().plus(initialTimeoutInterval);
   }
 
   /** @deprecated in 5.0 - will not be removed until after 2026-06-13. Use [addAttributions] instead. */
@@ -253,12 +267,16 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     // ###TODO why does he update the access token when reading the mesh instead of when requesting it?
     // This function only returns undefined if it fails to acquire token - but it doesn't need the token...
     if (BeTimePoint.now().milliseconds > this._tokenTimeOut.milliseconds) {
-      const accessTokenAndEndpointUrl = await getCesiumAccessTokenAndEndpointUrl(this._assetId);
-      if (!accessTokenAndEndpointUrl.token || args.isCanceled())
+      const client = IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
+      const endpoint = await client.getAssetEndpoint(this._assetId, this._iTwinId);
+      if (!endpoint.accessToken || args.isCanceled())
         return undefined;
 
-      this._accessToken = accessTokenAndEndpointUrl.token;
-      this._tokenTimeOut = BeTimePoint.now().plus(CesiumTerrainProvider._tokenTimeoutInterval);
+      this._accessToken = endpoint.accessToken;
+      const timeoutInterval = endpoint.expiresAt
+        ? BeDuration.fromMilliseconds(Math.max(0, endpoint.expiresAt.getTime() - Date.now()))
+        : CesiumTerrainProvider._tokenTimeoutInterval;
+      this._tokenTimeOut = BeTimePoint.now().plus(timeoutInterval);
     }
 
     const { data, tile } = args;
@@ -487,5 +505,19 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     const heightRange = quadId.level <= 6 ? ApproximateTerrainHeights.instance.getTileHeightRange(quadId) : undefined;
 
     return undefined === heightRange ? parentRange : heightRange;
+  }
+}
+
+/** Default [[CesiumAccessClient]] that authenticates directly with Cesium ion using [[TileAdmin.cesiumIonKey]].
+ * This is used when no custom [[CesiumAccessClient]] is registered via [[TileAdmin.Props.cesiumAccess]].
+ * @internal
+ */
+class CesiumIonClient implements CesiumAccessClient {
+  public async getAssetEndpoint(assetId: string, _iTwinId?: GuidString): Promise<CesiumAssetEndpoint> {
+    const result = await getCesiumAccessTokenAndEndpointUrl(assetId);
+    if (!result.token || !result.url)
+      return {};
+
+    return { accessToken: result.token, url: result.url };
   }
 }

--- a/core/frontend/src/tile/map/CesiumTerrainProvider.ts
+++ b/core/frontend/src/tile/map/CesiumTerrainProvider.ts
@@ -28,7 +28,7 @@ enum QuantizedMeshExtensionIds {
   Metadata = 4,
 }
 
-/** Return the URL for a Cesium ion asset from its asset ID and request Key.
+/** Return the URL for a Cesium Ion asset from its asset ID and request Key.
  * @public
  */
 export function getCesiumAssetUrl(osmAssetId: number, requestKey: string): string {
@@ -508,7 +508,7 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
   }
 }
 
-/** Default [[CesiumAccessClient]] that authenticates directly with Cesium ion using [[TileAdmin.cesiumIonKey]].
+/** Default [[CesiumAccessClient]] that authenticates directly with Cesium Ion using [[TileAdmin.cesiumIonKey]].
  * This is used when no custom [[CesiumAccessClient]] is registered via [[TileAdmin.Props.cesiumAccess]].
  * @internal
  */

--- a/core/frontend/src/tile/map/CesiumTerrainProvider.ts
+++ b/core/frontend/src/tile/map/CesiumTerrainProvider.ts
@@ -37,7 +37,7 @@ export function getCesiumAssetUrl(osmAssetId: number, requestKey: string): strin
 
 /** @internal */
 export function getCesiumOSMBuildingsUrl(): string | undefined {
-  if (!IModelApp.tileAdmin.hasCesiumAccess)
+  if (!IModelApp.tileAdmin.canAccessCesium)
     return undefined;
 
   return getCesiumAssetUrl(+CesiumIonAssetId.OSMBuildings, "");
@@ -48,6 +48,25 @@ export function getCesiumOSMBuildingsUrl(): string | undefined {
  */
 export function getCesiumAccessClient(): CesiumAccessClient {
   return IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
+}
+
+const cesiumTokenTimeoutInterval = BeDuration.fromSeconds(60 * 30);    // Request a new access token every 30 minutes...
+const cesiumMinTokenTimeoutInterval = BeDuration.fromSeconds(60);      // ...but never re-resolve more often than once per minute.
+
+/** Compute when to next re-resolve a Cesium access token. Honors the endpoint's `expiresAt` when it is a valid
+ * future time, but guards against an invalid (NaN) date - which would otherwise disable refresh entirely - and
+ * against a past/imminent expiry that would re-resolve the endpoint on essentially every tile read.
+ * @internal
+ */
+export function computeCesiumTokenTimeoutInterval(expiresAt: Date | undefined): BeDuration {
+  if (undefined === expiresAt)
+    return cesiumTokenTimeoutInterval;
+
+  const remainingMs = expiresAt.getTime() - Date.now();
+  if (!Number.isFinite(remainingMs))
+    return cesiumTokenTimeoutInterval;
+
+  return BeDuration.fromMilliseconds(Math.max(remainingMs, cesiumMinTokenTimeoutInterval.milliseconds));
 }
 
 /** @internal */
@@ -88,17 +107,20 @@ function notifyTerrainError(detailedDescription?: string): void {
 /** @internal */
 export async function getCesiumTerrainProvider(opts: TerrainMeshProviderOptions): Promise<TerrainMeshProvider | undefined> {
   const assetId = opts.dataSource || CesiumTerrainAssetId.Default;
-  const client = IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
+  const client = getCesiumAccessClient();
   const endpoint = await client.getAssetEndpoint(assetId, opts.iTwinId);
-  if (!endpoint.accessToken || !endpoint.url) {
+  if (!endpoint) {
     notifyTerrainError(IModelApp.localization.getLocalizedString(`iModelJs:BackgroundMap.MissingCesiumToken`));
     return undefined;
   }
 
+  // Resource paths (layer.json, tiles) are appended directly to the base URL, so ensure it ends with a slash.
+  const baseUrl = endpoint.url.endsWith("/") ? endpoint.url : `${endpoint.url}/`;
+
   let layers;
   try {
     const layerRequestOptions: RequestOptions = { headers: { authorization: `Bearer ${endpoint.accessToken}` } };
-    const layerUrl = `${endpoint.url}layer.json`;
+    const layerUrl = `${baseUrl}layer.json`;
     layers = await request(layerUrl, "json", layerRequestOptions);
   } catch {
     notifyTerrainError();
@@ -129,7 +151,7 @@ export async function getCesiumTerrainProvider(opts: TerrainMeshProviderOptions)
     }
   }
 
-  let tileUrlTemplate = endpoint.url + layers.tiles[0].replace("{version}", layers.version);
+  let tileUrlTemplate = baseUrl + layers.tiles[0].replace("{version}", layers.version);
   if (opts.wantNormals)
     tileUrlTemplate = tileUrlTemplate.replace("?", "?extensions=octvertexnormals-watermask-metadata&");
 
@@ -184,7 +206,6 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
   private static _scratchPoint = Point3d.createZero();
   private static _scratchNormal = Vector3d.createZero();
   private static _scratchHeightRange = Range1d.createNull();
-  private static _tokenTimeoutInterval = BeDuration.fromSeconds(60 * 30);      // Request a new access token every 30 minutes...
   private _tokenTimeOut: BeTimePoint;
 
   public override forceTileLoad(tile: Tile): boolean {
@@ -208,10 +229,7 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     this._assetId = opts.dataSource || CesiumTerrainAssetId.Default;
     this._iTwinId = opts.iTwinId;
 
-    const initialTimeoutInterval = expiresAt
-      ? BeDuration.fromMilliseconds(Math.max(0, expiresAt.getTime() - Date.now()))
-      : CesiumTerrainProvider._tokenTimeoutInterval;
-    this._tokenTimeOut = BeTimePoint.now().plus(initialTimeoutInterval);
+    this._tokenTimeOut = BeTimePoint.now().plus(computeCesiumTokenTimeoutInterval(expiresAt));
   }
 
   /** @deprecated in 5.0 - will not be removed until after 2026-06-13. Use [addAttributions] instead. */
@@ -267,16 +285,13 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
     // ###TODO why does he update the access token when reading the mesh instead of when requesting it?
     // This function only returns undefined if it fails to acquire token - but it doesn't need the token...
     if (BeTimePoint.now().milliseconds > this._tokenTimeOut.milliseconds) {
-      const client = IModelApp.tileAdmin.cesiumAccess ?? new CesiumIonClient();
+      const client = getCesiumAccessClient();
       const endpoint = await client.getAssetEndpoint(this._assetId, this._iTwinId);
-      if (!endpoint.accessToken || args.isCanceled())
+      if (!endpoint || args.isCanceled())
         return undefined;
 
       this._accessToken = endpoint.accessToken;
-      const timeoutInterval = endpoint.expiresAt
-        ? BeDuration.fromMilliseconds(Math.max(0, endpoint.expiresAt.getTime() - Date.now()))
-        : CesiumTerrainProvider._tokenTimeoutInterval;
-      this._tokenTimeOut = BeTimePoint.now().plus(timeoutInterval);
+      this._tokenTimeOut = BeTimePoint.now().plus(computeCesiumTokenTimeoutInterval(endpoint.expiresAt));
     }
 
     const { data, tile } = args;
@@ -513,10 +528,10 @@ class CesiumTerrainProvider extends TerrainMeshProvider {
  * @internal
  */
 class CesiumIonClient implements CesiumAccessClient {
-  public async getAssetEndpoint(assetId: string, _iTwinId?: GuidString): Promise<CesiumAssetEndpoint> {
+  public async getAssetEndpoint(assetId: string, _iTwinId?: GuidString): Promise<CesiumAssetEndpoint | undefined> {
     const result = await getCesiumAccessTokenAndEndpointUrl(assetId);
     if (!result.token || !result.url)
-      return {};
+      return undefined;
 
     return { accessToken: result.token, url: result.url };
   }

--- a/core/frontend/src/tile/map/MapTileTree.ts
+++ b/core/frontend/src/tile/map/MapTileTree.ts
@@ -694,6 +694,7 @@ class MapTreeSupplier implements TileTreeSupplier {
       wantNormals: id.wantNormals,
       dataSource: id.terrainDataSource,
       produceGeometry: id.produceGeometry,
+      iTwinId: iModel.iTwinId,
     };
 
     if (id.applyTerrain) {

--- a/core/frontend/src/tile/map/TerrainMeshProvider.ts
+++ b/core/frontend/src/tile/map/TerrainMeshProvider.ts
@@ -6,7 +6,7 @@
  * @module Tiles
  */
 
-import { GuidString } from "@itwin/core-bentley";
+import type { GuidString } from "@itwin/core-bentley";
 import { Range1d } from "@itwin/core-geometry";
 import { ApproximateTerrainHeights } from "../../ApproximateTerrainHeights";
 import { ScreenViewport } from "../../Viewport";

--- a/core/frontend/src/tile/map/TerrainMeshProvider.ts
+++ b/core/frontend/src/tile/map/TerrainMeshProvider.ts
@@ -6,6 +6,7 @@
  * @module Tiles
  */
 
+import { GuidString } from "@itwin/core-bentley";
 import { Range1d } from "@itwin/core-geometry";
 import { ApproximateTerrainHeights } from "../../ApproximateTerrainHeights";
 import { ScreenViewport } from "../../Viewport";
@@ -47,7 +48,7 @@ export interface TerrainMeshProviderOptions {
    * that scope requests to an iTwin context can use it. Not required by the iTwin Platform Cesium Curated Content API.
    * @beta
    */
-  iTwinId?: string;
+  iTwinId?: GuidString;
 }
 
 /** Arguments supplied to [[TerrainMeshProvider.requestMeshData]].

--- a/core/frontend/src/tile/map/TerrainMeshProvider.ts
+++ b/core/frontend/src/tile/map/TerrainMeshProvider.ts
@@ -43,6 +43,11 @@ export interface TerrainMeshProviderOptions {
    * @beta
    */
   produceGeometry?: boolean;
+  /** Optional iTwin context identifier. Passed to [[CesiumAccessClient.getAssetEndpoint]] so implementations
+   * that scope requests to an iTwin context can use it. Not required by the iTwin Platform Cesium Curated Content API.
+   * @beta
+   */
+  iTwinId?: string;
 }
 
 /** Arguments supplied to [[TerrainMeshProvider.requestMeshData]].

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -32,13 +32,14 @@ Two authentication paths coexist:
 When both are supplied, `cesiumAccess` takes precedence. The new [TileAdmin.canAccessCesium]($frontend) getter returns `true` if either option is configured.
 
 ```typescript
+import { GuidString } from "@itwin/core-bentley";
 import { CesiumAccessClient, CesiumAssetEndpoint } from "@itwin/core-frontend";
 
 // Example: implement CesiumAccessClient using the iTwin Platform Cesium Curated Content API.
 class ITPCesiumClient implements CesiumAccessClient {
   constructor(private readonly getAccessToken: () => Promise<string>) {}
 
-  async getAssetEndpoint(assetId: string, _iTwinId?: string): Promise<CesiumAssetEndpoint | undefined> {
+  async getAssetEndpoint(assetId: string, _iTwinId?: GuidString): Promise<CesiumAssetEndpoint | undefined> {
     const token = await this.getAccessToken();
     const response = await fetch(`https://api.bentley.com/curated-content/cesium/${assetId}/tiles`, {
       headers: { Authorization: `Bearer ${token}` },

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,6 +5,7 @@ publish: false
 
 - [NextVersion](#nextversion)
   - [@itwin/core-frontend](#itwincore-frontend)
+    - [Pluggable Cesium ion authentication via `CesiumAccessClient`](#pluggable-cesium-ion-authentication-via-cesiumaccessclient)
     - [Configurable precision for graphical editing at high coordinates](#configurable-precision-for-graphical-editing-at-high-coordinates)
     - [`IModelConnection.createQueryReader` now terminates gracefully if the connection is closed](#imodelconnectioncreatequeryreader-now-terminates-gracefully-if-the-connection-is-closed)
     - [Quantity property description classes deprecated](#quantity-property-description-classes-deprecated)
@@ -13,6 +14,48 @@ publish: false
     - [Azure Maps basemap support is available through map-layers-formats](#azure-maps-basemap-support-is-available-through-map-layers-formats)
 
 ## @itwin/core-frontend
+
+### Pluggable Cesium ion authentication via `CesiumAccessClient`
+
+A new [`CesiumAccessClient`]($frontend) interface and [`TileAdmin.Props.cesiumAccess`]($frontend) option let apps plug in a custom Cesium asset resolver (such as the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)) without requiring a personal Cesium ion subscription or adding a platform dependency to `@itwin/core-frontend`.
+
+Two authentication paths coexist:
+
+| Path | When to use | How to configure |
+|---|---|---|
+| `cesiumIonKey` (existing) | App has a direct Cesium ion subscription | `tileAdmin: { cesiumIonKey: "my-key" }` |
+| `cesiumAccess` (new, `@beta`) | iTwin Platform proxy or any custom resolver | `tileAdmin: { cesiumAccess: new MyClient() }` |
+
+When both are supplied, `cesiumAccess` takes precedence. The new [`TileAdmin.hasCesiumAccess`]($frontend) getter returns `true` if either option is configured.
+
+```typescript
+import { CesiumAccessClient, CesiumAssetEndpoint } from "@itwin/core-frontend";
+
+// Example: implement CesiumAccessClient using the iTwin Platform Cesium Curated Content API.
+class ITPCesiumClient implements CesiumAccessClient {
+  constructor(private readonly getAccessToken: () => Promise<string>) {}
+
+  async getAssetEndpoint(assetId: string, _iTwinId?: string): Promise<CesiumAssetEndpoint> {
+    const token = await this.getAccessToken();
+    const response = await fetch(`https://api.bentley.com/curated-content/cesium/${assetId}/tiles`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const json = await response.json();
+    return {
+      accessToken: json.accessToken,
+      url: json.url,
+      expiresAt: json.expiresAt ? new Date(json.expiresAt) : undefined,
+    };
+  }
+}
+
+// Register at startup:
+await IModelApp.startup({
+  tileAdmin: {
+    cesiumAccess: new ITPCesiumClient(() => myAuthClient.getAccessToken()),
+  },
+});
+```
 
 ### Configurable precision for graphical editing at high coordinates
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,7 +18,7 @@ publish: false
 
 ### Pluggable Cesium Ion authentication via `CesiumAccessClient`
 
-A new [`CesiumAccessClient`]($frontend) interface and [`TileAdmin.Props.cesiumAccess`]($frontend) option let apps plug in a custom Cesium asset resolver (such as the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)) without requiring a personal Cesium Ion subscription or adding a platform dependency to `@itwin/core-frontend`.
+A new [CesiumAccessClient]($frontend) interface and [TileAdmin.Props.cesiumAccess]($frontend) option let apps plug in a custom Cesium asset resolver (such as the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)) without requiring a personal Cesium Ion subscription or adding a platform dependency to `@itwin/core-frontend`.
 
 Two authentication paths coexist:
 
@@ -27,7 +27,7 @@ Two authentication paths coexist:
 | `cesiumIonKey` (existing) | App has a direct Cesium Ion subscription | `tileAdmin: { cesiumIonKey: "my-key" }` |
 | `cesiumAccess` (new, `@beta`) | iTwin Platform proxy or any custom resolver | `tileAdmin: { cesiumAccess: new MyClient() }` |
 
-When both are supplied, `cesiumAccess` takes precedence. The new [`TileAdmin.canAccessCesium`]($frontend) getter returns `true` if either option is configured.
+When both are supplied, `cesiumAccess` takes precedence. The new [TileAdmin.canAccessCesium]($frontend) getter returns `true` if either option is configured.
 
 ```typescript
 import { CesiumAccessClient, CesiumAssetEndpoint } from "@itwin/core-frontend";

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -27,7 +27,7 @@ Two authentication paths coexist:
 | `cesiumIonKey` (existing) | App has a direct Cesium Ion subscription | `tileAdmin: { cesiumIonKey: "my-key" }` |
 | `cesiumAccess` (new, `@beta`) | iTwin Platform proxy or any custom resolver | `tileAdmin: { cesiumAccess: new MyClient() }` |
 
-When both are supplied, `cesiumAccess` takes precedence. The new [`TileAdmin.hasCesiumAccess`]($frontend) getter returns `true` if either option is configured.
+When both are supplied, `cesiumAccess` takes precedence. The new [`TileAdmin.canAccessCesium`]($frontend) getter returns `true` if either option is configured.
 
 ```typescript
 import { CesiumAccessClient, CesiumAssetEndpoint } from "@itwin/core-frontend";
@@ -36,11 +36,14 @@ import { CesiumAccessClient, CesiumAssetEndpoint } from "@itwin/core-frontend";
 class ITPCesiumClient implements CesiumAccessClient {
   constructor(private readonly getAccessToken: () => Promise<string>) {}
 
-  async getAssetEndpoint(assetId: string, _iTwinId?: string): Promise<CesiumAssetEndpoint> {
+  async getAssetEndpoint(assetId: string, _iTwinId?: string): Promise<CesiumAssetEndpoint | undefined> {
     const token = await this.getAccessToken();
     const response = await fetch(`https://api.bentley.com/curated-content/cesium/${assetId}/tiles`, {
       headers: { Authorization: `Bearer ${token}` },
     });
+    if (!response.ok)
+      return undefined; // asset cannot be accessed
+
     const json = await response.json();
     return {
       accessToken: json.accessToken,

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,7 +5,7 @@ publish: false
 
 - [NextVersion](#nextversion)
   - [@itwin/core-frontend](#itwincore-frontend)
-    - [Pluggable Cesium ion authentication via `CesiumAccessClient`](#pluggable-cesium-ion-authentication-via-cesiumaccessclient)
+    - [Pluggable Cesium Ion authentication via `CesiumAccessClient`](#pluggable-cesium-ion-authentication-via-cesiumaccessclient)
     - [Configurable precision for graphical editing at high coordinates](#configurable-precision-for-graphical-editing-at-high-coordinates)
     - [`IModelConnection.createQueryReader` now terminates gracefully if the connection is closed](#imodelconnectioncreatequeryreader-now-terminates-gracefully-if-the-connection-is-closed)
     - [Reality model tiles with JSON glTF content now render](#reality-model-tiles-with-json-gltf-content-now-render)
@@ -16,15 +16,15 @@ publish: false
 
 ## @itwin/core-frontend
 
-### Pluggable Cesium ion authentication via `CesiumAccessClient`
+### Pluggable Cesium Ion authentication via `CesiumAccessClient`
 
-A new [`CesiumAccessClient`]($frontend) interface and [`TileAdmin.Props.cesiumAccess`]($frontend) option let apps plug in a custom Cesium asset resolver (such as the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)) without requiring a personal Cesium ion subscription or adding a platform dependency to `@itwin/core-frontend`.
+A new [`CesiumAccessClient`]($frontend) interface and [`TileAdmin.Props.cesiumAccess`]($frontend) option let apps plug in a custom Cesium asset resolver (such as the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/)) without requiring a personal Cesium Ion subscription or adding a platform dependency to `@itwin/core-frontend`.
 
 Two authentication paths coexist:
 
 | Path | When to use | How to configure |
 |---|---|---|
-| `cesiumIonKey` (existing) | App has a direct Cesium ion subscription | `tileAdmin: { cesiumIonKey: "my-key" }` |
+| `cesiumIonKey` (existing) | App has a direct Cesium Ion subscription | `tileAdmin: { cesiumIonKey: "my-key" }` |
 | `cesiumAccess` (new, `@beta`) | iTwin Platform proxy or any custom resolver | `tileAdmin: { cesiumAccess: new MyClient() }` |
 
 When both are supplied, `cesiumAccess` takes precedence. The new [`TileAdmin.hasCesiumAccess`]($frontend) getter returns `true` if either option is configured.


### PR DESCRIPTION
## Summary

Implements pluggable Cesium asset authentication via a new `CesiumAccessClient` interface, allowing apps to route Cesium ion asset requests through the [iTwin Platform Cesium Curated Content API](https://developer.bentley.com/apis/cesium-curated-content/overview/) — or any custom resolver — without requiring a personal Cesium ion subscription.

## Changes

### `@itwin/core-frontend`

- **New `CesiumAccessClient` interface** (`@beta`) — pluggable resolver for Cesium asset endpoints
- **New `CesiumAssetEndpoint` interface** (`@beta`) — shape of the resolved endpoint (token, URL, expiry)
- **`TileAdmin.Props.cesiumAccess`** — optional startup option to supply a `CesiumAccessClient`
- **`TileAdmin.canAccessCesium`** — getter that returns `true` if either `cesiumAccess` or `cesiumIonKey` is configured
- Both auth paths coexist; `cesiumAccess` takes precedence when both are set
- Terrain (`CesiumTerrainProvider`) and OSM Buildings (`RealityDataSourceCesiumIonAssetImpl`) both route through `cesiumAccess` when available
- `MapTileTree` now passes `iModel.iTwinId` to terrain options (was missing)
- `CesiumTerrainProvider` constructor now respects `expiresAt` from the first endpoint fetch (was hardcoded to 30 min)
- `DisplayStyleState` uses `startsWith` instead of `===` for OSM Buildings URL matching to handle keyless URLs (`$CesiumIonAsset=96188:`)

## Validation

**Targeted verification** (manual):

- **`cesiumAccess` path** — tested in both DTA (Electron) and a scaffolded `@itwin/web-viewer-react` app against the live iTwin Platform Cesium Curated Content API. Console logs confirmed local build running and `ITPCesiumAccessClient` used for all requests:
  - ✅ Cesium terrain loads
  - ✅ OSM Buildings load

- **`cesiumIonKey` regression** — swapped to `cesiumIonKey` only in both apps. Logs confirmed `CesiumIonClient` fallback used:
  - ✅ Cesium terrain still loads
  - ✅ OSM Buildings still load
