### PR TITLE
Fix OPC elevation offset

### DIFF
--- a/common/changes/@itwin/core-frontend/fix-opc-elev-shift_2026-08-20-13-00-00.json
+++ b/common/changes/@itwin/core-frontend/fix-opc-elev-shift_2026-08-20-13-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Fix OPC point clouds whose CRS has no vertical datum displaying offset vertically by the geoid-ellipsoid separation: their heights are now treated as orthometric.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/core/frontend/src/internal/tile/OrbitGtTileTree.ts
+++ b/core/frontend/src/internal/tile/OrbitGtTileTree.ts
@@ -6,7 +6,7 @@
  * @module TileTreeSupplier
  */
 
-import { assert, BeTimePoint, compareStringsOrUndefined, expectDefined, Id64, Id64String } from "@itwin/core-bentley";
+import { assert, BeTimePoint, compareStringsOrUndefined, expectDefined, Id64, Id64String, Logger } from "@itwin/core-bentley";
 import {
   BatchType, Cartographic, ColorDef, Feature, FeatureTable, Frustum, FrustumPlanes, GeoCoordStatus, OrbitGtBlobProps, PackedFeatureTable, QParams3d,
   Quantization, RealityDataFormat, RealityDataProvider, RealityDataSourceKey, ViewFlagOverrides,
@@ -18,6 +18,7 @@ import {
   OrbitGtTransform, PageCachedFile, PointDataRaw, UrlFS,
 } from "@itwin/core-orbitgt";
 import { calculateEcefToDbTransformAtLocation } from "../../BackgroundMapGeometry";
+import { FrontendLoggerCategory } from "../../common/FrontendLoggerCategory";
 import { DisplayStyleState } from "../../DisplayStyleState";
 import { HitDetail } from "../../HitDetail";
 import { IModelApp } from "../../IModelApp";
@@ -359,6 +360,34 @@ export class OrbitGtTileTree extends TileTree {
   }
 }
 
