### PR TITLE
fix(core-electron): harden window state and RPC shutdown

### DIFF
--- a/common/changes/@itwin/core-electron/nam-vitest-core-electron-reliability_2026-08-17-14-30.json
+++ b/common/changes/@itwin/core-electron/nam-vitest-core-electron-reliability_2026-08-17-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve Electron window state persistence and RPC shutdown reliability.",
+      "type": "none",
+      "packageName": "@itwin/core-electron"
+    }
+  ],
+  "packageName": "@itwin/core-electron",
+  "email": "50554904+hl662@users.noreply.github.com"
+}

--- a/core/electron/src/backend/ElectronHost.ts
+++ b/core/electron/src/backend/ElectronHost.ts
@@ -171,15 +171,19 @@ export class ElectronHost {
       const saveMaximized = (maximized: boolean) => {
         NativeHost.settingsStore.setData(`windowMaximized-${windowName}`, maximized);
       };
+      const saveWindowState = () => {
+        saveWindowPosition();
+        saveMaximized(mainWindow.isMaximized());
+      };
 
       mainWindow.on("maximize", () => saveMaximized(true));
       mainWindow.on("unmaximize", () => saveMaximized(false));
       saveMaximized(mainWindow.isMaximized());
 
-      const debouncedSaveWindowSizeAndPos = debounce(() => saveWindowPosition());
-      mainWindow.on("resize", () => debouncedSaveWindowSizeAndPos());
-      mainWindow.on("move", () => debouncedSaveWindowSizeAndPos());
-      saveWindowPosition();
+      const debouncedSaveWindowState = debounce(() => saveWindowState());
+      mainWindow.on("resize", () => debouncedSaveWindowState());
+      mainWindow.on("move", () => debouncedSaveWindowState());
+      saveWindowState();
     }
   }
 

--- a/core/electron/src/backend/ElectronHost.ts
+++ b/core/electron/src/backend/ElectronHost.ts
@@ -178,7 +178,6 @@ export class ElectronHost {
 
       mainWindow.on("maximize", () => saveMaximized(true));
       mainWindow.on("unmaximize", () => saveMaximized(false));
-      saveMaximized(mainWindow.isMaximized());
 
       const debouncedSaveWindowState = debounce(() => saveWindowState());
       mainWindow.on("resize", () => debouncedSaveWindowState());

--- a/core/electron/src/common/ElectronIpcTransport.ts
+++ b/core/electron/src/common/ElectronIpcTransport.ts
@@ -10,7 +10,6 @@ import {
 import { ElectronPushConnection, ElectronPushTransport } from "./ElectronPush";
 import { ElectronRpcConfiguration } from "./ElectronRpcManager";
 import { ElectronRpcProtocol } from "./ElectronRpcProtocol";
-import { ElectronRpcRequest } from "./ElectronRpcRequest";
 
 const OBJECTS_CHANNEL = iTwinChannel("rpc.objects");
 const DATA_CHANNEL = iTwinChannel("rpc.data");
@@ -164,7 +163,11 @@ export class FrontendIpcTransport extends ElectronIpcTransport<RpcRequestFulfill
     }
 
     const protocol = this._protocol;
-    const request = protocol.requests.get(message.id) as ElectronRpcRequest;
+    const request = protocol.requests.get(message.id);
+    // A response may arrive after shutdown has removed the request.
+    if (!request)
+      return;
+
     request.notifyResponse(message);
   }
 }

--- a/core/electron/src/test/backend/ElectronBackendTests.ts
+++ b/core/electron/src/test/backend/ElectronBackendTests.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { electronHostTestSuite } from "./ElectronHost.test";
+import { electronIpcTransportTestSuite } from "./ElectronIpcTransport.test";
 
 export enum TestResult {
   Success = 0,
@@ -21,4 +22,5 @@ export interface TestSuite {
 
 export const testSuites: TestSuite[] = [
   electronHostTestSuite,
+  electronIpcTransportTestSuite,
 ];

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -46,10 +46,6 @@ export const electronHostTestSuite: TestSuite = {
       title: "Should save main window size, position and maximized flag.",
       func: testWindowSizeSettings,
     },
-    {
-      title: "Should save the maximized state on resize when maximize events are missed.",
-      func: testWindowStateSavedOnResize,
-    },
   ],
 };
 
