### PR TITLE
Add workflow to update imodel-native packages on release

### DIFF
--- a/.github/workflows/update-imodel-native-packages.yml
+++ b/.github/workflows/update-imodel-native-packages.yml
@@ -1,0 +1,108 @@
+# This workflow triggers when a new release is published in itwinjs-core.
+# For minor/major releases (tag ending in .0), it creates a PR in iTwin/imodel-native
+# to bump the iTwin.js devDependency versions to the next dev version.
+#
+# Release tags in this repo use the format: release/X.Y.Z (e.g., release/5.11.0)
+#
+# Example: If release/5.11.0 is published:
+#   - Next dev version = 5.12.0-dev
+#   - Update imodel-native's package.json devDependencies to ^5.12.0-dev
+#   - Regenerate package-lock.json
+#   - Open a PR in iTwin/imodel-native targeting main
+
+name: Update imodel-native packages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-imodel-native:
+    runs-on: ubuntu-latest
+
+    # Only run for minor/major releases (version ends with .0)
+    if: endsWith(github.event.release.tag_name, '.0')
+
+    steps:
+      - name: Extract version info
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+
+          # Tag format is "release/X.Y.Z" — strip the "release/" prefix
+          VERSION="${TAG#release/}"
+
+          # Parse major.minor
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+
+          # Compute next dev version: increment minor by 1
+          NEXT_MINOR=$((MINOR + 1))
+          NEXT_DEV_VERSION="${MAJOR}.${NEXT_MINOR}.0-dev"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_dev_version=$NEXT_DEV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Released version: $VERSION"
+          echo "Next dev version: $NEXT_DEV_VERSION"
+
+      - name: Checkout imodel-native
+        uses: actions/checkout@v4
+        with:
+          repository: iTwin/imodel-native
+          token: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Update package.json devDependencies
+        run: |
+          PACKAGE_JSON="iModelJsNodeAddon/api_package/ts/package.json"
+          NEXT_DEV="^${{ steps.version.outputs.next_dev_version }}"
+
+          echo "Updating devDependencies in $PACKAGE_JSON to $NEXT_DEV"
+
+          # Update the 4 iTwin.js devDependencies using jq
+          jq --arg ver "$NEXT_DEV" '
+            .devDependencies["@itwin/build-tools"] = $ver |
+            .devDependencies["@itwin/core-bentley"] = $ver |
+            .devDependencies["@itwin/core-common"] = $ver |
+            .devDependencies["@itwin/core-geometry"] = $ver
+          ' "$PACKAGE_JSON" > tmp.json && mv tmp.json "$PACKAGE_JSON"
+
+      - name: Regenerate package-lock.json
+        working-directory: iModelJsNodeAddon/api_package/ts
+        run: npm install
+
+      - name: Commit changes and push branch
+        run: |
+          BRANCH="itwinjs-update/${{ steps.version.outputs.next_dev_version }}"
+
+          git config user.name "imodeljs-admin"
+          git config user.email "imodeljs-admin@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add iModelJsNodeAddon/api_package/ts/package.json iModelJsNodeAddon/api_package/ts/package-lock.json
+          git commit -m "Update iTwin.js packages to ^${{ steps.version.outputs.next_dev_version }}"
+          git push origin "$BRANCH"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
+        run: |
+          gh pr create \
+            --repo iTwin/imodel-native \
+            --base main \
+            --head "itwinjs-update/${{ steps.version.outputs.next_dev_version }}" \
+            --title "Update iTwin.js packages to ^${{ steps.version.outputs.next_dev_version }}" \
+            --body "Automated PR triggered by the release of [itwinjs-core ${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}).
+
+          Updates the following devDependencies in \`iModelJsNodeAddon/api_package/ts/package.json\`:
+          - \`@itwin/build-tools\` → \`^${{ steps.version.outputs.next_dev_version }}\`
+          - \`@itwin/core-bentley\` → \`^${{ steps.version.outputs.next_dev_version }}\`
+          - \`@itwin/core-common\` → \`^${{ steps.version.outputs.next_dev_version }}\`
+          - \`@itwin/core-geometry\` → \`^${{ steps.version.outputs.next_dev_version }}\`
+
+          Also regenerated \`package-lock.json\` via \`npm install\`." \
+            --label "dependencies"

--- a/.github/workflows/update-imodel-native-packages.yml
+++ b/.github/workflows/update-imodel-native-packages.yml
@@ -1,6 +1,6 @@
 # This workflow triggers when a new release is published in itwinjs-core.
-# For minor/major releases (tag ending in .0), it creates a PR in iTwin/imodel-native
-# to bump the iTwin.js devDependency versions to the next dev version.
+# For minor/major releases (tag matching release/X.Y.0), it creates a PR in
+# iTwin/imodel-native to bump the iTwin.js devDependency versions to the next dev version.
 #
 # Release tags in this repo use the format: release/X.Y.Z (e.g., release/5.11.0)
 #
@@ -15,20 +15,36 @@ name: Update imodel-native packages
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to process (e.g. release/5.11.0)"
+        required: true
 
 jobs:
   update-imodel-native:
     runs-on: ubuntu-latest
 
-    # Only run for minor/major releases (version ends with .0)
-    if: endsWith(github.event.release.tag_name, '.0')
+    permissions:
+      contents: read
+
+    concurrency:
+      group: update-imodel-native-${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+      cancel-in-progress: false
+
+    # Only run for minor/major releases (tag matches release/X.Y.0 pattern)
+    if: >-
+      startsWith(github.event.inputs.tag_name || github.event.release.tag_name, 'release/')
+      && endsWith(github.event.inputs.tag_name || github.event.release.tag_name, '.0')
+      && (github.event.release.prerelease == false || github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Extract version info
         id: version
+        env:
+          TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url || '' }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-
           # Tag format is "release/X.Y.Z" — strip the "release/" prefix
           VERSION="${TAG#release/}"
 
@@ -42,6 +58,7 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "next_dev_version=$NEXT_DEV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
           echo "Released version: $VERSION"
           echo "Next dev version: $NEXT_DEV_VERSION"
 
@@ -55,12 +72,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "20"
 
       - name: Update package.json devDependencies
+        env:
+          NEXT_DEV_VERSION: ${{ steps.version.outputs.next_dev_version }}
         run: |
           PACKAGE_JSON="iModelJsNodeAddon/api_package/ts/package.json"
-          NEXT_DEV="^${{ steps.version.outputs.next_dev_version }}"
+          NEXT_DEV="^${NEXT_DEV_VERSION}"
 
           echo "Updating devDependencies in $PACKAGE_JSON to $NEXT_DEV"
 
@@ -74,35 +93,47 @@ jobs:
 
       - name: Regenerate package-lock.json
         working-directory: iModelJsNodeAddon/api_package/ts
-        run: npm install
+        run: npm install --ignore-scripts
 
       - name: Commit changes and push branch
+        env:
+          NEXT_DEV_VERSION: ${{ steps.version.outputs.next_dev_version }}
         run: |
-          BRANCH="itwinjs-update/${{ steps.version.outputs.next_dev_version }}"
+          BRANCH="itwinjs-update/${NEXT_DEV_VERSION}"
 
           git config user.name "imodeljs-admin"
           git config user.email "imodeljs-admin@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add iModelJsNodeAddon/api_package/ts/package.json iModelJsNodeAddon/api_package/ts/package-lock.json
-          git commit -m "Update iTwin.js packages to ^${{ steps.version.outputs.next_dev_version }}"
-          git push origin "$BRANCH"
+          git commit -m "Update iTwin.js packages to ^${NEXT_DEV_VERSION}"
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
+          NEXT_DEV_VERSION: ${{ steps.version.outputs.next_dev_version }}
+          RELEASE_URL: ${{ steps.version.outputs.release_url }}
+          TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
         run: |
+          BRANCH="itwinjs-update/${NEXT_DEV_VERSION}"
+
+          # Skip PR creation if one already exists for this branch
+          if gh pr view --repo iTwin/imodel-native --head "$BRANCH" &>/dev/null; then
+            echo "PR already exists for branch $BRANCH — skipping creation."
+            exit 0
+          fi
+
           gh pr create \
             --repo iTwin/imodel-native \
             --base main \
-            --head "itwinjs-update/${{ steps.version.outputs.next_dev_version }}" \
-            --title "Update iTwin.js packages to ^${{ steps.version.outputs.next_dev_version }}" \
-            --body "Automated PR triggered by the release of [itwinjs-core ${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}).
+            --head "$BRANCH" \
+            --title "Update iTwin.js packages to ^${NEXT_DEV_VERSION}" \
+            --body "Automated PR triggered by the release of [itwinjs-core ${TAG}](${RELEASE_URL}).
 
           Updates the following devDependencies in \`iModelJsNodeAddon/api_package/ts/package.json\`:
-          - \`@itwin/build-tools\` → \`^${{ steps.version.outputs.next_dev_version }}\`
-          - \`@itwin/core-bentley\` → \`^${{ steps.version.outputs.next_dev_version }}\`
-          - \`@itwin/core-common\` → \`^${{ steps.version.outputs.next_dev_version }}\`
-          - \`@itwin/core-geometry\` → \`^${{ steps.version.outputs.next_dev_version }}\`
+          - \`@itwin/build-tools\` → \`^${NEXT_DEV_VERSION}\`
+          - \`@itwin/core-bentley\` → \`^${NEXT_DEV_VERSION}\`
+          - \`@itwin/core-common\` → \`^${NEXT_DEV_VERSION}\`
+          - \`@itwin/core-geometry\` → \`^${NEXT_DEV_VERSION}\`
 
-          Also regenerated \`package-lock.json\` via \`npm install\`." \
-            --label "dependencies"
+          Also regenerated \`package-lock.json\` via \`npm install\`."


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically creates a PR in `iTwin/imodel-native` when a minor/major release is published in itwinjs-core.

## How it works

1. **Trigger**: Runs on `release: published` events
2. **Filter**: Only acts on tags ending in `.0` (minor/major releases, e.g., `release/5.11.0`)
3. **Logic**: Increments the minor version to compute the next dev version (e.g., `5.11.0` → `5.12.0-dev`)
4. **Updates** in imodel-native (`iModelJsNodeAddon/api_package/ts/package.json`):
   - `@itwin/build-tools` → `^X.Y.0-dev`
   - `@itwin/core-bentley` → `^X.Y.0-dev`
   - `@itwin/core-common` → `^X.Y.0-dev`
   - `@itwin/core-geometry` → `^X.Y.0-dev`
5. Regenerates `package-lock.json` via `npm install`
6. Creates a PR in `iTwin/imodel-native` using `gh pr create`

## Secret

Uses `IMJS_ADMIN_GH_TOKEN` (already configured in this repo) for cross-repo access.

## Validation

- Targeted verification: Reviewed existing workflows (`create-release.yaml`, `finalize-release.yaml`) to match tag format (`release/X.Y.Z`), secret name (`IMJS_ADMIN_GH_TOKEN`), and git identity (`imodeljs-admin`)
- Known baseline issues: N/A