### PR TITLE
Modify bug report template to be less confusing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,8 +9,8 @@ body:
   - type: input
     id: title-hint
     attributes:
-      label: Clear title
-      description: "State the problem concisely (e.g., \"Crash in v2.0 when passing null to `user.update()`\"). Your issue title above should reflect this."
+      label: Brief Summary
+      description: "State the problem concisely (e.g., \"Crash in v2.0 when passing null to `user.update()`\"). Your issue title above should reflect this (or even be identical)."
       placeholder: "Brief summary of the bug"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,7 +9,7 @@ body:
   - type: input
     id: title-hint
     attributes:
-      label: Brief Summary
+      label: Brief summary
       description: "State the problem concisely (e.g., \"Crash in v2.0 when passing null to `user.update()`\"). Your issue title above should reflect this (or even be identical)."
       placeholder: "Brief summary of the bug"
     validations:


### PR DESCRIPTION
The old template had "Clear title" as the first section in the bug report body, which was confusing since the issue title had already been asked for.