### PR TITLE
Redact SAS token during logging

### DIFF
--- a/common/changes/@itwin/core-backend/tcobbs-sas-token-redact_2026-08-06-05-08-03.json
+++ b/common/changes/@itwin/core-backend/tcobbs-sas-token-redact_2026-08-06-05-08-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-mobile/tcobbs-sas-token-redact_2026-08-06-05-08-03.json
+++ b/common/changes/@itwin/core-mobile/tcobbs-sas-token-redact_2026-08-06-05-08-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-mobile",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-mobile"
+}

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -26,6 +26,11 @@ import { _hubAccess, _mockCheckpoint, _nativeDb } from "./internal/Symbols";
 
 const loggerCategory = BackendLoggerCategory.IModelDb;
 
+/** Returns a copy of `props` with the SAS token redacted. Always use this when including [[V2CheckpointAccessProps]] in a log message. */
+function redactSasToken(props: V2CheckpointAccessProps): V2CheckpointAccessProps {
+  return props.sasToken ? { ...props, sasToken: "..." } : props;
+}
+
 /** @internal */
 export interface MockCheckpoint {
   mockAttach(checkpoint: CheckpointProps): string;
@@ -238,8 +243,7 @@ export class V2CheckpointManager {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           logPrefetch(CloudSqlite.startCloudPrefetch(container, dbName, { minRequests, nRequests: maxRequests, timeout }));
         } else {
-          const logV2Props = v2props.sasToken ? { ...v2props, sasToken: "..." } : v2props;
-          Logger.logInfo(loggerCategory, `Skipping prefetch due to size limits or ongoing prefetch.`, { maxBlocks, numPrefetches: dbStats?.nPrefetch, totalBlocksInDb: dbStats?.totalBlocks, v2props: logV2Props });
+          Logger.logInfo(loggerCategory, `Skipping prefetch due to size limits or ongoing prefetch.`, { maxBlocks, numPrefetches: dbStats?.nPrefetch, totalBlocksInDb: dbStats?.totalBlocks, v2props: redactSasToken(v2props) });
         }
       }
       return { dbName, container };

--- a/core/backend/src/CheckpointManager.ts
+++ b/core/backend/src/CheckpointManager.ts
@@ -238,7 +238,8 @@ export class V2CheckpointManager {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           logPrefetch(CloudSqlite.startCloudPrefetch(container, dbName, { minRequests, nRequests: maxRequests, timeout }));
         } else {
-          Logger.logInfo(loggerCategory, `Skipping prefetch due to size limits or ongoing prefetch.`, { maxBlocks, numPrefetches: dbStats?.nPrefetch, totalBlocksInDb: dbStats?.totalBlocks, v2props });
+          const logV2Props = v2props.sasToken ? { ...v2props, sasToken: "..." } : v2props;
+          Logger.logInfo(loggerCategory, `Skipping prefetch due to size limits or ongoing prefetch.`, { maxBlocks, numPrefetches: dbStats?.nPrefetch, totalBlocksInDb: dbStats?.totalBlocks, v2props: logV2Props });
         }
       }
       return { dbName, container };

--- a/core/backend/src/test/hubaccess/CheckpointManager.test.ts
+++ b/core/backend/src/test/hubaccess/CheckpointManager.test.ts
@@ -6,8 +6,10 @@
 import { assert } from "chai";
 import * as path from "path";
 import * as sinon from "sinon";
-import { Guid } from "@itwin/core-bentley";
-import { V2CheckpointManager } from "../../CheckpointManager";
+import { Guid, Logger } from "@itwin/core-bentley";
+import { CheckpointProps, V2CheckpointManager } from "../../CheckpointManager";
+import { CloudSqlite } from "../../CloudSqlite";
+import { IModelHost } from "../../IModelHost";
 import { IModelJsFs } from "../../IModelJsFs";
 import { _hubAccess, _nativeDb } from "../../internal/Symbols";
 import { IModelTestUtils } from "../IModelTestUtils";
