### PR TITLE
Skip reserved-element PRIMARY KEY conflicts during rebase

### DIFF
--- a/common/changes/@itwin/core-backend/wbg-component-conflict_2026-08-27-17-49-11.json
+++ b/common/changes/@itwin/core-backend/wbg-component-conflict_2026-08-27-17-49-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/SynchronousChannel.ts
+++ b/core/backend/src/SynchronousChannel.ts
@@ -38,7 +38,7 @@ export namespace SynchronousChannel {
    * changes between briefcases, allowing users to concurrently add and use identical dependencies (e.g., component definitions, schemas, etc.) without introducing conflicts.
    *
    * @note A reserved element is a *shared* element: every briefcase that inserts it must insert the **exact same element**. The reservation assigns a single shared
-   * [ElementId]($common) that all briefcases use, and when multiple briefcases push their inserts they are merged together as one row rather than producing a conflict.
+   * ElementId that all briefcases use, and when multiple briefcases push their inserts they are merged together as one row rather than producing a conflict.
    * Because these duplicate inserts are silently collapsed, the property values written by each briefcase are **not** reconciled — if two briefcases insert the same reserved
    * element with *different* contents, one briefcase's values win arbitrarily and the other's changes will be lost. Callers are therefore responsible for ensuring that every
    * insert of a given reserved element has the same property values across all briefcases.  Only use reservations for content that is deterministically identical everywhere.

--- a/core/backend/src/SynchronousChannel.ts
+++ b/core/backend/src/SynchronousChannel.ts
@@ -20,7 +20,9 @@ export namespace SynchronousChannel {
    * @beta
    */
   export interface ReserveElementsArgs {
-    /** The elements to reserve. The whole batch succeeds or fails together. */
+    /** The elements to reserve. The whole batch succeeds or fails together.
+     * @note Every element listed here becomes a *shared* element that must be inserted identically by every briefcase. See the note on [[SynchronousChannel.Reservations]].
+     */
     elements: Iterable<{
       /** The federationGuid that stably identifies this element across briefcases. Reservations always require an explicit federationGuid. */
       federationGuid: GuidString;
@@ -34,6 +36,12 @@ export namespace SynchronousChannel {
    * Interface used to ***reserve*** elements with shared identities as part of [coordinating simultaneous edits]($docs/learning/backend/ConcurrencyControl.md) from multiple briefcases.
    * Unlike **locks** (via [[LockControl]]), which block users from making conflicting changes to existing elements, **reservations** can be used to communicate "in-flight"
    * changes between briefcases, allowing users to concurrently add and use identical dependencies (e.g., component definitions, schemas, etc.) without introducing conflicts.
+   *
+   * @note A reserved element is a *shared* element: every briefcase that inserts it must insert the **exact same element**. The reservation assigns a single shared
+   * [ElementId]($common) that all briefcases use, and when multiple briefcases push their inserts they are merged together as one row rather than producing a conflict.
+   * Because these duplicate inserts are silently collapsed, the property values written by each briefcase are **not** reconciled — if two briefcases insert the same reserved
+   * element with *different* contents, one briefcase's values win arbitrarily and the other's changes will be lost. Callers are therefore responsible for ensuring that every
+   * insert of a given reserved element has the same property values across all briefcases.  Only use reservations for content that is deterministically identical everywhere.
    * @see [[IModelDb.reservations]] to access the reservations for an iModel.
    * @beta
    */
@@ -66,6 +74,8 @@ export namespace SynchronousChannel {
 
     /**
      * Acquire reservations for one or more elements from the reservation service, if required and not already reserved by another user.
+     * @note Reserving an element establishes a shared identity that every briefcase must insert *identically*. See the note on [[SynchronousChannel.Reservations]] for why divergent
+     * inserts of the same reserved element are unsafe.
      * @throws Error if the requested elements are inconsistent with existing reservations, or if any other error occurs while updating the reservations.
      */
     reserveElements(args: ReserveElementsArgs): Promise<void>;

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -10,7 +10,7 @@ import * as touch from "touch";
 import {
   assert, BeEvent, BentleyError, compareStrings, CompressedId64Set, DbConflictResolution, DbResult, Id64, Id64Array, Id64String, IModelStatus, IndexMap, Logger, OrderedId64Array
 } from "@itwin/core-bentley";
-import { ChangesetIdWithIndex, ChangesetIndexAndId, ChangesetProps, EntityIdAndClassId, EntityIdAndClassIdIterable, IModelError, ModelGeometryChangesProps, ModelIdAndGeometryGuid, NotifyEntitiesChangedArgs, NotifyEntitiesChangedMetadata, ReinstateTxnArgs, ReverseTxnArgs, TxnEntityMetadata, TxnProps } from "@itwin/core-common";
+import { BriefcaseIdValue, ChangesetIdWithIndex, ChangesetIndexAndId, ChangesetProps, EntityIdAndClassId, EntityIdAndClassIdIterable, IModelError, ModelGeometryChangesProps, ModelIdAndGeometryGuid, NotifyEntitiesChangedArgs, NotifyEntitiesChangedMetadata, ReinstateTxnArgs, ReverseTxnArgs, TxnEntityMetadata, TxnProps } from "@itwin/core-common";
 import { BackendLoggerCategory } from "./BackendLoggerCategory";
 import { BriefcaseDb } from "./IModelDb";
 import { Element } from "./Element";
@@ -1164,6 +1164,12 @@ export class TxnManager {
 
     if (args.cause === "Conflict") {
       if (args.tableName.startsWith("ec_")) {
+        return DbConflictResolution.Skip;
+      }
+
+      // Skip PRIMARY KEY conflicts for inserted rows that were pre-reserved via SchemaSync - these are the same shared element.
+      const isReserved = (id: any) => typeof (id) === "string" && Id64.getBriefcaseId(id) === BriefcaseIdValue.SchemaSyncElementReserved;
+      if (args.opcode === "Inserted" && args.getPrimaryKeyValues().every(isReserved)) {
         return DbConflictResolution.Skip;
       }
     }

--- a/core/backend/src/TxnManager.ts
+++ b/core/backend/src/TxnManager.ts
@@ -1168,8 +1168,9 @@ export class TxnManager {
       }
 
       // Skip PRIMARY KEY conflicts for inserted rows that were pre-reserved via SchemaSync - these are the same shared element.
-      const isReserved = (id: any) => typeof (id) === "string" && Id64.getBriefcaseId(id) === BriefcaseIdValue.SchemaSyncElementReserved;
-      if (args.opcode === "Inserted" && args.getPrimaryKeyValues().every(isReserved)) {
+      const isReserved = (id: unknown) => typeof id === "string" && Id64.getBriefcaseId(id) === BriefcaseIdValue.SchemaSyncElementReserved;
+      const pkValues = args.getPrimaryKeyValues();
+      if (args.opcode === "Inserted" && pkValues.length > 0 && pkValues.every(isReserved)) {
         return DbConflictResolution.Skip;
       }
     }

--- a/full-stack-tests/backend/src/integration/SchemaSyncReservations.test.ts
+++ b/full-stack-tests/backend/src/integration/SchemaSyncReservations.test.ts
@@ -318,6 +318,147 @@ describe("SchemaSync element reservations (concurrent users)", function (this: S
       await b2.reservations.reserveElements({ elements: [catReservation(b2, guid, "Shared-Def")] });
       const idOnB2 = await insertReservedCategory(b2, guid, "Shared-Def");
       expect(idOnB2).to.equal(idOnB1);
+
+      // Both briefcases now have the same reserved id for the shared definition - no conflicts should occur.
+      await b1.pushChanges({ accessToken: "token 1", description: "insert Shared-Def" });
+      await b2.pushChanges({ accessToken: "token 2", description: "insert Shared-Def" });
+
+      // Both briefcases converge on the single shared element with no id/code conflict.
+      await b1.pullChanges({ accessToken: "token 2" });
+      expect(b1.elements.tryGetElementProps(idOnB1)).to.not.be.undefined;
+      expect(b2.elements.tryGetElementProps(idOnB2)).to.not.be.undefined;
+    });
+
+    it("resolves a shared definition when the briefcases push in the opposite order", async () => {
+      const ctx = await createTestIModel();
+      const b1 = await openBriefcase(ctx, "token 1", "briefcase1");
+      const b2 = await openBriefcase(ctx, "token 2", "briefcase2");
+      await enableSchemaSyncOnFirst(b1, ctx);
+      await enableSchemaSyncViaPull(b2, "token 2");
+
+      const guid = Guid.createValue();
+
+      // Both briefcases reserve + insert the same definition offline; they resolve the same reserved id.
+      await b1.reservations.reserveElements({ elements: [catReservation(b1, guid, "Shared-Def")] });
+      const sharedId = await insertReservedCategory(b1, guid, "Shared-Def");
+      await b2.reservations.reserveElements({ elements: [catReservation(b2, guid, "Shared-Def")] });
+      expect(await insertReservedCategory(b2, guid, "Shared-Def")).to.equal(sharedId);
+
+      // Opposite of the previous test: b2 pushes first, then b1 rebases its identical insert on top.
+      // Whichever briefcase pushes second hits the benign reserved-id PRIMARY KEY conflict that is skipped.
+      await b2.pushChanges({ accessToken: "token 2", description: "insert Shared-Def" });
+      await b1.pushChanges({ accessToken: "token 1", description: "insert Shared-Def" });
+
+      // Both briefcases converge on the single shared element with no id/code conflict.
+      await b2.pullChanges({ accessToken: "token 2" });
+      expect(b1.elements.tryGetElementProps(sharedId)).to.not.be.undefined;
+      expect(b2.elements.tryGetElementProps(sharedId)).to.not.be.undefined;
+    });
+
+    it("merges concurrent inserts of multiple shared definitions", async () => {
+      const ctx = await createTestIModel();
+      const b1 = await openBriefcase(ctx, "token 1", "briefcase1");
+      const b2 = await openBriefcase(ctx, "token 2", "briefcase2");
+      await enableSchemaSyncOnFirst(b1, ctx);
+      await enableSchemaSyncViaPull(b2, "token 2");
+
+      const defs = [0, 1, 2].map((i) => ({ guid: Guid.createValue(), name: `Multi-Def-${i}` }));
+
+      // Both briefcases reserve + insert the SAME batch of definitions, offline from each other.
+      await b1.reservations.reserveElements({ elements: defs.map((d) => catReservation(b1, d.guid, d.name)) });
+      await b2.reservations.reserveElements({ elements: defs.map((d) => catReservation(b2, d.guid, d.name)) });
+
+      const ids: Id64String[] = [];
+      for (const d of defs)
+        ids.push(await insertReservedCategory(b1, d.guid, d.name));
+      for (let i = 0; i < defs.length; i++)
+        expect(await insertReservedCategory(b2, defs[i].guid, defs[i].name)).to.equal(ids[i]);
+
+      await b1.pushChanges({ accessToken: "token 1", description: "b1 insert batch" });
+      // b2 rebases its identical batch on top of b1's; every reserved-id insert conflict is skipped.
+      await b2.pushChanges({ accessToken: "token 2", description: "b2 insert batch" });
+
+      await b1.pullChanges({ accessToken: "token 1" });
+      for (const id of ids) {
+        expect(isReservedId(id)).to.be.true;
+        expect(b1.elements.tryGetElementProps(id)).to.not.be.undefined;
+        expect(b2.elements.tryGetElementProps(id)).to.not.be.undefined;
+      }
+    });
+
+    it("keeps independently-reserved definitions while skipping the shared reserved-id conflict", async () => {
+      const ctx = await createTestIModel();
+      const b1 = await openBriefcase(ctx, "token 1", "briefcase1");
+      const b2 = await openBriefcase(ctx, "token 2", "briefcase2");
+      await enableSchemaSyncOnFirst(b1, ctx);
+      await enableSchemaSyncViaPull(b2, "token 2");
+
+      const shared = Guid.createValue();
+      const ownB1 = Guid.createValue();
+      const ownB2 = Guid.createValue();
+
+      // Both briefcases reserve the shared definition; each also reserves its own distinct one.
+      await b1.reservations.reserveElements({ elements: [catReservation(b1, shared, "Shared"), catReservation(b1, ownB1, "Own-B1")] });
+      await b2.reservations.reserveElements({ elements: [catReservation(b2, shared, "Shared"), catReservation(b2, ownB2, "Own-B2")] });
+
+      const sharedIdB1 = await insertReservedCategory(b1, shared, "Shared");
+      const ownIdB1 = await insertReservedCategory(b1, ownB1, "Own-B1");
+      await b1.pushChanges({ accessToken: "token 1", description: "b1 shared + own" });
+
+      const sharedIdB2 = await insertReservedCategory(b2, shared, "Shared");
+      const ownIdB2 = await insertReservedCategory(b2, ownB2, "Own-B2");
+      expect(sharedIdB2).to.equal(sharedIdB1);
+      expect(ownIdB2).to.not.equal(ownIdB1);
+
+      // b2 rebases: the shared reserved-id insert conflicts (skipped), while its own insert lands cleanly.
+      await b2.pushChanges({ accessToken: "token 2", description: "b2 shared + own" });
+
+      // Every definition survives on both briefcases: the shared one and each briefcase's own.
+      await b1.pullChanges({ accessToken: "token 1" });
+      for (const id of [sharedIdB1, ownIdB1, ownIdB2]) {
+        expect(b1.elements.tryGetElementProps(id)).to.not.be.undefined;
+        expect(b2.elements.tryGetElementProps(id)).to.not.be.undefined;
+      }
+    });
+
+    it("aborts the rebase when two briefcases mint the same ordinary (unreserved) ElementId", async () => {
+      // Reservations exist precisely to hand out globally-unique ids. When that coordination is bypassed
+      // and two briefcases independently force the SAME ordinary ElementId, the second push must NOT be
+      // silently skipped the way a reserved-id conflict is - it is a genuine divergence, so the rebase aborts.
+      const ctx = await createTestIModel();
+      const b1 = await openBriefcase(ctx, "token 1", "briefcase1");
+      const b2 = await openBriefcase(ctx, "token 2", "briefcase2");
+      await enableSchemaSyncOnFirst(b1, ctx);
+      await enableSchemaSyncViaPull(b2, "token 2");
+
+      // An ordinary id outside the reserved range (briefcase id 500 is never assigned to these briefcases).
+      const collidingId = Id64.fromLocalAndBriefcaseIds(1, 500);
+      expect(isReservedId(collidingId)).to.be.false;
+
+      // No federationGuid => no reservation gate; forceUseId pins both inserts to the same id.
+      const insertForcedLineStyle = async (bc: BriefcaseDb, name: string): Promise<void> => {
+        await bc.locks.acquireLocks({ shared: IModel.dictionaryId });
+        withEditTxn(bc, (txn) => txn.insertElement({
+          classFullName: LineStyle.classFullName,
+          model: IModel.dictionaryId,
+          code: LineStyle.createCode(bc, IModel.dictionaryId, name),
+          id: collidingId,
+        }, { forceUseId: true }));
+      };
+
+      await insertForcedLineStyle(b1, "Collide-A");
+      await b1.pushChanges({ accessToken: "token 1", description: "b1 insert" });
+
+      await insertForcedLineStyle(b2, "Collide-B");
+
+      // b2 rebases its insert on top of b1's; the non-reserved PRIMARY KEY conflict aborts the rebase.
+      let error: Error | undefined;
+      try {
+        await b2.pushChanges({ accessToken: "token 2", description: "b2 insert" });
+      } catch (e) {
+        error = e as Error;
+      }
+      expect(error?.message).to.equal("PRIMARY KEY insert conflict. Aborting rebase.");
     });
   });
 

--- a/full-stack-tests/backend/src/integration/SchemaSyncReservations.test.ts
+++ b/full-stack-tests/backend/src/integration/SchemaSyncReservations.test.ts
@@ -324,7 +324,7 @@ describe("SchemaSync element reservations (concurrent users)", function (this: S
       await b2.pushChanges({ accessToken: "token 2", description: "insert Shared-Def" });
 
       // Both briefcases converge on the single shared element with no id/code conflict.
-      await b1.pullChanges({ accessToken: "token 2" });
+      await b1.pullChanges({ accessToken: "token 1" });
       expect(b1.elements.tryGetElementProps(idOnB1)).to.not.be.undefined;
       expect(b2.elements.tryGetElementProps(idOnB2)).to.not.be.undefined;
     });


### PR DESCRIPTION
Follow-up to #9483 (concurrent definition "reservations" via SchemaSync).

When two briefcases concurrently insert the *same* reserved definition, both resolve to the identical reserved `ElementId` (keyed by `federationGuid`) to avoid conflicts. That is by design — but whoever pushed second then failed to rebase with a `PRIMARY KEY insert conflict`, leaving the briefcase stuck. This was a known limitation called out in [an earlier review comment in #9483](https://github.com/iTwin/itwinjs-core/pull/9483#discussion_r3812408849).

To fix this, `TxnManager._onRebaseLocalTxnConflict` now recognizes a benign reserved-element collision: when an `Inserted`  primary-key conflict's key values are *all* in the dedicated `BriefcaseIdValue.SchemaSyncElementReserved` range, the local insert is skipped so the already-merged, identical row is kept. Genuine (non-reserved) primary-key conflicts still abort the rebase, and the guard is insert-only, so `Update`/`Delete` conflicts are unaffected.