### PR TITLE
Remove unused `open` dependency from @itwin/core-electron

### DIFF
--- a/common/changes/@itwin/core-electron/master_2026-07-30-08-02-24.json
+++ b/common/changes/@itwin/core-electron/master_2026-07-30-08-02-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "Removed unused 'open' dependency",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -649,9 +649,6 @@ importers:
       '@openid/appauth':
         specifier: ^1.3.2
         version: 1.3.2
-      open:
-        specifier: ^7.0.0
-        version: 7.4.2
       username:
         specifier: ^7.0.0
         version: 7.0.0
@@ -9052,10 +9049,6 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
-
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -15868,11 +15861,6 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
-
-  open@7.4.2:
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
 
   open@8.4.2:
     dependencies:

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "@openid/appauth": "^1.3.2",
-    "open": "^7.0.0",
     "username": "^7.0.0"
   }
 }


### PR DESCRIPTION
`@itwin/core-electron` declares a dependency on `open@^7.0.0` but no source file imports or requires it. It's been dead code since Oct 2021 when the OAuth authorization logic was extracted to `@iTwin/electron-authorization` (PR #2519).

---

*This PR was created by an AI Assistant (powered by Claude Opus 4.6).*