### PR TITLE
Fix graphics disappearance on category insert

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -10392,6 +10392,7 @@ export { Storage_2 as Storage }
 export class SubCategoriesCache {
     constructor(imodel: IModelConnection);
     add(categoryId: string, subCategoryId: string, appearance: SubCategoryAppearance, override: boolean): void;
+    addChangedListener(listener: () => void): () => void;
     // (undocumented)
     attachToBriefcase(imodel: IModelConnection): void;
     // (undocumented)

--- a/common/changes/@itwin/core-frontend/benpolinsky-fix-graphics-disappear-on-category-insert_2026-06-22-18-39.json
+++ b/common/changes/@itwin/core-frontend/benpolinsky-fix-graphics-disappear-on-category-insert_2026-06-22-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Stop clearing SubCategoriesCache on subcategory insert; reload instead",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/SubCategoriesCache.ts
+++ b/core/frontend/src/SubCategoriesCache.ts
@@ -149,7 +149,7 @@ export class SubCategoriesCache {
             staleCategories.add(row.parentId);
 
         if (staleCategories.size > 0)
-          this.processResults(results.filter((row) => staleCategories.has(row.parentId)), staleCategories, false);
+          this.processResults(results.filter((row) => staleCategories.has(row.parentId)), staleCategories);
 
         for (const row of results)
           if (!staleCategories.has(row.parentId))
@@ -277,9 +277,10 @@ export class SubCategoriesCache {
     const map = new Map<Id64String, IModelConnection.Categories.CategoryInfo>();
     for (const categoryId of categoryIds) {
       const subCategoryIds = this._byCategoryId.get(categoryId);
-      const subCategories = subCategoryIds
-        ? this.mapSubCategoryInfos(categoryId, subCategoryIds)
-        : new Map<Id64String, IModelConnection.Categories.SubCategoryInfo>();
+      if (!subCategoryIds)
+        continue;
+
+      const subCategories = this.mapSubCategoryInfos(categoryId, subCategoryIds);
       map.set(categoryId, { id: categoryId, subCategories });
     }
 

--- a/core/frontend/src/SubCategoriesCache.ts
+++ b/core/frontend/src/SubCategoriesCache.ts
@@ -3,9 +3,9 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { assert, CompressedId64Set, Id64, Id64Arg, Id64Set, Id64String, OrderedId64Iterable } from "@itwin/core-bentley";
+import { assert, BeEvent, CompressedId64Set, Id64, Id64Arg, Id64Set, Id64String, OrderedId64Iterable } from "@itwin/core-bentley";
 import { SubCategoryAppearance, SubCategoryResultRow } from "@itwin/core-common";
-import { IModelConnection } from "./IModelConnection";
+import type { IModelConnection } from "./IModelConnection";
 
 /** A cancelable paginated request for subcategory information.
  * @see SubCategoriesCache
@@ -15,14 +15,12 @@ export interface SubCategoriesRequest {
   /** The Ids of any categories which were requested but were not yet loaded. */
   readonly missingCategoryIds: Id64Set;
   /** A promise which resolves to true when all of the requested categories have been loaded, or to false if not all categories were loaded.
-   * Categories may fail to load if the request is explicitly canceled or if the IModelConnection is closed before all categories are loaded.
+   * Categories may fail to load if the request is explicitly canceled, if the IModelConnection is closed before all categories are loaded, or if the query fails.
    */
   readonly promise: Promise<boolean>;
   /** Cancels the request. */
   cancel(): void;
 }
-
-const invalidCategoryIdEntry = new Set<string>();
 
 /** A cache of information about the subcategories contained within an [[IModelConnection]]. It is populated on demand.
  * @internal
@@ -30,8 +28,11 @@ const invalidCategoryIdEntry = new Set<string>();
 export class SubCategoriesCache {
   private readonly _byCategoryId = new Map<string, Id64Set>();
   private readonly _appearances = new Map<string, SubCategoryAppearance>();
+  private readonly _staleCategoryIds = new Set<string>();
   private readonly _imodel: IModelConnection;
-  private _missingAtTimeOfPreload: Id64Set | undefined;
+  private _invalidationGeneration = 0;
+
+  private readonly _onChanged = new BeEvent<() => void>();
 
   public constructor(imodel: IModelConnection) {
     this._imodel = imodel;
@@ -44,37 +45,62 @@ export class SubCategoriesCache {
     assert(imodel.isBriefcaseConnection());
     imodel.txns.onElementsChanged.addListener((changes) => {
       const affectedSubCategories = new Set<string>();
+      const affectedCategories = new Set<string>();
+      let invalidateAllCategories = false;
+      let changed = false;
       for (const change of changes) {
         if (change.metadata.is("BisCore:Category")) {
           if (change.type === "deleted") {
-            this._byCategoryId.delete(change.id);
+            this.deleteCategory(change.id);
+            changed = true;
           }
         } else if (change.metadata.is("BisCore:SubCategory")) {
           if (change.type === "inserted") {
-            // We don't know to which category the subcategory belongs. Blow away the entire cache.
-            this._byCategoryId.clear();
-            this._appearances.clear();
-            return;
+            // We don't know to which category the subcategory belongs, so every cached category may be stale.
+            invalidateAllCategories = true;
+            changed = true;
+            continue;
           }
 
-          this._appearances.delete(change.id);
           affectedSubCategories.add(change.id);
         }
       }
 
-      if (affectedSubCategories.size > 0) {
+      if (invalidateAllCategories) {
+        this.markAllCategoriesStale();
+      } else if (affectedSubCategories.size > 0) {
         for (const [catId, subCatIds] of this._byCategoryId) {
           for (const subCatId of affectedSubCategories) {
             if (subCatIds.has(subCatId)) {
-              this._byCategoryId.delete(catId);
+              affectedCategories.add(catId);
+              changed = true;
               affectedSubCategories.delete(subCatId);
               break;
             }
           }
         }
+
+        if (affectedCategories.size > 0)
+          this.markCategoriesStale(affectedCategories);
+
+        // If any affected subcategories were NOT found in cache and categories are currently stale,
+        // bump generation to invalidate in-flight reload queries that may return stale data.
+        if (affectedSubCategories.size > 0 && this.hasStaleCategories()) {
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        this._invalidationGeneration++;
+        this._onChanged.raiseEvent();
       }
     });
   }
+  /** Register a listener to be notified when transaction changes invalidate cached subcategory information.
+   * @internal
+   */
+  public addChangedListener(listener: () => void): () => void { return this._onChanged.addListener(listener); }
+
   /** Get the Ids of all subcategories belonging to the category with the specified Id, or undefined if no such information is present. */
   public getSubCategories(categoryId: string): Id64Set | undefined { return this._byCategoryId.get(categoryId); }
 
@@ -92,11 +118,15 @@ export class SubCategoriesCache {
       return undefined;
 
     const request = new SubCategoriesCache.Request(missing, this._imodel);
+    const generation = this._invalidationGeneration;
     const promise = request.dispatch().then((result?: SubCategoriesCache.Result) => {
-      if (undefined !== result)
+      const completed = undefined !== result && !request.wasCanceled && generation === this._invalidationGeneration;
+      if (completed)
         this.processResults(result, missing);
 
-      return !request.wasCanceled;
+      // On failure (result undefined due to query error), do NOT cache empty sets for uncached categories.
+      // Leave them absent so getMissing() will include them in subsequent load() retries.
+      return completed;
     });
     return {
       missingCategoryIds: missing,
@@ -108,9 +138,22 @@ export class SubCategoriesCache {
   /** Load all subcategories that come from used spatial categories of the iModel into the cache. */
   public async loadAllUsedSpatialSubCategories(): Promise<void> {
     try {
+      const generation = this._invalidationGeneration;
       const results = await this._imodel.queryAllUsedSpatialSubCategories();
-      if (undefined !== results) {
-        this.processResults(results, new Set<string>(), false);
+      if (generation === this._invalidationGeneration && undefined !== results) {
+        // Stale categories get a full reset+repopulate (removes outdated subcategory entries).
+        // Non-stale categories get an additive update to preserve any manually-added entries.
+        const staleCategories = new Set<string>();
+        for (const row of results)
+          if (this.isCategoryStale(row.parentId))
+            staleCategories.add(row.parentId);
+
+        if (staleCategories.size > 0)
+          this.processResults(results.filter((row) => staleCategories.has(row.parentId)), staleCategories, false);
+
+        for (const row of results)
+          if (!staleCategories.has(row.parentId))
+            this.add(row.parentId, row.id, SubCategoriesCache.createSubCategoryAppearance(row.appearance), false);
       }
     } catch {
       // In case of a truncated response, gracefully handle the error and exit.
@@ -121,7 +164,7 @@ export class SubCategoriesCache {
   private getMissing(categoryIds: Id64Arg): Id64Set | undefined {
     let missing: Id64Set | undefined;
     for (const catId of Id64.iterable(categoryIds)) {
-      if (undefined === this._byCategoryId.get(catId)) {
+      if (undefined === this._byCategoryId.get(catId) || this.isCategoryStale(catId)) {
         if (undefined === missing)
           missing = new Set<string>();
 
@@ -135,6 +178,8 @@ export class SubCategoriesCache {
   public clear(): void {
     this._byCategoryId.clear();
     this._appearances.clear();
+    this._staleCategoryIds.clear();
+    this._invalidationGeneration++;
   }
 
   public onIModelConnectionClose(): void {
@@ -149,15 +194,28 @@ export class SubCategoriesCache {
     return new SubCategoryAppearance(props);
   }
 
-  private processResults(result: SubCategoriesCache.Result, missing: Id64Set, override: boolean = true): void {
+  private processResults(result: SubCategoriesCache.Result, refreshedCategoryIds: Id64Set, override: boolean = true): void {
+    const previousSubCategoryIds = new Map<Id64String, Id64Set>();
+    for (const id of refreshedCategoryIds) {
+      const previous = this._byCategoryId.get(id);
+      if (undefined !== previous)
+        previousSubCategoryIds.set(id, previous);
+
+      this._byCategoryId.set(id, new Set<string>());
+      this.markCategoryFresh(id);
+    }
+
     for (const row of result) {
       this.add(row.parentId, row.id, SubCategoriesCache.createSubCategoryAppearance(row.appearance), override);
     }
 
-    // Ensure that any category Ids which returned no results (e.g., non-existent category, invalid Id, etc) are still recorded so they are not repeatedly re-requested
-    for (const id of missing)
-      if (undefined === this._byCategoryId.get(id))
-        this._byCategoryId.set(id, invalidCategoryIdEntry);
+    for (const [categoryId, previous] of previousSubCategoryIds) {
+      const current = this._byCategoryId.get(categoryId);
+      for (const subCategoryId of previous) {
+        if (!current?.has(subCategoryId))
+          this._appearances.delete(subCategoryId);
+      }
+    }
   }
 
   /** Exposed strictly for tests.
@@ -169,8 +227,44 @@ export class SubCategoriesCache {
       this._byCategoryId.set(categoryId, set = new Set<string>());
 
     set.add(subCategoryId);
+    this.markCategoryFresh(categoryId);
     if (override || !this._appearances.has(subCategoryId))
       this._appearances.set(subCategoryId, appearance);
+  }
+
+  private isCategoryStale(categoryId: Id64String): boolean {
+    return this._staleCategoryIds.has(categoryId);
+  }
+
+  private markCategoryFresh(categoryId: Id64String): void {
+    this._staleCategoryIds.delete(categoryId);
+  }
+
+  private markAllCategoriesStale(): void {
+    // We don't know which cached category the inserted subcategory belongs to, so every currently-cached
+    // category may now be missing a subcategory. Mark them all stale so they are re-requested on next load.
+    // Categories cached after this point are loaded fresh and are intentionally left out.
+    for (const categoryId of this._byCategoryId.keys())
+      this._staleCategoryIds.add(categoryId);
+  }
+
+  private markCategoriesStale(categoryIds: Iterable<Id64String>): void {
+    for (const categoryId of categoryIds)
+      this._staleCategoryIds.add(categoryId);
+  }
+
+  private hasStaleCategories(): boolean {
+    return this._staleCategoryIds.size > 0;
+  }
+
+  private deleteCategory(categoryId: Id64String): void {
+    const subCategoryIds = this._byCategoryId.get(categoryId);
+    if (undefined !== subCategoryIds)
+      for (const subCategoryId of subCategoryIds)
+        this._appearances.delete(subCategoryId);
+
+    this._byCategoryId.delete(categoryId);
+    this._staleCategoryIds.delete(categoryId);
   }
 
   public async getCategoryInfo(inputCategoryIds: Id64String | Iterable<Id64String>): Promise<Map<Id64String, IModelConnection.Categories.CategoryInfo>> {
@@ -183,10 +277,9 @@ export class SubCategoriesCache {
     const map = new Map<Id64String, IModelConnection.Categories.CategoryInfo>();
     for (const categoryId of categoryIds) {
       const subCategoryIds = this._byCategoryId.get(categoryId);
-      if (!subCategoryIds)
-        continue;
-
-      const subCategories = this.mapSubCategoryInfos(categoryId, subCategoryIds);
+      const subCategories = subCategoryIds
+        ? this.mapSubCategoryInfos(categoryId, subCategoryIds)
+        : new Map<Id64String, IModelConnection.Categories.SubCategoryInfo>();
       map.set(categoryId, { id: categoryId, subCategories });
     }
 
@@ -255,9 +348,7 @@ export namespace SubCategoriesCache {
         if (this.wasCanceled)
           return undefined;
       } catch {
-        // ###TODO: detect cases in which retry is warranted
-        // Note that currently, if we succeed in obtaining some pages of results and fail to retrieve another page, we will end up processing the
-        // incomplete results. Since we're not retrying, that's the best we can do.
+        return undefined;
       }
 
       // Finished with current batch of categoryIds. Dispatch the next batch if one exists.

--- a/core/frontend/src/SubCategoriesCache.ts
+++ b/core/frontend/src/SubCategoriesCache.ts
@@ -141,19 +141,14 @@ export class SubCategoriesCache {
       const generation = this._invalidationGeneration;
       const results = await this._imodel.queryAllUsedSpatialSubCategories();
       if (generation === this._invalidationGeneration && undefined !== results) {
-        // Stale categories get a full reset+repopulate (removes outdated subcategory entries).
-        // Non-stale categories get an additive update to preserve any manually-added entries.
-        const staleCategories = new Set<string>();
+        const staleCategories = new Set(this._staleCategoryIds);
+        // This preload can return partial results on very large iModels, so keep stale categories additive and
+        // preserve their stale state until a targeted reload can fully reconcile them.
         for (const row of results)
-          if (this.isCategoryStale(row.parentId))
-            staleCategories.add(row.parentId);
+          this.add(row.parentId, row.id, SubCategoriesCache.createSubCategoryAppearance(row.appearance), staleCategories.has(row.parentId));
 
         if (staleCategories.size > 0)
-          this.processResults(results.filter((row) => staleCategories.has(row.parentId)), staleCategories);
-
-        for (const row of results)
-          if (!staleCategories.has(row.parentId))
-            this.add(row.parentId, row.id, SubCategoriesCache.createSubCategoryAppearance(row.appearance), false);
+          this.markCategoriesStale(staleCategories);
       }
     } catch {
       // In case of a truncated response, gracefully handle the error and exit.
@@ -277,10 +272,7 @@ export class SubCategoriesCache {
     const map = new Map<Id64String, IModelConnection.Categories.CategoryInfo>();
     for (const categoryId of categoryIds) {
       const subCategoryIds = this._byCategoryId.get(categoryId);
-      if (!subCategoryIds)
-        continue;
-
-      const subCategories = this.mapSubCategoryInfos(categoryId, subCategoryIds);
+      const subCategories = undefined !== subCategoryIds ? this.mapSubCategoryInfos(categoryId, subCategoryIds) : new Map<Id64String, IModelConnection.Categories.SubCategoryInfo>();
       map.set(categoryId, { id: categoryId, subCategories });
     }
 

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -1211,6 +1211,14 @@ export abstract class Viewport implements Disposable, TileUser {
     this.updateSubCategories(this.view.categorySelector.categories, undefined);
   }
 
+  private getSubCategoryReloadCategoryIds(): Id64Set {
+    const categoryIds = Id64.toIdSet(this.view.categorySelector.categories);
+    for (const { categoryId } of this.perModelCategoryVisibility)
+      categoryIds.add(categoryId);
+
+    return categoryIds;
+  }
+
   private registerViewListeners(): void {
     const view = this.view;
     const removals = this._detachFromView;
@@ -1228,7 +1236,7 @@ export abstract class Viewport implements Disposable, TileUser {
     }));
 
     removals.push(this.iModel.subcategories.addChangedListener(() => {
-      this.updateSubCategories(view.categorySelector.categories, undefined);
+      this.updateSubCategories(this.getSubCategoryReloadCategoryIds(), undefined);
     }));
 
     removals.push(view.onDisplayStyleChanged.addListener((newStyle) => {

--- a/core/frontend/src/Viewport.ts
+++ b/core/frontend/src/Viewport.ts
@@ -804,8 +804,11 @@ export abstract class Viewport implements Disposable, TileUser {
       if (true === enableAllSubCategories)
         this.enableAllSubCategories(categoryIds);
 
-      if (undefined !== enableAllSubCategories || anySubCategoriesLoaded)
+      if (undefined !== enableAllSubCategories || anySubCategoriesLoaded) {
         this._changeFlags.setViewedCategories();
+        this.maybeInvalidateScene();
+        IModelApp.requestNextAnimation();
+      }
     });
   }
 
@@ -1222,6 +1225,10 @@ export abstract class Viewport implements Disposable, TileUser {
       this._changeFlags.setViewedCategories();
       this.updateSubCategories(view.categorySelector.categories, undefined);
       this.maybeInvalidateScene();
+    }));
+
+    removals.push(this.iModel.subcategories.addChangedListener(() => {
+      this.updateSubCategories(view.categorySelector.categories, undefined);
     }));
 
     removals.push(view.onDisplayStyleChanged.addListener((newStyle) => {

--- a/core/frontend/src/test/SubCategoriesCache.test.ts
+++ b/core/frontend/src/test/SubCategoriesCache.test.ts
@@ -285,16 +285,21 @@ describe("SubCategoriesCache", () => {
     expect((await cache.getSubCategoryInfo(categoryId, oldSubCategoryId)).has(oldSubCategoryId)).toBe(false);
   });
 
-  it("reconciles stale categories loaded by the used spatial subcategory preload", async () => {
+  it("keeps stale categories reloadable when the used spatial subcategory preload returns partial results", async () => {
     const categoryId = "0x1";
     const oldSubCategoryId = "0x2";
     const freshSubCategoryId = "0x3";
     const queryAllUsedSpatialSubCategories = vi.fn(async () => [{ parentId: categoryId, id: freshSubCategoryId, appearance: {} }]);
+    const querySubCategories = vi.fn(async () => [
+      { parentId: categoryId, id: oldSubCategoryId, appearance: {} },
+      { parentId: categoryId, id: freshSubCategoryId, appearance: {} },
+    ]);
     const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
 
     const iModel = {
       isClosed: false,
       isBriefcaseConnection: () => true,
+      querySubCategories,
       queryAllUsedSpatialSubCategories,
       txns: { onElementsChanged },
     } as unknown as IModelConnection;
@@ -306,9 +311,17 @@ describe("SubCategoriesCache", () => {
     await cache.loadAllUsedSpatialSubCategories();
 
     expect(queryAllUsedSpatialSubCategories).toHaveBeenCalledTimes(1);
-    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(false);
+    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(true);
     expect(cache.getSubCategories(categoryId)?.has(freshSubCategoryId)).toBe(true);
-    expect(cache.getSubCategoryAppearance(oldSubCategoryId)).toBeUndefined();
+    expect(cache.getSubCategoryAppearance(oldSubCategoryId)).not.toBeUndefined();
+
+    const request = cache.load([categoryId]);
+    expect(request).not.toBeUndefined();
+    expect(await request!.promise).toBe(true);
+
+    expect(querySubCategories).toHaveBeenCalledTimes(1);
+    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(true);
+    expect(cache.getSubCategories(categoryId)?.has(freshSubCategoryId)).toBe(true);
   });
 
   it("overwrites stale subcategory appearances during the used spatial subcategory preload", async () => {
@@ -389,7 +402,7 @@ describe("SubCategoriesCache", () => {
     expect(cache.getSubCategories(categoryId)?.has(subCategoryId)).toBe(true);
   });
 
-  it("omits categories whose cache entry is still absent after a failed load", async () => {
+  it("returns requested categories with empty subcategory maps when load fails", async () => {
     const categoryId = "0x1";
     const querySubCategories = vi.fn().mockRejectedValueOnce(new Error("backend error"));
 
@@ -401,7 +414,9 @@ describe("SubCategoriesCache", () => {
     const cache = new SubCategoriesCache(iModel);
 
     const categoryInfo = await cache.getCategoryInfo(categoryId);
-    expect(categoryInfo.has(categoryId)).toBe(false);
+    expect(categoryInfo.size).toBe(1);
+    expect(categoryInfo.get(categoryId)?.id).toBe(categoryId);
+    expect(categoryInfo.get(categoryId)?.subCategories.size).toBe(0);
   });
 
   it("bumps generation on update/delete of subcategory not in cache when categories are stale", async () => {

--- a/core/frontend/src/test/SubCategoriesCache.test.ts
+++ b/core/frontend/src/test/SubCategoriesCache.test.ts
@@ -1,0 +1,415 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from "vitest";
+import { BeEvent, CompressedId64Set } from "@itwin/core-bentley";
+import { FeatureOverrides, NotifyEntitiesChangedArgs, SubCategoryAppearance, SubCategoryResultRow } from "@itwin/core-common";
+import type { IModelConnection } from "../IModelConnection";
+import { SubCategoriesCache } from "../SubCategoriesCache";
+import { EntityChanges, TxnEntityChanges } from "../TxnEntityChanges";
+
+function createChanges(args: NotifyEntitiesChangedArgs): TxnEntityChanges {
+  return new EntityChanges(args);
+}
+
+function createSubCategoryChange(id: string, type: "inserted" | "deleted" | "updated"): NotifyEntitiesChangedArgs {
+  const changedIds = CompressedId64Set.compressIds([id]);
+  return {
+    inserted: type === "inserted" ? changedIds : undefined,
+    deleted: type === "deleted" ? changedIds : undefined,
+    updated: type === "updated" ? changedIds : undefined,
+    insertedMeta: type === "inserted" ? [0] : [],
+    deletedMeta: type === "deleted" ? [0] : [],
+    updatedMeta: type === "updated" ? [0] : [],
+    meta: [{ name: "BisCore:SubCategory", bases: [] }],
+  };
+}
+
+function createCategoryChange(id: string, type: "inserted" | "deleted" | "updated"): NotifyEntitiesChangedArgs {
+  const changedIds = CompressedId64Set.compressIds([id]);
+  return {
+    inserted: type === "inserted" ? changedIds : undefined,
+    deleted: type === "deleted" ? changedIds : undefined,
+    updated: type === "updated" ? changedIds : undefined,
+    insertedMeta: type === "inserted" ? [0] : [],
+    deletedMeta: type === "deleted" ? [0] : [],
+    updatedMeta: type === "updated" ? [0] : [],
+    meta: [{ name: "BisCore:Category", bases: [] }],
+  };
+}
+
+async function waitForPromises(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createDeferred<T>(): { promise: Promise<T>, resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createRenderOverrides(cache: SubCategoriesCache, categoryIds: Iterable<string>): FeatureOverrides {
+  const overrides = new FeatureOverrides();
+  for (const categoryId of categoryIds) {
+    const subCategoryIds = cache.getSubCategories(categoryId);
+    if (undefined === subCategoryIds)
+      continue;
+
+    for (const subCategoryId of subCategoryIds)
+      overrides.setVisibleSubCategory(subCategoryId);
+  }
+
+  return overrides;
+}
+
+describe("SubCategoriesCache", () => {
+  it("raises onChanged when an inserted subcategory invalidates cached category data", () => {
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+    const iModel = {
+      isBriefcaseConnection: () => true,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+
+    const cache = new SubCategoriesCache(iModel);
+    cache.add("0x1", "0x2", new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+
+    let numChanges = 0;
+    cache.addChangedListener(() => numChanges++);
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x20", "inserted")));
+
+    expect(numChanges).toBe(1);
+    expect(cache.getSubCategories("0x1")?.has("0x2")).toBe(true);
+  });
+
+  it("supports reloading viewed categories after cache invalidation", async () => {
+    const querySubCategories = vi.fn(async (compressedCategoryIds: string) => {
+      return Array.from(CompressedId64Set.iterable(compressedCategoryIds)).map((parentId): SubCategoryResultRow => ({
+        parentId,
+        id: "0x2",
+        appearance: {},
+      }));
+    });
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+
+    const cache = new SubCategoriesCache(iModel);
+    const queue = new SubCategoriesCache.Queue();
+    const viewedCategories = new Set(["0x1"]);
+    const reloaded = vi.fn();
+
+    cache.add("0x1", "0x2", new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+    cache.addChangedListener(() => queue.push(cache, viewedCategories, reloaded));
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x20", "inserted")));
+    await waitForPromises();
+
+    expect(querySubCategories).toHaveBeenCalledTimes(1);
+    expect([...CompressedId64Set.iterable(querySubCategories.mock.calls[0][0])]).toEqual(["0x1"]);
+    expect(reloaded).toHaveBeenCalledWith(true);
+    queue[Symbol.dispose]();
+  });
+
+  it("preserves render visibility while viewed categories reload after subcategory cache invalidation", async () => {
+    const categoryId = "0x1";
+    const subCategoryId = "0x2";
+    const otherCategoryId = "0x3";
+    const otherSubCategoryId = "0x4";
+    const querySubCategories = vi.fn(async (compressedCategoryIds: string) => {
+      return Array.from(CompressedId64Set.iterable(compressedCategoryIds)).map((parentId): SubCategoryResultRow => ({
+        parentId,
+        id: parentId === categoryId ? subCategoryId : otherSubCategoryId,
+        appearance: {},
+      }));
+    });
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    const queue = new SubCategoriesCache.Queue();
+    const viewedCategories = new Set([categoryId, otherCategoryId]);
+    cache.add(categoryId, subCategoryId, new SubCategoryAppearance(), true);
+    cache.add(otherCategoryId, otherSubCategoryId, new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+
+    const beforeInvalidation = createRenderOverrides(cache, viewedCategories);
+    expect(beforeInvalidation.isSubCategoryIdVisible(subCategoryId)).toBe(true);
+    expect(beforeInvalidation.isSubCategoryIdVisible(otherSubCategoryId)).toBe(true);
+
+    cache.addChangedListener(() => queue.push(cache, viewedCategories, () => {}));
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x20", "inserted")));
+    const whileReloading = createRenderOverrides(cache, viewedCategories);
+    expect(whileReloading.isSubCategoryIdVisible(subCategoryId)).toBe(true);
+    expect(whileReloading.isSubCategoryIdVisible(otherSubCategoryId)).toBe(true);
+
+    await waitForPromises();
+
+    const afterReload = createRenderOverrides(cache, viewedCategories);
+    expect(querySubCategories).toHaveBeenCalledTimes(1);
+    expect(afterReload.isSubCategoryIdVisible(subCategoryId)).toBe(true);
+    expect(afterReload.isSubCategoryIdVisible(otherSubCategoryId)).toBe(true);
+
+    queue[Symbol.dispose]();
+  });
+
+  it("does not satisfy a post-invalidation reload from an in-flight stale request", async () => {
+    const categoryId = "0x1";
+    const oldSubCategoryId = "0x2";
+    const staleSubCategoryId = "0x3";
+    const freshSubCategoryId = "0x4";
+    const staleResult = createDeferred<SubCategoryResultRow[]>();
+    const freshResult = createDeferred<SubCategoryResultRow[]>();
+    const querySubCategories = vi.fn()
+      .mockReturnValueOnce(staleResult.promise)
+      .mockReturnValueOnce(freshResult.promise);
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    const queue = new SubCategoriesCache.Queue();
+    const viewedCategories = new Set([categoryId]);
+    const reloaded = vi.fn();
+    cache.add(categoryId, oldSubCategoryId, new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+    cache.addChangedListener(() => queue.push(cache, viewedCategories, reloaded));
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x10", "inserted")));
+    expect(querySubCategories).toHaveBeenCalledTimes(1);
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x11", "inserted")));
+    expect(querySubCategories).toHaveBeenCalledTimes(1);
+
+    staleResult.resolve([{ parentId: categoryId, id: staleSubCategoryId, appearance: {} }]);
+    await waitForPromises();
+
+    expect(querySubCategories).toHaveBeenCalledTimes(2);
+    let overrides = createRenderOverrides(cache, viewedCategories);
+    expect(overrides.isSubCategoryIdVisible(oldSubCategoryId)).toBe(true);
+    expect(overrides.isSubCategoryIdVisible(staleSubCategoryId)).toBe(false);
+
+    freshResult.resolve([{ parentId: categoryId, id: freshSubCategoryId, appearance: {} }]);
+    await waitForPromises();
+
+    expect(reloaded).toHaveBeenCalledTimes(1);
+    overrides = createRenderOverrides(cache, viewedCategories);
+    expect(overrides.isSubCategoryIdVisible(oldSubCategoryId)).toBe(false);
+    expect(overrides.isSubCategoryIdVisible(freshSubCategoryId)).toBe(true);
+
+    queue[Symbol.dispose]();
+  });
+
+  it("preserves stale category data when a reload fails", async () => {
+    const categoryId = "0x1";
+    const oldSubCategoryId = "0x2";
+    const freshSubCategoryId = "0x3";
+    const querySubCategories = vi.fn()
+      .mockRejectedValueOnce(new Error("query failed"))
+      .mockResolvedValueOnce([{ parentId: categoryId, id: freshSubCategoryId, appearance: {} }]);
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    cache.add(categoryId, oldSubCategoryId, new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x20", "inserted")));
+
+    const failedRequest = cache.load([categoryId]);
+    expect(failedRequest).not.toBeUndefined();
+    expect(await failedRequest!.promise).toBe(false);
+    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(true);
+    expect(cache.getSubCategoryAppearance(oldSubCategoryId)).not.toBeUndefined();
+
+    const retryRequest = cache.load([categoryId]);
+    expect(retryRequest).not.toBeUndefined();
+    expect(await retryRequest!.promise).toBe(true);
+    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(false);
+    expect(cache.getSubCategories(categoryId)?.has(freshSubCategoryId)).toBe(true);
+    expect(cache.getSubCategoryAppearance(oldSubCategoryId)).toBeUndefined();
+  });
+
+  it("reconciles subcategory membership and appearances after a stale category reload", async () => {
+    const categoryId = "0x1";
+    const oldSubCategoryId = "0x2";
+    const freshSubCategoryId = "0x3";
+    const querySubCategories = vi.fn(async () => [{ parentId: categoryId, id: freshSubCategoryId, appearance: {} }]);
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    cache.add(categoryId, oldSubCategoryId, new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange(oldSubCategoryId, "deleted")));
+
+    const request = cache.load([categoryId]);
+    expect(request).not.toBeUndefined();
+    expect(await request!.promise).toBe(true);
+
+    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(false);
+    expect(cache.getSubCategories(categoryId)?.has(freshSubCategoryId)).toBe(true);
+    expect(cache.getSubCategoryAppearance(oldSubCategoryId)).toBeUndefined();
+    expect((await cache.getSubCategoryInfo(categoryId, oldSubCategoryId)).has(oldSubCategoryId)).toBe(false);
+  });
+
+  it("reconciles stale categories loaded by the used spatial subcategory preload", async () => {
+    const categoryId = "0x1";
+    const oldSubCategoryId = "0x2";
+    const freshSubCategoryId = "0x3";
+    const queryAllUsedSpatialSubCategories = vi.fn(async () => [{ parentId: categoryId, id: freshSubCategoryId, appearance: {} }]);
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      queryAllUsedSpatialSubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    cache.add(categoryId, oldSubCategoryId, new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x20", "inserted")));
+    await cache.loadAllUsedSpatialSubCategories();
+
+    expect(queryAllUsedSpatialSubCategories).toHaveBeenCalledTimes(1);
+    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(false);
+    expect(cache.getSubCategories(categoryId)?.has(freshSubCategoryId)).toBe(true);
+    expect(cache.getSubCategoryAppearance(oldSubCategoryId)).toBeUndefined();
+  });
+
+  it("removes cached subcategory appearances when a category is deleted", async () => {
+    const categoryId = "0x1";
+    const subCategoryId = "0x2";
+    const querySubCategories = vi.fn(async () => []);
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    cache.add(categoryId, subCategoryId, new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+
+    onElementsChanged.raiseEvent(createChanges(createCategoryChange(categoryId, "deleted")));
+
+    expect(cache.getSubCategories(categoryId)).toBeUndefined();
+    expect(cache.getSubCategoryAppearance(subCategoryId)).toBeUndefined();
+    expect((await cache.getSubCategoryInfo(categoryId, subCategoryId)).has(subCategoryId)).toBe(false);
+  });
+
+  it("does not cache empty sets on failed cold load, allowing retry to succeed", async () => {
+    const categoryId = "0x1";
+    const subCategoryId = "0x2";
+    const querySubCategories = vi.fn()
+      .mockRejectedValueOnce(new Error("backend error"))
+      .mockResolvedValueOnce([{ parentId: categoryId, id: subCategoryId, appearance: {} }]);
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+
+    // First load fails - category should remain absent from cache (not cached as empty).
+    const failedRequest = cache.load([categoryId]);
+    expect(failedRequest).not.toBeUndefined();
+    expect(await failedRequest!.promise).toBe(false);
+    // getMissing should still report this category since it was never successfully loaded.
+    expect(cache.getSubCategories(categoryId)).toBeUndefined();
+
+    // Second load retries and succeeds.
+    const retryRequest = cache.load([categoryId]);
+    expect(retryRequest).not.toBeUndefined();
+    expect(await retryRequest!.promise).toBe(true);
+    expect(cache.getSubCategories(categoryId)?.has(subCategoryId)).toBe(true);
+  });
+
+  it("bumps generation on update/delete of subcategory not in cache when categories are stale", async () => {
+    const categoryId = "0x1";
+    const oldSubCategoryId = "0x2";
+    const newSubCategoryId = "0x10";
+    const freshSubCategoryId = "0x5";
+    const staleResult = createDeferred<SubCategoryResultRow[]>();
+    const freshResult = createDeferred<SubCategoryResultRow[]>();
+    const querySubCategories = vi.fn()
+      .mockReturnValueOnce(staleResult.promise)
+      .mockReturnValueOnce(freshResult.promise);
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    const queue = new SubCategoriesCache.Queue();
+    const viewedCategories = new Set([categoryId]);
+    const reloaded = vi.fn();
+    cache.add(categoryId, oldSubCategoryId, new SubCategoryAppearance(), true);
+    cache.attachToBriefcase(iModel);
+    cache.addChangedListener(() => queue.push(cache, viewedCategories, reloaded));
+
+    // Insert event marks all stale, starts reload (query 1).
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange(newSubCategoryId, "inserted")));
+    expect(querySubCategories).toHaveBeenCalledTimes(1);
+
+    // Update event for the newly inserted subcategory (not in old cache) fires before query 1 resolves.
+    // This must bump generation so the in-flight stale result is rejected.
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange(newSubCategoryId, "updated")));
+
+    // Stale query resolves - should be rejected due to generation bump.
+    staleResult.resolve([{ parentId: categoryId, id: oldSubCategoryId, appearance: {} }]);
+    await waitForPromises();
+
+    // A second query should have been triggered (queue re-pushes on changed event).
+    expect(querySubCategories).toHaveBeenCalledTimes(2);
+
+    // Fresh query resolves with updated data.
+    freshResult.resolve([{ parentId: categoryId, id: freshSubCategoryId, appearance: {} }]);
+    await waitForPromises();
+
+    expect(cache.getSubCategories(categoryId)?.has(freshSubCategoryId)).toBe(true);
+    expect(cache.getSubCategories(categoryId)?.has(oldSubCategoryId)).toBe(false);
+
+    queue[Symbol.dispose]();
+  });
+});

--- a/core/frontend/src/test/SubCategoriesCache.test.ts
+++ b/core/frontend/src/test/SubCategoriesCache.test.ts
@@ -311,6 +311,33 @@ describe("SubCategoriesCache", () => {
     expect(cache.getSubCategoryAppearance(oldSubCategoryId)).toBeUndefined();
   });
 
+  it("overwrites stale subcategory appearances during the used spatial subcategory preload", async () => {
+    const categoryId = "0x1";
+    const subCategoryId = "0x2";
+    const staleAppearance = new SubCategoryAppearance({ invisible: true });
+    const freshAppearance = new SubCategoryAppearance();
+    const queryAllUsedSpatialSubCategories = vi.fn(async () => [{ parentId: categoryId, id: subCategoryId, appearance: {} }]);
+    const onElementsChanged = new BeEvent<(changes: TxnEntityChanges) => void>();
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      queryAllUsedSpatialSubCategories,
+      txns: { onElementsChanged },
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+    cache.add(categoryId, subCategoryId, staleAppearance, true);
+    cache.attachToBriefcase(iModel);
+
+    onElementsChanged.raiseEvent(createChanges(createSubCategoryChange("0x20", "inserted")));
+    await cache.loadAllUsedSpatialSubCategories();
+
+    const reloadedAppearance = cache.getSubCategoryAppearance(subCategoryId);
+    expect(queryAllUsedSpatialSubCategories).toHaveBeenCalledTimes(1);
+    expect(reloadedAppearance).not.toBeUndefined();
+    expect(reloadedAppearance!.equals(freshAppearance)).toBe(true);
+  });
+
   it("removes cached subcategory appearances when a category is deleted", async () => {
     const categoryId = "0x1";
     const subCategoryId = "0x2";
@@ -360,6 +387,21 @@ describe("SubCategoriesCache", () => {
     expect(retryRequest).not.toBeUndefined();
     expect(await retryRequest!.promise).toBe(true);
     expect(cache.getSubCategories(categoryId)?.has(subCategoryId)).toBe(true);
+  });
+
+  it("omits categories whose cache entry is still absent after a failed load", async () => {
+    const categoryId = "0x1";
+    const querySubCategories = vi.fn().mockRejectedValueOnce(new Error("backend error"));
+
+    const iModel = {
+      isClosed: false,
+      isBriefcaseConnection: () => true,
+      querySubCategories,
+    } as unknown as IModelConnection;
+    const cache = new SubCategoriesCache(iModel);
+
+    const categoryInfo = await cache.getCategoryInfo(categoryId);
+    expect(categoryInfo.has(categoryId)).toBe(false);
   });
 
   it("bumps generation on update/delete of subcategory not in cache when categories are stale", async () => {

--- a/core/frontend/src/test/Viewport.test.ts
+++ b/core/frontend/src/test/Viewport.test.ts
@@ -27,6 +27,27 @@ describe("Viewport", () => {
   beforeAll(async () => IModelApp.startup({ localization: new EmptyLocalization() }));
   afterAll(async () => IModelApp.shutdown());
 
+  describe("subcategory reload category collection", () => {
+    it("includes per-model override categories outside the category selector", () => {
+      const viewport = {
+        view: {
+          categorySelector: {
+            categories: new Set(["0x1", "0x2"]),
+          },
+        },
+        perModelCategoryVisibility: {
+          *[Symbol.iterator]() {
+            yield { modelId: "0xa", categoryId: "0x3", visible: true };
+            yield { modelId: "0xb", categoryId: "0x2", visible: false };
+          },
+        },
+      };
+
+      const categoryIds = (Viewport.prototype as any).getSubCategoryReloadCategoryIds.call(viewport) as Set<string>;
+      expect([...categoryIds]).toEqual(["0x1", "0x2", "0x3"]);
+    });
+  });
+
   describe("constructor", () => {
     it("invokes initialize method", () => {
       class ScreenVp extends ScreenViewport {

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,6 +11,7 @@ publish: false
     - [Reality model tiles with JSON glTF content now render](#reality-model-tiles-with-json-gltf-content-now-render)
     - [Quantity property description classes deprecated](#quantity-property-description-classes-deprecated)
     - [Bing Maps deprecation and new geospatial provider interfaces](#bing-maps-deprecation-and-new-geospatial-provider-interfaces)
+    - [Graphics no longer disappear when a new category is inserted](#graphics-no-longer-disappear-when-a-new-category-is-inserted)
   - [@itwin/core-geometry](#itwincore-geometry)
     - [`CurveFactory.createFilletsInLineString` expanded options](#curve-factory-create-fillets-in-line-string-expanded-options)
   - [@itwin/map-layers-formats](#itwinmap-layers-formats)
@@ -166,6 +167,12 @@ if (iModel.isGeoLocated) {
   const height = await IModelApp.elevationProvider.getHeight(carto);
 }
 ```
+
+### Graphics no longer disappear when a new category is inserted
+
+Inserting a new `Category` also inserts that category's default `SubCategory`. The frontend's subcategory cache previously responded to *any* `SubCategory` insertion by clearing its entire contents, as the change notification does not identify which category the new subcategory belongs to. Because [Viewport]($frontend) rendering derives the set of visible subcategories from that cache, clearing it made every already-viewed category appear to have no subcategories, so all graphics disappeared until an unrelated action (such as toggling a category in the [CategorySelectorState]($frontend)) repopulated the cache.
+
+The cache now keeps serving the previously-loaded data and instead marks the affected categories as stale, reloading them in the background. Already-viewed graphics remain visible throughout, and the [Viewport]($frontend) automatically reloads and repaints the affected categories.
 
 ## @itwin/core-geometry
 

--- a/full-stack-tests/core/src/frontend/standalone/SubCategoriesCache.test.ts
+++ b/full-stack-tests/core/src/frontend/standalone/SubCategoriesCache.test.ts
@@ -480,8 +480,9 @@ describe("SubCategoriesCache", () => {
 
       const s2 = await ipc.insertElement(bc.key, s2Props);
       await saveAndExpectChanges([s2]);
-      expectCachedSubCategories(cat, undefined);
-      expectAppearance(s1, undefined);
+      // Soft invalidation: stale data is preserved for rendering continuity
+      expectCachedSubCategories(cat, [s1]);
+      expectAppearance(s1, ColorDef.blue);
       expectAppearance(s2, undefined);
 
       await bc.subcategories.load(cat)?.promise;
@@ -494,9 +495,10 @@ describe("SubCategoriesCache", () => {
       s2Props.appearance = { color: ColorDef.green.toJSON() };
       await ipc.updateElement(bc.key, s2Props);
       await saveAndExpectChanges([s2]);
-      expectCachedSubCategories(cat, undefined);
+      // Soft invalidation: stale subcategory IDs and appearances are preserved
+      expectCachedSubCategories(cat, [s1, s2]);
       expectAppearance(s1, ColorDef.blue);
-      expectAppearance(s2, undefined);
+      expectAppearance(s2, ColorDef.red);
 
       await bc.subcategories.load(cat)?.promise;
       expectCachedSubCategories(cat, [s1, s2]);
@@ -506,9 +508,10 @@ describe("SubCategoriesCache", () => {
       // Delete a subcategory
       await ipc.deleteDefinitionElements(bc.key, [s2]);
       await saveAndExpectChanges([s2]);
-      expectCachedSubCategories(cat, undefined);
+      // Soft invalidation: stale data (including the deleted s2) is preserved until reload
+      expectCachedSubCategories(cat, [s1, s2]);
       expectAppearance(s1, ColorDef.blue);
-      expectAppearance(s2, undefined);
+      expectAppearance(s2, ColorDef.green);
 
       await bc.subcategories.load(cat)?.promise;
       expectCachedSubCategories(cat, [s1]);
@@ -516,7 +519,8 @@ describe("SubCategoriesCache", () => {
       // Undo
       await bc.txns.reverseSingleTxn();
       expectChanges([s2]);
-      expectCachedSubCategories(cat, undefined);
+      // Soft invalidation: stale data from last reload (s1 only) is preserved
+      expectCachedSubCategories(cat, [s1]);
 
       await bc.subcategories.load(cat)?.promise;
       expectCachedSubCategories(cat, [s1, s2]);
@@ -525,7 +529,8 @@ describe("SubCategoriesCache", () => {
       // Redo
       await bc.txns.reinstateTxn();
       expectChanges([s2]);
-      expectCachedSubCategories(cat, undefined);
+      // Soft invalidation: stale data from last reload (s1 + s2) is preserved
+      expectCachedSubCategories(cat, [s1, s2]);
 
       await bc.subcategories.load(cat)?.promise;
       expectCachedSubCategories(cat, [s1]);


### PR DESCRIPTION
## Summary
 
 Inserting a new `Category` no longer makes graphics disappear. Builds on #8734 (which synchronized `SubCategoriesCache` on edits) by changing *how* the cache invalidates and by reloading + repainting affected categories automatically.
 
 ## Background
 
 #8734 correctly began invalidating `SubCategoriesCache` in read-write workflows. For an inserted subcategory — whose parent category isn't identified in the txn notification — it cleared the entire cache. That's fine for the on-demand query path (`getCategoryInfo` re-fetches lazily), but the render path treats an *empty* cache entry for a viewed category as
 "this category has no visible subcategories" and hides its geometry. Because creating a `Category` auto-inserts its default `SubCategory`, a routine edit blanked every viewed category, with nothing reloading the cache until an unrelated action.
 
 ## Changes
 
 - **`SubCategoriesCache`**: on a subcategory insert, mark affected categories *stale* and keep serving the previously-loaded data instead of clearing it. Stale categories are re-fetched on the next load; an `_invalidationGeneration` guard discards in-flight reloads that a newer edit has superseded, so concurrent edits can't apply outdated data. A new (internal)   `addChangedListener` notifies consumers when cached data is invalidated.
 - **`Viewport`**: subscribe to the cache's change event to reload the viewed categories and repaint. Scene-invalidation now lives inside `updateSubCategories` alongside the existing change-flag/repaint logic, so the cache-invalidation path needs no separate callback.