### PR TITLE
Try to auto-fix iOS Simulator failures when they happen

### DIFF
--- a/common/changes/@itwin/core-backend/tcobbs-ios-simulator-recovery_2026-07-31-16-52-23.json
+++ b/common/changes/@itwin/core-backend/tcobbs-ios-simulator-recovery_2026-07-31-16-52-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -187,7 +187,12 @@ jobs:
     condition: and(succeeded('ParseCommitNotes'), not(canceled()))
     strategy:
       matrix:
-        # TEMPORARY: mac-only, pinned to a specific machine, to reproduce the iOS simulator boot failure.
+        "Windows_Node_24":
+          platform: Windows_NT
+          name: $(win_pool)
+        "Linux_Node_24":
+          platform: Linux
+          name: $(linux_pool)
         "MacOS_Node_24":
           platform: Darwin
           name: $(mac_pool)
@@ -196,7 +201,6 @@ jobs:
       name: $(name)
       demands:
         - Agent.OS -equals $(platform)
-        - Agent.ComputerName -equals BuildMacM1Minion55
 
     timeoutInMinutes: 60
 

--- a/common/config/azure-pipelines/jobs/fast-ci.yaml
+++ b/common/config/azure-pipelines/jobs/fast-ci.yaml
@@ -187,12 +187,7 @@ jobs:
     condition: and(succeeded('ParseCommitNotes'), not(canceled()))
     strategy:
       matrix:
-        "Windows_Node_24":
-          platform: Windows_NT
-          name: $(win_pool)
-        "Linux_Node_24":
-          platform: Linux
-          name: $(linux_pool)
+        # TEMPORARY: mac-only, pinned to a specific machine, to reproduce the iOS simulator boot failure.
         "MacOS_Node_24":
           platform: Darwin
           name: $(mac_pool)
@@ -201,6 +196,7 @@ jobs:
       name: $(name)
       demands:
         - Agent.OS -equals $(platform)
+        - Agent.ComputerName -equals BuildMacM1Minion55
 
     timeoutInMinutes: 60
 

--- a/core/backend/scripts/runUnitTestsIosSimulator.mjs
+++ b/core/backend/scripts/runUnitTestsIosSimulator.mjs
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { createWriteStream, copyFile } from 'fs';
+import { execSync } from 'child_process';
 import { Simctl } from "node-simctl";
 import { fileURLToPath } from 'url';
 import * as path from "path";
