### PR TITLE
Test applying schema changesets that contain orphan custom attributes

### DIFF
--- a/common/changes/@itwin/core-backend/khanaffan-2331-orphan-ca-changeset-apply_2026-08-19-21-04-38.json
+++ b/common/changes/@itwin/core-backend/khanaffan-2331-orphan-ca-changeset-apply_2026-08-19-21-04-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "test: apply schema changeset that contains orphan ec_CustomAttribute rows",
+      "type": "none",
+      "packageName": "@itwin/core-backend"
+    }
+  ],
+  "packageName": "@itwin/core-backend",
+  "email": "khanaffan@users.noreply.github.com"
+}

--- a/common/changes/@itwin/core-backend/khanaffan-2331-orphan-ca-changeset-apply_2026-08-19-21-04-38.json
+++ b/common/changes/@itwin/core-backend/khanaffan-2331-orphan-ca-changeset-apply_2026-08-19-21-04-38.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "test: apply schema changeset that contains orphan ec_CustomAttribute rows",
+      "comment": "",
       "type": "none",
       "packageName": "@itwin/core-backend"
     }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^12.28.0
         version: 12.33.0
       '@bentley/imodeljs-native':
-        specifier: 5.13.14
-        version: 5.13.14
+        specifier: 5.13.15
+        version: 5.13.15
       '@itwin/object-storage-azure':
         specifier: ^3.0.4
         version: 3.1.3
@@ -4657,8 +4657,8 @@ packages:
   '@bentley/icons-generic@1.0.34':
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  '@bentley/imodeljs-native@5.13.14':
-    resolution: {integrity: sha512-xGuqKRjnY8F+nl1aa35i0I2R1f54fE8pYN6xkKaTgNuTEx8Jxvnonn0XgujklJoZMhQNYLshhIr3g0jHrylugg==}
+  '@bentley/imodeljs-native@5.13.15':
+    resolution: {integrity: sha512-ZV9Y4dtSmE8mWp0aaOxBbG0HH9qBwsMmw1J2PDR3jBG8/nSMZMIFj1ZIjfvGqVKWLlG6LNtpswjOTr/CqnTd1A==}
 
   '@bentley/linear-referencing-schema@2.0.3':
     resolution: {integrity: sha512-2pFIEN4BS7alIDhGous6N2icKAS8ZhVBfoWB8WvSFaYnneGv5YwbbXl46qATDdPO5jUFezkW6uVxdpp1eOgUHQ==}
@@ -10978,7 +10978,7 @@ snapshots:
 
   '@bentley/icons-generic@1.0.34': {}
 
-  '@bentley/imodeljs-native@5.13.14': {}
+  '@bentley/imodeljs-native@5.13.15': {}
 
   '@bentley/linear-referencing-schema@2.0.3': {}
 

