### PR TITLE
fix(core-backend): skip `undefined`/`null` bindings in `queryEntityIds` and `ViewStore` selector queries

### DIFF
--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -7831,6 +7831,8 @@ export class QueryBinder {
     bindString(indexOrName: string | number, val: string): this;
     bindStruct(indexOrName: string | number, val: object): this;
     static from(args: any[] | object | undefined): QueryBinder;
+    // @internal
+    static fromSkippingNullish(args: any[] | object | undefined): QueryBinder;
     // (undocumented)
     serialize(): object;
 }

--- a/common/changes/@itwin/core-backend/as-fix-queryentityids-undefined-bindings_2026-07-16-19-00.json
+++ b/common/changes/@itwin/core-backend/as-fix-queryentityids-undefined-bindings_2026-07-16-19-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fixed queryEntityIds and ViewStore selector queries throwing on undefined/null binding values.",
+      "type": "none",
+      "packageName": "@itwin/core-backend"
+    }
+  ],
+  "packageName": "@itwin/core-backend",
+  "email": "anmolshres98@users.noreply.github.com"
+}

--- a/common/changes/@itwin/core-common/as-fix-queryentityids-undefined-bindings_2026-07-16-19-00.json
+++ b/common/changes/@itwin/core-common/as-fix-queryentityids-undefined-bindings_2026-07-16-19-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Added an internal QueryBinder helper to support restoring legacy binding-skip semantics in downstream packages.",
+      "type": "none",
+      "packageName": "@itwin/core-common"
+    }
+  ],
+  "packageName": "@itwin/core-common",
+  "email": "anmolshres98@users.noreply.github.com"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -1159,7 +1159,7 @@ export abstract class IModelDb extends IModel {
           }
         }
       }
-    }, QueryBinder.from(params.bindings));
+    }, QueryBinder.fromSkippingNullish(params.bindings));
     return ids;
   }
 

--- a/core/backend/src/ViewStore.ts
+++ b/core/backend/src/ViewStore.ts
@@ -872,7 +872,7 @@ export namespace ViewStore {
             if (typeof id === "string")
               ids.add(id);
           }
