### PR TITLE
DefinitionSet.Rank is not persisted

### DIFF
--- a/common/api/core-backend.api.md
+++ b/common/api/core-backend.api.md
@@ -64,6 +64,7 @@ import { DbOpcode } from '@itwin/core-bentley';
 import { DbResult } from '@itwin/core-bentley';
 import { DbValueType } from '@itwin/core-bentley';
 import { DefinitionElementProps } from '@itwin/core-common';
+import { DefinitionSetProps } from '@itwin/core-common';
 import { DisplayStyle3dProps } from '@itwin/core-common';
 import { DisplayStyle3dSettings } from '@itwin/core-common';
 import { DisplayStyle3dSettingsProps } from '@itwin/core-common';
@@ -2070,8 +2071,19 @@ export class DefinitionPartition extends InformationPartitionElement {
 
 // @public @preview
 export abstract class DefinitionSet extends DefinitionElement {
+    protected constructor(props: DefinitionSetProps, iModel: IModelDb);
     // (undocumented)
     static get className(): string;
+    // @beta
+    protected static readonly _customHandledProps: CustomHandledProperty[];
+    // @beta
+    static deserialize(props: DeserializeEntityArgs): DefinitionSetProps;
+    // @beta
+    rank?: Rank;
+    // @beta
+    static serialize(props: DefinitionSetProps, iModel: IModelDb): ECSqlRow;
+    // (undocumented)
+    toJSON(): DefinitionSetProps;
 }
 
 // @beta

--- a/common/api/core-common.api.md
+++ b/common/api/core-common.api.md
@@ -2381,6 +2381,12 @@ export interface DefinitionElementProps extends ElementProps {
     isPrivate?: boolean;
 }
 
+// @beta
+export interface DefinitionSetProps extends DefinitionElementProps {
+    // (undocumented)
+    rank?: Rank;
+}
+
 // @public
 export interface DeletedElementGeometryChange {
     readonly id: Id64String;

--- a/common/api/summary/core-common.exports.csv
+++ b/common/api/summary/core-common.exports.csv
@@ -216,6 +216,7 @@ beta;enum;DefaultSupportedTypes
 internal;const;defaultTileOptions
 public;interface;DefinitionElementProps
 preview;interface;DefinitionElementProps
+beta;interface;DefinitionSetProps
 public;interface;DeletedElementGeometryChange
 public;interface;DeprecatedBackgroundMapProps
 internal;class;DevToolsRpcInterface

--- a/common/changes/@itwin/core-backend/2026-08-10-09-11.json
+++ b/common/changes/@itwin/core-backend/2026-08-10-09-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/common/changes/@itwin/core-common/2026-08-10-09-11.json
+++ b/common/changes/@itwin/core-common/2026-08-10-09-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-common"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^12.28.0
         version: 12.33.0
       '@bentley/imodeljs-native':
-        specifier: 5.13.7
-        version: 5.13.7
+        specifier: 5.13.8
+        version: 5.13.8
       '@itwin/object-storage-azure':
         specifier: ^3.0.4
         version: 3.1.3
@@ -4706,8 +4706,8 @@ packages:
   '@bentley/icons-generic@1.0.34':
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  '@bentley/imodeljs-native@5.13.7':
-    resolution: {integrity: sha512-RQr1TDrQrZTE9t91zp6MDpiCfkiCJXpoJTUvz4NpPdxzT4HGnsNQ3x5RoMY2G0prI8tiMo5sAUXNENll1p3ErQ==}
+  '@bentley/imodeljs-native@5.13.8':
+    resolution: {integrity: sha512-iEYXweAkKVg66MGQGrBP45j/lpGNda9iLl+EFfOATzYyF/seQoy6v2ovTDsGAVJ2XBRRqmW+URhuGhzA2cpwKg==}
 
   '@bentley/linear-referencing-schema@2.0.3':
     resolution: {integrity: sha512-2pFIEN4BS7alIDhGous6N2icKAS8ZhVBfoWB8WvSFaYnneGv5YwbbXl46qATDdPO5jUFezkW6uVxdpp1eOgUHQ==}
@@ -11042,7 +11042,7 @@ snapshots:
 
   '@bentley/icons-generic@1.0.34': {}
 
-  '@bentley/imodeljs-native@5.13.7': {}
+  '@bentley/imodeljs-native@5.13.8': {}
 
   '@bentley/linear-referencing-schema@2.0.3': {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -111,7 +111,7 @@
     "vite": "^6.4.3"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "5.13.7",
+    "@bentley/imodeljs-native": "5.13.8",
     "@itwin/object-storage-azure": "^3.0.4",
     "@azure/storage-blob": "^12.28.0",
     "form-data": "^4.0.6",

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -1612,8 +1612,6 @@ export abstract class DefinitionElement extends InformationContentElement {
 export abstract class DefinitionSet extends DefinitionElement {
   public static override get className(): string { return "DefinitionSet"; }
   /** The Rank of a DefinitionSet indicates how it was created, who is aware of it and where it can be used.
-   * @note Setting this property when inserting or updating an element is not currently persisted - see
-   * [[DefinitionSetProps.rank]] for details.
    * @beta
    */
   public rank?: Rank;

--- a/core/backend/src/Element.ts
+++ b/core/backend/src/Element.ts
@@ -8,9 +8,9 @@
 
 import { CompressedId64Set, GuidString, Id64, Id64String, JsonUtils, OrderedId64Array } from "@itwin/core-bentley";
 import {
-  AxisAlignedBox3d, BisCodeSpec, Code, CodeScopeProps, CodeSpec, ConcreteEntityTypes, DefinitionElementProps, DrawingProps, ElementAlignedBox3d,
+  AxisAlignedBox3d, BisCodeSpec, Code, CodeScopeProps, CodeSpec, ConcreteEntityTypes, DefinitionElementProps, DefinitionSetProps, DrawingProps, ElementAlignedBox3d,
   ElementProps, EntityMetaData, EntityReferenceSet, GeometricElement2dProps, GeometricElement3dProps, GeometricElementProps,
-  GeometricModel2dProps, GeometricModel3dProps, GeometryPartProps, GeometryStreamProps, IModel, InformationPartitionElementProps, LineStyleProps, ModelProps, PhysicalElementProps, PhysicalTypeProps, Placement2d, Placement2dProps, Placement3d, Placement3dProps, ProjectInformation, ProjectInformationRecordProps, RelatedElement, RenderSchedule,
+  GeometricModel2dProps, GeometricModel3dProps, GeometryPartProps, GeometryStreamProps, IModel, InformationPartitionElementProps, LineStyleProps, ModelProps, PhysicalElementProps, PhysicalTypeProps, Placement2d, Placement2dProps, Placement3d, Placement3dProps, ProjectInformation, ProjectInformationRecordProps, Rank, RelatedElement, RenderSchedule,
   RenderTimelineProps, RepositoryLinkProps, SectionDrawingLocationProps, SectionDrawingProps, SectionType,
   SheetBorderTemplateProps, SheetProps, SheetTemplateProps, SubjectProps, TypeDefinition, TypeDefinitionElementProps, UrlLinkProps
 } from "@itwin/core-common";
@@ -1611,6 +1611,58 @@ export abstract class DefinitionElement extends InformationContentElement {
  */
 export abstract class DefinitionSet extends DefinitionElement {
   public static override get className(): string { return "DefinitionSet"; }
+  /** The Rank of a DefinitionSet indicates how it was created, who is aware of it and where it can be used.
+   * @note Setting this property when inserting or updating an element is not currently persisted - see
+   * [[DefinitionSetProps.rank]] for details.
+   * @beta
+   */
+  public rank?: Rank;
+
+  protected constructor(props: DefinitionSetProps, iModel: IModelDb) {
+    super(props, iModel);
+    this.rank = props.rank;
+  }
+
+  /**
+   * DefinitionSet custom HandledProps include 'rank'.
+   * @inheritdoc
+   * @beta
+   */
+  protected static override readonly _customHandledProps: CustomHandledProperty[] = [
+    { propertyName: "rank", source: "Class" },
+  ];
+
+  /**
+   * DefinitionSet deserializes 'rank'.
+   * @inheritdoc
+   * @beta
+   */
+  public static override deserialize(props: DeserializeEntityArgs): DefinitionSetProps {
+    const elProps = super.deserialize(props) as DefinitionSetProps;
+    if (props.row.rank !== undefined)
+      elProps.rank = JsonUtils.asInt(props.row.rank);
+    return elProps;
+  }
+
+  /**
+   * DefinitionSet serializes 'rank'.
+   * @inheritdoc
+   * @beta
+   */
+  public static override serialize(props: DefinitionSetProps, iModel: IModelDb): ECSqlRow {
+    const inst = super.serialize(props, iModel);
+    if (undefined !== props.rank) {
+      inst.rank = props.rank;
+    }
+    return inst;
+  }
+
+  public override toJSON(): DefinitionSetProps {
+    const val = super.toJSON() as DefinitionSetProps;
+    if (undefined !== this.rank)
+      val.rank = this.rank;
+    return val;
+  }
 }
 
 /** A DefinitionContainer exclusively owns a set of DefinitionElements contained within its sub-model (of type DefinitionModel).

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1681,11 +1681,6 @@ describe("iModel", () => {
   });
 
   describe("DefinitionSet.rank", () => {
-    // BisCore:DefinitionSet.Rank is a CustomHandledProperty. Native insertElement/updateElement now persist it
-    // correctly (see https://github.com/iTwin/itwinjs-backlog/issues/2314 and
-    // https://github.com/iTwin/itwinjs-core/issues/9500). These tests exercise both the TypeScript-side
-    // (de)serialization of DefinitionSet.rank and its round-trip through the normal insert/update element APIs.
-
     function setRank(iModelDb: StandaloneDb, id: Id64String, className: string, rank: Rank | undefined): void {
       withEditTxn(iModelDb, (txn) => txn.updateElement<DefinitionSetProps>({ id, classFullName: className, rank }));
     }
@@ -2686,49 +2681,6 @@ describe("iModel", () => {
     expect((db as any)._statementCache.size).to.be.greaterThan(0);
 
     txn.end("abandon");
-    db.close();
-  });
-
-  it("hasSubModel should not re-prepare its ECSqlStatement on every call (regression, see #9489)", () => {
-    // `IModelDb.Elements.hasSubModel` (and several other per-element query helpers such as `getChildrenIds`,
-    // `getParentId`, and `queryLastModifiedTime`) were migrated from `withPreparedStatement` - which reuses a
-    // compiled statement via `IModelDb._statementCache` - to `withQueryReader`, whose own doc comment states it
-    // is "step by step behaviour from the reader without any intermediate caching involved". Since these methods
-    // are invoked once per element by callers like IModelTransformer, losing statement-reuse means every call
-    // pays for a full native ECSqlStatement prepare, even though the ECSQL text never changes between calls.
-    const standaloneFile = IModelTestUtils.prepareOutputFile("IModel", "HasSubModelStatementReuse.bim");
-    const db = StandaloneDb.createEmpty(standaloneFile, { rootSubject: { name: "HasSubModelStatementReuse" } });
-
-    const elementIds: Id64String[] = withEditTxn(db, "insert elements for hasSubModel reuse test", (txn) => {
-      const categoryId = SpatialCategory.insert(txn, IModel.dictionaryId, "TestCategory", { color: ColorDef.white.toJSON() });
-      const modelId = PhysicalModel.insert(txn, IModel.rootSubjectId, "TestPhysicalModel");
-      const ids: Id64String[] = [];
-      for (let i = 0; i < 25; i++) {
-        const props: PhysicalElementProps = {
-          classFullName: PhysicalObject.classFullName,
-          model: modelId,
-          category: categoryId,
-          code: Code.createEmpty(),
-        };
-        ids.push(txn.insertElement(props));
-      }
-      return ids;
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const prepareSpy = sinon.spy(ECSqlStatement.prototype, "prepare");
-
-    for (const elementId of elementIds) {
-      // None of these elements have a sub-model, but the ECSQL text `hasSubModel` runs is identical on every
-      // call - only the bound elementId changes - so a statement cache should let this prepare once and reuse
-      // the compiled statement for every element.
-      expect(db.elements.hasSubModel(elementId)).to.be.false;
-    }
-
-    // This currently fails: hasSubModel's use of withQueryReader (no caching) means `prepare` is called once
-    // per element instead of once total.
-    expect(prepareSpy.callCount).to.equal(1, "hasSubModel should reuse a single cached prepared statement across repeated calls instead of re-preparing on every call");
-
     db.close();
   });
 

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -1681,16 +1681,16 @@ describe("iModel", () => {
   });
 
   describe("DefinitionSet.rank", () => {
-    // BisCore:DefinitionSet.Rank is a CustomHandledProperty, but DefinitionSet has no ClassHasHandler, so native's
-    // insertElement/updateElement silently drop the value - see https://github.com/iTwin/itwinjs-backlog/issues/2314
-    // and https://github.com/iTwin/itwinjs-core/issues/9500. These tests exercise the TypeScript-side (de)serialization
-    // of DefinitionSet.rank using the native ECSQL instance-write API to seed the column directly.
+    // BisCore:DefinitionSet.Rank is a CustomHandledProperty. Native insertElement/updateElement now persist it
+    // correctly (see https://github.com/iTwin/itwinjs-backlog/issues/2314 and
+    // https://github.com/iTwin/itwinjs-core/issues/9500). These tests exercise both the TypeScript-side
+    // (de)serialization of DefinitionSet.rank and its round-trip through the normal insert/update element APIs.
 
     function setRank(iModelDb: StandaloneDb, id: Id64String, className: string, rank: Rank | undefined): void {
       withEditTxn(iModelDb, (txn) => txn.updateElement<DefinitionSetProps>({ id, classFullName: className, rank }));
     }
 
-    it("should read and serialize rank once persisted (write path is not yet supported by native)", () => {
+    it("should insert, update, read and serialize rank", () => {
       const iModelFileName = IModelTestUtils.prepareOutputFile("IModel", "DefinitionSetRank.bim");
       const iModelDb = StandaloneDb.createEmpty(iModelFileName, { rootSubject: { name: "DefinitionSetRank" } });
 
@@ -1742,10 +1742,7 @@ describe("iModel", () => {
       iModelDb.close();
     });
 
-    // The following reproduces the scenario from https://github.com/iTwin/itwinjs-backlog/issues/2314: setting `rank`
-    // on insert is not currently persisted because native's insertElement silently drops DefinitionSet.Rank. Skipped
-    // until there is native/bis-schemas support for handling this CustomHandledProperty.
-    it.skip("should insert a DefinitionContainer with rank property", () => {
+    it("should insert a DefinitionContainer with rank property", () => {
       const iModelFileName = IModelTestUtils.prepareOutputFile("IModel", "DefinitionContainerRank.bim");
       const iModelDb = StandaloneDb.createEmpty(iModelFileName, { rootSubject: { name: "DefinitionContainerRank" } });
 

--- a/core/backend/src/test/imodel/IModel.test.ts
+++ b/core/backend/src/test/imodel/IModel.test.ts
@@ -10,10 +10,10 @@ import { DbResult, Guid, GuidString, Id64, Id64String, IModelStatus, Logger, Ope
 import { EditTxn, withEditTxn } from "../../EditTxn";
 import {
   AxisAlignedBox3d, BisCodeSpec, BriefcaseIdValue, ChangesetIdWithIndex, Code, CodeScopeSpec, CodeSpec, ColorByName, ColorDef, DefinitionElementProps,
-  DisplayStyleProps, DisplayStyleSettings, DisplayStyleSettingsProps, EcefLocation, ElementProps, EntityProps, FilePropertyProps,
+  DefinitionSetProps, DisplayStyleProps, DisplayStyleSettings, DisplayStyleSettingsProps, EcefLocation, ElementProps, EntityProps, FilePropertyProps,
   FontMap, FontType, GeoCoordinatesRequestProps, GeoCoordStatus, GeographicCRS, GeographicCRSProps, GeometricElementProps, GeometryParams, GeometryStreamBuilder,
   ImageSourceFormat, IModel, IModelCoordinatesRequestProps, IModelError, LightLocationProps, MapImageryProps, PhysicalElementProps,
-  PointWithStatus, QueryBinder, RelatedElement, RelationshipProps, RenderMode, SchemaState, SpatialViewDefinitionProps, SubCategoryAppearance, SubjectProps, TextureMapping,
+  PointWithStatus, QueryBinder, Rank, RelatedElement, RelationshipProps, RenderMode, SchemaState, SpatialViewDefinitionProps, SubCategoryAppearance, SubjectProps, TextureMapping,
   TextureMapProps, TextureMapUnits, TypeDefinitionElementProps, ViewDefinitionProps, ViewFlagProps, ViewFlags,
 } from "@itwin/core-common";
 import {
@@ -1680,6 +1680,92 @@ describe("iModel", () => {
     iModelDb.close();
   });
 
+  describe("DefinitionSet.rank", () => {
+    // BisCore:DefinitionSet.Rank is a CustomHandledProperty, but DefinitionSet has no ClassHasHandler, so native's
+    // insertElement/updateElement silently drop the value - see https://github.com/iTwin/itwinjs-backlog/issues/2314
+    // and https://github.com/iTwin/itwinjs-core/issues/9500. These tests exercise the TypeScript-side (de)serialization
+    // of DefinitionSet.rank using the native ECSQL instance-write API to seed the column directly.
+
+    function setRank(iModelDb: StandaloneDb, id: Id64String, className: string, rank: Rank | undefined): void {
+      withEditTxn(iModelDb, (txn) => txn.updateElement<DefinitionSetProps>({ id, classFullName: className, rank }));
+    }
+
+    it("should read and serialize rank once persisted (write path is not yet supported by native)", () => {
+      const iModelFileName = IModelTestUtils.prepareOutputFile("IModel", "DefinitionSetRank.bim");
+      const iModelDb = StandaloneDb.createEmpty(iModelFileName, { rootSubject: { name: "DefinitionSetRank" } });
+
+      const containerId = withEditTxn(iModelDb, (txn) => DefinitionContainer.insert(txn, IModel.dictionaryId, Code.createEmpty()));
+      const groupId = withEditTxn(iModelDb, (txn) => DefinitionGroup.create(iModelDb, IModel.dictionaryId, Code.createEmpty()).insert(txn));
+
+      // Freshly inserted DefinitionSets have no rank persisted.
+      assert.isUndefined(iModelDb.elements.getElementProps<DefinitionSetProps>(containerId).rank);
+      assert.isUndefined(iModelDb.elements.getElement<DefinitionContainer>(containerId).rank);
+
+      setRank(iModelDb, containerId, DefinitionContainer.classFullName, Rank.Application);
+      setRank(iModelDb, groupId, DefinitionGroup.classFullName, Rank.Domain);
+
+      const containerProps = iModelDb.elements.getElementProps<DefinitionSetProps>(containerId);
+      assert.equal(containerProps.rank, Rank.Application);
+
+      const container = iModelDb.elements.getElement<DefinitionContainer>(containerId);
+      assert.equal(container.rank, Rank.Application);
+      assert.equal(container.toJSON().rank, Rank.Application);
+
+      const group = iModelDb.elements.getElement<DefinitionGroup>(groupId);
+      assert.equal(group.rank, Rank.Domain);
+      assert.equal(group.toJSON().rank, Rank.Domain);
+
+      iModelDb.close();
+    });
+
+    it("should serialize/deserialize DefinitionSet.rank via DefinitionSet.serialize/deserialize", () => {
+      const iModelFileName = IModelTestUtils.prepareOutputFile("IModel", "DefinitionSetRankSerialize.bim");
+      const iModelDb = StandaloneDb.createEmpty(iModelFileName, { rootSubject: { name: "DefinitionSetRankSerialize" } });
+
+      const props: DefinitionSetProps = {
+        classFullName: DefinitionContainer.classFullName,
+        model: IModel.dictionaryId,
+        code: Code.createEmpty(),
+        rank: Rank.User,
+      };
+      const row = DefinitionContainer.serialize(props, iModelDb);
+      assert.equal(row.rank, Rank.User);
+
+      const propsWithoutRank: DefinitionSetProps = {
+        classFullName: DefinitionContainer.classFullName,
+        model: IModel.dictionaryId,
+        code: Code.createEmpty(),
+      };
+      const rowWithoutRank = DefinitionContainer.serialize(propsWithoutRank, iModelDb);
+      assert.isUndefined(rowWithoutRank.rank);
+
+      iModelDb.close();
+    });
+
+    // The following reproduces the scenario from https://github.com/iTwin/itwinjs-backlog/issues/2314: setting `rank`
+    // on insert is not currently persisted because native's insertElement silently drops DefinitionSet.Rank. Skipped
+    // until there is native/bis-schemas support for handling this CustomHandledProperty.
+    it.skip("should insert a DefinitionContainer with rank property", () => {
+      const iModelFileName = IModelTestUtils.prepareOutputFile("IModel", "DefinitionContainerRank.bim");
+      const iModelDb = StandaloneDb.createEmpty(iModelFileName, { rootSubject: { name: "DefinitionContainerRank" } });
+
+      const containerId = withEditTxn(iModelDb, (txn) => {
+        const containerProps: DefinitionSetProps = {
+          classFullName: DefinitionContainer.classFullName,
+          model: IModel.dictionaryId,
+          code: Code.createEmpty(),
+          rank: Rank.Application,
+        };
+        return txn.insertElement(containerProps);
+      });
+
+      const inserted = iModelDb.elements.getElementProps<DefinitionSetProps>(containerId);
+      assert.equal(inserted.rank, Rank.Application);
+
+      iModelDb.close();
+    });
+  });
+
   it("should set EC properties of various types", async () => {
 
     const testImodel = imodel1;
@@ -2603,6 +2689,49 @@ describe("iModel", () => {
     expect((db as any)._statementCache.size).to.be.greaterThan(0);
 
     txn.end("abandon");
+    db.close();
+  });
+
+  it("hasSubModel should not re-prepare its ECSqlStatement on every call (regression, see #9489)", () => {
+    // `IModelDb.Elements.hasSubModel` (and several other per-element query helpers such as `getChildrenIds`,
+    // `getParentId`, and `queryLastModifiedTime`) were migrated from `withPreparedStatement` - which reuses a
+    // compiled statement via `IModelDb._statementCache` - to `withQueryReader`, whose own doc comment states it
+    // is "step by step behaviour from the reader without any intermediate caching involved". Since these methods
+    // are invoked once per element by callers like IModelTransformer, losing statement-reuse means every call
+    // pays for a full native ECSqlStatement prepare, even though the ECSQL text never changes between calls.
+    const standaloneFile = IModelTestUtils.prepareOutputFile("IModel", "HasSubModelStatementReuse.bim");
+    const db = StandaloneDb.createEmpty(standaloneFile, { rootSubject: { name: "HasSubModelStatementReuse" } });
+
+    const elementIds: Id64String[] = withEditTxn(db, "insert elements for hasSubModel reuse test", (txn) => {
+      const categoryId = SpatialCategory.insert(txn, IModel.dictionaryId, "TestCategory", { color: ColorDef.white.toJSON() });
+      const modelId = PhysicalModel.insert(txn, IModel.rootSubjectId, "TestPhysicalModel");
+      const ids: Id64String[] = [];
+      for (let i = 0; i < 25; i++) {
+        const props: PhysicalElementProps = {
+          classFullName: PhysicalObject.classFullName,
+          model: modelId,
+          category: categoryId,
+          code: Code.createEmpty(),
+        };
+        ids.push(txn.insertElement(props));
+      }
+      return ids;
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const prepareSpy = sinon.spy(ECSqlStatement.prototype, "prepare");
+
+    for (const elementId of elementIds) {
+      // None of these elements have a sub-model, but the ECSQL text `hasSubModel` runs is identical on every
+      // call - only the bound elementId changes - so a statement cache should let this prepare once and reuse
+      // the compiled statement for every element.
+      expect(db.elements.hasSubModel(elementId)).to.be.false;
+    }
+
+    // This currently fails: hasSubModel's use of withQueryReader (no caching) means `prepare` is called once
+    // per element instead of once total.
+    expect(prepareSpy.callCount).to.equal(1, "hasSubModel should reuse a single cached prepared statement across repeated calls instead of re-preparing on every call");
+
     db.close();
   });
 

--- a/core/common/src/ElementProps.ts
+++ b/core/common/src/ElementProps.ts
@@ -556,9 +556,6 @@ export enum Rank {
 }
 
 /** Parameters of a [DefinitionSet]($backend), unifying [DefinitionContainer]($backend) and [DefinitionGroup]($backend).
- * @note Setting `rank` when inserting or updating an element is not currently persisted - see the corresponding
- * [GitHub issue](https://github.com/iTwin/itwinjs-core/issues/9500) for details. Values already stored in an iModel
- * are read back correctly.
  * @beta
  */
 export interface DefinitionSetProps extends DefinitionElementProps {

--- a/core/common/src/ElementProps.ts
+++ b/core/common/src/ElementProps.ts
@@ -540,7 +540,7 @@ export interface LightLocationProps extends GeometricElement3dProps {
   enabled?: boolean;
 }
 
-/** The *rank* for a Category
+/** The *rank* for a [Category]($backend), [SubCategory]($backend), or [DefinitionSet]($backend).
  * @public @preview
  * @extensions
  */
@@ -553,6 +553,16 @@ export enum Rank {
   Application = 2,
   /** This category is defined by a user. Elements in this category are not recognized by system, schema, and application classes. */
   User = 3,
+}
+
+/** Parameters of a [DefinitionSet]($backend), unifying [DefinitionContainer]($backend) and [DefinitionGroup]($backend).
+ * @note Setting `rank` when inserting or updating an element is not currently persisted - see the corresponding
+ * [GitHub issue](https://github.com/iTwin/itwinjs-core/issues/9500) for details. Values already stored in an iModel
+ * are read back correctly.
+ * @beta
+ */
+export interface DefinitionSetProps extends DefinitionElementProps {
+  rank?: Rank;
 }
 
 /** Parameters of a [Category]($backend)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -8,6 +8,8 @@ publish: false
     - [Edit from element, model, and aspect callbacks](#edit-from-element-model-and-aspect-callbacks)
     - [WorkspaceDb file resource APIs deprecated](#workspacedb-file-resource-apis-deprecated)
     - [Stream element aspects for multiple elements](#stream-element-aspects-for-multiple-elements)
+  - [@itwin/core-common](#itwincore-common)
+    - [Rank support for DefinitionSet](#rank-support-for-definitionset)
   - [@itwin/core-geometry](#itwincore-geometry)
     - [Simplifying filleted line strings](#simplifying-filleted-line-strings)
 
@@ -49,7 +51,15 @@ The options support the same polymorphic `aspectClassFullName` filter as `getAsp
 
 [[include:CoreBackend.IModelDb.QueryAspects]]
 
-## @itwin/geometry
+## @itwin/core-common
+
+### Rank support for DefinitionSet
+
+[BisCore:DefinitionSet]($docs/bis/domains/BisCore.ecschema.md) (the base class of [DefinitionContainer]($backend) and [DefinitionGroup]($backend)) has a `Rank` property, but the iTwin.js API had no counterpart for it - `Rank` was only exposed for [Category]($backend)/[SubCategory]($backend). The new `@beta` [DefinitionSetProps.rank]($common) property (and the corresponding [DefinitionSet.rank]($backend) member) close that gap, using the same [Rank]($common) enum already used by `CategoryProps.rank`.
+
+**Note:** setting `rank` when inserting or updating a `DefinitionContainer` or `DefinitionGroup` is not yet persisted - see [itwinjs-core#9500](https://github.com/iTwin/itwinjs-core/issues/9500) for details and status. `rank` values already present in an iModel (for example, set directly via ECSQL) are read back correctly through [IModelDb.Elements.getElementProps]($backend) and [DefinitionSet.toJSON]($backend).
+
+## @itwin/core-geometry
 
 ### Simplifying filleted line strings
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -55,9 +55,7 @@ The options support the same polymorphic `aspectClassFullName` filter as `getAsp
 
 ### Rank support for DefinitionSet
 
-[BisCore:DefinitionSet]($docs/bis/domains/BisCore.ecschema.md) (the base class of [DefinitionContainer]($backend) and [DefinitionGroup]($backend)) has a `Rank` property, but the iTwin.js API had no counterpart for it - `Rank` was only exposed for [Category]($backend)/[SubCategory]($backend). The new `@beta` [DefinitionSetProps.rank]($common) property (and the corresponding [DefinitionSet.rank]($backend) member) close that gap, using the same [Rank]($common) enum already used by `CategoryProps.rank`.
-
-**Note:** setting `rank` when inserting or updating a `DefinitionContainer` or `DefinitionGroup` is not yet persisted - see [itwinjs-core#9500](https://github.com/iTwin/itwinjs-core/issues/9500) for details and status. `rank` values already present in an iModel (for example, set directly via ECSQL) are read back correctly through [IModelDb.Elements.getElementProps]($backend) and [DefinitionSet.toJSON]($backend).
+[BisCore:DefinitionSet]($docs/bis/domains/BisCore.ecschema.md) (the base class of [DefinitionContainer]($backend) and [DefinitionGroup]($backend)) has a `Rank` property, but the iTwin.js API had no counterpart for it - `Rank` was only exposed for [Category]($backend)/[SubCategory]($backend). The new `@beta` [DefinitionSetProps.rank]($common) property (and the corresponding [DefinitionSet.rank]($backend) member) close that gap, using the same [Rank]($common) enum already used by `CategoryProps.rank`. `rank` is persisted when inserting or updating a `DefinitionContainer` or `DefinitionGroup`, and is read back correctly through [IModelDb.Elements.getElementProps]($backend) and [DefinitionSet.toJSON]($backend).
 
 ## @itwin/core-geometry
 

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:5.13.7'
+    implementation 'com.github.itwin:mobile-native-android:5.13.8'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.13.7;
+				version = 5.13.8;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.13.7;
+				version = 5.13.8;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
imodel-native: https://github.com/iTwin/imodel-native/pull/1540

closes: https://github.com/iTwin/itwinjs-backlog/issues/2314

Expose `DefintionSet.Rank` via typescript. Also fix issue where we ignored the property when persisting the instance. 
