### PR TITLE
Fixed error codes for QueryReader apis

### DIFF
--- a/common/changes/@itwin/core-backend/soham-fixing-closed-db-errors-for-query-api_2026-07-08-10-19.json
+++ b/common/changes/@itwin/core-backend/soham-fixing-closed-db-errors-for-query-api_2026-07-08-10-19.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-backend",
-      "comment": "Changed error messages for \"createQueryReader\" and \"withQueryReader\" api for iModelDb and ECDb",
+      "comment": "Changed error codes for \"createQueryReader\" and \"withQueryReader\" api and made error messages consistent across the native node add-on apis for the case of db being closed",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-backend/soham-fixing-closed-db-errors-for-query-api_2026-07-08-10-19.json
+++ b/common/changes/@itwin/core-backend/soham-fixing-closed-db-errors-for-query-api_2026-07-08-10-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "Changed error messages for \"createQueryReader\" and \"withQueryReader\" api for iModelDb and ECDb",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^12.28.0
         version: 12.28.0
       '@bentley/imodeljs-native':
-        specifier: 5.12.4
-        version: 5.12.4
+        specifier: 5.12.5
+        version: 5.12.5
       '@itwin/object-storage-azure':
         specifier: ^3.0.4
         version: 3.0.4
@@ -4770,8 +4770,8 @@ packages:
   '@bentley/icons-generic@1.0.34':
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  '@bentley/imodeljs-native@5.12.4':
-    resolution: {integrity: sha512-CvwKxbKksc/h3/+2yup88re2UALdZ4JCU2YJ6j5kv42opps4VRGqddLqBDSL6qPOgrfNLKg/FSKCjUDOMR9jOg==}
+  '@bentley/imodeljs-native@5.12.5':
+    resolution: {integrity: sha512-Q1sZZiG2m1WSvQ+zLwfUVfWDUPUjjNtcx2SF5ykGAbvMseK8U7GLZDLPvmhepnUJlVmLLxLrmmEjP1vVKSNyPA==}
 
   '@bentley/linear-referencing-schema@2.0.3':
     resolution: {integrity: sha512-2pFIEN4BS7alIDhGous6N2icKAS8ZhVBfoWB8WvSFaYnneGv5YwbbXl46qATDdPO5jUFezkW6uVxdpp1eOgUHQ==}
@@ -11156,7 +11156,7 @@ snapshots:
 
   '@bentley/icons-generic@1.0.34': {}
 