@@ -57,5 +59,49 @@ describe("Checkpoint Manager", () => {
     };
     const db = IModelTestUtils.tryOpenLocalFile(request);
     assert.isUndefined(db);
+  });
+
+  it("should redact the sasToken when logging that prefetch was skipped", async () => {
+    const checkpoint: CheckpointProps = {
+      iTwinId: Guid.createValue(),
+      iModelId: Guid.createValue(),
+      changeset: { id: "1234", index: 1 },
+      accessToken: "userAccessToken",
+    };
+    const v2props = {
+      accountName: "testAccount",
+      containerId: Guid.createValue(), // unique so this test doesn't reuse a container cached by another test
+      sasToken: "?sv=2018-03-28&sr=c&sp=rl&sig=superSecretSignature",
+      dbName: "testDb",
+      storageType: "azure",
+    };
+
+    sinon.stub(IModelHost, _hubAccess).get(() => ({ queryV2Checkpoint: async () => v2props } as any));
+    sinon.stub(IModelHost, "appWorkspace").get(() => ({
+      settings: {
+        getBoolean: (name: string, defaultVal: boolean) => name === "Checkpoints/prefetch" ? true : defaultVal,
+        getNumber: (_name: string, defaultVal: number) => defaultVal,
+      },
+    } as any));
+    sinon.stub(CloudSqlite, "createCloudContainer").returns({
+      containerId: v2props.containerId,
+      accessToken: v2props.sasToken,
+      isConnected: true,
+      checkForChanges: () => { },
+      disconnect: () => { }, // V2CheckpointManager caches this container, and disconnects it when IModelHost shuts down
+      queryDatabase: () => ({ totalBlocks: 1, nPrefetch: 1 }), // an in-progress prefetch forces the "skipping prefetch" path
+    } as any);
+    const logInfo = sinon.stub(Logger, "logInfo");
+
+    await V2CheckpointManager.attach(checkpoint);
+
+    const skipped = logInfo.args.find((args) => args[1].includes("Skipping prefetch"));
+    if (undefined === skipped)
+      assert.fail("expected a log message about skipping prefetch");
+
+    const metaData = skipped[2] as any;
+    assert.equal(metaData.v2props.sasToken, "...");
+    assert.equal(metaData.v2props.containerId, v2props.containerId);
+    assert.notInclude(JSON.stringify(metaData), "superSecretSignature");
   });
 });

--- a/core/mobile/src/backend/MobileFileHandler.ts
+++ b/core/mobile/src/backend/MobileFileHandler.ts
@@ -11,7 +11,7 @@ import * as fs from "node:fs";
 import * as https from "node:https";
 import * as path from "node:path";
 import { AccessToken, BentleyError, GetMetaDataFunction, Logger } from "@itwin/core-bentley";
-import { ProgressCallback, ProgressInfo, request, RequestOptions } from "./Request";
+import { getSafeUrlForLogging, ProgressCallback, ProgressInfo, request, RequestOptions } from "./Request";
 import { MobileHost } from "./MobileHost";
 
 const loggerCategory: string = "mobile.filehandler";
