### PR TITLE
Officially document + prove support for KHR_mesh_primitive_restart for line strips

### DIFF
--- a/common/changes/@itwin/core-frontend/khr-mesh-primitive-restart_2026-07-16-14-48.json
+++ b/common/changes/@itwin/core-frontend/khr-mesh-primitive-restart_2026-07-16-14-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Clarify/document/prove support the KHR_mesh_primitive_restart glTF extension for line strip primitives.",
+      "comment": "Clarify/document/prove support for the KHR_mesh_primitive_restart glTF extension for line strip primitives.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-frontend/khr-mesh-primitive-restart_2026-07-16-14-48.json
+++ b/common/changes/@itwin/core-frontend/khr-mesh-primitive-restart_2026-07-16-14-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Clarify/document/prove support the KHR_mesh_primitive_restart glTF extension for line strip primitives.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/common/gltf/GltfSchema.ts
+++ b/core/frontend/src/common/gltf/GltfSchema.ts
@@ -212,6 +212,13 @@ export interface GltfMesh extends GltfChildOfRootProperty {
   /** For morph targets - currently unsupported. */
   weights?: number[];
   extensions?: GltfExtensions & {
+    /** The [EXT_mesh_primitive_restart](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_primitive_restart) extension
+     * describes groups of primitives that can be combined into a single draw call, using a "combined" index accessor containing primitive restart values
+     * to separate the individual primitives.
+     * It is superseded by [KHR_mesh_primitive_restart](https://github.com/KhronosGroup/glTF/pull/2569), which has no JSON payload at any level. A primitive's
+     * own indices accessor may contain restart values inline (the maximum value for the accessor's component type), with the extension declared in the
+     * asset's `extensionsUsed` and `extensionsRequired` arrays. See [[GltfReader.readPolylines]] for the handling of inline restart values.
+     */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     EXT_mesh_primitive_restart?: {
       primitiveGroups: Array<{

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { Range3d } from "@itwin/core-geometry";
-import { EmptyLocalization, FillFlags, GltfV2ChunkTypes, GltfVersions, LinePixels, RenderTexture, TileFormat } from "@itwin/core-common";
+import { EmptyLocalization, FillFlags, GltfV2ChunkTypes, GltfVersions, LinePixels, RenderTexture, TileFormat, TileReadStatus } from "@itwin/core-common";
 import { IModelConnection } from "../../IModelConnection";
 import { IModelApp } from "../../IModelApp";
 import { Gltf2Material, GltfDataType, GltfDocument, GltfId, GltfMesh, GltfMeshMode, GltfMeshPrimitive, GltfNode, GltfSampler, GltfWrapMode } from "../../common/gltf/GltfSchema";
@@ -1646,7 +1646,7 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
   describe("KHR_mesh_primitive_restart", () => {
     // The extension has no JSON payload - restart values appear inline in the primitive's own indices accessor.
     // The restart value is the maximum value for the accessor's componentType.
-    function makeLineStripGlb(componentType: GltfDataType.UnsignedByte | GltfDataType.UnsignedShort | GltfDataType.UInt32, indices: number[]): Uint8Array {
+    function makeLineStripGlb(componentType: GltfDataType.UnsignedByte | GltfDataType.UnsignedShort | GltfDataType.UInt32, indices: number[], mode = GltfMeshMode.LineStrip): Uint8Array {
       const numVerts = 5;
       const posBytes = numVerts * 3 * 4;
       const indexSize = GltfDataType.UnsignedByte === componentType ? 1 : (GltfDataType.UnsignedShort === componentType ? 2 : 4);
@@ -1671,7 +1671,7 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
           primitives: [{
             attributes: { POSITION: 0 },
             indices: 1,
-            mode: GltfMeshMode.LineStrip,
+            mode,
           }],
         }],
         buffers: [{ byteLength: binary.length }],
@@ -1750,6 +1750,22 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
         0xffff,
         [[0, 1], [1, 2], [2, 3], [3, 4]],
       );
+    });
+
+    it("gracefully ignores primitives with unsupported topologies", async () => {
+      // readMeshPrimitive does not support these modes at all, so restart values in their indices must never be
+      // misinterpreted as vertex indices - the primitive produces no geometry and the reader reports the tile as invalid.
+      // If support for these topologies is ever added, this test exists to force restart-awareness in the new code paths.
+      const indices = [0, 1, 2, 0xffff, 2, 3, 4];
+      for (const mode of [GltfMeshMode.LineLoop, GltfMeshMode.TriangleStrip, GltfMeshMode.TriangleFan]) {
+        const reader = createReader(makeLineStripGlb(GltfDataType.UnsignedShort, indices, mode))!;
+        expect(reader).toBeDefined();
+
+        const result = await reader.read();
+        expect(result.readStatus).toEqual(TileReadStatus.InvalidTileData);
+        expect(result.graphic).toBeUndefined();
+        expect(reader.meshes).toBeUndefined();
+      }
     });
   });
 

--- a/core/frontend/src/test/tile/GltfReader.test.ts
+++ b/core/frontend/src/test/tile/GltfReader.test.ts
@@ -1643,6 +1643,116 @@ const meshFeaturesExt: GltfDocument = JSON.parse(`
     });
   });
 
+  describe("KHR_mesh_primitive_restart", () => {
+    // The extension has no JSON payload - restart values appear inline in the primitive's own indices accessor.
+    // The restart value is the maximum value for the accessor's componentType.
+    function makeLineStripGlb(componentType: GltfDataType.UnsignedByte | GltfDataType.UnsignedShort | GltfDataType.UInt32, indices: number[]): Uint8Array {
+      const numVerts = 5;
+      const posBytes = numVerts * 3 * 4;
+      const indexSize = GltfDataType.UnsignedByte === componentType ? 1 : (GltfDataType.UnsignedShort === componentType ? 2 : 4);
+      const indexBytes = indices.length * indexSize;
+      const totalBytes = posBytes + indexBytes;
+      const binary = new Uint8Array(totalBytes + ((4 - (totalBytes % 4)) % 4));
+
+      const positions = new Float32Array(binary.buffer, 0, numVerts * 3);
+      positions.set([0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0]);
+
+      const IndexArray = GltfDataType.UnsignedByte === componentType ? Uint8Array : (GltfDataType.UnsignedShort === componentType ? Uint16Array : Uint32Array);
+      new IndexArray(binary.buffer, posBytes, indices.length).set(indices);
+
+      const json = {
+        asset: { version: "2.0" },
+        extensionsUsed: ["KHR_mesh_primitive_restart"],
+        extensionsRequired: ["KHR_mesh_primitive_restart"],
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ mesh: 0 }],
+        meshes: [{
+          primitives: [{
+            attributes: { POSITION: 0 },
+            indices: 1,
+            mode: GltfMeshMode.LineStrip,
+          }],
+        }],
+        buffers: [{ byteLength: binary.length }],
+        bufferViews: [{
+          buffer: 0,
+          byteOffset: 0,
+          byteLength: posBytes,
+          target: 34962,
+        }, {
+          buffer: 0,
+          byteOffset: posBytes,
+          byteLength: indexBytes,
+          target: 34963,
+        }],
+        accessors: [{
+          bufferView: 0,
+          byteOffset: 0,
+          componentType: GltfDataType.Float,
+          count: numVerts,
+          type: "VEC3",
+          max: [4, 0, 0],
+          min: [0, 0, 0],
+        }, {
+          bufferView: 1,
+          byteOffset: 0,
+          componentType,
+          count: indices.length,
+          type: "SCALAR",
+        }],
+      };
+
+      return makeGlb(json, binary);
+    }
+
+    async function expectPolylines(glb: Uint8Array, restart: number, expected: number[][]): Promise<void> {
+      const reader = createReader(glb)!;
+      expect(reader).toBeDefined();
+
+      await reader.read();
+
+      expect(reader.meshes).toBeDefined();
+      const polylines = reader.meshes!.primitive.polylines;
+      expect(polylines).toBeDefined();
+
+      // Prove the restart sentinel never survives into the polylines that produce the render geometry.
+      for (const polyline of polylines!)
+        for (const index of polyline.indices)
+          expect(index).not.toEqual(restart);
+
+      expect(polylines!.map((p) => Array.from(p.indices))).toEqual(expected);
+    }
+
+    it("splits a line strip at restart values for each component type", async () => {
+      const indices = [0, 1, 2];
+      const expected = [[0, 1, 2], [3, 4]];
+      await expectPolylines(makeLineStripGlb(GltfDataType.UnsignedByte, [...indices, 0xff, 3, 4]), 0xff, expected);
+      await expectPolylines(makeLineStripGlb(GltfDataType.UnsignedShort, [...indices, 0xffff, 3, 4]), 0xffff, expected);
+      await expectPolylines(makeLineStripGlb(GltfDataType.UInt32, [...indices, 0xffffffff, 3, 4]), 0xffffffff, expected);
+    });
+
+    it("produces a single polyline when no restart values are present", async () => {
+      await expectPolylines(makeLineStripGlb(GltfDataType.UnsignedShort, [0, 1, 2, 3, 4]), 0xffff, [[0, 1, 2, 3, 4]]);
+    });
+
+    it("tolerates leading, consecutive, and trailing restart values", async () => {
+      await expectPolylines(
+        makeLineStripGlb(GltfDataType.UnsignedShort, [0xffff, 0, 1, 0xffff, 0xffff, 2, 3, 0xffff]),
+        0xffff,
+        [[0, 1], [2, 3]],
+      );
+    });
+
+    it("splits multiple strips batched into one primitive", async () => {
+      await expectPolylines(
+        makeLineStripGlb(GltfDataType.UnsignedShort, [0, 1, 0xffff, 1, 2, 0xffff, 2, 3, 0xffff, 3, 4]),
+        0xffff,
+        [[0, 1], [1, 2], [2, 3], [3, 4]],
+      );
+    });
+  });
+
   describe("BENTLEY_materials_planar_fill", () => {
     // Simple glTF with a triangle and a material using the planar fill extension
     const planarFillGltf: GltfDocument = JSON.parse(`{

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -2319,6 +2319,9 @@ export abstract class GltfReader {
       }
       case GltfMeshMode.LineStrip: {
         assert(undefined !== bufferView); // compiler can't seem to infer this...
+        // Per the KHR_mesh_primitive_restart extension (https://github.com/KhronosGroup/glTF/pull/2569), the indices accessor may contain
+        // "primitive restart" values - the maximum value for the accessor's component type - each of which terminates the current line strip
+        // and begins a new one. This permits many strips to be batched into a single primitive.
         const restart = GltfDataType.UnsignedByte === bufferView.type ? 0xff : (GltfDataType.UnsignedShort === bufferView.type ? 0xffff : 0xffffffff);
         for (const index of data.buffer) {
           if (index === restart) {


### PR DESCRIPTION
## Description

[`KHR_mesh_primitive_restart`](https://github.com/KhronosGroup/glTF/pull/2569) is the successor to the published [`EXT_mesh_primitive_restart`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_primitive_restart) extension. Instead of the EXT's mesh-level `primitiveGroups` JSON (one glTF primitive per sub-strip plus a separate "combined" accessor), the KHR extension has **no JSON payload at all**: a primitive's own indices accessor may contain inline "restart" values (the maximum value for the accessor's component type (`0xff` / `0xffff` / `0xffffffff`)). Each of these terminates the current strip and begins a new one. This allows many line strips to be batched into a single primitive, avoiding significant glTF JSON bloat for polyline-heavy assets.

It turns out iTwin.js already supports this format inherently; no loader changes are required:

- `GltfReader.readPolylines` already splits `LINE_STRIP` index buffers at the component-type-appropriate restart value, CPU-side, into `MeshPolyline`s. Restart sentinels never propagate into render geometry.
- `extensionsRequired` is parsed but never used for rejection, so KHR-format assets load without issue.
- The existing EXT `primitiveGroups` handling (`getMeshPrimitives`) is unaffected and remains supported.

This PR makes that support **official** by adding test coverage and documentation. It is purely additive; no functional changes.

## Validation

- Targeted verification:
  - `npx vitest run src/test/tile/GltfReader.test.ts` in `core/frontend`: 41/41 tests pass, including the 4 new KHR tests.
  - `npx eslint` clean on all three touched source files.