### PR TITLE
Temporarily disable iOS Simulator tests on CI

### DIFF
--- a/common/config/azure-pipelines/templates/core-build.yaml
+++ b/common/config/azure-pipelines/templates/core-build.yaml
@@ -77,12 +77,14 @@ steps:
     env:
       IMJS_OIDC_CLIENT_ID: $(IMJS_OIDC_CLIENT_ID)
       IMJS_OIDC_CLIENT_SECRET: $(IMJS_OIDC_CLIENT_SECRET)
-    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
+    # TODO: Re-enable once the iOS Simulator runtime missing error is resolved.
+    condition: and(succeeded(), false, ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: npm run ios:all
     workingDirectory: core/backend
     displayName: Build & run iOS backend unit tests in Simulator
-    condition: and(succeeded(), ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
+    # TODO: Re-enable once the iOS Simulator runtime missing error is resolved.
+    condition: and(succeeded(), false, ${{ parameters.buildMobile }}, eq(variables['Agent.OS'], 'Darwin'))
 
   - script: node ./common/scripts/install-run-rush webpack:test -v
     workingDirectory: ${{ parameters.workingDir }}


### PR DESCRIPTION
These will be reenabled once the following runtime error has been corrected:

```
Error: The simulator 2C6AEEDF-6A12-4A7F-9ED2-EE3712D37FF4 has failed to finish booting after 0s. Original status: Device boot failed
An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=401):
The com.apple.CoreSimulator.SimRuntime.iOS-18-4 simulator runtime is not available.
```