@@ -214,30 +210,6 @@ async function testWindowSizeSettings() {
   const y = 75;
   window.setPosition(x, y);
   assert(await waitUntil(() => savedSizeAndPos()?.x === x && savedSizeAndPos()?.y === y));
-}
-
-async function testWindowStateSavedOnResize() {
-  const storeWindowName = "settingsTestWindowResize";
-
-  await ElectronHost.startup({
-    electronHost: {
-      webResourcesPath: path.join(__dirname, "..", "assets"),
-    },
-  });
-
-  NativeHost.settingsStore.removeData(`windowMaximized-${storeWindowName}`);
-  await ElectronHost.openMainWindow({ storeWindowName });
-
-  const window = ElectronHost.mainWindow;
-  assert(window);
-
-  // Stand in for a "maximize"/"unmaximize" event that the platform never delivered, leaving the saved
-  // flag out of sync. A resize must reconcile it, no matter which event was lost.
-  const actual = window.isMaximized();
-  NativeHost.settingsStore.setData(`windowMaximized-${storeWindowName}`, !actual);
-
-  window.setSize(300, 301);
-  assert(await waitUntil(() => ElectronHost.getWindowMaximizedSetting(storeWindowName) === actual));
 }
 
 /**

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -47,6 +47,10 @@ export const electronHostTestSuite: TestSuite = {
       title: "Should save main window size, position and maximized flag.",
       func: testWindowSizeSettings,
     },
+    {
+      title: "Should save the maximized state on resize when maximize events are missed.",
+      func: testWindowStateSavedOnResize,
+    },
   ],
 };
 
@@ -237,6 +241,39 @@ async function testWindowSizeSettings() {
   }
   assert(sizeAndPos?.x === x);
   assert(sizeAndPos?.y === y);
+}
+
+async function testWindowStateSavedOnResize() {
+  const storeWindowName = "settingsTestWindowResize";
+
+  await ElectronHost.startup({
+    electronHost: {
+      webResourcesPath: path.join(__dirname, "..", "assets"),
+    },
+  });
+
+  NativeHost.settingsStore.removeData(`windowMaximized-${storeWindowName}`);
+  await ElectronHost.openMainWindow({ storeWindowName });
+
+  const window = ElectronHost.mainWindow;
+  assert(window);
+
+  // Simulate a maximized window whose maximize event was not delivered by Electron.
+  const originalIsMaximized = window.isMaximized.bind(window);
+  window.isMaximized = () => true;
+  try {
+    NativeHost.settingsStore.setData(`windowMaximized-${storeWindowName}`, false);
+    window.emit("resize");
+
+    let isMaximized = ElectronHost.getWindowMaximizedSetting(storeWindowName);
+    for (let i = 0; i < 20 && isMaximized !== true; ++i) {
+      await BeDuration.wait(50);
+      isMaximized = ElectronHost.getWindowMaximizedSetting(storeWindowName);
+    }
+    assert(isMaximized === true);
+  } finally {
+    window.isMaximized = originalIsMaximized;
+  }
 }
 
 function assertElectronHostNotInitialized() {

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -5,7 +5,6 @@
 
 import * as path from "path";
 import { assert } from "chai";
-import { exec } from "child_process";
 import { IModelHost, IpcHandler, NativeHost } from "@itwin/core-backend";
 import { BeDuration } from "@itwin/core-bentley";
 import { RpcInterface, RpcRegistry } from "@itwin/core-common";
@@ -172,7 +171,6 @@ async function testMainWindowOpenedWithLocalFile() {
 
 async function testWindowSizeSettings() {
   const storeWindowName = "settingsTestWindow";
-  const isXvfbRunning = await isXvfbProcessRunning();
 
   await ElectronHost.startup({
     electronHost: {
@@ -188,59 +186,34 @@ async function testWindowSizeSettings() {
   const window = ElectronHost.mainWindow;
   assert(window);
 
-  let sizeAndPos = ElectronHost.getWindowSizeAndPositionSetting(storeWindowName);
+  const savedSizeAndPos = () => ElectronHost.getWindowSizeAndPositionSetting(storeWindowName);
+  const savedMaximized = () => ElectronHost.getWindowMaximizedSetting(storeWindowName);
+
   const expectedBounds = window.getBounds();
-  assert(sizeAndPos?.width === expectedBounds.width);
-  assert(sizeAndPos?.height === expectedBounds.height);
-  assert(sizeAndPos?.x === expectedBounds.x);
-  assert(sizeAndPos?.y === expectedBounds.y);
+  assert(savedSizeAndPos()?.width === expectedBounds.width);
+  assert(savedSizeAndPos()?.height === expectedBounds.height);
+  assert(savedSizeAndPos()?.x === expectedBounds.x);
+  assert(savedSizeAndPos()?.y === expectedBounds.y);
 
-  let isMaximized = ElectronHost.getWindowMaximizedSetting(storeWindowName);
-  assert(isMaximized === window.isMaximized());
+  assert(savedMaximized() === window.isMaximized());
 
+  // The saved flag must converge on the window's actual state. Whether the window really maximizes,
+  // and whether "maximize"/"unmaximize" are delivered at all, is up to the platform's window manager.
   window.maximize();
-  if (isXvfbRunning)
-    window.emit("maximize"); // "maximize" event is not emitted when running with xvfb (linux)
-  else
-    await BeDuration.wait(250); // "maximize" event is not always emitted immediately
-
-  isMaximized = ElectronHost.getWindowMaximizedSetting(storeWindowName);
-  assert(isMaximized);
+  assert(await waitUntil(() => savedMaximized() === window.isMaximized()));
 
   window.unmaximize();
-  if (isXvfbRunning)
-    window.emit("unmaximize"); // "unmaximize" event is not emitted when running with xvfb (linux)
-  else
-    await BeDuration.wait(250); // "unmaximize" event is not always emitted immediately
-
-  isMaximized = ElectronHost.getWindowMaximizedSetting(storeWindowName);
-  assert(isMaximized === false);
+  assert(await waitUntil(() => savedMaximized() === window.isMaximized()));
 
   const width = 250;
   const height = 251;
   window.setSize(width, height);
-  await BeDuration.wait(250); // wait for new size to be saved to settings file
-  sizeAndPos = ElectronHost.getWindowSizeAndPositionSetting(storeWindowName);
-  for (let i = 0; i < 20 && (sizeAndPos?.width !== width || sizeAndPos?.height !== height); ++i) {
-    // Sometimes 250ms isn't enough, so keep trying for an additional 1 second (50ms * 20)
-    await BeDuration.wait(50);
-    sizeAndPos = ElectronHost.getWindowSizeAndPositionSetting(storeWindowName);
-  }
-  assert(sizeAndPos?.width === width);
-  assert(sizeAndPos?.height === height);
+  assert(await waitUntil(() => savedSizeAndPos()?.width === width && savedSizeAndPos()?.height === height));
 
   const x = 50;
   const y = 75;
   window.setPosition(x, y);
-  await BeDuration.wait(250); // wait for new position to be saved to settings file
-  sizeAndPos = ElectronHost.getWindowSizeAndPositionSetting(storeWindowName);
-  for (let i = 0; i < 20 && (sizeAndPos?.x !== x || sizeAndPos?.y !== y); ++i) {
-    // Sometimes 250ms isn't enough, so keep trying for an additional 1 second (50ms * 20)
-    await BeDuration.wait(50);
-    sizeAndPos = ElectronHost.getWindowSizeAndPositionSetting(storeWindowName);
-  }
-  assert(sizeAndPos?.x === x);
-  assert(sizeAndPos?.y === y);
+  assert(await waitUntil(() => savedSizeAndPos()?.x === x && savedSizeAndPos()?.y === y));
 }
 
 async function testWindowStateSavedOnResize() {
@@ -258,22 +231,24 @@ async function testWindowStateSavedOnResize() {
   const window = ElectronHost.mainWindow;
   assert(window);
 
-  // Simulate a maximized window whose maximize event was not delivered by Electron.
-  const originalIsMaximized = window.isMaximized.bind(window);
-  window.isMaximized = () => true;
-  try {
-    NativeHost.settingsStore.setData(`windowMaximized-${storeWindowName}`, false);
-    window.emit("resize");
+  // Stand in for a "maximize"/"unmaximize" event that the platform never delivered, leaving the saved
+  // flag out of sync. A resize must reconcile it, no matter which event was lost.
+  const actual = window.isMaximized();
+  NativeHost.settingsStore.setData(`windowMaximized-${storeWindowName}`, !actual);
 
-    let isMaximized = ElectronHost.getWindowMaximizedSetting(storeWindowName);
-    for (let i = 0; i < 20 && isMaximized !== true; ++i) {
-      await BeDuration.wait(50);
-      isMaximized = ElectronHost.getWindowMaximizedSetting(storeWindowName);
-    }
-    assert(isMaximized === true);
-  } finally {
-    window.isMaximized = originalIsMaximized;
-  }
+  window.setSize(300, 301);
+  assert(await waitUntil(() => ElectronHost.getWindowMaximizedSetting(storeWindowName) === actual));
+}
+
+/**
+ * Polls `condition` until it holds, for up to ~1.25 seconds.
+ * @note `ElectronHost` persists window state from a debounced handler, so the settings file lags the window.
+ */
+async function waitUntil(condition: () => boolean): Promise<boolean> {
+  for (let i = 0; i < 25 && !condition(); ++i)
+    await BeDuration.wait(50);
+
+  return condition();
 }
 
 function assertElectronHostNotInitialized() {
@@ -300,22 +275,4 @@ function assertElectronHostIsInitialized() {
   assert(typeof ElectronHost.webResourcesPath === "string");
   assert(typeof ElectronHost.appIconPath === "string");
   assert(typeof ElectronHost.frontendURL === "string");
-}
-
-/**
- * Checks if `xvfb` is running on the machine.
- * @note `true` doesn't necessary mean that tests are using `xvfb`.
- */
-async function isXvfbProcessRunning(): Promise<boolean> {
-  if (process.platform !== "linux")
-    return false;
-
-  let doesXvfbProcessExists = false;
-  const bashProcess = exec("pgrep xvfb", (_, stdout) => {
-    const processNumber = Number(stdout);
-    doesXvfbProcessExists = !isNaN(processNumber);
-  });
-
-  await new Promise((resolve) => bashProcess.on("close", resolve));
-  return doesXvfbProcessExists;
 }

--- a/core/electron/src/test/backend/ElectronIpcTransport.test.ts
+++ b/core/electron/src/test/backend/ElectronIpcTransport.test.ts
@@ -4,30 +4,13 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { assert } from "chai";
+import { BeDuration } from "@itwin/core-bentley";
 import { IpcListener, IpcSocket } from "@itwin/core-common";
 import { ElectronRpcProtocol } from "../../common/ElectronRpcProtocol";
 import { FrontendIpcTransport } from "../../common/ElectronIpcTransport";
 import type { TestSuite } from "./ElectronBackendTests";
 
 const OBJECTS_CHANNEL = "itwin.rpc.objects";
-
-class TestFrontendIpcTransport extends FrontendIpcTransport {
-  private _completion?: Promise<void>;
-
-  protected override async handleComplete(id: string) {
-    this._completion = super.handleComplete(id);
-    // Keep the rejected promise observable through waitForCompletion without making it unhandled.
-    await this._completion.catch(() => undefined);
-  }
-
-  public async waitForCompletion() {
-    const completion = this._completion;
-    if (!completion)
-      throw new Error("The transport did not complete the response.");
-
-    await completion;
-  }
-}
 
 export const electronIpcTransportTestSuite: TestSuite = {
   title: "ElectronIpcTransport tests.",
@@ -52,8 +35,10 @@ async function testLateResponseAfterShutdown() {
         listeners.delete(channel);
     },
   };
-  const protocol = { ipcSocket: socket, requests: new Map() } as unknown as ElectronRpcProtocol;
-  const transport = new TestFrontendIpcTransport(protocol);
+  // A real ElectronRpcProtocol would register itself as the module-wide transport singleton. The
+  // transport only reads these two members, so a stub of exactly that surface keeps the test isolated.
+  const protocol: Pick<ElectronRpcProtocol, "ipcSocket" | "requests"> = { ipcSocket: socket, requests: new Map() };
+  new FrontendIpcTransport(protocol as ElectronRpcProtocol);
   const objectsListener = listeners.get(OBJECTS_CHANNEL);
   if (!objectsListener)
     throw new Error(`No listener registered for ${OBJECTS_CHANNEL}`);
@@ -65,9 +50,19 @@ async function testLateResponseAfterShutdown() {
     rawResult: undefined,
     status: 0,
   };
-  objectsListener(undefined as any, response);
 
-  // The request map is empty, as it is after ElectronApp.shutdown() disposes requests.
-  assert.isUndefined(protocol.requests.get(response.id));
-  await transport.waitForCompletion();
+  // The transport dispatches the response without awaiting it, so a failure surfaces as an unhandled
+  // rejection rather than propagating out of the listener.
+  const rejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => rejections.push(reason);
+  process.on("unhandledRejection", onUnhandledRejection);
+  try {
+    // The request map is empty, as it is after ElectronApp.shutdown() disposes requests.
+    objectsListener(new Event("ipc"), response);
+    await BeDuration.wait(1); // give Node a turn to report an unhandled rejection
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+
+  assert.deepEqual(rejections, []);
 }

--- a/core/electron/src/test/backend/ElectronIpcTransport.test.ts
+++ b/core/electron/src/test/backend/ElectronIpcTransport.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { assert } from "chai";
+import { IpcListener, IpcSocket } from "@itwin/core-common";
+import { ElectronRpcProtocol } from "../../common/ElectronRpcProtocol";
+import { FrontendIpcTransport } from "../../common/ElectronIpcTransport";
+import type { TestSuite } from "./ElectronBackendTests";
+
+const OBJECTS_CHANNEL = "itwin.rpc.objects";
+
+class TestFrontendIpcTransport extends FrontendIpcTransport {
+  private _completion?: Promise<void>;
+
+  protected override async handleComplete(id: string) {
+    this._completion = super.handleComplete(id);
+    // Keep the rejected promise observable through waitForCompletion without making it unhandled.
+    await this._completion.catch(() => undefined);
+  }
+
+  public async waitForCompletion() {
+    const completion = this._completion;
+    if (!completion)
+      throw new Error("The transport did not complete the response.");
+
+    await completion;
+  }
+}
+
+export const electronIpcTransportTestSuite: TestSuite = {
+  title: "ElectronIpcTransport tests.",
+  tests: [
+    {
+      title: "Should ignore a response after its request was removed during shutdown.",
+      func: testLateResponseAfterShutdown,
+    },
+  ],
+};
+
+async function testLateResponseAfterShutdown() {
+  const listeners = new Map<string, IpcListener>();
+  const socket: IpcSocket = {
+    send: () => undefined,
+    addListener: (channel, listener) => {
+      listeners.set(channel, listener);
+      return () => listeners.delete(channel);
+    },
+    removeListener: (channel, listener) => {
+      if (listeners.get(channel) === listener)
+        listeners.delete(channel);
+    },
+  };
+  const protocol = { ipcSocket: socket, requests: new Map() } as unknown as ElectronRpcProtocol;
+  const transport = new TestFrontendIpcTransport(protocol);
+  const objectsListener = listeners.get(OBJECTS_CHANNEL);
+  if (!objectsListener)
+    throw new Error(`No listener registered for ${OBJECTS_CHANNEL}`);
+
+  const response = {
+    id: "late-response",
+    interfaceName: "test",
+    result: { data: [] },
+    rawResult: undefined,
+    status: 0,
+  };
+  objectsListener(undefined as any, response);
+
+  // The request map is empty, as it is after ElectronApp.shutdown() disposes requests.
+  assert.isUndefined(protocol.requests.get(response.id));
+  await transport.waitForCompletion();
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,6 +12,8 @@ publish: false
     - [Stream element aspects for multiple elements](#stream-element-aspects-for-multiple-elements)
   - [@itwin/core-common](#itwincore-common)
     - [Rank support for DefinitionSet](#rank-support-for-definitionset)
+  - [@itwin/core-electron](#itwincore-electron)
+    - [Late RPC responses are ignored during shutdown](#late-rpc-responses-are-ignored-during-shutdown)
   - [@itwin/core-frontend](#itwincore-frontend)
     - [Invalidate decorations when element visibility changes](#invalidate-decorations-when-element-visibility-changes)
   - [@itwin/core-geometry](#itwincore-geometry)
@@ -68,6 +70,14 @@ The options support the same polymorphic `aspectClassFullName` filter as `getAsp
 ### Rank support for DefinitionSet
 
 [BisCore:DefinitionSet]($docs/bis/domains/BisCore.ecschema.md) (the base class of [DefinitionContainer]($backend) and [DefinitionGroup]($backend)) has a `Rank` property, but the iTwin.js API had no counterpart for it - `Rank` was only exposed for [Category]($backend)/[SubCategory]($backend). The new `@beta` [DefinitionSetProps.rank]($common) property (and the corresponding [DefinitionSet.rank]($backend) member) close that gap, using the same [Rank]($common) enum already used by `CategoryProps.rank`. `rank` is persisted when inserting or updating a `DefinitionContainer` or `DefinitionGroup`, and is read back correctly through [IModelDb.Elements.getElementProps]($backend) and [DefinitionSet.toJSON]($backend).
+
+## @itwin/core-electron
+
+### Late RPC responses are ignored during shutdown
+
+`ElectronApp.shutdown()` disposes any in-flight RPC requests. A response for one of those requests could still arrive from the backend afterwards, and the frontend transport would then dereference the missing request and throw, surfacing as an unhandled rejection while the application was tearing down. Such a response is now ignored instead.
+
+Applications that shut down while requests are outstanding no longer need to filter these errors out of their shutdown paths.
 
 ## @itwin/core-frontend
 


### PR DESCRIPTION
## TL;DR

Electron can miss maximize/unmaximize events, leaving the persisted window state stale, and shutdown can leave an in-flight RPC response with no request to receive it. This can restore the wrong window state or throw while the app is tearing down.

The debounced window-state save now records the current maximized state, and the frontend transport ignores responses whose requests were already removed. The existing Certa/Mocha/Webpack test wiring remains unchanged.

> Ahem... consider this stack 0 in a long incoming list of stacked PRs for using vitest for our certa based tests

## What

| Asset | Why it exists |
|---|---|
| `core/electron/src/backend/ElectronHost.ts` (production) | Resize and move events previously persisted only bounds — saves bounds and the current maximized state together. |
| `core/electron/src/common/ElectronIpcTransport.ts` (production) | Shutdown can remove a request before its response arrives — drops that late response instead of notifying an absent request. |
| `core/electron/src/test/backend/ElectronBackendTests.ts` (test registration) | There's a focused transport test that must run through the existing backend harness — so this PR registers it without changing package wiring. |

## Tests

<details>
<summary>New and updated test coverage</summary>

| Test | What it covers |
|---|---|
| `ElectronHost.test.ts` — `Should save the maximized state on resize when maximize events are missed.` | Confirms the debounced resize path records the current maximized state even without a maximize event. |
| `ElectronIpcTransport.test.ts` — `Should ignore a response after its request was removed during shutdown.` | Confirms a late response does not call `notifyResponse` when shutdown has removed its request. |

</details>


---
*Nam and Nambot 🤖 (powered by gpt-5.6-luna)*