### PR TITLE
Use PNPM 11 for `rush audit`

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -5,8 +5,8 @@
       "name": "audit",
       "commandKind": "global",
       "summary": "Runs pnpm audit for the entire monorepo",
-      "description": "Scans the entire monorepo for security vulnerabilities via npm audit",
-      "shellCommand": "npx -y pnpm@11 audit --audit-level high --dir common/temp"
+      "description": "Scans the entire monorepo for security vulnerabilities via pnpm audit",
+      "shellCommand": "npx -y pnpm@11.13.0 audit --audit-level high --dir common/temp"
     },
     {
       "name": "fix-copyrights",

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -4,9 +4,9 @@
     {
       "name": "audit",
       "commandKind": "global",
-      "summary": "Runs npm audit for the entire monorepo",
+      "summary": "Runs pnpm audit for the entire monorepo",
       "description": "Scans the entire monorepo for security vulnerabilities via npm audit",
-      "shellCommand": "node common/scripts/install-run-rush-pnpm.js audit --audit-level high"
+      "shellCommand": "npx -y pnpm@11 audit --audit-level high --dir common/temp"
     },
     {
       "name": "fix-copyrights",

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -29,12 +29,9 @@
   // "CVE-202x-xxxxxx", // https://github.com/advisories/GHSA-xxxx-xxxx-xxxx pkgName>subDepA>subDepB
   "unsupportedPackageJsonSettings": {
     "pnpm": {
+      // ⚠️ Currently ignored. For more information see https://github.com/iTwin/itwinjs-core/issues/9505
       "auditConfig": {
-        "ignoreCves": [
-          "CVE-2024-45296", // https://github.com/advisories/GHSA-9wv6-86v2-598j sinon>nise>path-to-regexp
-          "CVE-2025-27152", // https://github.com/advisories/GHSA-jr5f-v2jv-69x6 azurite>@azure/ms-rest-js>axios
-          "CVE-2025-58754" // https://github.com/advisories/GHSA-4hjh-wcwx-xvwj azurite>@azure/ms-rest-js>axios
-        ]
+        "ignoreCves": []
       }
     }
   },


### PR DESCRIPTION
A workaround until Rush.js supports PNPM 11

For more details, see https://github.com/iTwin/itwinjs-core/issues/9505