### PR TITLE
Fix Windows-only failures in the Electron backend integration tests

### DIFF
--- a/common/changes/@itwin/core-electron/tcobbs-electron-race-fixes_2026-08-27-22-34-10.json
+++ b/common/changes/@itwin/core-electron/tcobbs-electron-race-fixes_2026-08-27-22-34-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-electron",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-electron"
+}

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -206,15 +206,23 @@ async function testWindowSizeSettings() {
   // when the restored bounds arrive and win the last debounced write.
   await waitForStableBounds(window);
 
-  const width = 250;
-  const height = 251;
-  window.setSize(width, height);
-  assert(await waitUntil(() => savedSizeAndPos()?.width === width && savedSizeAndPos()?.height === height));
+  // A fractionally-scaled display rounds through physical pixels, so the realized bounds can differ from
+  // the requested bounds by a pixel or two. What must hold is that the saved state converges on whatever
+  // the window actually reports.
+  const savedMatchesWindow = () => {
+    const saved = savedSizeAndPos();
+    const bounds = window.getBounds();
+    return saved !== undefined && saved.width === bounds.width && saved.height === bounds.height
+      && saved.x === bounds.x && saved.y === bounds.y;
+  };
 
-  const x = 50;
-  const y = 75;
-  window.setPosition(x, y);
-  assert(await waitUntil(() => savedSizeAndPos()?.x === x && savedSizeAndPos()?.y === y));
+  window.setSize(250, 251);
+  assert(await waitUntil(() => window.getBounds().width !== expectedBounds.width && window.getBounds().height !== expectedBounds.height));
+  assert(await waitUntil(savedMatchesWindow));
+
+  window.setPosition(50, 75);
+  assert(await waitUntil(() => window.getBounds().x !== expectedBounds.x && window.getBounds().y !== expectedBounds.y));
+  assert(await waitUntil(savedMatchesWindow));
 }
 
 /** Longer than `ElectronHost`'s 200ms window state debounce, so a stable sample means nothing is pending. */

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -216,12 +216,20 @@ async function testWindowSizeSettings() {
       && saved.x === bounds.x && saved.y === bounds.y;
   };
 
+  const boundsBeforeResize = window.getBounds();
   window.setSize(250, 251);
-  assert(await waitUntil(() => window.getBounds().width !== expectedBounds.width && window.getBounds().height !== expectedBounds.height));
+  assert(await waitUntil(() => {
+    const bounds = window.getBounds();
+    return bounds.width !== boundsBeforeResize.width || bounds.height !== boundsBeforeResize.height;
+  }));
   assert(await waitUntil(savedMatchesWindow));
 
+  const boundsBeforeMove = window.getBounds();
   window.setPosition(50, 75);
-  assert(await waitUntil(() => window.getBounds().x !== expectedBounds.x && window.getBounds().y !== expectedBounds.y));
+  assert(await waitUntil(() => {
+    const bounds = window.getBounds();
+    return bounds.x !== boundsBeforeMove.x || bounds.y !== boundsBeforeMove.y;
+  }));
   assert(await waitUntil(savedMatchesWindow));
 }
 
@@ -239,7 +247,7 @@ async function waitUntil(condition: () => boolean): Promise<boolean> {
   return condition();
 }
 
