### PR TITLE
Updated concurrency control documentation

### DIFF
--- a/docs/learning/backend/ConcurrencyControl.md
+++ b/docs/learning/backend/ConcurrencyControl.md
@@ -41,7 +41,7 @@ This article assumes that you already know that:
 | **Push**                            | Upload a Changeset to iModelHub                                                                                                                                                                                                                                     |
 | **Pull**                            | Download a Changeset from iModelHub. See [IModelDb synchronization](./IModelDbSync.md)                                                                                                                                                                              |
 | **Tip**                             | The most recent version of an iModel. Also, the most recent Changeset in the timeline.                                                                                                                                                                              |
-| **Transaction**                     | A set of changes that are committed or abandoned atomically, making up a unit of work. A transaction is *committed* by calling [BriefcaseDb.saveChanges]($backend). Multiple transactions to a briefcase are combined into a [Changeset](../Glossary.md#Changeset). |
+| **Transaction**                     | A set of changes that are committed or abandoned atomically, making up a unit of work. A transaction is *committed* by calling [EditTxn.saveChanges]($backend). Multiple transactions to a briefcase are combined into a [Changeset](../Glossary.md#Changeset). |
 | **Version**                         | The state of an iModel as of a specific point in its timeline, that is, the result of the Changesets up to that point.                                                                                                                                              |
 
 ## Concurrency Control Policies
@@ -63,7 +63,7 @@ There are two types of locks:
 
 #### Acquiring Locks On Elements
 
-Locks are acquired via the [LockControl]($backend) interface by calling `BriefcaseDb.locks.acquireExclusiveLock` and `BriefcaseDb.locks.acquireSharedLock`, supplying one or more ElementIds.
+Locks are acquired via the [LockControl]($backend) interface by calling `BriefcaseDb.locks.acquireLocks`, passing an object with `shared` and/or `exclusive` element Ids.
 
 Rules for acquiring locks:
 
@@ -84,6 +84,9 @@ For reference, the pessimistic locking rules are as follows:
 | Insert element | Shared lock on Model and Parent Element, if present |
 | Modify element | Exclusive Lock                                      |
 | Delete element | Exclusive Lock                                      |
+| Insert aspect  | Exclusive Lock on owning Element                    |
+| Update aspect  | Exclusive Lock on owning Element                    |
+| Delete aspect  | Exclusive Lock on owning Element                    |
 
 Notes:
 
@@ -93,7 +96,7 @@ Notes:
 
 #### Releasing Locks
 
-Locks are normally released when the briefcase pushes its changes via [BriefcaseDb.pushChanges]($backend), though they may optionally be retained via the `retainLocks` option. If locks are acquired and no changes were made, or if all changes were abandoned, locks can be manually released via [BriefcaseDb.locks.releaseAllLocks].
+Locks are normally released when the briefcase pushes its changes via [BriefcaseDb.pushChanges]($backend), though they may optionally be retained via the `retainLocks` option. If locks were acquired but the associated elements were never modified, release them with [LockControl.abandonAllLocks]($backend). If changes were made and then abandoned (rather than pushed), first discard the changes and then call [LockControl.releaseAllLocks]($backend).
 
 ### Optimistic Concurrency Control
 


### PR DESCRIPTION
Fixes https://github.com/iTwin/itwinjs-backlog/issues/1819

## Summary

Corrects and updates [docs/learning/backend/ConcurrencyControl.md](docs/learning/backend/ConcurrencyControl.md). No code changes.

## Changes

### 1. Added Element Aspect lock requirements to the pessimistic locking table

The lock requirements table only listed operations on Elements. `ElementAspect.onInsert`, `onUpdate`, and `onDelete` all call `checkExclusiveLock` on the owning element's Id, so all three aspect mutations require an **Exclusive Lock on the owning Element**. These rows were missing entirely from the table.

### 2. Corrected lock-acquisition API names

The doc referred to `BriefcaseDb.locks.acquireExclusiveLock` and `BriefcaseDb.locks.acquireSharedLock`, neither of which exists. The actual `LockControl` interface exposes a single method:

```ts
acquireLocks(arg: { shared?: Id64Arg; exclusive?: Id64Arg }): Promise<void>
```

### 3. Corrected the lock-release guidance for abandoned / never-used locks

The old text directed readers to `releaseAllLocks` for the case where "no changes were made or all changes were abandoned." Per the `LockControl` JSDoc:

- `abandonAllLocks()` — use when the associated elements were **never modified**.
- `releaseAllLocks()` — use after discarding edits (requires no local changes to be present at call time).

### 4. Fixed glossary typo in Optimistic Concurrency Control definition

"allows apps to elements without acquiring locks" → "allows apps to **modify** elements without acquiring locks"

### 5. Updated deprecated API reference in Glossary

The Transaction glossary entry referenced `BriefcaseDb.saveChanges`, which was deprecated in 5.9.0. Updated to `EditTxn.saveChanges`.