### PR TITLE
AccuDraw shortcut to set rotation by 3 points.

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -765,6 +765,14 @@ export class AccuDrawRotateFrontTool extends Tool {
 }
 
 // @beta (undocumented)
+export class AccuDrawRotatePointsTool extends AccuDrawShortcutTool {
+    // @internal (undocumented)
+    protected createImplementation(): AccuDrawShortcutImplementation;
+    // (undocumented)
+    static toolId: string;
+}
+
+// @beta (undocumented)
 export class AccuDrawRotateSideTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -587,7 +587,7 @@ export class AccuDraw {
     protected readonly _yColor: ColorDef;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawChangeModeTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -701,7 +701,7 @@ export class AccuDrawHintBuilder {
     setXAxis2(xAxis: Vector3d): void;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotate90AboutXTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -709,7 +709,7 @@ export class AccuDrawRotate90AboutXTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotate90AboutYTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -717,7 +717,7 @@ export class AccuDrawRotate90AboutYTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotate90AboutZTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -725,7 +725,7 @@ export class AccuDrawRotate90AboutZTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotateAxesTool extends AccuDrawShortcutTool {
     constructor(aboutCurrentZ?: boolean);
     // (undocumented)
@@ -740,7 +740,7 @@ export class AccuDrawRotateAxesTool extends AccuDrawShortcutTool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotateCycleTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -748,7 +748,7 @@ export class AccuDrawRotateCycleTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotateElementTool extends AccuDrawShortcutTool {
     // @internal (undocumented)
     protected createImplementation(): AccuDrawShortcutImplementation;
@@ -756,7 +756,7 @@ export class AccuDrawRotateElementTool extends AccuDrawShortcutTool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotateFrontTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -764,7 +764,7 @@ export class AccuDrawRotateFrontTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotatePointsTool extends AccuDrawShortcutTool {
     // @internal (undocumented)
     protected createImplementation(): AccuDrawShortcutImplementation;
@@ -772,7 +772,7 @@ export class AccuDrawRotatePointsTool extends AccuDrawShortcutTool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotateSideTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -780,7 +780,7 @@ export class AccuDrawRotateSideTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotateTopTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -788,7 +788,7 @@ export class AccuDrawRotateTopTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawRotateViewTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -796,7 +796,7 @@ export class AccuDrawRotateViewTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSessionToggleTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -804,7 +804,7 @@ export class AccuDrawSessionToggleTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetLockAngleTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -812,7 +812,7 @@ export class AccuDrawSetLockAngleTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetLockDistanceTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -820,7 +820,7 @@ export class AccuDrawSetLockDistanceTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetLockIndexTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -828,7 +828,7 @@ export class AccuDrawSetLockIndexTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetLockSmartTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -836,7 +836,7 @@ export class AccuDrawSetLockSmartTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetLockXTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -844,7 +844,7 @@ export class AccuDrawSetLockXTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetLockYTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -852,7 +852,7 @@ export class AccuDrawSetLockYTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetLockZTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -860,7 +860,7 @@ export class AccuDrawSetLockZTool extends Tool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSetOriginTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -943,7 +943,7 @@ export class AccuDrawShortcuts {
     static writeACS(_acsName: string): BentleyStatus;
 }
 
-// @beta (undocumented)
+// @beta
 export class AccuDrawSuspendToggleTool extends Tool {
     // (undocumented)
     run(): Promise<boolean>;
@@ -2589,7 +2589,7 @@ export class DefaultViewTouchTool extends ViewManip implements Animator {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class DefineACSByElementTool extends AccuDrawShortcutTool {
     // @internal (undocumented)
     protected createImplementation(): AccuDrawShortcutImplementation;
@@ -2597,7 +2597,7 @@ export class DefineACSByElementTool extends AccuDrawShortcutTool {
     static toolId: string;
 }
 
-// @beta (undocumented)
+// @beta
 export class DefineACSByPointsTool extends AccuDrawShortcutTool {
     // @internal (undocumented)
     protected createImplementation(): AccuDrawShortcutImplementation;

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -12,6 +12,7 @@ beta;class;AccuDrawRotateAxesTool
 beta;class;AccuDrawRotateCycleTool
 beta;class;AccuDrawRotateElementTool
 beta;class;AccuDrawRotateFrontTool
+beta;class;AccuDrawRotatePointsTool
 beta;class;AccuDrawRotateSideTool
 beta;class;AccuDrawRotateTopTool
 beta;class;AccuDrawRotateViewTool

--- a/common/changes/@itwin/core-frontend/accudraw-rotate-by-points_2026-07-08-16-02.json
+++ b/common/changes/@itwin/core-frontend/accudraw-rotate-by-points_2026-07-08-16-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/public/locales/en/CoreTools.json
+++ b/core/frontend/src/public/locales/en/CoreTools.json
@@ -341,6 +341,16 @@
           "FirstPoint": "Identify element to define rotation"
         }
       },
+      "RotatePoints": {
+        "keyin": "accudraw rotate points",
+        "description": "Set AccuDraw rotation by points",
+        "flyover": "Rotate Points",
+        "Prompts": {
+          "FirstPoint": "Define X axis origin",
+          "SecondPoint": "Define X axis",
+          "NextPoint": "Define Y axis"
+        }
+      },
       "DefineACSByElement": {
         "keyin": "define acs byelement",
         "description": "Set view ACS from element",

--- a/core/frontend/src/tools/AccuDrawShortcutTool.ts
+++ b/core/frontend/src/tools/AccuDrawShortcutTool.ts
@@ -83,8 +83,10 @@ class AccuDrawShortcutInputCollector extends InputCollector {
   }
 
   public override async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
-    if (this._impl.doDataButtonDown(ev))
+    if (this._impl.doDataButtonDown(ev)) {
+      IModelApp.accuDraw.processHints(); // Process pending hints pre-exit so they don't override savedState "ignoreFlags"...
       await this.exitTool();
+    }
     return EventHandled.No;
   }
 
@@ -129,8 +131,10 @@ class AccuDrawShortcutViewTool extends ViewTool {
   }
 
   public override async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
-    if (this._impl.doDataButtonDown(ev))
+    if (this._impl.doDataButtonDown(ev)) {
+      IModelApp.accuDraw.processHints(); // Process pending hints pre-exit so they don't override savedState "ignoreFlags"...
       await this.exitTool();
+    }
     return EventHandled.No;
   }
 

--- a/core/frontend/src/tools/AccuDrawTool.ts
+++ b/core/frontend/src/tools/AccuDrawTool.ts
@@ -1404,7 +1404,7 @@ class RotatePointsImplementation extends AccuDrawShortcutImplementation {
     if (undefined === currentPoint)
       return;
 
-    if (2 === this._points.length) { // && CoordSource.User !== ev.coordsFrom) {
+    if (2 === this._points.length) {
       const xVec = Vector3d.createNormalizedStartEnd(this._points[0], this._points[1]);
       if (undefined === xVec)
         return;

--- a/core/frontend/src/tools/AccuDrawTool.ts
+++ b/core/frontend/src/tools/AccuDrawTool.ts
@@ -7,7 +7,7 @@
  */
 
 import { BentleyStatus } from "@itwin/core-bentley";
-import { Geometry, Matrix3d, Point3d, Transform, Vector3d } from "@itwin/core-geometry";
+import { AxisOrder, Geometry, Matrix3d, Plane3dByOriginAndUnitNormal, Point3d, Transform, Vector3d } from "@itwin/core-geometry";
 import { AccuDraw, AccuDrawFlags, CompassMode, ContextMode, ItemField, KeyinStatus, LockedStates, RotationMode, ThreeAxes } from "../AccuDraw";
 import { TentativeOrAccuSnap } from "../AccuSnap";
 import { ACSDisplayOptions, AuxCoordSystemState } from "../AuxCoordSys";
@@ -17,6 +17,7 @@ import { DecorateContext } from "../ViewContext";
 import { ScreenViewport, Viewport } from "../Viewport";
 import { BeButtonEvent, CoreTools, Tool } from "./Tool";
 import { AccuDrawShortcutImplementation, AccuDrawShortcutTool } from "./AccuDrawShortcutTool";
+import { GraphicType } from "../common/render/GraphicType";
 
 // cSpell:ignore dont unlockedz
 
@@ -98,16 +99,13 @@ export class AccuDrawShortcuts {
 
   public static updateACSByPoints(acs: AuxCoordSystemState, vp: Viewport, points: Point3d[], isDynamics: boolean): boolean {
     const accudraw = IModelApp.accuDraw;
-    if (!accudraw.isEnabled)
-      return false;
-
     let accept = false;
     const vec = [new Vector3d(), new Vector3d(), new Vector3d()];
     acs.setOrigin(points[0]);
     switch (points.length) {
       case 1:
         acs.setRotation(vp.rotation);
-        if (!isDynamics) {
+        if (!isDynamics && accudraw.isEnabled) {
           accudraw.published.origin.setFrom(points[0]);
           accudraw.published.flags = AccuDrawFlags.SetOrigin;
           accudraw.flags.fixedOrg = true;
@@ -121,7 +119,7 @@ export class AccuDrawShortcuts {
         }
 
         if (vp.view.is3d()) {
-          if (normalizedCrossProduct(accudraw.axes.y, vec[0], vec[1]) < 0.00001) {
+          if (accudraw.isEnabled && normalizedCrossProduct(accudraw.axes.y, vec[0], vec[1]) < 0.00001) {
             vec[2].set(0.0, 0.0, 1.0);
 
             if (normalizedCrossProduct(vec[2], vec[0], vec[1]) < 0.00001) {
@@ -133,7 +131,7 @@ export class AccuDrawShortcuts {
           normalizedCrossProduct(vec[0], vec[1], vec[2]);
           acs.setRotation(Matrix3d.createRows(vec[0], vec[1], vec[2]));
 
-          if (!isDynamics) {
+          if (!isDynamics && accudraw.isEnabled) {
             accudraw.published.origin.setFrom(points[0]);
             accudraw.published.flags = AccuDrawFlags.SetOrigin | AccuDrawFlags.SetNormal;
             accudraw.published.vector.setFrom(vec[0]);
@@ -1296,6 +1294,153 @@ export class AccuDrawRotateElementTool extends AccuDrawShortcutTool {
 }
 
 /** @internal */
+class RotatePointsImplementation extends AccuDrawShortcutImplementation {
+  private readonly _points: Point3d[] = [];
+  private _origin = IModelApp.tentativePoint.isActive ? IModelApp.tentativePoint.getPoint().clone() : undefined;
+  private _moveOrigin = !IModelApp.accuDraw.isActive || IModelApp.tentativePoint.isActive; // Preserve current origin if AccuDraw already active and not tentative snap...
+  private _lastPoint?: Point3d;
+
+  protected override onProvideToolAssistance(): void {
+    switch (this._points.length) {
+      case 0:
+        CoreTools.outputPromptByKey("AccuDraw.RotatePoints.Prompts.FirstPoint");
+        break;
+
+      case 1:
+        CoreTools.outputPromptByKey("AccuDraw.RotatePoints.Prompts.SecondPoint");
+        break;
+
+      default:
+        CoreTools.outputPromptByKey("AccuDraw.RotatePoints.Prompts.NextPoint");
+        break;
+    }
+  }
+
+  protected override onInitialize(): void {
+    if (undefined === this._origin)
+      return;
+
+    this._points.push(this._origin);
+    IModelApp.tentativePoint.clear(true); // Necessary when installed as an InputCollector...
+
+    IModelApp.accuDraw.activate();
+    IModelApp.accuDraw.setContext(AccuDrawFlags.SetOrigin | AccuDrawFlags.FixedOrigin, this._origin);
+    IModelApp.accuDraw.refreshDecorationsAndDynamics();
+  }
+
+  protected override onComplete(): AccuDrawFlags {
+    let ignoreFlags = AccuDrawFlags.SetRMatrix | AccuDrawFlags.Disable; // If AccuDraw wasn't active when the shortcut started, let it remain active for suspended tool when shortcut completes...
+    if (this._moveOrigin)
+      ignoreFlags |= AccuDrawFlags.SetOrigin;
+    return ignoreFlags;
+  }
+
+  public doManipulation(ev: BeButtonEvent | undefined, isMotion: boolean): boolean {
+    if (!ev || !ev.viewport)
+      return false;
+
+    IModelApp.viewManager.invalidateDecorationsAllViews();
+    if (isMotion) {
+      this._lastPoint = ev.point.clone();
+      return false;
+    }
+
+    const accuDraw = IModelApp.accuDraw;
+    accuDraw.activate();
+
+    switch (this._points.length) {
+      case 0: {
+        this._points.push(ev.point.clone());
+        accuDraw.setContext(AccuDrawFlags.SetOrigin | AccuDrawFlags.FixedOrigin, this._points[0]);
+        break;
+      }
+
+      case 1: {
+        const xVec = Vector3d.createNormalizedStartEnd(this._points[0], ev.point);
+        if (undefined === xVec)
+          return false;
+
+        if (!ev.viewport.view.is3d() || !ev.viewport.view.allow3dManipulations()) {
+          accuDraw.setContext(AccuDrawFlags.SetOrigin | AccuDrawFlags.SetXAxis, this._points[0], xVec);
+          return true; // Complete
+        }
+
+        this._points.push(ev.point.clone());
+        accuDraw.setContext(AccuDrawFlags.SetOrigin | AccuDrawFlags.FixedOrigin | AccuDrawFlags.SetNormal, this._points[0], xVec);
+        break;
+      }
+
+      case 2: {
+        const xVec = Vector3d.createNormalizedStartEnd(this._points[0], this._points[1]);
+        if (undefined === xVec)
+          return false;
+
+        const yVec = Vector3d.createNormalizedStartEnd(this._points[0], ev.point);
+        if (undefined === yVec)
+          return false;
+
+        const matrix = Matrix3d.createRigidFromColumns(xVec, yVec, AxisOrder.XYZ);
+        if (undefined === matrix)
+          return false;
+
+        const invMatrix = matrix.inverse();
+        if (undefined === invMatrix)
+          return false;
+
+        accuDraw.setContext(AccuDrawFlags.SetOrigin | AccuDrawFlags.SetRMatrix, this._points[0], invMatrix);
+        return true; // Complete
+      }
+    }
+
+    this.onProvideToolAssistance();
+    return false;
+  }
+
+  public override doDecorate(context: DecorateContext): void {
+    if (0 === this._points.length)
+      return;
+
+    const currentPoint = this._lastPoint;
+    if (undefined === currentPoint)
+      return;
+
+    if (2 === this._points.length) { // && CoordSource.User !== ev.coordsFrom) {
+      const xVec = Vector3d.createNormalizedStartEnd(this._points[0], this._points[1]);
+      if (undefined === xVec)
+        return;
+
+      const plane = Plane3dByOriginAndUnitNormal.create(this._points[0], xVec);
+      if (undefined === plane)
+        return;
+
+      plane.projectPointToPlane(currentPoint, currentPoint);
+    }
+
+    const tmpPoints = this._points.slice(0, 1);
+    tmpPoints.push(currentPoint);
+
+    const vp = context.viewport;
+    const color = vp.getContrastToBackgroundColor();
+    const builder = context.createGraphicBuilder(GraphicType.WorldOverlay);
+
+    builder.setSymbology(color, color, 2);
+    builder.addLineString(tmpPoints);
+
+    context.addDecorationFromBuilder(builder);
+  }
+}
+
+/** @beta */
+export class AccuDrawRotatePointsTool extends AccuDrawShortcutTool {
+  public static override toolId = "AccuDraw.RotatePoints";
+
+  /** @internal */
+  protected override createImplementation(): AccuDrawShortcutImplementation {
+    return new RotatePointsImplementation();
+  }
+}
+
+/** @internal */
 class DefineACSByElementImplementation extends AccuDrawShortcutImplementation {
   private _origin = Point3d.create();
   private _rMatrix = Matrix3d.createIdentity();
@@ -1362,6 +1507,7 @@ class DefineACSByPointsImplementation extends AccuDrawShortcutImplementation {
   private readonly _points: Point3d[] = [];
   private _acs?: AuxCoordSystemState;
   private _origin = IModelApp.tentativePoint.isActive ? IModelApp.tentativePoint.getPoint().clone() : undefined;
+  private _lastPoint?: Point3d;
 
   protected override onProvideToolAssistance(): void {
     switch (this._points.length) {
@@ -1383,9 +1529,12 @@ class DefineACSByPointsImplementation extends AccuDrawShortcutImplementation {
     if (undefined === this._origin)
       return;
 
-    IModelApp.accuDraw.setContext(AccuDrawFlags.SetOrigin | AccuDrawFlags.FixedOrigin, this._origin);
     this._points.push(this._origin);
     IModelApp.tentativePoint.clear(true); // Necessary when installed as an InputCollector...
+
+    IModelApp.accuDraw.activate();
+    IModelApp.accuDraw.setContext(AccuDrawFlags.SetOrigin | AccuDrawFlags.FixedOrigin, this._origin);
+    IModelApp.accuDraw.refreshDecorationsAndDynamics();
   }
 
   public doManipulation(ev: BeButtonEvent | undefined, isMotion: boolean): boolean {
@@ -1393,8 +1542,10 @@ class DefineACSByPointsImplementation extends AccuDrawShortcutImplementation {
       return false;
 
     IModelApp.viewManager.invalidateDecorationsAllViews();
-    if (isMotion)
+    if (isMotion) {
+      this._lastPoint = ev.point.clone();
       return false;
+    }
 
     IModelApp.accuDraw.activate();
     this._points.push(ev.point.clone());
@@ -1414,12 +1565,12 @@ class DefineACSByPointsImplementation extends AccuDrawShortcutImplementation {
   }
 
   public override doDecorate(context: DecorateContext): void {
+    if (undefined === this._lastPoint)
+      return;
+
     const tmpPoints: Point3d[] = [];
     this._points.forEach((pt) => tmpPoints.push(pt));
-
-    const ev = new BeButtonEvent();
-    IModelApp.toolAdmin.fillEventFromCursorLocation(ev);
-    tmpPoints.push(ev.point);
+    tmpPoints.push(this._lastPoint);
 
     const vp = context.viewport;
     if (!this._acs)

--- a/core/frontend/src/tools/AccuDrawTool.ts
+++ b/core/frontend/src/tools/AccuDrawTool.ts
@@ -993,7 +993,11 @@ export class AccuDrawShortcuts {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle AccuDraw's availability for the current session.
+ * @note AccuDraw is enabled by default
+ * @beta
+ */
 export class AccuDrawSessionToggleTool extends Tool {
   public static override toolId = "AccuDraw.SessionToggle";
   public override async run() {
@@ -1002,7 +1006,11 @@ export class AccuDrawSessionToggleTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle AccuDraw on/off temporarily for the current interactive tool.
+ * @note Typically used to disable AccuDraw for a single data button.
+ * @beta
+ */
 export class AccuDrawSuspendToggleTool extends Tool {
   public static override toolId = "AccuDraw.SuspendToggle";
   public override async run() {
@@ -1011,7 +1019,11 @@ export class AccuDrawSuspendToggleTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to enable AccuDraw and position it at the current AccuSnap or Tentative snap location.
+ * @note When not snapped, AccuDraw is activated at the last data button location when inactive, or moved to the current cursor location when active.
+ * @beta
+ */
 export class AccuDrawSetOriginTool extends Tool {
   public static override toolId = "AccuDraw.SetOrigin";
   public override async run() {
@@ -1020,7 +1032,11 @@ export class AccuDrawSetOriginTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to lock the closer of the x or y axis based on the current cursor location.
+ * @note When an axis is locked, points are projected onto the axis line.
+ * @beta
+ */
 export class AccuDrawSetLockSmartTool extends Tool {
   public static override toolId = "AccuDraw.LockSmart";
   public override async run() {
@@ -1029,7 +1045,10 @@ export class AccuDrawSetLockSmartTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle the locked state of an indexed axis of the AccuDraw compass.
+ * @beta
+ */
 export class AccuDrawSetLockIndexTool extends Tool {
   public static override toolId = "AccuDraw.LockIndex";
   public override async run() {
@@ -1038,7 +1057,10 @@ export class AccuDrawSetLockIndexTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle the locked state of the X text field.
+ * @beta
+ */
 export class AccuDrawSetLockXTool extends Tool {
   public static override toolId = "AccuDraw.LockX";
   public override async run(): Promise<boolean> {
@@ -1047,7 +1069,10 @@ export class AccuDrawSetLockXTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle the locked state of the Y text field.
+ * @beta
+ */
 export class AccuDrawSetLockYTool extends Tool {
   public static override toolId = "AccuDraw.LockY";
   public override async run(): Promise<boolean> {
@@ -1056,7 +1081,10 @@ export class AccuDrawSetLockYTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle the locked state of the Z text field.
+ * @beta
+ */
 export class AccuDrawSetLockZTool extends Tool {
   public static override toolId = "AccuDraw.LockZ";
   public override async run(): Promise<boolean> {
@@ -1065,7 +1093,10 @@ export class AccuDrawSetLockZTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle the locked state of the Distance text field.
+ * @beta
+ */
 export class AccuDrawSetLockDistanceTool extends Tool {
   public static override toolId = "AccuDraw.LockDistance";
   public override async run(): Promise<boolean> {
@@ -1074,7 +1105,10 @@ export class AccuDrawSetLockDistanceTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle the locked state of the Angle text field.
+ * @beta
+ */
 export class AccuDrawSetLockAngleTool extends Tool {
   public static override toolId = "AccuDraw.LockAngle";
   public override async run(): Promise<boolean> {
@@ -1083,7 +1117,10 @@ export class AccuDrawSetLockAngleTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to toggle between polar and rectangular compass modes.
+ * @beta
+ */
 export class AccuDrawChangeModeTool extends Tool {
   public static override toolId = "AccuDraw.ChangeMode";
   public override async run(): Promise<boolean> {
@@ -1092,7 +1129,10 @@ export class AccuDrawChangeModeTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to cycle between XY, XZ, and YZ planes for the current AccuDraw rotation.
+ * @beta
+ */
 export class AccuDrawRotateCycleTool extends Tool {
   public static override toolId = "AccuDraw.RotateCycle";
   public override async run(): Promise<boolean> {
@@ -1101,7 +1141,11 @@ export class AccuDrawRotateCycleTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to set the AccuDraw rotation to a standard Top view.
+ * @note When IModelApp.toolAdmin.acsContextLock is true, rotation is set relative to the view's ACS.
+ * @beta
+ */
 export class AccuDrawRotateTopTool extends Tool {
   public static override toolId = "AccuDraw.RotateTop";
   public override async run(): Promise<boolean> {
@@ -1110,7 +1154,11 @@ export class AccuDrawRotateTopTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to set the AccuDraw rotation to a standard Front view.
+ * @note When IModelApp.toolAdmin.acsContextLock is true, rotation is set relative to the view's ACS.
+ * @beta
+ */
 export class AccuDrawRotateFrontTool extends Tool {
   public static override toolId = "AccuDraw.RotateFront";
   public override async run(): Promise<boolean> {
@@ -1119,7 +1167,11 @@ export class AccuDrawRotateFrontTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to set the AccuDraw rotation to a standard Side view.
+ * @note When IModelApp.toolAdmin.acsContextLock is true, rotation is set relative to the view's ACS.
+ * @beta
+ */
 export class AccuDrawRotateSideTool extends Tool {
   public static override toolId = "AccuDraw.RotateSide";
   public override async run(): Promise<boolean> {
@@ -1128,7 +1180,10 @@ export class AccuDrawRotateSideTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to set the AccuDraw rotation to match the rotation of the current view.
+ * @beta
+ */
 export class AccuDrawRotateViewTool extends Tool {
   public static override toolId = "AccuDraw.RotateView";
   public override async run(): Promise<boolean> {
@@ -1137,7 +1192,10 @@ export class AccuDrawRotateViewTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to set the AccuDraw rotation to be a 90 degree rotation about the current x axis.
+ * @beta
+ */
 export class AccuDrawRotate90AboutXTool extends Tool {
   public static override toolId = "AccuDraw.Rotate90AboutX";
   public override async run(): Promise<boolean> {
@@ -1146,7 +1204,10 @@ export class AccuDrawRotate90AboutXTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to set the AccuDraw rotation to be a 90 degree rotation about the current y axis.
+ * @beta
+ */
 export class AccuDrawRotate90AboutYTool extends Tool {
   public static override toolId = "AccuDraw.Rotate90AboutY";
   public override async run(): Promise<boolean> {
@@ -1155,7 +1216,10 @@ export class AccuDrawRotate90AboutYTool extends Tool {
   }
 }
 
-/** @beta */
+/**
+ * Immediate tool to set the AccuDraw rotation to be a 90 degree rotation about the current z axis.
+ * @beta
+ */
 export class AccuDrawRotate90AboutZTool extends Tool {
   public static override toolId = "AccuDraw.Rotate90AboutZ";
   public override async run(): Promise<boolean> {
@@ -1207,7 +1271,11 @@ class RotateAxesImplementation extends AccuDrawShortcutImplementation {
   }
 }
 
-/** @beta */
+/**
+ * Interactive tool to set the AccuDraw rotation by rotating about the current z axis to a point on the x axis.
+ * @note When AccuSnap or Tentative snap is active, the snap point is immediately used to define the x axis and not further input is required.
+ * @beta
+ */
 export class AccuDrawRotateAxesTool extends AccuDrawShortcutTool {
   public static override toolId = "AccuDraw.RotateAxes";
   public static override get maxArgs(): number { return 1; }
@@ -1283,7 +1351,10 @@ class RotateElementImplementation extends AccuDrawShortcutImplementation {
   }
 }
 
-/** @beta */
+/**
+ * Interactive tool to set the AccuDraw rotation using the snapped to geometry under the cursor.
+ * @beta
+ */
 export class AccuDrawRotateElementTool extends AccuDrawShortcutTool {
   public static override toolId = "AccuDraw.RotateElement";
 
@@ -1430,7 +1501,10 @@ class RotatePointsImplementation extends AccuDrawShortcutImplementation {
   }
 }
 
-/** @beta */
+/**
+ * Interactive tool to set the AccuDraw rotation by 3 points: x axis origin, x axis direction, and y axis direction.
+ * @beta
+ */
 export class AccuDrawRotatePointsTool extends AccuDrawShortcutTool {
   public static override toolId = "AccuDraw.RotatePoints";
 
@@ -1492,7 +1566,10 @@ class DefineACSByElementImplementation extends AccuDrawShortcutImplementation {
   }
 }
 
-/** @beta */
+/**
+ * Interactive tool to set the view's ACS rotation by 3 points: x axis origin, x axis direction, and y axis direction/
+ * @beta
+ */
 export class DefineACSByElementTool extends AccuDrawShortcutTool {
   public static override toolId = "AccuDraw.DefineACSByElement";
 
@@ -1581,7 +1658,10 @@ class DefineACSByPointsImplementation extends AccuDrawShortcutImplementation {
   }
 }
 
-/** @beta */
+/**
+ * Interactive tool to set the view's ACS rotation by 3 points: x axis origin, x axis direction, and y axis direction.
+ * @beta
+ */
 export class DefineACSByPointsTool extends AccuDrawShortcutTool {
   public static override toolId = "AccuDraw.DefineACSByPoints";
 

--- a/core/frontend/src/tools/ClipViewTool.ts
+++ b/core/frontend/src/tools/ClipViewTool.ts
@@ -564,8 +564,8 @@ export class ViewClipByPlaneTool extends ViewClipTool {
 export class ViewClipByShapeTool extends ViewClipTool {
   public static override toolId = "ViewClip.ByShape";
   public static override iconSpec = "icon-section-shape";
-  /** @internal */
   private _orientationValue: DialogItemValue = { value: ContextRotationId.Top };
+  private _lastMotion?: BeButtonEvent;
   /** @internal */
   protected readonly _points: Point3d[] = [];
   /** @internal */
@@ -718,9 +718,8 @@ export class ViewClipByShapeTool extends ViewClipTool {
     if (context.viewport !== this.targetView)
       return;
 
-    const ev = new BeButtonEvent();
-    IModelApp.toolAdmin.fillEventFromCursorLocation(ev);
-    if (undefined === ev.viewport)
+    const ev = this._lastMotion;
+    if (undefined === ev?.viewport)
       return;
     const points = this.getClipPoints(ev);
     if (points.length < 2)
@@ -747,6 +746,7 @@ export class ViewClipByShapeTool extends ViewClipTool {
 
   /** @internal */
   public override async onMouseMotion(ev: BeButtonEvent): Promise<void> {
+    this._lastMotion = ev;
     if (this._points.length > 0 && undefined !== ev.viewport)
       ev.viewport.invalidateDecorations();
   }
@@ -805,6 +805,7 @@ export class ViewClipByShapeTool extends ViewClipTool {
 export class ViewClipByRangeTool extends ViewClipTool {
   public static override toolId = "ViewClip.ByRange";
   public static override iconSpec = "icon-section-range";
+  private _lastMotion?: BeButtonEvent;
   /** @internal */
   protected _corner?: Point3d;
 
@@ -855,9 +856,8 @@ export class ViewClipByRangeTool extends ViewClipTool {
     if (context.viewport !== this.targetView || undefined === this._corner)
       return;
 
-    const ev = new BeButtonEvent();
-    IModelApp.toolAdmin.fillEventFromCursorLocation(ev);
-    if (undefined === ev.viewport)
+    const ev = this._lastMotion;
+    if (undefined === ev?.viewport)
       return;
     const range = Range3d.create();
     const transform = Transform.createIdentity();
@@ -881,6 +881,7 @@ export class ViewClipByRangeTool extends ViewClipTool {
 
   /** @internal */
   public override async onMouseMotion(ev: BeButtonEvent): Promise<void> {
+    this._lastMotion = ev;
     if (undefined !== this._corner && undefined !== ev.viewport)
       ev.viewport.invalidateDecorations();
   }

--- a/test-apps/display-test-app/src/frontend/DrawingAidTestTool.ts
+++ b/test-apps/display-test-app/src/frontend/DrawingAidTestTool.ts
@@ -5,7 +5,7 @@
 
 import { Angle, IModelJson as GeomJson, LineString3d, Point3d, Vector3d } from "@itwin/core-geometry";
 import { ColorDef, GeometryStreamProps } from "@itwin/core-common";
-import { AccuDrawChangeModeTool, AccuDrawHintBuilder, AccuDrawRotateAxesTool, AccuDrawRotateCycleTool, AccuDrawRotateElementTool, AccuDrawRotateFrontTool, AccuDrawRotateSideTool, AccuDrawRotateTopTool, AccuDrawRotateViewTool, AccuDrawSetLockAngleTool, AccuDrawSetLockDistanceTool, AccuDrawSetLockIndexTool, AccuDrawSetLockSmartTool, AccuDrawSetLockXTool, AccuDrawSetLockYTool, AccuDrawSetLockZTool, AccuDrawSetOriginTool, AccuDrawShortcuts, AccuDrawSuspendToggleTool, AccuDrawViewportUI, BeButtonEvent, DecorateContext, DefineACSByElementTool, DefineACSByPointsTool, DynamicsContext, EventHandled, GraphicType, HitDetail, IModelApp, PrimitiveTool, ScreenViewport, SnapMode, SnapStatus, ToolType } from "@itwin/core-frontend";
+import { AccuDrawChangeModeTool, AccuDrawHintBuilder, AccuDrawRotate90AboutXTool, AccuDrawRotate90AboutYTool, AccuDrawRotate90AboutZTool, AccuDrawRotateAxesTool, AccuDrawRotateCycleTool, AccuDrawRotateElementTool, AccuDrawRotateFrontTool, AccuDrawRotatePointsTool, AccuDrawRotateSideTool, AccuDrawRotateTopTool, AccuDrawRotateViewTool, AccuDrawSetLockAngleTool, AccuDrawSetLockDistanceTool, AccuDrawSetLockIndexTool, AccuDrawSetLockSmartTool, AccuDrawSetLockXTool, AccuDrawSetLockYTool, AccuDrawSetLockZTool, AccuDrawSetOriginTool, AccuDrawShortcuts, AccuDrawSuspendToggleTool, AccuDrawViewportUI, BeButtonEvent, DecorateContext, DefineACSByElementTool, DefineACSByPointsTool, DynamicsContext, EventHandled, GraphicType, HitDetail, IModelApp, PrimitiveTool, ScreenViewport, SnapMode, SnapStatus, ToolType } from "@itwin/core-frontend";
 import { PlaceLineStringTool } from "./EditingTools";
 import { DisplayTestApp } from "./App";
 
@@ -265,7 +265,11 @@ export class DisplayTestAppShortcutsUI {
       this.addShortcutForTool("V", AccuDrawRotateViewTool, shortcutsForR);
       this.addShortcutForTool("C", AccuDrawRotateCycleTool, shortcutsForR);
       this.addShortcutForTool("Q", AccuDrawRotateAxesTool, shortcutsForR);
+      this.addShortcutForTool("P", AccuDrawRotatePointsTool, shortcutsForR);
       this.addShortcutForTool("E", AccuDrawRotateElementTool, shortcutsForR);
+      this.addShortcutForTool("X", AccuDrawRotate90AboutXTool, shortcutsForR);
+      this.addShortcutForTool("Y", AccuDrawRotate90AboutYTool, shortcutsForR);
+      this.addShortcutForTool("Z", AccuDrawRotate90AboutZTool, shortcutsForR);
     }
 
     const shortcutsForQ = this.addShortcutSubMenu("Q", this._shortcuts);


### PR DESCRIPTION
There was no longer a way to set AccuDraw's rotation by 3 points. This used to be handled by the "Rotate ACS" shortcut including a tool setting toggle that only updated the view's ACS when enabled. That shortcut became the DefineACSByPointsTool, which did not keep the somewhat confusing toggle.

While doing this I noticed an issue with a few tools that were calling fillEventFromCursorLocation. For tools that require a fully adjusted point, save the button event from the motion function.

Added Rotate Points and Rotate 90 shortcuts to dta for testing.