### PR TITLE
Disable Android emulator test while root bug is being fixed

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -60,15 +60,16 @@ steps:
       RUSH_BUILD_CACHE_ENABLED: ${{parameters.rushBuildCacheEnabled}}
       VITE_CI: true
 
-  # - script: npm run android:all
-  #   workingDirectory: test-apps/display-test-app
-  #   displayName: Build & run Android display-test-app
-  #   env:
-  #     IMJS_OIDC_CLIENT_ID: $(IMJS_OIDC_CLIENT_ID)
-  #     IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
-  #     AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-  #     TOKEN: $(GitHubPAT)
-  #   condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
+  - script: npm run android:all
+    workingDirectory: test-apps/display-test-app
+    displayName: Build & run Android display-test-app
+    env:
+      IMJS_OIDC_CLIENT_ID: $(IMJS_OIDC_CLIENT_ID)
+      IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
+      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+      TOKEN: $(GitHubPAT)
+    # TODO: Re-enable once the Android crash after the OpenSSL update is resolved.
+    condition: and(succeeded(), false, ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: npm run ios:all
     workingDirectory: test-apps/display-test-app

--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -60,15 +60,15 @@ steps:
       RUSH_BUILD_CACHE_ENABLED: ${{parameters.rushBuildCacheEnabled}}
       VITE_CI: true
 
-  - script: npm run android:all
-    workingDirectory: test-apps/display-test-app
-    displayName: Build & run Android display-test-app
-    env:
-      IMJS_OIDC_CLIENT_ID: $(IMJS_OIDC_CLIENT_ID)
-      IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
-      AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-      TOKEN: $(GitHubPAT)
-    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
+  # - script: npm run android:all
+  #   workingDirectory: test-apps/display-test-app
+  #   displayName: Build & run Android display-test-app
+  #   env:
+  #     IMJS_OIDC_CLIENT_ID: $(IMJS_OIDC_CLIENT_ID)
+  #     IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
+  #     AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+  #     TOKEN: $(GitHubPAT)
+  #   condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: npm run ios:all
     workingDirectory: test-apps/display-test-app


### PR DESCRIPTION
It appears that the OpenSSL update is triggering a crash on Android, and this is preventing the test from passing. Temporarily disable that step while the crash is tracked down and fixed.