### PR TITLE
Update @loaders.gl dependency range to ^4.4.5

### DIFF
--- a/common/changes/@itwin/core-frontend/restore-loaders-gl-range_2026-09-01-13-17-18.json
+++ b/common/changes/@itwin/core-frontend/restore-loaders-gl-range_2026-09-01-13-17-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-frontend",
+      "comment": "Changed @loaders.gl dependency range to ^4.4.5.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-frontend"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -793,11 +793,11 @@ importers:
         specifier: workspace:*
         version: link:../webgl-compatibility
       '@loaders.gl/core':
-        specifier: ~4.3.4
-        version: 4.3.4
+        specifier: ^4.4.5
+        version: 4.4.5
       '@loaders.gl/draco':
-        specifier: ~4.3.4
-        version: 4.3.4(@loaders.gl/core@4.3.4)
+        specifier: ^4.4.5
+        version: 4.4.5(@loaders.gl/core@4.4.5)
       fuse.js:
         specifier: ^3.3.0
         version: 3.6.1
@@ -2227,7 +2227,7 @@ importers:
         version: link:../../tools/perf-tools
       azurite:
         specifier: ^3.35.0
-        version: 3.36.0(@types/node@24.13.3)
+        version: 3.36.0(@types/node@25.9.5)
       chai:
         specifier: ^4.3.10
         version: 4.5.0
@@ -5175,28 +5175,32 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@loaders.gl/core@4.3.4':
-    resolution: {integrity: sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw==}
+  '@loaders.gl/core@4.4.5':
+    resolution: {integrity: sha512-hlpE200MinDAyU0kMjEM4yk+0TDxiB9nT+GcwOCrXc7buE0e0YwTn+Ynz2Q85dwDKvJZw3kNHTTBGvQwq9533A==}
 
-  '@loaders.gl/draco@4.3.4':
-    resolution: {integrity: sha512-4Lx0rKmYENGspvcgV5XDpFD9o+NamXoazSSl9Oa3pjVVjo+HJuzCgrxTQYD/3JvRrolW/QRehZeWD/L/cEC6mw==}
+  '@loaders.gl/draco@4.4.5':
+    resolution: {integrity: sha512-J4DuzoUQNJhjxmErCArF5J1PC0LCMbhPkY/YdkTaDmUwxSQdh1M/VWg85AXKLAxUiwGkhmC8AUUaSyPxTpCUrQ==}
     peerDependencies:
-      '@loaders.gl/core': ^4.3.0
+      '@loaders.gl/core': ~4.4.0
 
-  '@loaders.gl/loader-utils@4.3.4':
-    resolution: {integrity: sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==}
-    peerDependencies:
-      '@loaders.gl/core': ^4.3.0
+  '@loaders.gl/loader-utils@4.4.5':
+    resolution: {integrity: sha512-c4h2RUMEru+hbfvgZEIy5cLQKyQka2TPQZW/2Wy+yIPr3FU7RKwfp+vLwIfir6Xkdn2zniWyWretZwE02aY/Ug==}
 
-  '@loaders.gl/schema@4.3.4':
-    resolution: {integrity: sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==}
+  '@loaders.gl/schema-utils@4.4.5':
+    resolution: {integrity: sha512-vi6AROLWvoLIN609tVmchwotTaHK5rHv8SWjoVUWLhPCXmIc9npz0rCl7NJScCgr7UjYifZG1rWOnrAxaYTlyA==}
     peerDependencies:
-      '@loaders.gl/core': ^4.3.0
+      '@loaders.gl/core': ~4.4.0
 
-  '@loaders.gl/worker-utils@4.3.4':
-    resolution: {integrity: sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==}
+  '@loaders.gl/schema@4.4.5':
+    resolution: {integrity: sha512-q2XNquegw+hX+ZEshacKYL/+FKBUIS5FHA+2Ft3JWmcNiR6umGnYCdXQhDcFCqAm8Ks87fMCV+z/zTloxaIZgQ==}
+
+  '@loaders.gl/worker-utils@4.4.5':
+    resolution: {integrity: sha512-ZQDoM6f/HpZ3Lzj6vjtPHXSvi+cUK0QG7yJz+MKWAokmeWa98WMZwswS8zkn/qNkY95rLcxh66N4Sl96+7hqAQ==}
     peerDependencies:
