### PR TITLE
docs: use rushx in documentation snippet instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Documentation code snippets are extracted from actively tested code to ensure th
    ```
 4. **Update docs script**: Chain extraction with documentation generation:
    ```json
-   "docs": "betools docs --json=../../generated-docs/{package}/file.json --tsIndexFile=./{package}.ts --onlyJson && npm run -s extract"
+   "docs": "betools docs --json=../../generated-docs/{package}/file.json --tsIndexFile=./{package}.ts --onlyJson && rushx extract"
    ```
 5. **Reference in documentation**: In markdown files, reference the snippets using:
    <pre>```ts


### PR DESCRIPTION
## Summary
This PR makes a small, focused documentation improvement related to the monorepo command guidance.

## Changes
- Replace `npm run -s extract` with the Rush-compatible `rushx extract` command in the documentation-snippet example in `CONTRIBUTING.md`.
- Keep the example aligned with the repository guidance to use `rushx` for package scripts.

## Related issue
Related to #9492. This PR intentionally addresses the `CONTRIBUTING.md` snippet only; the broader documentation sweep remains open.

## Validation
Commands run:
```bash
git diff --cached --check
python3 - <<'PY'
# Extract and validate the JSON documentation snippet; assert it ends in `rushx extract`.
PY
git grep -nF '"extract"' -- '*/package.json'
```
Result:
- Tests: not applicable for this one-line documentation correction; dependencies were not installed.
- Lint: not available for Markdown in the checked-out environment.
- Build: not applicable; no executable source or package configuration changed.

## Notes
The documented `extract` script exists in multiple workspace packages, and `rushx extract` is the repository's documented package-script runner.