+/** Computes the vertical shift, in meters along geodetic up, to correctly place a point cloud whose CRS does not
+ * define a vertical datum, assuming its heights are orthometric (relative to the geoid).
+ *
+ * The shift is the difference between converting the point cloud's origin with its height treated as orthometric
+ * versus ellipsoidal (`heightAsEllipsoidalDbZ`, already computed by the caller). Returns zero if the shift cannot
+ * be computed or the iModel's converter makes no distinction between the two.
+ * Exported strictly for tests.
+ * @internal
+ */
+export async function computeOrthometricVerticalShift(geoOrigin: Point3d, heightAsEllipsoidalDbZ: number, iModel: IModelConnection): Promise<number> {
+  const geoidConverter = iModel.noGcsDefined ? undefined : iModel.geoServices.getConverter({ horizontalCRS: { epsg: 4326 }, verticalCRS: { id: "GEOID" } });
+  if (undefined === geoidConverter)
+    return 0;
+
+  try {
+    const response = await geoidConverter.getIModelCoordinatesFromGeoCoordinates([geoOrigin]);
+    if (response.iModelCoords[0].s !== GeoCoordStatus.Success) {
+      Logger.logWarning(FrontendLoggerCategory.RealityData, `Failed to compute orthometric height correction for point cloud (status ${response.iModelCoords[0].s}); heights will be treated as ellipsoidal`);
+      return 0;
+    }
+
+    return Point3d.fromJSON(response.iModelCoords[0].p).z - heightAsEllipsoidalDbZ;
+  } catch (err) {
+    Logger.logError(FrontendLoggerCategory.RealityData, err);
+    return 0;
+  }
+}
+
 export namespace OrbitGtTileTree {
   export interface ReferenceProps extends RealityModelTileTree.ReferenceBaseProps {
     orbitGtBlob?: OrbitGtBlobProps;
@@ -450,7 +479,7 @@ export namespace OrbitGtTileTree {
       const wgs84CRS = "4978";
       await CRSManager.ENGINE.prepareForArea(wgs84CRS, new OrbitGtBounds());
       const pointCloudToEcef = transformFromOrbitGt(CRSManager.createTransform(pointCloudCRS, new OrbitGtCoordinate(pointCloudCenter.x, pointCloudCenter.y, pointCloudCenter.z), wgs84CRS));
-      const pointCloudCenterToEcef = pointCloudToEcef.multiplyTransformTransform(addCloudCenter);
+      let pointCloudCenterToEcef = pointCloudToEcef.multiplyTransformTransform(addCloudCenter);
       ecefTransform.setFrom(pointCloudCenterToEcef);
 
       let ecefToDb = iModel.getMapEcefToDb(0);
@@ -471,7 +500,26 @@ export namespace OrbitGtTileTree {
           const geoOrigin = Point3d.create(cartographicOrigin.longitudeDegrees, cartographicOrigin.latitudeDegrees, cartographicOrigin.height);
           const response = await geoConverter.getIModelCoordinatesFromGeoCoordinates([geoOrigin]);
           if (response.iModelCoords[0].s === GeoCoordStatus.Success) {
-            const ecefToDbOrigin = await calculateEcefToDbTransformAtLocation(Point3d.fromJSON(response.iModelCoords[0].p), iModel);
+            const dbOriginFromGcs = Point3d.fromJSON(response.iModelCoords[0].p);
+
+            // A projected CRS defines no vertical datum, so the point cloud's heights are conventionally orthometric -
+            // but pointCloudToEcef above treated them as ellipsoidal. Correct the placement by the difference.
+            // (A compound CRS also takes this path; that stays correct unless orbitgt gains a geoid model.)
+            if (CRSManager.ENGINE.isProjectedCRS(pointCloudCRS)) {
+              const verticalShift = await computeOrthometricVerticalShift(geoOrigin, dbOriginFromGcs.z, iModel);
+              if (0 !== verticalShift) {
+                const upVector = Vector3d.createStartEnd(
+                  cartographicOrigin.toEcef(),
+                  Cartographic.fromRadians({ longitude: cartographicOrigin.longitude, latitude: cartographicOrigin.latitude, height: cartographicOrigin.height + 1 }).toEcef(),
+                ).normalize();
+                if (undefined !== upVector) {
+                  pointCloudCenterToEcef = Transform.createTranslation(upVector.scale(verticalShift)).multiplyTransformTransform(pointCloudCenterToEcef);
+                  ecefTransform.setFrom(pointCloudCenterToEcef);
+                }
+              }
+            }
+
+            const ecefToDbOrigin = await calculateEcefToDbTransformAtLocation(dbOriginFromGcs, iModel);
             if (ecefToDbOrigin)
               ecefToDb = ecefToDbOrigin;
           }

--- a/core/frontend/src/test/tile/OrbitGtTileTree.test.ts
+++ b/core/frontend/src/test/tile/OrbitGtTileTree.test.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { describe, expect, it, vi } from "vitest";
+import { GeoCoordStatus, GeographicCRSProps } from "@itwin/core-common";
+import { Point3d } from "@itwin/core-geometry";
+import { IModelConnection } from "../../IModelConnection";
+import { computeOrthometricVerticalShift } from "../../internal/tile/OrbitGtTileTree";
+
+interface FakeConnectionOptions {
+  noGcsDefined?: boolean;
+  converterUndefined?: boolean;
+  status?: GeoCoordStatus;
+  geoidZ?: number;
+  throws?: boolean;
+}
+
+function createFakeConnection(options: FakeConnectionOptions) {
+  const getConverter = vi.fn((_datumOrGCRS?: string | GeographicCRSProps) => {
+    if (options.converterUndefined)
+      return undefined;
+
+    return {
+      getIModelCoordinatesFromGeoCoordinates: async (_geoPoints: Point3d[]) => {
+        if (options.throws)
+          throw new Error("conversion failed");
+
+        return {
+          iModelCoords: [{ p: { x: 1, y: 2, z: options.geoidZ ?? 0 }, s: options.status ?? GeoCoordStatus.Success }],
+          fromCache: 0,
+        };
+      },
+    };
+  });
+
+  const iModel = {
+    noGcsDefined: options.noGcsDefined ?? false,
+    geoServices: { getConverter },
+  } as unknown as IModelConnection;
+
+  return { iModel, getConverter };
+}
+
+describe("computeOrthometricVerticalShift", () => {
+  const geoOrigin = Point3d.create(-116.87, 33.04, 457);
+
+  it("returns the difference between geoid-based and ellipsoid-based conversions", async () => {
+    // Ellipsoidal interpretation put the origin ~33m higher than the orthometric (geoid) interpretation.
+    const { iModel } = createFakeConnection({ geoidZ: 457 });
+    const shift = await computeOrthometricVerticalShift(geoOrigin, 489.96, iModel);
+    expect(shift).toBeCloseTo(-32.96, 10);
+  });
+
+  it("requests a converter with a geoid-based vertical CRS", async () => {
+    const { iModel, getConverter } = createFakeConnection({ geoidZ: 0 });
+    await computeOrthometricVerticalShift(geoOrigin, 0, iModel);
+    expect(getConverter).toHaveBeenCalledWith({ horizontalCRS: { epsg: 4326 }, verticalCRS: { id: "GEOID" } });
+  });
+
+  it("returns zero when the iModel has no GCS", async () => {
+    const { iModel, getConverter } = createFakeConnection({ noGcsDefined: true, geoidZ: 457 });
+    expect(await computeOrthometricVerticalShift(geoOrigin, 489.96, iModel)).toBe(0);
+    expect(getConverter).not.toHaveBeenCalled();
+  });
+
+  it("returns zero when no converter is available", async () => {
+    const { iModel } = createFakeConnection({ converterUndefined: true });
+    expect(await computeOrthometricVerticalShift(geoOrigin, 489.96, iModel)).toBe(0);
+  });
+
+  it("returns zero when the conversion does not succeed", async () => {
+    const { iModel } = createFakeConnection({ geoidZ: 457, status: GeoCoordStatus.OutOfMathematicalDomain });
+    expect(await computeOrthometricVerticalShift(geoOrigin, 489.96, iModel)).toBe(0);
+  });
+
+  it("returns zero when the conversion throws", async () => {
+    const { iModel } = createFakeConnection({ throws: true });
+    expect(await computeOrthometricVerticalShift(geoOrigin, 489.96, iModel)).toBe(0);
+  });
+
+  it("returns zero when both interpretations agree", async () => {
+    const { iModel } = createFakeConnection({ geoidZ: 457 });
+    expect(await computeOrthometricVerticalShift(geoOrigin, 457, iModel)).toBe(0);
+  });
+});

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -17,6 +17,7 @@ publish: false
     - [Late RPC responses are ignored during shutdown](#late-rpc-responses-are-ignored-during-shutdown)
   - [@itwin/core-frontend](#itwincore-frontend)
     - [Invalidate decorations when element visibility changes](#invalidate-decorations-when-element-visibility-changes)
+    - [OPC point clouds without a vertical datum are now placed using orthometric heights](#opc-point-clouds-without-a-vertical-datum-are-now-placed-using-orthometric-heights)
   - [@itwin/core-geometry](#itwincore-geometry)
     - [Simplifying filleted line strings](#simplifying-filleted-line-strings)
 
@@ -102,6 +103,10 @@ Applications that shut down while requests are outstanding no longer need to fil
 ### Invalidate decorations when element visibility changes
 
 [ViewportDecorator]($frontend)s often produce decoration graphics associated with elements in the scene. Such graphics should be updated if the visibility of the associated element changes. For example, a measurement tool might draw a label near a pipe indicating its length. The label should disappear if the user hides the pipe. To facilitate this, all cached decorations (produced and reused when [ViewportDecorator.useCachedDecorations]($frontend) is `true`) are now recreated in response to potential changes to the visibility of elements in a viewport, including modification of the sets of always- and never-drawn elements, displayed categories and subcategories, and feature symbology overrides.
+
+### OPC point clouds without a vertical datum are now placed using orthometric heights
+
+OPC point clouds whose CRS defines no vertical datum were displayed too high or low by the local geoid-ellipsoid separation, because their heights (conventionally orthometric) were treated as ellipsoidal. Such heights are now interpreted as orthometric. If you previously applied a manual vertical offset to compensate for this fact, you may need to remove it.
 
 ## @itwin/core-geometry
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -110,6 +110,7 @@ Applications that shut down while requests are outstanding no longer need to fil
 ### OPC point clouds without a vertical datum are now placed using orthometric heights
 
 OPC point clouds whose CRS defines no vertical datum were displayed too high or low by the local geoid-ellipsoid separation, because their heights (conventionally orthometric, meaning measured against the geoid/mean sea level) were treated as ellipsoidal. Such heights are now interpreted as orthometric. If you previously applied a manual vertical offset to compensate for this fact, you may need to remove it.
+
 ### Map-layer security hardening
 
 #### Origin-restricted credentials (opt-in)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -106,7 +106,7 @@ Applications that shut down while requests are outstanding no longer need to fil
 
 ### OPC point clouds without a vertical datum are now placed using orthometric heights
 
-OPC point clouds whose CRS defines no vertical datum were displayed too high or low by the local geoid-ellipsoid separation, because their heights (conventionally orthometric) were treated as ellipsoidal. Such heights are now interpreted as orthometric. If you previously applied a manual vertical offset to compensate for this fact, you may need to remove it.
+OPC point clouds whose CRS defines no vertical datum were displayed too high or low by the local geoid-ellipsoid separation, because their heights (conventionally orthometric, meaning measured against the geoid/mean sea level) were treated as ellipsoidal. Such heights are now interpreted as orthometric. If you previously applied a manual vertical offset to compensate for this fact, you may need to remove it.
 
 ## @itwin/core-geometry
 


### PR DESCRIPTION
Fixes https://github.com/iTwin/imodel-native/issues/1546

### Problem

Most OPC files declare a projected CRS with no vertical datum. Their heights are orthometric (geoid-relative), but the display code treated them as ellipsoidal, so on iModels with a vertical datum the point cloud floats by the local geoid-ellipsoid separation. This was masked until core 5.8, when iTwin/imodel-native#1308 (correctly) fixed the compensating bug in `ecefToDb`.

### Fix

When the file CRS is projected, treat heights as orthometric. To do this, convert the point cloud origin twice with the iModel's geocoord services: height as ellipsoidal and as geoid. Then shift the ECEF placement by the difference. If the backend applies no vertical handling, the shift is zero and nothing changes. Other CRS types and no-GCS iModels are unaffected.