### PR TITLE
Presentation: Prevent unbounded presentation managers' growth on the backend

### DIFF
--- a/common/api/presentation-backend.api.md
+++ b/common/api/presentation-backend.api.md
@@ -272,6 +272,7 @@ export interface PresentationManagerProps {
 // @public
 export interface PresentationProps extends Omit<PresentationManagerProps, "enableSchemasPreload"> {
     enableSchemasPreload?: boolean;
+    maxClientManagers?: number;
     requestTimeout?: number;
     unusedClientLifetime?: number;
 }

--- a/common/api/presentation-frontend.api.md
+++ b/common/api/presentation-frontend.api.md
@@ -295,6 +295,7 @@ export interface PresentationManagerProps {
     activeLocale?: string;
     // @deprecated
     activeUnitSystem?: UnitSystemKey;
+    // @deprecated
     clientId?: string;
     // @deprecated
     defaultFormats?: FormatsMap;

--- a/common/changes/@itwin/presentation-backend/presentation-manager-clientid_2026-07-13-11-16.json
+++ b/common/changes/@itwin/presentation-backend/presentation-manager-clientid_2026-07-13-11-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "`Presentation.initialize`: Added `maxClientManagers` prop to cap the number of concurrent client `PresentationManager` instances kept in memory (default 100, least-recently-used evicted first), bounding memory and native-resource usage from many distinct client ids.",
+      "type": "none",
+      "packageName": "@itwin/presentation-backend"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/common/changes/@itwin/presentation-backend/presentation-manager-clientid_2026-07-14-05-19.json
+++ b/common/changes/@itwin/presentation-backend/presentation-manager-clientid_2026-07-14-05-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Presentation manager caching no longer keys on the untrusted, caller-supplied clientId. In web (RPC) deployments the manager is keyed by the authenticated user (JWT sub claim); in IPC apps a single shared manager is used. This prevents arbitrary client ids from allocating unbounded managers.",
+      "type": "none",
+      "packageName": "@itwin/presentation-backend"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend",
+  "email": "35135765+grigasp@users.noreply.github.com"
+}

--- a/common/changes/@itwin/presentation-common/unformatted-content-traversal_2026-07-08-14-13.json
+++ b/common/changes/@itwin/presentation-common/unformatted-content-traversal_2026-07-08-14-13.json
@@ -6,5 +6,6 @@
       "type": "none"
     }
   ],
-  "packageName": "@itwin/presentation-common"
+  "packageName": "@itwin/presentation-common",
+  "email": "35135765+grigasp@users.noreply.github.com"
 }

--- a/common/changes/@itwin/presentation-frontend/deprecate-clientid_2026-07-14-06-00.json
+++ b/common/changes/@itwin/presentation-frontend/deprecate-clientid_2026-07-14-06-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "Deprecated `PresentationManagerProps.clientId`. It is no longer used and has no effect: the backend now keys `PresentationManager` instances by the authenticated user (web deployments) or uses a single shared manager (IPC apps) instead of by a caller-supplied `clientId`. The value is still sent to the backend for backwards compatibility with older backends.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/common/changes/@itwin/presentation-frontend/deprecate-clientid_2026-07-14-06-00.json
+++ b/common/changes/@itwin/presentation-frontend/deprecate-clientid_2026-07-14-06-00.json
@@ -6,5 +6,6 @@
       "type": "none"
     }
   ],
-  "packageName": "@itwin/presentation-frontend"
+  "packageName": "@itwin/presentation-frontend",
+  "email": "35135765+grigasp@users.noreply.github.com"
 }

--- a/presentation/backend/src/presentation-backend/Presentation.ts
+++ b/presentation/backend/src/presentation-backend/Presentation.ts
@@ -38,6 +38,16 @@ export interface PresentationProps extends Omit<PresentationManagerProps, "enabl
    * before it's disposed.
    */
   unusedClientLifetime?: number;
