### PR TITLE
Enhance integrity check documentation and result structures

### DIFF
--- a/common/changes/@itwin/core-backend/rschili-integrity-documentation_2026-09-10-09-43-25.json
+++ b/common/changes/@itwin/core-backend/rschili-integrity-documentation_2026-09-10-09-43-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-backend",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-backend"
+}

--- a/core/backend/src/IModelDb.ts
+++ b/core/backend/src/IModelDb.ts
@@ -233,31 +233,38 @@ export interface ComputedProjectExtents {
  * @beta
  */
 export interface IntegrityCheckOptions {
-  /** If true, perform a quick integrity check that only reports whether each check passed or failed, without detailed results. */
+  /**
+   * If true, perform a quick check of the ten integrity checks other than the missing child rows check.
+   * The quick check reports pass/fail for each check without problem details. If false is specified without
+   * enabling a specific check, the quick check is still performed by default.
+   */
   quickCheck?: boolean;
-  /** Options for performing specific integrity checks with detailed results. */
+  /**
+   * Options for performing specific integrity checks with detailed results. Each selected check returns all
+   * problem rows. If quickCheck is also true, the selected checks are performed again in specific mode.
+   */
   specificChecks?: {
-    /** If true, checks if all the required columns exist in data tables. Issues are returned as a list of those tables/columns. */
+    /** If true, checks for missing nonvirtual physical columns in mapped data tables. It does not compare column types. */
     checkDataColumns?: boolean;
-    /** If true, checks if the profile table, indexes, and triggers are present. Does not check be_* tables. Issues are returned as a list of tables/indexes/triggers which were not found or have different DDL. */
+    /** If true, checks expected EC profile tables, indexes, and iModel triggers for missing or mismatching SQL definitions. It does not check be_* tables. */
     checkECProfile?: boolean;
-    /** If true, checks if RelClassId of a Navigation property is a valid ECClassId. It does not check the value to match the relationship class. */
+    /** If true, checks that each non-null persisted RelECClassId is the declared relationship class or one of its derived classes. */
     checkNavigationClassIds?: boolean;
-    /** If true, checks if Id of a Navigation property matches a valid row primary class. */
+    /** If true, checks that a navigation property's non-null .Id (the referenced instance's ECInstanceId) resolves to a row in the first relationship constraint class in the navigation direction, including derived classes. */
     checkNavigationIds?: boolean;
-    /** If true, checks if SourceECClassId or TargetECClassId of a link table matches a valid ECClassId. */
+    /** If true, checks that SourceECClassId and TargetECClassId have matching meta.ECClassDef entries. This checks class existence only, not endpoint-class validity. */
     checkLinktableForeignKeyClassIds?: boolean;
-    /** If true, checks if SourceECInstanceId or TargetECInstanceId of a link table matches a valid row in primary class. */
+    /** If true, checks SourceECInstanceId and TargetECInstanceId for null or an unresolved row in the first endpoint constraint class, including derived classes. */
     checkLinktableForeignKeyIds?: boolean;
-    /** If true, checks persisted ECClassId in all data tables and makes sure they are valid. */
+    /** If true, checks persisted ECClassId values for a corresponding class definition. This checks class existence, not whether the class belongs in that table. */
     checkClassIds?: boolean;
-    /** If true, checks if all the required data tables and indexes exist for mapped classes. Issues are returned as a list of tables/columns which were not found or have different DDL. */
+    /** If true, checks for missing mapped data tables and indexes. Results report object names and types, not DDL differences. */
     checkDataSchema?: boolean;
-    /** If true, checks if all schemas can be loaded into memory. */
+    /** If true, checks whether the schema manager can load each schema recorded in the database. A problem reports the schema name without a reason. */
     checkSchemaLoad?: boolean;
-    /** If true, checks if all child rows have a corresponding parent row. */
+    /** If true, checks whether each existing bis_Element row has all required mapped child-table rows. */
     checkMissingChildRows?: boolean;
-    /** If true, checks if a class maps every inherited property to the same column as each of its base classes. */
+    /** If true, checks whether an inherited property maps to different columns for a base and derived class under the same physical table root. */
     checkDivergedPropMaps?: boolean;
   }
 }
@@ -838,24 +845,30 @@ export abstract class IModelDb extends IModel {
 
   /**
    * Performs integrity checks on this iModel.
-   * Types of integrity checks that can be performed are:
    *
-   * Default Check:
-   * - Quick Check: Runs all integrity checks below and returns whether each check passed or failed, without detailed results.
+   * The quick check runs the ten checks below other than Missing Child Rows. It reports pass/fail for each check
+   * based on the first problem found, without returning problem details. The specific checks return all problem rows.
+   * Selecting both quickCheck and specific checks repeats the selected work in both modes.
    *
-   * Specific Checks:
-   * - Data Columns Check: Checks if all the required columns exist in data tables. Issues are returned as a list of those tables/columns.
-   * - EC Profile Check: Checks if the profile table, indexes, and triggers are present. Does not check be_* tables. Issues are returned as a list of tables/indexes/triggers which were not found or have different DDL.
-   * - Navigation Class Ids Check: Checks if RelClassId of a Navigation property is a valid ECClassId. It does not check the value to match the relationship class.
-   * - Navigation Ids Check: Checks if Id of a Navigation property matches a valid row primary class.
-   * - Linktable Foreign Key Class Ids Check: Checks if SourceECClassId or TargetECClassId of a link table matches a valid ECClassId.
-   * - Linktable Foreign Key Ids Check: Checks if SourceECInstanceId or TargetECInstanceId of a link table matches a valid row in primary class.
-   * - Class Ids Check: Checks persisted ECClassId in all data tables and makes sure they are valid.
-   * - Data Schema Check: Checks if all the required data tables and indexes exist for mapped classes. Issues are returned as a list of tables/columns which were not found or have different DDL.
-   * - Schema Load Check: Checks if all schemas can be loaded into memory.
-   * - Missing Child Rows Check: Checks if all child rows have a corresponding parent row.
+   * The checks are:
+   * - Data Columns Check: Checks for missing nonvirtual physical columns in mapped data tables. It does not compare column types.
+   * - EC Profile Check: Checks expected EC profile tables, indexes, and iModel triggers for missing or mismatching SQL definitions. It does not check be_* tables.
+   * - Navigation Class Ids Check: Checks that each non-null persisted RelECClassId is the declared relationship class or one of its derived classes.
+   * - Navigation Ids Check: Checks that a navigation property's non-null .Id (the referenced instance's ECInstanceId) resolves to a row in the first relationship constraint class in the navigation direction, including derived classes.
+   * - Linktable Foreign Key Class Ids Check: Checks that SourceECClassId and TargetECClassId have matching meta.ECClassDef entries. This checks class existence only, not endpoint-class validity.
+   * - Linktable Foreign Key Ids Check: Checks SourceECInstanceId and TargetECInstanceId for null or an unresolved row in the first endpoint constraint class, including derived classes.
+   * - Class Ids Check: Checks persisted ECClassId values for a corresponding class definition. This checks class existence, not whether the class belongs in that table.
+   * - Data Schema Check: Checks for missing mapped data tables and indexes. Results report object names and types, not DDL differences.
+   * - Schema Load Check: Checks whether the schema manager can load each schema recorded in the database. A problem reports the schema name without a reason.
+   * - Missing Child Rows Check: Checks whether each existing bis_Element row has all required mapped child-table rows.
+   * - Diverged Property Maps Check: Checks whether an inherited property maps to different columns for a base and derived class under the same physical table root.
    *
-   * @param options Options specifying which integrity checks to perform. If no options are provided or all options are false, a quick check will be performed by default.
+   * If no options are provided, or if quickCheck is false and no specific check is enabled, a quick check is performed by default.
+   * The checks are read-only and use the current primary connection. They have no callbacks, and the native operation
+   * blocks the backend while each check runs.
+   *
+   * @see [ECSQL integrity checks]($docs/learning/ECSqlReference/Pragmas.md#pragma-integrity_check-experimental)
+   * @param options Options specifying which integrity checks to perform.
    * @returns An array of integrity check results.
    * @throws [[IModelError]] if the iModel is not open.
    * @beta

--- a/core/backend/src/internal/IntegrityCheck.ts
+++ b/core/backend/src/internal/IntegrityCheck.ts
@@ -107,8 +107,11 @@ type IntegrityCheckResultRow<K extends IntegrityCheckKey> = IntegrityCheckResult
  * Return type for quick integrity check
  */
 export interface QuickIntegrityCheckResultRow {
+  /** Name of the integrity check. */
   check: string;
+  /** Whether the check passed. Quick checks do not include problem details. */
   passed: boolean;
+  /** Elapsed time for the check, in seconds. */
   elapsedSeconds: string;
 }
 
@@ -116,8 +119,11 @@ export interface QuickIntegrityCheckResultRow {
  * Return type for Check Data Columns integrity check
  */
 export interface CheckDataColumnsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** Mapped data table containing a missing column. */
   table: string;
+  /** Name of the missing nonvirtual physical column. */
   column: string;
 }
 
@@ -125,9 +131,13 @@ export interface CheckDataColumnsResultRow {
  * Return type for Check EC Profile integrity check
  */
 export interface CheckECProfileResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** Type of EC profile object, such as a table, index, or iModel trigger. */
   type: string;
+  /** Name of the EC profile object. */
   name: string;
+  /** Description of the missing or mismatching object definition. */
   issue: string;
 }
 
@@ -135,11 +145,17 @@ export interface CheckECProfileResultRow {
  * Return type for Check Navigation Class Ids integrity check
  */
 export interface CheckNavClassIdsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** ID of the source instance row containing the navigation property. */
   id: string;
+  /** Declaring or scanned class for the source row; rows from derived classes may be included. */
   class: string;
+  /** Name of the navigation property. */
   property: string;
+  /** ID of the referenced instance stored by the navigation property. */
   navId: string;
+  /** Relationship class ID stored by the navigation property, not the target instance class ID. */
   navClassId: string;
 }
 
@@ -147,11 +163,17 @@ export interface CheckNavClassIdsResultRow {
  * Return type for Check Navigation Ids integrity check
  */
 export interface CheckNavIdsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** ID of the source instance row containing the navigation property. */
   id: string;
+  /** Declaring or scanned class for the source row; rows from derived classes may be included. */
   class: string;
+  /** Name of the navigation property. */
   property: string;
+  /** ID of the referenced instance stored by the navigation property. */
   navId: string;
+  /** Class queried for the referenced row: the first relationship constraint class in the navigation direction, including derived classes. */
   primaryClass: string;
 }
 
@@ -159,11 +181,17 @@ export interface CheckNavIdsResultRow {
  * Return type for Check Link Table Foreign Key Class Ids integrity check
  */
 export interface CheckLinkTableFkClassIdsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** ID of the relationship row containing the foreign key. */
   id: string;
+  /** Link-table relationship class. */
   relationship: string;
+  /** Endpoint class-ID property: SourceECClassId or TargetECClassId. */
   property: string;
+  /** Source or target endpoint instance ID stored in the link table. */
   keyId: string;
+  /** Source or target endpoint class ID; the check verifies that the class exists. */
   keyClassId: string;
 }
 
@@ -171,11 +199,17 @@ export interface CheckLinkTableFkClassIdsResultRow {
  * Return type for Check Link Table Foreign Key Ids integrity check
  */
 export interface CheckLinkTableFkIdsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** ID of the relationship row containing the foreign key. */
   id: string;
+  /** Link-table relationship class. */
   relationship: string;
+  /** Endpoint instance-ID property: SourceECInstanceId or TargetECInstanceId. */
   property: string;
+  /** Source or target endpoint instance ID stored in the link table. */
   keyId: string;
+  /** Class queried for the referenced endpoint row: the first endpoint constraint class, including derived classes. */
   primaryClass: string;
 }
 
@@ -183,10 +217,15 @@ export interface CheckLinkTableFkIdsResultRow {
  * Return type for Check Class Ids integrity check
  */
 export interface CheckClassIdsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** Declaring or scanned class for the row; rows from derived classes may be included. */
   class: string;
+  /** ECInstanceId for primary/joined results, or the physical RowId for overflow results. */
   id: string;
+  /** Persisted ECClassId value with no matching class definition. */
   classId: string;
+  /** Check category: "primary", "joined", or "overflow". */
   type: string;
 }
 
@@ -194,8 +233,11 @@ export interface CheckClassIdsResultRow {
  * Return type for Check Data Schema integrity check
  */
 export interface CheckDataSchemaResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** Type of missing mapped schema object, such as a table or index. */
   type: string;
+  /** Name of the missing mapped schema object. */
   name: string;
 }
 
@@ -203,7 +245,9 @@ export interface CheckDataSchemaResultRow {
  * Return type for Check Schema Load integrity check
  */
 export interface CheckSchemaLoadResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** Name of the schema that the schema manager could not load. */
   schema: string;
 }
 
@@ -211,10 +255,15 @@ export interface CheckSchemaLoadResultRow {
  * Return type for Check Missing Child Rows integrity check
  */
 export interface CheckMissingChildRowsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** Class used to identify the checked rows: "BisCore:Element". */
   class: string;
+  /** ID of the existing bis_Element row missing a required child row. */
   id: string;
+  /** Persisted ECClassId of the existing element row. */
   classId: string;
+  /** Comma-separated names of all child tables checked for the row, not only tables with a missing child row. */
   missingRowInTables: string;
 }
 
@@ -222,13 +271,21 @@ export interface CheckMissingChildRowsResultRow {
  * Return type for Check Diverged Property Maps integrity check
  */
 export interface CheckDivergedPropMapsResultRow {
+  /** Sequential result row number. */
   sno: number;
+  /** ID of the derived class whose inherited property map diverges. */
   derivedClassId: Id64String;
+  /** Name of the derived class whose inherited property map diverges. */
   derivedClassName: string;
+  /** ID of the base class whose mapping was compared with the derived class. */
   baseClassId: Id64String;
+  /** Name of the base class whose mapping was compared with the derived class. */
   baseClassName: string;
+  /** Access path of the inherited property with different column mappings. */
   propertyName: string;
+  /** Base class mapping, formatted as table.column. */
   baseColumn: string;
+  /** Derived class mapping, formatted as table.column. */
   divergedColumn: string;
 }
 

--- a/docs/learning/ECSqlReference/Pragmas.md
+++ b/docs/learning/ECSqlReference/Pragmas.md
@@ -136,33 +136,91 @@ PRAGMA explain_query ('SELECT * FROM bis.GeometricElement3d')
 
 ## `PRAGMA integrity_check` (experimental)
 
-1. `check_ec_profile` - checks if the profile table, indexes, and triggers are present. Does not check be\_\* tables. Issues are returned as a list of tables/indexes/triggers which were not found or have different DDL.
-2. `check_data_schema` - checks if all the required data tables and indexes exist for mapped classes. Issues are returned as a list of tables/columns which were not found or have different DDL.
-3. `check_data_columns` - checks if all the required columns exist in data tables. Issues are returned as a list of those tables/columns.
-4. `check_nav_class_ids` - checks if `RelClassId` of a Navigation property is a valid ECClassId. It does not check the value to match the relationship class.
-5. `check_nav_ids` - checks if `Id` of a Navigation property matches a valid row primary class.
-6. `check_linktable_fk_class_ids` - checks if `SourceECClassId` or `TargetECClassId` of a link table matches a valid ECClassId.
-7. `check_linktable_fk_ids`- checks if `SourceECInstanceId` or `TargetECInstanceId` of a link table matches a valid row in primary class.
-8. `check_class_ids`- checks persisted `ECClassId` in all data tables and makes sure they are valid.
-9. `check_schema_load` - checks if all schemas can be loaded into memory.
+Checks ECDb schema and data consistency without modifying the database. It is available on read-only connections. [IModelDb.integrityCheck]($core-backend) wraps the pragma for backend TypeScript callers.
+
+| Check | Reports |
+| --- | --- |
+| `check_ec_profile` | Expected EC profile tables/indexes or iModel triggers that are missing or have different SQL definitions. Does not check `be_*` tables. |
+| `check_data_schema` | Missing physical tables or indexes recorded in ECDb's mapping metadata. Checks names and object types, not SQL definitions. |
+| `check_data_columns` | Nonvirtual mapped columns missing from their physical tables. Checks column names, not types or constraints. |
+| `check_nav_class_ids` | Non-null stored `RelECClassId` values outside the navigation property's declared relationship class and its derived classes. This is a relationship class ID, not the referenced instance's class ID. |
+| `check_nav_ids` | Non-null navigation `.Id` values that do not resolve to an instance in the referenced-class query. See [Navigation ID results](#navigation-id-results). |
+| `check_linktable_fk_class_ids` | `SourceECClassId` or `TargetECClassId` values that do not match an ECClass definition. Does not compare the class ID with the endpoint instance's actual class. |
+| `check_linktable_fk_ids` | Source or target instance IDs that are null or do not resolve to a row in the endpoint-class query. The query uses the first relationship constraint class for that endpoint and includes derived classes. |
+| `check_class_ids` | Persisted `ECClassId` values with no matching ECClass definition, checked through primary, joined and overflow tables. Checks class existence, not whether the class belongs in that table. |
+| `check_schema_load` | Schemas recorded in the database that the schema manager cannot load. The result identifies the schema but does not explain why loading failed. |
+| `check_missing_child_rows` | Elements with a `bis_Element` row but missing a required row in another mapped table. See [Missing child-row results](#missing-child-row-results). |
+| `check_diverged_prop_maps` | An inherited property mapped to different columns by a derived class and a base class within the same physical table hierarchy. See [Diverged property-map results](#diverged-property-map-results). |
+
+### Summary results
+
+Without a check name, the pragma runs all checks listed above **except `check_missing_child_rows`**. It stops each check at its first problem and returns one summary row per check. This is the quick mode used by `IModelDb.integrityCheck()` by default.
 
 ```sql
 PRAGMA integrity_check ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES;
 ```
 
-The output of `integrety_check` is a table with each test performed, the result and time took to run the test.
+| Column | Meaning |
+| --- | --- |
+| `sno` | One-based result row number. |
+| `check` | Check name from the table above. |
+| `result` | `true` if the check found no problems; `false` if it found a problem. |
+| `elapsed_sec` | Elapsed time for that check, in seconds, formatted as a string. |
 
-| sno | check                        | result | elapsed_sec |
-| --- | ---------------------------- | ------ | ----------- |
-| 1   | check_data_columns           | True   | 0.005       |
-| 2   | check_ec_profile             | True   | 0.001       |
-| 3   | check_nav_class_ids          | True   | 0.179       |
-| 4   | check_nav_ids                | True   | 0.403       |
-| 5   | check_linktable_fk_class_ids | True   | 0.001       |
-| 6   | check_linktable_fk_ids       | False  | 0.003       |
-| 7   | check_class_ids              | True   | 0.039       |
-| 8   | check_data_schema            | True   | 0.000       |
-| 9   | check_schema_load            | True   | 0.000       |
+### Detailed results
+
+Pass a check name to return its problem rows. An empty result means the selected check found no problems. Query execution errors can prevent a check from completing and are distinct from returned problem rows.
+
+```sql
+PRAGMA integrity_check(check_nav_ids) ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES;
+```
+
+Each detailed result includes a one-based `sno`. Other fields depend on the selected check. `IModelDb.integrityCheck` accepts selections through `IntegrityCheckOptions.specificChecks`; enable all eleven options and set `quickCheck: false` to get full detailed coverage without also running the summary checks.
+
+### Navigation ID results
+
+A [navigation property](../ECSQL.md#navigation-properties) stores the **referenced instance's ECInstanceId** in its `.Id` member. For example, `Element.Model.Id` identifies the model containing that element.
+
+`check_nav_ids` resolves the navigation property's relationship constraint class, then looks for a referenced row with that ID. The query includes derived classes and uses the first constraint class for the navigation direction. Null navigation IDs are ignored.
+
+| Pragma column | API field | Meaning |
+| --- | --- | --- |
+| `id` | `id` | ECInstanceId of the instance containing the navigation property. |
+| `class` | `class` | Class declaring the navigation property and used to query source rows. A reported instance may belong to a derived class. |
+| `property` | `property` | Navigation property name. |
+| `nav_id` | `navId` | The property's non-null `.Id`: the referenced instance's ECInstanceId. |
+| `primary_class` | `primaryClass` | The class queried for the referenced instance, including derived classes. |
+
+A result means the referenced-class query found **no row with that ID**. The class definition was resolved before the query ran. The result does not distinguish an absent instance from an instance outside that class hierarchy, and contains no further per-row error message.
+
+For `Element.Model`, the check is equivalent to:
+
+```sql
+SELECT e.ECInstanceId AS id, e.Model.Id AS nav_id
+FROM BisCore.Element e
+LEFT JOIN BisCore.Model m ON m.ECInstanceId = e.Model.Id
+WHERE e.Model.Id IS NOT NULL AND m.ECInstanceId IS NULL;
+```
+
+### Missing child-row results
+
+```sql
+PRAGMA integrity_check(check_missing_child_rows) ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES;
+```
+
+An element can occupy rows in several physical tables. This check starts with existing `bis_Element` rows and looks for required child-table rows with the same element ID. It checks physical storage rows, not parent/child element relationships.
+
+Results contain `class` (`BisCore:Element`), `id` (element ID), `class_id` (the element's ECClassId), and `MissingRowInTables`. The last field is a comma-separated list of **all child tables checked** for that class; at least one lacks a row, but the list does not identify which ones are missing. The TypeScript API names these last two fields `classId` and `missingRowInTables`.
+
+### Diverged property-map results
+
+```sql
+PRAGMA integrity_check(check_diverged_prop_maps) ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES;
+```
+
+This check compares the storage mappings of an inherited property in a derived class and each base class. It reports different columns within a shared physical table hierarchy. It excludes `ECDbSystem` properties and mappings under different physical table roots, and does not compare instance values.
+
+Results identify the derived class (`derivedClassId`, `derivedClassName`), base class (`baseClassId`, `baseClassName`), property access path (`propertyName`), and the two `table.column` mappings (`baseColumn`, `divergedColumn`).
 
 ## `PRAGMA parse_tree` (experimental)
 


### PR DESCRIPTION
I ran an integrity check today and found the documentation about it a bit lacking.
Improved the comments and written documentation to clear up some details.