### PR TITLE
Replace the full integration Cartesian matrix with targeted compatibility lanes

### DIFF
--- a/common/config/azure-pipelines/integration-validation.yaml
+++ b/common/config/azure-pipelines/integration-validation.yaml
@@ -1,7 +1,31 @@
 # iTwin.js Core Integration Validation Build
 #
-# This integration test job currently runs on all supported operating systems and node versions of iTwin.js.
-# Runs against master on a weekly schedule, in the future this should be a required check before bumping versions.
+# Runs against master on a weekly schedule; in the future this should be a required check before bumping versions.
+#
+# Rather than running every integration test on the full Cartesian product of
+# OS x architecture x Node version, coverage is separated into targeted lanes:
+#
+# | Lane                  | Pool / image         | Node | Core renderer tests | Owns coverage for                            |
+# | --------------------- | -------------------- | ---- | ------------------- | -------------------------------------------- |
+# | Renderer_Linux_x64    | ubuntu-latest        | 24.x | yes                 | Chrome + Electron rendering on Linux x64     |
+# | Renderer_Windows_x64  | windows-latest       | 24.x | yes                 | Chrome + Electron rendering on Windows x64   |
+# | Renderer_MacOS_arm64  | iModelTechMacArm     | 24.x | yes                 | Chrome + Electron rendering on macOS arm64   |
+# | Arch_Linux_arm64      | Platform-Debian12-ARM| 24.x | yes                 | Linux arm64 architecture (incl. rendering)   |
+# | NodeCompat_20         | ubuntu-latest        | 20.x | no                  | Node 20 backend/RPC compatibility            |
+# | NodeCompat_22         | ubuntu-latest        | 22.x | no                  | Node 22 backend/RPC compatibility            |
+#
+# Rationale:
+# - Renderer behavior varies by OS, GPU stack, and architecture -- not by Node
+#   version (Chrome bundles its own runtime; Electron pins its own Node). So the
+#   graphics-heavy Core full-stack tests run once per OS/architecture on the
+#   latest supported Node only.
+# - Node-version compatibility concerns the backend/RPC layers, so older Node
+#   versions are validated on a single representative OS (Linux x64) with the
+#   expensive renderer suites skipped (runRendererTests: false).
+# - Architecture coverage (arm64) runs on the latest supported Node.
+#
+# The PR integration pipeline (integration-pr-validation.yaml) additionally runs
+# the full suite on Linux x64 with the latest Node for every pull request.
 
 trigger: none
 pr: none
@@ -19,49 +43,25 @@ variables:
   - group: Rush Build Cache SAS Token
 
 jobs:
-  - job: Integration_Tests_Full
+  # Renderer + architecture lanes: full integration suite (including the
+  # graphics-heavy Core full-stack tests) on the latest supported Node.
+  - job: Integration_Renderer_Lanes
     strategy:
       matrix:
-        Linux_node_20_x:
-          imageName: ubuntu-latest
-          poolName:
-          nodeVersion: 20.x
-        Windows_node_20_x:
-          imageName: windows-latest
-          poolName:
-          nodeVersion: 20.x
-        MacOS_node_20_x:
-          imageName: macos-latest
-          poolName: "iModelTechMacArm"
-          nodeVersion: 20.x
-        Linux_node_22_x:
-          imageName: ubuntu-latest
-          poolName:
-          nodeVersion: 22.x
-        Windows_node_22_x:
-          imageName: windows-latest
-          poolName:
-          nodeVersion: 22.x
-        MacOS_node_22_x:
-          imageName: macos-latest
-          poolName: "iModelTechMacArm"
-          nodeVersion: 22.x
-        LinuxARM64_node_22_x:
-          poolName: "Platform-Debian12-ARM"
-          nodeVersion: 22.x
-        LinuxX64_node_24_x:
+        Renderer_Linux_x64_node_24_x:
           imageName: ubuntu-latest
           poolName:
           nodeVersion: 24.x
-        Windows_node_24_x:
+        Renderer_Windows_x64_node_24_x:
           imageName: windows-latest
           poolName:
           nodeVersion: 24.x
-        MacOS_node_24_x:
+        Renderer_MacOS_arm64_node_24_x:
           imageName: macos-latest
           poolName: "iModelTechMacArm"
           nodeVersion: 24.x
-        LinuxARM64_node_24_x:
+        Arch_Linux_arm64_node_24_x:
+          imageName:
           poolName: "Platform-Debian12-ARM"
           nodeVersion: 24.x
     pool:
@@ -75,3 +75,25 @@ jobs:
       - template: templates/integration-test-steps.yaml
         parameters:
           nodeVersion: $(nodeVersion)
+          runRendererTests: true
+
+  # Node-compatibility lanes: backend/RPC integration suites on older supported
+  # Node versions, on one representative OS, skipping the renderer suites.
+  - job: Integration_Node_Compat_Lanes
+    strategy:
+      matrix:
+        NodeCompat_Linux_x64_node_20_x:
+          nodeVersion: 20.x
+        NodeCompat_Linux_x64_node_22_x:
+          nodeVersion: 22.x
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 1
+
+      - template: templates/integration-test-steps.yaml
+        parameters:
+          nodeVersion: $(nodeVersion)
+          runRendererTests: false

--- a/common/config/azure-pipelines/templates/integration-test-steps.yaml
+++ b/common/config/azure-pipelines/templates/integration-test-steps.yaml
@@ -2,6 +2,12 @@ parameters:
   - name: nodeVersion # name of the parameter; required
     type: string # data type of the parameter; required
 