+
+  /**
+   * The maximum number of client [[PresentationManager]] instances to keep in memory
+   * at once. When creating a manager for a new client would exceed this limit, the
+   * least-recently-used manager is disposed first. This bounds memory and native
+   * resource usage regardless of how many distinct clients make requests.
+   *
+   * Defaults to `100`. A value less than `1` disables the limit.
+   */
+  maxClientManagers?: number;
 }
 
 interface PresentationInternalProps {
@@ -133,6 +143,8 @@ export class Presentation {
       cleanupInterval: 60 * 1000,
       // by default, manager is disposed after 1 hour of being unused
       unusedValueLifetime: this._initProps.unusedClientLifetime ?? 60 * 60 * 1000,
+      // by default, keep at most 100 client managers in memory at once
+      maxValues: this._initProps.maxClientManagers ?? 100,
       // add some logging
       /* c8 ignore next 5 */
       onDisposedSingle: (id: string) =>

--- a/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
+++ b/presentation/backend/src/presentation-backend/PresentationIpcHandler.ts
@@ -16,13 +16,13 @@ export class PresentationIpcHandler extends IpcHandler implements PresentationIp
   public channelName = PRESENTATION_IPC_CHANNEL_NAME;
 
   public async setRulesetVariable(params: Parameters<PresentationIpcInterface["setRulesetVariable"]>[0]): Promise<void> {
-    const { clientId, rulesetId, variable } = params;
+    const { rulesetId, variable } = params;
     const parsedVariable = RulesetVariable.fromJSON(variable);
-    Presentation.getManager(clientId).vars(rulesetId).setValue(parsedVariable.id, parsedVariable.type, parsedVariable.value);
+    Presentation.getManager().vars(rulesetId).setValue(parsedVariable.id, parsedVariable.type, parsedVariable.value);
   }
 
   public async unsetRulesetVariable(params: Parameters<PresentationIpcInterface["unsetRulesetVariable"]>[0]): Promise<void> {
-    const { clientId, rulesetId, variableId } = params;
-    Presentation.getManager(clientId).vars(rulesetId).unset(variableId);
+    const { rulesetId, variableId } = params;
+    Presentation.getManager().vars(rulesetId).unset(variableId);
   }
 }

--- a/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
+++ b/presentation/backend/src/presentation-backend/PresentationRpcImpl.ts
@@ -6,8 +6,8 @@
  * @module RPC
  */
 
-import { IModelDb, RpcTrace } from "@itwin/core-backend";
-import { BeEvent, ErrorCategory, Logger, omit, StatusCategory, SuccessCategory } from "@itwin/core-bentley";
+import { IModelDb, IpcHost, RpcTrace } from "@itwin/core-backend";
+import { AccessToken, BeEvent, ErrorCategory, Logger, omit, StatusCategory, SuccessCategory } from "@itwin/core-bentley";
 import { IModelRpcProps, RpcPendingResponse } from "@itwin/core-common";
 import {
   ClientDiagnostics,
@@ -74,6 +74,30 @@ export const MAX_ALLOWED_PAGE_SIZE = 1000;
 export const MAX_ALLOWED_KEYS_PAGE_SIZE = 10000;
 
 const DEFAULT_REQUEST_TIMEOUT = 5000;
+
+/**
+ * Derives a stable cache key for a client `PresentationManager` from the given access token.
+ * Returns the JWT `sub` (subject) claim - a stable, server-issued identifier for the authenticated
+ * user - when the token is a well-formed JWT. Returns `undefined` otherwise (e.g. no token, opaque
+ * token or malformed token), in which case the default shared manager is used.
+ */
+function getManagerKeyFromAccessToken(accessToken: AccessToken | undefined): string | undefined {
+  if (!accessToken) {
+    return undefined;
+  }
+  try {
+    // the token may be prefixed with the authorization scheme (e.g. "Bearer <jwt>")
+    const jwt = accessToken.substring(accessToken.lastIndexOf(" ") + 1);
+    const parts = jwt.split(".");
+    if (parts.length !== 3) {
+      return undefined;
+    }
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as { sub?: unknown };
+    return typeof payload.sub === "string" && payload.sub.length > 0 ? payload.sub : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * The backend implementation of PresentationRpcInterface. All it's basically
@@ -146,10 +170,16 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
   }
 
   /**
-   * Get the [[PresentationManager]] used by this RPC impl.
+   * Get the [[PresentationManager]] used by this RPC impl for the currently authenticated client.
+   *
+   * In IPC apps there's a single trusted local user, so a single shared manager is used for all
+   * requests (consistent with [[PresentationIpcHandler]]). In web apps, the manager is keyed by the
+   * JWT `sub` (subject) claim derived from the request's access token, so all sessions of the same
+   * user share a manager. When there's no usable token, the default shared manager is used.
    */
-  public getManager(clientId?: string): PresentationManager {
-    return Presentation.getManager(clientId);
+  public getManager(): PresentationManager {
+    const managerKey = IpcHost.isValid ? undefined : getManagerKeyFromAccessToken(RpcTrace.expectCurrentActivity.accessToken);
+    return Presentation.getManager(managerKey);
   }
 
   private async getIModel(token: IModelRpcProps): Promise<IModelDb> {
@@ -253,7 +283,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
 
   public override async getNodesCount(token: IModelRpcProps, requestOptions: HierarchyRpcRequestOptions): PresentationRpcResponse<number> {
     return this.makeRequest(token, "getNodesCount", requestOptions, async (options) => {
-      return this.getManager(requestOptions.clientId).getNodesCount(options);
+      return this.getManager().getNodesCount(options);
     });
   }
 
@@ -261,8 +291,8 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     return this.makeRequest(token, "getPagedNodes", requestOptions, async (options) => {
       options = enforceValidPageSize(options);
       const [serializedHierarchyLevel, count] = await Promise.all([
-        this.getManager(requestOptions.clientId)[_presentation_manager_detail].getNodes(options),
-        this.getManager(requestOptions.clientId).getNodesCount(options),
+        this.getManager()[_presentation_manager_detail].getNodes(options),
+        this.getManager().getNodesCount(options),
       ]);
       const hierarchyLevel: HierarchyLevel = deepReplaceNullsToUndefined(JSON.parse(serializedHierarchyLevel));
       return {
@@ -277,7 +307,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: HierarchyLevelDescriptorRpcRequestOptions,
   ): PresentationRpcResponse<string | DescriptorJSON | undefined> {
     return this.makeRequest(token, "getNodesDescriptor", requestOptions, async (options) => {
-      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getNodesDescriptor(options);
+      return this.getManager()[_presentation_manager_detail].getNodesDescriptor(options);
     });
   }
 
@@ -286,7 +316,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: FilterByInstancePathsHierarchyRpcRequestOptions,
   ): PresentationRpcResponse<NodePathElement[]> {
     return this.makeRequest(token, "getNodePaths", requestOptions, async (options) => {
-      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getNodePaths(options);
+      return this.getManager()[_presentation_manager_detail].getNodePaths(options);
     });
   }
 
@@ -295,7 +325,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: FilterByTextHierarchyRpcRequestOptions,
   ): PresentationRpcResponse<NodePathElement[]> {
     return this.makeRequest(token, "getFilteredNodePaths", requestOptions, async (options) => {
-      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getFilteredNodePaths(options);
+      return this.getManager()[_presentation_manager_detail].getFilteredNodePaths(options);
     });
   }
 
@@ -306,7 +336,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: ContentSourcesRpcRequestOptions,
   ): PresentationRpcResponse<ContentSourcesRpcResult> {
     return this.makeRequest(token, "getContentSources", requestOptions, async (options) => {
-      const result = await this.getManager(requestOptions.clientId).getContentSources(options);
+      const result = await this.getManager().getContentSources(options);
       const classesMap = {};
       const selectClasses = result.map((sci) => SelectClassInfo.toCompressedJSON(sci, classesMap));
       return { sources: selectClasses, classesMap };
@@ -325,9 +355,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
       };
       // Here we send a plain JSON string but we will parse it to DescriptorJSON on the frontend. This way we are
       // bypassing unnecessary deserialization and serialization.
-      return Presentation.getManager(requestOptions.clientId)[_presentation_manager_detail].getContentDescriptor(options) as unknown as
-        | DescriptorJSON
-        | undefined;
+      return this.getManager()[_presentation_manager_detail].getContentDescriptor(options) as unknown as DescriptorJSON | undefined;
     });
   }
 
@@ -337,7 +365,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
         ...options,
         keys: KeySet.fromJSON(options.keys),
       };
-      return this.getManager(requestOptions.clientId).getContentSetSize(options);
+      return this.getManager().getContentSetSize(options);
     });
   }
 