@@ -83,19 +83,6 @@ export class MobileFileHandler {
   }
 
   /**
-   * Make url safe for logging by removing sensitive information
-   * @param url input url that will be strip of search and query parameters and replace them by ... for security reason
-   */
-  private static getSafeUrlForLogging(url: string): string {
-    const safeToLogDownloadUrl = new URL(url);
-    if (safeToLogDownloadUrl.search && safeToLogDownloadUrl.search.length > 0)
-      safeToLogDownloadUrl.search = "...";
-    if (safeToLogDownloadUrl.hash && safeToLogDownloadUrl.hash.length > 0)
-      safeToLogDownloadUrl.hash = "...";
-    return safeToLogDownloadUrl.toString();
-  }
-
-  /**
    * Check if sas url has expired
    * @param download sas url for download
    * @param futureSeconds should be valid in future for given seconds.
@@ -125,7 +112,7 @@ export class MobileFileHandler {
    */
   public async downloadFile(_accessToken: AccessToken, downloadUrl: string, downloadToPathname: string, fileSize?: number, progressCallback?: ProgressCallback, cancelRequest?: CancelRequest): Promise<void> {
     // strip search and hash parameters from download Url for logging purpose
-    const safeToLogUrl = MobileFileHandler.getSafeUrlForLogging(downloadUrl);
+    const safeToLogUrl = getSafeUrlForLogging(downloadUrl);
     Logger.logInfo(loggerCategory, `Downloading file from ${safeToLogUrl}`);
 
     defined("downloadUrl", downloadUrl);
@@ -196,7 +183,7 @@ export class MobileFileHandler {
    * @throws [[IModelHubClientError]] with [IModelHubStatus.UndefinedArgumentError]($bentley) if one of the arguments is undefined or empty.
    */
   public async uploadFile(accessToken: AccessToken, uploadUrlString: string, uploadFromPathname: string, progressCallback?: ProgressCallback): Promise<void> {
-    const safeToLogUrl = MobileFileHandler.getSafeUrlForLogging(uploadUrlString);
+    const safeToLogUrl = getSafeUrlForLogging(uploadUrlString);
     Logger.logTrace(loggerCategory, `Uploading file to ${safeToLogUrl}`);
     defined("uploadUrlString", uploadUrlString);
     defined("uploadFromPathname", uploadFromPathname);

--- a/core/mobile/src/backend/Request.ts
+++ b/core/mobile/src/backend/Request.ts
@@ -193,6 +193,20 @@ const logRequest = (req: sarequest.SuperAgentRequest): sarequest.SuperAgentReque
   return req.on("response", logResponse(req, startTime));
 };
 
+/**
+ * Make url safe for logging by removing sensitive information
+ * @param url input url that will be strip of search and query parameters and replace them by ... for security reason
+ * @internal
+ */
+export function getSafeUrlForLogging(url: string): string {
+  const safeToLogDownloadUrl = new URL(url);
+  if (safeToLogDownloadUrl.search && safeToLogDownloadUrl.search.length > 0)
+    safeToLogDownloadUrl.search = "...";
+  if (safeToLogDownloadUrl.hash && safeToLogDownloadUrl.hash.length > 0)
+    safeToLogDownloadUrl.hash = "...";
+  return safeToLogDownloadUrl.toString();
+}
+
 /** Wrapper around making HTTP requests with the specific options.
  *
  * Usable in both a browser and node based environment.
@@ -214,7 +228,7 @@ export async function request(url: string, options: RequestOptions): Promise<Res
   if (options.headers)
     sareq = sareq.set(options.headers);
 
-  Logger.logInfo(loggerCategory, url);
+  Logger.logInfo(loggerCategory, getSafeUrlForLogging(url));
 
   if (options.accept)
     sareq = sareq.accept(options.accept);

--- a/core/mobile/src/backend/Request.ts
+++ b/core/mobile/src/backend/Request.ts
@@ -185,7 +185,7 @@ export class ResponseError extends BentleyError {
 const logResponse = (req: sarequest.SuperAgentRequest, startTime: number) => (res: sarequest.Response) => {
   const elapsed = new Date().getTime() - startTime;
   const elapsedTime = `${elapsed}ms`;
-  Logger.logTrace(loggerCategory, `${req.method.toUpperCase()} ${res.status} ${req.url} (${elapsedTime})`);
+  Logger.logTrace(loggerCategory, `${req.method.toUpperCase()} ${res.status} ${getSafeUrlForLogging(req.url)} (${elapsedTime})`);
 };
 
 const logRequest = (req: sarequest.SuperAgentRequest): sarequest.SuperAgentRequest => {
@@ -199,12 +199,16 @@ const logRequest = (req: sarequest.SuperAgentRequest): sarequest.SuperAgentReque
  * @internal
  */
 export function getSafeUrlForLogging(url: string): string {
-  const safeToLogDownloadUrl = new URL(url);
-  if (safeToLogDownloadUrl.search && safeToLogDownloadUrl.search.length > 0)
-    safeToLogDownloadUrl.search = "...";
-  if (safeToLogDownloadUrl.hash && safeToLogDownloadUrl.hash.length > 0)
-    safeToLogDownloadUrl.hash = "...";
-  return safeToLogDownloadUrl.toString();
+  try {
+    const safeToLogDownloadUrl = new URL(url);
+    if (safeToLogDownloadUrl.search && safeToLogDownloadUrl.search.length > 0)
+      safeToLogDownloadUrl.search = "...";
+    if (safeToLogDownloadUrl.hash && safeToLogDownloadUrl.hash.length > 0)
+      safeToLogDownloadUrl.hash = "...";
+    return safeToLogDownloadUrl.toString();
+  } catch {
+    return "<unparsable url>"; // never fall back to the raw url - it may contain a token
+  }
 }
 
 /** Wrapper around making HTTP requests with the specific options.


### PR DESCRIPTION
## Redact SAS tokens from logs

Prevents SAS tokens from being written to logs.

- `CheckpointManager`: redact `sasToken` in the "Skipping prefetch" log metadata.
- `Request.ts`: log request URLs through `getSafeUrlForLogging()` so query/hash values are stripped.
- Moved `getSafeUrlForLogging()` out of `MobileFileHandler` into `Request.ts` (exported as `@internal`) so both can use it.
- Added CheckpointManager test of SAS token redacting