-      '@loaders.gl/core': ^4.3.0
+      '@loaders.gl/core': ~4.4.0
+
+  '@math.gl/types@4.1.0':
+    resolution: {integrity: sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==}
 
   '@microsoft/api-extractor-model@7.33.10':
     resolution: {integrity: sha512-uPUK17xGxeQ3av6TN7awp+dTTSTvx8fZC0XFL1gyt7hFapYuxND3XLXH8vkmI7UjfW92oogzFAFqHSifmJROaw==}
@@ -5784,6 +5788,9 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
+  '@types/node@25.9.5':
+    resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
+
   '@types/object-hash@1.3.4':
     resolution: {integrity: sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA==}
 
@@ -6204,6 +6211,10 @@ packages:
 
   anynum@1.0.1:
     resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
+  apache-arrow@21.2.0:
+    resolution: {integrity: sha512-Hxe6Agq26gQOM954qpzYSllJBPJl+e16U5CkfuMUhLrNba+5nKkttIVlflaovN6oaTratqMGAO8H5u/aNhmHWQ==}
+    hasBin: true
 
   append-transform@2.0.0:
     resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
@@ -7466,6 +7477,9 @@ packages:
   flatbuffers@1.12.0:
     resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatbush@4.4.1:
     resolution: {integrity: sha512-g3eA6ZF0viCV0UslH/mdUzCLcT7aGj0Fjk9MBxxNkbADSXqSHDZhthFBDFgo2umc6SVmSItNefTjWnfyo7DunA==}
 
@@ -8279,6 +8293,9 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -10137,6 +10154,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
@@ -11516,37 +11536,50 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@loaders.gl/core@4.3.4':
+  '@loaders.gl/core@4.4.5':
     dependencies:
-      '@loaders.gl/loader-utils': 4.3.4(@loaders.gl/core@4.3.4)
-      '@loaders.gl/schema': 4.3.4(@loaders.gl/core@4.3.4)
-      '@loaders.gl/worker-utils': 4.3.4(@loaders.gl/core@4.3.4)
+      '@loaders.gl/loader-utils': 4.4.5(@loaders.gl/core@4.4.5)
+      '@loaders.gl/schema': 4.4.5
+      '@loaders.gl/schema-utils': 4.4.5(@loaders.gl/core@4.4.5)
+      '@loaders.gl/worker-utils': 4.4.5(@loaders.gl/core@4.4.5)
       '@probe.gl/log': 4.1.1
 
-  '@loaders.gl/draco@4.3.4(@loaders.gl/core@4.3.4)':
+  '@loaders.gl/draco@4.4.5(@loaders.gl/core@4.4.5)':
     dependencies:
-      '@loaders.gl/core': 4.3.4
-      '@loaders.gl/loader-utils': 4.3.4(@loaders.gl/core@4.3.4)
-      '@loaders.gl/schema': 4.3.4(@loaders.gl/core@4.3.4)
-      '@loaders.gl/worker-utils': 4.3.4(@loaders.gl/core@4.3.4)
+      '@loaders.gl/core': 4.4.5
+      '@loaders.gl/loader-utils': 4.4.5(@loaders.gl/core@4.4.5)
+      '@loaders.gl/schema': 4.4.5
+      '@loaders.gl/schema-utils': 4.4.5(@loaders.gl/core@4.4.5)
+      '@loaders.gl/worker-utils': 4.4.5(@loaders.gl/core@4.4.5)
       draco3d: 1.5.7
 
-  '@loaders.gl/loader-utils@4.3.4(@loaders.gl/core@4.3.4)':
+  '@loaders.gl/loader-utils@4.4.5(@loaders.gl/core@4.4.5)':
     dependencies:
