### PR TITLE
`RegionOps` tolerance issue fixes

### DIFF
--- a/common/api/core-geometry.api.md
+++ b/common/api/core-geometry.api.md
@@ -5589,6 +5589,7 @@ export class RegionOps {
         outsideOffsets: AnyCurve[];
         chains?: AnyChain;
     };
+    static computeMinimumArea(distanceTolerance?: number): number;
     static computeXYArea(region: AnyRegion): number | undefined;
     static computeXYAreaMoments(region: AnyRegion): MomentData | undefined;
     static computeXYAreaTolerance(range: Range3d, distanceTolerance?: number): number;

--- a/common/changes/@itwin/core-geometry/da4-regionops-tolerance-issues_2026-07-22-19-06-52.json
+++ b/common/changes/@itwin/core-geometry/da4-regionops-tolerance-issues_2026-07-22-19-06-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-geometry",
+      "comment": "RegionOps tolerance fixes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-geometry"
+}

--- a/core/geometry/src/curve/Query/PlanarSubdivision.ts
+++ b/core/geometry/src/curve/Query/PlanarSubdivision.ts
@@ -214,17 +214,15 @@ export class PlanarSubdivision {
   /**
    * Based on computed (and toleranced) area, push the loop (pointer) onto the appropriate array of positive, negative,
    * or sliver loops.
-   * @param zeroAreaTolerance absolute area tolerance for sliver face detection
+   * @param areaTol absolute area tolerance for sliver face detection
    * @param isSliverFace whether the loop is known a priori (e.g., via topology) to have zero area
    * @returns the area (forced to zero if within tolerance)
    */
-  public static collectSignedLoop(
-    loop: Loop, outLoops: SignedLoops, zeroAreaTolerance: number = 1.0e-10, isSliverFace?: boolean,
-  ): number {
+  public static collectSignedLoop(loop: Loop, outLoops: SignedLoops, areaTol: number = 1.0e-10, isSliverFace?: boolean): number {
     let area = isSliverFace ? 0.0 : RegionOps.computeXYArea(loop);
     if (area === undefined)
       area = 0;
-    if (Math.abs(area) < zeroAreaTolerance)
+    if (Math.abs(area) < areaTol)
       area = 0.0;
     (loop as any).computedAreaInPlanarSubdivision = area;
     if (area > 0)
@@ -357,7 +355,7 @@ export class PlanarSubdivision {
     }
     return e1;
   }
-  public static collectSignedLoopSetsInHalfEdgeGraph(graph: HalfEdgeGraph, zeroAreaTolerance: number = 1.0e-10): SignedLoops[] {
+  public static collectSignedLoopSetsInHalfEdgeGraph(graph: HalfEdgeGraph, closureTol: number = Geometry.smallMetricDistance, areaTol: number = 1.0e-10): SignedLoops[] {
     const q = HalfEdgeGraphSearch.collectConnectedComponentsWithExteriorParityMasks(graph, undefined);
     const result: SignedLoops[] = [];
     const edgeMap = new Map<HalfEdge, LoopCurveLoopCurve>();
@@ -381,9 +379,9 @@ export class PlanarSubdivision {
             }
           }
         };
-        const loop = this.createLoopInFace(faceSeed, { announceEdge });
+        const loop = this.createLoopInFace(faceSeed, { announceEdge, closureTol });
         if (loop)
-          this.collectSignedLoop(loop, componentAreas, zeroAreaTolerance, isNullFace);
+          this.collectSignedLoop(loop, componentAreas, areaTol, isNullFace);
       }
       componentAreas.edges = edges;
       result.push(componentAreas);

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -1182,7 +1182,7 @@ export class RegionOps {
     if (addBridges && hasOpenCurve)
       RegionOps.removeExtraneousBridgeEdges(graph);
     const areaTol = this.computeMinimumArea(tolerance);
-    return PlanarSubdivision.collectSignedLoopSetsInHalfEdgeGraph(graph, areaTol);
+    return PlanarSubdivision.collectSignedLoopSetsInHalfEdgeGraph(graph, tolerance, areaTol);
   }
   /**
    * Collect all `CurvePrimitives` in loosely typed input.

--- a/core/geometry/src/curve/RegionOps.ts
+++ b/core/geometry/src/curve/RegionOps.ts
@@ -151,9 +151,10 @@ export class RegionOps {
     return undefined;
   }
   /**
-   * Return an area tolerance for a given xy-range and optional distance tolerance.
+   * Return an area tolerance for a given xy-range and distance tolerance.
    * @param range range of planar region to tolerance.
-   * @param distanceTolerance optional absolute distance tolerance.
+   * @param distanceTolerance optional absolute distance tolerance. Default is [[Geometry.smallMetricDistance]].
+   * @see [[computeMinimumArea]] for an area tolerance unscaled by geometry size, which is more widely applicable for degeneracy testing.
    */
   public static computeXYAreaTolerance(range: Range3d, distanceTolerance: number = Geometry.smallMetricDistance): number {
     // ensure the result is nonzero: we never want to report a zero-area loop as a signed-area loop
@@ -164,6 +165,17 @@ export class RegionOps {
     const halfDistTol = 0.5 * Math.abs(distanceTolerance);
     return halfDistTol * (range.xLength() + range.yLength() + halfDistTol);
   }
+  /**
+   * Return an area tolerance for a given distance tolerance.
+   * * The result can be used to determine whether a region's area is small enough to be considered degenerate.
+   * @param distanceTolerance optional minimum absolute distance between unique points. Default is [[Geometry.smallMetricDistance]].
+   */
+  public static computeMinimumArea(distanceTolerance: number = Geometry.smallMetricDistance): number {
+    const areaTol = Math.PI * distanceTolerance * distanceTolerance;
+    const minAreaTol = Geometry.smallFloatingPoint * 10; // observed area 2e-15 computed for a degenerate loop
+    return areaTol < minAreaTol ? minAreaTol : areaTol;
+  }
+
   /**
    * Return a (signed) xy area for a region.
    * * The input region should lie in a plane parallel to the xy-plane, as z-coords will be ignored.
@@ -479,8 +491,7 @@ export class RegionOps {
     const outMask = simplifyUnion ? context.graph.grabMask(false) : HalfEdgeMask.NULL_MASK;
     const outSeeds: HalfEdge[] | undefined = simplifyUnion ? [] : undefined;
     context.graph.clearMask(visitMask | outMask);
-    const range = context.groupA.range().union(context.groupB.range());
-    const areaTol = this.computeXYAreaTolerance(range, mergeTolerance);
+    const areaTol = this.computeMinimumArea(mergeTolerance);
     const z = RegionOps.getZCoordinate(operation === RegionBinaryOpType.BMinusA ? loopsB : loopsA);
     const options: PlanarSubdivision.CreateRegionInFaceOptions = { compress: true, closureTol: mergeTolerance, bridgeMask, visitMask, z };
     let numFacesIn = 0;
@@ -885,7 +896,7 @@ export class RegionOps {
     let senseEdge0 = false;
     let senseEdge1 = false;
     if (edge0.edgeTag instanceof CurveLocationDetail && edge0.edgeTag.curve !== undefined && edge0.edgeTag.isInterval() && edge0.sortData &&
-        edge1.edgeTag instanceof CurveLocationDetail && edge1.edgeTag.curve !== undefined && edge1.edgeTag.isInterval() && edge1.sortData
+      edge1.edgeTag instanceof CurveLocationDetail && edge1.edgeTag.curve !== undefined && edge1.edgeTag.isInterval() && edge1.sortData
     ) {
       sameCurves = edge0.edgeTag.curve === edge1.edgeTag.curve || edge0.edgeTag.curve.isAlmostEqual(edge1.edgeTag.curve);
       reversedCurves = !sameCurves && edge0.edgeTag.curve.isAlmostEqual(edge1.edgeTag.curve.clone().reverse());
@@ -1146,9 +1157,7 @@ export class RegionOps {
   ): SignedLoops[] {
     let primitives = RegionOps.collectCurvePrimitives(curvesAndRegions, undefined, true, true);
     primitives = TransferWithSplitArcs.clone(BagOfCurves.create(...primitives)).children as CurvePrimitive[];
-    const range = this.curveArrayRange(primitives);
-    const areaTol = this.computeXYAreaTolerance(range, tolerance);
-    let hasOpenCurve: boolean = false;
+    let hasOpenCurve = false;
     if (addBridges) { // generate a temp graph from ONLY the closed inputs to extract its bridge edges
       const context = RegionBooleanContext.create(RegionGroupOpType.Union, RegionGroupOpType.Union);
       const openCurves: AnyCurve[] = [];
@@ -1172,6 +1181,7 @@ export class RegionOps {
     const graph = PlanarSubdivision.assembleHalfEdgeGraph(primitives, intersections, tolerance);
     if (addBridges && hasOpenCurve)
       RegionOps.removeExtraneousBridgeEdges(graph);
+    const areaTol = this.computeMinimumArea(tolerance);
     return PlanarSubdivision.collectSignedLoopSetsInHalfEdgeGraph(graph, areaTol);
   }
   /**

--- a/core/geometry/src/curve/RegionOpsClassificationSweeps.ts
+++ b/core/geometry/src/curve/RegionOpsClassificationSweeps.ts
@@ -490,12 +490,12 @@ export class RegionBooleanContext implements RegionOpsFaceToFaceSearchCallbacks 
     const rangeA = this.groupA.range();
     const rangeB = this.groupB.range();
     const rangeAB = rangeA.union(rangeB);
-    const areaTol = RegionOps.computeXYAreaTolerance(rangeAB);
     let margin = 0.1;
     this._workSegment = PlaneAltitudeRangeContext.findExtremePointsInDirection(rangeAB.corners(), RegionBooleanContext._bridgeDirection, this._workSegment);
     if (this._workSegment)
       margin *= this._workSegment.point0Ref.distanceXY(this._workSegment.point1Ref);  // how much further to extend each bridge ray
     const maxPoints: Point3d[] = [];
+    const areaTol = RegionOps.computeMinimumArea(); // TODO: default tolerance used!
     const findExtremePointsInLoop = (region: Loop) => {
       const area = RegionOps.computeXYArea(region);
       if (area === undefined || Math.abs(area) < areaTol)

--- a/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
+++ b/core/geometry/src/curve/internalContexts/MultiChainCollector.ts
@@ -42,8 +42,6 @@ export class MultiChainCollector {
   private _chains: CurvePrimitive[][];
   /** Largest gap distance to close. */
   private _gapTolerance: number;
-  /** End point snap tolerance. Internally, this is an upper bound on gapTolerance. */
-  private _snapTolerance: number;
   /** Planarity tolerance, used to determine whether to return a Path or Loop in `grabResult(true)`. If undefined, always Path. */
   private _planeTolerance: number | undefined;
 
@@ -54,30 +52,28 @@ export class MultiChainCollector {
 
   /** Initialize with an empty array of chains.
    * @param gapTolerance distance tolerance for calling endpoints identical
-   * @param planeTolerance distance tolerance for considering a closed chain to be planar. If undefined, only create Path. If defined, create Loops for closed chains within tolerance of a plane.
+   * @param planeTolerance distance tolerance for considering a closed chain to be planar. If undefined, only create Path. If defined, create Loops for closed chains within this tolerance of a plane.
    */
   public constructor(gapTolerance = Geometry.smallMetricDistance, planeTolerance?: number) {
     this._chains = [];
     this._gapTolerance = gapTolerance;
-    this._snapTolerance = Geometry.smallMetricDistance;
     this._planeTolerance = planeTolerance;
   }
   /**
    * Find a chain (with index _other than_ exceptChainIndex) that starts or ends at xyz
    * @param xyz endpoint to check
-   * @param distanceTol absolute distance tolerance for equating endpoints
    * @param exceptChainIndex index of chain to ignore. Send -1 to consider all chains.
    */
-  private findAnyChainToConnect(xyz: Point3d, distanceTol: number, exceptChainIndex: number = -1): { chainIndex: number, atEnd: boolean } | undefined {
+  private findAnyChainToConnect(xyz: Point3d, exceptChainIndex: number = -1): { chainIndex: number, atEnd: boolean } | undefined {
     for (let chainIndexA = 0; chainIndexA < this._chains.length; chainIndexA++) {
       if (exceptChainIndex === chainIndexA)
         continue;
       const chain = this._chains[chainIndexA];
       this._xyzWork1 = chain[chain.length - 1].endPoint(this._xyzWork1);
-      if (this._xyzWork1.isAlmostEqual(xyz, distanceTol))
+      if (this._xyzWork1.isAlmostEqual(xyz, this._gapTolerance))
         return { chainIndex: chainIndexA, atEnd: true };
       this._xyzWork1 = chain[0].startPoint(this._xyzWork1);
-      if (this._xyzWork1.isAlmostEqual(xyz, distanceTol))
+      if (this._xyzWork1.isAlmostEqual(xyz, this._gapTolerance))
         return { chainIndex: chainIndexA, atEnd: false };
     }
     return undefined;
@@ -89,11 +85,7 @@ export class MultiChainCollector {
    * @param candidate curve to add to the context
    */
   public captureCurvePrimitive(candidate: CurvePrimitive) {
-    if (this._snapTolerance < this._gapTolerance) {
-      if (this.attachPrimitiveToAnyChain(candidate, this._snapTolerance))
-        return;
-    }
-    if (this.attachPrimitiveToAnyChain(candidate, this._gapTolerance))
+    if (this.attachPrimitiveToAnyChain(candidate))
       return;
     this._chains.push([candidate]);
   }
@@ -112,7 +104,7 @@ export class MultiChainCollector {
     }
   }
   /** If allowed by the geometry type, move an endpoint. */
-  private static simpleEndPointMove(curve: CurvePrimitive, atEnd: boolean, to: XYAndZ): boolean {
+  private simpleEndPointMove(curve: CurvePrimitive, atEnd: boolean, to: XYAndZ): boolean {
     if (curve instanceof (LineSegment3d)) {
       if (atEnd) {
         curve.point1Ref.setFrom(to);
@@ -132,39 +124,44 @@ export class MultiChainCollector {
    * * All z-coordinates are ignored.
    * @param curve0 first curve, assumed to end close to the start of curve1
    * @param curve1 second curve, assumed to start close to the end of curve0
-   * @param gapTolerance max distance to move a curve start/end point
    * @returns whether curve start/end point(s) moved
    */
-  private static moveHeadOrTail(curve0: CurvePrimitive, curve1: CurvePrimitive, gapTolerance: number): boolean {
+  private moveHeadOrTail(curve0: CurvePrimitive, curve1: CurvePrimitive): boolean {
     const xyz0 = curve0.endPoint();
     const xyz1 = curve1.startPoint();
     const minShift = Geometry.smallMetricDistance * 0.001;
-    const d01 = xyz0.distanceXY(xyz1);
-    if (d01 < minShift)
+    let dist2 = xyz0.distanceSquaredXY(xyz1);
+    if (dist2 <= minShift * minShift)
+      return false; // if the move would be miniscule, don't bother
+    const gap2 = this._gapTolerance * this._gapTolerance;
+    if (dist2 > gap2)
       return false;
     // try lines and linestrings
-    if (d01 < gapTolerance) {
-      if (this.simpleEndPointMove(curve1, false, xyz0) || this.simpleEndPointMove(curve0, true, xyz1))
-        return true;
-    }
+    if (this.simpleEndPointMove(curve1, false, xyz0) || this.simpleEndPointMove(curve0, true, xyz1))
+      return true;
+
     // try other primitive types
+    if (!(curve0 instanceof Arc3d && curve1 instanceof Arc3d))
+      return false; // currently we only consider 2 arcs
+
     const intersections = CurveCurve.intersectionXYPairs(curve0, true, curve1, true);
-    const shiftFactor = 5.0;
-    for (const pair of intersections) {
-      const detail0 = pair.detailA;
-      const detail1 = pair.detailB;
-      const distance0 = detail0.point.distanceXY(xyz0);
-      const distance1 = detail1.point.distanceXY(xyz1);
-      if (distance0 < shiftFactor * gapTolerance && distance1 < shiftFactor * gapTolerance) {
-        if (curve0 instanceof Arc3d && curve1 instanceof Arc3d) {
-          const radians0End = curve0.sweep.fractionToRadians(detail0.fraction);
-          curve0.sweep.setStartEndRadians(curve0.sweep.startRadians, radians0End);
-          const radians1Start = curve1.sweep.fractionToRadians(detail1.fraction);
-          curve1.sweep.setStartEndRadians(radians1Start, curve1.sweep.endRadians);
-          return true;
-        }
-        // TODO: other combinations of types
+    let iClosest = -1;
+    let minDist2 = Infinity;
+    for (let i = 0; i < intersections.length; ++i) { // find intersection closest to the joint
+      const dist20 = intersections[i].detailA.point.distanceSquaredXY(xyz0);
+      const dist21 = intersections[i].detailB.point.distanceSquaredXY(xyz1);
+      dist2 = dist20 + dist21;
+      if (dist20 <= gap2 && dist21 <= gap2 && dist2 < minDist2) {
+        minDist2 = dist2;
+        iClosest = i;
       }
+    }
+    if (iClosest >= 0) { // move arc ends to the intersection point
+      const radians0End = curve0.sweep.fractionToRadians(intersections[iClosest].detailA.fraction);
+      curve0.sweep.setStartEndRadians(curve0.sweep.startRadians, radians0End);
+      const radians1Start = curve1.sweep.fractionToRadians(intersections[iClosest].detailB.fraction);
+      curve1.sweep.setStartEndRadians(radians1Start, curve1.sweep.endRadians);
+      return true;
     }
     return false;
   }
@@ -172,45 +169,45 @@ export class MultiChainCollector {
    * * If a "nearby" connection is possible, insert the candidate in the chain and force endpoint match.
    * * Otherwise start a new chain.
    */
-  private attachPrimitiveToAnyChain(candidate: CurvePrimitive, distanceTol: number): boolean {
-    if (candidate.curveLength() < distanceTol) {
+  private attachPrimitiveToAnyChain(candidate: CurvePrimitive): boolean {
+    if (candidate.curveLength() < this._gapTolerance) {
       return true;
     } else {
       this._xyzWork0 = candidate.startPoint(this._xyzWork0);
-      let connect = this.findAnyChainToConnect(this._xyzWork0, distanceTol);
+      let connect = this.findAnyChainToConnect(this._xyzWork0);
       if (connect) {
         if (connect.atEnd) {
           const chain = this._chains[connect.chainIndex];
           const index0 = chain.length - 1;
           this._chains[connect.chainIndex].push(candidate);
-          MultiChainCollector.moveHeadOrTail(chain[index0], chain[index0 + 1], this._gapTolerance);
-          this.searchAndMergeChainIndex(connect.chainIndex, distanceTol);
+          this.moveHeadOrTail(chain[index0], chain[index0 + 1]);
+          this.searchAndMergeChainIndex(connect.chainIndex);
           return true;
         } else {
           candidate.reverseInPlace();
           const chain = this._chains[connect.chainIndex];
           chain.splice(0, 0, candidate);
-          MultiChainCollector.moveHeadOrTail(chain[0], chain[1], this._gapTolerance);
-          this.searchAndMergeChainIndex(connect.chainIndex, distanceTol);
+          this.moveHeadOrTail(chain[0], chain[1]);
+          this.searchAndMergeChainIndex(connect.chainIndex);
           return true;
         }
       } else {
         this._xyzWork0 = candidate.endPoint(this._xyzWork0);
-        connect = this.findAnyChainToConnect(this._xyzWork0, distanceTol);
+        connect = this.findAnyChainToConnect(this._xyzWork0);
         if (connect) {
           if (connect.atEnd) {
             candidate.reverseInPlace();
             const chain = this._chains[connect.chainIndex];
             const index0 = chain.length - 1;
             this._chains[connect.chainIndex].push(candidate);
-            MultiChainCollector.moveHeadOrTail(chain[index0], chain[index0 + 1], this._gapTolerance);
-            this.searchAndMergeChainIndex(connect.chainIndex, distanceTol);
+            this.moveHeadOrTail(chain[index0], chain[index0 + 1]);
+            this.searchAndMergeChainIndex(connect.chainIndex);
             return true;
           } else {
             const chain = this._chains[connect.chainIndex];
             chain.splice(0, 0, candidate);
-            MultiChainCollector.moveHeadOrTail(chain[0], chain[1], this._gapTolerance);
-            this.searchAndMergeChainIndex(connect.chainIndex, distanceTol);
+            this.moveHeadOrTail(chain[0], chain[1]);
+            this.searchAndMergeChainIndex(connect.chainIndex);
             return true;
           }
         }
@@ -247,13 +244,13 @@ export class MultiChainCollector {
       p.reverseInPlace();
   }
   /** See if the head or tail of chainIndex matches any existing chain. If so, merge the two chains. */
-  private searchAndMergeChainIndex(chainIndex: number, distanceTol: number): void {
+  private searchAndMergeChainIndex(chainIndex: number): void {
     // ASSUME valid index of non-empty chain
     const chain = this._chains[chainIndex];
     const lastIndexInChain = chain.length - 1;
     this._xyzWork0 = chain[0].startPoint(this._xyzWork0);
     // try start with any other chain
-    let connect = this.findAnyChainToConnect(this._xyzWork0, distanceTol, chainIndex);
+    let connect = this.findAnyChainToConnect(this._xyzWork0, chainIndex);
     if (connect) {
       if (!connect.atEnd)
         this.reverseChain(connect.chainIndex);
@@ -262,7 +259,7 @@ export class MultiChainCollector {
     }
     // try end with any other chain
     this._xyzWork0 = chain[lastIndexInChain].endPoint(this._xyzWork0);
-    connect = this.findAnyChainToConnect(this._xyzWork0, distanceTol, chainIndex);
+    connect = this.findAnyChainToConnect(this._xyzWork0, chainIndex);
     if (connect) {
       if (connect.atEnd)
         this.reverseChain(connect.chainIndex);
@@ -284,7 +281,7 @@ export class MultiChainCollector {
       const primitiveN = curves[curves.length - 1];
       MultiChainCollector._staticPointA = primitive0.startPoint(MultiChainCollector._staticPointA);
       MultiChainCollector._staticPointB = primitiveN.endPoint(MultiChainCollector._staticPointB);
-      if (MultiChainCollector.moveHeadOrTail(primitiveN, primitive0, this._gapTolerance)) {
+      if (this.moveHeadOrTail(primitiveN, primitive0)) {
         // get the corrected coordinates
         MultiChainCollector._staticPointA = primitive0.startPoint(MultiChainCollector._staticPointA);
         MultiChainCollector._staticPointB = primitiveN.endPoint(MultiChainCollector._staticPointB);

--- a/core/geometry/src/test/curve/RegionBoolean.test.ts
+++ b/core/geometry/src/test/curve/RegionBoolean.test.ts
@@ -698,7 +698,7 @@ describe("RegionBoolean", () => {
       { jsonFilePath: "./src/test/data/curve/laurynasRegion9.imjs", expectedNumComponents: 2 },
       { jsonFilePath: "./src/test/data/curve/disconnectedRegions.imjs", expectedNumComponents: 2 },
       { jsonFilePath: "./src/test/data/curve/laurynasLoops.imjs", expectedNumComponents: 1 },
-      { jsonFilePath: "./src/test/data/curve/laurynasLoops.imjs", expectedNumComponents: 1, tolerance: 0.0001 },
+      { jsonFilePath: "./src/test/data/curve/laurynasLoops.imjs", expectedNumComponents: 1, tolerance: 0.0001 }, // has ||v0-v1|| > 3.8e-5
       { jsonFilePath: "./src/test/data/curve/laurynasLoopsSimplified.imjs", expectedNumComponents: 1 },
       { jsonFilePath: "./src/test/data/curve/laurynasLoopsSimplified.imjs", expectedNumComponents: 1, tolerance: 0.0001 },
       { jsonFilePath: "./src/test/data/curve/laurynasLoopsInRectangle.imjs", expectedNumComponents: 1 },
@@ -725,15 +725,8 @@ describe("RegionBoolean", () => {
         let merged: AnyRegion | AnyRegion[] | undefined = inputs;
         if (!testCase.skipMerge) {
           // Merge inputs to split overlapping loops into disjoint loops.
-          // * This improves the results of constructAllXYRegionLoops.
-          // * This does not discover holes; this is OK, as we're only interested in the outer loop here.
-          // * It is hard to use RegionOps.regionBooleanXY to discover holes: you have to know a priori how to separate
-          //   the loops into arrays of solids and holes (for AMinusB operation) because both input arrays undergo a
-          //   union before the main parity operation starts.
-          // * RegionOps.sortOuterAndHoleLoopsXY can produce a Union/ParityRegion from loops, after which you know which
-          //   input loops are "holes". But because it doesn't compute intersections, it doesn't discover holes that
-          //   aren't already loops in the input array, and if a hole loop intersects any other loop, you don't know its
-          //   parity-rule-defined subregions.
+          // * This can improve the result of constructAllXYRegionLoops on sloppy data.
+          // * We don't use the `simplifyUnion` option, as we're only interested in the outer loop here.
           merged = RegionOps.regionBooleanXY(inputs, undefined, RegionBinaryOpType.Union, testCase.tolerance);
           if (ck.testDefined(merged, "regionBooleanXY succeeded")) {
             x0 += xDelta;

--- a/core/geometry/src/test/polyface/SearchableSetOfRange2d.test.ts
+++ b/core/geometry/src/test/polyface/SearchableSetOfRange2d.test.ts
@@ -301,7 +301,7 @@ describe("GriddedRaggedRange2dSet", () => {
     GeometryCoreTestIO.saveGeometry(allGeometry, "GriddedRaggedRange2dSet", "HelloWorld");
     expect(ck.getNumErrors()).toBe(0);
   });
-  it("FacetGrid", {timeout: 100000}, () => {
+  it("FacetGrid", {timeout: 400000}, () => {
     if (!GeometryCoreTestIO.enableLongTests)
       return;
     const ck = new Checker();

--- a/core/geometry/src/test/topology/RegionOps.test.ts
+++ b/core/geometry/src/test/topology/RegionOps.test.ts
@@ -2755,4 +2755,47 @@ describe("RegionOps.constructCurveXYOffset", () => {
   });
 });
 
+describe("RegionOps.tolerance", () => {
+  it("constructAllXYRegionLoops", () => { // verifies new tighter RegionOps area tolerance
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
 
+    const ls0 = LineString3d.create([[207039.29367799047, 503422.8479069836], [207062.3835876877, 503422.8479069836]]);
+    const ls1 = LineString3d.create([[207062.3835876877, 503422.8479069836], [207062.3835876877,503413.95902289683]]);
+    const arc = Arc3d.create(Point3d.create(207057.3835876877, 503417.8479069836), Vector3d.create(3.5355339059327373, 3.5355339059327373), Vector3d.create(3.5355339059327373, -3.5355339059327373), AngleSweep.createStartEndDegrees(-45, 45));
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, [ls0, ls1, arc]);
+
+    const tol = 1.0068472040005956; // really large! Area to find is only 5.4 m^2.
+    const result = RegionOps.constructAllXYRegionLoops([ls0, ls1, arc], tol);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, [...result.map((component) => component.positiveAreaLoops).flat()], 0, 0, 10);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, [...result.map((component) => component.negativeAreaLoops).flat()], 0, 0, -10);
+    ck.testExactNumber(1, result.length, "RegionOps.constructAllXYRegionLoops found one component");
+    if (result.length > 0) {
+      ck.testExactNumber(1, result[0].positiveAreaLoops.length, "RegionOps.constructAllXYRegionLoops found one positive area loop");
+      ck.testExactNumber(1, result[0].negativeAreaLoops.length, "RegionOps.constructAllXYRegionLoops found one negative area loop");
+    }
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.tolerance", "constructAllXYRegionLoops");
+    expect(ck.getNumErrors()).toBe(0);
+  });
+
+  it("collectChains", () => { // verifies simpler gapTolerance logic
+    const ck = new Checker();
+    const allGeometry: GeometryQuery[] = [];
+
+    const ls0 = LineString3d.create([[207062.3835876877, 503426.3516881777], [207039.0272559555, 503426.3516881777]]);
+    const ls1 = LineString3d.create([[207039.29367799047, 503435.2405722644], [207057.38360602525, 503435.2405722644]]);
+    const arc = Arc3d.create(Point3d.create(207057.3835876877, 503430.2405722644), Vector3d.create(3.5355339059327373, 3.5355339059327373), Vector3d.create(3.5355339059327373, -3.5355339059327373), AngleSweep.createStartEndDegrees(-45, 45));
+    const ls2 = LineString3d.create([[207062.3835876877, 503430.2405821084], [207062.3835876877, 503426.3516881777]]);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, [ls0, ls1, arc, ls2]);
+
+    const gapTolerance = 0.5034352405722644;
+    const result = RegionOps.collectChains([ls0, ls1, arc, ls2], gapTolerance);
+    GeometryCoreTestIO.captureCloneGeometry(allGeometry, result, 0, 0, 10);
+    if (ck.testType(result, Path, "RegionOps.collectChains joined all curves into a Path"))
+      ck.testExactNumber(4, result.children.length, "RegionOps.collectChains returned a Path with 4 children");
+
+    GeometryCoreTestIO.saveGeometry(allGeometry, "RegionOps.tolerance", "collectChains");
+    expect(ck.getNumErrors()).toBe(0);
+  });
+});


### PR DESCRIPTION
`RegionOps.collectChains` and `RegionOps.constructAllXYRegionLoops` could produce unexpected results given relatively large tolerances in some cases.

Fixes:
* In `collectChains`, remove the internal `snapTolerance` which attempted to ignore the supplied `gapTolerance` when it was too large. The problem was that `snapTolerance` was inconsistently applied. Now we honor the caller's `gapTolerance`, which is what the caller expects.
* In `constructAllXYRegionLoops` we previously used an area tolerance scaled by the geometry range perimeter to detect sliver faces. In retrospect, this was a bad idea, as the range can be skewed with non-participating (wire) geometry. In the test case this is exactly what happened, and the scaling produced an area tolerance three times as large as the area of the region the caller expected to be returned, so the region was returned as a sliver face, not as a positive-area face. Now we use a simpler, tighter area tolerance, based solely on the supplied distance tolerance.