### PR TITLE
`BriefcaseConnection.pushChanges` now updates local `changeset` state and fires `onChangesetChanged`

### DIFF
--- a/common/changes/@itwin/core-frontend/master_2026-07-29-10-28-48.json
+++ b/common/changes/@itwin/core-frontend/master_2026-07-29-10-28-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Fix changeset not being updated and onChangesetChanged not being fired after BriefcaseConnection.pullChanges",
+      "comment": "Fix changeset not being updated and onChangesetChanged not being fired after BriefcaseConnection.pushChanges",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-frontend/master_2026-07-29-10-28-48.json
+++ b/common/changes/@itwin/core-frontend/master_2026-07-29-10-28-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix changeset not being updated and onChangesetChanged not being fired after BriefcaseConnection.pullChanges",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/BriefcaseConnection.ts
+++ b/core/frontend/src/BriefcaseConnection.ts
@@ -430,7 +430,7 @@ export class BriefcaseConnection extends IModelConnection {
    */
   public async pushChanges(description: string): Promise<ChangesetIndexAndId> {
     this.requireTimeline();
-    return IpcApp.appFunctionIpc.pushChanges(this.key, description);
+    return this.changeset = await IpcApp.appFunctionIpc.pushChanges(this.key, description);
   }
 
   /** The current graphical editing scope, if one is in progress.

--- a/core/frontend/src/test/BriefcaseConnection.test.ts
+++ b/core/frontend/src/test/BriefcaseConnection.test.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChangesetIndexAndId } from "@itwin/core-common";
 import { BriefcaseConnection, LockService, LockServiceFactory } from "../BriefcaseConnection";
 import { IModelApp } from "../IModelApp";
 import { IpcApp } from "../IpcApp";
@@ -43,5 +44,84 @@ describe("BriefcaseConnection", () => {
 
     expect(lockServiceFactory).toHaveBeenCalledExactlyOnceWith(connection);
     expect(connection.locks).toBe(mockLockService);
+  });
+
+  describe("pullChanges", () => {
+    it("updates changeset and fires onChangesetChanged", async () => {
+      const originalChangeset: ChangesetIndexAndId = { index: 1, id: "original-changeset-id" };
+      const pulledChangeset: ChangesetIndexAndId = { index: 3, id: "pulled-changeset-id" };
+
+      const fakeBriefcaseProps = {
+        key: "test-key",
+        rootSubject: { name: "test" },
+        iTwinId: "11111111-1111-1111-1111-111111111111",
+        iModelId: "00000000-0000-0000-0000-000000000000",
+        changeset: originalChangeset,
+      };
+
+      vi.spyOn(IpcApp, "appFunctionIpc", "get").mockReturnValue({
+        openBriefcase: vi.fn().mockResolvedValue(fakeBriefcaseProps),
+        pullChanges: vi.fn().mockResolvedValue(pulledChangeset),
+      } as any);
+
+      const connection = await BriefcaseConnection.openFile({ fileName: "test.bim" });
+
+      expect(connection.changeset.index).toBe(originalChangeset.index);
+      expect(connection.changeset.id).toBe(originalChangeset.id);
+
+      const changesetChangedListener = vi.fn();
+      const removeListener = connection.onChangesetChanged.addListener(changesetChangedListener);
+
+      try {
+        await connection.pullChanges();
+
+        expect(connection.changeset.index).toBe(pulledChangeset.index);
+        expect(connection.changeset.id).toBe(pulledChangeset.id);
+        expect(changesetChangedListener).toHaveBeenCalledOnce();
+        expect(changesetChangedListener).toHaveBeenCalledWith(originalChangeset);
+      } finally {
+        removeListener();
+      }
+    });
+  });
+
+  describe("pushChanges", () => {
+    it("updates changeset and fires onChangesetChanged", async () => {
+      const originalChangeset: ChangesetIndexAndId = { index: 1, id: "original-changeset-id" };
+      const pushedChangeset: ChangesetIndexAndId = { index: 5, id: "pushed-changeset-id" };
+
+      const fakeBriefcaseProps = {
+        key: "test-key",
+        rootSubject: { name: "test" },
+        iTwinId: "11111111-1111-1111-1111-111111111111",
+        iModelId: "00000000-0000-0000-0000-000000000000",
+        changeset: originalChangeset,
+      };
+
+      vi.spyOn(IpcApp, "appFunctionIpc", "get").mockReturnValue({
+        openBriefcase: vi.fn().mockResolvedValue(fakeBriefcaseProps),
+        pushChanges: vi.fn().mockResolvedValue(pushedChangeset),
+      } as any);
+
+      const connection = await BriefcaseConnection.openFile({ fileName: "test.bim" });
+
+      expect(connection.changeset.index).toBe(originalChangeset.index);
+      expect(connection.changeset.id).toBe(originalChangeset.id);
+
+      const changesetChangedListener = vi.fn();
+      const removeListener = connection.onChangesetChanged.addListener(changesetChangedListener);
+
+      try {
+        const result = await connection.pushChanges("test push");
+
+        expect(result).toEqual(pushedChangeset);
+        expect(connection.changeset.index).toBe(pushedChangeset.index);
+        expect(connection.changeset.id).toBe(pushedChangeset.id);
+        expect(changesetChangedListener).toHaveBeenCalledOnce();
+        expect(changesetChangedListener).toHaveBeenCalledWith(originalChangeset);
+      } finally {
+        removeListener();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Problem

After a successful `BriefcaseConnection.pushChanges()`, the frontend connection's `changeset.id` and `changeset.index` were not updated, and `onChangesetChanged` was not fired. This meant any code relying on `iModel.changeset` or listening to `onChangesetChanged` would see stale state after pushing.

## Tests

Added unit tests for both `pullChanges` and `pushChanges` verifying that:
- `changeset.id` and `changeset.index` are updated on the connection
- `onChangesetChanged` event fires with the previous changeset

Fixes #9554

---

*This PR was created by an AI Assistant (powered by Claude Opus 4.6).*