### PR TITLE
feat(core-frontend): add async formats provider setter

### DIFF
--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3566,7 +3566,6 @@ export class FormatsProviderManager implements FormatsProvider {
     getFormat(name: string, system?: UnitSystemKey): Promise<FormatDefinition | undefined>;
     // (undocumented)
     onFormatsChanged: BeEvent<(args: FormatsChangedArgs) => void>;
-    // (undocumented)
     setFormatsProvider(formatsProvider: FormatsProvider, impliedUnitSystem?: UnitSystemKey): void;
 }
 
@@ -8237,6 +8236,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     registerQuantityType(entry: CustomQuantityTypeDefinition, replace?: boolean): Promise<boolean>;
     reinitializeFormatAndParsingsMaps(overrideFormatPropsByUnitSystem: Map<UnitSystemKey, Map<QuantityTypeKey, FormatProps>>, unitSystemKey?: UnitSystemKey, fireUnitSystemChanged?: boolean, startDefaultTool?: boolean): Promise<void>;
     resetToUseInternalUnitsProvider(): Promise<void>;
+    // @internal
+    runAndWaitForReload(action: () => void): Promise<void>;
     // @internal
     protected scheduleReload(intent: ReloadIntent): Promise<void>;
     setActiveUnitSystem(isImperialOrUnitSystem: UnitSystemKey | boolean, restartActiveTool?: boolean): Promise<void>;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3566,6 +3566,8 @@ export class FormatsProviderManager implements FormatsProvider {
     getFormat(name: string, system?: UnitSystemKey): Promise<FormatDefinition | undefined>;
     // (undocumented)
     onFormatsChanged: BeEvent<(args: FormatsChangedArgs) => void>;
+    // (undocumented)
+    setFormatsProvider(formatsProvider: FormatsProvider, impliedUnitSystem?: UnitSystemKey): void;
 }
 
 // @beta @deprecated