@@ -352,8 +380,8 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
       });
 
       const [size, content] = await Promise.all([
-        this.getManager(requestOptions.clientId).getContentSetSize(options),
-        this.getManager(requestOptions.clientId)[_presentation_manager_detail].getContent(options),
+        this.getManager().getContentSetSize(options),
+        this.getManager()[_presentation_manager_detail].getContent(options),
       ]);
 
       if (!content) {
@@ -393,8 +421,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: SingleElementPropertiesRpcRequestOptions,
   ): PresentationRpcResponse<ElementProperties | undefined> {
     return this.makeRequest(token, "getElementProperties", { ...requestOptions }, async (options) => {
-      const { clientId, ...restOptions } = options;
-      return this.getManager(clientId).getElementProperties(restOptions);
+      return this.getManager().getElementProperties(options);
     });
   }
 
@@ -407,7 +434,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
         ...options,
         keys: KeySet.fromJSON(options.keys),
       });
-      return this.getManager(requestOptions.clientId)[_presentation_manager_detail].getPagedDistinctValues(options);
+      return this.getManager()[_presentation_manager_detail].getPagedDistinctValues(options);
     });
   }
 
@@ -430,8 +457,8 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
       );
 
       const [size, content] = await Promise.all([
-        this.getManager(requestOptions.clientId).getContentSetSize(options),
-        this.getManager(requestOptions.clientId)[_presentation_manager_detail].getContent(options),
+        this.getManager().getContentSetSize(options),
+        this.getManager()[_presentation_manager_detail].getContent(options),
       ]);
 
       if (size === 0 || !content) {
@@ -450,7 +477,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
     requestOptions: DisplayLabelRpcRequestOptions,
   ): PresentationRpcResponse<LabelDefinition> {
     return this.makeRequest(token, "getDisplayLabelDefinition", requestOptions, async (options) => {
-      const label = await this.getManager(requestOptions.clientId)[_presentation_manager_detail].getDisplayLabelDefinition(options);
+      const label = await this.getManager()[_presentation_manager_detail].getDisplayLabelDefinition(options);
       return label;
     });
   }
