### PR TITLE
Pin mobile RPC to 127.0.0.1, client and server

### DIFF
--- a/common/changes/@itwin/core-mobile/tcobbs-mobile-localhost-only_2026-08-05-21-06-26.json
+++ b/common/changes/@itwin/core-mobile/tcobbs-mobile-localhost-only_2026-08-05-21-06-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/mobile/src/backend/MobileRpcServer.ts
+++ b/core/mobile/src/backend/MobileRpcServer.ts
@@ -46,7 +46,7 @@ export class MobileRpcServer {
      */
     this._pingTimer = setInterval(() => { }, 5);
     this._port = MobileRpcConfiguration.setup.obtainPort();
-    this._server = new ws.Server({ port: this._port });
+    this._server = new ws.Server({ host: "127.0.0.1", port: this._port });
     this._connectionId = ++MobileRpcServer._nextId;
     MobileRpcServer.interop.connectionId = this._connectionId;
     this._onListening();

--- a/core/mobile/src/common/MobileRpcProtocol.ts
+++ b/core/mobile/src/common/MobileRpcProtocol.ts
@@ -104,7 +104,7 @@ export class MobileRpcProtocol extends RpcProtocol {
   }
 
   private connect(port: number, reset: boolean) {
-    const socket = new WebSocket(`ws://localhost:${port}`);
+    const socket = new WebSocket(`ws://127.0.0.1:${port}`);
     socket.binaryType = "arraybuffer";
     this.connectMessageHandler(socket);
     this.connectOpenHandler(socket, reset);


### PR DESCRIPTION
# Mobile RPC loopback-only changes

## Summary

Restricted the mobile RPC WebSocket connection to the IPv4 loopback interface
(`127.0.0.1`) on both the server and client, so it no longer listens on or
connects across all network interfaces.

## Rationale

- **Loopback-only:** Binding the server to a loopback address prevents remote
  hosts from reaching the RPC server.
- **Why `127.0.0.1` instead of `localhost`:** `host: "localhost"` triggers a DNS
  lookup and binds to a single resolved address (either `127.0.0.1` or `::1`),
  chosen by the resolver order (which varies by platform and Node version). If
  the server and client resolve `localhost` to different families, the
  connection is refused. Pinning both sides to `127.0.0.1` removes the DNS
  lookup and the IPv4/IPv6 ambiguity.
