### PR TITLE
ObservableMap plus ObservableSet fixes

### DIFF
--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -1406,7 +1406,7 @@ export type NonFunctionPropertyNamesOf<T> = {
 
 // @public
 export class ObservableMap<K, V> extends Map<K, V> {
-    // (undocumented)
+    // @internal (undocumented)
     get [Symbol.toStringTag](): string;
     constructor(elements?: Iterable<readonly [K, V]> | undefined);
     clear(): void;
@@ -1424,7 +1424,7 @@ export class ObservableMap<K, V> extends Map<K, V> {
 
 // @public
 export class ObservableSet<T> extends Set<T> {
-    // (undocumented)
+    // @internal (undocumented)
     get [Symbol.toStringTag](): string;
     constructor(elements?: Iterable<T> | undefined);
     add(item: T): this;

--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -1412,14 +1412,9 @@ export class ObservableMap<K, V> extends Map<K, V> {
     clear(): void;
     delete(key: K): boolean;
     deleteAll(keys: Iterable<K>): number;
-    readonly onAdded: BeEvent<(key: K, value: V) => void>;
-    readonly onBatchAdded: BeEvent<() => void>;
-    readonly onBatchDeleted: BeEvent<() => void>;
     readonly onChanged: BeEvent<() => void>;
-    readonly onCleared: BeEvent<() => void>;
-    readonly onDeleted: BeEvent<(key: K) => void>;
     set(key: K, value: V): this;
-    setAll(items: Iterable<readonly [K, V]>): number;
+    setAll(items: Iterable<readonly [K, V]>): void;
 }
 
 // @public

--- a/common/api/core-bentley.api.md
+++ b/common/api/core-bentley.api.md
@@ -1405,8 +1405,29 @@ export type NonFunctionPropertyNamesOf<T> = {
 }[keyof T];
 
 // @public
+export class ObservableMap<K, V> extends Map<K, V> {
+    // (undocumented)
+    get [Symbol.toStringTag](): string;
+    constructor(elements?: Iterable<readonly [K, V]> | undefined);
+    clear(): void;
+    delete(key: K): boolean;
+    deleteAll(keys: Iterable<K>): number;
+    readonly onAdded: BeEvent<(key: K, value: V) => void>;
+    readonly onBatchAdded: BeEvent<() => void>;
+    readonly onBatchDeleted: BeEvent<() => void>;
+    readonly onChanged: BeEvent<() => void>;
+    readonly onCleared: BeEvent<() => void>;
+    readonly onDeleted: BeEvent<(key: K) => void>;
+    set(key: K, value: V): this;
+    setAll(items: Iterable<readonly [K, V]>): number;
+}
+
+// @public
 export class ObservableSet<T> extends Set<T> {
+    // (undocumented)
+    get [Symbol.toStringTag](): string;
     constructor(elements?: Iterable<T> | undefined);
+    add(item: T): this;
     addAll(items: Iterable<T>): number;
     clear(): void;
     delete(item: T): boolean;
@@ -1414,6 +1435,7 @@ export class ObservableSet<T> extends Set<T> {
     readonly onAdded: BeEvent<(item: T) => void>;
     readonly onBatchAdded: BeEvent<() => void>;
     readonly onBatchDeleted: BeEvent<() => void>;
+    readonly onChanged: BeEvent<() => void>;
     readonly onCleared: BeEvent<() => void>;
     readonly onDeleted: BeEvent<(item: T) => void>;
 }

--- a/common/api/summary/core-bentley.exports.csv
+++ b/common/api/summary/core-bentley.exports.csv
@@ -112,6 +112,7 @@ public;class;MutableCompressedId64Set
 beta;type;NestedValueOf
 public;type;NonFunctionPropertiesOf
 public;type;NonFunctionPropertyNamesOf
+public;class;ObservableMap
 public;class;ObservableSet
 public;function;omit
 beta;class;OneAtATimeAction

--- a/common/changes/@itwin/core-bentley/pmc-observable-collections_2026-08-28-15-36-25.json
+++ b/common/changes/@itwin/core-bentley/pmc-observable-collections_2026-08-28-15-36-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-bentley",
+      "comment": "Add ObservableMap; fix subclassing of ObservableSet and add ObservableSet.onChanged event.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-bentley"
+}

--- a/core/bentley/src/ObservableMap.ts
+++ b/core/bentley/src/ObservableMap.ts
@@ -9,23 +9,13 @@
 
 import { BeEvent } from "./BeEvent";
 
-/** A standard [Map<K,V>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) that emits events when its contents change.
+/** A standard [Map<K,V>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) that emits an event when its contents change.
  * @public
  */
 export class ObservableMap<K, V> extends Map<K, V> {
   /** @internal */
   public override get [Symbol.toStringTag]() { return "ObservableMap"; }
 
-  /** Emitted after a key/value pair is added to this map. */
-  public readonly onAdded = new BeEvent<(key: K, value: V) => void>();
-  /** Emitted after `key` is deleted from this map. */
-  public readonly onDeleted = new BeEvent<(key: K) => void>();
-  /** Emitted after this map's contents are cleared. */
-  public readonly onCleared = new BeEvent<() => void>();
-  /** Emitted after multiple entries are added to this map via [[setAll]]. */
-  public readonly onBatchAdded = new BeEvent<() => void>();
-  /** Emitted after multiple entries are deleted from this map via [[deleteAll]]. */
-  public readonly onBatchDeleted = new BeEvent<() => void>();
   /** Emitted after any change to the contents of this map. */
   public readonly onChanged = new BeEvent<() => void>();
 
@@ -33,8 +23,8 @@ export class ObservableMap<K, V> extends Map<K, V> {
    * @param elements Optional elements with which to populate the new map.
    */
   public constructor(elements?: Iterable<readonly [K, V]> | undefined) {
-    // IMPORTANT: do not pass `elements` to `super()`. It will invoke `set` which is overridden to invoke `onAdded.raiseEvent`, but
-    // `onAdded` is not initialized until `super()` returns.
+    // IMPORTANT: do not pass `elements` to `super()`. It will invoke `set` which is overridden to invoke `onChanged.raiseEvent`, but
+    // `onChanged` is not initialized until `super()` returns.
     super();
 
     if (elements)
@@ -42,23 +32,21 @@ export class ObservableMap<K, V> extends Map<K, V> {
   }
 
   /** Invokes [Map.set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set), raising
-   * the [[onAdded]] event.
+   * the [[onChanged]] event.
    */
   public override set(key: K, value: V): this {
     const ret = super.set(key, value);
-    this.onAdded.raiseEvent(key, value);
     this.onChanged.raiseEvent();
 
     return ret;
   }
 
   /** Invokes [Map.delete](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete), raising
-   * the [[onDeleted]] event if the key was removed from the map.
+   * the [[onChanged]] event if the key was removed from the map.
    */
   public override delete(key: K): boolean {
     const ret = super.delete(key);
     if (ret) {
-      this.onDeleted.raiseEvent(key);
       this.onChanged.raiseEvent();
     }
 
@@ -66,35 +54,32 @@ export class ObservableMap<K, V> extends Map<K, V> {
   }
 
   /** If this map is not already empty, invokes [Map.clear](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear)
-   * and raises the [[onCleared]] event.
+   * and raises the [[onChanged]] event.
    */
   public override clear(): void {
     if (0 !== this.size) {
       super.clear();
-      this.onCleared.raiseEvent();
       this.onChanged.raiseEvent();
     }
   }
 
-  /** Add multiple entries to the map, raising [[onBatchAdded]] only once after all items are added.
-   * This is more efficient than calling [[set]] in a loop when listeners need not be notified of each individual addition.
-   * @param items The entries to add.
-   * @returns The number of entries that were actually added (i.e., keys that were not already present).
+  /** Add or update multiple entries in the map, raising [[onChanged]] only once after all items are set.
+   * This is more efficient than calling [[set]] in a loop when listeners need not be notified of each individual change.
+   * @param items The entries to add or update.
    */
-  public setAll(items: Iterable<readonly [K, V]>): number {
-    const prevSize = this.size;
-    for (const [key, value] of items)
+  public setAll(items: Iterable<readonly [K, V]>): void {
+    let anyEntries = false;
+    for (const [key, value] of items) {
+      anyEntries = true;
       super.set(key, value);
-
-    if (this.size !== prevSize) {
-      this.onBatchAdded.raiseEvent();
-      this.onChanged.raiseEvent();
     }
 
-    return this.size - prevSize;
+    if (anyEntries) {
+      this.onChanged.raiseEvent();
+    }
   }
 
-  /** Delete multiple keys from the map, raising [[onBatchDeleted]] only once after all keys are deleted.
+  /** Delete multiple keys from the map, raising [[onChanged]] only once after all keys are deleted.
    * This is more efficient than calling [[delete]] in a loop when listeners need not be notified of each individual deletion.
    * @param keys The keys to delete.
    * @returns The number of keys that were actually deleted (i.e., were present in the map).
@@ -105,7 +90,6 @@ export class ObservableMap<K, V> extends Map<K, V> {
       super.delete(key);
 
     if (this.size !== prevSize) {
-      this.onBatchDeleted.raiseEvent();
       this.onChanged.raiseEvent();
     }
 

--- a/core/bentley/src/ObservableMap.ts
+++ b/core/bentley/src/ObservableMap.ts
@@ -32,7 +32,7 @@ export class ObservableMap<K, V> extends Map<K, V> {
   }
 
   /** Invokes [Map.set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set), raising
-   * the [[onChanged]] event.
+   * the [[onChanged]] event unless `key` is already present with the same `value`.
    */
   public override set(key: K, value: V): this {
     const valueChanged = !this.has(key) || !Object.is(this.get(key), value);
@@ -68,22 +68,25 @@ export class ObservableMap<K, V> extends Map<K, V> {
     }
   }
 
-  /** Add or update multiple entries in the map, raising [[onChanged]] only once after all items are set.
+  /** Add or update multiple entries in the map, raising [[onChanged]] only once after all items are set, if the contents of
+   * the map changed as a result.
    * This is more efficient than calling [[set]] in a loop when listeners need not be notified of each individual change.
    * @param items The entries to add or update.
    */
   public setAll(items: Iterable<readonly [K, V]>): void {
     let changed = false;
-    for (const [key, value] of items) {
-      const shouldSet = !this.has(key) || !Object.is(this.get(key), value);
-      if (shouldSet) {
-        super.set(key, value);
-        changed = true;
+    try {
+      for (const [key, value] of items) {
+        const shouldSet = !this.has(key) || !Object.is(this.get(key), value);
+        if (shouldSet) {
+          super.set(key, value);
+          changed = true;
+        }
       }
-    }
-
-    if (changed) {
-      this.onChanged.raiseEvent();
+    } finally {
+      if (changed) {
+        this.onChanged.raiseEvent();
+      }
     }
   }
 
@@ -94,11 +97,13 @@ export class ObservableMap<K, V> extends Map<K, V> {
    */
   public deleteAll(keys: Iterable<K>): number {
     const prevSize = this.size;
-    for (const key of keys)
-      super.delete(key);
-
-    if (this.size !== prevSize) {
-      this.onChanged.raiseEvent();
+    try {
+      for (const key of keys)
+        super.delete(key);
+    } finally {
+      if (this.size !== prevSize) {
+        this.onChanged.raiseEvent();
+      }
     }
 
     return prevSize - this.size;

--- a/core/bentley/src/ObservableMap.ts
+++ b/core/bentley/src/ObservableMap.ts
@@ -1,0 +1,114 @@
+
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Collections
+ */
+
+import { BeEvent } from "./BeEvent";
+
+/** A standard [Map<K,V>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) that emits events when its contents change.
+ * @public
+ */
+export class ObservableMap<K, V> extends Map<K, V> {
+  public override get [Symbol.toStringTag]() { return "ObservableMap"; }
+
+  /** Emitted after a key/value pair is added to this map. */
+  public readonly onAdded = new BeEvent<(key: K, value: V) => void>();
+  /** Emitted after `key` is deleted from this map. */
+  public readonly onDeleted = new BeEvent<(key: K) => void>();
+  /** Emitted after this map's contents are cleared. */
+  public readonly onCleared = new BeEvent<() => void>();
+  /** Emitted after multiple entries are added to this map via [[setAll]]. */
+  public readonly onBatchAdded = new BeEvent<() => void>();
+  /** Emitted after multiple entries are deleted from this map via [[deleteAll]]. */
+  public readonly onBatchDeleted = new BeEvent<() => void>();
+  /** Emitted after any change to the contents of this map. */
+  public readonly onChanged = new BeEvent<() => void>();
+
+  /** Construct a new ObservableMap.
+   * @param elements Optional elements with which to populate the new map.
+   */
+  public constructor(elements?: Iterable<readonly [K, V]> | undefined) {
+    // IMPORTANT: do not pass `elements` to `super()`. It will invoke `set` which is overridden to invoke `onAdded.raiseEvent`, but
+    // `onAdded` is not initialized until `super()` returns.
+    super();
+
+    if (elements)
+      this.setAll(elements);
+  }
+
+  /** Invokes [Map.set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set), raising
+   * the [[onAdded]] event.
+   */
+  public override set(key: K, value: V): this {
+    const ret = super.set(key, value);
+    this.onAdded.raiseEvent(key, value);
+    this.onChanged.raiseEvent();
+
+    return ret;
+  }
+
+  /** Invokes [Map.delete](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete), raising
+   * the [[onDeleted]] event if the key was removed from the map.
+   */
+  public override delete(key: K): boolean {
+    const ret = super.delete(key);
+    if (ret) {
+      this.onDeleted.raiseEvent(key);
+      this.onChanged.raiseEvent();
+    }
+
+    return ret;
+  }
+
+  /** If this map is not already empty, invokes [Map.clear](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear)
+   * and raises the [[onCleared]] event.
+   */
+  public override clear(): void {
+    if (0 !== this.size) {
+      super.clear();
+      this.onCleared.raiseEvent();
+      this.onChanged.raiseEvent();
+    }
+  }
+
+  /** Add multiple entries to the map, raising [[onBatchAdded]] only once after all items are added.
+   * This is more efficient than calling [[set]] in a loop when listeners need not be notified of each individual addition.
+   * @param items The entries to add.
+   * @returns The number of entries that were actually added (i.e., keys that were not already present).
+   */
+  public setAll(items: Iterable<readonly [K, V]>): number {
+    const prevSize = this.size;
+    for (const [key, value] of items)
+      super.set(key, value);
+
+    if (this.size !== prevSize) {
+      this.onBatchAdded.raiseEvent();
+      this.onChanged.raiseEvent();
+    }
+
+    return this.size - prevSize;
+  }
+
+  /** Delete multiple keys from the map, raising [[onBatchDeleted]] only once after all keys are deleted.
+   * This is more efficient than calling [[delete]] in a loop when listeners need not be notified of each individual deletion.
+   * @param keys The keys to delete.
+   * @returns The number of keys that were actually deleted (i.e., were present in the map).
+   */
+  public deleteAll(keys: Iterable<K>): number {
+    const prevSize = this.size;
+    for (const key of keys)
+      super.delete(key);
+
+    if (this.size !== prevSize) {
+      this.onBatchDeleted.raiseEvent();
+      this.onChanged.raiseEvent();
+    }
+
+    return prevSize - this.size;
+  }
+
+}

--- a/core/bentley/src/ObservableMap.ts
+++ b/core/bentley/src/ObservableMap.ts
@@ -77,8 +77,7 @@ export class ObservableMap<K, V> extends Map<K, V> {
     let changed = false;
     try {
       for (const [key, value] of items) {
-        const shouldSet = !this.has(key) || !Object.is(this.get(key), value);
-        if (shouldSet) {
+        if (!this.has(key) || !Object.is(this.get(key), value)) {
           super.set(key, value);
           changed = true;
         }
@@ -97,11 +96,14 @@ export class ObservableMap<K, V> extends Map<K, V> {
    */
   public deleteAll(keys: Iterable<K>): number {
     const prevSize = this.size;
+    let deletedAny = false;
     try {
-      for (const key of keys)
-        super.delete(key);
+      for (const key of keys) {
+        if (super.delete(key))
+          deletedAny = true;
+      }
     } finally {
-      if (this.size !== prevSize) {
+      if (deletedAny) {
         this.onChanged.raiseEvent();
       }
     }

--- a/core/bentley/src/ObservableMap.ts
+++ b/core/bentley/src/ObservableMap.ts
@@ -13,6 +13,7 @@ import { BeEvent } from "./BeEvent";
  * @public
  */
 export class ObservableMap<K, V> extends Map<K, V> {
+  /** @internal */
   public override get [Symbol.toStringTag]() { return "ObservableMap"; }
 
   /** Emitted after a key/value pair is added to this map. */

--- a/core/bentley/src/ObservableMap.ts
+++ b/core/bentley/src/ObservableMap.ts
@@ -35,10 +35,15 @@ export class ObservableMap<K, V> extends Map<K, V> {
    * the [[onChanged]] event.
    */
   public override set(key: K, value: V): this {
-    const ret = super.set(key, value);
-    this.onChanged.raiseEvent();
+    const valueChanged = !this.has(key) || !Object.is(this.get(key), value);
+    if (valueChanged)
+      super.set(key, value);
 
-    return ret;
+    if (valueChanged) {
+      this.onChanged.raiseEvent();
+    }
+
+    return this;
   }
 
   /** Invokes [Map.delete](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete), raising
@@ -68,13 +73,16 @@ export class ObservableMap<K, V> extends Map<K, V> {
    * @param items The entries to add or update.
    */
   public setAll(items: Iterable<readonly [K, V]>): void {
-    let anyEntries = false;
+    let changed = false;
     for (const [key, value] of items) {
-      anyEntries = true;
-      super.set(key, value);
+      const shouldSet = !this.has(key) || !Object.is(this.get(key), value);
+      if (shouldSet) {
+        super.set(key, value);
+        changed = true;
+      }
     }
 
-    if (anyEntries) {
+    if (changed) {
       this.onChanged.raiseEvent();
     }
   }

--- a/core/bentley/src/ObservableSet.ts
+++ b/core/bentley/src/ObservableSet.ts
@@ -85,12 +85,14 @@ export class ObservableSet<T> extends Set<T> {
    */
   public addAll(items: Iterable<T>): number {
     const prevSize = this.size;
-    for (const item of items)
-      super.add(item);
-
-    if (this.size !== prevSize) {
-      this.onBatchAdded.raiseEvent();
-      this.onChanged.raiseEvent();
+    try {
+      for (const item of items)
+        super.add(item);
+    } finally {
+      if (this.size !== prevSize) {
+        this.onBatchAdded.raiseEvent();
+        this.onChanged.raiseEvent();
+      }
     }
 
     return this.size - prevSize;
@@ -103,12 +105,14 @@ export class ObservableSet<T> extends Set<T> {
    */
   public deleteAll(items: Iterable<T>): number {
     const prevSize = this.size;
-    for (const item of items)
-      super.delete(item);
-
-    if (this.size !== prevSize) {
-      this.onBatchDeleted.raiseEvent();
-      this.onChanged.raiseEvent();
+    try {
+      for (const item of items)
+        super.delete(item);
+    } finally {
+      if (this.size !== prevSize) {
+        this.onBatchDeleted.raiseEvent();
+        this.onChanged.raiseEvent();
+      }
     }
 
     return prevSize - this.size;

--- a/core/bentley/src/ObservableSet.ts
+++ b/core/bentley/src/ObservableSet.ts
@@ -12,6 +12,7 @@ import { BeEvent } from "./BeEvent";
  * @public
  */
 export class ObservableSet<T> extends Set<T> {
+  /** @internal */
   public override get [Symbol.toStringTag]() { return "ObservableSet"; }
 
   /** Emitted after `item` is added to this set. */

--- a/core/bentley/src/ObservableSet.ts
+++ b/core/bentley/src/ObservableSet.ts
@@ -85,11 +85,16 @@ export class ObservableSet<T> extends Set<T> {
    */
   public addAll(items: Iterable<T>): number {
     const prevSize = this.size;
+    let addedAny = false;
     try {
-      for (const item of items)
+      for (const item of items) {
+        const prevSetSize = this.size;
         super.add(item);
+        if (this.size !== prevSetSize)
+          addedAny = true;
+      }
     } finally {
-      if (this.size !== prevSize) {
+      if (addedAny) {
         this.onBatchAdded.raiseEvent();
         this.onChanged.raiseEvent();
       }
@@ -105,11 +110,16 @@ export class ObservableSet<T> extends Set<T> {
    */
   public deleteAll(items: Iterable<T>): number {
     const prevSize = this.size;
+    let deletedAny = false;
     try {
-      for (const item of items)
+      for (const item of items) {
+        const prevSetSize = this.size;
         super.delete(item);
+        if (this.size !== prevSetSize)
+          deletedAny = true;
+      }
     } finally {
-      if (this.size !== prevSize) {
+      if (deletedAny) {
         this.onBatchDeleted.raiseEvent();
         this.onChanged.raiseEvent();
       }

--- a/core/bentley/src/ObservableSet.ts
+++ b/core/bentley/src/ObservableSet.ts
@@ -12,6 +12,8 @@ import { BeEvent } from "./BeEvent";
  * @public
  */
 export class ObservableSet<T> extends Set<T> {
+  public override get [Symbol.toStringTag]() { return "ObservableSet"; }
+
   /** Emitted after `item` is added to this set. */
   public readonly onAdded = new BeEvent<(item: T) => void>();
   /** Emitted after `item` is deleted from this set. */
@@ -22,22 +24,33 @@ export class ObservableSet<T> extends Set<T> {
   public readonly onBatchAdded = new BeEvent<() => void>();
   /** Emitted after multiple items are deleted from this set via [[deleteAll]]. */
   public readonly onBatchDeleted = new BeEvent<() => void>();
+  /** Emitted after any change to the contents of this set. */
+  public readonly onChanged = new BeEvent<() => void>();
 
   /** Construct a new ObservableSet.
    * @param elements Optional elements with which to populate the new set.
    */
   public constructor(elements?: Iterable<T> | undefined) {
-    // NB: Set constructor will invoke add(). Do not override until initialized.
-    super(elements);
+    // IMPORTANT: do not pass `elements` to `super()`. It will invoke `add` which is overridden to invoke `onAdded.raiseEvent`, but
+    // `onAdded` is not initialized until `super()` returns.
+    super();
 
-    this.add = (item: T) => {
-      const prevSize = this.size;
-      const ret = super.add(item);
-      if (this.size !== prevSize)
-        this.onAdded.raiseEvent(item);
+    if (elements)
+      this.addAll(elements);
+  }
 
-      return ret;
-    };
+  /** Invokes [Set.add](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add), raising
+   * the [[onAdded]] event if the item was not already present in the set.
+   */
+  public override add(item: T): this {
+    const prevSize = this.size;
+    const ret = super.add(item);
+    if (this.size !== prevSize) {
+      this.onAdded.raiseEvent(item);
+      this.onChanged.raiseEvent();
+    }
+
+    return ret;
   }
 
   /** Invokes [Set.delete](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/delete), raising
@@ -45,8 +58,10 @@ export class ObservableSet<T> extends Set<T> {
    */
   public override delete(item: T): boolean {
     const ret = super.delete(item);
-    if (ret)
+    if (ret) {
       this.onDeleted.raiseEvent(item);
+      this.onChanged.raiseEvent();
+    }
 
     return ret;
   }
@@ -58,6 +73,7 @@ export class ObservableSet<T> extends Set<T> {
     if (0 !== this.size) {
       super.clear();
       this.onCleared.raiseEvent();
+      this.onChanged.raiseEvent();
     }
   }
 
@@ -71,8 +87,10 @@ export class ObservableSet<T> extends Set<T> {
     for (const item of items)
       super.add(item);
 
-    if (this.size !== prevSize)
+    if (this.size !== prevSize) {
       this.onBatchAdded.raiseEvent();
+      this.onChanged.raiseEvent();
+    }
 
     return this.size - prevSize;
   }
@@ -87,8 +105,10 @@ export class ObservableSet<T> extends Set<T> {
     for (const item of items)
       super.delete(item);
 
-    if (this.size !== prevSize)
+    if (this.size !== prevSize) {
       this.onBatchDeleted.raiseEvent();
+      this.onChanged.raiseEvent();
+    }
 
     return prevSize - this.size;
   }

--- a/core/bentley/src/core-bentley.ts
+++ b/core/bentley/src/core-bentley.ts
@@ -22,6 +22,7 @@ export * from "./JsonSchema";
 export * from "./JsonUtils";
 export * from "./Logger";
 export * from "./LRUMap";
+export * from "./ObservableMap";
 export * from "./ObservableSet";
 export * from "./OneAtATimeAction";
 export * from "./OrderedId64Iterable";

--- a/core/bentley/src/test/ObservableMap.test.ts
+++ b/core/bentley/src/test/ObservableMap.test.ts
@@ -90,6 +90,30 @@ describe("ObservableMap", () => {
     expect(map.size).to.equal(2);
   });
 
+  it("setAll should raise event if iteration throws after a change", () => {
+    const map = new ObservableMap<string, string>();
+    let changedCount = 0;
+    map.onChanged.addListener(() => changedCount++);
+    const throwing = {
+      [Symbol.iterator]() {
+        let index = 0;
+        return {
+          next() {
+            if (index === 0) {
+              index++;
+              return { value: ["a", "1"] as const, done: false };
+            }
+            throw new Error("fail");
+          },
+        };
+      },
+    };
+
+    expect(() => map.setAll(throwing as Iterable<readonly [string, string]>)).to.throw("fail");
+    expect(map.get("a")).to.equal("1");
+    expect(changedCount).to.equal(1);
+  });
+
   it("deleteAll should raise onChanged only once", () => {
     const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"], ["c", "3"]]);
     const listener = new Listener(map);

--- a/core/bentley/src/test/ObservableMap.test.ts
+++ b/core/bentley/src/test/ObservableMap.test.ts
@@ -31,7 +31,7 @@ describe("ObservableMap", () => {
     listener.expectCount(1, () => map.set("abc", "1"));
     listener.expectCount(1, () => map.set("def", "2"));
     listener.expectCount(1, () => map.set("abc", "3")); // updating an existing key
-    listener.expectCount(1, () => map.set("abc", "3")); // no suppression for setting same value
+    listener.expectNone(() => map.set("abc", "3")); // same value should not emit
     listener.expectCount(1, () => map.delete("def"));
     listener.expectCount(1, () => map.clear());
   });
@@ -67,11 +67,23 @@ describe("ObservableMap", () => {
     });
   });
 
-  it("setAll should raise event when updating existing keys' values", () => {
+  it("setAll should raise event when updating existing keys' values to different values", () => {
     const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"]]);
     const listener = new Listener(map);
 
     listener.expectCount(1, () => {
+      map.setAll([["a", "3"], ["b", "2"]]);
+      expect(map.size).to.equal(2);
+    });
+    expect(map.size).to.equal(2);
+    expect(map.get("a")).to.equal("3");
+  });
+
+  it("setAll should not raise event when all values are unchanged", () => {
+    const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"]]);
+    const listener = new Listener(map);
+
+    listener.expectNone(() => {
       map.setAll([["a", "1"], ["b", "2"]]);
       expect(map.size).to.equal(2);
     });

--- a/core/bentley/src/test/ObservableMap.test.ts
+++ b/core/bentley/src/test/ObservableMap.test.ts
@@ -1,0 +1,176 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { describe, expect, it } from "vitest";
+import { ObservableMap } from "../core-bentley";
+
+class Listener {
+  private _added = false;
+  private _deleted = false;
+  private _cleared = false;
+  private _changed = false;
+  private _addCount = 0;
+  private _deleteCount = 0;
+  private _batchAddCount = 0;
+  private _batchDeleteCount = 0;
+
+  public constructor(map: ObservableMap<string, any>) {
+    map.onAdded.addListener((_, __) => { this._added = true; this._addCount++; });
+    map.onDeleted.addListener((_) => { this._deleted = true; this._deleteCount++; });
+    map.onCleared.addListener(() => this._cleared = true);
+    map.onChanged.addListener(() => { this._changed = true; });
+    map.onBatchAdded.addListener(() => this._batchAddCount++);
+    map.onBatchDeleted.addListener(() => this._batchDeleteCount++);
+  }
+
+  private clear() {
+    this._added = this._deleted = this._cleared = this._changed = false;
+    this._addCount = this._deleteCount = this._batchAddCount = this._batchDeleteCount = 0;
+  }
+
+  public expect(added: boolean, deleted: boolean, cleared: boolean, func: () => void): void {
+    this.clear();
+    func();
+    expect(this._added).to.equal(added);
+    expect(this._deleted).to.equal(deleted);
+    expect(this._cleared).to.equal(cleared);
+    const deducedChanged = added || deleted || cleared;
+    expect(this._changed).to.equal(deducedChanged);
+    this.clear();
+  }
+
+  public expectBatch(batchAddCount: number, batchDeleteCount: number, func: () => void): void {
+    this.clear();
+    func();
+    expect(this._batchAddCount).to.equal(batchAddCount);
+    expect(this._batchDeleteCount).to.equal(batchDeleteCount);
+    expect(this._addCount).to.equal(0);
+    expect(this._deleteCount).to.equal(0);
+    const deducedChanged = batchAddCount > 0 || batchDeleteCount > 0;
+    expect(this._changed).to.equal(deducedChanged);
+    this.clear();
+  }
+
+  public expectNone(func: () => void) { this.expect(false, false, false, func); }
+  public expectAdd(func: () => void) { this.expect(true, false, false, func); }
+  public expectDelete(func: () => void) { this.expect(false, true, false, func); }
+  public expectClear(func: () => void) { this.expect(false, false, true, func); }
+}
+
+describe("ObservableMap", () => {
+  it("should raise events only when contents change", () => {
+    const map = new ObservableMap<string, string>();
+    const listener = new Listener(map);
+
+    listener.expectNone(() => {
+      map.clear();
+      map.delete("abc");
+    });
+
+    listener.expectAdd(() => map.set("abc", "1"));
+    listener.expectAdd(() => map.set("def", "2"));
+    listener.expectAdd(() => map.set("abc", "3")); // updating an existing key
+    listener.expectAdd(() => map.set("abc", "3")); // no special case for updating an existing key to its existing value.
+    listener.expectDelete(() => map.delete("def"));
+    listener.expectClear(() => map.clear());
+  });
+
+  it("should construct from iterable", () => {
+    // Map constructor invokes set(), which ObservableMap overrides to raise an event.
+    // The event is undefined until Map constructor finishes, producing an exception.
+    // Solution: suppress events during construction - no listeners can be registered yet anyway.
+    const elems: Array<readonly [string, string]> = [["a", "1"], ["b", "2"], ["c", "3"]];
+    const observable = new ObservableMap<string, string>(elems);
+    const map = new Map<string, string>(elems);
+    expect(Array.from(observable.entries())).to.deep.equal(Array.from(map.entries()));
+  });
+
+  it("setAll should raise onBatchAdded only once", () => {
+    const map = new ObservableMap<string, string>();
+    const listener = new Listener(map);
+
+    listener.expectBatch(1, 0, () => {
+      const count = map.setAll([["a", "1"], ["b", "2"], ["c", "3"]]);
+      expect(count).to.equal(3);
+    });
+    expect(map.size).to.equal(3);
+  });
+
+  it("setAll should not raise any event for empty iterable", () => {
+    const map = new ObservableMap<string, string>();
+    const listener = new Listener(map);
+
+    listener.expectBatch(0, 0, () => {
+      const count = map.setAll([]);
+      expect(count).to.equal(0);
+    });
+  });
+
+  it("setAll should not raise event when all keys already exist", () => {
+    const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"]]);
+    const listener = new Listener(map);
+
+    listener.expectBatch(0, 0, () => {
+      const count = map.setAll([["a", "1"], ["b", "2"]]);
+      expect(count).to.equal(0);
+    });
+    expect(map.size).to.equal(2);
+  });
+
+  it("setAll should count only newly added items", () => {
+    const map = new ObservableMap<string, string>([["a", "1"]]);
+    const listener = new Listener(map);
+
+    listener.expectBatch(1, 0, () => {
+      const count = map.setAll([["a", "1"], ["b", "2"], ["c", "3"]]);
+      expect(count).to.equal(2);
+    });
+    expect(map.size).to.equal(3);
+  });
+
+  it("deleteAll should raise onBatchDeleted only once", () => {
+    const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"], ["c", "3"]]);
+    const listener = new Listener(map);
+
+    listener.expectBatch(0, 1, () => {
+      const count = map.deleteAll(["a", "b", "c"]);
+      expect(count).to.equal(3);
+    });
+    expect(map.size).to.equal(0);
+  });
+
+  it("deleteAll should not raise any event for empty iterable", () => {
+    const map = new ObservableMap<string, string>([["a", "1"]]);
+    const listener = new Listener(map);
+
+    listener.expectBatch(0, 0, () => {
+      const count = map.deleteAll([]);
+      expect(count).to.equal(0);
+    });
+    expect(map.size).to.equal(1);
+  });
+
+  it("deleteAll should not raise event when no keys exist in map", () => {
+    const map = new ObservableMap<string, string>([["a", "1"]]);
+    const listener = new Listener(map);
+
+    listener.expectBatch(0, 0, () => {
+      const count = map.deleteAll(["x", "y"]);
+      expect(count).to.equal(0);
+    });
+    expect(map.size).to.equal(1);
+  });
+
+  it("deleteAll should count only actually deleted items", () => {
+    const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"]]);
+    const listener = new Listener(map);
+
+    listener.expectBatch(0, 1, () => {
+      const count = map.deleteAll(["a", "x"]);
+      expect(count).to.equal(1);
+    });
+    expect(map.size).to.equal(1);
+    expect(map.has("b")).to.be.true;
+  });
+});

--- a/core/bentley/src/test/ObservableMap.test.ts
+++ b/core/bentley/src/test/ObservableMap.test.ts
@@ -114,6 +114,32 @@ describe("ObservableMap", () => {
     expect(changedCount).to.equal(1);
   });
 
+  it("setAll should not let listener mutation change whether the current event is raised", () => {
+    const map = new ObservableMap<string, string>([["a", "1"]]);
+    let listenerInvocations = 0;
+    let reentrant = false;
+    map.onChanged.addListener(() => {
+      if (reentrant)
+        return;
+
+      reentrant = true;
+      listenerInvocations++;
+      map.delete("a");
+      map.set("b", "2");
+      reentrant = false;
+    });
+    let changedEventCount = 0;
+    map.onChanged.addListener(() => ++changedEventCount);
+
+    map.setAll([["a", "3"], ["c", "4"]]);
+
+    expect(listenerInvocations).to.equal(1);
+    expect(changedEventCount).to.equal(3);
+    expect(map.get("b")).to.equal("2");
+    expect(map.get("c")).to.equal("4");
+    expect(map.has("a")).to.be.false;
+  });
+
   it("deleteAll should raise onChanged only once", () => {
     const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"], ["c", "3"]]);
     const listener = new Listener(map);

--- a/core/bentley/src/test/ObservableMap.test.ts
+++ b/core/bentley/src/test/ObservableMap.test.ts
@@ -6,56 +6,16 @@ import { describe, expect, it } from "vitest";
 import { ObservableMap } from "../core-bentley";
 
 class Listener {
-  private _added = false;
-  private _deleted = false;
-  private _cleared = false;
-  private _changed = false;
-  private _addCount = 0;
-  private _deleteCount = 0;
-  private _batchAddCount = 0;
-  private _batchDeleteCount = 0;
+  private _changedCount = 0;
 
   public constructor(map: ObservableMap<string, any>) {
-    map.onAdded.addListener((_, __) => { this._added = true; this._addCount++; });
-    map.onDeleted.addListener((_) => { this._deleted = true; this._deleteCount++; });
-    map.onCleared.addListener(() => this._cleared = true);
-    map.onChanged.addListener(() => { this._changed = true; });
-    map.onBatchAdded.addListener(() => this._batchAddCount++);
-    map.onBatchDeleted.addListener(() => this._batchDeleteCount++);
+    map.onChanged.addListener(() => { this._changedCount++; });
   }
 
-  private clear() {
-    this._added = this._deleted = this._cleared = this._changed = false;
-    this._addCount = this._deleteCount = this._batchAddCount = this._batchDeleteCount = 0;
-  }
+  private clear() { this._changedCount = 0; }
 
-  public expect(added: boolean, deleted: boolean, cleared: boolean, func: () => void): void {
-    this.clear();
-    func();
-    expect(this._added).to.equal(added);
-    expect(this._deleted).to.equal(deleted);
-    expect(this._cleared).to.equal(cleared);
-    const deducedChanged = added || deleted || cleared;
-    expect(this._changed).to.equal(deducedChanged);
-    this.clear();
-  }
-
-  public expectBatch(batchAddCount: number, batchDeleteCount: number, func: () => void): void {
-    this.clear();
-    func();
-    expect(this._batchAddCount).to.equal(batchAddCount);
-    expect(this._batchDeleteCount).to.equal(batchDeleteCount);
-    expect(this._addCount).to.equal(0);
-    expect(this._deleteCount).to.equal(0);
-    const deducedChanged = batchAddCount > 0 || batchDeleteCount > 0;
-    expect(this._changed).to.equal(deducedChanged);
-    this.clear();
-  }
-
-  public expectNone(func: () => void) { this.expect(false, false, false, func); }
-  public expectAdd(func: () => void) { this.expect(true, false, false, func); }
-  public expectDelete(func: () => void) { this.expect(false, true, false, func); }
-  public expectClear(func: () => void) { this.expect(false, false, true, func); }
+  public expectNone(func: () => void) { this.clear(); func(); expect(this._changedCount).to.equal(0); }
+  public expectCount(count: number, func: () => void) { this.clear(); func(); expect(this._changedCount).to.equal(count); }
 }
 
 describe("ObservableMap", () => {
@@ -68,12 +28,12 @@ describe("ObservableMap", () => {
       map.delete("abc");
     });
 
-    listener.expectAdd(() => map.set("abc", "1"));
-    listener.expectAdd(() => map.set("def", "2"));
-    listener.expectAdd(() => map.set("abc", "3")); // updating an existing key
-    listener.expectAdd(() => map.set("abc", "3")); // no special case for updating an existing key to its existing value.
-    listener.expectDelete(() => map.delete("def"));
-    listener.expectClear(() => map.clear());
+    listener.expectCount(1, () => map.set("abc", "1"));
+    listener.expectCount(1, () => map.set("def", "2"));
+    listener.expectCount(1, () => map.set("abc", "3")); // updating an existing key
+    listener.expectCount(1, () => map.set("abc", "3")); // no suppression for setting same value
+    listener.expectCount(1, () => map.delete("def"));
+    listener.expectCount(1, () => map.clear());
   });
 
   it("should construct from iterable", () => {
@@ -86,13 +46,13 @@ describe("ObservableMap", () => {
     expect(Array.from(observable.entries())).to.deep.equal(Array.from(map.entries()));
   });
 
-  it("setAll should raise onBatchAdded only once", () => {
+  it("setAll should raise onChanged only once", () => {
     const map = new ObservableMap<string, string>();
     const listener = new Listener(map);
 
-    listener.expectBatch(1, 0, () => {
-      const count = map.setAll([["a", "1"], ["b", "2"], ["c", "3"]]);
-      expect(count).to.equal(3);
+    listener.expectCount(1, () => {
+      map.setAll([["a", "1"], ["b", "2"], ["c", "3"]]);
+      expect(map.size).to.equal(3);
     });
     expect(map.size).to.equal(3);
   });
@@ -101,39 +61,28 @@ describe("ObservableMap", () => {
     const map = new ObservableMap<string, string>();
     const listener = new Listener(map);
 
-    listener.expectBatch(0, 0, () => {
-      const count = map.setAll([]);
-      expect(count).to.equal(0);
+    listener.expectNone(() => {
+      map.setAll([]);
+      expect(map.size).to.equal(0);
     });
   });
 
-  it("setAll should not raise event when all keys already exist", () => {
+  it("setAll should raise event when updating existing keys' values", () => {
     const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"]]);
     const listener = new Listener(map);
 
-    listener.expectBatch(0, 0, () => {
-      const count = map.setAll([["a", "1"], ["b", "2"]]);
-      expect(count).to.equal(0);
+    listener.expectCount(1, () => {
+      map.setAll([["a", "1"], ["b", "2"]]);
+      expect(map.size).to.equal(2);
     });
     expect(map.size).to.equal(2);
   });
 
-  it("setAll should count only newly added items", () => {
-    const map = new ObservableMap<string, string>([["a", "1"]]);
-    const listener = new Listener(map);
-
-    listener.expectBatch(1, 0, () => {
-      const count = map.setAll([["a", "1"], ["b", "2"], ["c", "3"]]);
-      expect(count).to.equal(2);
-    });
-    expect(map.size).to.equal(3);
-  });
-
-  it("deleteAll should raise onBatchDeleted only once", () => {
+  it("deleteAll should raise onChanged only once", () => {
     const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"], ["c", "3"]]);
     const listener = new Listener(map);
 
-    listener.expectBatch(0, 1, () => {
+    listener.expectCount(1, () => {
       const count = map.deleteAll(["a", "b", "c"]);
       expect(count).to.equal(3);
     });
@@ -144,7 +93,7 @@ describe("ObservableMap", () => {
     const map = new ObservableMap<string, string>([["a", "1"]]);
     const listener = new Listener(map);
 
-    listener.expectBatch(0, 0, () => {
+    listener.expectNone(() => {
       const count = map.deleteAll([]);
       expect(count).to.equal(0);
     });
@@ -155,7 +104,7 @@ describe("ObservableMap", () => {
     const map = new ObservableMap<string, string>([["a", "1"]]);
     const listener = new Listener(map);
 
-    listener.expectBatch(0, 0, () => {
+    listener.expectNone(() => {
       const count = map.deleteAll(["x", "y"]);
       expect(count).to.equal(0);
     });
@@ -166,11 +115,21 @@ describe("ObservableMap", () => {
     const map = new ObservableMap<string, string>([["a", "1"], ["b", "2"]]);
     const listener = new Listener(map);
 
-    listener.expectBatch(0, 1, () => {
+    listener.expectCount(1, () => {
       const count = map.deleteAll(["a", "x"]);
       expect(count).to.equal(1);
     });
     expect(map.size).to.equal(1);
     expect(map.has("b")).to.be.true;
+  });
+
+  it("clear should only raise an event if the map is not empty", () => {
+    const map = new ObservableMap<string, string>();
+    const listener = new Listener(map);
+
+    listener.expectCount(0, () => map.clear());
+    listener.expectCount(1, () => map.set("a", "1"));
+    listener.expectCount(1, () => map.clear());
+    listener.expectCount(0, () => map.clear());
   });
 });

--- a/core/bentley/src/test/ObservableSet.test.ts
+++ b/core/bentley/src/test/ObservableSet.test.ts
@@ -155,6 +155,32 @@ describe("ObservableSet", () => {
     expect(changedCount).to.equal(1);
   });
 
+  it("addAll should not let listener mutation change whether the current event is raised", () => {
+    const set = new ObservableSet<string>(["a"]);
+    let batchAddedCount = 0;
+    let changedCount = 0;
+    let reentrant = false;
+    set.onBatchAdded.addListener(() => {
+      if (reentrant)
+        return;
+
+      reentrant = true;
+      batchAddedCount++;
+      set.delete("a");
+      set.add("b");
+      reentrant = false;
+    });
+    set.onChanged.addListener(() => changedCount++);
+
+    set.addAll(["a", "c"]);
+
+    expect(batchAddedCount).to.equal(1);
+    expect(changedCount).to.equal(3);
+    expect(set.has("a")).to.be.false;
+    expect(set.has("b")).to.be.true;
+    expect(set.has("c")).to.be.true;
+  });
+
   it("deleteAll should raise onBatchDeleted only once", () => {
     const set = new ObservableSet<string>(["a", "b", "c"]);
     const listener = new Listener(set);
@@ -225,6 +251,32 @@ describe("ObservableSet", () => {
     expect(set.has("a")).to.be.false;
     expect(batchDeletedCount).to.equal(1);
     expect(changedCount).to.equal(1);
+  });
+
+  it("deleteAll should not let listener mutation change whether the current event is raised", () => {
+    const set = new ObservableSet<string>(["a", "b"]);
+    let batchDeletedCount = 0;
+    let changedCount = 0;
+    let reentrant = false;
+    set.onBatchDeleted.addListener(() => {
+      if (reentrant)
+        return;
+
+      reentrant = true;
+      batchDeletedCount++;
+      set.add("c");
+      set.delete("b");
+      reentrant = false;
+    });
+    set.onChanged.addListener(() => changedCount++);
+
+    set.deleteAll(["a", "b"]);
+
+    expect(batchDeletedCount).to.equal(1);
+    expect(changedCount).to.equal(2);
+    expect(set.has("a")).to.be.false;
+    expect(set.has("b")).to.be.false;
+    expect(set.has("c")).to.be.true;
   });
 
   it("subclasses can override `add`", () => {

--- a/core/bentley/src/test/ObservableSet.test.ts
+++ b/core/bentley/src/test/ObservableSet.test.ts
@@ -9,6 +9,7 @@ class Listener {
   private _added = false;
   private _deleted = false;
   private _cleared = false;
+  private _changed = false;
   private _addCount = 0;
   private _deleteCount = 0;
   private _batchAddCount = 0;
@@ -18,12 +19,13 @@ class Listener {
     set.onAdded.addListener((_) => { this._added = true; this._addCount++; });
     set.onDeleted.addListener((_) => { this._deleted = true; this._deleteCount++; });
     set.onCleared.addListener(() => this._cleared = true);
+    set.onChanged.addListener(() => { this._changed = true; });
     set.onBatchAdded.addListener(() => this._batchAddCount++);
     set.onBatchDeleted.addListener(() => this._batchDeleteCount++);
   }
 
   private clear() {
-    this._added = this._deleted = this._cleared = false;
+    this._added = this._deleted = this._cleared = this._changed = false;
     this._addCount = this._deleteCount = this._batchAddCount = this._batchDeleteCount = 0;
   }
 
@@ -33,6 +35,8 @@ class Listener {
     expect(this._added).to.equal(added);
     expect(this._deleted).to.equal(deleted);
     expect(this._cleared).to.equal(cleared);
+    const deducedChanged = added || deleted || cleared;
+    expect(this._changed).to.equal(deducedChanged);
     this.clear();
   }
 
@@ -43,6 +47,8 @@ class Listener {
     expect(this._batchDeleteCount).to.equal(batchDeleteCount);
     expect(this._addCount).to.equal(0);
     expect(this._deleteCount).to.equal(0);
+    const deducedChanged = batchAddCount > 0 || batchDeleteCount > 0;
+    expect(this._changed).to.equal(deducedChanged);
     this.clear();
   }
 
@@ -76,7 +82,7 @@ describe("ObservableSet", () => {
     const elems = ["a", "b", "c"];
     const observable = new ObservableSet<string>(elems);
     const set = new Set<string>(elems);
-    expect(observable).to.deep.equal(set);
+    expect(Array.from(observable)).to.deep.equal(Array.from(set));
   });
 
   it("addAll should raise onBatchAdded only once", () => {

--- a/core/bentley/src/test/ObservableSet.test.ts
+++ b/core/bentley/src/test/ObservableSet.test.ts
@@ -128,6 +128,33 @@ describe("ObservableSet", () => {
     expect(set.size).to.equal(3);
   });
 
+  it("addAll should raise events if iteration throws after a change", () => {
+    const set = new ObservableSet<string>();
+    let batchAddedCount = 0;
+    let changedCount = 0;
+    set.onBatchAdded.addListener(() => batchAddedCount++);
+    set.onChanged.addListener(() => changedCount++);
+    const throwing = {
+      [Symbol.iterator]() {
+        let index = 0;
+        return {
+          next() {
+            if (index === 0) {
+              index++;
+              return { value: "a", done: false };
+            }
+            throw new Error("fail");
+          },
+        };
+      },
+    };
+
+    expect(() => set.addAll(throwing as Iterable<string>)).to.throw("fail");
+    expect(set.has("a")).to.be.true;
+    expect(batchAddedCount).to.equal(1);
+    expect(changedCount).to.equal(1);
+  });
+
   it("deleteAll should raise onBatchDeleted only once", () => {
     const set = new ObservableSet<string>(["a", "b", "c"]);
     const listener = new Listener(set);
@@ -173,6 +200,32 @@ describe("ObservableSet", () => {
     expect(set.has("b")).to.be.true;
   });
 
+  it("deleteAll should raise events if iteration throws after a change", () => {
+    const set = new ObservableSet<string>(["a", "b"]);
+    let batchDeletedCount = 0;
+    let changedCount = 0;
+    set.onBatchDeleted.addListener(() => batchDeletedCount++);
+    set.onChanged.addListener(() => changedCount++);
+    const throwing = {
+      [Symbol.iterator]() {
+        let index = 0;
+        return {
+          next() {
+            if (index === 0) {
+              index++;
+              return { value: "a", done: false };
+            }
+            throw new Error("fail");
+          },
+        };
+      },
+    };
+
+    expect(() => set.deleteAll(throwing as Iterable<string>)).to.throw("fail");
+    expect(set.has("a")).to.be.false;
+    expect(batchDeletedCount).to.equal(1);
+    expect(changedCount).to.equal(1);
+  });
 
   it("subclasses can override `add`", () => {
     class MySet extends ObservableSet<string> {

--- a/core/bentley/src/test/ObservableSet.test.ts
+++ b/core/bentley/src/test/ObservableSet.test.ts
@@ -172,6 +172,7 @@ describe("ObservableSet", () => {
     expect(set.size).to.equal(1);
     expect(set.has("b")).to.be.true;
   });
+
   it("subclasses can override `add`", () => {
     class MySet extends ObservableSet<string> {
       public myAddWasCalled = false;

--- a/core/bentley/src/test/ObservableSet.test.ts
+++ b/core/bentley/src/test/ObservableSet.test.ts
@@ -172,8 +172,6 @@ describe("ObservableSet", () => {
     expect(set.size).to.equal(1);
     expect(set.has("b")).to.be.true;
   });
-
-
   it("subclasses can override `add`", () => {
     class MySet extends ObservableSet<string> {
       public myAddWasCalled = false;

--- a/core/bentley/src/test/ObservableSet.test.ts
+++ b/core/bentley/src/test/ObservableSet.test.ts
@@ -172,4 +172,22 @@ describe("ObservableSet", () => {
     expect(set.size).to.equal(1);
     expect(set.has("b")).to.be.true;
   });
+
+
+  it("subclasses can override `add`", () => {
+    class MySet extends ObservableSet<string> {
+      public myAddWasCalled = false;
+
+      public override add(value: string): this {
+        const ret = super.add(value);
+        this.myAddWasCalled = true;
+        return ret;
+      }
+    }
+
+    const set = new MySet();
+    expect(set.myAddWasCalled).to.be.false;
+    set.add("stuff");
+    expect(set.myAddWasCalled).to.be.true;
+  });
 });


### PR DESCRIPTION
- `ObservableMap` is to `Map` as `ObservableSet` is to `Set`. I need it for a larger PR I'm working on.
- Usually you just want to know when a collection changes without listening for discrete onAdd/Delete/Clear events. `ObservableSet.onChanged` has you covered. I didn't bother adding the more granular events to `ObservableMap` - they aren't very useful.
- `ObservableSet` had a bug where if you subclassed it and overrode `add`, your `add` method would not be invoked, because `ObservableSet`'s constructor would clobber it in an attempt to work around JavaScript's non-intuitive order of initialization for subclass fields vs subclass methods.

NOTE: I did not implement the new [getOrInsert](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsert) nor its computed version, because our versions of TS and JS don't appear to know about them yet. They may be a bug waiting to happen - if people call them on an `ObservableMap`, the `onChanged` event won't be raised, unless the base implementation calls the derived `set` method.