-      '@loaders.gl/core': 4.3.4
-      '@loaders.gl/schema': 4.3.4(@loaders.gl/core@4.3.4)
-      '@loaders.gl/worker-utils': 4.3.4(@loaders.gl/core@4.3.4)
+      '@loaders.gl/schema': 4.4.5
+      '@loaders.gl/worker-utils': 4.4.5(@loaders.gl/core@4.4.5)
       '@probe.gl/log': 4.1.1
       '@probe.gl/stats': 4.1.1
+    transitivePeerDependencies:
+      - '@loaders.gl/core'
 
-  '@loaders.gl/schema@4.3.4(@loaders.gl/core@4.3.4)':
+  '@loaders.gl/schema-utils@4.4.5(@loaders.gl/core@4.4.5)':
     dependencies:
-      '@loaders.gl/core': 4.3.4
+      '@loaders.gl/core': 4.4.5
+      '@loaders.gl/schema': 4.4.5
+      '@math.gl/types': 4.1.0
       '@types/geojson': 7946.0.16
+      apache-arrow: 21.2.0
 
-  '@loaders.gl/worker-utils@4.3.4(@loaders.gl/core@4.3.4)':
+  '@loaders.gl/schema@4.4.5':
     dependencies:
-      '@loaders.gl/core': 4.3.4
+      '@types/geojson': 7946.0.16
+      apache-arrow: 21.2.0
+
+  '@loaders.gl/worker-utils@4.4.5(@loaders.gl/core@4.4.5)':
+    dependencies:
+      '@loaders.gl/core': 4.4.5
+
+  '@math.gl/types@4.1.0': {}
 
   '@microsoft/api-extractor-model@7.33.10(@types/node@20.17.58)':
     dependencies:
@@ -12095,6 +12128,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.9.5':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/object-hash@1.3.4': {}
 
   '@types/qs@6.15.1': {}
@@ -12621,6 +12658,13 @@ snapshots:
 
   anynum@1.0.1: {}
 
+  apache-arrow@21.2.0:
+    dependencies:
+      '@types/node': 25.9.5
+      flatbuffers: 25.9.23
+      json-with-bigint: 3.5.12
+      tslib: 2.8.1
+
   append-transform@2.0.0:
     dependencies:
       default-require-extensions: 3.0.1
@@ -12847,7 +12891,7 @@ snapshots:
       - sqlite3
       - supports-color
 
-  azurite@3.36.0(@types/node@24.13.3):
+  azurite@3.36.0(@types/node@25.9.5):
     dependencies:
       '@azure/ms-rest-js': 2.7.0
       applicationinsights: 2.9.8
@@ -12861,9 +12905,9 @@ snapshots:
       lokijs: 1.5.12
       morgan: 1.11.0
       multistream: 2.1.1
-      mysql2: 3.23.3(@types/node@24.13.3)
+      mysql2: 3.23.3(@types/node@25.9.5)
       rimraf: 3.0.2
-      sequelize: 6.37.8(mysql2@3.23.3(@types/node@24.13.3))(tedious@18.6.2)
+      sequelize: 6.37.8(mysql2@3.23.3(@types/node@25.9.5))(tedious@18.6.2)
       stoppable: 1.1.0
       tedious: 18.6.2
       to-readable-stream: 2.1.0
@@ -14174,6 +14218,8 @@ snapshots:
 
   flatbuffers@1.12.0: {}
 
+  flatbuffers@25.9.23: {}
+
   flatbush@4.4.1:
     dependencies:
       flatqueue: 2.0.3
@@ -15092,6 +15138,8 @@ snapshots:
 
   json-stringify-safe@5.0.1: {}
 
+  json-with-bigint@3.5.12: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -15517,9 +15565,9 @@ snapshots:
       named-placeholders: 1.1.6
       sql-escaper: 1.5.1
 
-  mysql2@3.23.3(@types/node@24.13.3):
+  mysql2@3.23.3(@types/node@25.9.5):
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 25.9.5
       aws-ssl-profiles: 1.1.2
       generate-function: 2.3.1
       iconv-lite: 0.7.3