@@ -99,6 +100,75 @@ class SimctlWithOpts extends Simctl {
 /** @param {string} message */
 function log(message) {
   console.log(message);
+}
+
+// Best-effort repair for CI agents whose CoreSimulator service is in a bad state. Two known
+// symptoms: an iOS runtime reported as available while its profile can't actually load ("runtime
+// profile not found using 'System' match policy"), and a boot that hangs indefinitely (e.g. stuck
+// "Waiting on System App"). Pruning stale devices and restarting CoreSimulator forces the daemon to
+// re-scan the installed runtimes and clears the wedged service. Invoked reactively by bootSimulator
+// when a boot fails or times out.
+function repairSimulators() {
+  const commands = [
+    "xcrun simctl shutdown all",
+    "xcrun simctl delete unavailable",
+    "killall -9 com.apple.CoreSimulator.CoreSimulatorService",
+  ];
+  for (const command of commands) {
+    try {
+      log(`Running: ${command}`);
+      const output = execSync(command, { encoding: "utf-8", stdio: "pipe" });
+      if (output.trim())
+        log(output.trim());
+    } catch (err) {
+      log(`Command failed (continuing): ${command}\n${err}`);
+    }
+  }
+}
+
+/**
+ * Boots and monitors the simulator, logging diagnostics before rethrowing on failure.
+ * @param {SimctlWithOpts} simctl
+ * @param {string} [context] extra text appended to the failure message (e.g. " after repair")
+ */
+async function startBoot(simctl, context = "") {
+  try {
+    await simctl.startBootMonitor({ shouldPreboot: true });
+  } catch (err) {
+    log(`Failed to boot simulator${context}: ${err}`);
+    await simctl.logDiagnostics();
+    throw err;
+  }
+}
+
+/**
+ * Boots the given simulator, monitoring until it finishes. Booting occasionally fails outright or
+ * hangs indefinitely (e.g. stuck "Waiting on System App" until the boot monitor times out) when a
+ * CI agent's CoreSimulator service is wedged or the device state is corrupted. When that happens,
+ * repair the service, erase the device to clear the corrupted state, and retry the boot once.
+ * @param {SimctlWithOpts} simctl
+ * @param {{ name: string; udid: string; state: string; }} device
+ */
+async function bootSimulator(simctl, device) {
+  log(`Booting simulator: ${device.name}`);
+  try {
+    await startBoot(simctl);
+    return;
+  } catch {
+    // Fall through to repair-and-retry below.
+  }
+
+  // Recover a wedged CoreSimulator service and clear any corrupted device state, then retry once.
+  log("Attempting to repair simulators and retry boot");
+  repairSimulators();
+  try {
+    await simctl.exec("erase", { args: [device.udid] });
+  } catch (err) {
+    log(`Failed to erase simulator (continuing): ${err}`);
+  }
+
+  log(`Re-booting simulator: ${device.name}`);
+  await startBoot(simctl, " after repair");
 }
 
 /**
@@ -217,14 +287,7 @@ async function main() {
 
   // Boot the simulator if needed
   if (device.state !== "Booted") {
-    log(`Booting simulator: ${device.name}`);
-    try {
-      await simctl.startBootMonitor({ shouldPreboot: true });
-    } catch (err) {
-      log(`Failed to boot simulator: ${err}`);
-      await simctl.logDiagnostics();
-      throw err;
-    }
+    await bootSimulator(simctl, device);
   }
 
   // Install the app

--- a/core/backend/scripts/runUnitTestsIosSimulator.mjs
+++ b/core/backend/scripts/runUnitTestsIosSimulator.mjs
@@ -227,6 +227,11 @@ async function main() {
   // default to exiting with an error, only when we fully complete everything will it get set to 0
   process.exitCode = 1;
 
+  // By default we never trust a leftover running simulator: a clean run always shuts its simulator
+  // down, so a still-booted one likely means a wedged/aborted previous run. Pass --use-booted to
+  // opt into reusing an already-booted simulator, e.g. to watch execution locally in a running one.
+  const useBooted = process.argv.includes("--use-booted");
+
   // get all iOS devices
   log("Getting iOS devices");
   const allResults = await simctl.getDevices(undefined, 'iOS');
@@ -252,13 +257,15 @@ async function main() {
   /** @type {{ name: string; sdk: string; udid: string; state: string; } | undefined} */
   var device;
   if (keys.length) {
-    // Look for a booted simulator
-    for (const key of keys) {
-      device = results[key].find(/** @param {{ state: string; }} curr*/(curr) => curr.state === "Booted");
-      if (device)
-        break;
+    // Only reuse an already-booted simulator when explicitly opted in (see --use-booted above).
+    if (useBooted) {
+      for (const key of keys) {
+        device = results[key].find(/** @param {{ state: string; }} curr*/(curr) => curr.state === "Booted");
+        if (device)
+          break;
+      }
     }
-    // If none are booted, use the deviceBaseName or fall back to the first one
+    // Otherwise (or if none are booted), use the deviceBaseName or fall back to the first one
     if (!device) {
       device = results[keys[0]].find(/** @param {{ name: string; }} device*/(device) => device.name.startsWith(deviceBaseName)) ?? results[keys[0]][0];
     }
@@ -285,9 +292,23 @@ async function main() {
   log(`Using simulator: ${device.name} iOS: ${device.sdk}`);
   simctl.udid = device.udid;
 
+  // Unless we're intentionally reusing a running simulator, shut down a leftover booted one so we
+  // always start from a clean boot (a still-booted sim here signals a wedged/aborted previous run).
+  if (device.state === "Booted" && !useBooted) {
+    log(`Shutting down leftover booted simulator to start fresh: ${device.name}`);
+    try {
+      await simctl.shutdownDevice();
+    } catch (err) {
+      log(`Failed to shut down simulator (continuing): ${err}`);
+    }
+    device.state = "Shutdown";
+  }
+
   // Boot the simulator if needed
   if (device.state !== "Booted") {
     await bootSimulator(simctl, device);
+  } else {
+    log(`Reusing already-booted simulator: ${device.name}`);
   }
 
   // Install the app

--- a/test-apps/display-test-app/scripts/runIosSimulator.mjs
+++ b/test-apps/display-test-app/scripts/runIosSimulator.mjs
@@ -102,11 +102,12 @@ function log(message) {
   console.log(message);
 }
 
-// Best-effort repair for CI agents that report an iOS runtime as available while its profile
-// can't actually load ("runtime profile not found using 'System' match policy"), which makes
-// boot fail. Pruning stale devices and restarting CoreSimulator forces the daemon to re-scan the
-// installed runtimes. Kept in the code so the call in main() can be re-enabled when an agent gets
-// into this state again.
+// Best-effort repair for CI agents whose CoreSimulator service is in a bad state. Two known
+// symptoms: an iOS runtime reported as available while its profile can't actually load ("runtime
+// profile not found using 'System' match policy"), and a boot that hangs indefinitely (e.g. stuck
+// "Waiting on System App"). Pruning stale devices and restarting CoreSimulator forces the daemon to
+// re-scan the installed runtimes and clears the wedged service. Invoked reactively by bootSimulator
+// when a boot fails or times out.
 function repairSimulators() {
   const commands = [
     "xcrun simctl shutdown all",
@@ -125,6 +126,51 @@ function repairSimulators() {
   }
 }
 
+/**
+ * Boots and monitors the simulator, logging diagnostics before rethrowing on failure.
+ * @param {SimctlWithOpts} simctl
+ * @param {string} [context] extra text appended to the failure message (e.g. " after repair")
+ */
+async function startBoot(simctl, context = "") {
+  try {
+    await simctl.startBootMonitor({ shouldPreboot: true });
+  } catch (err) {
+    log(`Failed to boot simulator${context}: ${err}`);
+    await simctl.logDiagnostics();
+    throw err;
+  }
+}
+
+/**
+ * Boots the given simulator, monitoring until it finishes. Booting occasionally fails outright or
+ * hangs indefinitely (e.g. stuck "Waiting on System App" until the boot monitor times out) when a
+ * CI agent's CoreSimulator service is wedged or the device state is corrupted. When that happens,
+ * repair the service, erase the device to clear the corrupted state, and retry the boot once.
+ * @param {SimctlWithOpts} simctl
+ * @param {{ name: string; udid: string; state: string; }} device
+ */
+async function bootSimulator(simctl, device) {
+  log(`Booting simulator: ${device.name}`);
+  try {
+    await startBoot(simctl);
+    return;
+  } catch {
+    // Fall through to repair-and-retry below.
+  }
+
+  // Recover a wedged CoreSimulator service and clear any corrupted device state, then retry once.
+  log("Attempting to repair simulators and retry boot");
+  repairSimulators();
+  try {
+    await simctl.exec("erase", { args: [device.udid] });
+  } catch (err) {
+    log(`Failed to erase simulator (continuing): ${err}`);
+  }
+
+  log(`Re-booting simulator: ${device.name}`);
+  await startBoot(simctl, " after repair");
+}
+
 async function main() {
   const simctl = new SimctlWithOpts();
 
@@ -133,9 +179,7 @@ async function main() {
 
   // Normally disabled. Uncomment to repair a CI agent whose simulator runtime is reported as
   // available but fails to boot ("runtime profile not found using 'System' match policy").
-  // repairSimulators();
-
-  // get all iOS devices
+  // repairSimulators();  // get all iOS devices
   log("Getting iOS devices");
   const allResults = await simctl.getDevices(undefined, 'iOS');
   // If xcode-select picks an earlier Xcode, allResults can contain entries for newer iOS versions with
@@ -195,14 +239,7 @@ async function main() {
 
   // Boot the simulator if needed
   if (device.state !== "Booted") {
-    log(`Booting simulator: ${device.name}`);
-    try {
-      await simctl.startBootMonitor({ shouldPreboot: true });
-    } catch (err) {
-      log(`Failed to boot simulator: ${err}`);
-      await simctl.logDiagnostics();
-      throw err;
-    }
+    await bootSimulator(simctl, device);
   }
 
   // Install the app

--- a/test-apps/display-test-app/scripts/runIosSimulator.mjs
+++ b/test-apps/display-test-app/scripts/runIosSimulator.mjs
@@ -177,9 +177,16 @@ async function main() {
   // default to exiting with an error, only when we fully complete everything will it get set to 0
   process.exitCode = 1;
 
+  // By default we never trust a leftover running simulator: a clean run always shuts its simulator
+  // down, so a still-booted one likely means a wedged/aborted previous run. Pass --use-booted to
+  // opt into reusing an already-booted simulator, e.g. to watch execution locally in a running one.
+  const useBooted = process.argv.includes("--use-booted");
+
   // Normally disabled. Uncomment to repair a CI agent whose simulator runtime is reported as
   // available but fails to boot ("runtime profile not found using 'System' match policy").
-  // repairSimulators();  // get all iOS devices
+  // repairSimulators();
+
+  // get all iOS devices
   log("Getting iOS devices");
   const allResults = await simctl.getDevices(undefined, 'iOS');
   // If xcode-select picks an earlier Xcode, allResults can contain entries for newer iOS versions with
@@ -204,13 +211,15 @@ async function main() {
   /** @type {{ name: string; sdk: string; udid: string; state: string; } | undefined} */
   var device;
   if (keys.length) {
-    // Look for a booted simulator
-    for (const key of keys) {
-      device = results[key].find(/** @param {{ state: string; }} curr*/(curr) => curr.state === "Booted");
-      if (device)
-        break;
+    // Only reuse an already-booted simulator when explicitly opted in (see --use-booted above).
+    if (useBooted) {
+      for (const key of keys) {
+        device = results[key].find(/** @param {{ state: string; }} curr*/(curr) => curr.state === "Booted");
+        if (device)
+          break;
+      }
     }
-    // If none are booted, use the deviceBaseName or fall back to the first one
+    // Otherwise (or if none are booted), use the deviceBaseName or fall back to the first one
     if (!device) {
       device = results[keys[0]].find(/** @param {{ name: string; }} device*/(device) => device.name.startsWith(deviceBaseName)) ?? results[keys[0]][0];
     }
@@ -237,9 +246,23 @@ async function main() {
   log(`Using simulator: ${device.name} iOS: ${device.sdk}`);
   simctl.udid = device.udid;
 
+  // Unless we're intentionally reusing a running simulator, shut down a leftover booted one so we
+  // always start from a clean boot (a still-booted sim here signals a wedged/aborted previous run).
+  if (device.state === "Booted" && !useBooted) {
+    log(`Shutting down leftover booted simulator to start fresh: ${device.name}`);
+    try {
+      await simctl.shutdownDevice();
+    } catch (err) {
+      log(`Failed to shut down simulator (continuing): ${err}`);
+    }
+    device.state = "Shutdown";
+  }
+
   // Boot the simulator if needed
   if (device.state !== "Booted") {
     await bootSimulator(simctl, device);
+  } else {
+    log(`Reusing already-booted simulator: ${device.name}`);
   }
 
   // Install the app


### PR DESCRIPTION
Update the scripts that run iOS Simulator tests in the CI Pipelines to catch any startup failure, then run some cleanup operations to try to fix any problems, then retry once.