@@ -5106,6 +5108,8 @@ export class IModelApp {
     static resetFormatsProvider(): void;
     static get securityOptions(): FrontendSecurityOptions;
     static sessionId: GuidString;
+    // @beta
+    static setFormatsProvider(provider: FormatsProvider, options?: SetFormatsProviderOptions): Promise<void>;
     static shutdown(): Promise<void>;
     // @internal (undocumented)
     static startEventLoop(): void;
@@ -9904,6 +9908,11 @@ export function setBasicAuthorization(headers: Headers, credentials: RequestBasi
 
 // @internal (undocumented)
 export function setBasicAuthorization(headers: Headers, user: string, password: string): void;
+
+// @beta
+export interface SetFormatsProviderOptions {
+    readonly unitSystem?: UnitSystemKey;
+}
 
 // @internal
 export function setRequestTimeout(opts: RequestInit, ms: number, abortController?: AbortController): void;

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3560,12 +3560,18 @@ export function formatAnimationBranchId(modelId: Id64String, branchId: number): 
 export class FormatsProviderManager implements FormatsProvider {
     constructor(_formatsProvider: FormatsProvider);
     // (undocumented)
+    applyFormatsProviderChange(change: FormatsProviderChange): boolean;
+    // (undocumented)
     get formatsProvider(): FormatsProvider;
     set formatsProvider(formatsProvider: FormatsProvider);
     // (undocumented)
     getFormat(name: string, system?: UnitSystemKey): Promise<FormatDefinition | undefined>;
     // (undocumented)
+    isCurrentFormatsProviderReload(provider: FormatsProvider, change?: FormatsProviderChange): boolean;
+    // (undocumented)
     onFormatsChanged: BeEvent<(args: FormatsChangedArgs) => void>;
+    // (undocumented)
+    onFormatsChangedInternal: BeEvent<(event: FormatsProviderManagerEvent) => void>;
     restoreProviderChange(change: FormatsProviderChange): boolean;
     setFormatsProvider(formatsProvider: FormatsProvider, impliedUnitSystem?: UnitSystemKey): void;
 }

--- a/common/api/core-frontend.api.md
+++ b/common/api/core-frontend.api.md
@@ -3566,6 +3566,7 @@ export class FormatsProviderManager implements FormatsProvider {
     getFormat(name: string, system?: UnitSystemKey): Promise<FormatDefinition | undefined>;
     // (undocumented)
     onFormatsChanged: BeEvent<(args: FormatsChangedArgs) => void>;
+    restoreProviderChange(change: FormatsProviderChange): boolean;
     setFormatsProvider(formatsProvider: FormatsProvider, impliedUnitSystem?: UnitSystemKey): void;
 }
 

--- a/common/api/summary/core-frontend.exports.csv
+++ b/common/api/summary/core-frontend.exports.csv
@@ -607,6 +607,7 @@ public;interface;SelectRemoveEvent
 public;interface;SelectReplaceEvent
 internal;function;setBasicAuthorization
 internal;function;setBasicAuthorization
+beta;interface;SetFormatsProviderOptions
 internal;function;setRequestTimeout
 public;class;SetupCameraTool
 public;class;SetupWalkCameraTool

--- a/common/changes/@itwin/core-frontend/nam-set-formats-provider_2026-08-14-11-08-06.json
+++ b/common/changes/@itwin/core-frontend/nam-set-formats-provider_2026-08-14-11-08-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Add an asynchronous formats provider setter that can synchronize the active unit system in one reload.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/changes/@itwin/core-frontend/nam-set-formats-provider_2026-08-14-11-08-06.json
+++ b/common/changes/@itwin/core-frontend/nam-set-formats-provider_2026-08-14-11-08-06.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Add an asynchronous formats provider setter that can synchronize the active unit system in one reload.",
+      "comment": "Add an asynchronous formats provider setter that can synchronize the active unit system and await the resulting formatting reload.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-frontend/nam-set-formats-provider_2026-08-14-11-08-06.json
+++ b/common/changes/@itwin/core-frontend/nam-set-formats-provider_2026-08-14-11-08-06.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-frontend",
-      "comment": "Add an asynchronous formats provider setter that can synchronize the active unit system and await the resulting formatting reload.",
+      "comment": "Add an asynchronous formats provider setter that synchronizes the active unit system, awaits the resulting formatting reload, and rejects superseded or disposed requests.",
       "type": "none"
     }
   ],

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -355,6 +355,7 @@ export class IModelApp {
 
   /** The [[FormatsProvider]] for this session.
    * @param provider The provider to use for formatting quantities.
+   * @note Prefer [[IModelApp.setFormatsProvider]] when replacing the provider; assigning this property starts an asynchronous reload without returning a promise.
    * @beta
    */
   public static get formatsProvider(): FormatsProvider { return this._formatsProviderManager; }

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -17,7 +17,7 @@ import { UiAdmin } from "@itwin/appui-abstract";
 import { AccessToken, BeDuration, BeEvent, BentleyStatus, DbResult, dispose, expectDefined, Guid, GuidString, IModelStatus, Logger, ProcessDetector } from "@itwin/core-bentley";
 import { AuthorizationClient, Localization, RealityDataAccess, RpcConfiguration, RpcInterfaceDefinition, RpcRequest, SerializedRpcActivity } from "@itwin/core-common";
 import { ITwinLocalization } from "@itwin/core-i18n";
-import { FormatsProvider } from "@itwin/core-quantity";
+import { FormatsProvider, UnitSystemKey } from "@itwin/core-quantity";
 import { queryRenderCompatibility, WebGLRenderCompatibilityInfo } from "@itwin/webgl-compatibility";
 import { AccuDraw } from "./AccuDraw";
 import { AccuSnap } from "./AccuSnap";
@@ -161,6 +161,14 @@ export interface IModelAppOptions {
    * @beta
    */
   incrementalSchemaLoading?: "enabled" | "disabled";
+}
+
+/** Options for [[IModelApp.setFormatsProvider]].
+ * @beta
+ */
+export interface SetFormatsProviderOptions {
+  /** The unit system implied by the formats provider. If omitted, the active unit system remains unchanged. */
+  readonly unitSystem?: UnitSystemKey;
 }
 
 /** Options for [[IModelApp.makeModalDiv]]
@@ -352,6 +360,30 @@ export class IModelApp {
   public static get formatsProvider(): FormatsProvider { return this._formatsProviderManager; }
   public static set formatsProvider(provider: FormatsProvider) {
     this._formatsProviderManager.formatsProvider = provider;
+  }
+
+  /**
+   * Replaces the formats provider and optionally changes the active unit system as part of the same reload.
+   * Resolves after the [[QuantityFormatter]] has finished reloading its formatting and parsing specifications.
+   * @beta
+   */
+  public static async setFormatsProvider(provider: FormatsProvider, options?: SetFormatsProviderOptions): Promise<void> {
+    const quantityFormatter = this.quantityFormatter;
+    if (!quantityFormatter.isReady) {
+      this._formatsProviderManager.setFormatsProvider(provider, options?.unitSystem);
+      await quantityFormatter.whenInitialized;
+      return;
+    }
+
+    let removeReadyListener: (() => void) | undefined;
+    const ready = new Promise<void>((resolve) => {
+      removeReadyListener = quantityFormatter.onFormattingReady.addListener(() => {
+        removeReadyListener?.();
+        resolve();
+      });
+    });
+    this._formatsProviderManager.setFormatsProvider(provider, options?.unitSystem);
+    await ready;
   }
 
   /** @alpha */

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -365,7 +365,10 @@ export class IModelApp {
 
   /**
    * Replaces the formats provider and optionally changes the active unit system as part of the same reload.
-   * Resolves after the [[QuantityFormatter]] has finished reloading its formatting and parsing specifications.
+   * Resolves after the [[QuantityFormatter]] has finished reloading its formatting and parsing specifications. Individual incompatible
+   * provider entries may be omitted from the registry and logged as warnings; they do not cause this Promise to reject.
+   * If another call is made before this reload queue drains, the newer call wins and this Promise rejects. The Promise also rejects if the
+   * application shuts down before the reload completes.
    * @beta
    */
   public static async setFormatsProvider(provider: FormatsProvider, options?: SetFormatsProviderOptions): Promise<void> {

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -369,22 +369,9 @@ export class IModelApp {
    * @beta
    */
   public static async setFormatsProvider(provider: FormatsProvider, options?: SetFormatsProviderOptions): Promise<void> {
-    const quantityFormatter = this.quantityFormatter;
-    if (!quantityFormatter.isReady) {
+    await this.quantityFormatter.runAndWaitForReload(() => {
       this._formatsProviderManager.setFormatsProvider(provider, options?.unitSystem);
-      await quantityFormatter.whenInitialized;
-      return;
-    }
-
-    let removeReadyListener: (() => void) | undefined;
-    const ready = new Promise<void>((resolve) => {
-      removeReadyListener = quantityFormatter.onFormattingReady.addListener(() => {
-        removeReadyListener?.();
-        resolve();
-      });
     });
-    this._formatsProviderManager.setFormatsProvider(provider, options?.unitSystem);
-    await ready;
   }
 
   /** @alpha */

--- a/core/frontend/src/IModelApp.ts
+++ b/core/frontend/src/IModelApp.ts
@@ -364,11 +364,11 @@ export class IModelApp {
   }
 
   /**
-   * Replaces the formats provider and optionally changes the active unit system as part of the same reload.
-   * Resolves after the [[QuantityFormatter]] has finished reloading its formatting and parsing specifications. Individual incompatible
-   * provider entries may be omitted from the registry and logged as warnings; they do not cause this Promise to reject.
-   * If another call is made before this reload queue drains, the newer call wins and this Promise rejects. The Promise also rejects if the
-   * application shuts down before the reload completes.
+   * Replaces the formats provider and optionally changes the active unit system.
+   * Resolves after the formatter has rebuilt its formatting and parsing caches.
+   * Incompatible provider entries are logged and skipped, so they do not reject this Promise.
+   * If a later setFormatsProvider call supersedes this request, this Promise rejects.
+   * It also rejects if the application shuts down first.
    * @beta
    */
   public static async setFormatsProvider(provider: FormatsProvider, options?: SetFormatsProviderOptions): Promise<void> {

--- a/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
+++ b/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
@@ -45,8 +45,6 @@ interface ReloadCaller {
   reject: (reason?: unknown) => void;
 }
 
-type ProviderReloadIntent = Extract<ReloadIntent, { scope: "formatsChanged" }> & { providerChange: FormatsProviderChange };
-
 /**
  * Serializes formatting reloads, keeps the newest pending request, and resolves or rejects callers waiting for formatting to become ready.
  * @internal
@@ -54,7 +52,7 @@ type ProviderReloadIntent = Extract<ReloadIntent, { scope: "formatsChanged" }> &
 export class FormatsProviderReloadCoordinator {
   private _reloadInFlight = false;
   private _pendingReload: ReloadIntent | undefined;
-  private _pendingProviderReload: ProviderReloadIntent | undefined;
+  private _pendingProviderReload: ReloadIntent | undefined;
   private _reloadCaller: ReloadCaller | undefined;
   private _isDisposed = false;
 
@@ -171,7 +169,7 @@ export class FormatsProviderReloadCoordinator {
   }
 
   private _queuePendingReload(intent: ReloadIntent): void {
-    if (this._isProviderReload(intent))
+    if (intent.scope === "formatsChanged" && intent.providerChange)
       this._pendingProviderReload = intent;
     else
       this._pendingReload = intent;
@@ -200,10 +198,6 @@ export class FormatsProviderReloadCoordinator {
     const nextReload = this._pendingReload;
     this._pendingReload = undefined;
     return nextReload;
-  }
-
-  private _isProviderReload(intent: ReloadIntent): intent is ProviderReloadIntent {
-    return intent.scope === "formatsChanged" && intent.providerChange !== undefined;
   }
 
   /** Resolves the caller after the reload queue finishes successfully. */

--- a/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
+++ b/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
@@ -40,16 +40,19 @@ export interface ReloadCoordinatorHost {
   handleReloadFailure(error: unknown): void;
 }
 
-interface ReloadWaiter {
+interface ReloadCaller {
   resolve: () => void;
   reject: (reason?: unknown) => void;
 }
 
-/** Serializes formatting reloads, keeps the newest pending request, and completes or rejects callers waiting for formatting to become ready. @internal */
+/**
+ * Serializes formatting reloads, keeps the newest pending request, and resolves or rejects callers waiting for formatting to become ready.
+ * @internal
+ */
 export class FormatsProviderReloadCoordinator {
   private _reloadInFlight = false;
   private _pendingReload: ReloadIntent | undefined;
-  private _reloadWaiters = new Set<ReloadWaiter>();
+  private _reloadCallers = new Set<ReloadCaller>();
   private _isDisposed = false;
 
   public constructor(private readonly _host: ReloadCoordinatorHost, private readonly _disposedError: Error) {}
@@ -60,33 +63,43 @@ export class FormatsProviderReloadCoordinator {
 
     this._isDisposed = true;
     this._pendingReload = undefined;
-    this._rejectReloadWaiters(this._disposedError);
+    this._rejectReloadCallers(this._disposedError);
   }
 
+  /**
+   * Runs an action that schedules a reload and waits for the reload queue to drain.
+   * A newer call rejects an older call that is still waiting.
+   * @internal
+   */
   public async runAndWaitForReload(action: () => void): Promise<void> {
     if (this._isDisposed || this._host.isDisposed())
       throw this._disposedError;
 
-    let waiter!: ReloadWaiter;
+    let caller!: ReloadCaller;
     const reload = new Promise<void>((resolve, reject) => {
-      waiter = { resolve, reject };
+      caller = { resolve, reject };
     });
 
-    // Register the waiter before invoking the action. The action raises provider events synchronously,
+    // Register the caller before invoking the action. The action raises provider events synchronously,
     // and an event listener can start a second awaited request.
-    this._rejectReloadWaiters(new ReloadSupersededError());
-    this._reloadWaiters.add(waiter);
+    this._rejectReloadCallers(new ReloadSupersededError());
+    this._reloadCallers.add(caller);
 
     try {
       action();
     } catch (error) {
-      this._reloadWaiters.delete(waiter);
+      this._reloadCallers.delete(caller);
       throw error;
     }
 
     await reload;
   }
 
+  /**
+   * Schedules a reload and keeps only the newest pending reload while another is running.
+   * If a reload is already running, this method returns immediately; use [[runAndWaitForReload]] when the caller must wait for completion.
+   * @internal
+   */
   public async scheduleReload(intent: ReloadIntent): Promise<void> {
     if (this._isDisposed || this._host.isDisposed())
       return;
@@ -123,9 +136,10 @@ export class FormatsProviderReloadCoordinator {
       return this.scheduleReload(nextReload);
 
     this._reloadInFlight = false;
-    this._resolveReloadWaiters();
+    this._resolveReloadCallers();
   }
 
+  /** Stops reload processing when this coordinator or its host is disposed. */
   private _stopAfterDisposal(): boolean {
     if (!this._isDisposed && !this._host.isDisposed())
       return false;
@@ -135,6 +149,7 @@ export class FormatsProviderReloadCoordinator {
     return true;
   }
 
+  /** Removes the newest pending reload and marks the current reload complete before starting it. */
   private _takePendingReload(): ReloadIntent | undefined {
     const next = this._pendingReload;
     if (next) {
@@ -144,11 +159,12 @@ export class FormatsProviderReloadCoordinator {
     return next;
   }
 
+  /** Handles a reload failure and, when appropriate, starts the newest pending reload. */
   private _handleReloadFailure(error: unknown, continueWithPending: boolean): Promise<void> | void {
     this._reloadInFlight = false;
     if (this._isDisposed || this._host.isDisposed()) {
       this._pendingReload = undefined;
-      this._rejectReloadWaiters(this._disposedError);
+      this._rejectReloadCallers(this._disposedError);
       return;
     }
 
@@ -159,20 +175,22 @@ export class FormatsProviderReloadCoordinator {
     if (next)
       return this.scheduleReload(next);
 
-    this._rejectReloadWaiters(error);
+    this._rejectReloadCallers(error);
   }
 
-  private _resolveReloadWaiters(): void {
-    const waiters = [...this._reloadWaiters];
-    this._reloadWaiters.clear();
-    for (const waiter of waiters)
-      waiter.resolve();
+  /** Resolves all callers after the reload queue finishes successfully. */
+  private _resolveReloadCallers(): void {
+    const callers = [...this._reloadCallers];
+    this._reloadCallers.clear();
+    for (const caller of callers)
+      caller.resolve();
   }
 
-  private _rejectReloadWaiters(error: unknown): void {
-    const waiters = [...this._reloadWaiters];
-    this._reloadWaiters.clear();
-    for (const waiter of waiters)
-      waiter.reject(error);
+  /** Rejects all callers when the reload queue fails or is superseded. */
+  private _rejectReloadCallers(error: unknown): void {
+    const callers = [...this._reloadCallers];
+    this._reloadCallers.clear();
+    for (const caller of callers)
+      caller.reject(error);
   }
 }

--- a/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
+++ b/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { FormatsChangedArgs, FormatsProvider, UnitSystemKey } from "@itwin/core-quantity";
+
+/** @internal */
+export interface FormatsProviderChange {
+  readonly baseProvider: FormatsProvider;
+  readonly replacementProvider: FormatsProvider;
+  readonly targetUnitSystem: UnitSystemKey;
+}
+
+/** @internal */
+export class ReloadSupersededError extends Error {
+  public constructor() {
+    super("QuantityFormatter reload was superseded by a newer request.");
+    this.name = "ReloadSupersededError";
+  }
+}
+
+/** @internal */
+export type ReloadIntent =
+  | { scope: "full" }
+  | {
+    scope: "formatsChanged";
+    args: FormatsChangedArgs;
+    provider: FormatsProvider;
+    providerChange?: FormatsProviderChange;
+    targetUnitSystem: UnitSystemKey;
+  }
+  | { scope: "activeSystem"; system: UnitSystemKey; emitSystemChanged?: boolean };
+
+export interface ReloadCoordinatorHost {
+  isDisposed(): boolean;
+  startReload(): void;
+  executeReload(intent: ReloadIntent): Promise<void>;
+  finalizeReload(): Promise<void>;
+  handleReloadFailure(error: unknown): void;
+}
+
+interface ReloadWaiter {
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+}
+
+/** Serializes formatting reloads, keeps the newest pending request, and completes or rejects callers waiting for formatting to become ready. @internal */
+export class FormatsProviderReloadCoordinator {
+  private _reloadInFlight = false;
+  private _pendingReload: ReloadIntent | undefined;
+  private _reloadWaiters = new Set<ReloadWaiter>();
+  private _isDisposed = false;
+
+  public constructor(private readonly _host: ReloadCoordinatorHost, private readonly _disposedError: Error) {}
+
+  public dispose(): void {
+    if (this._isDisposed)
+      return;
+
+    this._isDisposed = true;
+    this._pendingReload = undefined;
+    this._rejectReloadWaiters(this._disposedError);
+  }
+
+  public async runAndWaitForReload(action: () => void): Promise<void> {
+    if (this._isDisposed || this._host.isDisposed())
+      throw this._disposedError;
+
+    let waiter!: ReloadWaiter;
+    const reload = new Promise<void>((resolve, reject) => {
+      waiter = { resolve, reject };
+    });
+
+    // Register the waiter before invoking the action. The action raises provider events synchronously,
+    // and an event listener can start a second awaited request.
+    this._rejectReloadWaiters(new ReloadSupersededError());
+    this._reloadWaiters.add(waiter);
+
+    try {
+      action();
+    } catch (error) {
+      this._reloadWaiters.delete(waiter);
+      throw error;
+    }
+
+    await reload;
+  }
+
+  public async scheduleReload(intent: ReloadIntent): Promise<void> {
+    if (this._isDisposed || this._host.isDisposed())
+      return;
+
+    if (this._reloadInFlight) {
+      this._pendingReload = intent;
+      return;
+    }
+
+    this._reloadInFlight = true;
+    this._host.startReload();
+    let continueWithPending = true;
+    let nextReload: ReloadIntent | undefined;
+
+    try {
+      await this._host.executeReload(intent);
+      if (this._stopAfterDisposal())
+        return;
+
+      nextReload = this._takePendingReload();
+      if (!nextReload) {
+        continueWithPending = false;
+        await this._host.finalizeReload();
+        if (this._stopAfterDisposal())
+          return;
+
+        nextReload = this._takePendingReload();
+      }
+    } catch (error) {
+      return this._handleReloadFailure(error, continueWithPending);
+    }
+
+    if (nextReload)
+      return this.scheduleReload(nextReload);
+
+    this._reloadInFlight = false;
+    this._resolveReloadWaiters();
+  }
+
+  private _stopAfterDisposal(): boolean {
+    if (!this._isDisposed && !this._host.isDisposed())
+      return false;
+
+    this._reloadInFlight = false;
+    this._pendingReload = undefined;
+    return true;
+  }
+
+  private _takePendingReload(): ReloadIntent | undefined {
+    const next = this._pendingReload;
+    if (next) {
+      this._pendingReload = undefined;
+      this._reloadInFlight = false;
+    }
+    return next;
+  }
+
+  private _handleReloadFailure(error: unknown, continueWithPending: boolean): Promise<void> | void {
+    this._reloadInFlight = false;
+    if (this._isDisposed || this._host.isDisposed()) {
+      this._pendingReload = undefined;
+      this._rejectReloadWaiters(this._disposedError);
+      return;
+    }
+
+    if (!continueWithPending || !(error instanceof ReloadSupersededError))
+      this._host.handleReloadFailure(error);
+
+    const next = continueWithPending ? this._takePendingReload() : undefined;
+    if (next)
+      return this.scheduleReload(next);
+
+    this._rejectReloadWaiters(error);
+  }
+
+  private _resolveReloadWaiters(): void {
+    const waiters = [...this._reloadWaiters];
+    this._reloadWaiters.clear();
+    for (const waiter of waiters)
+      waiter.resolve();
+  }
+
+  private _rejectReloadWaiters(error: unknown): void {
+    const waiters = [...this._reloadWaiters];
+    this._reloadWaiters.clear();
+    for (const waiter of waiters)
+      waiter.reject(error);
+  }
+}

--- a/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
+++ b/core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts
@@ -9,7 +9,7 @@ import { FormatsChangedArgs, FormatsProvider, UnitSystemKey } from "@itwin/core-
 export interface FormatsProviderChange {
   readonly baseProvider: FormatsProvider;
   readonly replacementProvider: FormatsProvider;
-  readonly targetUnitSystem: UnitSystemKey;
+  readonly impliedUnitSystem?: UnitSystemKey;
 }
 
 /** @internal */
@@ -32,7 +32,7 @@ export type ReloadIntent =
   }
   | { scope: "activeSystem"; system: UnitSystemKey; emitSystemChanged?: boolean };
 
-export interface ReloadCoordinatorHost {
+interface ReloadCoordinatorHost {
   isDisposed(): boolean;
   startReload(): void;
   executeReload(intent: ReloadIntent): Promise<void>;
@@ -45,6 +45,8 @@ interface ReloadCaller {
   reject: (reason?: unknown) => void;
 }
 
+type ProviderReloadIntent = Extract<ReloadIntent, { scope: "formatsChanged" }> & { providerChange: FormatsProviderChange };
+
 /**
  * Serializes formatting reloads, keeps the newest pending request, and resolves or rejects callers waiting for formatting to become ready.
  * @internal
@@ -52,7 +54,8 @@ interface ReloadCaller {
 export class FormatsProviderReloadCoordinator {
   private _reloadInFlight = false;
   private _pendingReload: ReloadIntent | undefined;
-  private _reloadCallers = new Set<ReloadCaller>();
+  private _pendingProviderReload: ProviderReloadIntent | undefined;
+  private _reloadCaller: ReloadCaller | undefined;
   private _isDisposed = false;
 
   public constructor(private readonly _host: ReloadCoordinatorHost, private readonly _disposedError: Error) {}
@@ -63,7 +66,8 @@ export class FormatsProviderReloadCoordinator {
 
     this._isDisposed = true;
     this._pendingReload = undefined;
-    this._rejectReloadCallers(this._disposedError);
+    this._pendingProviderReload = undefined;
+    this._rejectReloadCaller(this._disposedError);
   }
 
   /**
@@ -80,15 +84,14 @@ export class FormatsProviderReloadCoordinator {
       caller = { resolve, reject };
     });
 
-    // Register the caller before invoking the action. The action raises provider events synchronously,
-    // and an event listener can start a second awaited request.
-    this._rejectReloadCallers(new ReloadSupersededError());
-    this._reloadCallers.add(caller);
+    this._rejectReloadCaller(new ReloadSupersededError());
+    this._reloadCaller = caller;
 
     try {
       action();
     } catch (error) {
-      this._reloadCallers.delete(caller);
+      if (this._reloadCaller === caller)
+        this._reloadCaller = undefined;
       throw error;
     }
 
@@ -96,47 +99,82 @@ export class FormatsProviderReloadCoordinator {
   }
 
   /**
-   * Schedules a reload and keeps only the newest pending reload while another is running.
+   * Schedules a reload and keeps the newest pending reload while another is running.
+   * Provider replacement reloads are retained separately because the manager has already changed the active provider and the transaction must not be discarded by an unrelated reload.
    * If a reload is already running, this method returns immediately; use [[runAndWaitForReload]] when the caller must wait for completion.
    * @internal
    */
   public async scheduleReload(intent: ReloadIntent): Promise<void> {
-    if (this._isDisposed || this._host.isDisposed())
+    if (this._isDisposed || this._host.isDisposed()) {
+      this._rejectReloadCaller(this._disposedError);
       return;
+    }
 
     if (this._reloadInFlight) {
-      this._pendingReload = intent;
+      this._queuePendingReload(intent);
       return;
     }
 
     this._reloadInFlight = true;
-    this._host.startReload();
-    let continueWithPending = true;
-    let nextReload: ReloadIntent | undefined;
-
-    try {
-      await this._host.executeReload(intent);
-      if (this._stopAfterDisposal())
-        return;
-
-      nextReload = this._takePendingReload();
-      if (!nextReload) {
-        continueWithPending = false;
-        await this._host.finalizeReload();
+    let current: ReloadIntent | undefined = intent;
+    while (current) {
+      try {
+        this._host.startReload();
+        await this._host.executeReload(current);
+      } catch (error) {
         if (this._stopAfterDisposal())
           return;
 
-        nextReload = this._takePendingReload();
+        if (!(error instanceof ReloadSupersededError))
+          this._host.handleReloadFailure(error);
+
+        current = this._takePendingReload();
+        if (current)
+          continue;
+
+        this._reloadInFlight = false;
+        this._rejectReloadCaller(error);
+        return;
       }
-    } catch (error) {
-      return this._handleReloadFailure(error, continueWithPending);
+
+      if (this._stopAfterDisposal())
+        return;
+
+      current = this._takePendingReload();
+      if (current)
+        continue;
+
+      try {
+        await this._host.finalizeReload();
+      } catch (error) {
+        if (this._stopAfterDisposal())
+          return;
+
+        this._host.handleReloadFailure(error);
+        current = this._takePendingReload();
+        if (current)
+          continue;
+
+        this._reloadInFlight = false;
+        this._rejectReloadCaller(error);
+        return;
+      }
+
+      if (this._stopAfterDisposal())
+        return;
+
+      current = this._takePendingReload();
     }
 
-    if (nextReload)
-      return this.scheduleReload(nextReload);
-
     this._reloadInFlight = false;
-    this._resolveReloadCallers();
+    this._resolveReloadCaller();
+  }
+
+  private _queuePendingReload(intent: ReloadIntent): void {
+    if (this._isProviderReload(intent))
+      this._pendingProviderReload = intent;
+    else
+      this._pendingReload = intent;
   }
 
   /** Stops reload processing when this coordinator or its host is disposed. */
@@ -146,51 +184,39 @@ export class FormatsProviderReloadCoordinator {
 
     this._reloadInFlight = false;
     this._pendingReload = undefined;
+    this._pendingProviderReload = undefined;
+    this._rejectReloadCaller(this._disposedError);
     return true;
   }
 
-  /** Removes the newest pending reload and marks the current reload complete before starting it. */
+  /** Removes the newest pending reload, retaining provider transactions ahead of unrelated reloads. */
   private _takePendingReload(): ReloadIntent | undefined {
-    const next = this._pendingReload;
-    if (next) {
-      this._pendingReload = undefined;
-      this._reloadInFlight = false;
-    }
-    return next;
-  }
-
-  /** Handles a reload failure and, when appropriate, starts the newest pending reload. */
-  private _handleReloadFailure(error: unknown, continueWithPending: boolean): Promise<void> | void {
-    this._reloadInFlight = false;
-    if (this._isDisposed || this._host.isDisposed()) {
-      this._pendingReload = undefined;
-      this._rejectReloadCallers(this._disposedError);
-      return;
+    if (this._pendingProviderReload) {
+      const providerReload = this._pendingProviderReload;
+      this._pendingProviderReload = undefined;
+      return providerReload;
     }
 
-    if (!continueWithPending || !(error instanceof ReloadSupersededError))
-      this._host.handleReloadFailure(error);
-
-    const next = continueWithPending ? this._takePendingReload() : undefined;
-    if (next)
-      return this.scheduleReload(next);
-
-    this._rejectReloadCallers(error);
+    const nextReload = this._pendingReload;
+    this._pendingReload = undefined;
+    return nextReload;
   }
 
-  /** Resolves all callers after the reload queue finishes successfully. */
-  private _resolveReloadCallers(): void {
-    const callers = [...this._reloadCallers];
-    this._reloadCallers.clear();
-    for (const caller of callers)
-      caller.resolve();
+  private _isProviderReload(intent: ReloadIntent): intent is ProviderReloadIntent {
+    return intent.scope === "formatsChanged" && intent.providerChange !== undefined;
   }
 
-  /** Rejects all callers when the reload queue fails or is superseded. */
-  private _rejectReloadCallers(error: unknown): void {
-    const callers = [...this._reloadCallers];
-    this._reloadCallers.clear();
-    for (const caller of callers)
-      caller.reject(error);
+  /** Resolves the caller after the reload queue finishes successfully. */
+  private _resolveReloadCaller(): void {
+    const caller = this._reloadCaller;
+    this._reloadCaller = undefined;
+    caller?.resolve();
+  }
+
+  /** Rejects the caller when the reload queue fails or is superseded. */
+  private _rejectReloadCaller(error: unknown): void {
+    const caller = this._reloadCaller;
+    this._reloadCaller = undefined;
+    caller?.reject(error);
   }
 }

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -511,6 +511,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   private _pendingReload: ReloadIntent | undefined;
   private _deferredSystemChangedEmit: FormattingUnitSystemChangedArgs | undefined;
   private _reloadWaiters = new Set<ReloadWaiter>();
+  private _isDisposed = false;
+  private readonly _disposedError = new Error("QuantityFormatter was disposed before the reload completed.");
 
   private _removeFormatsProviderListener?: () => void;
   /**
@@ -531,30 +533,39 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   }
 
   public [Symbol.dispose](): void {
+    if (this._isDisposed)
+      return;
+
+    this._isDisposed = true;
+    this._isReady = false;
+    this._reloadInFlight = false;
+    this._pendingReload = undefined;
+    this._deferredSystemChangedEmit = undefined;
     if (this._removeFormatsProviderListener) {
       this._removeFormatsProviderListener();
       this._removeFormatsProviderListener = undefined;
     }
-    this._rejectReloadWaiters(new Error("QuantityFormatter was disposed before the reload completed."));
+    this._rejectReloadWaiters(this._disposedError);
   }
 
   /** Runs an action that schedules a reload and waits for the reload queue to drain.
+   * The most recent call wins. If another call is made before this reload queue drains, this call is rejected.
    * @internal
    */
   public async runAndWaitForReload(action: () => void): Promise<void> {
+    if (this._isDisposed)
+      throw this._disposedError;
+
     let waiter!: ReloadWaiter;
     const reload = new Promise<void>((resolve, reject) => {
       waiter = { resolve, reject };
-      this._reloadWaiters.add(waiter);
     });
 
-    try {
-      action();
-    } catch (err) {
-      this._reloadWaiters.delete(waiter);
-      throw err;
-    }
+    action();
 
+    // A newer explicitly awaited request supersedes any older request waiting for the queue.
+    this._rejectReloadWaiters(new Error("QuantityFormatter reload was superseded by a newer request."));
+    this._reloadWaiters.add(waiter);
     await reload;
   }
 
@@ -573,6 +584,9 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal
    */
   protected async scheduleReload(intent: ReloadIntent): Promise<void> {
+    if (this._isDisposed)
+      return;
+
     if (this._reloadInFlight) {
       // A reload is already running — queue this one (latest-wins)
       this._pendingReload = intent;
@@ -585,9 +599,22 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
 
     try {
       await this._executeReload(intent);
+      if (this._isDisposed) {
+        this._reloadInFlight = false;
+        this._pendingReload = undefined;
+        this._deferredSystemChangedEmit = undefined;
+        return;
+      }
     } catch (err) {
-      Logger.logError(`${FrontendLoggerCategory.Package}.QuantityFormatter`, BentleyError.getErrorMessage(err));
+      if (!this._isDisposed)
+        Logger.logError(`${FrontendLoggerCategory.Package}.QuantityFormatter`, BentleyError.getErrorMessage(err));
       this._reloadInFlight = false;
+      if (this._isDisposed) {
+        this._pendingReload = undefined;
+        this._deferredSystemChangedEmit = undefined;
+        this._rejectReloadWaiters(this._disposedError);
+        return;
+      }
       // If there's a pending reload, still try to run it
       if (this._pendingReload) {
         const next = this._pendingReload;
@@ -613,6 +640,12 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
 
     // Queue is drained — finalize
     await this.finalizeReload();
+    if (this._isDisposed) {
+      this._reloadInFlight = false;
+      this._pendingReload = undefined;
+      this._deferredSystemChangedEmit = undefined;
+      return;
+    }
 
     // A new reload may have been queued during the async finalizeReload window
     if (this._pendingReload) {
@@ -674,16 +707,23 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal
    */
   private async finalizeReload(): Promise<void> {
+    if (this._isDisposed)
+      return;
+
     // Phase 1: Let providers register async work
     const collector = new FormattingReadyCollector();
     this.onBeforeFormattingReady.raiseEvent(collector);
     await collector.awaitAll();
+    if (this._isDisposed)
+      return;
 
     // Phase 2: Signal ready to consumers
     this._isReady = true;
     this._hasEverBeenReady = true;
     this._resolveInitialized();
     this.onFormattingReady.emit();
+    if (this._isDisposed)
+      return;
 
     // Phase 3: Emit deferred unit-system-changed if the winning reload set one.
     // This fires after isReady === true so listeners can safely use the formatter.
@@ -985,6 +1025,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       return;
     }
 
+    if (this._isDisposed)
+      return;
     this.onUnitsProviderChanged.emit();
   }
 
@@ -1033,6 +1075,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
 
     unitSystemKey && (this._activeUnitSystem = unitSystemKey);
     await this.scheduleReload({ scope: "activeSystem", emitSystemChanged: fireUnitSystemChanged });
+    if (this._isDisposed)
+      return;
     IModelApp.toolAdmin && startDefaultTool && await IModelApp.toolAdmin.startDefaultTool();
   }
 
@@ -1049,6 +1093,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
 
     this._activeUnitSystem = systemType;
     await this.scheduleReload({ scope: "activeSystem", emitSystemChanged: true });
+    if (this._isDisposed)
+      return;
     // allow settings provider to store the change
     await this._unitFormattingSettingsProvider?.storeUnitSystemSetting({ system: systemType });
     if (IModelApp.toolAdmin && restartActiveTool)

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -362,7 +362,6 @@ type FormatsProviderManagerListener = (event: FormatsProviderManagerEvent) => vo
 interface FormatsProviderManagerState {
   listeners: Set<FormatsProviderManagerListener>;
   pendingFormatsProviderChange?: FormatsProviderChange;
-  restoreProvider: (provider: FormatsProvider) => void;
   notifyingPublicEvent: boolean;
 }
 
@@ -371,7 +370,7 @@ const formatsProviderManagerStates = new WeakMap<object, FormatsProviderManagerS
 function getFormatsProviderManagerState(manager: object): FormatsProviderManagerState {
   let state = formatsProviderManagerStates.get(manager);
   if (!state) {
-    state = { listeners: new Set(), restoreProvider: () => undefined, notifyingPublicEvent: false };
+    state = { listeners: new Set(), notifyingPublicEvent: false };
     formatsProviderManagerStates.set(manager, state);
   }
   return state;
@@ -387,8 +386,6 @@ export class FormatsProviderManager implements FormatsProvider {
   private _removeProviderListener?: () => void;
 
   constructor(private _formatsProvider: FormatsProvider) {
-    const state = getFormatsProviderManagerState(this);
-    state.restoreProvider = (provider) => this._setUnderlyingProvider(provider);
     this._setUnderlyingProvider(_formatsProvider);
   }
 
@@ -424,6 +421,20 @@ export class FormatsProviderManager implements FormatsProvider {
     if (impliedUnitSystem !== undefined)
       args.impliedUnitSystem = impliedUnitSystem;
     notifyFormatsProviderManagerListeners(this, { args, provider: formatsProvider, providerChange });
+  }
+
+  /**
+   * Restores a failed provider change without raising another formats-changed event.
+   * @internal
+   */
+  public restoreProviderChange(change: FormatsProviderChange): boolean {
+    const state = getFormatsProviderManagerState(this);
+    if (state.pendingFormatsProviderChange !== change)
+      return false;
+
+    state.pendingFormatsProviderChange = undefined;
+    this._setUnderlyingProvider(change.baseProvider);
+    return true;
   }
 
   private _setUnderlyingProvider(provider: FormatsProvider): void {
@@ -474,16 +485,6 @@ function applyFormatsProviderChange(manager: FormatsProviderManager, change: For
     return false;
 
   state.pendingFormatsProviderChange = undefined;
-  return true;
-}
-
-function restoreFormatsProviderChange(manager: FormatsProviderManager, change: FormatsProviderChange): boolean {
-  const state = getFormatsProviderManagerState(manager);
-  if (state.pendingFormatsProviderChange !== change)
-    return false;
-
-  state.pendingFormatsProviderChange = undefined;
-  state.restoreProvider(change.baseProvider);
   return true;
 }
 
@@ -691,7 +692,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     } catch (error) {
       this._restoreFormattingState(snapshot);
       if (intent.scope === "formatsChanged" && intent.providerChange && this._ownsFormatsProviderTransactions)
-        restoreFormatsProviderChange(IModelApp.formatsProvider as FormatsProviderManager, intent.providerChange);
+        (IModelApp.formatsProvider as FormatsProviderManager).restoreProviderChange(intent.providerChange);
       throw error;
     }
   }

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -658,6 +658,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     }
   }
 
+  /** Builds a provider replacement into temporary registry and spec maps, then commits them only after all async work succeeds. */
   private async _executeFormatsChangedReload(intent: Extract<ReloadIntent, { scope: "formatsChanged" }>): Promise<void> {
     const manager = IModelApp.formatsProvider as FormatsProviderManager;
     if (this._ownsFormatsProviderTransactions && !manager.isCurrentFormatsProviderReload(intent.provider, intent.providerChange))
@@ -692,6 +693,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       this._deferredSystemChangedEmit = { system: intent.targetUnitSystem };
   }
 
+  /** Builds active-system specs in temporary maps before replacing the currently active maps. */
   private async _executeActiveSystemReload(intent: Extract<ReloadIntent, { scope: "activeSystem" }>): Promise<void> {
     const nextFormatSpecs = new Map<QuantityTypeKey, FormatterSpec>();
     const nextParserSpecs = new Map<QuantityTypeKey, ParserSpec>();
@@ -711,10 +713,12 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       this._deferredSystemChangedEmit = { system: intent.system };
   }
 
+  /** Only the global IModelApp.quantityFormatter owns the provider transaction; other formatters may observe the event but must not apply or roll it back. */
   private get _ownsFormatsProviderTransactions(): boolean {
     return IModelApp.quantityFormatter === this;
   }
 
+  /** Captures the last committed formatting state so a failed reload can restore usable caches. */
   private _captureFormattingState(): FormattingStateSnapshot {
     return {
       formatSpecsRegistry: this._cloneFormatSpecsRegistry(this._formatSpecsRegistry),
@@ -846,11 +850,13 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     const formatPropsByType = new Map<QuantityTypeDefinition, FormatProps>();
 
     // load cache for every registered QuantityType
-    for (const [_, entry] of this.quantityTypesRegistry)
+    for (const [_, entry] of this.quantityTypesRegistry) {
       formatPropsByType.set(entry, this.getFormatPropsByQuantityTypeEntryAndSystem(entry, systemKey));
+    };
 
-    for (const [entry, formatProps] of formatPropsByType)
+    for (const [entry, formatProps] of formatPropsByType) {
       await this.loadFormatAndParserSpec(entry, formatProps);
+    }
   }
 
   private getFormatPropsByQuantityTypeEntryAndSystem(quantityEntry: QuantityTypeDefinition, requestedSystem: UnitSystemKey, ignoreOverrides?: boolean): FormatProps {

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -17,6 +17,7 @@ import { FrontendLoggerCategory } from "../common/FrontendLoggerCategory";
 import { IModelApp } from "../IModelApp";
 import { IModelConnection } from "../IModelConnection";
 import { getDefaultAlternateUnitLabels } from "./AlternateUnitLabels";
+import { FormatsProviderChange, FormatsProviderReloadCoordinator, ReloadIntent, ReloadSupersededError } from "./FormatsProviderReloadCoordinator";
 import { CustomFormatPropEditorSpec } from "./QuantityTypesEditorSpecs";
 
 // cSpell:ignore FORMATPROPS FORMATKEY ussurvey uscustomary USCUSTOM
@@ -350,6 +351,32 @@ export class QuantityTypeFormatsProvider implements FormatsProvider {
   }
 }
 
+interface FormatsProviderManagerEvent {
+  readonly args: FormatsChangedArgs;
+  readonly provider: FormatsProvider;
+  readonly providerChange?: FormatsProviderChange;
+}
+
+type FormatsProviderManagerListener = (event: FormatsProviderManagerEvent) => void;
+
+interface FormatsProviderManagerState {
+  listeners: Set<FormatsProviderManagerListener>;
+  pendingFormatsProviderChange?: FormatsProviderChange;
+  restoreProvider: (provider: FormatsProvider) => void;
+  notifyingPublicEvent: boolean;
+}
+
+const formatsProviderManagerStates = new WeakMap<object, FormatsProviderManagerState>();
+
+function getFormatsProviderManagerState(manager: object): FormatsProviderManagerState {
+  let state = formatsProviderManagerStates.get(manager);
+  if (!state) {
+    state = { listeners: new Set(), restoreProvider: () => undefined, notifyingPublicEvent: false };
+    formatsProviderManagerStates.set(manager, state);
+  }
+  return state;
+}
+
 /**
  * An implementation of the [[FormatsProvider]] interface that forwards calls to getFormats to the underlying FormatsProvider.
  * Also fires the onFormatsChanged event when the underlying FormatsProvider fires its own onFormatsChanged event.
@@ -360,9 +387,9 @@ export class FormatsProviderManager implements FormatsProvider {
   private _removeProviderListener?: () => void;
 
   constructor(private _formatsProvider: FormatsProvider) {
-    this._removeProviderListener = this._formatsProvider.onFormatsChanged.addListener((args: FormatsChangedArgs) => {
-      this.onFormatsChanged.raiseEvent(args);
-    });
+    const state = getFormatsProviderManagerState(this);
+    state.restoreProvider = (provider) => this._setUnderlyingProvider(provider);
+    this._setUnderlyingProvider(_formatsProvider);
   }
 
   public async getFormat(name: string, system?: UnitSystemKey): Promise<FormatDefinition | undefined> {
@@ -382,41 +409,100 @@ export class FormatsProviderManager implements FormatsProvider {
    * @internal
    */
   public setFormatsProvider(formatsProvider: FormatsProvider, impliedUnitSystem?: UnitSystemKey): void {
-    this._removeProviderListener?.();
-    this._formatsProvider = formatsProvider;
-    this._removeProviderListener = this._formatsProvider.onFormatsChanged.addListener((args: FormatsChangedArgs) => {
-      this.onFormatsChanged.raiseEvent(args);
-    });
+    const state = getFormatsProviderManagerState(this);
+    const baseProvider = state.pendingFormatsProviderChange?.baseProvider ?? this._formatsProvider;
+    const targetUnitSystem = impliedUnitSystem ?? IModelApp.quantityFormatter?.activeUnitSystem ?? "imperial";
+    const providerChange: FormatsProviderChange = {
+      baseProvider,
+      replacementProvider: formatsProvider,
+      targetUnitSystem,
+    };
+    this._setUnderlyingProvider(formatsProvider);
+    state.pendingFormatsProviderChange = providerChange;
+
     const args: FormatsChangedArgs = { formatsChanged: "all" };
     if (impliedUnitSystem !== undefined)
       args.impliedUnitSystem = impliedUnitSystem;
-    this.onFormatsChanged.raiseEvent(args);
+    notifyFormatsProviderManagerListeners(this, { args, provider: formatsProvider, providerChange });
+  }
+
+  private _setUnderlyingProvider(provider: FormatsProvider): void {
+    // Attach the new listener before changing fields so a malformed provider leaves the old
+    // provider and its listener intact if listener registration throws synchronously.
+    const removeProviderListener = provider.onFormatsChanged.addListener((args: FormatsChangedArgs) => {
+      const pendingChange = getFormatsProviderManagerState(this).pendingFormatsProviderChange;
+      const providerChange = pendingChange?.replacementProvider === provider ? pendingChange : undefined;
+      notifyFormatsProviderManagerListeners(this, { args, provider, providerChange });
+    });
+    this._removeProviderListener?.();
+    this._formatsProvider = provider;
+    this._removeProviderListener = removeProviderListener;
   }
 }
 
-/** Class that supports formatting quantity values into strings and parsing strings into quantity values. This class also maintains
- * the "active" unit system and caches FormatterSpecs and ParserSpecs for the "active" unit system to allow synchronous access to
- * parsing and formatting values. The support unit systems are defined by [[UnitSystemKey]] and is kept in synch with the unit systems
- * provided by the Presentation Manager on the backend. The QuantityFormatter contains a registry of quantity type definitions. These definitions implement
- * the [[QuantityTypeDefinition]] interface, which among other things, provide default [[FormatProps]], and provide methods
- * to generate both a [[FormatterSpec]] and a [[ParserSpec]]. There are built-in quantity types that are
- * identified by the [[QuantityType]] enum. [[CustomQuantityTypeDefinition]] can be registered to extend the available quantity types available
- * by frontend tools. The QuantityFormatter also allows the default formats to be overriden.
- *
- * @public
+/**
+ * Notify internal reload listeners, then raise the public formats-changed event.
+ * The notification flag prevents the public listener from scheduling the same reload twice.
  */
+function notifyFormatsProviderManagerListeners(manager: FormatsProviderManager, event: FormatsProviderManagerEvent): void {
+  const state = getFormatsProviderManagerState(manager);
+  const wasNotifyingPublicEvent = state.notifyingPublicEvent;
+  state.notifyingPublicEvent = true;
+  try {
+    const listeners = [...state.listeners];
+    for (const listener of listeners)
+      listener(event);
+    manager.onFormatsChanged.raiseEvent(event.args);
+  } finally {
+    state.notifyingPublicEvent = wasNotifyingPublicEvent;
+  }
+}
 
-/** Discriminated union describing what a queued reload should do.
- * @internal
- */
-type ReloadIntent =
-  | { scope: "full" }
-  | { scope: "formatsChanged"; args: FormatsChangedArgs }
-  | { scope: "activeSystem"; emitSystemChanged?: boolean };
+function isFormatsProviderManagerNotifyingPublicEvent(manager: FormatsProviderManager): boolean {
+  return getFormatsProviderManagerState(manager).notifyingPublicEvent;
+}
 
-interface ReloadWaiter {
-  resolve: () => void;
-  reject: (reason?: unknown) => void;
+function addFormatsProviderManagerListener(manager: FormatsProviderManager, listener: FormatsProviderManagerListener): () => void {
+  const listeners = getFormatsProviderManagerState(manager).listeners;
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function applyFormatsProviderChange(manager: FormatsProviderManager, change: FormatsProviderChange): boolean {
+  const state = getFormatsProviderManagerState(manager);
+  if (state.pendingFormatsProviderChange !== change)
+    return false;
+
+  state.pendingFormatsProviderChange = undefined;
+  return true;
+}
+
+function restoreFormatsProviderChange(manager: FormatsProviderManager, change: FormatsProviderChange): boolean {
+  const state = getFormatsProviderManagerState(manager);
+  if (state.pendingFormatsProviderChange !== change)
+    return false;
+
+  state.pendingFormatsProviderChange = undefined;
+  state.restoreProvider(change.baseProvider);
+  return true;
+}
+
+function isCurrentFormatsProviderReload(manager: FormatsProviderManager, provider: FormatsProvider, change?: FormatsProviderChange): boolean {
+  const pendingChange = getFormatsProviderManagerState(manager).pendingFormatsProviderChange;
+  if (change)
+    return pendingChange === change;
+  if (!pendingChange)
+    return true;
+  return provider === manager || provider === pendingChange.replacementProvider;
+}
+
+type FormatSpecsRegistry = Map<string, Map<string, Map<UnitSystemKey, FormattingSpecEntry>>>;
+
+interface FormattingStateSnapshot {
+  formatSpecsRegistry: FormatSpecsRegistry;
+  activeFormatSpecsByType: Map<QuantityTypeKey, FormatterSpec>;
+  activeParserSpecsByType: Map<QuantityTypeKey, ParserSpec>;
+  activeUnitSystem: UnitSystemKey;
 }
 
 /** The QuantityFormatter class provides methods for formatting and parsing quantities. There are a set of standard quantity types
@@ -507,14 +593,13 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   private _hasEverBeenReady = false;
   private _initializedPromise: Promise<void>;
   private _resolveInitialized!: () => void;
-  private _reloadInFlight = false;
-  private _pendingReload: ReloadIntent | undefined;
   private _deferredSystemChangedEmit: FormattingUnitSystemChangedArgs | undefined;
-  private _reloadWaiters = new Set<ReloadWaiter>();
   private _isDisposed = false;
   private readonly _disposedError = new Error("QuantityFormatter was disposed before the reload completed.");
-
+  private readonly _reloadCoordinator: FormatsProviderReloadCoordinator;
   private _removeFormatsProviderListener?: () => void;
+  private _activeFormatSpecsTarget?: Map<QuantityTypeKey, FormatterSpec>;
+  private _activeParserSpecsTarget?: Map<QuantityTypeKey, ParserSpec>;
   /**
    * constructor
    * @param showMetricOrUnitSystem - Pass in `true` to show Metric formatted quantity values. Defaults to Imperial. To explicitly
@@ -524,6 +609,15 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     this._initializedPromise = new Promise<void>((resolve) => {
       this._resolveInitialized = resolve;
     });
+    this._reloadCoordinator = new FormatsProviderReloadCoordinator({
+      isDisposed: () => this._isDisposed,
+      startReload: () => {
+        this._isReady = false;
+      },
+      executeReload: async (intent) => this._executeReload(intent),
+      finalizeReload: async () => this.finalizeReload(),
+      handleReloadFailure: (error) => this._handleReloadFailure(error),
+    }, this._disposedError);
     if (undefined !== showMetricOrUnitSystem) {
       if (typeof showMetricOrUnitSystem === "boolean")
         this._activeUnitSystem = showMetricOrUnitSystem ? "metric" : "imperial";
@@ -538,14 +632,12 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
 
     this._isDisposed = true;
     this._isReady = false;
-    this._reloadInFlight = false;
-    this._pendingReload = undefined;
     this._deferredSystemChangedEmit = undefined;
+    this._reloadCoordinator.dispose();
     if (this._removeFormatsProviderListener) {
       this._removeFormatsProviderListener();
       this._removeFormatsProviderListener = undefined;
     }
-    this._rejectReloadWaiters(this._disposedError);
   }
 
   /** Runs an action that schedules a reload and waits for the reload queue to drain.
@@ -553,20 +645,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal
    */
   public async runAndWaitForReload(action: () => void): Promise<void> {
-    if (this._isDisposed)
-      throw this._disposedError;
-
-    let waiter!: ReloadWaiter;
-    const reload = new Promise<void>((resolve, reject) => {
-      waiter = { resolve, reject };
-    });
-
-    action();
-
-    // A newer explicitly awaited request supersedes any older request waiting for the queue.
-    this._rejectReloadWaiters(new Error("QuantityFormatter reload was superseded by a newer request."));
-    this._reloadWaiters.add(waiter);
-    await reload;
+    return this._reloadCoordinator.runAndWaitForReload(action);
   }
 
   /** Schedule an async reload. If no reload is in flight, runs immediately. If a reload is
@@ -577,129 +656,129 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * immediately *without* the requested reload having run. Callers that need to know when
    * an explicitly triggered reload has actually completed should use [[runAndWaitForReload]].
    *
-   * Reload intents:
-   * - `"full"` — rebuild entire registry + re-register provider listener (onInitialized, setUnitsProvider)
-   * - `"formatsChanged"` — patch registry from provider + load maps (formatsChanged listener)
-   * - `"activeSystem"` — reload format/parsing maps for current unit system (setActiveUnitSystem, reinitializeFormatAndParsingsMaps)
    * @internal
    */
   protected async scheduleReload(intent: ReloadIntent): Promise<void> {
-    if (this._isDisposed)
-      return;
-
-    if (this._reloadInFlight) {
-      // A reload is already running — queue this one (latest-wins)
-      this._pendingReload = intent;
-      return;
-    }
-
-    this._reloadInFlight = true;
-    this._isReady = false;
-    this._deferredSystemChangedEmit = undefined; // Clear stale deferred from prior cycle
-
-    try {
-      await this._executeReload(intent);
-      if (this._isDisposed) {
-        this._reloadInFlight = false;
-        this._pendingReload = undefined;
-        this._deferredSystemChangedEmit = undefined;
-        return;
-      }
-    } catch (err) {
-      if (!this._isDisposed)
-        Logger.logError(`${FrontendLoggerCategory.Package}.QuantityFormatter`, BentleyError.getErrorMessage(err));
-      this._reloadInFlight = false;
-      if (this._isDisposed) {
-        this._pendingReload = undefined;
-        this._deferredSystemChangedEmit = undefined;
-        this._rejectReloadWaiters(this._disposedError);
-        return;
-      }
-      // If there's a pending reload, still try to run it
-      if (this._pendingReload) {
-        const next = this._pendingReload;
-        this._pendingReload = undefined;
-        return this.scheduleReload(next);
-      }
-      // Restore prior ready state so stale-but-usable specs remain accessible
-      if (this._hasEverBeenReady) {
-        Logger.logWarning(`${FrontendLoggerCategory.Package}.QuantityFormatter`, "Reload failed — restoring previous ready state. Cached specs may be stale.");
-        this._isReady = true;
-      }
-      this._rejectReloadWaiters(err);
-      return;
-    }
-
-    // Current reload succeeded — check if another was queued
-    if (this._pendingReload) {
-      const next = this._pendingReload;
-      this._pendingReload = undefined;
-      this._reloadInFlight = false;
-      return this.scheduleReload(next);
-    }
-
-    // Queue is drained — finalize
-    await this.finalizeReload();
-    if (this._isDisposed) {
-      this._reloadInFlight = false;
-      this._pendingReload = undefined;
-      this._deferredSystemChangedEmit = undefined;
-      return;
-    }
-
-    // A new reload may have been queued during the async finalizeReload window
-    if (this._pendingReload) {
-      const next = this._pendingReload;
-      this._pendingReload = undefined;
-      this._reloadInFlight = false;
-      return this.scheduleReload(next);
-    }
-
-    this._reloadInFlight = false;
-    this._resolveReloadWaiters();
+    return this._reloadCoordinator.scheduleReload(intent);
   }
 
-  private _resolveReloadWaiters(): void {
-    const waiters = [...this._reloadWaiters];
-    this._reloadWaiters.clear();
-    for (const waiter of waiters)
-      waiter.resolve();
-  }
-
-  private _rejectReloadWaiters(error: unknown): void {
-    const waiters = [...this._reloadWaiters];
-    this._reloadWaiters.clear();
-    for (const waiter of waiters)
-      waiter.reject(error);
+  private _handleReloadFailure(error: unknown): void {
+    if (!this._isDisposed)
+      Logger.logError(`${FrontendLoggerCategory.Package}.QuantityFormatter`, BentleyError.getErrorMessage(error));
+    if (this._hasEverBeenReady && !this._isDisposed) {
+      Logger.logWarning(`${FrontendLoggerCategory.Package}.QuantityFormatter`, "Reload failed — restoring previous ready state. Cached specs may be stale.");
+      this._isReady = true;
+    }
   }
 
   /** Execute the reload work for a given intent. All reload logic is centralized here.
    * @internal
    */
   private async _executeReload(intent: ReloadIntent): Promise<void> {
-    switch (intent.scope) {
-      case "full":
-        await this._reloadCore();
-        break;
-      case "formatsChanged": {
-        const { args } = intent;
-        await this._rebuildRegistryFromProvider(args);
-        if (args.impliedUnitSystem && args.impliedUnitSystem !== this._activeUnitSystem) {
-          this._activeUnitSystem = args.impliedUnitSystem;
-        }
-        await this.loadFormatAndParsingMapsForSystem(this._activeUnitSystem);
-        if (args.impliedUnitSystem) {
-          this._deferredSystemChangedEmit = { system: this._activeUnitSystem };
-        }
-        break;
+    const snapshot = this._captureFormattingState();
+    try {
+      switch (intent.scope) {
+        case "full":
+          await this._reloadCore();
+          break;
+        case "formatsChanged":
+          await this._executeFormatsChangedReload(intent);
+          break;
+        case "activeSystem":
+          await this._executeActiveSystemReload(intent);
+          break;
       }
-      case "activeSystem":
-        await this.loadFormatAndParsingMapsForSystem(this._activeUnitSystem);
-        if (intent.emitSystemChanged) {
-          this._deferredSystemChangedEmit = { system: this._activeUnitSystem };
-        }
-        break;
+    } catch (error) {
+      this._restoreFormattingState(snapshot);
+      if (intent.scope === "formatsChanged" && intent.providerChange && this._ownsFormatsProviderTransactions)
+        restoreFormatsProviderChange(IModelApp.formatsProvider as FormatsProviderManager, intent.providerChange);
+      throw error;
     }
+  }
+
+  private async _executeFormatsChangedReload(intent: Extract<ReloadIntent, { scope: "formatsChanged" }>): Promise<void> {
+    if (this._ownsFormatsProviderTransactions &&
+      !isCurrentFormatsProviderReload(IModelApp.formatsProvider as FormatsProviderManager, intent.provider, intent.providerChange))
+      throw new ReloadSupersededError();
+
+    const nextRegistry = this._cloneFormatSpecsRegistry(this._formatSpecsRegistry);
+    await this._rebuildRegistryFromProvider(intent.args, intent.provider, nextRegistry);
+
+    const previousSystem = this._activeUnitSystem;
+    const nextFormatSpecs = new Map<QuantityTypeKey, FormatterSpec>();
+    const nextParserSpecs = new Map<QuantityTypeKey, ParserSpec>();
+    this._activeFormatSpecsTarget = nextFormatSpecs;
+    this._activeParserSpecsTarget = nextParserSpecs;
+    try {
+      await this.loadFormatAndParsingMapsForSystem(intent.targetUnitSystem);
+    } finally {
+      this._activeFormatSpecsTarget = undefined;
+      this._activeParserSpecsTarget = undefined;
+    }
+
+    this._formatSpecsRegistry = nextRegistry;
+    this._activeFormatSpecsByType = nextFormatSpecs;
+    this._activeParserSpecsByType = nextParserSpecs;
+    this._activeUnitSystem = intent.targetUnitSystem;
+
+    if (intent.providerChange && this._ownsFormatsProviderTransactions &&
+      !applyFormatsProviderChange(IModelApp.formatsProvider as FormatsProviderManager, intent.providerChange))
+      throw new ReloadSupersededError();
+
+    if (intent.args.impliedUnitSystem && intent.targetUnitSystem !== previousSystem)
+      this._deferredSystemChangedEmit = { system: intent.targetUnitSystem };
+  }
+
+  private async _executeActiveSystemReload(intent: Extract<ReloadIntent, { scope: "activeSystem" }>): Promise<void> {
+    const nextFormatSpecs = new Map<QuantityTypeKey, FormatterSpec>();
+    const nextParserSpecs = new Map<QuantityTypeKey, ParserSpec>();
+    this._activeFormatSpecsTarget = nextFormatSpecs;
+    this._activeParserSpecsTarget = nextParserSpecs;
+    try {
+      await this.loadFormatAndParsingMapsForSystem(intent.system);
+    } finally {
+      this._activeFormatSpecsTarget = undefined;
+      this._activeParserSpecsTarget = undefined;
+    }
+
+    this._activeFormatSpecsByType = nextFormatSpecs;
+    this._activeParserSpecsByType = nextParserSpecs;
+    this._activeUnitSystem = intent.system;
+    if (intent.emitSystemChanged)
+      this._deferredSystemChangedEmit = { system: intent.system };
+  }
+
+  private get _ownsFormatsProviderTransactions(): boolean {
+    return IModelApp.quantityFormatter === this;
+  }
+
+  private _captureFormattingState(): FormattingStateSnapshot {
+    return {
+      formatSpecsRegistry: this._cloneFormatSpecsRegistry(this._formatSpecsRegistry),
+      activeFormatSpecsByType: new Map(this._activeFormatSpecsByType),
+      activeParserSpecsByType: new Map(this._activeParserSpecsByType),
+      activeUnitSystem: this._activeUnitSystem,
+    };
+  }
+
+  private _restoreFormattingState(snapshot: FormattingStateSnapshot): void {
+    this._activeFormatSpecsTarget = undefined;
+    this._activeParserSpecsTarget = undefined;
+    this._formatSpecsRegistry = snapshot.formatSpecsRegistry;
+    this._activeFormatSpecsByType = snapshot.activeFormatSpecsByType;
+    this._activeParserSpecsByType = snapshot.activeParserSpecsByType;
+    this._activeUnitSystem = snapshot.activeUnitSystem;
+  }
+
+  private _cloneFormatSpecsRegistry(source: FormatSpecsRegistry): FormatSpecsRegistry {
+    const clone: FormatSpecsRegistry = new Map();
+    for (const [name, unitMap] of source.entries()) {
+      const clonedUnitMap = new Map<string, Map<UnitSystemKey, FormattingSpecEntry>>();
+      for (const [persistenceUnitName, systemMap] of unitMap.entries())
+        clonedUnitMap.set(persistenceUnitName, new Map(systemMap));
+      clone.set(name, clonedUnitMap);
+    }
+    return clone;
   }
 
   /** Called when the reload queue is fully drained after a successful reload.
@@ -826,8 +905,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   private async loadFormatAndParserSpec(quantityTypeDefinition: QuantityTypeDefinition, formatProps: FormatProps) {
     const formatterSpec = await quantityTypeDefinition.generateFormatterSpec(formatProps, this.unitsProvider);
     const parserSpec = await quantityTypeDefinition.generateParserSpec(formatProps, this.unitsProvider, this.alternateUnitLabelsProvider);
-    this._activeFormatSpecsByType.set(quantityTypeDefinition.key, formatterSpec);
-    this._activeParserSpecsByType.set(quantityTypeDefinition.key, parserSpec);
+    (this._activeFormatSpecsTarget ?? this._activeFormatSpecsByType).set(quantityTypeDefinition.key, formatterSpec);
+    (this._activeParserSpecsTarget ?? this._activeParserSpecsByType).set(quantityTypeDefinition.key, parserSpec);
   }
 
   // repopulate formatSpec and parserSpec entries using only default format
@@ -891,19 +970,46 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal
    */
   public async onInitialized() {
+    this._ensureFormatsProviderListener();
     await this.scheduleReload({ scope: "full" });
+  }
+
+  private _ensureFormatsProviderListener(): void {
+    if (this._removeFormatsProviderListener)
+      return;
+
+    const manager = IModelApp.formatsProvider as FormatsProviderManager;
+    const removeInternalListener = addFormatsProviderManagerListener(manager, (event) => {
+      const targetUnitSystem = event.args.impliedUnitSystem ??
+        (this._ownsFormatsProviderTransactions ? event.providerChange?.targetUnitSystem : undefined) ?? this._activeUnitSystem;
+      void this.scheduleReload({
+        scope: "formatsChanged",
+        args: event.args,
+        provider: event.provider,
+        providerChange: event.providerChange,
+        targetUnitSystem,
+      });
+    });
+    const removePublicListener = manager.onFormatsChanged.addListener((args) => {
+      if (isFormatsProviderManagerNotifyingPublicEvent(manager))
+        return;
+      void this.scheduleReload({
+        scope: "formatsChanged",
+        args,
+        provider: manager,
+        targetUnitSystem: args.impliedUnitSystem ?? this._activeUnitSystem,
+      });
+    });
+    this._removeFormatsProviderListener = () => {
+      removeInternalListener();
+      removePublicListener();
+    };
   }
 
   /** Core reload logic — does all async I/O and cache rebuilding without events or state management.
    * @internal
    */
   private async _reloadCore(): Promise<void> {
-    // Remove any existing listener before re-registering to avoid duplicates when called via setUnitsProvider.
-    if (this._removeFormatsProviderListener) {
-      this._removeFormatsProviderListener();
-      this._removeFormatsProviderListener = undefined;
-    }
-
     await this.initializeQuantityTypesRegistry();
 
     const initialKoQs = [["DefaultToolsUnits.LENGTH", "Units.M"], ["DefaultToolsUnits.ANGLE", "Units.RAD"], ["DefaultToolsUnits.AREA", "Units.SQ_M"], ["DefaultToolsUnits.VOLUME", "Units.CUB_M"], ["DefaultToolsUnits.LENGTH_COORDINATE", "Units.M"], ["CivilUnits.STATION", "Units.M"], ["CivilUnits.LENGTH", "Units.M"], ["AecUnits.LENGTH", "Units.M"]];
@@ -917,41 +1023,35 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       }
     }
 
-    // Register formatsProvider listener that triggers a queued reload when formats change
-    this._removeFormatsProviderListener = IModelApp.formatsProvider.onFormatsChanged.addListener((args: FormatsChangedArgs) => {
-      void this.scheduleReload({ scope: "formatsChanged", args });
-    });
-
     // initialize default format and parsing specs
     await this.loadFormatAndParsingMapsForSystem();
   }
 
-  /** Rebuild the formatting specs registry from the current formatsProvider based on changed args.
+  /** Rebuild the formatting specs registry from a provider based on changed args.
    * @internal
    */
-  private async _rebuildRegistryFromProvider(args: FormatsChangedArgs): Promise<void> {
+  private async _rebuildRegistryFromProvider(args: FormatsChangedArgs, provider: FormatsProvider, registry: FormatSpecsRegistry): Promise<void> {
     if (args.formatsChanged === "all") {
-      for (const [name, unitMap] of this._formatSpecsRegistry.entries()) {
-        await this._rebuildRegistryForName(name, unitMap);
-      }
+      for (const [name, unitMap] of registry.entries())
+        await this._rebuildRegistryForName(name, unitMap, provider, registry);
     } else {
       for (const name of args.formatsChanged) {
-        const unitMap = this._formatSpecsRegistry.get(name);
-        if (unitMap) {
-          await this._rebuildRegistryForName(name, unitMap);
-        }
+        const unitMap = registry.get(name);
+        if (unitMap)
+          await this._rebuildRegistryForName(name, unitMap, provider, registry);
       }
     }
   }
 
   /** Rebuild all system entries for a single KoQ name in the registry. */
-  private async _rebuildRegistryForName(name: string, unitMap: Map<string, Map<UnitSystemKey, FormattingSpecEntry>>): Promise<void> {
+  private async _rebuildRegistryForName(name: string, unitMap: Map<string, Map<UnitSystemKey, FormattingSpecEntry>>,
+    provider: FormatsProvider, registry: FormatSpecsRegistry): Promise<void> {
     for (const system of QuantityFormatter._allUnitSystems) {
-      const formatProps = await IModelApp.formatsProvider.getFormat(name, system);
+      const formatProps = await provider.getFormat(name, system);
       if (formatProps) {
         for (const [persistenceUnitName, systemMap] of unitMap.entries()) {
           try {
-            await this.addFormattingSpecsToRegistry({ name, persistenceUnitName, formatProps, system });
+            await this._addFormattingSpecsToRegistry({ name, persistenceUnitName, formatProps, system }, registry);
           } catch (err) {
             systemMap.delete(system);
             Logger.logWarning(
@@ -974,7 +1074,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
         unitMap.delete(persistenceUnitName);
     }
     if (unitMap.size === 0)
-      this._formatSpecsRegistry.delete(name);
+      registry.delete(name);
   }
 
   /** Return a map that serves as a registry of all standard and custom quantity types. */
@@ -1025,6 +1125,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       return;
     }
 
+    // Disposal can occur while the reload is awaited, so do not notify afterward.
     if (this._isDisposed)
       return;
     this.onUnitsProviderChanged.emit();
@@ -1073,8 +1174,9 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       this._overrideFormatPropsByUnitSystem = overrideFormatPropsByUnitSystem;
     }
 
-    unitSystemKey && (this._activeUnitSystem = unitSystemKey);
-    await this.scheduleReload({ scope: "activeSystem", emitSystemChanged: fireUnitSystemChanged });
+    const targetUnitSystem = unitSystemKey ?? this._activeUnitSystem;
+    this._activeUnitSystem = targetUnitSystem;
+    await this.scheduleReload({ scope: "activeSystem", system: targetUnitSystem, emitSystemChanged: fireUnitSystemChanged });
     if (this._isDisposed)
       return;
     IModelApp.toolAdmin && startDefaultTool && await IModelApp.toolAdmin.startDefaultTool();
@@ -1092,7 +1194,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       return;
 
     this._activeUnitSystem = systemType;
-    await this.scheduleReload({ scope: "activeSystem", emitSystemChanged: true });
+    await this.scheduleReload({ scope: "activeSystem", system: systemType, emitSystemChanged: true });
     if (this._isDisposed)
       return;
     // allow settings provider to store the change
@@ -1502,39 +1604,41 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
  * @beta
  */
   public async addFormattingSpecsToRegistry(args: AddFormattingSpecArgs): Promise<void> {
+    return this._addFormattingSpecsToRegistry(args, this._formatSpecsRegistry);
+  }
+
+  private async _addFormattingSpecsToRegistry(args: AddFormattingSpecArgs, registry: FormatSpecsRegistry): Promise<void> {
     const { name, persistenceUnitName } = args;
     const effectiveSystem = args.system ?? this._activeUnitSystem;
     let formatProps = args.formatProps;
-    if (!formatProps) {
+    if (!formatProps)
       formatProps = await IModelApp.formatsProvider.getFormat(name, effectiveSystem);
-    }
-    if (formatProps) {
-      const formatterSpec = await this.createFormatterSpec({
-        persistenceUnitName,
-        formatProps,
-        formatName: name,
-      });
-      const parserSpec = await this.createParserSpec({
-        persistenceUnitName,
-        formatProps,
-        formatName: name,
-      });
-      let unitMap = this._formatSpecsRegistry.get(name);
-      if (!unitMap) {
-        unitMap = new Map();
-        this._formatSpecsRegistry.set(name, unitMap);
-      }
-
-      let systemMap = unitMap.get(persistenceUnitName);
-      if (!systemMap) {
-        systemMap = new Map();
-        unitMap.set(persistenceUnitName, systemMap);
-      }
-
-      systemMap.set(effectiveSystem, { formatterSpec, parserSpec });
-    } else {
+    if (!formatProps)
       throw new Error(`Unable to find format properties for ${name} with persistence unit ${persistenceUnitName}`);
+
+    const formatterSpec = await this.createFormatterSpec({
+      persistenceUnitName,
+      formatProps,
+      formatName: name,
+    });
+    const parserSpec = await this.createParserSpec({
+      persistenceUnitName,
+      formatProps,
+      formatName: name,
+    });
+    let unitMap = registry.get(name);
+    if (!unitMap) {
+      unitMap = new Map();
+      registry.set(name, unitMap);
     }
+
+    let systemMap = unitMap.get(persistenceUnitName);
+    if (!systemMap) {
+      systemMap = new Map();
+      unitMap.set(persistenceUnitName, systemMap);
+    }
+
+    systemMap.set(effectiveSystem, { formatterSpec, parserSpec });
   }
 }
 

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -372,12 +372,25 @@ export class FormatsProviderManager implements FormatsProvider {
   public get formatsProvider(): FormatsProvider { return this; }
 
   public set formatsProvider(formatsProvider: FormatsProvider) {
+    this.setFormatsProvider(formatsProvider);
+  }
+
+  /**
+   * Replaces the underlying formats provider and raises an event indicating that all formats changed.
+   * @param formatsProvider The formats provider to use for subsequent format lookups.
+   * @param impliedUnitSystem The unit system implied by the replacement provider, if any. It is forwarded as `FormatsChangedArgs.impliedUnitSystem`.
+   * @internal
+   */
+  public setFormatsProvider(formatsProvider: FormatsProvider, impliedUnitSystem?: UnitSystemKey): void {
     this._removeProviderListener?.();
     this._formatsProvider = formatsProvider;
     this._removeProviderListener = this._formatsProvider.onFormatsChanged.addListener((args: FormatsChangedArgs) => {
       this.onFormatsChanged.raiseEvent(args);
     });
-    this.onFormatsChanged.raiseEvent({ formatsChanged: "all" });
+    const args: FormatsChangedArgs = { formatsChanged: "all" };
+    if (impliedUnitSystem !== undefined)
+      args.impliedUnitSystem = impliedUnitSystem;
+    this.onFormatsChanged.raiseEvent(args);
   }
 }
 

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -357,25 +357,6 @@ interface FormatsProviderManagerEvent {
   readonly providerChange?: FormatsProviderChange;
 }
 
-type FormatsProviderManagerListener = (event: FormatsProviderManagerEvent) => void;
-
-interface FormatsProviderManagerState {
-  listeners: Set<FormatsProviderManagerListener>;
-  pendingFormatsProviderChange?: FormatsProviderChange;
-  notifyingPublicEvent: boolean;
-}
-
-const formatsProviderManagerStates = new WeakMap<object, FormatsProviderManagerState>();
-
-function getFormatsProviderManagerState(manager: object): FormatsProviderManagerState {
-  let state = formatsProviderManagerStates.get(manager);
-  if (!state) {
-    state = { listeners: new Set(), notifyingPublicEvent: false };
-    formatsProviderManagerStates.set(manager, state);
-  }
-  return state;
-}
-
 /**
  * An implementation of the [[FormatsProvider]] interface that forwards calls to getFormats to the underlying FormatsProvider.
  * Also fires the onFormatsChanged event when the underlying FormatsProvider fires its own onFormatsChanged event.
@@ -383,9 +364,13 @@ function getFormatsProviderManagerState(manager: object): FormatsProviderManager
  */
 export class FormatsProviderManager implements FormatsProvider {
   public onFormatsChanged = new BeEvent<(args: FormatsChangedArgs) => void>();
+  /** @internal */
+  public onFormatsChangedInternal = new BeEvent<(event: FormatsProviderManagerEvent) => void>();
   private _removeProviderListener?: () => void;
+  private _formatsProviderChange?: FormatsProviderChange;
 
   constructor(private _formatsProvider: FormatsProvider) {
+    this.onFormatsChanged.addListener((args) => this._notifyInternalListeners(args));
     this._setUnderlyingProvider(_formatsProvider);
   }
 
@@ -406,21 +391,18 @@ export class FormatsProviderManager implements FormatsProvider {
    * @internal
    */
   public setFormatsProvider(formatsProvider: FormatsProvider, impliedUnitSystem?: UnitSystemKey): void {
-    const state = getFormatsProviderManagerState(this);
-    const baseProvider = state.pendingFormatsProviderChange?.baseProvider ?? this._formatsProvider;
-    const targetUnitSystem = impliedUnitSystem ?? IModelApp.quantityFormatter?.activeUnitSystem ?? "imperial";
     const providerChange: FormatsProviderChange = {
-      baseProvider,
+      baseProvider: this._formatsProviderChange?.baseProvider ?? this._formatsProvider,
       replacementProvider: formatsProvider,
-      targetUnitSystem,
+      impliedUnitSystem,
     };
     this._setUnderlyingProvider(formatsProvider);
-    state.pendingFormatsProviderChange = providerChange;
+    this._formatsProviderChange = providerChange;
 
     const args: FormatsChangedArgs = { formatsChanged: "all" };
     if (impliedUnitSystem !== undefined)
       args.impliedUnitSystem = impliedUnitSystem;
-    notifyFormatsProviderManagerListeners(this, { args, provider: formatsProvider, providerChange });
+    this.onFormatsChanged.raiseEvent(args);
   }
 
   /**
@@ -428,22 +410,43 @@ export class FormatsProviderManager implements FormatsProvider {
    * @internal
    */
   public restoreProviderChange(change: FormatsProviderChange): boolean {
-    const state = getFormatsProviderManagerState(this);
-    if (state.pendingFormatsProviderChange !== change)
+    if (this._formatsProviderChange !== change)
       return false;
 
-    state.pendingFormatsProviderChange = undefined;
+    this._formatsProviderChange = undefined;
     this._setUnderlyingProvider(change.baseProvider);
     return true;
+  }
+
+  /** @internal */
+  public applyFormatsProviderChange(change: FormatsProviderChange): boolean {
+    if (this._formatsProviderChange !== change)
+      return false;
+
+    this._formatsProviderChange = undefined;
+    return true;
+  }
+
+  /** @internal */
+  public isCurrentFormatsProviderReload(provider: FormatsProvider, change?: FormatsProviderChange): boolean {
+    if (change)
+      return this._formatsProviderChange === change;
+    if (!this._formatsProviderChange)
+      return true;
+    return provider === this || provider === this._formatsProviderChange.replacementProvider;
+  }
+
+  private _notifyInternalListeners(args: FormatsChangedArgs): void {
+    const provider = this._formatsProvider;
+    const providerChange = this._formatsProviderChange?.replacementProvider === provider ? this._formatsProviderChange : undefined;
+    this.onFormatsChangedInternal.raiseEvent({ args, provider, providerChange });
   }
 
   private _setUnderlyingProvider(provider: FormatsProvider): void {
     // Attach the new listener before changing fields so a malformed provider leaves the old
     // provider and its listener intact if listener registration throws synchronously.
     const removeProviderListener = provider.onFormatsChanged.addListener((args: FormatsChangedArgs) => {
-      const pendingChange = getFormatsProviderManagerState(this).pendingFormatsProviderChange;
-      const providerChange = pendingChange?.replacementProvider === provider ? pendingChange : undefined;
-      notifyFormatsProviderManagerListeners(this, { args, provider, providerChange });
+      this.onFormatsChanged.raiseEvent(args);
     });
     this._removeProviderListener?.();
     this._formatsProvider = provider;
@@ -451,59 +454,18 @@ export class FormatsProviderManager implements FormatsProvider {
   }
 }
 
-/**
- * Notify internal reload listeners, then raise the public formats-changed event.
- * The notification flag prevents the public listener from scheduling the same reload twice.
- */
-function notifyFormatsProviderManagerListeners(manager: FormatsProviderManager, event: FormatsProviderManagerEvent): void {
-  const state = getFormatsProviderManagerState(manager);
-  const wasNotifyingPublicEvent = state.notifyingPublicEvent;
-  state.notifyingPublicEvent = true;
-  try {
-    const listeners = [...state.listeners];
-    for (const listener of listeners)
-      listener(event);
-    manager.onFormatsChanged.raiseEvent(event.args);
-  } finally {
-    state.notifyingPublicEvent = wasNotifyingPublicEvent;
-  }
-}
-
-function isFormatsProviderManagerNotifyingPublicEvent(manager: FormatsProviderManager): boolean {
-  return getFormatsProviderManagerState(manager).notifyingPublicEvent;
-}
-
-function addFormatsProviderManagerListener(manager: FormatsProviderManager, listener: FormatsProviderManagerListener): () => void {
-  const listeners = getFormatsProviderManagerState(manager).listeners;
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
-
-function applyFormatsProviderChange(manager: FormatsProviderManager, change: FormatsProviderChange): boolean {
-  const state = getFormatsProviderManagerState(manager);
-  if (state.pendingFormatsProviderChange !== change)
-    return false;
-
-  state.pendingFormatsProviderChange = undefined;
-  return true;
-}
-
-function isCurrentFormatsProviderReload(manager: FormatsProviderManager, provider: FormatsProvider, change?: FormatsProviderChange): boolean {
-  const pendingChange = getFormatsProviderManagerState(manager).pendingFormatsProviderChange;
-  if (change)
-    return pendingChange === change;
-  if (!pendingChange)
-    return true;
-  return provider === manager || provider === pendingChange.replacementProvider;
-}
-
 type FormatSpecsRegistry = Map<string, Map<string, Map<UnitSystemKey, FormattingSpecEntry>>>;
 
-interface FormattingStateSnapshot {
-  formatSpecsRegistry: FormatSpecsRegistry;
+interface FormattingSpecMaps {
   activeFormatSpecsByType: Map<QuantityTypeKey, FormatterSpec>;
   activeParserSpecsByType: Map<QuantityTypeKey, ParserSpec>;
+}
+
+interface FormattingStateCandidate extends FormattingSpecMaps {
+  formatSpecsRegistry: FormatSpecsRegistry;
   activeUnitSystem: UnitSystemKey;
+  requestedUnitSystem?: UnitSystemKey;
+  deferredSystemChanged?: FormattingUnitSystemChangedArgs;
 }
 
 /** The QuantityFormatter class provides methods for formatting and parsing quantities. There are a set of standard quantity types
@@ -525,6 +487,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
 
   /** Active UnitSystem key - must be one of "imperial", "metric", "usCustomary", or "usSurvey". */
   protected _activeUnitSystem: UnitSystemKey = "imperial";
+  private _requestedUnitSystem: UnitSystemKey = "imperial";
   /** Map of FormatSpecs for all available QuantityTypes, keyed by quantity type */
   protected _activeFormatSpecsByType = new Map<QuantityTypeKey, FormatterSpec>();
   /** Map of ParserSpecs for all available QuantityTypes, keyed by quantity type */
@@ -599,8 +562,6 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   private readonly _disposedError = new Error("QuantityFormatter was disposed before the reload completed.");
   private readonly _reloadCoordinator: FormatsProviderReloadCoordinator;
   private _removeFormatsProviderListener?: () => void;
-  private _activeFormatSpecsTarget?: Map<QuantityTypeKey, FormatterSpec>;
-  private _activeParserSpecsTarget?: Map<QuantityTypeKey, ParserSpec>;
   /**
    * constructor
    * @param showMetricOrUnitSystem - Pass in `true` to show Metric formatted quantity values. Defaults to Imperial. To explicitly
@@ -614,6 +575,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       isDisposed: () => this._isDisposed,
       startReload: () => {
         this._isReady = false;
+        this._deferredSystemChangedEmit = undefined;
       },
       executeReload: async (intent) => this._executeReload(intent),
       finalizeReload: async () => this.finalizeReload(),
@@ -624,6 +586,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
         this._activeUnitSystem = showMetricOrUnitSystem ? "metric" : "imperial";
       else
         this._activeUnitSystem = showMetricOrUnitSystem;
+      this._requestedUnitSystem = this._activeUnitSystem;
     }
   }
 
@@ -650,8 +613,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   }
 
   /** Schedule an async reload. If no reload is in flight, runs immediately. If a reload is
-   * already in flight, stores the intent as pending (latest-wins: only the last scheduled reload
-   * is kept). `finalizeReload()` fires only when the queue is fully drained.
+   * already in flight, stores the latest ordinary intent as pending while retaining any pending
+   * provider replacement. `finalizeReload()` fires only when the queue is fully drained.
    *
    * **Await semantics:** When a reload is already in flight, the returned promise resolves
    * immediately *without* the requested reload having run. Callers that need to know when
@@ -676,99 +639,82 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal
    */
   private async _executeReload(intent: ReloadIntent): Promise<void> {
-    const snapshot = this._captureFormattingState();
     try {
+      let candidate: FormattingStateCandidate;
       switch (intent.scope) {
         case "full":
-          await this._reloadCore();
+          candidate = await this._reloadCore();
           break;
         case "formatsChanged":
-          await this._executeFormatsChangedReload(intent);
+          candidate = await this._buildFormatsChangedCandidate(intent);
           break;
         case "activeSystem":
-          await this._executeActiveSystemReload(intent);
+          candidate = await this._buildActiveSystemCandidate(intent);
           break;
       }
+
+      if (intent.scope === "formatsChanged" && intent.providerChange && this._ownsFormatsProviderTransactions) {
+        const manager = IModelApp.formatsProvider as FormatsProviderManager;
+        if (!manager.applyFormatsProviderChange(intent.providerChange))
+          throw new ReloadSupersededError();
+      }
+
+      this._commitFormattingState(candidate);
     } catch (error) {
-      this._restoreFormattingState(snapshot);
       if (intent.scope === "formatsChanged" && intent.providerChange && this._ownsFormatsProviderTransactions)
         (IModelApp.formatsProvider as FormatsProviderManager).restoreProviderChange(intent.providerChange);
+      if (intent.scope === "activeSystem" && this._requestedUnitSystem === intent.system)
+        this._requestedUnitSystem = this._activeUnitSystem;
       throw error;
     }
   }
 
-  private async _executeFormatsChangedReload(intent: Extract<ReloadIntent, { scope: "formatsChanged" }>): Promise<void> {
-    if (this._ownsFormatsProviderTransactions &&
-      !isCurrentFormatsProviderReload(IModelApp.formatsProvider as FormatsProviderManager, intent.provider, intent.providerChange))
+  private async _buildFormatsChangedCandidate(intent: Extract<ReloadIntent, { scope: "formatsChanged" }>): Promise<FormattingStateCandidate> {
+    const manager = IModelApp.formatsProvider as FormatsProviderManager;
+    if (this._ownsFormatsProviderTransactions && !manager.isCurrentFormatsProviderReload(intent.provider, intent.providerChange))
       throw new ReloadSupersededError();
 
     const nextRegistry = this._cloneFormatSpecsRegistry(this._formatSpecsRegistry);
     await this._rebuildRegistryFromProvider(intent.args, intent.provider, nextRegistry);
+    const nextSpecs = await this._buildFormatAndParsingMapsForSystem(intent.targetUnitSystem);
+    const deferredSystemChanged = intent.args.impliedUnitSystem && intent.targetUnitSystem !== this._activeUnitSystem
+      ? { system: intent.targetUnitSystem }
+      : undefined;
+    const requestedUnitSystem = intent.args.impliedUnitSystem && this._requestedUnitSystem === this._activeUnitSystem
+      ? intent.targetUnitSystem
+      : undefined;
 
-    const previousSystem = this._activeUnitSystem;
-    const nextFormatSpecs = new Map<QuantityTypeKey, FormatterSpec>();
-    const nextParserSpecs = new Map<QuantityTypeKey, ParserSpec>();
-    this._activeFormatSpecsTarget = nextFormatSpecs;
-    this._activeParserSpecsTarget = nextParserSpecs;
-    try {
-      await this.loadFormatAndParsingMapsForSystem(intent.targetUnitSystem);
-    } finally {
-      this._activeFormatSpecsTarget = undefined;
-      this._activeParserSpecsTarget = undefined;
-    }
-
-    this._formatSpecsRegistry = nextRegistry;
-    this._activeFormatSpecsByType = nextFormatSpecs;
-    this._activeParserSpecsByType = nextParserSpecs;
-    this._activeUnitSystem = intent.targetUnitSystem;
-
-    if (intent.providerChange && this._ownsFormatsProviderTransactions &&
-      !applyFormatsProviderChange(IModelApp.formatsProvider as FormatsProviderManager, intent.providerChange))
-      throw new ReloadSupersededError();
-
-    if (intent.args.impliedUnitSystem && intent.targetUnitSystem !== previousSystem)
-      this._deferredSystemChangedEmit = { system: intent.targetUnitSystem };
+    return {
+      formatSpecsRegistry: nextRegistry,
+      ...nextSpecs,
+      activeUnitSystem: intent.targetUnitSystem,
+      requestedUnitSystem,
+      deferredSystemChanged,
+    };
   }
 
-  private async _executeActiveSystemReload(intent: Extract<ReloadIntent, { scope: "activeSystem" }>): Promise<void> {
-    const nextFormatSpecs = new Map<QuantityTypeKey, FormatterSpec>();
-    const nextParserSpecs = new Map<QuantityTypeKey, ParserSpec>();
-    this._activeFormatSpecsTarget = nextFormatSpecs;
-    this._activeParserSpecsTarget = nextParserSpecs;
-    try {
-      await this.loadFormatAndParsingMapsForSystem(intent.system);
-    } finally {
-      this._activeFormatSpecsTarget = undefined;
-      this._activeParserSpecsTarget = undefined;
-    }
+  private async _buildActiveSystemCandidate(intent: Extract<ReloadIntent, { scope: "activeSystem" }>): Promise<FormattingStateCandidate> {
+    const nextSpecs = await this._buildFormatAndParsingMapsForSystem(intent.system);
+    return {
+      formatSpecsRegistry: this._formatSpecsRegistry,
+      ...nextSpecs,
+      activeUnitSystem: intent.system,
+      deferredSystemChanged: intent.emitSystemChanged ? { system: intent.system } : undefined,
+    };
+  }
 
-    this._activeFormatSpecsByType = nextFormatSpecs;
-    this._activeParserSpecsByType = nextParserSpecs;
-    this._activeUnitSystem = intent.system;
-    if (intent.emitSystemChanged)
-      this._deferredSystemChangedEmit = { system: intent.system };
+  private _commitFormattingState(candidate: FormattingStateCandidate): void {
+    this._formatSpecsRegistry = candidate.formatSpecsRegistry;
+    this._activeFormatSpecsByType = candidate.activeFormatSpecsByType;
+    this._activeParserSpecsByType = candidate.activeParserSpecsByType;
+    this._activeUnitSystem = candidate.activeUnitSystem;
+    if (candidate.requestedUnitSystem !== undefined)
+      this._requestedUnitSystem = candidate.requestedUnitSystem;
+    this._deferredSystemChangedEmit = candidate.deferredSystemChanged;
   }
 
   private get _ownsFormatsProviderTransactions(): boolean {
     return IModelApp.quantityFormatter === this;
-  }
-
-  private _captureFormattingState(): FormattingStateSnapshot {
-    return {
-      formatSpecsRegistry: this._cloneFormatSpecsRegistry(this._formatSpecsRegistry),
-      activeFormatSpecsByType: new Map(this._activeFormatSpecsByType),
-      activeParserSpecsByType: new Map(this._activeParserSpecsByType),
-      activeUnitSystem: this._activeUnitSystem,
-    };
-  }
-
-  private _restoreFormattingState(snapshot: FormattingStateSnapshot): void {
-    this._activeFormatSpecsTarget = undefined;
-    this._activeParserSpecsTarget = undefined;
-    this._formatSpecsRegistry = snapshot.formatSpecsRegistry;
-    this._activeFormatSpecsByType = snapshot.activeFormatSpecsByType;
-    this._activeParserSpecsByType = snapshot.activeParserSpecsByType;
-    this._activeUnitSystem = snapshot.activeUnitSystem;
   }
 
   private _cloneFormatSpecsRegistry(source: FormatSpecsRegistry): FormatSpecsRegistry {
@@ -880,17 +826,23 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal public for unit test usage
    */
   protected async loadFormatAndParsingMapsForSystem(systemType?: UnitSystemKey): Promise<void> {
-    const systemKey = (undefined !== systemType) ? systemType : this._activeUnitSystem;
-    const formatPropsByType = new Map<QuantityTypeDefinition, FormatProps>();
+    const specs = await this._buildFormatAndParsingMapsForSystem(systemType ?? this._activeUnitSystem);
+    this._activeFormatSpecsByType = specs.activeFormatSpecsByType;
+    this._activeParserSpecsByType = specs.activeParserSpecsByType;
+  }
 
-    // load cache for every registered QuantityType
-    for (const [_, entry] of this.quantityTypesRegistry) {
-      formatPropsByType.set(entry, this.getFormatPropsByQuantityTypeEntryAndSystem(entry, systemKey));
-    };
+  private async _buildFormatAndParsingMapsForSystem(systemKey: UnitSystemKey): Promise<FormattingSpecMaps> {
+    const activeFormatSpecsByType = new Map<QuantityTypeKey, FormatterSpec>();
+    const activeParserSpecsByType = new Map<QuantityTypeKey, ParserSpec>();
 
-    for (const [entry, formatProps] of formatPropsByType) {
-      await this.loadFormatAndParserSpec(entry, formatProps);
+    for (const entry of this.quantityTypesRegistry.values()) {
+      const formatProps = this.getFormatPropsByQuantityTypeEntryAndSystem(entry, systemKey);
+      const specs = await this._createFormatAndParserSpecs(entry, formatProps);
+      activeFormatSpecsByType.set(entry.key, specs.formatterSpec);
+      activeParserSpecsByType.set(entry.key, specs.parserSpec);
     }
+
+    return { activeFormatSpecsByType, activeParserSpecsByType };
   }
 
   private getFormatPropsByQuantityTypeEntryAndSystem(quantityEntry: QuantityTypeDefinition, requestedSystem: UnitSystemKey, ignoreOverrides?: boolean): FormatProps {
@@ -903,11 +855,16 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     return quantityEntry.getDefaultFormatPropsBySystem(requestedSystem);
   }
 
-  private async loadFormatAndParserSpec(quantityTypeDefinition: QuantityTypeDefinition, formatProps: FormatProps) {
+  private async _createFormatAndParserSpecs(quantityTypeDefinition: QuantityTypeDefinition, formatProps: FormatProps): Promise<{ formatterSpec: FormatterSpec; parserSpec: ParserSpec }> {
     const formatterSpec = await quantityTypeDefinition.generateFormatterSpec(formatProps, this.unitsProvider);
     const parserSpec = await quantityTypeDefinition.generateParserSpec(formatProps, this.unitsProvider, this.alternateUnitLabelsProvider);
-    (this._activeFormatSpecsTarget ?? this._activeFormatSpecsByType).set(quantityTypeDefinition.key, formatterSpec);
-    (this._activeParserSpecsTarget ?? this._activeParserSpecsByType).set(quantityTypeDefinition.key, parserSpec);
+    return { formatterSpec, parserSpec };
+  }
+
+  private async loadFormatAndParserSpec(quantityTypeDefinition: QuantityTypeDefinition, formatProps: FormatProps) {
+    const specs = await this._createFormatAndParserSpecs(quantityTypeDefinition, formatProps);
+    this._activeFormatSpecsByType.set(quantityTypeDefinition.key, specs.formatterSpec);
+    this._activeParserSpecsByType.set(quantityTypeDefinition.key, specs.parserSpec);
   }
 
   // repopulate formatSpec and parserSpec entries using only default format
@@ -971,61 +928,53 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal
    */
   public async onInitialized() {
+    if (this._isDisposed)
+      return;
+
     this._ensureFormatsProviderListener();
     await this.scheduleReload({ scope: "full" });
   }
 
   private _ensureFormatsProviderListener(): void {
-    if (this._removeFormatsProviderListener)
+    if (this._isDisposed || this._removeFormatsProviderListener)
       return;
 
     const manager = IModelApp.formatsProvider as FormatsProviderManager;
-    const removeInternalListener = addFormatsProviderManagerListener(manager, (event) => {
-      const targetUnitSystem = event.args.impliedUnitSystem ??
-        (this._ownsFormatsProviderTransactions ? event.providerChange?.targetUnitSystem : undefined) ?? this._activeUnitSystem;
+    const removeInternalListener = manager.onFormatsChangedInternal.addListener((event) => {
       void this.scheduleReload({
         scope: "formatsChanged",
         args: event.args,
         provider: event.provider,
         providerChange: event.providerChange,
-        targetUnitSystem,
+        targetUnitSystem: event.args.impliedUnitSystem ?? this._requestedUnitSystem,
       });
     });
-    const removePublicListener = manager.onFormatsChanged.addListener((args) => {
-      if (isFormatsProviderManagerNotifyingPublicEvent(manager))
-        return;
-      void this.scheduleReload({
-        scope: "formatsChanged",
-        args,
-        provider: manager,
-        targetUnitSystem: args.impliedUnitSystem ?? this._activeUnitSystem,
-      });
-    });
-    this._removeFormatsProviderListener = () => {
-      removeInternalListener();
-      removePublicListener();
-    };
+    this._removeFormatsProviderListener = removeInternalListener;
   }
 
   /** Core reload logic — does all async I/O and cache rebuilding without events or state management.
    * @internal
    */
-  private async _reloadCore(): Promise<void> {
+  private async _reloadCore(): Promise<FormattingStateCandidate> {
     await this.initializeQuantityTypesRegistry();
 
+    const nextRegistry = this._cloneFormatSpecsRegistry(this._formatSpecsRegistry);
     const initialKoQs = [["DefaultToolsUnits.LENGTH", "Units.M"], ["DefaultToolsUnits.ANGLE", "Units.RAD"], ["DefaultToolsUnits.AREA", "Units.SQ_M"], ["DefaultToolsUnits.VOLUME", "Units.CUB_M"], ["DefaultToolsUnits.LENGTH_COORDINATE", "Units.M"], ["CivilUnits.STATION", "Units.M"], ["CivilUnits.LENGTH", "Units.M"], ["AecUnits.LENGTH", "Units.M"]];
     for (const entry of initialKoQs) {
       for (const system of QuantityFormatter._allUnitSystems) {
         try {
-          await this.addFormattingSpecsToRegistry({ name: entry[0], persistenceUnitName: entry[1], system });
+          await this._addFormattingSpecsToRegistry({ name: entry[0], persistenceUnitName: entry[1], system }, nextRegistry);
         } catch (err: any) {
           Logger.logWarning(`${FrontendLoggerCategory.Package}.QuantityFormatter`, err.toString());
         }
       }
     }
 
-    // initialize default format and parsing specs
-    await this.loadFormatAndParsingMapsForSystem();
+    return {
+      formatSpecsRegistry: nextRegistry,
+      ...(await this._buildFormatAndParsingMapsForSystem(this._activeUnitSystem)),
+      activeUnitSystem: this._activeUnitSystem,
+    };
   }
 
   /** Rebuild the formatting specs registry from a provider based on changed args.
@@ -1175,8 +1124,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       this._overrideFormatPropsByUnitSystem = overrideFormatPropsByUnitSystem;
     }
 
-    const targetUnitSystem = unitSystemKey ?? this._activeUnitSystem;
-    this._activeUnitSystem = targetUnitSystem;
+    const targetUnitSystem = unitSystemKey ?? this._requestedUnitSystem;
+    this._requestedUnitSystem = targetUnitSystem;
     await this.scheduleReload({ scope: "activeSystem", system: targetUnitSystem, emitSystemChanged: fireUnitSystemChanged });
     if (this._isDisposed)
       return;
@@ -1191,10 +1140,10 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     else
       systemType = isImperialOrUnitSystem;
 
-    if (this._activeUnitSystem === systemType)
+    if (this._requestedUnitSystem === systemType)
       return;
 
-    this._activeUnitSystem = systemType;
+    this._requestedUnitSystem = systemType;
     await this.scheduleReload({ scope: "activeSystem", system: systemType, emitSystemChanged: true });
     if (this._isDisposed)
       return;

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -414,6 +414,11 @@ type ReloadIntent =
   | { scope: "formatsChanged"; args: FormatsChangedArgs }
   | { scope: "activeSystem"; emitSystemChanged?: boolean };
 
+interface ReloadWaiter {
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+}
+
 /** The QuantityFormatter class provides methods for formatting and parsing quantities. There are a set of standard quantity types
  * identified by the [[QuantityType]] enum. [[CustomQuantityTypeDefinition]] can be registered to extend the available quantity types available
  * by frontend tools. The QuantityFormatter also allows the default formats to be overriden.
@@ -505,6 +510,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   private _reloadInFlight = false;
   private _pendingReload: ReloadIntent | undefined;
   private _deferredSystemChangedEmit: FormattingUnitSystemChangedArgs | undefined;
+  private _reloadWaiters = new Set<ReloadWaiter>();
 
   private _removeFormatsProviderListener?: () => void;
   /**
@@ -529,6 +535,27 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
       this._removeFormatsProviderListener();
       this._removeFormatsProviderListener = undefined;
     }
+    this._rejectReloadWaiters(new Error("QuantityFormatter was disposed before the reload completed."));
+  }
+
+  /** Runs an action that schedules a reload and waits for the reload queue to drain.
+   * @internal
+   */
+  public async runAndWaitForReload(action: () => void): Promise<void> {
+    let waiter!: ReloadWaiter;
+    const reload = new Promise<void>((resolve, reject) => {
+      waiter = { resolve, reject };
+      this._reloadWaiters.add(waiter);
+    });
+
+    try {
+      action();
+    } catch (err) {
+      this._reloadWaiters.delete(waiter);
+      throw err;
+    }
+
+    await reload;
   }
 
   /** Schedule an async reload. If no reload is in flight, runs immediately. If a reload is
@@ -537,7 +564,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    *
    * **Await semantics:** When a reload is already in flight, the returned promise resolves
    * immediately *without* the requested reload having run. Callers that need to know when
-   * the reload has actually completed should listen for `onFormattingReady` instead.
+   * an explicitly triggered reload has actually completed should use [[runAndWaitForReload]].
    *
    * Reload intents:
    * - `"full"` — rebuild entire registry + re-register provider listener (onInitialized, setUnitsProvider)
@@ -572,6 +599,7 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
         Logger.logWarning(`${FrontendLoggerCategory.Package}.QuantityFormatter`, "Reload failed — restoring previous ready state. Cached specs may be stale.");
         this._isReady = true;
       }
+      this._rejectReloadWaiters(err);
       return;
     }
 
@@ -595,6 +623,21 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     }
 
     this._reloadInFlight = false;
+    this._resolveReloadWaiters();
+  }
+
+  private _resolveReloadWaiters(): void {
+    const waiters = [...this._reloadWaiters];
+    this._reloadWaiters.clear();
+    for (const waiter of waiters)
+      waiter.resolve();
+  }
+
+  private _rejectReloadWaiters(error: unknown): void {
+    const waiters = [...this._reloadWaiters];
+    this._reloadWaiters.clear();
+    for (const waiter of waiters)
+      waiter.reject(error);
   }
 
   /** Execute the reload work for a given intent. All reload logic is centralized here.

--- a/core/frontend/src/quantity-formatting/QuantityFormatter.ts
+++ b/core/frontend/src/quantity-formatting/QuantityFormatter.ts
@@ -364,7 +364,6 @@ interface FormatsProviderManagerEvent {
  */
 export class FormatsProviderManager implements FormatsProvider {
   public onFormatsChanged = new BeEvent<(args: FormatsChangedArgs) => void>();
-  /** @internal */
   public onFormatsChangedInternal = new BeEvent<(event: FormatsProviderManagerEvent) => void>();
   private _removeProviderListener?: () => void;
   private _formatsProviderChange?: FormatsProviderChange;
@@ -456,16 +455,11 @@ export class FormatsProviderManager implements FormatsProvider {
 
 type FormatSpecsRegistry = Map<string, Map<string, Map<UnitSystemKey, FormattingSpecEntry>>>;
 
-interface FormattingSpecMaps {
+interface FormattingStateSnapshot {
+  formatSpecsRegistry: FormatSpecsRegistry;
   activeFormatSpecsByType: Map<QuantityTypeKey, FormatterSpec>;
   activeParserSpecsByType: Map<QuantityTypeKey, ParserSpec>;
-}
-
-interface FormattingStateCandidate extends FormattingSpecMaps {
-  formatSpecsRegistry: FormatSpecsRegistry;
   activeUnitSystem: UnitSystemKey;
-  requestedUnitSystem?: UnitSystemKey;
-  deferredSystemChanged?: FormattingUnitSystemChangedArgs;
 }
 
 /** The QuantityFormatter class provides methods for formatting and parsing quantities. There are a set of standard quantity types
@@ -562,6 +556,8 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   private readonly _disposedError = new Error("QuantityFormatter was disposed before the reload completed.");
   private readonly _reloadCoordinator: FormatsProviderReloadCoordinator;
   private _removeFormatsProviderListener?: () => void;
+  private _activeFormatSpecsTarget?: Map<QuantityTypeKey, FormatterSpec>;
+  private _activeParserSpecsTarget?: Map<QuantityTypeKey, ParserSpec>;
   /**
    * constructor
    * @param showMetricOrUnitSystem - Pass in `true` to show Metric formatted quantity values. Defaults to Imperial. To explicitly
@@ -639,28 +635,21 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal
    */
   private async _executeReload(intent: ReloadIntent): Promise<void> {
+    const snapshot = this._captureFormattingState();
     try {
-      let candidate: FormattingStateCandidate;
       switch (intent.scope) {
         case "full":
-          candidate = await this._reloadCore();
+          await this._reloadCore();
           break;
         case "formatsChanged":
-          candidate = await this._buildFormatsChangedCandidate(intent);
+          await this._executeFormatsChangedReload(intent);
           break;
         case "activeSystem":
-          candidate = await this._buildActiveSystemCandidate(intent);
+          await this._executeActiveSystemReload(intent);
           break;
       }
-
-      if (intent.scope === "formatsChanged" && intent.providerChange && this._ownsFormatsProviderTransactions) {
-        const manager = IModelApp.formatsProvider as FormatsProviderManager;
-        if (!manager.applyFormatsProviderChange(intent.providerChange))
-          throw new ReloadSupersededError();
-      }
-
-      this._commitFormattingState(candidate);
     } catch (error) {
+      this._restoreFormattingState(snapshot);
       if (intent.scope === "formatsChanged" && intent.providerChange && this._ownsFormatsProviderTransactions)
         (IModelApp.formatsProvider as FormatsProviderManager).restoreProviderChange(intent.providerChange);
       if (intent.scope === "activeSystem" && this._requestedUnitSystem === intent.system)
@@ -669,52 +658,79 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     }
   }
 
-  private async _buildFormatsChangedCandidate(intent: Extract<ReloadIntent, { scope: "formatsChanged" }>): Promise<FormattingStateCandidate> {
+  private async _executeFormatsChangedReload(intent: Extract<ReloadIntent, { scope: "formatsChanged" }>): Promise<void> {
     const manager = IModelApp.formatsProvider as FormatsProviderManager;
     if (this._ownsFormatsProviderTransactions && !manager.isCurrentFormatsProviderReload(intent.provider, intent.providerChange))
       throw new ReloadSupersededError();
 
     const nextRegistry = this._cloneFormatSpecsRegistry(this._formatSpecsRegistry);
     await this._rebuildRegistryFromProvider(intent.args, intent.provider, nextRegistry);
-    const nextSpecs = await this._buildFormatAndParsingMapsForSystem(intent.targetUnitSystem);
-    const deferredSystemChanged = intent.args.impliedUnitSystem && intent.targetUnitSystem !== this._activeUnitSystem
-      ? { system: intent.targetUnitSystem }
-      : undefined;
-    const requestedUnitSystem = intent.args.impliedUnitSystem && this._requestedUnitSystem === this._activeUnitSystem
-      ? intent.targetUnitSystem
-      : undefined;
 
-    return {
-      formatSpecsRegistry: nextRegistry,
-      ...nextSpecs,
-      activeUnitSystem: intent.targetUnitSystem,
-      requestedUnitSystem,
-      deferredSystemChanged,
-    };
+    const previousSystem = this._activeUnitSystem;
+    const nextFormatSpecs = new Map<QuantityTypeKey, FormatterSpec>();
+    const nextParserSpecs = new Map<QuantityTypeKey, ParserSpec>();
+    this._activeFormatSpecsTarget = nextFormatSpecs;
+    this._activeParserSpecsTarget = nextParserSpecs;
+    try {
+      await this.loadFormatAndParsingMapsForSystem(intent.targetUnitSystem);
+    } finally {
+      this._activeFormatSpecsTarget = undefined;
+      this._activeParserSpecsTarget = undefined;
+    }
+
+    this._formatSpecsRegistry = nextRegistry;
+    this._activeFormatSpecsByType = nextFormatSpecs;
+    this._activeParserSpecsByType = nextParserSpecs;
+    this._activeUnitSystem = intent.targetUnitSystem;
+
+    if (intent.providerChange && this._ownsFormatsProviderTransactions && !manager.applyFormatsProviderChange(intent.providerChange))
+      throw new ReloadSupersededError();
+
+    if (intent.args.impliedUnitSystem && this._requestedUnitSystem === previousSystem)
+      this._requestedUnitSystem = intent.targetUnitSystem;
+    if (intent.args.impliedUnitSystem && intent.targetUnitSystem !== previousSystem)
+      this._deferredSystemChangedEmit = { system: intent.targetUnitSystem };
   }
 
-  private async _buildActiveSystemCandidate(intent: Extract<ReloadIntent, { scope: "activeSystem" }>): Promise<FormattingStateCandidate> {
-    const nextSpecs = await this._buildFormatAndParsingMapsForSystem(intent.system);
-    return {
-      formatSpecsRegistry: this._formatSpecsRegistry,
-      ...nextSpecs,
-      activeUnitSystem: intent.system,
-      deferredSystemChanged: intent.emitSystemChanged ? { system: intent.system } : undefined,
-    };
-  }
+  private async _executeActiveSystemReload(intent: Extract<ReloadIntent, { scope: "activeSystem" }>): Promise<void> {
+    const nextFormatSpecs = new Map<QuantityTypeKey, FormatterSpec>();
+    const nextParserSpecs = new Map<QuantityTypeKey, ParserSpec>();
+    this._activeFormatSpecsTarget = nextFormatSpecs;
+    this._activeParserSpecsTarget = nextParserSpecs;
+    try {
+      await this.loadFormatAndParsingMapsForSystem(intent.system);
+    } finally {
+      this._activeFormatSpecsTarget = undefined;
+      this._activeParserSpecsTarget = undefined;
+    }
 
-  private _commitFormattingState(candidate: FormattingStateCandidate): void {
-    this._formatSpecsRegistry = candidate.formatSpecsRegistry;
-    this._activeFormatSpecsByType = candidate.activeFormatSpecsByType;
-    this._activeParserSpecsByType = candidate.activeParserSpecsByType;
-    this._activeUnitSystem = candidate.activeUnitSystem;
-    if (candidate.requestedUnitSystem !== undefined)
-      this._requestedUnitSystem = candidate.requestedUnitSystem;
-    this._deferredSystemChangedEmit = candidate.deferredSystemChanged;
+    this._activeFormatSpecsByType = nextFormatSpecs;
+    this._activeParserSpecsByType = nextParserSpecs;
+    this._activeUnitSystem = intent.system;
+    if (intent.emitSystemChanged)
+      this._deferredSystemChangedEmit = { system: intent.system };
   }
 
   private get _ownsFormatsProviderTransactions(): boolean {
     return IModelApp.quantityFormatter === this;
+  }
+
+  private _captureFormattingState(): FormattingStateSnapshot {
+    return {
+      formatSpecsRegistry: this._cloneFormatSpecsRegistry(this._formatSpecsRegistry),
+      activeFormatSpecsByType: new Map(this._activeFormatSpecsByType),
+      activeParserSpecsByType: new Map(this._activeParserSpecsByType),
+      activeUnitSystem: this._activeUnitSystem,
+    };
+  }
+
+  private _restoreFormattingState(snapshot: FormattingStateSnapshot): void {
+    this._activeFormatSpecsTarget = undefined;
+    this._activeParserSpecsTarget = undefined;
+    this._formatSpecsRegistry = snapshot.formatSpecsRegistry;
+    this._activeFormatSpecsByType = snapshot.activeFormatSpecsByType;
+    this._activeParserSpecsByType = snapshot.activeParserSpecsByType;
+    this._activeUnitSystem = snapshot.activeUnitSystem;
   }
 
   private _cloneFormatSpecsRegistry(source: FormatSpecsRegistry): FormatSpecsRegistry {
@@ -826,23 +842,15 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
    * @internal public for unit test usage
    */
   protected async loadFormatAndParsingMapsForSystem(systemType?: UnitSystemKey): Promise<void> {
-    const specs = await this._buildFormatAndParsingMapsForSystem(systemType ?? this._activeUnitSystem);
-    this._activeFormatSpecsByType = specs.activeFormatSpecsByType;
-    this._activeParserSpecsByType = specs.activeParserSpecsByType;
-  }
+    const systemKey = (undefined !== systemType) ? systemType : this._activeUnitSystem;
+    const formatPropsByType = new Map<QuantityTypeDefinition, FormatProps>();
 
-  private async _buildFormatAndParsingMapsForSystem(systemKey: UnitSystemKey): Promise<FormattingSpecMaps> {
-    const activeFormatSpecsByType = new Map<QuantityTypeKey, FormatterSpec>();
-    const activeParserSpecsByType = new Map<QuantityTypeKey, ParserSpec>();
+    // load cache for every registered QuantityType
+    for (const [_, entry] of this.quantityTypesRegistry)
+      formatPropsByType.set(entry, this.getFormatPropsByQuantityTypeEntryAndSystem(entry, systemKey));
 
-    for (const entry of this.quantityTypesRegistry.values()) {
-      const formatProps = this.getFormatPropsByQuantityTypeEntryAndSystem(entry, systemKey);
-      const specs = await this._createFormatAndParserSpecs(entry, formatProps);
-      activeFormatSpecsByType.set(entry.key, specs.formatterSpec);
-      activeParserSpecsByType.set(entry.key, specs.parserSpec);
-    }
-
-    return { activeFormatSpecsByType, activeParserSpecsByType };
+    for (const [entry, formatProps] of formatPropsByType)
+      await this.loadFormatAndParserSpec(entry, formatProps);
   }
 
   private getFormatPropsByQuantityTypeEntryAndSystem(quantityEntry: QuantityTypeDefinition, requestedSystem: UnitSystemKey, ignoreOverrides?: boolean): FormatProps {
@@ -855,16 +863,11 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
     return quantityEntry.getDefaultFormatPropsBySystem(requestedSystem);
   }
 
-  private async _createFormatAndParserSpecs(quantityTypeDefinition: QuantityTypeDefinition, formatProps: FormatProps): Promise<{ formatterSpec: FormatterSpec; parserSpec: ParserSpec }> {
+  private async loadFormatAndParserSpec(quantityTypeDefinition: QuantityTypeDefinition, formatProps: FormatProps) {
     const formatterSpec = await quantityTypeDefinition.generateFormatterSpec(formatProps, this.unitsProvider);
     const parserSpec = await quantityTypeDefinition.generateParserSpec(formatProps, this.unitsProvider, this.alternateUnitLabelsProvider);
-    return { formatterSpec, parserSpec };
-  }
-
-  private async loadFormatAndParserSpec(quantityTypeDefinition: QuantityTypeDefinition, formatProps: FormatProps) {
-    const specs = await this._createFormatAndParserSpecs(quantityTypeDefinition, formatProps);
-    this._activeFormatSpecsByType.set(quantityTypeDefinition.key, specs.formatterSpec);
-    this._activeParserSpecsByType.set(quantityTypeDefinition.key, specs.parserSpec);
+    (this._activeFormatSpecsTarget ?? this._activeFormatSpecsByType).set(quantityTypeDefinition.key, formatterSpec);
+    (this._activeParserSpecsTarget ?? this._activeParserSpecsByType).set(quantityTypeDefinition.key, parserSpec);
   }
 
   // repopulate formatSpec and parserSpec entries using only default format
@@ -955,26 +958,22 @@ export class QuantityFormatter implements UnitsProvider, FormattingSpecProvider 
   /** Core reload logic — does all async I/O and cache rebuilding without events or state management.
    * @internal
    */
-  private async _reloadCore(): Promise<FormattingStateCandidate> {
+  private async _reloadCore(): Promise<void> {
     await this.initializeQuantityTypesRegistry();
 
-    const nextRegistry = this._cloneFormatSpecsRegistry(this._formatSpecsRegistry);
     const initialKoQs = [["DefaultToolsUnits.LENGTH", "Units.M"], ["DefaultToolsUnits.ANGLE", "Units.RAD"], ["DefaultToolsUnits.AREA", "Units.SQ_M"], ["DefaultToolsUnits.VOLUME", "Units.CUB_M"], ["DefaultToolsUnits.LENGTH_COORDINATE", "Units.M"], ["CivilUnits.STATION", "Units.M"], ["CivilUnits.LENGTH", "Units.M"], ["AecUnits.LENGTH", "Units.M"]];
     for (const entry of initialKoQs) {
       for (const system of QuantityFormatter._allUnitSystems) {
         try {
-          await this._addFormattingSpecsToRegistry({ name: entry[0], persistenceUnitName: entry[1], system }, nextRegistry);
+          await this.addFormattingSpecsToRegistry({ name: entry[0], persistenceUnitName: entry[1], system });
         } catch (err: any) {
           Logger.logWarning(`${FrontendLoggerCategory.Package}.QuantityFormatter`, err.toString());
         }
       }
     }
 
-    return {
-      formatSpecsRegistry: nextRegistry,
-      ...(await this._buildFormatAndParsingMapsForSystem(this._activeUnitSystem)),
-      activeUnitSystem: this._activeUnitSystem,
-    };
+    // initialize default format and parsing specs
+    await this.loadFormatAndParsingMapsForSystem();
   }
 
   /** Rebuild the formatting specs registry from a provider based on changed args.

--- a/core/frontend/src/test/FormatsProviderReload.test.ts
+++ b/core/frontend/src/test/FormatsProviderReload.test.ts
@@ -10,12 +10,7 @@ import { FormatDefinition, FormatsChangedArgs, FormatsProvider } from "@itwin/co
 import { IModelApp } from "../IModelApp";
 import { QuantityFormatter, QuantityTypeFormatsProvider } from "../quantity-formatting/QuantityFormatter";
 
-interface Deferred<T> {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-}
-
-function deferred<T>(): Deferred<T> {
+function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   const promise = new Promise<T>((res) => { resolve = res; });
   return { promise, resolve };

--- a/core/frontend/src/test/FormatsProviderReload.test.ts
+++ b/core/frontend/src/test/FormatsProviderReload.test.ts
@@ -1,0 +1,203 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { BeEvent } from "@itwin/core-bentley";
+import { EmptyLocalization } from "@itwin/core-common";
+import { FormatDefinition, FormatsChangedArgs, FormatsProvider } from "@itwin/core-quantity";
+import { IModelApp } from "../IModelApp";
+import { QuantityFormatter, QuantityTypeFormatsProvider } from "../quantity-formatting/QuantityFormatter";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+function createFormatsProvider(getFormat: FormatsProvider["getFormat"]): FormatsProvider {
+  return {
+    onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
+    getFormat,
+  };
+}
+
+const simpleFormat: FormatDefinition = {
+  type: "Decimal",
+  precision: 2,
+  formatTraits: ["showUnitLabel"],
+  uomSeparator: " ",
+  composite: {
+    includeZero: true,
+    spacer: "",
+    units: [{ name: "Units.M", label: "m" }],
+  },
+};
+
+describe("Formats provider reload invariants", () => {
+  beforeAll(async () => {
+    await IModelApp.startup({ localization: new EmptyLocalization() });
+  });
+
+  afterAll(async () => {
+    await IModelApp.shutdown();
+  });
+
+  it("keeps latest-wins ownership correct under reentrant provider events", async () => {
+    const providerA = createFormatsProvider(async () => undefined);
+    const providerB = createFormatsProvider(async () => undefined);
+    let secondRequest: Promise<void> | undefined;
+    let eventCount = 0;
+    const removeListener = IModelApp.formatsProvider.onFormatsChanged.addListener(() => {
+      if (eventCount++ === 0)
+        secondRequest = IModelApp.setFormatsProvider(providerB);
+    });
+
+    try {
+      const firstRequest = IModelApp.setFormatsProvider(providerA);
+      expect(secondRequest).toBeDefined();
+      await Promise.all([
+        expect(firstRequest).rejects.toThrow(/superseded/i),
+        expect(secondRequest!).resolves.toBeUndefined(),
+      ]);
+    } finally {
+      removeListener();
+      await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
+    }
+  });
+
+  it("applies the newest unit-system intent when it overlaps a provider reload", async () => {
+    const quantityFormatter = IModelApp.quantityFormatter;
+    const originalUnitSystem = quantityFormatter.activeUnitSystem;
+    await quantityFormatter.setActiveUnitSystem("usSurvey");
+    const name = "TestKoQ.UNIT_SYSTEM_INTENT";
+    await quantityFormatter.addFormattingSpecsToRegistry({ name, persistenceUnitName: "Units.M", formatProps: simpleFormat, system: "metric" });
+    const loadStarted = deferred<void>();
+    const releaseLoad = deferred<void>();
+    let getFormatCount = 0;
+    const provider = createFormatsProvider(async () => {
+      if (getFormatCount++ === 0) {
+        loadStarted.resolve();
+        await releaseLoad.promise;
+      }
+      return undefined;
+    });
+
+    try {
+      const providerReload = IModelApp.setFormatsProvider(provider, { unitSystem: "metric" });
+      await loadStarted.promise;
+      const unitSystemReload = quantityFormatter.setActiveUnitSystem("imperial");
+      releaseLoad.resolve();
+
+      await providerReload;
+      await unitSystemReload;
+      expect(quantityFormatter.activeUnitSystem).toBe("imperial");
+    } finally {
+      releaseLoad.resolve();
+      await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
+    }
+  });
+
+  it("does not carry forward an uncommitted implied unit system when the next replacement omits it", async () => {
+    const quantityFormatter = IModelApp.quantityFormatter;
+    const originalUnitSystem = quantityFormatter.activeUnitSystem;
+    await quantityFormatter.setActiveUnitSystem("imperial");
+    const name = "TestKoQ.OMITTED_UNIT_SYSTEM";
+    await quantityFormatter.addFormattingSpecsToRegistry({ name, persistenceUnitName: "Units.M", formatProps: simpleFormat, system: "metric" });
+    const firstLookupStarted = deferred<void>();
+    const releaseFirstLookup = deferred<void>();
+    let lookupCount = 0;
+    const provider = createFormatsProvider(async () => {
+      if (lookupCount++ === 0) {
+        firstLookupStarted.resolve();
+        await releaseFirstLookup.promise;
+      }
+      return undefined;
+    });
+
+    try {
+      const firstReplacement = IModelApp.setFormatsProvider(provider, { unitSystem: "metric" });
+      await firstLookupStarted.promise;
+      const secondReplacement = IModelApp.setFormatsProvider(provider);
+      releaseFirstLookup.resolve();
+
+      await Promise.all([
+        firstReplacement.catch(() => undefined),
+        secondReplacement,
+      ]);
+      expect(quantityFormatter.activeUnitSystem).toBe("imperial");
+    } finally {
+      releaseFirstLookup.resolve();
+      await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
+    }
+  });
+
+  it("keeps the applied provider and cache coherent after a fatal replacement failure", async () => {
+    const quantityFormatter = IModelApp.quantityFormatter;
+    const name = "TestKoQ.PROVIDER_REPLACEMENT_ATOMICITY";
+    const providerA = createFormatsProvider(async (formatName) => formatName === name ? simpleFormat : undefined);
+    const providerB = createFormatsProvider(async (formatName) => {
+      if (formatName === name)
+        throw new Error("provider B failed");
+      return undefined;
+    });
+
+    await quantityFormatter.addFormattingSpecsToRegistry({
+      name,
+      persistenceUnitName: "Units.M",
+      formatProps: simpleFormat,
+      system: "metric",
+    });
+
+    try {
+      await IModelApp.setFormatsProvider(providerA);
+      await expect(IModelApp.setFormatsProvider(providerB)).rejects.toThrow("provider B failed");
+
+      await expect(IModelApp.formatsProvider.getFormat(name, "metric")).resolves.toEqual(simpleFormat);
+      expect(quantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.M", system: "metric" })).toBeDefined();
+    } finally {
+      await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
+    }
+  });
+
+  it("does not emit a unit-system change when the implied system is already active", async () => {
+    const quantityFormatter = new QuantityFormatter();
+    await quantityFormatter.onInitialized();
+    const systemChanged = vi.fn();
+    const removeSystemChangedListener = quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(systemChanged);
+    const ready = new Promise<void>((resolve) => quantityFormatter.onFormattingReady.addOnce(resolve));
+
+    try {
+      IModelApp.formatsProvider.onFormatsChanged.raiseEvent({
+        formatsChanged: "all",
+        impliedUnitSystem: quantityFormatter.activeUnitSystem,
+      });
+      await ready;
+      expect(systemChanged).not.toHaveBeenCalled();
+    } finally {
+      removeSystemChangedListener();
+      quantityFormatter[Symbol.dispose]();
+    }
+  });
+
+  it("does not register a provider listener after disposal during initialization", async () => {
+    const quantityFormatter = new QuantityFormatter();
+    const providerEvents = IModelApp.formatsProvider.onFormatsChanged;
+    const listenerCountBeforeInitialization = providerEvents.numberOfListeners;
+
+    try {
+      const initialization = quantityFormatter.onInitialized();
+      quantityFormatter[Symbol.dispose]();
+      await initialization;
+      expect(providerEvents.numberOfListeners).toBe(listenerCountBeforeInitialization);
+    } finally {
+      quantityFormatter[Symbol.dispose]();
+    }
+  });
+});

--- a/core/frontend/src/test/FormatsProviderReload.test.ts
+++ b/core/frontend/src/test/FormatsProviderReload.test.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { BeEvent } from "@itwin/core-bentley";
 import { EmptyLocalization } from "@itwin/core-common";
 import { FormatDefinition, FormatsChangedArgs, FormatsProvider } from "@itwin/core-quantity";
@@ -40,6 +40,43 @@ const simpleFormat: FormatDefinition = {
   },
 };
 
+const incompatibleBearingFormat: FormatDefinition = {
+  type: "Bearing",
+  precision: 2,
+  revolutionUnit: "Units.REVOLUTION",
+  formatTraits: ["showUnitLabel"],
+  uomSeparator: "",
+  composite: {
+    includeZero: true,
+    spacer: "",
+    units: [{ name: "Units.ARC_DEG", label: "°" }],
+  },
+};
+
+const compatibleBearingFormat: FormatDefinition = {
+  ...incompatibleBearingFormat,
+  revolutionUnit: "Units.HORIZONTAL_DIR_REVOLUTION",
+  composite: {
+    ...incompatibleBearingFormat.composite,
+    units: [{ name: "Units.HORIZONTAL_DIR_ARC_DEG", label: "°" }],
+  },
+};
+
+function createIncompatibleBearingProvider(name: string): FormatsProvider {
+  return createFormatsProvider(async (formatName) => formatName === name ? incompatibleBearingFormat : undefined);
+}
+
+function rejectCrossPhenomenonConversions(quantityFormatter: QuantityFormatter): () => void {
+  const unitsProvider = quantityFormatter.unitsProvider;
+  const originalGetConversion = unitsProvider.getConversion.bind(unitsProvider);
+  unitsProvider.getConversion = async (fromUnit, toUnit) => {
+    if (fromUnit.phenomenon !== toUnit.phenomenon)
+      throw new Error("Source and target units do not belong to same phenomenon");
+    return originalGetConversion(fromUnit, toUnit);
+  };
+  return () => unitsProvider.getConversion = originalGetConversion;
+}
+
 describe("Formats provider reload invariants", () => {
   beforeAll(async () => {
     await IModelApp.startup({ localization: new EmptyLocalization() });
@@ -50,8 +87,13 @@ describe("Formats provider reload invariants", () => {
   });
 
   it("keeps latest-wins ownership correct under reentrant provider events", async () => {
-    const providerA = createFormatsProvider(async () => undefined);
-    const providerB = createFormatsProvider(async () => undefined);
+    const name = "TestKoQ.REENTRANT_PROVIDER";
+    const providerFormatA = { ...simpleFormat, precision: 3 };
+    const providerFormatB = { ...simpleFormat, precision: 4 };
+    const quantityFormatter = IModelApp.quantityFormatter;
+    await quantityFormatter.addFormattingSpecsToRegistry({ name, persistenceUnitName: "Units.M", formatProps: simpleFormat, system: "metric" });
+    const providerA = createFormatsProvider(async (formatName) => formatName === name ? providerFormatA : undefined);
+    const providerB = createFormatsProvider(async (formatName) => formatName === name ? providerFormatB : undefined);
     let secondRequest: Promise<void> | undefined;
     let eventCount = 0;
     const removeListener = IModelApp.formatsProvider.onFormatsChanged.addListener(() => {
@@ -66,6 +108,8 @@ describe("Formats provider reload invariants", () => {
         expect(firstRequest).rejects.toThrow(/superseded/i),
         expect(secondRequest!).resolves.toBeUndefined(),
       ]);
+      await expect(IModelApp.formatsProvider.getFormat(name, "metric")).resolves.toEqual(providerFormatB);
+      expect(quantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.M", system: "metric" })?.formatterSpec.format.precision).toBe(4);
     } finally {
       removeListener();
       await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
@@ -120,6 +164,8 @@ describe("Formats provider reload invariants", () => {
       }
       return undefined;
     });
+    const systemChanged = vi.fn();
+    const removeSystemChangedListener = quantityFormatter.onActiveFormattingUnitSystemChanged.addListener(systemChanged);
 
     try {
       const firstReplacement = IModelApp.setFormatsProvider(provider, { unitSystem: "metric" });
@@ -127,13 +173,54 @@ describe("Formats provider reload invariants", () => {
       const secondReplacement = IModelApp.setFormatsProvider(provider);
       releaseFirstLookup.resolve();
 
-      await Promise.all([
-        firstReplacement.catch(() => undefined),
-        secondReplacement,
-      ]);
+      await expect(firstReplacement).rejects.toThrow(/superseded/i);
+      await expect(secondReplacement).resolves.toBeUndefined();
       expect(quantityFormatter.activeUnitSystem).toBe("imperial");
+      expect(systemChanged).not.toHaveBeenCalled();
     } finally {
       releaseFirstLookup.resolve();
+      removeSystemChangedListener();
+      await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
+    }
+  });
+
+  it("does not drop a provider replacement queued ahead of an unrelated reload", async () => {
+    const quantityFormatter = IModelApp.quantityFormatter;
+    const originalUnitSystem = quantityFormatter.activeUnitSystem;
+    const nextUnitSystem = originalUnitSystem === "metric" ? "imperial" : "metric";
+    const name = "TestKoQ.PROVIDER_QUEUED_AHEAD_OF_SYSTEM";
+    const providerFormat = { ...simpleFormat, precision: 5 };
+    await quantityFormatter.addFormattingSpecsToRegistry({ name, persistenceUnitName: "Units.M", formatProps: simpleFormat, system: "metric" });
+
+    const loadStarted = deferred<void>();
+    const releaseLoad = deferred<void>();
+    const originalBuild = (quantityFormatter as any)._buildFormatAndParsingMapsForSystem.bind(quantityFormatter);
+    let shouldBlock = true;
+    (quantityFormatter as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
+      if (shouldBlock) {
+        shouldBlock = false;
+        loadStarted.resolve();
+        await releaseLoad.promise;
+      }
+      return originalBuild(...args);
+    };
+
+    const provider = createFormatsProvider(async (formatName) => formatName === name ? providerFormat : undefined);
+    try {
+      const unrelatedReload = quantityFormatter.setUnitsProvider(quantityFormatter.unitsProvider);
+      await loadStarted.promise;
+      const providerReload = IModelApp.setFormatsProvider(provider);
+      const systemReload = quantityFormatter.setActiveUnitSystem(nextUnitSystem);
+      releaseLoad.resolve();
+
+      await unrelatedReload;
+      await providerReload;
+      await systemReload;
+      await expect(IModelApp.formatsProvider.getFormat(name, "metric")).resolves.toEqual(providerFormat);
+      expect(quantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.M", system: "metric" })?.formatterSpec.format.precision).toBe(5);
+    } finally {
+      releaseLoad.resolve();
+      (quantityFormatter as any)._buildFormatAndParsingMapsForSystem = originalBuild;
       await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
     }
   });
@@ -141,7 +228,8 @@ describe("Formats provider reload invariants", () => {
   it("keeps the applied provider and cache coherent after a fatal replacement failure", async () => {
     const quantityFormatter = IModelApp.quantityFormatter;
     const name = "TestKoQ.PROVIDER_REPLACEMENT_ATOMICITY";
-    const providerA = createFormatsProvider(async (formatName) => formatName === name ? simpleFormat : undefined);
+    const providerAFormat = { ...simpleFormat, precision: 3 };
+    const providerA = createFormatsProvider(async (formatName) => formatName === name ? providerAFormat : undefined);
     const providerB = createFormatsProvider(async (formatName) => {
       if (formatName === name)
         throw new Error("provider B failed");
@@ -157,10 +245,12 @@ describe("Formats provider reload invariants", () => {
 
     try {
       await IModelApp.setFormatsProvider(providerA);
-      await expect(IModelApp.setFormatsProvider(providerB)).rejects.toThrow("provider B failed");
+      await expect(IModelApp.formatsProvider.getFormat(name, "metric")).resolves.toEqual(providerAFormat);
+      expect(quantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.M", system: "metric" })?.formatterSpec.format.precision).toBe(3);
 
-      await expect(IModelApp.formatsProvider.getFormat(name, "metric")).resolves.toEqual(simpleFormat);
-      expect(quantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.M", system: "metric" })).toBeDefined();
+      await expect(IModelApp.setFormatsProvider(providerB)).rejects.toThrow("provider B failed");
+      await expect(IModelApp.formatsProvider.getFormat(name, "metric")).resolves.toEqual(providerAFormat);
+      expect(quantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.M", system: "metric" })?.formatterSpec.format.precision).toBe(3);
     } finally {
       await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
     }
@@ -199,5 +289,406 @@ describe("Formats provider reload invariants", () => {
     } finally {
       quantityFormatter[Symbol.dispose]();
     }
+  });
+
+  it("does not register a provider listener after initialization is called on a disposed formatter", async () => {
+    const quantityFormatter = new QuantityFormatter();
+    const providerEvents = IModelApp.formatsProvider.onFormatsChanged;
+    const listenerCountBeforeInitialization = providerEvents.numberOfListeners;
+    quantityFormatter[Symbol.dispose]();
+
+    await quantityFormatter.onInitialized();
+    expect(providerEvents.numberOfListeners).toBe(listenerCountBeforeInitialization);
+  });
+
+  it("drains a reload queued before formatting finalization fails", async () => {
+    const quantityFormatter = new QuantityFormatter();
+    await quantityFormatter.onInitialized();
+    let failFinalization = true;
+    let pendingSystemChange: Promise<void> | undefined;
+    const removeReadyWork = quantityFormatter.onBeforeFormattingReady.addListener(() => {
+      if (failFinalization) {
+        failFinalization = false;
+        pendingSystemChange = quantityFormatter.setActiveUnitSystem("imperial");
+        throw new Error("simulated finalization failure");
+      }
+    });
+
+    try {
+      await expect(quantityFormatter.runAndWaitForReload(() => {
+        void quantityFormatter.setActiveUnitSystem("metric");
+      })).resolves.toBeUndefined();
+      await pendingSystemChange;
+      expect(quantityFormatter.activeUnitSystem).toBe("imperial");
+      expect(quantityFormatter.isReady).toBe(true);
+    } finally {
+      removeReadyWork();
+      quantityFormatter[Symbol.dispose]();
+    }
+  });
+
+  describe("FormatsProviderManager", async () => {
+
+    it("Should raise formatsChanged event when updating formatsProvider", () => {
+      const spy = vi.fn();
+      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
+
+      const testProvider = new QuantityTypeFormatsProvider();
+      IModelApp.formatsProvider = testProvider;
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith({ formatsChanged: "all" });
+    });
+
+    it("should raise formatsChanged event when calling resetFormatsProvider", () => {
+      const spy = vi.fn();
+      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
+
+      IModelApp.resetFormatsProvider();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith({ formatsChanged: "all" });
+    });
+
+    it("should set the optional unit system in the same formats provider reload", async () => {
+      const appQuantityFormatter = IModelApp.quantityFormatter;
+      const originalUnitSystem = appQuantityFormatter.activeUnitSystem;
+      await appQuantityFormatter.setActiveUnitSystem("imperial");
+      const provider = {
+        onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
+        async getFormat(): Promise<undefined> { return undefined; },
+      };
+      const formatsChangedSpy = vi.fn();
+      const readySpy = vi.fn();
+      const removeFormatsChangedListener = IModelApp.formatsProvider.onFormatsChanged.addListener(formatsChangedSpy);
+      const removeReadyListener = appQuantityFormatter.onFormattingReady.addListener(readySpy);
+
+      try {
+        await IModelApp.setFormatsProvider(provider, { unitSystem: "metric" });
+        expect(appQuantityFormatter.activeUnitSystem).toBe("metric");
+        expect(formatsChangedSpy).toHaveBeenCalledTimes(1);
+        expect(formatsChangedSpy).toHaveBeenCalledWith({ formatsChanged: "all", impliedUnitSystem: "metric" });
+        expect(readySpy).toHaveBeenCalledTimes(1);
+
+        formatsChangedSpy.mockClear();
+        readySpy.mockClear();
+        await IModelApp.setFormatsProvider(provider);
+        expect(appQuantityFormatter.activeUnitSystem).toBe("metric");
+        expect(formatsChangedSpy).toHaveBeenCalledTimes(1);
+        expect(formatsChangedSpy).toHaveBeenCalledWith({ formatsChanged: "all" });
+        expect(readySpy).toHaveBeenCalledTimes(1);
+      } finally {
+        removeFormatsChangedListener();
+        removeReadyListener();
+        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
+      }
+    });
+
+    it("resolves when incompatible provider entries are omitted from the registry", async () => {
+      const appQuantityFormatter = IModelApp.quantityFormatter;
+      const name = "TestKoQ.INCOMPATIBLE_BEARING";
+      const registeredFormat = compatibleBearingFormat;
+      const provider = createIncompatibleBearingProvider(name);
+      const restoreConversion = rejectCrossPhenomenonConversions(appQuantityFormatter);
+
+      await appQuantityFormatter.addFormattingSpecsToRegistry({
+        name,
+        persistenceUnitName: "Units.HORIZONTAL_DIR_RAD",
+        formatProps: registeredFormat,
+        system: "metric",
+      });
+      expect(appQuantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeDefined();
+
+      try {
+        await expect(IModelApp.setFormatsProvider(provider)).resolves.toBeUndefined();
+        expect(appQuantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeUndefined();
+      } finally {
+        restoreConversion();
+        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
+      }
+    });
+
+    it("should wait for provider-triggered reloads queued during formatting readiness", async () => {
+      const appQuantityFormatter = IModelApp.quantityFormatter;
+      const originalUnitSystem = appQuantityFormatter.activeUnitSystem;
+      const nextUnitSystem = originalUnitSystem === "metric" ? "imperial" : "metric";
+      const provider = new QuantityTypeFormatsProvider();
+      const readySpy = vi.fn();
+      const removeReadyListener = appQuantityFormatter.onFormattingReady.addListener(readySpy);
+
+      try {
+        await IModelApp.setFormatsProvider(provider, { unitSystem: nextUnitSystem });
+        expect(readySpy).toHaveBeenCalledTimes(2);
+      } finally {
+        removeReadyListener();
+        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
+        provider[Symbol.dispose]();
+      }
+    });
+
+    it("should raise formatsChanged event when underlying formatsProvider raises formatsChanged event", async () => {
+
+      const testProvider = new QuantityTypeFormatsProvider();
+      IModelApp.formatsProvider = testProvider;
+
+      const spy = vi.fn();
+      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
+      testProvider.onFormatsChanged.raiseEvent({ formatsChanged: ["foobar"]});
+
+
+      IModelApp.resetFormatsProvider();
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy.mock.calls[0][0]).toEqual({ formatsChanged: ["foobar"] });
+      expect(spy.mock.calls[1][0]).toEqual({ formatsChanged: "all" });
+
+    });
+
+    it("getFormat should honor the requested unit system", async () => {
+      const provider = new QuantityTypeFormatsProvider();
+      const metricFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "metric");
+      const imperialFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "imperial");
+      expect(metricFormat).toBeDefined();
+      expect(imperialFormat).toBeDefined();
+      // Before the fix, the requested system was ignored and both returned the active-system format.
+      expect(metricFormat).not.toEqual(imperialFormat);
+    });
+
+    it("should not leak listeners when formatsProvider is replaced multiple times", () => {
+      const provider1 = new QuantityTypeFormatsProvider();
+      const provider2 = new QuantityTypeFormatsProvider();
+
+      IModelApp.formatsProvider = provider1;
+      IModelApp.formatsProvider = provider2;
+
+      const spy = vi.fn();
+      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
+
+      // Raising on provider1 should NOT fire — the old listener was removed
+      provider1.onFormatsChanged.raiseEvent({ formatsChanged: ["old"] });
+      expect(spy).toHaveBeenCalledTimes(0);
+
+      // Raising on provider2 SHOULD fire — it's the current provider
+      provider2.onFormatsChanged.raiseEvent({ formatsChanged: ["new"] });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0]).toEqual({ formatsChanged: ["new"] });
+    });
+  });
+
+  it("latest runAndWaitForReload request supersedes the previous request", async () => {
+    const qf = new QuantityFormatter();
+    await qf.onInitialized();
+
+    let releaseFirstLoad!: () => void;
+    const firstLoad = new Promise<void>((resolve) => { releaseFirstLoad = resolve; });
+    let firstLoadStarted!: () => void;
+    const firstLoadStartedPromise = new Promise<void>((resolve) => { firstLoadStarted = resolve; });
+    const originalLoad = (qf as any)._buildFormatAndParsingMapsForSystem.bind(qf);
+    let loadCount = 0;
+    (qf as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
+      if (++loadCount === 1) {
+        firstLoadStarted();
+        await firstLoad;
+      }
+      return originalLoad(...args);
+    };
+
+    let firstSet!: Promise<void>;
+    let secondSet!: Promise<void>;
+    try {
+      const firstRequest = qf.runAndWaitForReload(() => {
+        firstSet = qf.setActiveUnitSystem("metric");
+      });
+      await firstLoadStartedPromise;
+
+      const secondRequest = qf.runAndWaitForReload(() => {
+        secondSet = qf.setActiveUnitSystem("imperial");
+      });
+
+      await expect(firstRequest).rejects.toThrow("superseded");
+      releaseFirstLoad();
+      await expect(secondRequest).resolves.toBeUndefined();
+      await firstSet;
+      await secondSet;
+      expect(qf.activeUnitSystem).toBe("imperial");
+    } finally {
+      releaseFirstLoad();
+      (qf as any)._buildFormatAndParsingMapsForSystem = originalLoad;
+      qf[Symbol.dispose]();
+    }
+  });
+
+  it("rejects a waiting reload when disposed and suppresses completion events", async () => {
+    const qf = new QuantityFormatter();
+    await qf.onInitialized();
+
+    let releaseLoad!: () => void;
+    const load = new Promise<void>((resolve) => { releaseLoad = resolve; });
+    let loadStarted!: () => void;
+    const loadStartedPromise = new Promise<void>((resolve) => { loadStarted = resolve; });
+    const originalLoad = (qf as any)._buildFormatAndParsingMapsForSystem.bind(qf);
+    (qf as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
+      loadStarted();
+      await load;
+      return originalLoad(...args);
+    };
+
+    const readySpy = vi.fn();
+    const removeReadyListener = qf.onFormattingReady.addListener(readySpy);
+    let setActiveSystem!: Promise<void>;
+    try {
+      const reload = qf.runAndWaitForReload(() => {
+        setActiveSystem = qf.setActiveUnitSystem("metric");
+      });
+      await loadStartedPromise;
+
+      qf[Symbol.dispose]();
+      await expect(reload).rejects.toThrow("disposed");
+      releaseLoad();
+      await setActiveSystem;
+      expect(qf.isReady).toBe(false);
+      expect(readySpy).not.toHaveBeenCalled();
+    } finally {
+      releaseLoad();
+      removeReadyListener();
+      (qf as any)._buildFormatAndParsingMapsForSystem = originalLoad;
+      qf[Symbol.dispose]();
+    }
+  });
+
+  describe("_rebuildRegistryFromProvider", () => {
+    const localFormatters: QuantityFormatter[] = [];
+    afterEach(() => {
+      for (const quantityFormatter of localFormatters)
+        quantityFormatter[Symbol.dispose]();
+      localFormatters.length = 0;
+      IModelApp.resetFormatsProvider();
+    });
+
+    const simpleDecimalFormat = {
+      type: "Decimal" as const,
+      precision: 4,
+      formatTraits: ["keepSingleZero", "showUnitLabel"],
+      composite: { includeZero: true, units: [{ name: "Units.M", label: "m" }] },
+    };
+
+    it("rebuilds registry when formatsProvider raises formatsChanged with 'all'", async () => {
+      const qf = new QuantityFormatter();
+      localFormatters.push(qf);
+      await qf.onInitialized();
+
+      // Add a custom entry to the registry
+      await qf.addFormattingSpecsToRegistry({
+        name: "TestKoQ.CUSTOM",
+        persistenceUnitName: "Units.M",
+        formatProps: simpleDecimalFormat,
+        system: "metric",
+      });
+      const entryBefore = qf.getSpecsByNameAndUnit({ name: "TestKoQ.CUSTOM", persistenceUnitName: "Units.M", system: "metric" });
+      expect(entryBefore).toBeDefined();
+
+      // Trigger a formatsChanged "all" event — the provider returns undefined for our custom name,
+      // so the entry should be removed from the registry
+      const provider = new QuantityTypeFormatsProvider();
+      IModelApp.formatsProvider = provider;
+
+      // Wait for reload to finish
+      await new Promise<void>((resolve) => {
+        qf.onFormattingReady.addListener(resolve);
+      });
+
+      // Our custom KoQ is not in QuantityTypeFormatsProvider, so _rebuildRegistryFromProvider
+      // should have removed it (anySystemHadFormat === false → delete from registry)
+      const entryAfter = qf.getSpecsByNameAndUnit({ name: "TestKoQ.CUSTOM", persistenceUnitName: "Units.M", system: "metric" });
+      expect(entryAfter).toBeUndefined();
+    });
+
+    it("rebuilds only named formats when formatsChanged is a string array", async () => {
+      const qf = new QuantityFormatter();
+      localFormatters.push(qf);
+      await qf.onInitialized();
+
+      // The default initialization creates entries for DefaultToolsUnits.LENGTH, etc.
+      const lengthBefore = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.LENGTH", persistenceUnitName: "Units.M", system: "metric" });
+      expect(lengthBefore).toBeDefined();
+
+      const angleBefore = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.ANGLE", persistenceUnitName: "Units.RAD", system: "metric" });
+      expect(angleBefore).toBeDefined();
+
+      // Create a provider and trigger a formatsChanged with only "DefaultToolsUnits.LENGTH"
+      const provider = new QuantityTypeFormatsProvider();
+      IModelApp.formatsProvider = provider;
+
+      // Wait for "all" reload
+      await new Promise<void>((resolve) => {
+        qf.onFormattingReady.addListener(resolve);
+      });
+
+      // Now fire a targeted change event for just LENGTH
+      provider.onFormatsChanged.raiseEvent({ formatsChanged: ["DefaultToolsUnits.LENGTH"] });
+
+      await new Promise<void>((resolve) => {
+        qf.onFormattingReady.addListener(resolve);
+      });
+
+      // Both should still exist (the provider returns formats for both)
+      const lengthAfter = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.LENGTH", persistenceUnitName: "Units.M", system: "metric" });
+      const angleAfter = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.ANGLE", persistenceUnitName: "Units.RAD", system: "metric" });
+      expect(lengthAfter).toBeDefined();
+      expect(angleAfter).toBeDefined();
+    });
+
+    it("allows onBeforeFormattingReady to replace an incompatible provider format", async () => {
+      const name = "TestKoQ.HORIZONTAL_BEARING";
+      const manuallyRegisteredFormat = compatibleBearingFormat;
+      const provider = createIncompatibleBearingProvider(name);
+      const qf = new QuantityFormatter();
+      let removeReadyListener: (() => void) | undefined;
+      let restoreConversion: (() => void) | undefined;
+
+      try {
+        IModelApp.formatsProvider = provider;
+        await qf.onInitialized();
+
+        // Schema-backed units providers throw when a format and persistence unit belong to different phenomena.
+        restoreConversion = rejectCrossPhenomenonConversions(qf);
+
+        await qf.addFormattingSpecsToRegistry({
+          name,
+          persistenceUnitName: "Units.HORIZONTAL_DIR_RAD",
+          formatProps: manuallyRegisteredFormat,
+          system: "metric",
+        });
+        expect(qf.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeDefined();
+
+        let replacementRegistered = false;
+        qf.onBeforeFormattingReady.addListener((collector) => {
+          if (!qf.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })) {
+            replacementRegistered = true;
+            collector.addPendingWork(qf.addFormattingSpecsToRegistry({
+              name,
+              persistenceUnitName: "Units.HORIZONTAL_DIR_RAD",
+              formatProps: manuallyRegisteredFormat,
+              system: "metric",
+            }));
+          }
+        });
+
+        const readySpy = vi.fn();
+        removeReadyListener = qf.onFormattingReady.addListener(readySpy);
+        provider.onFormatsChanged.raiseEvent({ formatsChanged: [name] });
+
+        await vi.waitFor(() => expect(readySpy).toHaveBeenCalledTimes(1), { timeout: 1000 });
+        expect(replacementRegistered).toBe(true);
+        const entryAfter = qf.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" });
+        expect(entryAfter).toBeDefined();
+        expect(entryAfter?.formatterSpec.format.revolutionUnit?.name).toBe("Units.HORIZONTAL_DIR_REVOLUTION");
+        expect(entryAfter?.parserSpec.format.revolutionUnit?.name).toBe("Units.HORIZONTAL_DIR_REVOLUTION");
+      } finally {
+        removeReadyListener?.();
+        restoreConversion?.();
+        qf[Symbol.dispose]();
+        IModelApp.resetFormatsProvider();
+      }
+    });
   });
 });

--- a/core/frontend/src/test/FormatsProviderReload.test.ts
+++ b/core/frontend/src/test/FormatsProviderReload.test.ts
@@ -194,15 +194,15 @@ describe("Formats provider reload invariants", () => {
 
     const loadStarted = deferred<void>();
     const releaseLoad = deferred<void>();
-    const originalBuild = (quantityFormatter as any)._buildFormatAndParsingMapsForSystem.bind(quantityFormatter);
+    const originalLoad = (quantityFormatter as any).loadFormatAndParsingMapsForSystem.bind(quantityFormatter);
     let shouldBlock = true;
-    (quantityFormatter as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
+    (quantityFormatter as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
       if (shouldBlock) {
         shouldBlock = false;
         loadStarted.resolve();
         await releaseLoad.promise;
       }
-      return originalBuild(...args);
+      return originalLoad(...args);
     };
 
     const provider = createFormatsProvider(async (formatName) => formatName === name ? providerFormat : undefined);
@@ -220,7 +220,7 @@ describe("Formats provider reload invariants", () => {
       expect(quantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.M", system: "metric" })?.formatterSpec.format.precision).toBe(5);
     } finally {
       releaseLoad.resolve();
-      (quantityFormatter as any)._buildFormatAndParsingMapsForSystem = originalBuild;
+      (quantityFormatter as any).loadFormatAndParsingMapsForSystem = originalLoad;
       await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
     }
   });
@@ -482,9 +482,9 @@ describe("Formats provider reload invariants", () => {
     const firstLoad = new Promise<void>((resolve) => { releaseFirstLoad = resolve; });
     let firstLoadStarted!: () => void;
     const firstLoadStartedPromise = new Promise<void>((resolve) => { firstLoadStarted = resolve; });
-    const originalLoad = (qf as any)._buildFormatAndParsingMapsForSystem.bind(qf);
+    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
     let loadCount = 0;
-    (qf as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
+    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
       if (++loadCount === 1) {
         firstLoadStarted();
         await firstLoad;
@@ -512,7 +512,7 @@ describe("Formats provider reload invariants", () => {
       expect(qf.activeUnitSystem).toBe("imperial");
     } finally {
       releaseFirstLoad();
-      (qf as any)._buildFormatAndParsingMapsForSystem = originalLoad;
+      (qf as any).loadFormatAndParsingMapsForSystem = originalLoad;
       qf[Symbol.dispose]();
     }
   });
@@ -525,8 +525,8 @@ describe("Formats provider reload invariants", () => {
     const load = new Promise<void>((resolve) => { releaseLoad = resolve; });
     let loadStarted!: () => void;
     const loadStartedPromise = new Promise<void>((resolve) => { loadStarted = resolve; });
-    const originalLoad = (qf as any)._buildFormatAndParsingMapsForSystem.bind(qf);
-    (qf as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
+    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
+    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
       loadStarted();
       await load;
       return originalLoad(...args);
@@ -550,7 +550,7 @@ describe("Formats provider reload invariants", () => {
     } finally {
       releaseLoad();
       removeReadyListener();
-      (qf as any)._buildFormatAndParsingMapsForSystem = originalLoad;
+      (qf as any).loadFormatAndParsingMapsForSystem = originalLoad;
       qf[Symbol.dispose]();
     }
   });

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -763,6 +763,63 @@ describe("Quantity formatter", async () => {
       }
     });
 
+    it("resolves when incompatible provider entries are omitted from the registry", async () => {
+      const appQuantityFormatter = IModelApp.quantityFormatter;
+      const name = "TestKoQ.INCOMPATIBLE_BEARING";
+      const registeredFormat: FormatDefinition = {
+        type: "Decimal",
+        precision: 2,
+        formatTraits: ["showUnitLabel"],
+        uomSeparator: "",
+        composite: {
+          includeZero: true,
+          spacer: "",
+          units: [{ name: "Units.HORIZONTAL_DIR_ARC_DEG", label: "°" }],
+        },
+      };
+      const providerFormat: FormatDefinition = {
+        type: "Bearing",
+        precision: 2,
+        revolutionUnit: "Units.REVOLUTION",
+        formatTraits: ["showUnitLabel"],
+        uomSeparator: "",
+        composite: {
+          includeZero: true,
+          spacer: "",
+          units: [{ name: "Units.ARC_DEG", label: "°" }],
+        },
+      };
+      const provider = {
+        onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
+        async getFormat(formatName: string, _system?: UnitSystemKey): Promise<FormatDefinition | undefined> {
+          return formatName === name ? providerFormat : undefined;
+        },
+      };
+      const originalGetConversion = appQuantityFormatter.unitsProvider.getConversion.bind(appQuantityFormatter.unitsProvider);
+
+      await appQuantityFormatter.addFormattingSpecsToRegistry({
+        name,
+        persistenceUnitName: "Units.HORIZONTAL_DIR_RAD",
+        formatProps: registeredFormat,
+        system: "metric",
+      });
+      expect(appQuantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeDefined();
+
+      appQuantityFormatter.unitsProvider.getConversion = async (fromUnit, toUnit) => {
+        if (fromUnit.phenomenon !== toUnit.phenomenon)
+          throw new Error("Source and target units do not belong to same phenomenon");
+        return originalGetConversion(fromUnit, toUnit);
+      };
+
+      try {
+        await expect(IModelApp.setFormatsProvider(provider)).resolves.toBeUndefined();
+        expect(appQuantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeUndefined();
+      } finally {
+        appQuantityFormatter.unitsProvider.getConversion = originalGetConversion;
+        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
+      }
+    });
+
     it("should wait for provider-triggered reloads queued during formatting readiness", async () => {
       const appQuantityFormatter = IModelApp.quantityFormatter;
       const originalUnitSystem = appQuantityFormatter.activeUnitSystem;
@@ -1017,6 +1074,87 @@ describe("Reload queue and onFormattingReady", () => {
     expect(readyIndices.length).toBeGreaterThanOrEqual(1);
     // The system-changed event must fire after the last formattingReady
     expect(changedIndices[0]).toBeGreaterThan(readyIndices[readyIndices.length - 1]);
+  });
+
+  it("latest runAndWaitForReload request supersedes the previous request", async () => {
+    const qf = new QuantityFormatter();
+    await qf.onInitialized();
+
+    let releaseFirstLoad!: () => void;
+    const firstLoad = new Promise<void>((resolve) => { releaseFirstLoad = resolve; });
+    let firstLoadStarted!: () => void;
+    const firstLoadStartedPromise = new Promise<void>((resolve) => { firstLoadStarted = resolve; });
+    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
+    let loadCount = 0;
+    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
+      if (++loadCount === 1) {
+        firstLoadStarted();
+        await firstLoad;
+      }
+      return originalLoad(...args);
+    };
+
+    let firstSet!: Promise<void>;
+    let secondSet!: Promise<void>;
+    try {
+      const firstRequest = qf.runAndWaitForReload(() => {
+        firstSet = qf.setActiveUnitSystem("metric");
+      });
+      await firstLoadStartedPromise;
+
+      const secondRequest = qf.runAndWaitForReload(() => {
+        secondSet = qf.setActiveUnitSystem("imperial");
+      });
+
+      await expect(firstRequest).rejects.toThrow("superseded");
+      releaseFirstLoad();
+      await expect(secondRequest).resolves.toBeUndefined();
+      await firstSet;
+      await secondSet;
+      expect(qf.activeUnitSystem).toBe("imperial");
+    } finally {
+      releaseFirstLoad();
+      (qf as any).loadFormatAndParsingMapsForSystem = originalLoad;
+      qf[Symbol.dispose]();
+    }
+  });
+
+  it("rejects a waiting reload when disposed and suppresses completion events", async () => {
+    const qf = new QuantityFormatter();
+    await qf.onInitialized();
+
+    let releaseLoad!: () => void;
+    const load = new Promise<void>((resolve) => { releaseLoad = resolve; });
+    let loadStarted!: () => void;
+    const loadStartedPromise = new Promise<void>((resolve) => { loadStarted = resolve; });
+    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
+    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
+      loadStarted();
+      await load;
+      return originalLoad(...args);
+    };
+
+    const readySpy = vi.fn();
+    const removeReadyListener = qf.onFormattingReady.addListener(readySpy);
+    let setActiveSystem!: Promise<void>;
+    try {
+      const reload = qf.runAndWaitForReload(() => {
+        setActiveSystem = qf.setActiveUnitSystem("metric");
+      });
+      await loadStartedPromise;
+
+      qf[Symbol.dispose]();
+      await expect(reload).rejects.toThrow("disposed");
+      releaseLoad();
+      await setActiveSystem;
+      expect(qf.isReady).toBe(false);
+      expect(readySpy).not.toHaveBeenCalled();
+    } finally {
+      releaseLoad();
+      removeReadyListener();
+      (qf as any).loadFormatAndParsingMapsForSystem = originalLoad;
+      qf[Symbol.dispose]();
+    }
   });
 
   describe("Composite-keyed spec registry", () => {

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -742,6 +742,45 @@ describe("Quantity formatter", async () => {
       }
     });
 
+    it("should reject when the formats provider reload fails", async () => {
+      const appQuantityFormatter = IModelApp.quantityFormatter;
+      const originalLoad = (appQuantityFormatter as any).loadFormatAndParsingMapsForSystem;
+      const initialReadyListeners = appQuantityFormatter.onFormattingReady.numberOfListeners;
+      const provider = {
+        onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
+        async getFormat(): Promise<undefined> { return undefined; },
+      };
+      (appQuantityFormatter as any).loadFormatAndParsingMapsForSystem = async () => {
+        throw new Error("simulated provider reload failure");
+      };
+
+      try {
+        await expect(IModelApp.setFormatsProvider(provider)).rejects.toThrow("simulated provider reload failure");
+        expect(appQuantityFormatter.onFormattingReady.numberOfListeners).toBe(initialReadyListeners);
+      } finally {
+        (appQuantityFormatter as any).loadFormatAndParsingMapsForSystem = originalLoad;
+        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
+      }
+    });
+
+    it("should wait for provider-triggered reloads queued during formatting readiness", async () => {
+      const appQuantityFormatter = IModelApp.quantityFormatter;
+      const originalUnitSystem = appQuantityFormatter.activeUnitSystem;
+      const nextUnitSystem = originalUnitSystem === "metric" ? "imperial" : "metric";
+      const provider = new QuantityTypeFormatsProvider();
+      const readySpy = vi.fn();
+      const removeReadyListener = appQuantityFormatter.onFormattingReady.addListener(readySpy);
+
+      try {
+        await IModelApp.setFormatsProvider(provider, { unitSystem: nextUnitSystem });
+        expect(readySpy).toHaveBeenCalledTimes(2);
+      } finally {
+        removeReadyListener();
+        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
+        provider[Symbol.dispose]();
+      }
+    });
+
     it("should raise formatsChanged event when underlying formatsProvider raises formatsChanged event", async () => {
 
       const testProvider = new QuantityTypeFormatsProvider();

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -4,10 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { assert as bAssert, BeEvent } from "@itwin/core-bentley";
+import { assert as bAssert } from "@itwin/core-bentley";
 import { isCustomFormattedNumberParams, PropertyEditorParamTypes, StandardEditorNames, StandardTypeNames } from "@itwin/appui-abstract";
 import { EmptyLocalization } from "@itwin/core-common";
-import { FormatDefinition, FormatsChangedArgs, FormatterSpec, FormattingReadyCollector, ParsedQuantity, Parser, UnitProps, UnitSystemKey } from "@itwin/core-quantity";
+import { FormatterSpec, FormattingReadyCollector, ParsedQuantity, Parser, UnitProps } from "@itwin/core-quantity";
 import { IModelApp } from "../IModelApp";
 import { createQuantityDescription } from "../properties/FormattedQuantityDescription";
 import { LocalUnitFormatProvider } from "../quantity-formatting/LocalUnitFormatProvider";
@@ -686,205 +686,7 @@ describe("Quantity formatter", async () => {
     });
   });
 
-  describe("FormatsProviderManager", async () => {
 
-    it("Should raise formatsChanged event when updating formatsProvider", () => {
-      const spy = vi.fn();
-      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
-
-      const testProvider = new QuantityTypeFormatsProvider();
-      IModelApp.formatsProvider = testProvider;
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith({ formatsChanged: "all" });
-    });
-
-    it("should raise formatsChanged event when calling resetFormatsProvider", () => {
-      const spy = vi.fn();
-      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
-
-      IModelApp.resetFormatsProvider();
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith({ formatsChanged: "all" });
-    });
-
-    it("should set the optional unit system in the same formats provider reload", async () => {
-      const appQuantityFormatter = IModelApp.quantityFormatter;
-      const originalUnitSystem = appQuantityFormatter.activeUnitSystem;
-      const provider = {
-        onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
-        async getFormat(): Promise<undefined> { return undefined; },
-      };
-      const formatsChangedSpy = vi.fn();
-      const readySpy = vi.fn();
-      const removeFormatsChangedListener = IModelApp.formatsProvider.onFormatsChanged.addListener(formatsChangedSpy);
-      const removeReadyListener = appQuantityFormatter.onFormattingReady.addListener(readySpy);
-
-      try {
-        await IModelApp.setFormatsProvider(provider, { unitSystem: "metric" });
-        expect(appQuantityFormatter.activeUnitSystem).toBe("metric");
-        expect(formatsChangedSpy).toHaveBeenCalledTimes(1);
-        expect(formatsChangedSpy).toHaveBeenCalledWith({ formatsChanged: "all", impliedUnitSystem: "metric" });
-        expect(readySpy).toHaveBeenCalledTimes(1);
-
-        formatsChangedSpy.mockClear();
-        readySpy.mockClear();
-        await IModelApp.setFormatsProvider(provider);
-        expect(appQuantityFormatter.activeUnitSystem).toBe("metric");
-        expect(formatsChangedSpy).toHaveBeenCalledTimes(1);
-        expect(formatsChangedSpy).toHaveBeenCalledWith({ formatsChanged: "all" });
-        expect(readySpy).toHaveBeenCalledTimes(1);
-      } finally {
-        removeFormatsChangedListener();
-        removeReadyListener();
-        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
-      }
-    });
-
-    it("should reject when the formats provider reload fails", async () => {
-      const appQuantityFormatter = IModelApp.quantityFormatter;
-      const originalLoad = (appQuantityFormatter as any).loadFormatAndParsingMapsForSystem;
-      const initialReadyListeners = appQuantityFormatter.onFormattingReady.numberOfListeners;
-      const provider = {
-        onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
-        async getFormat(): Promise<undefined> { return undefined; },
-      };
-      (appQuantityFormatter as any).loadFormatAndParsingMapsForSystem = async () => {
-        throw new Error("simulated provider reload failure");
-      };
-
-      try {
-        await expect(IModelApp.setFormatsProvider(provider)).rejects.toThrow("simulated provider reload failure");
-        expect(appQuantityFormatter.onFormattingReady.numberOfListeners).toBe(initialReadyListeners);
-      } finally {
-        (appQuantityFormatter as any).loadFormatAndParsingMapsForSystem = originalLoad;
-        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
-      }
-    });
-
-    it("resolves when incompatible provider entries are omitted from the registry", async () => {
-      const appQuantityFormatter = IModelApp.quantityFormatter;
-      const name = "TestKoQ.INCOMPATIBLE_BEARING";
-      const registeredFormat: FormatDefinition = {
-        type: "Decimal",
-        precision: 2,
-        formatTraits: ["showUnitLabel"],
-        uomSeparator: "",
-        composite: {
-          includeZero: true,
-          spacer: "",
-          units: [{ name: "Units.HORIZONTAL_DIR_ARC_DEG", label: "°" }],
-        },
-      };
-      const providerFormat: FormatDefinition = {
-        type: "Bearing",
-        precision: 2,
-        revolutionUnit: "Units.REVOLUTION",
-        formatTraits: ["showUnitLabel"],
-        uomSeparator: "",
-        composite: {
-          includeZero: true,
-          spacer: "",
-          units: [{ name: "Units.ARC_DEG", label: "°" }],
-        },
-      };
-      const provider = {
-        onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
-        async getFormat(formatName: string, _system?: UnitSystemKey): Promise<FormatDefinition | undefined> {
-          return formatName === name ? providerFormat : undefined;
-        },
-      };
-      const originalGetConversion = appQuantityFormatter.unitsProvider.getConversion.bind(appQuantityFormatter.unitsProvider);
-
-      await appQuantityFormatter.addFormattingSpecsToRegistry({
-        name,
-        persistenceUnitName: "Units.HORIZONTAL_DIR_RAD",
-        formatProps: registeredFormat,
-        system: "metric",
-      });
-      expect(appQuantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeDefined();
-
-      appQuantityFormatter.unitsProvider.getConversion = async (fromUnit, toUnit) => {
-        if (fromUnit.phenomenon !== toUnit.phenomenon)
-          throw new Error("Source and target units do not belong to same phenomenon");
-        return originalGetConversion(fromUnit, toUnit);
-      };
-
-      try {
-        await expect(IModelApp.setFormatsProvider(provider)).resolves.toBeUndefined();
-        expect(appQuantityFormatter.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeUndefined();
-      } finally {
-        appQuantityFormatter.unitsProvider.getConversion = originalGetConversion;
-        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider());
-      }
-    });
-
-    it("should wait for provider-triggered reloads queued during formatting readiness", async () => {
-      const appQuantityFormatter = IModelApp.quantityFormatter;
-      const originalUnitSystem = appQuantityFormatter.activeUnitSystem;
-      const nextUnitSystem = originalUnitSystem === "metric" ? "imperial" : "metric";
-      const provider = new QuantityTypeFormatsProvider();
-      const readySpy = vi.fn();
-      const removeReadyListener = appQuantityFormatter.onFormattingReady.addListener(readySpy);
-
-      try {
-        await IModelApp.setFormatsProvider(provider, { unitSystem: nextUnitSystem });
-        expect(readySpy).toHaveBeenCalledTimes(2);
-      } finally {
-        removeReadyListener();
-        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
-        provider[Symbol.dispose]();
-      }
-    });
-
-    it("should raise formatsChanged event when underlying formatsProvider raises formatsChanged event", async () => {
-
-      const testProvider = new QuantityTypeFormatsProvider();
-      IModelApp.formatsProvider = testProvider;
-
-      const spy = vi.fn();
-      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
-      testProvider.onFormatsChanged.raiseEvent({ formatsChanged: ["foobar"]});
-
-
-      IModelApp.resetFormatsProvider();
-      expect(spy).toHaveBeenCalledTimes(2);
-      expect(spy.mock.calls[0][0]).toEqual({ formatsChanged: ["foobar"] });
-      expect(spy.mock.calls[1][0]).toEqual({ formatsChanged: "all" });
-
-    });
-
-    it("getFormat should honor the requested unit system", async () => {
-      const provider = new QuantityTypeFormatsProvider();
-      const metricFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "metric");
-      const imperialFormat = await provider.getFormat("DefaultToolsUnits.LENGTH", "imperial");
-      expect(metricFormat).toBeDefined();
-      expect(imperialFormat).toBeDefined();
-      // Before the fix, the requested system was ignored and both returned the active-system format.
-      expect(metricFormat).not.toEqual(imperialFormat);
-    });
-
-    it("should not leak listeners when formatsProvider is replaced multiple times", () => {
-      const provider1 = new QuantityTypeFormatsProvider();
-      const provider2 = new QuantityTypeFormatsProvider();
-
-      IModelApp.formatsProvider = provider1;
-      IModelApp.formatsProvider = provider2;
-
-      const spy = vi.fn();
-      IModelApp.formatsProvider.onFormatsChanged.addListener(spy);
-
-      // Raising on provider1 should NOT fire — the old listener was removed
-      provider1.onFormatsChanged.raiseEvent({ formatsChanged: ["old"] });
-      expect(spy).toHaveBeenCalledTimes(0);
-
-      // Raising on provider2 SHOULD fire — it's the current provider
-      provider2.onFormatsChanged.raiseEvent({ formatsChanged: ["new"] });
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy.mock.calls[0][0]).toEqual({ formatsChanged: ["new"] });
-    });
-  });
 });
 
 describe("Test Custom QuantityType", async () => {
@@ -1076,86 +878,6 @@ describe("Reload queue and onFormattingReady", () => {
     expect(changedIndices[0]).toBeGreaterThan(readyIndices[readyIndices.length - 1]);
   });
 
-  it("latest runAndWaitForReload request supersedes the previous request", async () => {
-    const qf = new QuantityFormatter();
-    await qf.onInitialized();
-
-    let releaseFirstLoad!: () => void;
-    const firstLoad = new Promise<void>((resolve) => { releaseFirstLoad = resolve; });
-    let firstLoadStarted!: () => void;
-    const firstLoadStartedPromise = new Promise<void>((resolve) => { firstLoadStarted = resolve; });
-    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
-    let loadCount = 0;
-    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
-      if (++loadCount === 1) {
-        firstLoadStarted();
-        await firstLoad;
-      }
-      return originalLoad(...args);
-    };
-
-    let firstSet!: Promise<void>;
-    let secondSet!: Promise<void>;
-    try {
-      const firstRequest = qf.runAndWaitForReload(() => {
-        firstSet = qf.setActiveUnitSystem("metric");
-      });
-      await firstLoadStartedPromise;
-
-      const secondRequest = qf.runAndWaitForReload(() => {
-        secondSet = qf.setActiveUnitSystem("imperial");
-      });
-
-      await expect(firstRequest).rejects.toThrow("superseded");
-      releaseFirstLoad();
-      await expect(secondRequest).resolves.toBeUndefined();
-      await firstSet;
-      await secondSet;
-      expect(qf.activeUnitSystem).toBe("imperial");
-    } finally {
-      releaseFirstLoad();
-      (qf as any).loadFormatAndParsingMapsForSystem = originalLoad;
-      qf[Symbol.dispose]();
-    }
-  });
-
-  it("rejects a waiting reload when disposed and suppresses completion events", async () => {
-    const qf = new QuantityFormatter();
-    await qf.onInitialized();
-
-    let releaseLoad!: () => void;
-    const load = new Promise<void>((resolve) => { releaseLoad = resolve; });
-    let loadStarted!: () => void;
-    const loadStartedPromise = new Promise<void>((resolve) => { loadStarted = resolve; });
-    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
-    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
-      loadStarted();
-      await load;
-      return originalLoad(...args);
-    };
-
-    const readySpy = vi.fn();
-    const removeReadyListener = qf.onFormattingReady.addListener(readySpy);
-    let setActiveSystem!: Promise<void>;
-    try {
-      const reload = qf.runAndWaitForReload(() => {
-        setActiveSystem = qf.setActiveUnitSystem("metric");
-      });
-      await loadStartedPromise;
-
-      qf[Symbol.dispose]();
-      await expect(reload).rejects.toThrow("disposed");
-      releaseLoad();
-      await setActiveSystem;
-      expect(qf.isReady).toBe(false);
-      expect(readySpy).not.toHaveBeenCalled();
-    } finally {
-      releaseLoad();
-      removeReadyListener();
-      (qf as any).loadFormatAndParsingMapsForSystem = originalLoad;
-      qf[Symbol.dispose]();
-    }
-  });
 
   describe("Composite-keyed spec registry", () => {
     const simpleDecimalFormat = {
@@ -1305,32 +1027,34 @@ describe("Failed reload recovery (Issue 5)", () => {
     await qf.onInitialized();
     expect(qf.isReady).toBe(true);
 
-    // Spy on loadFormatAndParsingMapsForSystem to force it to throw
-    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
+    // Spy on the candidate builder to force it to throw
+    const originalLoad = (qf as any)._buildFormatAndParsingMapsForSystem.bind(qf);
     let shouldThrow = true;
-    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
+    (qf as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
       if (shouldThrow) {
         throw new Error("simulated reload failure");
       }
       return originalLoad(...args);
     };
 
-    // setActiveUnitSystem triggers scheduleReload → calls loadFormatAndParsingMapsForSystem
+    // setActiveUnitSystem triggers scheduleReload → calls the candidate builder
     await qf.setActiveUnitSystem("metric");
 
-    // After failure: isReady should be restored (stale-but-usable)
+    // After failure: isReady and the committed active system should remain usable.
     expect(qf.isReady).toBe(true);
+    expect(qf.activeUnitSystem).toBe("imperial");
 
     // Verify that a successful reload still works after recovery
     shouldThrow = false;
-    await qf.setActiveUnitSystem("imperial");
+    await qf.setActiveUnitSystem("metric");
+    expect(qf.activeUnitSystem).toBe("metric");
     expect(qf.isReady).toBe(true);
   });
 
   it("isReady stays false if first init fails (was never ready)", async () => {
     const qf = new QuantityFormatter();
-    // Override loadFormatAndParsingMapsForSystem before onInitialized
-    (qf as any).loadFormatAndParsingMapsForSystem = async function () {
+    // Override the candidate builder before onInitialized
+    (qf as any)._buildFormatAndParsingMapsForSystem = async function () {
       throw new Error("simulated first load failure");
     };
 
@@ -1700,168 +1424,5 @@ describe("Deferred unit-system-changed emit (race condition validation)", () => 
 
     // No unit system change should have been emitted
     expect(spy).not.toHaveBeenCalled();
-  });
-});
-
-describe("_rebuildRegistryFromProvider", () => {
-  const simpleDecimalFormat = {
-    type: "Decimal" as const,
-    precision: 4,
-    formatTraits: ["keepSingleZero", "showUnitLabel"],
-    composite: { includeZero: true, units: [{ name: "Units.M", label: "m" }] },
-  };
-
-  beforeAll(async () => {
-    await IModelApp.startup({ localization: new EmptyLocalization() });
-  });
-
-  afterAll(async () => {
-    await IModelApp.shutdown();
-  });
-
-  it("rebuilds registry when formatsProvider raises formatsChanged with 'all'", async () => {
-    const qf = new QuantityFormatter();
-    await qf.onInitialized();
-
-    // Add a custom entry to the registry
-    await qf.addFormattingSpecsToRegistry({
-      name: "TestKoQ.CUSTOM",
-      persistenceUnitName: "Units.M",
-      formatProps: simpleDecimalFormat,
-      system: "metric",
-    });
-    const entryBefore = qf.getSpecsByNameAndUnit({ name: "TestKoQ.CUSTOM", persistenceUnitName: "Units.M", system: "metric" });
-    expect(entryBefore).toBeDefined();
-
-    // Trigger a formatsChanged "all" event — the provider returns undefined for our custom name,
-    // so the entry should be removed from the registry
-    const provider = new QuantityTypeFormatsProvider();
-    IModelApp.formatsProvider = provider;
-
-    // Wait for reload to finish
-    await new Promise<void>((resolve) => {
-      qf.onFormattingReady.addListener(resolve);
-    });
-
-    // Our custom KoQ is not in QuantityTypeFormatsProvider, so _rebuildRegistryFromProvider
-    // should have removed it (anySystemHadFormat === false → delete from registry)
-    const entryAfter = qf.getSpecsByNameAndUnit({ name: "TestKoQ.CUSTOM", persistenceUnitName: "Units.M", system: "metric" });
-    expect(entryAfter).toBeUndefined();
-  });
-
-  it("rebuilds only named formats when formatsChanged is a string array", async () => {
-    const qf = new QuantityFormatter();
-    await qf.onInitialized();
-
-    // The default initialization creates entries for DefaultToolsUnits.LENGTH, etc.
-    const lengthBefore = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.LENGTH", persistenceUnitName: "Units.M", system: "metric" });
-    expect(lengthBefore).toBeDefined();
-
-    const angleBefore = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.ANGLE", persistenceUnitName: "Units.RAD", system: "metric" });
-    expect(angleBefore).toBeDefined();
-
-    // Create a provider and trigger a formatsChanged with only "DefaultToolsUnits.LENGTH"
-    const provider = new QuantityTypeFormatsProvider();
-    IModelApp.formatsProvider = provider;
-
-    // Wait for "all" reload
-    await new Promise<void>((resolve) => {
-      qf.onFormattingReady.addListener(resolve);
-    });
-
-    // Now fire a targeted change event for just LENGTH
-    provider.onFormatsChanged.raiseEvent({ formatsChanged: ["DefaultToolsUnits.LENGTH"] });
-
-    await new Promise<void>((resolve) => {
-      qf.onFormattingReady.addListener(resolve);
-    });
-
-    // Both should still exist (the provider returns formats for both)
-    const lengthAfter = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.LENGTH", persistenceUnitName: "Units.M", system: "metric" });
-    const angleAfter = qf.getSpecsByNameAndUnit({ name: "DefaultToolsUnits.ANGLE", persistenceUnitName: "Units.RAD", system: "metric" });
-    expect(lengthAfter).toBeDefined();
-    expect(angleAfter).toBeDefined();
-  });
-
-  it("allows onBeforeFormattingReady to replace an incompatible provider format", async () => {
-    const name = "TestKoQ.HORIZONTAL_BEARING";
-    const providerFormat: FormatDefinition = {
-      type: "Bearing",
-      precision: 2,
-      revolutionUnit: "Units.REVOLUTION",
-      formatTraits: ["showUnitLabel"],
-      uomSeparator: "",
-      composite: {
-        includeZero: true,
-        spacer: "",
-        units: [{ name: "Units.ARC_DEG", label: "°" }],
-      },
-    };
-    const manuallyRegisteredFormat: FormatDefinition = {
-      ...providerFormat,
-      revolutionUnit: "Units.HORIZONTAL_DIR_REVOLUTION",
-      composite: {
-        ...providerFormat.composite,
-        units: [{ name: "Units.HORIZONTAL_DIR_ARC_DEG", label: "°" }],
-      },
-    };
-    const provider = {
-      onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
-      async getFormat(formatName: string, _system?: UnitSystemKey): Promise<FormatDefinition | undefined> {
-        return formatName === name ? providerFormat : undefined;
-      },
-    };
-    const qf = new QuantityFormatter();
-    let removeReadyListener: (() => void) | undefined;
-
-    try {
-      IModelApp.formatsProvider = provider;
-      await qf.onInitialized();
-
-      // Schema-backed units providers throw when a format and persistence unit belong to different phenomena.
-      const unitsProvider = qf.unitsProvider;
-      const originalGetConversion = unitsProvider.getConversion.bind(unitsProvider);
-      unitsProvider.getConversion = async (fromUnit, toUnit) => {
-        if (fromUnit.phenomenon !== toUnit.phenomenon)
-          throw new Error("Source and target units do not belong to same phenomenon");
-        return originalGetConversion(fromUnit, toUnit);
-      };
-
-      await qf.addFormattingSpecsToRegistry({
-        name,
-        persistenceUnitName: "Units.HORIZONTAL_DIR_RAD",
-        formatProps: manuallyRegisteredFormat,
-        system: "metric",
-      });
-      expect(qf.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })).toBeDefined();
-
-      let replacementRegistered = false;
-      qf.onBeforeFormattingReady.addListener((collector) => {
-        if (!qf.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" })) {
-          replacementRegistered = true;
-          collector.addPendingWork(qf.addFormattingSpecsToRegistry({
-            name,
-            persistenceUnitName: "Units.HORIZONTAL_DIR_RAD",
-            formatProps: manuallyRegisteredFormat,
-            system: "metric",
-          }));
-        }
-      });
-
-      const readySpy = vi.fn();
-      removeReadyListener = qf.onFormattingReady.addListener(readySpy);
-      provider.onFormatsChanged.raiseEvent({ formatsChanged: [name] });
-
-      await vi.waitFor(() => expect(readySpy).toHaveBeenCalledTimes(1), { timeout: 1000 });
-      expect(replacementRegistered).toBe(true);
-      const entryAfter = qf.getSpecsByNameAndUnit({ name, persistenceUnitName: "Units.HORIZONTAL_DIR_RAD", system: "metric" });
-      expect(entryAfter).toBeDefined();
-      expect(entryAfter?.formatterSpec.format.revolutionUnit?.name).toBe("Units.HORIZONTAL_DIR_REVOLUTION");
-      expect(entryAfter?.parserSpec.format.revolutionUnit?.name).toBe("Units.HORIZONTAL_DIR_REVOLUTION");
-    } finally {
-      removeReadyListener?.();
-      qf[Symbol.dispose]();
-      IModelApp.resetFormatsProvider();
-    }
   });
 });

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -4,10 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { assert as bAssert } from "@itwin/core-bentley";
+import { assert as bAssert, BeEvent } from "@itwin/core-bentley";
 import { isCustomFormattedNumberParams, PropertyEditorParamTypes, StandardEditorNames, StandardTypeNames } from "@itwin/appui-abstract";
 import { EmptyLocalization } from "@itwin/core-common";
-import { FormatterSpec, FormattingReadyCollector, ParsedQuantity, Parser, UnitProps } from "@itwin/core-quantity";
+import { FormatsChangedArgs, FormatterSpec, FormattingReadyCollector, ParsedQuantity, Parser, UnitProps } from "@itwin/core-quantity";
 import { IModelApp } from "../IModelApp";
 import { createQuantityDescription } from "../properties/FormattedQuantityDescription";
 import { LocalUnitFormatProvider } from "../quantity-formatting/LocalUnitFormatProvider";
@@ -707,6 +707,39 @@ describe("Quantity formatter", async () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith({ formatsChanged: "all" });
+    });
+
+    it("should set the optional unit system in the same formats provider reload", async () => {
+      const appQuantityFormatter = IModelApp.quantityFormatter;
+      const originalUnitSystem = appQuantityFormatter.activeUnitSystem;
+      const provider = {
+        onFormatsChanged: new BeEvent<(args: FormatsChangedArgs) => void>(),
+        async getFormat(): Promise<undefined> { return undefined; },
+      };
+      const formatsChangedSpy = vi.fn();
+      const readySpy = vi.fn();
+      const removeFormatsChangedListener = IModelApp.formatsProvider.onFormatsChanged.addListener(formatsChangedSpy);
+      const removeReadyListener = appQuantityFormatter.onFormattingReady.addListener(readySpy);
+
+      try {
+        await IModelApp.setFormatsProvider(provider, { unitSystem: "metric" });
+        expect(appQuantityFormatter.activeUnitSystem).toBe("metric");
+        expect(formatsChangedSpy).toHaveBeenCalledTimes(1);
+        expect(formatsChangedSpy).toHaveBeenCalledWith({ formatsChanged: "all", impliedUnitSystem: "metric" });
+        expect(readySpy).toHaveBeenCalledTimes(1);
+
+        formatsChangedSpy.mockClear();
+        readySpy.mockClear();
+        await IModelApp.setFormatsProvider(provider);
+        expect(appQuantityFormatter.activeUnitSystem).toBe("metric");
+        expect(formatsChangedSpy).toHaveBeenCalledTimes(1);
+        expect(formatsChangedSpy).toHaveBeenCalledWith({ formatsChanged: "all" });
+        expect(readySpy).toHaveBeenCalledTimes(1);
+      } finally {
+        removeFormatsChangedListener();
+        removeReadyListener();
+        await IModelApp.setFormatsProvider(new QuantityTypeFormatsProvider(), { unitSystem: originalUnitSystem });
+      }
     });
 
     it("should raise formatsChanged event when underlying formatsProvider raises formatsChanged event", async () => {

--- a/core/frontend/src/test/QuantityFormatter.test.ts
+++ b/core/frontend/src/test/QuantityFormatter.test.ts
@@ -1027,17 +1027,17 @@ describe("Failed reload recovery (Issue 5)", () => {
     await qf.onInitialized();
     expect(qf.isReady).toBe(true);
 
-    // Spy on the candidate builder to force it to throw
-    const originalLoad = (qf as any)._buildFormatAndParsingMapsForSystem.bind(qf);
+    // Spy on the format/parser map loader to force it to throw
+    const originalLoad = (qf as any).loadFormatAndParsingMapsForSystem.bind(qf);
     let shouldThrow = true;
-    (qf as any)._buildFormatAndParsingMapsForSystem = async function (...args: any[]) {
+    (qf as any).loadFormatAndParsingMapsForSystem = async function (...args: any[]) {
       if (shouldThrow) {
         throw new Error("simulated reload failure");
       }
       return originalLoad(...args);
     };
 
-    // setActiveUnitSystem triggers scheduleReload → calls the candidate builder
+    // setActiveUnitSystem triggers scheduleReload → calls the format/parser map loader
     await qf.setActiveUnitSystem("metric");
 
     // After failure: isReady and the committed active system should remain usable.
@@ -1053,8 +1053,8 @@ describe("Failed reload recovery (Issue 5)", () => {
 
   it("isReady stays false if first init fails (was never ready)", async () => {
     const qf = new QuantityFormatter();
-    // Override the candidate builder before onInitialized
-    (qf as any)._buildFormatAndParsingMapsForSystem = async function () {
+    // Override the format/parser map loader before onInitialized
+    (qf as any).loadFormatAndParsingMapsForSystem = async function () {
       throw new Error("simulated first load failure");
     };
 


### PR DESCRIPTION

## TL;DR

Replacing `IModelApp.formatsProvider` does not let callers provide an implied unit system or await the resulting formatter reload, so applications can trigger separate reloads and observe stale or incomplete formatting state.

The new beta `setFormatsProvider()` on IModelApp allows the caller to pass along a unit system, waits for the latest reload to finish, and rejects requests superseded by a newer change or interrupted by cleanup logic.

There's lifecycle logic to be handled cleanly when a formatsProvider is updated, that was introduced in #9143 . So I added a new internal coordinator helper API to handle lifecycle appropriately and in one place.

If anyone is curious, read the unit test assertions in FormatsProviderReload.test.ts on the 'invariant's, aka the things I assert can not happen as applications update formatting at runtime.

> Note: There are tradeoffs made in this PR, pertaining to `QuantityFormatter`. I deliberately excluded handling events from QuantityType overrides, changing alternate unit labels, things in QuantityFormatter that don't align with our new Format Set + KoQ-based formatting approach. It would bloat the PR up for something we are actively trying to move away from. So if an agent review flags this PR doesn't covering all the lifecycle boundaries QuantityFormatter has, I've seen them, and I accept the consequences.

Closes #9615.

## Why

Applications that replace a formats provider and change the active unit system currently have to coordinate two separate operations. Provider events can also queue more work while formatting is becoming ready, so a single readiness event is not enough to tell the caller that its request has fully settled. This change gives the caller one completion boundary while preserving latest-wins behavior for concurrent changes. Latest wins means if we have 2 concurrent calls to IModelApp to update a formatsProvider, the formatting data from the most recent one will be the one used.

## Shape

```text
setFormatsProvider(provider, options)
  -> record provider + optional unit system
  -> serialize the reload (newest pending request wins)
  -> rebuild formatting and parsing caches
  -> finalize ready state and resolve callers

reload failure
  -> restore the previous provider and formatter state
  -> reject callers waiting on the failed request
```

## What

| Asset | Why it exists |
|---|---|
| `core/frontend/src/IModelApp.ts` (beta API) | Callers need one operation that carries provider and unit-system intent and reports completion — exposes `setFormatsProvider` with optional `unitSystem` and explicit rejection semantics. |
| `core/frontend/src/quantity-formatting/FormatsProviderReloadCoordinator.ts` (internal coordinator) | Overlapping or reentrant reloads need one owner for latest-wins scheduling and caller completion — serializes pending intents and handles success, failure, supersession, and disposal. |
| `core/frontend/src/quantity-formatting/QuantityFormatter.ts` (provider manager and reload path) | Provider replacement can otherwise leave listeners, caches, and active unit-system state out of sync — tracks replacement transactions, stages cache updates, restores failed changes, and controls readiness events. |
| `core/frontend/src/test/FormatsProviderReload.test.ts` (new contract tests) | Reload ordering and provider/unit-system ownership are easy to regress — covers reentrant changes, overlapping unit-system intent, fatal replacement failure, no-op implied systems, and disposal. |
| `core/frontend/src/test/QuantityFormatter.test.ts` (regression coverage) | The public setter and formatter lifecycle need end-to-end protection — covers same-reload unit-system changes, incompatible provider entries, provider-triggered reloads, superseded callers, disposal, and readiness ordering. |

## Tests

<details>
<summary>New and updated test coverage</summary>

| Test | What it covers |
|---|---|
| `FormatsProviderReload.test.ts` — keeps latest-wins ownership correct under reentrant provider events | Ensures a newer provider request remains the owner when provider events synchronously start another request. |
| `FormatsProviderReload.test.ts` — applies the newest unit-system intent when it overlaps a provider reload | Ensures the final formatter state uses the winning provider and unit system together. |
| `FormatsProviderReload.test.ts` — keeps the applied provider and cache coherent after a fatal replacement failure | Ensures failed replacement work restores the previous provider and cache state. |
| `QuantityFormatter.test.ts` — should set the optional unit system in the same formats provider reload | Ensures provider replacement and active unit-system changes share one reload. |
| `QuantityFormatter.test.ts` — resolves when incompatible provider entries are omitted from the registry | Ensures an incompatible individual format does not reject the provider replacement request. |
| `QuantityFormatter.test.ts` — should wait for provider-triggered reloads queued during formatting readiness | Ensures the async setter does not resolve before reload work raised during readiness has drained. |
| `QuantityFormatter.test.ts` — latest `runAndWaitForReload` request supersedes the previous request and disposal rejects a waiting reload | Ensures callers receive deterministic rejection instead of hanging or resolving after disposal. |

</details>


---
*Nam and Nambot 🤖 (powered by gpt-5.6-luna)*