### PR TITLE
Enable safe Rush build-cache reads in integration pipelines

### DIFF
--- a/common/config/azure-pipelines/integration-client-regression-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-client-regression-pr-validation.yaml
@@ -10,6 +10,7 @@ pr: none
 variables:
   - group: iModel.js non-secret config variables
   - group: iModel.js Integration Test Users
+  - group: Rush Build Cache SAS Token
 
 jobs:
   - job: Node_24_x

--- a/common/config/azure-pipelines/integration-pr-validation.yaml
+++ b/common/config/azure-pipelines/integration-pr-validation.yaml
@@ -27,6 +27,7 @@ pr:
 variables:
   - group: iTwin.js non-secret config variables
   - group: iTwin.js Integration Test Users
+  - group: Rush Build Cache SAS Token
 
 jobs:
   - job: Node_24_x

--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -16,6 +16,7 @@ schedules:
 variables:
   - group: iTwin.js non-secret config variables
   - group: iTwin.js Integration Test Users
+  - group: Rush Build Cache SAS Token
 
 jobs:
   - job: Integration_Tests_Full

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -19,6 +19,11 @@ steps:
   - script: node ./common/scripts/install-run-rush install
     displayName: rush install
 
+  # Determines whether this run is allowed to write to the Rush build cache
+  # (only trusted, non-PR builds on Linux; see the script for details).
+  - script: node common/scripts/set-rush-write-cache-variables.js
+    displayName: "Set Rush Write Cache Variables"
+
   # Build every package needed by the integration test suites in a single Rush
   # invocation. Each frontend test package (and @itwin/core-electron) already runs
   # webpack:test as part of its normal build script, so no separate webpack pass is needed.
@@ -30,6 +35,9 @@ steps:
       --to rpc-full-stack-tests
       --to rpcinterface-full-stack-tests
     displayName: "Rush build"
+    env:
+      RUSH_BUILD_CACHE_CREDENTIAL: $(RushBuildCacheSAS)
+      RUSH_BUILD_CACHE_ENABLED: 1
 
   # Electron 42+ no longer downloads the binary during npm install (postinstall removed).
   # Ensure the binary is present before configuring the AppArmor profile.


### PR DESCRIPTION
## Summary

Enables the existing Azure-backed Rush build cache for the integration pipelines, reusing the credential and write-control pattern already used by `core-build.yaml` and `fast-ci.yaml`.

- `templates/integration-test-steps.yaml`: adds the `common/scripts/set-rush-write-cache-variables.js` step and sets `RUSH_BUILD_CACHE_ENABLED=1` + `RUSH_BUILD_CACHE_CREDENTIAL: $(RushBuildCacheSAS)` on the Rush build step.
- Adds the `Rush Build Cache SAS Token` variable group to all three consuming pipelines (`integration-pr-validation`, `integration-validation`, `integration-client-regression-pr-validation`) so `$(RushBuildCacheSAS)` resolves.

## Security

- Cache **writes** are gated by `set-rush-write-cache-variables.js`: `RUSH_BUILD_CACHE_WRITE_ALLOWED=1` only for Linux builds with `BUILD_REASON` of `IndividualCI` or `Manual`. PR builds (`BUILD_REASON=PullRequest`) are read-only, so untrusted PR code cannot poison the cache.
- Cache entries are keyed `[os]-[arch]-[hash]` and populated by trusted master/CI builds; this is the same pattern `fast-ci.yaml` already uses on PR builds.
- Caveat for reviewers: the SAS is a secret exposed to the build job. Definition 4301 builds PRs; ADO's default of withholding secrets from fork builds should be confirmed on that definition.

Stacked on #9679. Part of iTwin/itwinjs-backlog#2352. Closes iTwin/itwinjs-backlog#2358.