-  '@bentley/imodeljs-native@5.12.4': {}
+  '@bentley/imodeljs-native@5.12.5': {}
 
   '@bentley/linear-referencing-schema@2.0.3': {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -113,7 +113,7 @@
     "webpack": "^5.97.1"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "5.12.4",
+    "@bentley/imodeljs-native": "5.12.5",
     "@itwin/object-storage-azure": "^3.0.4",
     "@azure/storage-blob": "^12.28.0",
     "form-data": "^4.0.6",

--- a/core/backend/src/ECDb.ts
+++ b/core/backend/src/ECDb.ts
@@ -453,7 +453,7 @@ export class ECDb implements Disposable {
    * */
   public createQueryReader(ecsql: string, params?: QueryBinder, config?: QueryOptions): ECSqlReader {
     if (!this._nativeDb || !this._nativeDb.isOpen()) {
-      throw new IModelError(DbResult.BE_SQLITE_ERROR, "db not open");
+      throw new IModelError(DbResult.BE_SQLITE_ERROR_NOTOPEN, "db not open");
     }
     const executor = {
       execute: async (request: DbQueryRequest) => {
@@ -479,7 +479,7 @@ export class ECDb implements Disposable {
    * */
   public withQueryReader<T>(ecsql: string, callback: (reader: ECSqlSyncReader) => T, params?: QueryBinder, config?: SynchronousQueryOptions): T {
     if (!this[_nativeDb].isOpen())
-      throw new IModelError(DbResult.BE_SQLITE_ERROR, "db not open");
+      throw new IModelError(DbResult.BE_SQLITE_ERROR_NOTOPEN, "db not open");
 
     const executor = new ECSqlRowExecutor(this);
     const reader = new ECSqlSyncReader(executor, ecsql, params, config);

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -960,7 +960,7 @@ export abstract class IModelDb extends IModel {
    * */
   public createQueryReader(ecsql: string, params?: QueryBinder, config?: QueryOptions): ECSqlReader {
     if (!this[_nativeDb].isOpen())
-      throw new IModelError(DbResult.BE_SQLITE_ERROR, "db not open");
+      throw new IModelError(DbResult.BE_SQLITE_ERROR_NOTOPEN, "db not open");
 
     const executor = {
       execute: async (request: DbQueryRequest) => {
@@ -987,7 +987,7 @@ export abstract class IModelDb extends IModel {
    * */
   public withQueryReader<T>(ecsql: string, callback: (reader: ECSqlSyncReader) => T, params?: QueryBinder, config?: SynchronousQueryOptions): T {
     if (!this[_nativeDb].isOpen())
-      throw new IModelError(DbResult.BE_SQLITE_ERROR, "db not open");
+      throw new IModelError(DbResult.BE_SQLITE_ERROR_NOTOPEN, "db not open");
 
     const executor = new ECSqlRowExecutor(this);
     const reader = new ECSqlSyncReader(executor, ecsql, params, config);
@@ -1186,7 +1186,7 @@ export abstract class IModelDb extends IModel {
       if (this._schemasPromise) {
         const old = this._schemasPromise;
         this._schemasPromise = undefined;
-        old.then((view) => view.markOutdated()).catch(() => {});
+        old.then((view) => view.markOutdated()).catch(() => { });
       }
       this[_nativeDb].clearECDbCache();
     }

--- a/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
+++ b/core/backend/src/test/hubaccess/BriefcaseManager.test.ts
@@ -78,7 +78,7 @@ describe("BriefcaseManager", async () => {
       await HubWrappers.closeAndDeleteBriefcaseDb(accessToken, iModel2Dup);
       assert.fail("iModel2Dup failure should fail due to already being closed when iModel2 closed");
     } catch (err: any) {
-      assert.isTrue(err.message.includes("db is not open"), "iModel2Dup failure must be due to db not being open");
+      assert.isTrue(err.message.includes("db not open"), "iModel2Dup failure must be due to db not being open");
     }
     await HubWrappers.closeAndDeleteBriefcaseDb(accessToken, iModel3);
   });

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -3510,7 +3510,7 @@ describe("iModel", () => {
     testImodel.close();
     assert.isFalse(testImodel.isOpen);
 
-    const closedDbError = "Cannot query a closed Db";
+    const closedDbError = "db not open";
     expect(() => testImodel.withPreparedSqliteStatement("SELECT 1", () => { })).to.throw(closedDbError);
     expect(() => testImodel.withPreparedSqliteStatement("SELECT 1", () => { })).to.throw(closedDbError);
     expect(() => testImodel.prepareSqliteStatement("SELECT 1")).to.throw(closedDbError);
@@ -3519,8 +3519,8 @@ describe("iModel", () => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(() => testImodel.withPreparedStatement("SELECT ECInstanceId FROM BisCore:Element LIMIT 1", () => { })).to.throw(closedDbError);
     expect(() => testImodel.elements.queryChildren(IModel.rootSubjectId)).to.throw(closedDbError);
-    expect(() => testImodel.elements.getAspects("0x1", "WrongSchema:WrongClass")).to.throw("db is not open");
-    expect(() => testImodel.createQueryReader("SELECT 1")).to.throw("db not open");
+    expect(() => testImodel.elements.getAspects("0x1", "WrongSchema:WrongClass")).to.throw(closedDbError);
+    expect(() => testImodel.createQueryReader("SELECT 1")).to.throw(closedDbError);
   });
 
   describe("Delete relationship instances", () => {

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:5.12.4'
+    implementation 'com.github.itwin:mobile-native-android:5.12.5'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.12.4;
+				version = 5.12.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.12.4;
+				version = 5.12.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/1495

## Summary

Corrects the error code thrown by `createQueryReader` and `withQueryReader` on both `IModelDb` and `ECDb` when called against a closed database.

## Changes

- **`ECDb.ts` / `IModelDb.ts`**: Changed error code from `DbResult.BE_SQLITE_ERROR` → `DbResult.BE_SQLITE_ERROR_NOTOPEN` in `createQueryReader` and `withQueryReader` when `db not open`.
- **Tests**: Updated `IModel.test.ts` and `BriefcaseManager.test.ts` to assert the now-unified `"db not open"` error message across all closed-db error paths.