### PR TITLE
fix(build-tools): make mocha-junit-reporter an optional peer dependency

### DIFF
--- a/common/changes/@itwin/appui-abstract/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/appui-abstract/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-abstract",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-abstract"
+}

--- a/common/changes/@itwin/build-tools/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/build-tools/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Made mocha-junit-reporter an optional peer dependency of @itwin/build-tools so consumers that do not use the public mocha reporter do not install its Mocha dependency closure.",
+      "type": "none",
+      "packageName": "@itwin/build-tools"
+    }
+  ],
+  "packageName": "@itwin/build-tools",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/common/changes/@itwin/core-electron/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/core-electron/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/common/changes/@itwin/core-i18n/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/core-i18n/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-i18n",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-i18n"
+}

--- a/common/changes/@itwin/core-markup/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/core-markup/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-markup",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-markup"
+}

--- a/common/changes/@itwin/ecschema-rpcinterface-tests/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/ecschema-rpcinterface-tests/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/ecschema-rpcinterface-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/ecschema-rpcinterface-tests"
+}

--- a/common/changes/@itwin/frontend-tiles/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/frontend-tiles/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/frontend-tiles",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/frontend-tiles"
+}

--- a/common/changes/@itwin/hypermodeling-frontend/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/hypermodeling-frontend/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/hypermodeling-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/hypermodeling-frontend"
+}

--- a/common/changes/@itwin/map-layers-auth/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/map-layers-auth/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-auth",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-auth"
+}

--- a/common/changes/@itwin/map-layers-formats/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/map-layers-formats/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/map-layers-formats",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/map-layers-formats"
+}

--- a/common/changes/@itwin/presentation-backend/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/presentation-backend/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-backend"
+}

--- a/common/changes/@itwin/presentation-common/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/presentation-common/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-common",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-common"
+}

--- a/common/changes/@itwin/presentation-frontend/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/presentation-frontend/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/presentation-frontend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/presentation-frontend"
+}

--- a/common/changes/@itwin/rpcinterface-full-stack-tests/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/rpcinterface-full-stack-tests/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/rpcinterface-full-stack-tests",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/rpcinterface-full-stack-tests"
+}