@@ -464,7 +491,7 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
       requestOptions.keys.splice(pageOpts.paging.size);
     }
     return this.makeRequest(token, "getPagedDisplayLabelDefinitions", requestOptions, async (options) => {
-      const labels = await this.getManager(requestOptions.clientId)[_presentation_manager_detail].getDisplayLabelDefinitions({
+      const labels = await this.getManager()[_presentation_manager_detail].getDisplayLabelDefinitions({
         ...options,
         keys: options.keys,
       });
@@ -477,14 +504,12 @@ export class PresentationRpcImpl extends PresentationRpcInterface implements Dis
 
   /* eslint-disable @typescript-eslint/no-deprecated */
   public override async getSelectionScopes(token: IModelRpcProps, requestOptions: SelectionScopeRpcRequestOptions): PresentationRpcResponse<SelectionScope[]> {
-    return this.makeRequest(token, "getSelectionScopes", requestOptions, async (options) =>
-      this.getManager(requestOptions.clientId).getSelectionScopes(options),
-    );
+    return this.makeRequest(token, "getSelectionScopes", requestOptions, async (options) => this.getManager().getSelectionScopes(options));
   }
 
   public override async computeSelection(token: IModelRpcProps, requestOptions: ComputeSelectionRpcRequestOptions): PresentationRpcResponse<KeySetJSON> {
     return this.makeRequest(token, "computeSelection", requestOptions, async (options) => {
-      const keys = await this.getManager(requestOptions.clientId).computeSelection(options);
+      const keys = await this.getManager().computeSelection(options);
       return keys.toJSON();
     });
   }

--- a/presentation/backend/src/presentation-backend/TemporaryStorage.ts
+++ b/presentation/backend/src/presentation-backend/TemporaryStorage.ts
@@ -15,7 +15,7 @@ import { PresentationError, PresentationStatus } from "@itwin/presentation-commo
  */
 export interface TemporaryStorageProps<T> {
   /** A method that's called for every value before it's removed from storage */
-  cleanupHandler?: (id: string, value: T, reason: "timeout" | "dispose" | "request") => void;
+  cleanupHandler?: (id: string, value: T, reason: "timeout" | "dispose" | "request" | "eviction") => void;
 
   onDisposedSingle?: (id: string) => void;
   onDisposedAll?: () => void;
@@ -49,6 +49,14 @@ export interface TemporaryStorageProps<T> {
    * or scheduled (controlled by [[cleanupInterval]])).
    */
   maxValueLifetime?: number;
+
+  /**
+   * The maximum number of values the storage is allowed to hold at once. When adding
+   * a value would exceed this limit, the least-recently-used value is evicted first.
+   *
+   * `undefined` (or any value less than `1`) means the number of values is not capped.
+   */
+  maxValues?: number;
 }
 
 /** Value with know last used time */
@@ -120,15 +128,39 @@ export class TemporaryStorage<T> implements Disposable {
       }
     }
     for (const id of valuesToDispose) {
-      this.deleteExistingEntry(id, true);
+      this.deleteExistingEntry(id, "timeout");
     }
   };
 
-  private deleteExistingEntry(id: string, isTimeout: boolean) {
+  private deleteExistingEntry(id: string, reason: "timeout" | "request" | "eviction") {
     assert(this._values.has(id));
-    this.props.cleanupHandler && this.props.cleanupHandler(id, this._values.get(id)!.value, isTimeout ? "timeout" : "request");
+    this.props.cleanupHandler && this.props.cleanupHandler(id, this._values.get(id)!.value, reason);
     this._values.delete(id);
     this.props.onDisposedSingle && this.props.onDisposedSingle(id);
+  }
+
+  /**
+   * Evicts least-recently-used values until there's room to add one more value
+   * without exceeding the configured [[TemporaryStorageProps.maxValues]] limit.
+   */
+  private evictForNewValue() {
+    const maxValues = this.props.maxValues;
+    if (maxValues === undefined || maxValues < 1) {
+      return;
+    }
+    while (this._values.size >= maxValues) {
+      let lruId: string | undefined;
+      let lruTime = Number.POSITIVE_INFINITY;
+      for (const [key, entry] of this._values.entries()) {
+        const time = entry.lastUsed.getTime();
+        if (time < lruTime) {
+          lruTime = time;
+          lruId = key;
+        }
+      }
+      assert(!!lruId);
+      this.deleteExistingEntry(lruId, "eviction");
+    }
   }
 
   /**
@@ -160,13 +192,14 @@ export class TemporaryStorage<T> implements Disposable {
     if (this._values.has(id)) {
       throw new PresentationError(PresentationStatus.InvalidArgument, `A value with given ID "${id}" already exists in this storage.`);
     }
+    this.evictForNewValue();
     this._values.set(id, { value, created: new Date(), lastUsed: new Date() });
   }
 
   /** Deletes a value with given id. */
   public deleteValue(id: string) {
     if (this._values.has(id)) {
-      this.deleteExistingEntry(id, false);
+      this.deleteExistingEntry(id, "request");
     }
   }
 

--- a/presentation/backend/src/test/PresentationRpcImpl.test.ts
+++ b/presentation/backend/src/test/PresentationRpcImpl.test.ts
@@ -5,7 +5,7 @@
 
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { IModelDb, RpcTrace } from "@itwin/core-backend";
+import { IModelDb, IpcHost, RpcTrace } from "@itwin/core-backend";
 import { BeEvent, Guid } from "@itwin/core-bentley";
 import { IModelRpcProps } from "@itwin/core-common";
 import {
@@ -223,6 +223,92 @@ describe("PresentationRpcImpl", () => {
       } as unknown as IModelDb);
     using impl = new PresentationRpcImpl();
     await expect(impl.getSelectionScopes(imodelToken, {})).to.eventually.be.rejectedWith("test error");
+  });
+
+  describe("getManager() keying", () => {
+    let accessToken: string;
+    let isIpcApp: boolean;
+
+    beforeEach(() => {
+      accessToken = "";
+      // `isIpcApp` is read at `getManager` call time. It's kept `false` during `initialize` so the
+      // IPC handler isn't registered against a non-started `IpcHost`.
+      isIpcApp = false;
+      sinon.stub(RpcTrace, "expectCurrentActivity").get(() => ({ accessToken }));
+      sinon.stub(IpcHost, "isValid").get(() => isIpcApp);
+      Presentation.initialize({
+        // @ts-expect-error internal prop
+        clientManagerFactory: () => stubPresentationManager(),
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+      Presentation.terminate();
+    });
+
+    function makeJwt(payload: object): string {
+      const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+      const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+      return `${header}.${body}.signature`;
+    }
+
+    it("keys manager by JWT `sub` claim when access token is present", () => {
+      const spy = sinon.spy(Presentation, "getManager");
+      accessToken = `Bearer ${makeJwt({ sub: "user-123" })}`;
+      using impl = new PresentationRpcImpl();
+      impl.getManager();
+      expect(spy).to.be.calledWith("user-123");
+    });
+
+    it("keys manager by `sub` even without an authorization scheme prefix", () => {
+      const spy = sinon.spy(Presentation, "getManager");
+      accessToken = makeJwt({ sub: "user-456" });
+      using impl = new PresentationRpcImpl();
+      impl.getManager();
+      expect(spy).to.be.calledWith("user-456");
+    });
+
+    it("uses default manager when there's no access token", () => {
+      const spy = sinon.spy(Presentation, "getManager");
+      accessToken = "";
+      using impl = new PresentationRpcImpl();
+      impl.getManager();
+      expect(spy).to.be.calledWith(undefined);
+    });
+
+    it("uses default manager when access token is not a JWT", () => {
+      const spy = sinon.spy(Presentation, "getManager");
+      accessToken = "opaque-token";
+      using impl = new PresentationRpcImpl();
+      impl.getManager();
+      expect(spy).to.be.calledWith(undefined);
+    });
+
+    it("uses default manager when JWT has no `sub` claim", () => {
+      const spy = sinon.spy(Presentation, "getManager");
+      accessToken = `Bearer ${makeJwt({ name: "no-subject" })}`;
+      using impl = new PresentationRpcImpl();
+      impl.getManager();
+      expect(spy).to.be.calledWith(undefined);
+    });
+
+    it("uses default manager when JWT payload is malformed", () => {
+      const spy = sinon.spy(Presentation, "getManager");
+      accessToken = "Bearer not-base64.@@@.signature";
+      using impl = new PresentationRpcImpl();
+      impl.getManager();
+      expect(spy).to.be.calledWith(undefined);
+    });
+
+    it("uses default manager in IPC apps regardless of access token", () => {
+      const spy = sinon.spy(Presentation, "getManager");
+      accessToken = `Bearer ${makeJwt({ sub: "user-123" })}`;
+      isIpcApp = true;
+      using impl = new PresentationRpcImpl();
+      impl.getManager();
+      expect(spy).to.be.calledWith(undefined);
+    });
   });
 
   describe("calls forwarding", () => {

--- a/presentation/backend/src/test/TemporaryStorage.test.ts
+++ b/presentation/backend/src/test/TemporaryStorage.test.ts
@@ -98,6 +98,68 @@ describe("TemporaryStorage", () => {
     });
   });
 
+  describe("`maxValues` eviction", () => {
+    it("doesn't evict when `maxValues` is not specified", () => {
+      using storage = new TemporaryStorage<string>({});
+      ["a", "b", "c"].forEach((v) => storage.addValue(v, v));
+      expect(storage.values).to.deep.eq(["a", "b", "c"]);
+    });
+
+    it("doesn't evict when `maxValues` is less than 1", () => {
+      using storage = new TemporaryStorage<string>({ maxValues: 0 });
+      ["a", "b", "c"].forEach((v) => storage.addValue(v, v));
+      expect(storage.values).to.deep.eq(["a", "b", "c"]);
+    });
+
+    it("evicts least-recently-used value when exceeding `maxValues`", () => {
+      const cleanupHandler = sinon.spy();
+      using storage = new TemporaryStorage<string>({ maxValues: 2, cleanupHandler });
+
+      storage.addValue("a", "A");
+      clock.tick(1);
+      storage.addValue("b", "B");
+      clock.tick(1);
+      // adding a third value should evict the least-recently-used ("a")
+      storage.addValue("c", "C");
+
+      expect(storage.values).to.deep.eq(["B", "C"]);
+      expect(cleanupHandler).to.be.calledOnceWithExactly("a", "A", "eviction");
+    });
+
+    it("doesn't evict a value that was recently used", () => {
+      using storage = new TemporaryStorage<string>({ maxValues: 2 });
+
+      storage.addValue("a", "A");
+      clock.tick(1);
+      storage.addValue("b", "B");
+      clock.tick(1);
+      // touch "a" so it's no longer the least-recently-used
+      storage.getValue("a");
+      clock.tick(1);
+      storage.addValue("c", "C");
+
+      expect(storage.values).to.deep.eq(["A", "C"]);
+    });
+
+    it("evicts through `FactoryBasedTemporaryStorage.getValue`", () => {
+      const cleanupHandler = sinon.spy();
+      using storage = new FactoryBasedTemporaryStorage<string>({
+        factory: (id) => id.toUpperCase(),
+        maxValues: 2,
+        cleanupHandler,
+      });
+
+      storage.getValue("a");
+      clock.tick(1);
+      storage.getValue("b");
+      clock.tick(1);
+      storage.getValue("c");
+
+      expect(storage.values).to.deep.eq(["B", "C"]);
+      expect(cleanupHandler).to.be.calledOnceWithExactly("a", "A", "eviction");
+    });
+  });
+
   describe("getValue", () => {
     it("returns undefined if value does not exist", () => {
       const storage = new TemporaryStorage<string>({});

--- a/presentation/frontend/src/presentation-frontend/PresentationManager.ts
+++ b/presentation/frontend/src/presentation-frontend/PresentationManager.ts
@@ -161,7 +161,7 @@ export interface PresentationManagerProps {
    * store this ID in their local storage so the ID can be reused across
    * sessions - this allows reusing some caches.
    *
-   * Defaults to a unique GUID as a client id.
+   * @deprecated in 5.12. This property is no longer used and has no effect.
    */
   clientId?: string;
 
@@ -254,6 +254,7 @@ export class PresentationManager implements Disposable {
 
     this._requestsHandler =
       (props as PresentationManagerInternalProps)?.rpcRequestsHandler ??
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- `clientId` is still forwarded for backwards compatibility with older backends
       new RpcRequestsHandler(props ? { clientId: props.clientId, timeout: props.requestTimeout } : undefined);
     this._rulesetVars = new Map<string, RulesetVariablesManager>();
     this._rulesets = RulesetManagerImpl.create();


### PR DESCRIPTION
The Presentation RPC surface accepted a caller-controlled `clientId` and used it as the cache key for backend `PresentationManager` instances. The store had no size cap, so repeated requests with fresh `clientId` values created distinct managers that were retained for the default one-hour unused lifetime — an availability / resource-exhaustion vector (each manager can back native Presentation components).

This PR removes that vector in two layers and deprecates the now-unused `clientId` knob:

1. **Hard cap on concurrent managers** (the actual fix) — the manager store now evicts least-recently-used entries past a configurable limit, so the number of live managers is bounded regardless of how many distinct ids arrive.
2. **Stop trusting `clientId` as the cache key** — managers are keyed by the authenticated user (web) or shared (IPC apps) instead of by an untrusted, caller-supplied id.