### PR TITLE
Consolidate integration Rush builds and remove redundant webpack execution

### DIFF
--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -19,19 +19,16 @@ steps:
   - script: node ./common/scripts/install-run-rush install
     displayName: rush install
 
-  - script: |
-      # full-stack-tests/backend/package.json
-      node ./common/scripts/install-run-rush build -v --to backend-integration-tests
-      # full-stack-tests/core/package.json
-      node ./common/scripts/install-run-rush build -v --to core-full-stack-tests
-      # full-stack-tests/ecschema-rpc-interface/package.json
-      node ./common/scripts/install-run-rush build -v --to @itwin/ecschema-rpcinterface-tests
-      # full-stack-tests/rpc/package.json
-      node ./common/scripts/install-run-rush build -v --to rpc-full-stack-tests
-      # full-stack-tests/rpc-interface/package.json
-      node ./common/scripts/install-run-rush build -v --to rpcinterface-full-stack-tests
-
-      node ./common/scripts/install-run-rush webpack:test -v
+  # Build every package needed by the integration test suites in a single Rush
+  # invocation. Each frontend test package (and @itwin/core-electron) already runs
+  # webpack:test as part of its normal build script, so no separate webpack pass is needed.
+  - script: >
+      node ./common/scripts/install-run-rush build -v
+      --to backend-integration-tests
+      --to core-full-stack-tests
+      --to @itwin/ecschema-rpcinterface-tests
+      --to rpc-full-stack-tests
+      --to rpcinterface-full-stack-tests
     displayName: "Rush build"
 
   # Electron 42+ no longer downloads the binary during npm install (postinstall removed).


### PR DESCRIPTION
## Summary

Replaces the five sequential `rush build --to <selector>` invocations in `integration-test-steps.yaml` with a single invocation using multiple `--to` selectors, and removes the trailing unscoped `rush webpack:test`.

## Why the webpack pass is safe to remove

Every frontend test package selected by the build (`core-full-stack-tests`, `@itwin/ecschema-rpcinterface-tests`, `rpc-full-stack-tests`, `rpcinterface-full-stack-tests`) runs `webpack:test` from its own `build` script, and `@itwin/core-electron` (whose webpacked frontend tests also run in this pipeline) is a dependency of `core-full-stack-tests`, so its `webpack:test` executes inside the `--to` closure. `backend-integration-tests` has no webpack step and needs none.

The unscoped pass cost ~45s per job (~8 agent-minutes across the old full matrix).

Stacked on #9678. Part of iTwin/itwinjs-backlog#2352. Closes iTwin/itwinjs-backlog#2357.