### PR TITLE
Fix `PresentationManager.getElementProperties` failing when called with class names that match SQLite keywords

### DIFF
--- a/common/changes/@itwin/presentation-backend/presentation-fix-element-properties-with-specific-class-names_2026-08-11-07-50-31.json
+++ b/common/changes/@itwin/presentation-backend/presentation-fix-element-properties-with-specific-class-names_2026-08-11-07-50-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "Fix `PresentationManager.getElementProperties` failing when called with class names that match SQLite keywords.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
+++ b/full-stack-tests/presentation/src/backend/PresentationManager.test.ts
@@ -170,16 +170,22 @@ describe("PresentationManager", () => {
   });
 
   describe("getElementProperties", () => {
+    it("returns properties of specific elements by element ID", async () => {
+      using manager = new PresentationManager();
+      const { iterator } = await manager.getElementProperties({ imodel, elementIds: ["0x74", "0x1", "0x75"] });
+      expect((await collect(iterator())).flat()).to.matchSnapshot();
+    });
+
     it("returns properties for some elements of class 'PhysicalObject", async () => {
       using manager = new PresentationManager();
       const { iterator } = await manager.getElementProperties({ imodel, elementClasses: ["Generic:PhysicalObject"] });
       expect((await collect(iterator())).flat()).to.matchSnapshot();
     });
 
-    it("returns properties of specific elements by element ID", async () => {
+    it("succeeds in requesting properties of elements whose classes match SQLite keywords", async () => {
       using manager = new PresentationManager();
-      const { iterator } = await manager.getElementProperties({ imodel, elementIds: ["0x74", "0x1", "0x75"] });
-      expect((await collect(iterator())).flat()).to.matchSnapshot();
+      const { iterator } = await manager.getElementProperties({ imodel, elementClasses: ["Generic:Group"] });
+      expect((await collect(iterator())).flat()).to.be.empty;
     });
   });
 

--- a/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
+++ b/presentation/backend/src/presentation-backend/ElementPropertiesHelper.ts
@@ -21,15 +21,10 @@ import {
   Ruleset,
   RulesetVariable,
 } from "@itwin/presentation-common";
-
-/** @internal */
-export function parseFullClassName(fullClassName: string): [string, string] {
-  const [schemaName, className] = fullClassName.split(/[:\.]/);
-  return [schemaName, className];
-}
+import { parseFullClassName } from "@itwin/presentation-shared";
 
 function getECSqlName(fullClassName: string) {
-  const [schemaName, className] = parseFullClassName(fullClassName);
+  const { schemaName, className } = parseFullClassName(fullClassName);
   return `[${schemaName}].[${className}]`;
 }
 
@@ -158,7 +153,7 @@ function createElementIdsECExpressionFilter(batch: Array<{ from: Id64String; to:
 }
 
 function createClassContentRuleset(fullClassName: string): Ruleset {
-  const [schemaName, className] = parseFullClassName(fullClassName);
+  const { schemaName, className } = parseFullClassName(fullClassName);
   return {
     id: `content/class-descriptor/${fullClassName}`,
     rules: [
@@ -293,7 +288,7 @@ export async function getElementsCount(db: IModelDb, classNames: string[]) {
         Valid class name formats: "<schema name or alias>.<class name>", "<schema name or alias>:<class name>"`,
       );
     }
-    return `e.ECClassId IS (${classNames.join(",")})`;
+    return `e.ECClassId IS (${classNames.map(getECSqlName).join(",")})`;
   })();
   const query = `
     SELECT COUNT(e.ECInstanceId) AS elementCount


### PR DESCRIPTION
Fixes:
```
Extracting elements via getElementProperties...
  Generic:Group: skipped — Failed to parse ECSQL 'select * from (SELECT COUNT(e.ECInstanceId) AS elementCount
    FROM bis.Element e
    WHERE e.ECClassId IS (Generic:Group) 
) limit :sys_ecdb_count offset :sys_ecdb_offset': syntax error
  A1_Gebaeude:Window: skipped — Failed to parse ECSQL 'select * from (SELECT COUNT(e.ECInstanceId) AS elementCount
    FROM bis.Element e
    WHERE e.ECClassId IS (A1_Gebaeude:Window) 
) limit :sys_ecdb_count offset :sys_ecdb_offset': syntax error
```