+  # When false, skips the graphics-heavy Core full-stack tests (Chrome + Electron
+  # renderer suites). Used by Node-compatibility lanes that do not own renderer coverage.
+  - name: runRendererTests
+    type: boolean
+    default: true
+
 steps:
   - template: setup-integration-users.yaml
 
@@ -88,20 +94,21 @@ steps:
     condition: succeededOrFailed()
 
   # Linux agents do not have a real display so use the virtual framebuffer
-  - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run test:integration
-    workingDirectory: "full-stack-tests/core"
-    env:
-      NODE_ENV: development
-    displayName: "Run Core Full Stack Tests"
-    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+  - ${{ if eq(parameters.runRendererTests, true) }}:
+      - script: xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run test:integration
+        workingDirectory: "full-stack-tests/core"
+        env:
+          NODE_ENV: development
+        displayName: "Run Core Full Stack Tests"
+        condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
 
-  # MacOS and Windows agents work without any virtual display
-  - script: npm run test:integration
-    workingDirectory: "full-stack-tests/core"
-    env:
-      NODE_ENV: development
-    displayName: "Run Core Full Stack Tests"
-    condition: and(succeededOrFailed(), ne(variables['Agent.OS'], 'Linux'))
+      # MacOS and Windows agents work without any virtual display
+      - script: npm run test:integration
+        workingDirectory: "full-stack-tests/core"
+        env:
+          NODE_ENV: development
+        displayName: "Run Core Full Stack Tests"
+        condition: and(succeededOrFailed(), ne(variables['Agent.OS'], 'Linux'))
 
   - script: npm run test:integration
     workingDirectory: "full-stack-tests/ecschema-rpc-interface"
@@ -169,19 +176,20 @@ steps:
     continueOnError: true
     condition: succeededOrFailed()
 
-  - task: PublishTestResults@2
-    displayName: "Publish Core Integration Test Results (Chrome)"
-    inputs:
-      testResultsFiles: "full-stack-tests/core/lib/test/junit_results_chrome.xml"
-      testRunTitle: "Core - Integration Tests (Chrome) - ${{ parameters.nodeVersion }}"
-    condition: succeededOrFailed()
+  - ${{ if eq(parameters.runRendererTests, true) }}:
+      - task: PublishTestResults@2
+        displayName: "Publish Core Integration Test Results (Chrome)"
+        inputs:
+          testResultsFiles: "full-stack-tests/core/lib/test/junit_results_chrome.xml"
+          testRunTitle: "Core - Integration Tests (Chrome) - ${{ parameters.nodeVersion }}"
+        condition: succeededOrFailed()
 
-  - task: PublishTestResults@2
-    displayName: "Publish Core Integration Test Results (Electron)"
-    inputs:
-      testResultsFiles: "full-stack-tests/core/lib/test/junit_results_electron.xml"
-      testRunTitle: "Core - Integration Tests (Electron) - ${{ parameters.nodeVersion }}"
-    condition: succeededOrFailed()
+      - task: PublishTestResults@2
+        displayName: "Publish Core Integration Test Results (Electron)"
+        inputs:
+          testResultsFiles: "full-stack-tests/core/lib/test/junit_results_electron.xml"
+          testRunTitle: "Core - Integration Tests (Electron) - ${{ parameters.nodeVersion }}"
+        condition: succeededOrFailed()
 
   - task: PublishTestResults@2
     displayName: "Publish ECSchema Rpc Interface Integration Test Results"


### PR DESCRIPTION
## Summary

Replaces the 11-cell OS x architecture x Node matrix in `integration-validation.yaml` with 6 targeted lanes, separating renderer, Node, OS, and architecture compatibility concerns.

- `templates/integration-test-steps.yaml`: new `runRendererTests` boolean parameter (default `true`, so the PR pipeline is unchanged). When `false`, the graphics-heavy Core full-stack test steps and their publish steps are compile-time excluded; all backend/RPC/ECSchema/Electron suites still run.
- `integration-validation.yaml`: lane design with coverage-ownership table documented in the file header.

| Lane | Agent | Node | Renderer tests |
| --- | --- | --- | --- |
| Renderer_Linux_x64 | ubuntu-latest | 24.x | yes |
| Renderer_Windows_x64 | windows-latest | 24.x | yes |
| Renderer_MacOS_arm64 | iModelTechMacArm | 24.x | yes |
| Arch_Linux_arm64 | Platform-Debian12-ARM | 24.x | yes |
| NodeCompat_Linux_x64_20 | ubuntu-latest | 20.x | no |
| NodeCompat_Linux_x64_22 | ubuntu-latest | 22.x | no |

## Rationale

Renderer behavior varies by OS/GPU/architecture, not Node version (Chrome bundles its own runtime; Electron pins its own Node), so renderer coverage runs once per OS/arch on latest Node. Node compatibility concerns the backend/RPC layers and is validated on one representative OS.

## Expected impact

- Estimated ~140 agent-minutes vs the ~331 measured baseline (target: <=250).
- No lane repeats the graphics suite, so Windows should no longer hit the 60-minute job timeout.

## Coverage deltas (intentional)

- Renderer suites no longer run on Node 20/22 anywhere.
- Linux arm64 now runs Node 24 only (was 22 + 24).
- Windows/macOS no longer run backend tests on Node 20/22; Node-compat is Linux x64 only.

Stacked on #9680. Part of iTwin/itwinjs-backlog#2352. Closes iTwin/itwinjs-backlog#2356.