### PR TITLE
Remove companion files when removing test bim

### DIFF
--- a/common/changes/@itwin/core-backend/tcobbs-test-bim-cleanup-fix_2026-08-18-16-33-35.json
+++ b/common/changes/@itwin/core-backend/tcobbs-test-bim-cleanup-fix_2026-08-18-16-33-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/test/IModelTestUtils.ts
+++ b/core/backend/src/test/IModelTestUtils.ts
@@ -318,7 +318,7 @@ export class IModelTestUtils {
   /** Prepare for an output file by:
    * - Resolving the output file name under the known test output directory
    * - Making directories as necessary
-   * - Removing a previous copy of the output file
+   * - Removing a previous copy of the output file, along with -wal, -shm, and -journal files if they exist.
    * @param subDirName Sub-directory under known test output directory. Should match the name of the test file minus the .test.ts file extension.
    * @param fileName Name of output fille
    */
@@ -331,8 +331,13 @@ export class IModelTestUtils {
       IModelJsFs.mkdirSync(outputDir);
 
     const outputFile = path.join(outputDir, fileName);
-    if (IModelJsFs.existsSync(outputFile))
-      IModelJsFs.unlinkSync(outputFile);
+    // Remove the db and any SQLite sidecar files. A stale -wal left by a previous run would be
+    // replayed against the newly created db and reported as BE_SQLITE_CORRUPT.
+    for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+      const file = `${outputFile}${suffix}`;
+      if (IModelJsFs.existsSync(file))
+        IModelJsFs.unlinkSync(file);
+    }
 
     return outputFile;
   }


### PR DESCRIPTION
When a bim file is generated by a test, SQLite may also generate -wal, -shm, and -journal files. The presence of one of these -wal files was causing test failures on the second iOS simulator run on a given computer. This deletes the companion files at the time the .bim is deleted.