--- a/common/changes/@itwin/webgl-compatibility/nam-build-tools-junit-peer_2026-08-14.json
+++ b/common/changes/@itwin/webgl-compatibility/nam-build-tools-junit-peer_2026-08-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/webgl-compatibility",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/webgl-compatibility"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -720,7 +720,7 @@
     },
     {
       "name": "mocha-junit-reporter",
-      "allowedCategories": [ "tools" ]
+      "allowedCategories": [ "backend", "common", "extensions", "frontend", "integration-testing", "internal", "tools" ]
     },
     {
       "name": "multiparty",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -695,6 +695,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1049,6 +1052,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -1122,6 +1128,12 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      mocha:
+        specifier: ^11.1.0
+        version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1192,6 +1204,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -1380,6 +1395,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1737,6 +1755,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1861,6 +1882,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       npm-run-all2:
         specifier: ^7.0.2
         version: 7.0.2
@@ -1984,6 +2008,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -2044,6 +2071,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -2141,6 +2171,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -2522,6 +2555,12 @@ importers:
       mkdirp:
         specifier: ^1.0.4
         version: 1.0.4
+      mocha:
+        specifier: ^11.1.0
+        version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       nock:
         specifier: ^12.0.3
         version: 12.0.3
@@ -2676,6 +2715,9 @@ importers:
       internal-tools:
         specifier: workspace:*
         version: link:../../tools/internal
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       npm-run-all2:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2847,6 +2889,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       prettier:
         specifier: ^3.2.5
         version: 3.9.6
@@ -2947,6 +2992,12 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      mocha:
+        specifier: ^11.1.0
+        version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       null-loader:
         specifier: ^4.0.1
         version: 4.0.1(webpack@5.108.4)
@@ -3089,6 +3140,9 @@ importers:
       internal-tools:
         specifier: workspace:*
         version: link:../../tools/internal
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       npm-run-all2:
         specifier: ^7.0.2
         version: 7.0.2
@@ -3237,6 +3291,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       prettier:
         specifier: ^3.2.5
         version: 3.9.6
@@ -3340,6 +3397,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       prettier:
         specifier: ^3.2.5
         version: 3.9.6
@@ -3464,6 +3524,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       prettier:
         specifier: ^3.2.5
         version: 3.9.6
@@ -4101,9 +4164,6 @@ importers:
       fs-extra:
         specifier: ^8.1.0
         version: 8.1.0
-      mocha-junit-reporter:
-        specifier: ^2.0.2
-        version: 2.2.1(mocha@11.7.6)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -4138,6 +4198,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
 
   ../../tools/certa:
     dependencies:
@@ -4312,6 +4375,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
 
   ../../tools/perf-tools:
     dependencies:
@@ -4385,6 +4451,9 @@ importers:
       mocha:
         specifier: ^11.1.0
         version: 11.7.6
+      mocha-junit-reporter:
+        specifier: ^2.0.2
+        version: 2.2.1(mocha@11.7.6)
       raf:
         specifier: ^3.4.0
         version: 3.4.1

--- a/core/electron/package.json
+++ b/core/electron/package.json
@@ -57,6 +57,7 @@
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "rimraf": "^6.0.1",
     "source-map-loader": "^5.0.0",
     "typescript": "~5.6.2",

--- a/core/hypermodeling/package.json
+++ b/core/hypermodeling/package.json
@@ -60,6 +60,7 @@
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "nyc": "^17.1.0",
     "rimraf": "^6.0.1",
     "source-map-loader": "^5.0.0",

--- a/core/i18n/package.json
+++ b/core/i18n/package.json
@@ -58,6 +58,8 @@
     "chai": "^4.3.10",
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
+    "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "rimraf": "^6.0.1",
     "source-map-loader": "^5.0.0",
     "typescript": "~5.6.2",

--- a/core/markup/package.json
+++ b/core/markup/package.json
@@ -65,6 +65,7 @@
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "nyc": "^17.1.0",
     "rimraf": "^6.0.1",
     "source-map-loader": "^5.0.0",

--- a/core/webgl-compatibility/package.json
+++ b/core/webgl-compatibility/package.json
@@ -51,6 +51,7 @@
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "rimraf": "^6.0.1",
     "source-map-loader": "^5.0.0",
     "typescript": "~5.6.2",

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -4,6 +4,8 @@ publish: false
 # NextVersion
 
 - [NextVersion](#nextversion)
+  - [@itwin/build-tools](#itwinbuild-tools)
+    - [`mocha-junit-reporter` is now an optional peer dependency](#mocha-junit-reporter-is-now-an-optional-peer-dependency)
   - [@itwin/core-common](#itwincore-common)
     - [QueryBinder.bindIdSet now throws on invalid ids](#querybinderbindidset-now-throws-on-invalid-ids)
   - [@itwin/core-backend](#itwincore-backend)
@@ -80,3 +82,11 @@ The options support the same polymorphic `aspectClassFullName` filter as `getAsp
 ### Simplifying filleted line strings
 
 The [CurveFactory.createFilletsInLineString]($core-geometry) options bundle [CreateFilletsInLineStringOptions]($core-geometry) has a new optional property `CreateFilletsInLineStringOptions.simplifyPath` defaulting to `false`. When set to `true`, the output [Path]($core-geometry) is simplified by removing small segments less than the `CreateFilletsInLineStringOptions.closureTolerance` in length, and by merging adjacent arcs where possible. This is particularly helpful in cleaning up an output `Path` containing fillets that entirely consume an input line string edge (or nearly so).
+
+## @itwin/build-tools
+
+### `mocha-junit-reporter` is now an optional peer dependency
+
+`@itwin/build-tools` now declares `mocha` and `mocha-junit-reporter` as optional peer dependencies. Consumers that use the public `@itwin/build-tools/mocha-reporter` entry point must declare both packages in their own development dependencies.
+
+Consumers that do not use the reporter no longer install the reporter's Mocha integration through `@itwin/build-tools`, avoiding its transitive test-tool dependencies in downstream audits. The reporter remains available and its runtime behavior is unchanged for consumers that declare the required packages.

--- a/example-code/app/package.json
+++ b/example-code/app/package.json
@@ -37,6 +37,7 @@
     "cpx2": "^8.0.0",
     "eslint": "^9.31.0",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"
   },

--- a/example-code/snippets/package.json
+++ b/example-code/snippets/package.json
@@ -60,6 +60,7 @@
     "jsdom": "^26.0.0",
     "mkdirp": "^1.0.4",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "npm-run-all2": "^7.0.2",
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2"

--- a/extensions/frontend-tiles/package.json
+++ b/extensions/frontend-tiles/package.json
@@ -68,6 +68,7 @@
     "glob": "^13.0.6",
     "internal-tools": "workspace:*",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "rimraf": "^6.0.1",
     "sinon": "^17.0.2",
     "source-map-loader": "^5.0.0",

--- a/extensions/map-layers-auth/package.json
+++ b/extensions/map-layers-auth/package.json
@@ -55,6 +55,7 @@
     "eslint": "^9.31.0",
     "internal-tools": "workspace:*",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "nyc": "^17.1.0",
     "rimraf": "^6.0.1",
     "sinon": "^17.0.2",

--- a/extensions/map-layers-formats/package.json
+++ b/extensions/map-layers-formats/package.json
@@ -67,6 +67,7 @@
     "internal-tools": "workspace:*",
     "jsdom": "^26.0.0",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "nyc": "^17.1.0",
     "rimraf": "^6.0.1",
     "sinon": "^17.0.2",

--- a/full-stack-tests/core/package.json
+++ b/full-stack-tests/core/package.json
@@ -93,6 +93,8 @@
     "glob": "^13.0.6",
     "https-browserify": "^1.0.0",
     "internal-tools": "workspace:*",
+    "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "mkdirp": "^1.0.4",
     "nock": "^12.0.3",
     "npm-run-all2": "^7.0.2",

--- a/full-stack-tests/ecschema-rpc-interface/package.json
+++ b/full-stack-tests/ecschema-rpc-interface/package.json
@@ -67,6 +67,7 @@
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
     "internal-tools": "workspace:*",
+    "mocha-junit-reporter": "^2.0.2",
     "npm-run-all2": "^7.0.2",
     "null-loader": "^4.0.1",
     "path-browserify": "^1.0.1",

--- a/full-stack-tests/presentation/package.json
+++ b/full-stack-tests/presentation/package.json
@@ -71,6 +71,7 @@
     "internal-tools": "workspace:*",
     "jsdom": "^26.0.0",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "prettier": "^3.2.5",
     "rimraf": "^6.0.1",
     "sanitize-filename": "^1.6.3",

--- a/full-stack-tests/rpc-interface/package.json
+++ b/full-stack-tests/rpc-interface/package.json
@@ -75,6 +75,7 @@
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
     "internal-tools": "workspace:*",
+    "mocha-junit-reporter": "^2.0.2",
     "npm-run-all2": "^7.0.2",
     "null-loader": "^4.0.1",
     "path-browserify": "^1.0.1",

--- a/full-stack-tests/rpc/package.json
+++ b/full-stack-tests/rpc/package.json
@@ -48,6 +48,8 @@
     "chai": "^4.3.10",
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
+    "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "null-loader": "^4.0.1",
     "rimraf": "^6.0.1",
     "source-map-loader": "^5.0.0",

--- a/presentation/backend/package.json
+++ b/presentation/backend/package.json
@@ -94,6 +94,7 @@
     "eslint-config-prettier": "^9.1.2",
     "internal-tools": "workspace:*",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "prettier": "^3.2.5",
     "rimraf": "^6.0.1",
     "sinon": "^17.0.2",

--- a/presentation/common/package.json
+++ b/presentation/common/package.json
@@ -102,6 +102,7 @@
     "eslint-config-prettier": "^9.1.2",
     "internal-tools": "workspace:*",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "prettier": "^3.2.5",
     "rimraf": "^6.0.1",
     "sinon": "^17.0.2",

--- a/presentation/frontend/package.json
+++ b/presentation/frontend/package.json
@@ -90,6 +90,7 @@
     "internal-tools": "workspace:*",
     "jsdom": "^26.0.0",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "prettier": "^3.2.5",
     "rimraf": "^6.0.1",
     "sinon": "^17.0.2",

--- a/tools/build/package.json
+++ b/tools/build/package.json
@@ -35,7 +35,6 @@
     "cpx2": "^8.0.0",
     "cross-spawn": "^7.0.5",
     "fs-extra": "^8.1.0",
-    "mocha-junit-reporter": "^2.0.2",
     "rimraf": "^6.0.1",
     "tree-kill": "^1.2.2",
     "typedoc": "^0.28.19",
@@ -45,10 +44,14 @@
     "yargs": "^17.4.0"
   },
   "peerDependencies": {
-    "mocha": "^11.1.0"
+    "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2"
   },
   "peerDependenciesMeta": {
     "mocha": {
+      "optional": true
+    },
+    "mocha-junit-reporter": {
       "optional": true
     }
   },
@@ -56,6 +59,7 @@
     "@itwin/eslint-plugin": "^6.0.0",
     "@types/node": "~20.17.0",
     "eslint": "^9.31.0",
-    "mocha": "^11.1.0"
+    "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2"
   }
 }

--- a/tools/internal/package.json
+++ b/tools/internal/package.json
@@ -27,6 +27,7 @@
     "@itwin/build-tools": "workspace:*",
     "glob": "^13.0.6",
     "magic-string": "^1.1.0",
-    "mocha": "^11.1.0"
+    "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2"
   }
 }

--- a/ui/appui-abstract/package.json
+++ b/ui/appui-abstract/package.json
@@ -60,6 +60,7 @@
     "eslint": "^9.31.0",
     "glob": "^13.0.6",
     "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.0.2",
     "raf": "^3.4.0",
     "rimraf": "^6.0.1",
     "sinon": "^17.0.2",


### PR DESCRIPTION
## TL;DR

`@itwin/build-tools` still pulled `mocha-junit-reporter` into consumers that did not use the public reporter entry point, keeping an unnecessary Mocha dependency closure in their audits. This change makes the reporter an optional peer dependency, keeps it available for build-tools development, and declares it directly in repository packages that use it. Closes #9232.

## What

| Asset | Why it exists |
|---|---|
| `tools/build/package.json` (dependency contract) | The reporter is only needed by the public reporter entry point, so making it an optional peer avoids installing its dependency closure for consumers that do not use it while retaining local development coverage. |
| Reporter-consuming package manifests (21 `package.json` files) | Packages that run the build-tools reporter now declare `mocha-junit-reporter` directly instead of relying on build-tools to provide it transitively. |
| `common/config/rush/pnpm-lock.yaml` (lockfile) | Keeps the workspace dependency graph aligned with the new peer and direct development dependencies. |
| `common/config/rush/browser-approved-packages.json` (package approval) | Allows the reporter to be used by the package categories that now declare it directly. |
| `docs/changehistory/NextVersion.md`| Records the dependency-contract change and tells consumers of the mocha reporter which packages they must declare. |

---
*Nam and Nambot 🤖 (powered by gpt-5.6-luna)*