-        }, bindings ? QueryBinder.from(bindings) : undefined);
+        }, bindings ? QueryBinder.fromSkippingNullish(bindings) : undefined);
         this.iterateCompressedGuidRows(props.query.adds, (id) => ids.add(id));
         this.iterateCompressedGuidRows(props.query.removes, (id) => ids.delete(id)); // removes take precedence over adds
       } catch (err: any) {

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1408,6 +1408,7 @@ describe("iModel", () => {
     assert.deepEqual(withUnusedNull, baseline);
 
     const someId = imodel2.queryEntityIds({ from: "bis.element", where: "CodeValue IS NOT NULL", limit: 1 }).values().next().value as string;
+    assert.isDefined(someId);
     const codeValue = imodel2.elements.getElement(someId).code.value;
     const mixed = imodel2.queryEntityIds({ from: "bis.element", where: "CodeValue=:cv", bindings: { cv: codeValue, parent: undefined } });
     assert.isTrue(mixed.has(someId));

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1393,6 +1393,32 @@ describe("iModel", () => {
     assert.equal(physicalObjectIds.size, 1);
   });
 
+  it("queryEntityIds should skip undefined and null bindings", () => {
+    // Callers commonly build the WHERE clause conditionally but pass the bindings object
+    // unconditionally, relying on undefined entries being skipped (legacy bindValues semantics).
+    const baseline = imodel2.queryEntityIds({ from: "generic.PhysicalObject", where: "codevalue is null" });
+    assert.isAtLeast(baseline.size, 1);
+
+    const parent: string | undefined = undefined;
+    let where = "codevalue is null";
+    if (parent !== undefined)
+      where += " AND Parent.Id=:parent";
+    const withUnusedUndefined = imodel2.queryEntityIds({ from: "generic.PhysicalObject", where, bindings: { parent } });
+    assert.deepEqual(withUnusedUndefined, baseline);
+
+    const withUnusedNull = imodel2.queryEntityIds({ from: "generic.PhysicalObject", where: "codevalue is null", bindings: { parent: null } });
+    assert.deepEqual(withUnusedNull, baseline);
+
+    const someId = imodel2.queryEntityIds({ from: "bis.element", where: "CodeValue IS NOT NULL", limit: 1 }).values().next().value as string;
+    const codeValue = imodel2.elements.getElement(someId).code.value;
+    const mixed = imodel2.queryEntityIds({ from: "bis.element", where: "CodeValue=:cv", bindings: { cv: codeValue, parent: undefined } });
+    assert.isTrue(mixed.has(someId));
+
+    // positional form: trailing undefined beyond the parameter count must be skipped, not bound
+    const positional = imodel2.queryEntityIds({ from: "bis.element", where: "CodeValue=?", bindings: [codeValue, undefined] });
+    assert.isTrue(positional.has(someId));
+  });
+
   it("validate BisCodeSpecs", async () => {
     assert.equal(imodel2.codeSpecs.getByName(BisCodeSpec.nullCodeSpec).scopeType, CodeScopeSpec.Type.Repository);
     assert.equal(imodel2.codeSpecs.getByName(BisCodeSpec.subCategory).scopeType, CodeScopeSpec.Type.ParentElement);

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1400,9 +1400,7 @@ describe("iModel", () => {
     assert.isAtLeast(baseline.size, 1);
 
     const parent: string | undefined = undefined;
-    let where = "codevalue is null";
-    if (parent !== undefined)
-      where += " AND Parent.Id=:parent";
+    const where = "codevalue is null";
     const withUnusedUndefined = imodel2.queryEntityIds({ from: "generic.PhysicalObject", where, bindings: { parent } });
     assert.deepEqual(withUnusedUndefined, baseline);
 

--- a/core/backend/src/test/standalone/ViewStoreDb.test.ts
+++ b/core/backend/src/test/standalone/ViewStoreDb.test.ts
@@ -10,6 +10,8 @@ import { Guid, GuidString, Logger, LogLevel, OpenMode } from "@itwin/core-bentle
 import { ViewStore } from "../../ViewStore";
 import { ThumbnailFormatProps } from "@itwin/core-common";
 import { KnownTestLocations } from "../KnownTestLocations";
+import { SnapshotDb } from "../../IModelDb";
+import { IModelTestUtils } from "../IModelTestUtils";
 
 describe("ViewStore", function (this: Suite) {
   this.timeout(0);
@@ -329,5 +331,31 @@ describe("ViewStore", function (this: Suite) {
     expect(ViewStore.toRowId(ViewStore.fromRowId(largeNumber))).equals(largeNumber);
 
     vs1.vacuum();
+  });
+
+  it("selector queries should skip undefined and null bindings", async () => {
+    const snapshot = SnapshotDb.openFile(IModelTestUtils.resolveAssetFile("test.bim"));
+    const dbName = join(KnownTestLocations.outputDir, "viewStoreBindings.db");
+    ViewStore.ViewDb.createNewDb(dbName);
+    const vs = new ViewStore.ViewDb({ guidMap: {} as any });
+    vs.openDb(dbName, OpenMode.ReadWrite);
+    vs.iModel = snapshot;
+    try {
+      const selectorId = await vs.addCategorySelector({ selector: { query: { from: "BisCore:SpatialCategory" } } });
+
+      const baseline = vs.getCategorySelectorSync({ id: selectorId });
+      expect(baseline.categories.length).greaterThan(0);
+
+      // Undefined/null bindings not referenced by the query must be skipped (legacy ECSqlStatement.bindValues
+      // semantics, per ViewStoreRpc.QueryBindings), not bound as NULL.
+      const withUnusedUndefined = vs.getCategorySelectorSync({ id: selectorId, bindings: { parent: undefined } });
+      expect(withUnusedUndefined.categories).deep.equal(baseline.categories);
+
+      const withUnusedNull = vs.getCategorySelectorSync({ id: selectorId, bindings: { parent: null } });
+      expect(withUnusedNull.categories).deep.equal(baseline.categories);
+    } finally {
+      vs.closeDb();
+      snapshot.close();
+    }
   });
 });

--- a/core/backend/src/test/standalone/ViewStoreDb.test.ts
+++ b/core/backend/src/test/standalone/ViewStoreDb.test.ts
@@ -334,13 +334,14 @@ describe("ViewStore", function (this: Suite) {
   });
 
   it("selector queries should skip undefined and null bindings", async () => {
-    const snapshot = SnapshotDb.openFile(IModelTestUtils.resolveAssetFile("test.bim"));
     const dbName = join(KnownTestLocations.outputDir, "viewStoreBindings.db");
-    ViewStore.ViewDb.createNewDb(dbName);
+    const snapshot = SnapshotDb.openFile(IModelTestUtils.resolveAssetFile("test.bim"));
     const vs = new ViewStore.ViewDb({ guidMap: {} as any });
-    vs.openDb(dbName, OpenMode.ReadWrite);
-    vs.iModel = snapshot;
     try {
+      ViewStore.ViewDb.createNewDb(dbName);
+      vs.openDb(dbName, OpenMode.ReadWrite);
+      vs.iModel = snapshot;
+
       const selectorId = await vs.addCategorySelector({ selector: { query: { from: "BisCore:SpatialCategory" } } });
 
       const baseline = vs.getCategorySelectorSync({ id: selectorId });
@@ -354,8 +355,10 @@ describe("ViewStore", function (this: Suite) {
       const withUnusedNull = vs.getCategorySelectorSync({ id: selectorId, bindings: { parent: null } });
       expect(withUnusedNull.categories).deep.equal(baseline.categories);
     } finally {
-      vs.closeDb();
-      snapshot.close();
+      if (vs.isOpen)
+        vs.closeDb();
+      if (snapshot.isOpen)
+        snapshot.close();
     }
   });
 });

--- a/core/backend/src/test/standalone/ViewStoreDb.test.ts
+++ b/core/backend/src/test/standalone/ViewStoreDb.test.ts
@@ -12,6 +12,7 @@ import { ThumbnailFormatProps } from "@itwin/core-common";
 import { KnownTestLocations } from "../KnownTestLocations";
 import { SnapshotDb } from "../../IModelDb";
 import { IModelTestUtils } from "../IModelTestUtils";
+import { IModelJsFs } from "../../IModelJsFs";
 
 describe("ViewStore", function (this: Suite) {
   this.timeout(0);
@@ -335,6 +336,8 @@ describe("ViewStore", function (this: Suite) {
 
   it("selector queries should skip undefined and null bindings", async () => {
     const dbName = join(KnownTestLocations.outputDir, "viewStoreBindings.db");
+    if (IModelJsFs.existsSync(dbName))
+      IModelJsFs.removeSync(dbName);
     const snapshot = SnapshotDb.openFile(IModelTestUtils.resolveAssetFile("test.bim"));
     const vs = new ViewStore.ViewDb({ guidMap: {} as any });
     try {

--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -664,26 +664,50 @@ export class QueryBinder {
   }
 
   /**
+   * Shared implementation for [[QueryBinder.from]] and [[QueryBinder.fromSkippingNullish]].
+   * @param args if array of values is provided then array index is used as index. If object is provided then object property name is used as parameter name of reach value.
+   * @param skipNullish if true, entries whose value is `undefined` or `null` are skipped instead of bound as NULL.
+   */
+  private static fromImpl(args: any[] | object | undefined, skipNullish: boolean): QueryBinder {
+    const params = new QueryBinder();
+    if (typeof args === "undefined")
+      return params;
+
+    const shouldBind = (val: any) => !skipNullish || (val !== undefined && val !== null);
+    if (Array.isArray(args)) {
+      let i = 1;
+      for (const val of args) {
+        const index = i++;
+        if (shouldBind(val))
+          this.bind(params, index, val);
+      }
+    } else {
+      for (const prop of Object.getOwnPropertyNames(args)) {
+        const val = (args as any)[prop];
+        if (shouldBind(val))
+          this.bind(params, prop, val);
+      }
+    }
+    return params;
+  }
+
+  /**
    * Allow bulk bind either parameters by index as value array or by parameter names as object.
    * @param args if array of values is provided then array index is used as index. If object is provided then object property name is used as parameter name of reach value.
    * @returns @type QueryBinder to allow fluent interface.
    */
   public static from(args: any[] | object | undefined): QueryBinder {
-    const params = new QueryBinder();
-    if (typeof args === "undefined")
-      return params;
+    return this.fromImpl(args, false);
+  }
 
-    if (Array.isArray(args)) {
-      let i = 1;
-      for (const val of args) {
-        this.bind(params, i++, val);
-      }
-    } else {
-      for (const prop of Object.getOwnPropertyNames(args)) {
-        this.bind(params, prop, (args as any)[prop]);
-      }
-    }
-    return params;
+  /**
+   * Same as [[QueryBinder.from]], except entries whose value is `undefined` or `null` are skipped instead of bound as NULL,
+   * matching the legacy `ECSqlStatement.bindValues` semantics. For positional arrays, skipped positions are left unbound
+   * and later positions keep their 1-based index.
+   * @internal
+   */
+  public static fromSkippingNullish(args: any[] | object | undefined): QueryBinder {
+    return this.fromImpl(args, true);
   }
 
   public serialize(): object {

--- a/core/common/src/ConcurrentQuery.ts
+++ b/core/common/src/ConcurrentQuery.ts
@@ -665,7 +665,7 @@ export class QueryBinder {
 
   /**
    * Shared implementation for [[QueryBinder.from]] and [[QueryBinder.fromSkippingNullish]].
-   * @param args if array of values is provided then array index is used as index. If object is provided then object property name is used as parameter name of reach value.
+   * @param args if array of values is provided then array index is used as index. If object is provided then object property name is used as parameter name of each value.
    * @param skipNullish if true, entries whose value is `undefined` or `null` are skipped instead of bound as NULL.
    */
   private static fromImpl(args: any[] | object | undefined, skipNullish: boolean): QueryBinder {
@@ -693,7 +693,7 @@ export class QueryBinder {
 
   /**
    * Allow bulk bind either parameters by index as value array or by parameter names as object.
-   * @param args if array of values is provided then array index is used as index. If object is provided then object property name is used as parameter name of reach value.
+   * @param args if array of values is provided then array index is used as index. If object is provided then object property name is used as parameter name of each value.
    * @returns @type QueryBinder to allow fluent interface.
    */
   public static from(args: any[] | object | undefined): QueryBinder {

--- a/core/common/src/test/ConcurrentQuery.test.ts
+++ b/core/common/src/test/ConcurrentQuery.test.ts
@@ -195,6 +195,44 @@ describe("QueryBinder", () => {
     assert.throw(() => QueryBinder.from([["a"]]), "unsupported type");
   });
 
+  it("fromSkippingNullish skips undefined and null values", () => {
+    assert.deepEqual(
+      QueryBinder.fromSkippingNullish({ model: "used", parent: undefined, other: null }).serialize(),
+      {
+        model: {
+          type: QueryParamType.String,
+          value: "used",
+        },
+      },
+    );
+
+    // positional-array form: undefined/null positions are left unbound, later positions keep their index
+    assert.deepEqual(
+      QueryBinder.fromSkippingNullish([1, undefined, "third", null]).serialize(),
+      {
+        1: {
+          type: QueryParamType.Double,
+          value: 1,
+        },
+        3: {
+          type: QueryParamType.String,
+          value: "third",
+        },
+      },
+    );
+
+    // QueryBinder.from behavior is unchanged: undefined/null bind NULL
+    assert.deepEqual(
+      QueryBinder.from({ parent: undefined }).serialize(),
+      {
+        parent: {
+          type: QueryParamType.Null,
+          value: null,
+        },
+      },
+    );
+  });
+
   it("Should not fail on empty array", () => {
     const idSet: Id64String[] = [];
     const binder = QueryBinder.from([idSet]);


### PR DESCRIPTION
PR to fix `queryEntityIds` throwing on undefined/null bindings

#9463 (["Migrate hollow public/beta ECSQL APIs off withPreparedStatement to withQueryReader"](https://github.com/iTwin/itwinjs-core/pull/9463), commit 1ec1071e8c) changed `IModelDb.queryEntityIds`'s binding semantics:

- **Before**: `ECSqlStatement.bindValues` silently skipped `undefined`/`null` binding entries.
- **After**: `QueryBinder.from(params.bindings)` binds `undefined`/`null` as `NULL`, which throws (`BE_SQLITE_ERROR: Failed to bind parameters: fail to find param index for named param '...'`) if that named parameter isn't actually referenced in the ECSQL statement

`ViewStore.querySelectorValues` has the same latent bug, but the error there is caught and logged, silently returning `[]` instead of crashing.

### Fix

Added `QueryBinder.fromSkippingNullish` (`@internal`, `core/common/src/ConcurrentQuery.ts`) that restores the legacy `bindValues` skip semantics — entries with `undefined`/`null` values are omitted from binding instead of bound as `NULL`. `QueryBinder.from` itself is unchanged (no public API change). Both `queryEntityIds` (`core/backend/src/IModelDb.ts`) and `ViewStore.querySelectorValues` (`core/backend/src/ViewStore.ts`) now use the new helper. Being `@internal` and shared from `core-common`, this can be reused by other packages affected by similar migrations.

w/ help from AnmolDroid🤖 