-/** Waits until the window reports the same bounds across a full settle interval, for up to ~4 seconds. */
+/** Waits until the window reports the same bounds across a full settle interval, throwing if it doesn't within ~4 seconds. */
 async function waitForStableBounds(window: BrowserWindow): Promise<void> {
   let previous = "";
   for (let i = 0; i < 10; ++i) {
@@ -250,6 +258,8 @@ async function waitForStableBounds(window: BrowserWindow): Promise<void> {
     previous = current;
     await settleInterval.wait();
   }
+
+  throw new Error("Window bounds did not stabilize");
 }
 
 function assertElectronHostNotInitialized() {

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+import type { BrowserWindow } from "electron";
 import * as path from "path";
 import { assert } from "chai";
 import { IModelHost, IpcHandler, NativeHost } from "@itwin/core-backend";
@@ -201,6 +202,10 @@ async function testWindowSizeSettings() {
   window.unmaximize();
   assert(await waitUntil(() => savedMaximized() === window.isMaximized()));
 
+  // Windows restores from maximized asynchronously. A resize issued before that settles is overwritten
+  // when the restored bounds arrive and win the last debounced write.
+  await waitForStableBounds(window);
+
   const width = 250;
   const height = 251;
   window.setSize(width, height);
@@ -212,15 +217,31 @@ async function testWindowSizeSettings() {
   assert(await waitUntil(() => savedSizeAndPos()?.x === x && savedSizeAndPos()?.y === y));
 }
 
+/** Longer than `ElectronHost`'s 200ms window state debounce, so a stable sample means nothing is pending. */
+const settleInterval = BeDuration.fromMilliseconds(400);
+
 /**
- * Polls `condition` until it holds, for up to ~1.25 seconds.
+ * Polls `condition` until it holds, for up to ~5 seconds.
  * @note `ElectronHost` persists window state from a debounced handler, so the settings file lags the window.
  */
 async function waitUntil(condition: () => boolean): Promise<boolean> {
-  for (let i = 0; i < 25 && !condition(); ++i)
+  for (let i = 0; i < 100 && !condition(); ++i)
     await BeDuration.wait(50);
 
   return condition();
+}
+
+/** Waits until the window reports the same bounds across a full settle interval, for up to ~4 seconds. */
+async function waitForStableBounds(window: BrowserWindow): Promise<void> {
+  let previous = "";
+  for (let i = 0; i < 10; ++i) {
+    const current = JSON.stringify(window.getBounds());
+    if (current === previous)
+      return;
+
+    previous = current;
+    await settleInterval.wait();
+  }
 }
 
 function assertElectronHostNotInitialized() {

--- a/core/electron/src/test/backend/ElectronHost.test.ts
+++ b/core/electron/src/test/backend/ElectronHost.test.ts
@@ -217,7 +217,9 @@ async function testWindowSizeSettings() {
   };
 
   const boundsBeforeResize = window.getBounds();
-  window.setSize(250, 251);
+  const targetWidth = boundsBeforeResize.width === 250 ? 300 : 250;
+  const targetHeight = boundsBeforeResize.height === 251 ? 301 : 251;
+  window.setSize(targetWidth, targetHeight);
   assert(await waitUntil(() => {
     const bounds = window.getBounds();
     return bounds.width !== boundsBeforeResize.width || bounds.height !== boundsBeforeResize.height;
@@ -225,7 +227,11 @@ async function testWindowSizeSettings() {
   assert(await waitUntil(savedMatchesWindow));
 
   const boundsBeforeMove = window.getBounds();
-  window.setPosition(50, 75);
+  // The OS chooses the initial position, so pick a target it can't already be at - otherwise setPosition
+  // is a no-op and the "window changed" assertion below can never be satisfied.
+  const targetX = boundsBeforeMove.x === 50 ? 100 : 50;
+  const targetY = boundsBeforeMove.y === 75 ? 150 : 75;
+  window.setPosition(targetX, targetY);
   assert(await waitUntil(() => {
     const bounds = window.getBounds();
     return bounds.x !== boundsBeforeMove.x || bounds.y !== boundsBeforeMove.y;

--- a/core/electron/src/test/backend/RunSingleTest.ts
+++ b/core/electron/src/test/backend/RunSingleTest.ts
@@ -14,20 +14,13 @@ import { TestResult, testSuites } from "./ElectronBackendTests";
  * and test must be defined in [testSuites].
  */
 async function run() {
-  // Tests that never start ElectronHost can finish before Chromium is done initializing. Tearing the main
-  // process down at that point aborts it (STATUS_BREAKPOINT on Windows), so wait for the app and let
-  // Electron own the exit.
-  await app.whenReady();
-
   const suiteTitle = process.env.ELECTRON_SUITE_TITLE;
   const testTitle = process.env.ELECTRON_TEST_TITLE;
 
   const suiteToRun = testSuites.find((suite) => suite.title === suiteTitle);
   const testToRun = suiteToRun?.tests.find((test) => test.title === testTitle);
-  if (testToRun === undefined) {
-    app.exit(TestResult.InvalidArguments);
-    return;
-  }
+  if (testToRun === undefined)
+    return exit(TestResult.InvalidArguments);
 
   let exitCode = TestResult.Success;
   try {
@@ -37,6 +30,16 @@ async function run() {
     exitCode = TestResult.Failure;
   }
 
+  return exit(exitCode);
+}
+
+/** Tests that never start `ElectronHost` can finish before Chromium is done initializing. Tearing the main
+ * process down at that point aborts it (STATUS_BREAKPOINT on Windows), so wait for the app before exiting.
+ * @note This must not be awaited before the test runs: `ElectronHost.startup` registers privileged schemes
+ * only while the app is not yet ready.
+ */
+async function exit(exitCode: number): Promise<void> {
+  await app.whenReady();
   app.exit(exitCode);
 }
 

--- a/core/electron/src/test/backend/RunSingleTest.ts
+++ b/core/electron/src/test/backend/RunSingleTest.ts
@@ -3,6 +3,9 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+// This file is only ever loaded as the entry point of a spawned Electron main process, so unlike
+// ElectronHost.ts it can import electron directly.
+import { app } from "electron";
 import { TestResult, testSuites } from "./ElectronBackendTests";
 
 /** Finds and runs a single test before terminating current process.
@@ -11,16 +14,20 @@ import { TestResult, testSuites } from "./ElectronBackendTests";
  * and test must be defined in [testSuites].
  */
 async function run() {
+  // Tests that never start ElectronHost can finish before Chromium is done initializing. Tearing the main
+  // process down at that point aborts it (STATUS_BREAKPOINT on Windows), so wait for the app and let
+  // Electron own the exit.
+  await app.whenReady();
+
   const suiteTitle = process.env.ELECTRON_SUITE_TITLE;
   const testTitle = process.env.ELECTRON_TEST_TITLE;
 
   const suiteToRun = testSuites.find((suite) => suite.title === suiteTitle);
-  if (suiteToRun === undefined)
-    process.exit(TestResult.InvalidArguments);
-
-  const testToRun = suiteToRun.tests.find((test) => test.title === testTitle);
-  if (testToRun === undefined)
-    process.exit(TestResult.InvalidArguments);
+  const testToRun = suiteToRun?.tests.find((test) => test.title === testTitle);
+  if (testToRun === undefined) {
+    app.exit(TestResult.InvalidArguments);
+    return;
+  }
 
   let exitCode = TestResult.Success;
   try {
@@ -30,7 +37,7 @@ async function run() {
     exitCode = TestResult.Failure;
   }
 
-  process.exit(exitCode);
+  app.exit(exitCode);
 }
 
 void run();


### PR DESCRIPTION
## Fix Windows-only failures in the Electron backend integration tests

Two causes of the failures were introduced by #9627 and reproduced on Windows in the Node 20 and Node 24 CI legs. The fractional scaling problem has probably always existed.

### `Should save main window size, position and maximized flag.`

Three separate problems in `ElectronHost.test.ts`:

- **Resize issued mid-restore.** #9627 replaced the unconditional 250 ms sleep after `unmaximize()` with a `waitUntil` that returns immediately, because `savedMaximized()` and `window.isMaximized()` flip in the same tick. `setSize` then landed while Windows was still restoring, and the restored bounds won the last debounced write. Added `waitForStableBounds()` to wait for the window to settle first.
- **Fractional display scaling.** On a display at non-integer scale (e.g. 250%), bounds round through physical pixels, so the realized size/position can differ from what was requested. The test now asserts that the saved state converges on whatever the window actually reports, plus a separate check that the window changed at all — instead of requiring exactly 250×251 at (50, 75).
- **Timeout too tight.** `waitUntil` budget raised from ~1.25 s to ~5 s.

### `Should ignore a response after its request was removed during shutdown.`

Exited with `0x80000003` (`STATUS_BREAKPOINT`) — a Chromium abort, not an assertion failure. This test never calls `ElectronHost.startup()`, so it could finish and tear down the main process while Chromium was still initializing. `RunSingleTest.ts` now awaits `app.whenReady()` and exits via `app.exit()` rather than `process.exit()`.

## Notes

- Test-only; no shipped behavior change.
- Targets `master` for backport to `release/5.13.x`. The affected files are identical on both branches, so the cherry-pick should be clean.
- The Windows leg was run multiple times to verify the fix — the `0x80000003` failure was intermittent and passed on the Node 24 leg.
