### PR TITLE
Add `CompressedId64Set.isValid` type guard

### DIFF
--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -276,6 +276,7 @@ export namespace CompressedId64Set {
     export function compressSet(ids: Id64Set): CompressedId64Set;
     export function decompressArray(compressedIds: CompressedId64Set, out?: Id64Array): Id64Array;
     export function decompressSet(compressedIds: CompressedId64Set, out?: Id64Set): Id64Set;
+    export function isValid(ids: unknown): ids is CompressedId64Set;
     export function iterable(ids: CompressedId64Set): OrderedId64Iterable;
     export function iterator(ids: CompressedId64Set): Iterator<Id64String>;
     export function sortAndCompress(ids: Iterable<Id64String>): CompressedId64Set;

--- a/common/changes/@itwin/core-backend/isValid-typeguard-2026-06-26.json
+++ b/common/changes/@itwin/core-backend/isValid-typeguard-2026-06-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Use `CompressedId64Set.isValid` in `DisplayStyle.deserialize` instead of an inline heuristic.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-bentley/isValid-typeguard-2026-06-26T17-16-46-620Z.json
+++ b/common/changes/@itwin/core-bentley/isValid-typeguard-2026-06-26T17-16-46-620Z.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Added `CompressedId64Set.isValid` type guard to test whether a value is a valid `CompressedId64Set`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/core/backend/src/DisplayStyle.ts
+++ b/core/backend/src/DisplayStyle.ts
@@ -36,10 +36,10 @@ export abstract class DisplayStyle extends DefinitionElement {
     const elProps = super.deserialize(props);
     const displayOptions = props.options?.element?.displayStyle;
     // Uncompress excludedElements if they are compressed
-    if (!displayOptions?.compressExcludedElementIds && elProps.jsonProperties?.styles?.excludedElements) {
-      const excludedElements = elProps.jsonProperties.styles.excludedElements;
+    if (!displayOptions?.compressExcludedElementIds) {
+      const excludedElements = elProps.jsonProperties?.styles?.excludedElements;
       if (CompressedId64Set.isValid(excludedElements)) {
-        elProps.jsonProperties.styles.excludedElements = CompressedId64Set.decompressArray(excludedElements);
+        elProps.jsonProperties!.styles!.excludedElements = CompressedId64Set.decompressArray(excludedElements);
       }
     }
     // Omit Schedule Script Element Ids if the option is set

--- a/core/backend/src/DisplayStyle.ts
+++ b/core/backend/src/DisplayStyle.ts
@@ -37,9 +37,9 @@ export abstract class DisplayStyle extends DefinitionElement {
     const displayOptions = props.options?.element?.displayStyle;
     // Uncompress excludedElements if they are compressed
     if (!displayOptions?.compressExcludedElementIds) {
-      const excludedElements = elProps.jsonProperties?.styles?.excludedElements;
-      if (CompressedId64Set.isValid(excludedElements)) {
-        elProps.jsonProperties!.styles!.excludedElements = CompressedId64Set.decompressArray(excludedElements);
+      const styles = elProps.jsonProperties?.styles;
+      if (styles && CompressedId64Set.isValid(styles.excludedElements)) {
+        styles.excludedElements = CompressedId64Set.decompressArray(styles.excludedElements);
       }
     }
     // Omit Schedule Script Element Ids if the option is set

--- a/core/backend/src/DisplayStyle.ts
+++ b/core/backend/src/DisplayStyle.ts
@@ -38,12 +38,8 @@ export abstract class DisplayStyle extends DefinitionElement {
     // Uncompress excludedElements if they are compressed
     if (!displayOptions?.compressExcludedElementIds && elProps.jsonProperties?.styles?.excludedElements) {
       const excludedElements = elProps.jsonProperties.styles.excludedElements;
-      if (typeof excludedElements === "string" && excludedElements.startsWith("+")) {
-        const ids: string[] = [];
-        CompressedId64Set.decompressSet(excludedElements).forEach((id: string) => {
-          ids.push(id);
-        });
-        elProps.jsonProperties.styles.excludedElements = ids;
+      if (CompressedId64Set.isValid(excludedElements)) {
+        elProps.jsonProperties.styles.excludedElements = CompressedId64Set.decompressArray(excludedElements);
       }
     }
     // Omit Schedule Script Element Ids if the option is set

--- a/core/bentley/src/CompressedId64Set.ts
+++ b/core/bentley/src/CompressedId64Set.ts
@@ -28,6 +28,9 @@ export namespace CompressedId64Set { // eslint-disable-line @typescript-eslint/n
    * (representing an empty set) or a non-empty string beginning with `'+'`.
    * Useful as a type guard to distinguish a compressed set from an [[Id64String]] or other
    * value when the type of a string is not known statically.
+   * @note This is a syntactic prefix check only — it does not validate the encoded content
+   * after `'+'`. A value may pass this guard and still throw during [[CompressedId64Set.iterator]]
+   * (e.g. `'+0'` or `'+garbage'`).
    * @see [[CompressedId64Set.iterable]] to iterate the Ids represented by a compressed string.
    */
   export function isValid(ids: unknown): ids is CompressedId64Set {

--- a/core/bentley/src/CompressedId64Set.ts
+++ b/core/bentley/src/CompressedId64Set.ts
@@ -24,6 +24,16 @@ export type CompressedId64Set = string;
  * @public
  */
 export namespace CompressedId64Set { // eslint-disable-line @typescript-eslint/no-redeclare
+  /** Returns `true` if `ids` is a valid [[CompressedId64Set]] — either an empty string
+   * (representing an empty set) or a non-empty string beginning with `'+'`.
+   * Useful as a type guard to distinguish a compressed set from an [[Id64String]] or other
+   * value when the type of a string is not known statically.
+   * @see [[CompressedId64Set.iterable]] to iterate the Ids represented by a compressed string.
+   */
+  export function isValid(ids: unknown): ids is CompressedId64Set {
+    return typeof ids === "string" && (ids.length === 0 || ids[0] === "+");
+  }
+
   function isHexDigit(ch: number): boolean {
     // ascii values:
     // '0' = 48

--- a/core/bentley/src/test/Id.test.ts
+++ b/core/bentley/src/test/Id.test.ts
@@ -631,6 +631,25 @@ describe("CompressedId64Set", () => {
     expect(CompressedId64Set.compressArray(["0"])).to.equal("");
     expect(CompressedId64Set.compressArray(["garbage", "0", "0x1", "0x4", "0", "0x5abc", "0x5xyz", "zzzzzzzz"])).to.equal("+1+3+5AB8");
   });
+
+  it("isValid", () => {
+    // valid: empty string = empty set
+    expect(CompressedId64Set.isValid("")).to.be.true;
+    // valid: non-empty compressed strings start with "+"
+    expect(CompressedId64Set.isValid("+1")).to.be.true;
+    expect(CompressedId64Set.isValid("+1*3")).to.be.true;
+    expect(CompressedId64Set.isValid("+1+3+5AB8")).to.be.true;
+
+    // invalid: Id64String
+    expect(CompressedId64Set.isValid("0x1")).to.be.false;
+    // invalid: arbitrary string
+    expect(CompressedId64Set.isValid("hello")).to.be.false;
+    // invalid: non-string types
+    expect(CompressedId64Set.isValid(undefined)).to.be.false;
+    expect(CompressedId64Set.isValid(null)).to.be.false;
+    expect(CompressedId64Set.isValid(42)).to.be.false;
+    expect(CompressedId64Set.isValid(new Set())).to.be.false;
+  });
 });
 
 describe("MutableCompressedId64Set", () => {

--- a/core/bentley/src/test/Id.test.ts
+++ b/core/bentley/src/test/Id.test.ts
@@ -649,6 +649,12 @@ describe("CompressedId64Set", () => {
     expect(CompressedId64Set.isValid(null)).to.be.false;
     expect(CompressedId64Set.isValid(42)).to.be.false;
     expect(CompressedId64Set.isValid(new Set())).to.be.false;
+
+    // prefix check only — passes isValid but throws during iteration
+    expect(CompressedId64Set.isValid("+0")).to.be.true;
+    expect(CompressedId64Set.isValid("+garbage")).to.be.true;
+    expect(() => [...CompressedId64Set.iterable("+0")]).to.throw();
+    expect(() => [...CompressedId64Set.iterable("+garbage")]).to.throw();
   });
 });
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -28,11 +28,11 @@ publish: false
 [CompressedId64Set.isValid]($bentley) is a new type guard that returns `true` if a value is a valid `CompressedId64Set` — either an empty string (representing an empty set) or a non-empty string beginning with `"+"`. This lets callers safely distinguish a compressed Id set from a plain [Id64String]($bentley) or any other value without duplicating the internal format heuristic:
 
 ```typescript
-function processIds(ids: CompressedId64Set | Id64String): void {
+function processIds(ids: unknown): void {
   if (CompressedId64Set.isValid(ids)) {
     for (const id of CompressedId64Set.iterable(ids))
       doSomething(id);
-  } else {
+  } else if (typeof ids === "string" && Id64.isValidId64(ids)) {
     doSomething(ids);
   }
 }

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -4,6 +4,8 @@ publish: false
 # NextVersion
 
 - [NextVersion](#nextversion)
+  - [@itwin/core-bentley](#itwincore-bentley)
+    - [`CompressedId64Set.isValid` type guard](#compressedid64setisvalid-type-guard)
   - [@itwin/core-frontend](#itwincore-frontend)
     - [Pluggable Cesium Ion authentication via `CesiumAccessClient`](#pluggable-cesium-ion-authentication-via-cesiumaccessclient)
     - [Configurable precision for graphical editing at high coordinates](#configurable-precision-for-graphical-editing-at-high-coordinates)
@@ -18,6 +20,23 @@ publish: false
     - [Azure Maps basemap support is available through map-layers-formats](#azure-maps-basemap-support-is-available-through-map-layers-formats)
   - [@itwin/build-tools](#itwinbuild-tools)
     - [`mocha` is now an optional peer dependency](#mocha-is-now-an-optional-peer-dependency)
+
+## @itwin/core-bentley
+
+### `CompressedId64Set.isValid` type guard
+
+[CompressedId64Set.isValid]($bentley) is a new type guard that returns `true` if a value is a valid `CompressedId64Set` — either an empty string (representing an empty set) or a non-empty string beginning with `"+"`. This lets callers safely distinguish a compressed Id set from a plain [Id64String]($bentley) or any other value without duplicating the internal format heuristic:
+
+```typescript
+function processIds(ids: CompressedId64Set | Id64String): void {
+  if (CompressedId64Set.isValid(ids)) {
+    for (const id of CompressedId64Set.iterable(ids))
+      doSomething(id);
+  } else {
+    doSomething(ids);
+  }
+}
+```
 
 ## @itwin/core-frontend
 


### PR DESCRIPTION
## Why

Consumers working with loosely-typed data (e.g. deserialized JSON) often need to test whether a string value is a `CompressedId64Set` or a plain `Id64String`. There was no public API for this — callers had to copy the internal heuristic (`typeof x === "string" && x.startsWith("+")`) themselves. `DisplayStyle.deserialize` in `core/backend` was doing exactly that.

## What

- Adds `CompressedId64Set.isValid(ids: unknown): ids is CompressedId64Set` to the `CompressedId64Set` namespace in `@itwin/core-bentley`.
  - Returns `true` for an empty string (empty set) or any string starting with `"+"`.
  - Takes `unknown` so it works as a proper narrowing type guard in any context.
- Updates `DisplayStyle.deserialize` in `core/backend` to use the new guard, and replaces the adjacent `decompressSet().forEach(push)` pattern with the more direct `decompressArray`.
- Adds tests covering valid inputs, plain `Id64String`, non-string types, and edge cases.
- Adds a `NextVersion.md` entry.

## Validation

- Targeted: `rushx build && vitest --run` in `core/bentley` — 174/174 passing.
- Known baseline: `core/backend` build requires sibling packages built via `rush build`; no errors in `DisplayStyle.ts` itself.

Fixes #9446

---

*Nambot 🤖 (powered by Claude Sonnet 4.6)*