--- a/core/backend/package.json
+++ b/core/backend/package.json
@@ -108,7 +108,7 @@
     "vite": "^6.4.3"
   },
   "dependencies": {
-    "@bentley/imodeljs-native": "5.13.14",
+    "@bentley/imodeljs-native": "5.13.15",
     "@itwin/object-storage-azure": "^3.0.4",
     "@azure/storage-blob": "^12.28.0",
     "form-data": "^4.0.6",

--- a/core/backend/src/test/standalone/IModelWrite.test.ts
+++ b/core/backend/src/test/standalone/IModelWrite.test.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { AccessToken, DbResult, GuidString, Id64, Id64String } from "@itwin/core-bentley";
-import { EditTxn } from "../../EditTxn";
+import { EditTxn, withEditTxn } from "../../EditTxn";
 import {
   ChangesetIdWithIndex, Code, ColorDef,
   GeometricElement2dProps, GeometryStreamProps, IModel, LockState, QueryRowFormat, RequestNewBriefcaseProps, SchemaState, SubCategoryAppearance,
@@ -886,6 +886,99 @@ describe("IModelWriteTest", () => {
     }
     rwIModel.close();
     rwIModel2.close();
+  });
+
+  // Simulates the escalation described in https://github.com/iTwin/itwinjs-backlog/issues/2331:
+  // user1 pushes a schema changeset which also carries orphan rows in ec_CustomAttribute (custom attributes
+  // whose ECProperty container no longer exists). user2 must still be able to apply that changeset.
+  // Applying a changeset replays already accepted timeline changes, so the ECDb map validation which runs on
+  // schema import must not run on the apply path.
+  it("apply schema changeset which contains orphan ec_CustomAttribute rows", async () => {
+    const adminToken = await HubWrappers.getAccessToken(TestUserType.SuperManager);
+    const userToken = await HubWrappers.getAccessToken(TestUserType.Super);
+    const iModelName = "OrphanCustomAttributeRows";
+    const rwIModelId = await HubMock.createNewIModel({ iTwinId, iModelName, description: "orphan ec_CustomAttribute rows" });
+    assert.isNotEmpty(rwIModelId);
+
+    // two different users working on the same iModel
+    const user1 = await HubWrappers.downloadAndOpenBriefcase({ iTwinId, iModelId: rwIModelId, accessToken: adminToken });
+    const user2 = await HubWrappers.downloadAndOpenBriefcase({ iTwinId, iModelId: rwIModelId, accessToken: userToken });
+    user1.channels.addAllowedChannel(ChannelControl.sharedChannelName);
+    user2.channels.addAllowedChannel(ChannelControl.sharedChannelName);
+
+    const schemaV1 = `<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestDomain" alias="ts" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="BisCore" version="01.00" alias="bis"/>
+        <ECEntityClass typeName="Test2dElement">
+            <BaseClass>bis:GraphicalElement2d</BaseClass>
+            <ECProperty propertyName="s" typeName="string"/>
+        </ECEntityClass>
+    </ECSchema>`;
+
+    // user1 pushes the initial schema, user2 picks it up
+    await user1.importSchemaStrings([schemaV1]);
+    await user1.pushChanges({ description: "schema v1", accessToken: adminToken });
+    await user2.pullChanges({ accessToken: userToken });
+    expect(user2.querySchemaVersion("TestDomain")).to.equal("1.0.0");
+
+    // user1 pushes a second schema changeset ...
+    const schemaV2 = `<?xml version="1.0" encoding="UTF-8"?>
+    <ECSchema schemaName="TestDomain" alias="ts" version="01.00.01" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.1">
+        <ECSchemaReference name="BisCore" version="01.00" alias="bis"/>
+        <ECEntityClass typeName="Test2dElement">
+            <BaseClass>bis:GraphicalElement2d</BaseClass>
+            <ECProperty propertyName="s" typeName="string"/>
+            <ECProperty propertyName="v" typeName="string"/>
+        </ECEntityClass>
+    </ECSchema>`;
+    await user1.importSchemaStrings([schemaV2]);
+
+    // ... which also carries orphan ec_CustomAttribute rows, as produced by older versions of the software.
+    // Those rows are custom attributes applied to an ECProperty (container type 992) which no longer exists.
+    const classId = user1.withSqliteStatement(
+      "SELECT c.Id FROM ec_Class c JOIN ec_Schema s ON c.SchemaId=s.Id WHERE s.Name='TestDomain' AND c.Name='Test2dElement'",
+      (stmt) => {
+        assert.equal(stmt.step(), DbResult.BE_SQLITE_ROW);
+        return stmt.getValueId(0);
+      });
+
+    const orphanContainerIds = [0x7ffffff1, 0x7ffffff2];
+    withEditTxn(user1, "orphan custom attribute rows", () => {
+      for (const containerId of orphanContainerIds) {
+        user1.withSqliteStatement("INSERT INTO ec_CustomAttribute(ClassId,ContainerId,ContainerType,Ordinal,Instance) VALUES(?,?,992,0,?)", (stmt) => {
+          stmt.bindId(1, classId);
+          stmt.bindInteger(2, containerId);
+          stmt.bindString(3, `<Dummy xmlns="TestDomain.01.00.01"/>`);
+          assert.equal(stmt.step(), DbResult.BE_SQLITE_DONE);
+        });
+      }
+    });
+    await user1.pushChanges({ description: "schema v2 with orphan custom attribute rows", accessToken: adminToken });
+
+    const countOrphanCustomAttributes = (db: BriefcaseDb) => db.withSqliteStatement(
+      "SELECT count(*) FROM ec_CustomAttribute WHERE ContainerType=992 AND ContainerId NOT IN (SELECT Id FROM ec_Property)",
+      (stmt) => {
+        assert.equal(stmt.step(), DbResult.BE_SQLITE_ROW);
+        return stmt.getValueInteger(0);
+      });
+    expect(countOrphanCustomAttributes(user1)).to.equal(orphanContainerIds.length);
+
+    // user2 applies the schema changeset. This used to fail with
+    // "Detected orphan custom attribute rows" because the changeset apply ran the ECDb map validator.
+    await user2.pullChanges({ accessToken: userToken });
+
+    // the schema change was applied and the orphan rows were replayed untouched
+    expect(user2.querySchemaVersion("TestDomain")).to.equal("1.0.1");
+    expect(countOrphanCustomAttributes(user2)).to.equal(orphanContainerIds.length);
+
+    // and the pulled schema is usable
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    user2.withPreparedStatement("SELECT s,v FROM TestDomain.Test2dElement", (stmt: ECSqlStatement) => {
+      expect(stmt.step()).to.equal(DbResult.BE_SQLITE_DONE);
+    });
+
+    user1.close();
+    user2.close();
   });
 
   it("parent lock should suffice when inserting into deeply nested sub-model", async () => {

--- a/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
+++ b/test-apps/display-test-app/android/imodeljs-test-app/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation 'com.github.itwin:mobile-native-android:5.13.14'
+    implementation 'com.github.itwin:mobile-native-android:5.13.15'
     implementation 'androidx.webkit:webkit:1.5.0'
 }
 

--- a/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
+++ b/test-apps/display-test-app/ios/imodeljs-test-app/imodeljs-test-app.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.13.14;
+				version = 5.13.15;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
+++ b/tools/internal/ios/core-test-runner/core-test-runner.xcodeproj/project.pbxproj
@@ -554,7 +554,7 @@
 			repositoryURL = "https://github.com/iTwin/mobile-native-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 5.13.14;
+				version = 5.13.15;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Adds a HubMock two-user test: user1 pushes a schema changeset that also carries orphan `ec_CustomAttribute` rows; user2 must still be able to pull it.

Fixes https://github.com/iTwin/itwinjs-backlog/issues/2331

imodel-native: https://github.com/iTwin/imodel-native/pull/1560