### PR TITLE
Add root-level documentation for using display-test-app for testing and reproductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ The following instructions will quickly set the repo up for you to edit the sour
 
 ​For more information, please refer to our [Contributing Guide](./CONTRIBUTING.md), which provides detailed instructions on source code editing workflows, debugging tests, contribution standards, FAQs, and guidelines for posting questions.​
 
+## Interactive Testing and Feature Development
+
+This repository includes [display-test-app](./test-apps/display-test-app/README.md) (DTA), a desktop-style test application built as part of the monorepo. It is the easiest way to exercise iTwin.js APIs directly against the source code in this repository — for example, to reproduce a bug, demonstrate a feature gap, or test a local change. Because it runs against the code in your working tree (not a published release), it is often a better vehicle for reproductions than online sandboxes, and as an Electron app it can also exercise desktop-only workflows such as editing.
+
+### Build and run
+
+After completing the [Developer Quick Start](#developer-quick-start) above (which builds display-test-app along with everything else):
+
+```sh
+cd test-apps/display-test-app
+npm run start            # run as an Electron app
+# or
+npm run start:servers    # run in a browser at http://localhost:3000
+```
+
+display-test-app opens iModel snapshot and briefcase files from the local file system — use the toolbar's open-file button, or set the `IMJS_STANDALONE_FILENAME` environment variable to the absolute path of an iModel to open it automatically at startup (e.g., in `test-apps/display-test-app/.env.local`). If you don't have an iModel handy, a small sample is included in the repository at [test-apps/display-test-app/test-models/JoesHouse.bim](./test-apps/display-test-app/test-models/JoesHouse.bim). See the [display-test-app README](./test-apps/display-test-app/README.md) for the full list of environment variables, UI documentation, and debugging instructions.
+
+### Calling iTwin.js APIs from display-test-app
+
+Much of display-test-app's functionality is driven by **key-ins** — commands typed into its key-in field (press the backtick key to focus it). Adding a new key-in that calls whatever iTwin.js API you want to test is a convenient, self-contained way to build a reproduction that others can run. See [Adding a key-in](./test-apps/display-test-app/README.md#adding-a-key-in) for a step-by-step guide with a skeletal example.
+
 ## Licensing
 
 Copyright © Bentley Systems, Incorporated. All rights reserved. See [LICENSE.md](./LICENSE.md) for license terms and full copyright notice.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following instructions will quickly set the repo up for you to edit the sour
 
 ## Interactive Testing and Feature Development
 
-This repository includes [display-test-app](./test-apps/display-test-app/README.md) (DTA), a desktop-style test application built as part of the monorepo. It is the easiest way to exercise iTwin.js APIs directly against the source code in this repository — for example, to reproduce a bug, demonstrate a feature gap, or test a local change. Because it runs against the code in your working tree (not a published release), it is often a better vehicle for reproductions than online sandboxes, and as an Electron app it can also exercise desktop-only workflows such as editing.
+This repository includes [display-test-app](./test-apps/display-test-app/README.md) (DTA), a desktop-style test application built as part of the monorepo. It is the easiest way to exercise iTwin.js APIs directly against the source code in this repository. It can be used, for example, to reproduce a bug, demonstrate a feature gap, or test a local change. Because it runs against the code in your working tree (not a published release), this can often be a better vehicle for reproductions than online sandboxes, and as an Electron app it can also exercise desktop-only workflows such as editing.
 
 ### Build and run
 
@@ -79,7 +79,7 @@ npm run start            # run as an Electron app
 npm run start:servers    # run in a browser at http://localhost:3000
 ```
 
-display-test-app opens iModel snapshot and briefcase files from the local file system — use the toolbar's open-file button, or set the `IMJS_STANDALONE_FILENAME` environment variable to the absolute path of an iModel to open it automatically at startup (e.g., in `test-apps/display-test-app/.env.local`). If you don't have an iModel handy, a small sample is included in the repository at [test-apps/display-test-app/test-models/JoesHouse.bim](./test-apps/display-test-app/test-models/JoesHouse.bim). See the [display-test-app README](./test-apps/display-test-app/README.md) for the full list of environment variables, UI documentation, and debugging instructions.
+display-test-app opens iModel snapshot and briefcase files from the local file system; use the toolbar's open-file button, or set the `IMJS_STANDALONE_FILENAME` environment variable to the absolute path of an iModel to open it automatically at startup (e.g., in `test-apps/display-test-app/.env` or your local environment). If you don't have an iModel handy, a small sample is included in the repository at [test-apps/display-test-app/test-models/JoesHouse.bim](./test-apps/display-test-app/test-models/JoesHouse.bim). See the [display-test-app README](./test-apps/display-test-app/README.md) for the full list of environment variables, UI documentation, and debugging instructions.
 
 ### Calling iTwin.js APIs from display-test-app
 

--- a/README.md
+++ b/README.md
@@ -66,24 +66,9 @@ The following instructions will quickly set the repo up for you to edit the sour
 
 ## Interactive Testing and Feature Development
 
-This repository includes [display-test-app](./test-apps/display-test-app/README.md) (DTA), a desktop-style test application built as part of the monorepo. It is the easiest way to exercise iTwin.js APIs directly against the source code in this repository. It can be used, for example, to reproduce a bug, demonstrate a feature gap, or test a local change. Because it runs against the code in your working tree (not a published release), this can often be a better vehicle for reproductions than online sandboxes, and as an Electron app it can also exercise desktop-only workflows such as editing.
+This repository includes [display-test-app](./test-apps/display-test-app/README.md) (DTA), a desktop-style test application built as part of the monorepo. It is the easiest way to exercise iTwin.js APIs directly against the source code in this repository. For example, it can be used to reproduce a bug, demonstrate a feature gap, or test a local change. Because it runs against the code in your working tree (not a published release), it is often a better vehicle for reproductions than online sandboxes, and as an Electron app it can also exercise desktop-only workflows such as editing.
 
-### Build and run
-
-After completing the [Developer Quick Start](#developer-quick-start) above (which builds display-test-app along with everything else):
-
-```sh
-cd test-apps/display-test-app
-npm run start            # run as an Electron app
-# or
-npm run start:servers    # run in a browser at http://localhost:3000
-```
-
-display-test-app opens iModel snapshot and briefcase files from the local file system; use the toolbar's open-file button, or set the `IMJS_STANDALONE_FILENAME` environment variable to the absolute path of an iModel to open it automatically at startup (e.g., in `test-apps/display-test-app/.env` or your local environment). If you don't have an iModel handy, a small sample is included in the repository at [test-apps/display-test-app/test-models/JoesHouse.bim](./test-apps/display-test-app/test-models/JoesHouse.bim). See the [display-test-app README](./test-apps/display-test-app/README.md) for the full list of environment variables, UI documentation, and debugging instructions.
-
-### Calling iTwin.js APIs from display-test-app
-
-Much of display-test-app's functionality is driven by **key-ins** — commands typed into its key-in field (press the backtick key to focus it). Adding a new key-in that calls whatever iTwin.js API you want to test is a convenient, self-contained way to build a reproduction that others can run. See [Adding a key-in](./test-apps/display-test-app/README.md#adding-a-key-in) for a step-by-step guide with a skeletal example.
+After completing the [Developer Quick Start](#developer-quick-start) above (which builds display-test-app along with everything else), see the display-test-app README's [Getting Started](./test-apps/display-test-app/README.md#getting-started) and [Using display-test-app](./test-apps/display-test-app/README.md#using-display-test-app) sections for how to run it and open an iModel. Adding a **key-in** is a convenient, self-contained way to invoke whatever iTwin.js API you want to test; see [Adding a key-in](./test-apps/display-test-app/README.md#adding-a-key-in) for a step-by-step guide with a skeletal example. If you use an AI coding agent, the repository also provides a [DTA repro agent](./.github/agents/dta-repro.agent.md) that specializes in scaffolding minimal reproductions in display-test-app.
 
 ## Licensing
 

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -238,7 +238,7 @@ You can use these environment variables to alter the default behavior of various
 
 ## Adding a key-in
 
-A key-in is a convenient way to invoke iTwin.js APIs from display-test-app - for example, to reproduce a bug or demonstrate a feature gap using code that others can easily run. A key-in is implemented as a subclass of [Tool](https://www.itwinjs.org/reference/core-frontend/tools/tool/) from `@itwin/core-frontend`, registered at startup, and invoked by typing its key-in string into the key-in field (press the backtick key to focus it).
+A key-in is a convenient way to invoke iTwin.js APIs from display-test-app. A key-in can be used, for example, to reproduce a bug or demonstrate a feature gap using code that others can easily run. A key-in is implemented as a subclass of [Tool](https://www.itwinjs.org/reference/core-frontend/tools/tool/) from `@itwin/core-frontend`, registered at startup, and invoked by typing its key-in string into the key-in field (press the backtick key to focus it).
 
 To add one:
 

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -22,7 +22,8 @@ The application contained within this directory provides a test environment for 
 The application may be run as an Electron app, Mobile app or within a browser. The following steps outline the procedure for successfully building the application as part of a larger monorepo, and then starting the application via npm scripts.
 
 * To get started, follow the instructions to setup the entire repository, located [here](../../README.md#developer-quick-start). This automatically builds all test apps.
-  * Tip: after `rush install`, you can build only display-test-app and the packages it depends on - skipping the rest of the monorepo - with `rush build -t display-test-app`.
+> [!TIP]
+> After `rush install`, you can build only display-test-app and the packages it depends on - skipping the rest of the monorepo - with `rush build -t display-test-app`.
 
 * Before starting display-test-app, there are optional environment variables that may be set to be recognized by the application upon startup. For a full list, [see below](#environment-variables).
 

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -22,6 +22,7 @@ The application contained within this directory provides a test environment for 
 The application may be run as an Electron app, Mobile app or within a browser. The following steps outline the procedure for successfully building the application as part of a larger monorepo, and then starting the application via npm scripts.
 
 * To get started, follow the instructions to setup the entire repository, located [here](../../README.md#developer-quick-start). This automatically builds all test apps.
+  * Tip: after `rush install`, you can build only display-test-app and the packages it depends on - skipping the rest of the monorepo - with `rush build -t display-test-app`.
 
 * Before starting display-test-app, there are optional environment variables that may be set to be recognized by the application upon startup. For a full list, [see below](#environment-variables).
 
@@ -39,8 +40,9 @@ npm run start:servers
 
 ## Using display-test-app
 
-display-test-app provides no UI for selecting iModels from iModelHub - only a toolbar button to open an iModel from the local file system. However, if the iModel is a briefcase that was downloaded from iModelHub and is opened in read-write mode, it can push and pull changesets.
-The `IMJS_STANDALONE_FILENAME` environment variable can be defined before startup to contain the absolute path to an iModel on disk; if so, it will be opened automatically at startup. If you don't have an iModel handy, a small sample is included in the repository at [test-models/JoesHouse.bim](./test-models/JoesHouse.bim).
+display-test-app's toolbar provides a button to open an iModel from the local file system and a drop-down to download and open an iModel from iModelHub (requires signing in). If the iModel is a briefcase that was downloaded from iModelHub and is opened in read-write mode, it can push and pull changesets.
+
+The `IMJS_STANDALONE_FILENAME` environment variable can be defined before startup to contain the absolute path to an iModel on disk; if so, it will be opened automatically at startup. If you don't have an iModel handy, a small sample is included in the repository at [test-models/JoesHouse.bim](./test-models/JoesHouse.bim). When working only with local files in the Electron app, also define `IMJS_NO_ELECTRON_AUTH` to avoid repeated authorization exceptions caused by a known bug (see [Environment Variables](#environment-variables)).
 
 display-test-app's UI consists of:
 
@@ -90,7 +92,7 @@ A more advanced debug experience will give you more quick turn around time for b
 1. Initialize the backend build using `npm run build:backend -- --watch` in one terminal
     * The `--watch` command allows the Typescript compiler watch all of the source files and any time they change will automatically re-run the compilation
     * One caveat is you will have to restart the debugger (#3) each time you make a change. Note this is different from the frontend experience that live reloads the browser with the updated code, the backend doesn't support that currently.
-1. Run `npm run start:webserver` in a separate terminal (`nmp run start:mobile` for Android and iOS)
+1. Run `npm run start:webserver` in a separate terminal (`npm run start:mobile` for Android and iOS)
     * Note: if the webserver and backend are run in the same terminal it will be hard to parse the output and attribute it to each one. This is why we recommend two different terminals instead of a single script to handle both.
 1. Launch the VSCode "display-test-app (electron)" or "display-test-app (chrome)" depending on which app type
 
@@ -412,6 +414,6 @@ display-test-app has access to all key-ins defined in the `@itwin/editor-fronten
 
 The steps to run the display test app in an iOS app:
 
-1. Run `npm run build:ios`
+1. Run `npm run build:mobile`
 2. Open `test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj`
 3. Start the XCode Project to an iPad

--- a/test-apps/display-test-app/README.md
+++ b/test-apps/display-test-app/README.md
@@ -40,7 +40,7 @@ npm run start:servers
 ## Using display-test-app
 
 display-test-app provides no UI for selecting iModels from iModelHub - only a toolbar button to open an iModel from the local file system. However, if the iModel is a briefcase that was downloaded from iModelHub and is opened in read-write mode, it can push and pull changesets.
-The `IMJS_STANDALONE_FILENAME` environment variable can be defined before startup to contain the absolute path to an iModel on disk; if so, it will be opened automatically at startup.
+The `IMJS_STANDALONE_FILENAME` environment variable can be defined before startup to contain the absolute path to an iModel on disk; if so, it will be opened automatically at startup. If you don't have an iModel handy, a small sample is included in the repository at [test-models/JoesHouse.bim](./test-models/JoesHouse.bim).
 
 display-test-app's UI consists of:
 
@@ -235,6 +235,61 @@ You can use these environment variables to alter the default behavior of various
   * If defined, decoding of iMdl content is performed in the main thread instead of in a web worker. This makes debugging easier.
 * IMJS_GOOGLEMAPS_UI
   * Enable the Google Maps toolbar button
+
+## Adding a key-in
+
+A key-in is a convenient way to invoke iTwin.js APIs from display-test-app - for example, to reproduce a bug or demonstrate a feature gap using code that others can easily run. A key-in is implemented as a subclass of [Tool](https://www.itwinjs.org/reference/core-frontend/tools/tool/) from `@itwin/core-frontend`, registered at startup, and invoked by typing its key-in string into the key-in field (press the backtick key to focus it).
+
+To add one:
+
+1. Create a new file in [test-apps/display-test-app/src/frontend](./src/frontend) (alongside the existing tool files such as `FrameStatsTool.ts` - the directory is intentionally flat; note this is display-test-app's own frontend directory, not the `core/frontend` package) defining your tool. A skeletal example:
+
+    ```ts
+    import { IModelApp, NotifyMessageDetails, OutputMessagePriority, Tool } from "@itwin/core-frontend";
+
+    /** Executes via the key-in `dta my example` with 0 or 1 argument(s). */
+    export class MyExampleTool extends Tool {
+      public static override toolId = "MyExample"; // must match the key in SVTTools.json
+      public static override get minArgs() { return 0; }
+      public static override get maxArgs() { return 1; }
+
+      public override async run(arg?: string): Promise<boolean> {
+        // Call whatever iTwin.js APIs you want to test here.
+        // e.g., inspect the selected viewport:
+        const vp = IModelApp.viewManager.selectedView;
+        if (vp)
+          IModelApp.notifications.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Info, `view is ${vp.view.id}, arg is ${arg}`));
+
+        return true;
+      }
+
+      /** Parses raw arguments typed after the key-in, then invokes run. */
+      public override async parseAndRun(...args: string[]): Promise<boolean> {
+        return this.run(args[0]);
+      }
+    }
+    ```
+
+    See [FrameStatsTool.ts](./src/frontend/FrameStatsTool.ts) for a complete real-world example, or browse the other tools in [src/frontend](./src/frontend) for more advanced patterns (interactive tools, decorators, etc.).
+
+2. Define the key-in string in [public/locales/en/SVTTools.json](./public/locales/en/SVTTools.json), under `tools`, keyed by your `toolId`:
+
+    ```json
+    "MyExample": {
+      "keyin": "dta my example"
+    }
+    ```
+
+3. Register the tool at startup by adding it to the list of tools registered in the `svtToolNamespace` in [src/frontend/App.ts](./src/frontend/App.ts):
+
+    ```ts
+    [
+      // ...existing tools...
+      MyExampleTool,
+    ].forEach((tool) => tool.register(svtToolNamespace));
+    ```
+
+4. Rebuild and run (`npm run build` then `npm run start` from this directory - see [Getting Started](#getting-started)), press backtick, and type `dta my example`.
 
 ## Key-ins
 


### PR DESCRIPTION
Fixes #9484

### Overview

Users of iTwin.js can face difficulty in providing clear, reproducible steps when reporting bugs or feature gaps. Deployed versions of iTwin.js can lag behind the current itwinjs-core version (including code sandboxes), and editing workflows are best reproduced in a desktop-style app. This PR documents display-test-app (DTA) as the recommended vehicle for interactive testing, reproductions, and feature development against the source in this repository. This PR also takes the main initial developer start-up documentation beyond `rush cover`, describing how to run `display-test-app` at a basic level.

### Changes

**`README.md`** — new "Interactive Testing and Feature Development" section
**`test-apps/display-test-app/README.md`** — new "Adding a key-in" section

### Validation

- Cloned + built this branch fresh and followed all steps; all successfully worked
- Verified the skeletal example can compile and run