### PR TITLE
Fix permissions in chmod call to be octal

### DIFF
--- a/full-stack-tests/backend/src/integration/Checkpoints.test.ts
+++ b/full-stack-tests/backend/src/integration/Checkpoints.test.ts
@@ -45,7 +45,7 @@ describe("Checkpoints", () => {
 
   const startDaemon = async () => {
     // Start daemon process and wait for it to be ready
-    fs.chmodSync((NativeCloudSqlite.Daemon as any).exeName({}), 744);
+    fs.chmodSync((NativeCloudSqlite.Daemon as any).exeName({}), 0o744);
     daemon = NativeCloudSqlite.Daemon.start({ ...daemonProps, ...cacheProps });
     while (!IModelJsFs.existsSync(path.join(cloudcacheDir, "portnumber.bcv"))) {
       await new Promise((resolve) => setImmediate(resolve));


### PR DESCRIPTION
CheckPoints.test.ts executes `chmodSync` on the `iTwinDaemon` executable file. The intent was to set the permissions to 744 octal, but it omitted the `0o` prefix, which resulted in very unusual permissions (which didn't cause the test to fail). This adds the octal prefix to produce the desired permissions.