@@ -16399,7 +16447,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sequelize@6.37.8(mysql2@3.23.3(@types/node@24.13.3))(tedious@18.6.2):
+  sequelize@6.37.8(mysql2@3.23.3(@types/node@25.9.5))(tedious@18.6.2):
     dependencies:
       '@types/debug': 4.1.13
       '@types/validator': 13.15.10
@@ -16418,7 +16466,7 @@ snapshots:
       validator: 13.15.35
       wkx: 0.5.0
     optionalDependencies:
-      mysql2: 3.23.3(@types/node@24.13.3)
+      mysql2: 3.23.3(@types/node@25.9.5)
       tedious: 18.6.2
     transitivePeerDependencies:
       - supports-color
@@ -17069,6 +17117,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@7.18.2: {}
+
+  undici-types@7.24.6: {}
 
   unicode-trie@2.0.0:
     dependencies:

--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -94,8 +94,8 @@
   "dependencies": {
     "@itwin/core-i18n": "workspace:*",
     "@itwin/webgl-compatibility": "workspace:*",
-    "@loaders.gl/core": "~4.3.4",
-    "@loaders.gl/draco": "~4.3.4",
+    "@loaders.gl/core": "^4.4.5",
+    "@loaders.gl/draco": "^4.4.5",
     "fuse.js": "^3.3.0",
     "wms-capabilities": "0.6.0"
   }

--- a/core/frontend/src/tile/GltfReader.ts
+++ b/core/frontend/src/tile/GltfReader.ts
@@ -2444,8 +2444,10 @@ export abstract class GltfReader {
         "draco_wasm_wrapper.js": `${IModelApp.publicPath}scripts/draco_wasm_wrapper.js`,
         "draco_decoder.wasm": `${IModelApp.publicPath}scripts/draco_decoder.wasm`,
       },
-      worker: false,
-      useLocalLibraries: true,
+      core: {
+        worker: false,
+        useLocalLibraries: true,
+      },
     });
     if (mesh)
       this._dracoMeshes.set(ext, mesh);


### PR DESCRIPTION
## Summary

`@loaders.gl/core` and `@loaders.gl/draco` were temporarily pinned to `~4.3.4` because `@loaders.gl/schema-utils` 4.4.0–4.4.3 imported `@math.gl/types` without declaring it as a dependency. That broke bundling for downstream apps (see visgl/loaders.gl#3341):

```
[vite]: Rollup failed to resolve import "@math.gl/types" from
".../@loaders.gl/schema-utils/dist/lib/table/batch-builder/columnar-table-batch-aggregator.js".
```

The missing dependency is declared again as of `4.4.4`, so the pin can be lifted. The range is set to `^4.4.5` — the latest release and the version verified here — rather than restoring `^4.3.4`, so the broken 4.4.0–4.4.3 versions can never be resolved.

## Changes

- `core/frontend/package.json` — `@loaders.gl/core` and `@loaders.gl/draco`: `~4.3.4` → `^4.4.5`
- `core/frontend/src/tile/GltfReader.ts` — nested the Draco loader's `worker` and `useLocalLibraries` options under `core`
- `common/config/rush/pnpm-lock.yaml` — regenerated with `rush update`

### Why the code change is required

`@loaders.gl` 4.4 restructured `LoaderOptions`. Worker/library options such as `worker` and `useLocalLibraries` moved into a nested `core` object, and `Loader`/`LoaderWithParser` now default to the new `StrictLoaderOptions` type, which only declares `core`, `modules`, and an index signature of `Record<string, unknown> | undefined`. The previous top-level usage therefore no longer compiles:

```
src/tile/GltfReader.ts(2447,7): error TS2322: Type 'boolean' is not assignable to type 'Record<string, unknown>'.
src/tile/GltfReader.ts(2448,7): error TS2322: Type 'boolean' is not assignable to type 'Record<string, unknown>'.
```

Since `core` does not exist in 4.3.x, the code can no longer support both major-minor lines — which is a further reason for the `^4.4.5` floor.

## Testing

- A freshly generated iTwin Viewer builds cleanly with `@loaders.gl` 4.4.5 forced via overrides

Fixes iTwin/viewer#426

---

*This PR was created by an AI Assistant (powered by Claude Opus 5).*
